### PR TITLE
Add short-circuiting for painless def equality

### DIFF
--- a/docs/changelog/92027.yaml
+++ b/docs/changelog/92027.yaml
@@ -1,0 +1,5 @@
+pr: 92027
+summary: Painless eq short-circuiting
+area: Infra/Scripting
+type: enhancement
+issues: []

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -87,7 +87,8 @@ public final class Def {
             ARRAY_LENGTH = methodHandlesLookup.findStatic(
                 MethodHandles.class,
                 "arrayLength",
-                MethodType.methodType(MethodHandle.class, Class.class));
+                MethodType.methodType(MethodHandle.class, Class.class)
+            );
         } catch (ReflectiveOperationException roe) {
             throw new AssertionError(roe);
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -87,9 +87,8 @@ public final class Def {
             ARRAY_LENGTH = methodHandlesLookup.findStatic(
                 MethodHandles.class,
                 "arrayLength",
-                MethodType.methodType(MethodHandle.class, Class.class)
-            );
-        } catch (final ReflectiveOperationException roe) {
+                MethodType.methodType(MethodHandle.class, Class.class));
+        } catch (ReflectiveOperationException roe) {
             throw new AssertionError(roe);
         }
 
@@ -768,8 +767,8 @@ public final class Def {
     // Conversion methods for def to primitive types.
 
     public static boolean defToboolean(final Object value) {
-        if (value instanceof Boolean b) {
-            return b;
+        if (value instanceof Boolean) {
+            return (boolean) value;
         } else {
             throw new ClassCastException(
                 "cannot cast "
@@ -782,8 +781,8 @@ public final class Def {
     }
 
     public static byte defTobyteImplicit(final Object value) {
-        if (value instanceof Byte b) {
-            return b;
+        if (value instanceof Byte) {
+            return (byte) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -796,10 +795,10 @@ public final class Def {
     }
 
     public static short defToshortImplicit(final Object value) {
-        if (value instanceof Byte b) {
-            return b;
-        } else if (value instanceof Short s) {
-            return s;
+        if (value instanceof Byte) {
+            return (byte) value;
+        } else if (value instanceof Short) {
+            return (short) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -812,8 +811,8 @@ public final class Def {
     }
 
     public static char defTocharImplicit(final Object value) {
-        if (value instanceof Character c) {
-            return c;
+        if (value instanceof Character) {
+            return (char) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -826,14 +825,14 @@ public final class Def {
     }
 
     public static int defTointImplicit(final Object value) {
-        if (value instanceof Byte b) {
-            return b;
-        } else if (value instanceof Short s) {
-            return s;
-        } else if (value instanceof Character c) {
-            return c;
-        } else if (value instanceof Integer i) {
-            return i;
+        if (value instanceof Byte) {
+            return (byte) value;
+        } else if (value instanceof Short) {
+            return (short) value;
+        } else if (value instanceof Character) {
+            return (char) value;
+        } else if (value instanceof Integer) {
+            return (int) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -846,16 +845,16 @@ public final class Def {
     }
 
     public static long defTolongImplicit(final Object value) {
-        if (value instanceof Byte b) {
-            return b;
-        } else if (value instanceof Short s) {
-            return s;
-        } else if (value instanceof Character c) {
-            return c;
-        } else if (value instanceof Integer i) {
-            return i;
-        } else if (value instanceof Long l) {
-            return l;
+        if (value instanceof Byte) {
+            return (byte) value;
+        } else if (value instanceof Short) {
+            return (short) value;
+        } else if (value instanceof Character) {
+            return (char) value;
+        } else if (value instanceof Integer) {
+            return (int) value;
+        } else if (value instanceof Long) {
+            return (long) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -868,18 +867,18 @@ public final class Def {
     }
 
     public static float defTofloatImplicit(final Object value) {
-        if (value instanceof Byte b) {
-            return b;
-        } else if (value instanceof Short s) {
-            return s;
-        } else if (value instanceof Character c) {
-            return c;
-        } else if (value instanceof Integer i) {
-            return i;
-        } else if (value instanceof Long l) {
-            return l;
-        } else if (value instanceof Float f) {
-            return f;
+        if (value instanceof Byte) {
+            return (byte) value;
+        } else if (value instanceof Short) {
+            return (short) value;
+        } else if (value instanceof Character) {
+            return (char) value;
+        } else if (value instanceof Integer) {
+            return (int) value;
+        } else if (value instanceof Long) {
+            return (long) value;
+        } else if (value instanceof Float) {
+            return (float) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -892,20 +891,20 @@ public final class Def {
     }
 
     public static double defTodoubleImplicit(final Object value) {
-        if (value instanceof Byte b) {
-            return b;
-        } else if (value instanceof Short s) {
-            return s;
-        } else if (value instanceof Character c) {
-            return c;
-        } else if (value instanceof Integer i) {
-            return i;
-        } else if (value instanceof Long l) {
-            return l;
-        } else if (value instanceof Float f) {
-            return f;
-        } else if (value instanceof Double d) {
-            return d;
+        if (value instanceof Byte) {
+            return (byte) value;
+        } else if (value instanceof Short) {
+            return (short) value;
+        } else if (value instanceof Character) {
+            return (char) value;
+        } else if (value instanceof Integer) {
+            return (int) value;
+        } else if (value instanceof Long) {
+            return (long) value;
+        } else if (value instanceof Float) {
+            return (float) value;
+        } else if (value instanceof Double) {
+            return (double) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -918,8 +917,8 @@ public final class Def {
     }
 
     public static byte defTobyteExplicit(final Object value) {
-        if (value instanceof Character c) {
-            return (byte) (char) c;
+        if (value instanceof Character) {
+            return (byte) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -939,8 +938,8 @@ public final class Def {
     }
 
     public static short defToshortExplicit(final Object value) {
-        if (value instanceof Character c) {
-            return (short) (char) c;
+        if (value instanceof Character) {
+            return (short) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -960,10 +959,10 @@ public final class Def {
     }
 
     public static char defTocharExplicit(final Object value) {
-        if (value instanceof String s) {
-            return Utility.StringTochar(s);
-        } else if (value instanceof Character c) {
-            return c;
+        if (value instanceof String) {
+            return Utility.StringTochar((String) value);
+        } else if (value instanceof Character) {
+            return (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -983,8 +982,8 @@ public final class Def {
     }
 
     public static int defTointExplicit(final Object value) {
-        if (value instanceof Character c) {
-            return c;
+        if (value instanceof Character) {
+            return (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1004,8 +1003,8 @@ public final class Def {
     }
 
     public static long defTolongExplicit(final Object value) {
-        if (value instanceof Character c) {
-            return c;
+        if (value instanceof Character) {
+            return (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1025,8 +1024,8 @@ public final class Def {
     }
 
     public static float defTofloatExplicit(final Object value) {
-        if (value instanceof Character c) {
-            return c;
+        if (value instanceof Character) {
+            return (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1046,8 +1045,8 @@ public final class Def {
     }
 
     public static double defTodoubleExplicit(final Object value) {
-        if (value instanceof Character c) {
-            return c;
+        if (value instanceof Character) {
+            return (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1071,8 +1070,8 @@ public final class Def {
     public static Boolean defToBoolean(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Boolean b) {
-            return b;
+        } else if (value instanceof Boolean) {
+            return (Boolean) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1087,8 +1086,8 @@ public final class Def {
     public static Byte defToByteImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Byte b) {
-            return b;
+        } else if (value instanceof Byte) {
+            return (Byte) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1103,10 +1102,10 @@ public final class Def {
     public static Short defToShortImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Byte b) {
-            return b.shortValue();
-        } else if (value instanceof Short s) {
-            return s;
+        } else if (value instanceof Byte) {
+            return (short) (byte) value;
+        } else if (value instanceof Short) {
+            return (Short) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1121,8 +1120,8 @@ public final class Def {
     public static Character defToCharacterImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return c;
+        } else if (value instanceof Character) {
+            return (Character) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1137,14 +1136,14 @@ public final class Def {
     public static Integer defToIntegerImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Byte b) {
-            return b.intValue();
-        } else if (value instanceof Short s) {
-            return s.intValue();
-        } else if (value instanceof Character c) {
-            return (int) (char) c;
-        } else if (value instanceof Integer i) {
-            return i;
+        } else if (value instanceof Byte) {
+            return (int) (byte) value;
+        } else if (value instanceof Short) {
+            return (int) (short) value;
+        } else if (value instanceof Character) {
+            return (int) (char) value;
+        } else if (value instanceof Integer) {
+            return (Integer) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1159,16 +1158,16 @@ public final class Def {
     public static Long defToLongImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Byte b) {
-            return b.longValue();
-        } else if (value instanceof Short s) {
-            return s.longValue();
-        } else if (value instanceof Character c) {
-            return (long) (char) c;
-        } else if (value instanceof Integer i) {
-            return i.longValue();
-        } else if (value instanceof Long l) {
-            return l;
+        } else if (value instanceof Byte) {
+            return (long) (byte) value;
+        } else if (value instanceof Short) {
+            return (long) (short) value;
+        } else if (value instanceof Character) {
+            return (long) (char) value;
+        } else if (value instanceof Integer) {
+            return (long) (int) value;
+        } else if (value instanceof Long) {
+            return (Long) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1183,18 +1182,18 @@ public final class Def {
     public static Float defToFloatImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Byte b) {
-            return b.floatValue();
-        } else if (value instanceof Short s) {
-            return s.floatValue();
-        } else if (value instanceof Character c) {
-            return (float) (char) c;
-        } else if (value instanceof Integer i) {
-            return i.floatValue();
-        } else if (value instanceof Long l) {
-            return l.floatValue();
-        } else if (value instanceof Float f) {
-            return f;
+        } else if (value instanceof Byte) {
+            return (float) (byte) value;
+        } else if (value instanceof Short) {
+            return (float) (short) value;
+        } else if (value instanceof Character) {
+            return (float) (char) value;
+        } else if (value instanceof Integer) {
+            return (float) (int) value;
+        } else if (value instanceof Long) {
+            return (float) (long) value;
+        } else if (value instanceof Float) {
+            return (Float) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1209,20 +1208,20 @@ public final class Def {
     public static Double defToDoubleImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Byte b) {
-            return b.doubleValue();
-        } else if (value instanceof Short s) {
-            return s.doubleValue();
-        } else if (value instanceof Character c) {
-            return (double) (char) c;
-        } else if (value instanceof Integer i) {
-            return i.doubleValue();
-        } else if (value instanceof Long l) {
-            return l.doubleValue();
-        } else if (value instanceof Float f) {
-            return f.doubleValue();
-        } else if (value instanceof Double d) {
-            return d;
+        } else if (value instanceof Byte) {
+            return (double) (byte) value;
+        } else if (value instanceof Short) {
+            return (double) (short) value;
+        } else if (value instanceof Character) {
+            return (double) (char) value;
+        } else if (value instanceof Integer) {
+            return (double) (int) value;
+        } else if (value instanceof Long) {
+            return (double) (long) value;
+        } else if (value instanceof Float) {
+            return (double) (float) value;
+        } else if (value instanceof Double) {
+            return (Double) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1237,8 +1236,8 @@ public final class Def {
     public static Byte defToByteExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return (byte) (char) c;
+        } else if (value instanceof Character) {
+            return (byte) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1260,8 +1259,8 @@ public final class Def {
     public static Short defToShortExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return (short) (char) c;
+        } else if (value instanceof Character) {
+            return (short) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1283,10 +1282,10 @@ public final class Def {
     public static Character defToCharacterExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof String s) {
-            return Utility.StringTochar(s);
-        } else if (value instanceof Character c) {
-            return c;
+        } else if (value instanceof String) {
+            return Utility.StringTochar((String) value);
+        } else if (value instanceof Character) {
+            return (Character) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1308,8 +1307,8 @@ public final class Def {
     public static Integer defToIntegerExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return (int) (char) c;
+        } else if (value instanceof Character) {
+            return (int) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1331,8 +1330,8 @@ public final class Def {
     public static Long defToLongExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return (long) (char) c;
+        } else if (value instanceof Character) {
+            return (long) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1354,8 +1353,8 @@ public final class Def {
     public static Float defToFloatExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return (float) (char) c;
+        } else if (value instanceof Character) {
+            return (float) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1377,8 +1376,8 @@ public final class Def {
     public static Double defToDoubleExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return (double) (char) c;
+        } else if (value instanceof Character) {
+            return (double) (char) value;
         } else if (value instanceof Byte
             || value instanceof Short
             || value instanceof Integer
@@ -1400,8 +1399,8 @@ public final class Def {
     public static String defToStringImplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof String s) {
-            return s;
+        } else if (value instanceof String) {
+            return (String) value;
         } else {
             throw new ClassCastException(
                 "cannot implicitly cast "
@@ -1416,10 +1415,10 @@ public final class Def {
     public static String defToStringExplicit(final Object value) {
         if (value == null) {
             return null;
-        } else if (value instanceof Character c) {
-            return Utility.charToString(c);
-        } else if (value instanceof String s) {
-            return s;
+        } else if (value instanceof Character) {
+            return Utility.charToString((char) value);
+        } else if (value instanceof String) {
+            return (String) value;
         } else {
             throw new ClassCastException(
                 "cannot explicitly cast "

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/Def.java
@@ -744,9 +744,7 @@ public final class Def {
                 throw new IllegalArgumentException("type must be an array");
             }
             MethodHandle iterator = ARRAY_TYPE_MH_MAPPING.get(arrayType);
-            return iterator != null
-                ? iterator
-                : OBJECT_ARRAY_MH.asType(OBJECT_ARRAY_MH.type().changeParameterType(0, arrayType));
+            return iterator != null ? iterator : OBJECT_ARRAY_MH.asType(OBJECT_ARRAY_MH.type().changeParameterType(0, arrayType));
         }
 
         private ArrayIteratorHelper() {}
@@ -1521,9 +1519,7 @@ public final class Def {
                 throw new IllegalArgumentException("type must be an array");
             }
             MethodHandle handle = ARRAY_TYPE_MH_MAPPING.get(arrayType);
-            return handle != null
-                ? handle
-                : OBJECT_ARRAY_MH.asType(OBJECT_ARRAY_MH.type().changeParameterType(0, arrayType));
+            return handle != null ? handle : OBJECT_ARRAY_MH.asType(OBJECT_ARRAY_MH.type().changeParameterType(0, arrayType));
         }
 
         private ArrayIndexNormalizeHelper() {}

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefBootstrap.java
@@ -388,7 +388,7 @@ public final class DefBootstrap {
                 } else {
                     // case 3: check both receiver and argument
                     MethodType testType = MethodType.methodType(boolean.class, type);
-                    MethodHandle binaryTest = CHECK_BOTH.bindTo(clazz0).bindTo(clazz1);
+                    MethodHandle binaryTest = MethodHandles.insertArguments(CHECK_BOTH, 0, clazz0, clazz1);
                     test = binaryTest.asType(testType);
                     nullCheck = BOTH_NON_NULL.asType(testType);
                 }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefBootstrap.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefBootstrap.java
@@ -382,8 +382,8 @@ public final class DefBootstrap {
                 } else if (type.parameterType(0) != Object.class) {
                     // case 2: only the argument is unknown, just check that
                     MethodType testType = MethodType.methodType(boolean.class, type);
-                    MethodHandle unaryTest = CHECK_RHS.bindTo(clazz0).bindTo(clazz1);
-                    test = unaryTest.asType(testType);
+                    MethodHandle unaryTest = CHECK_RHS.bindTo(clazz1);
+                    test = MethodHandles.dropArguments(unaryTest, 0, Object.class).asType(testType);
                     nullCheck = MethodHandles.dropArguments(NON_NULL, 0, clazz0).asType(testType);
                 } else {
                     // case 3: check both receiver and argument
@@ -423,7 +423,7 @@ public final class DefBootstrap {
          * guard method for inline caching: checks the first argument is the same
          * as the cached first argument.
          */
-        static boolean checkRHS(Class<?> left, Class<?> right, Object leftObject, Object rightObject) {
+        static boolean checkRHS(Class<?> right, Object rightObject) {
             return rightObject.getClass() == right;
         }
 
@@ -460,7 +460,7 @@ public final class DefBootstrap {
                 CHECK_RHS = methodHandlesLookup.findStatic(
                     methodHandlesLookup.lookupClass(),
                     "checkRHS",
-                    MethodType.methodType(boolean.class, Class.class, Class.class, Object.class, Object.class)
+                    MethodType.methodType(boolean.class, Class.class, Object.class)
                 );
                 CHECK_BOTH = methodHandlesLookup.findStatic(
                     methodHandlesLookup.lookupClass(),

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
@@ -52,16 +52,16 @@ public class DefMath {
     }
 
     private static Object not(Object unary) {
-        if (unary instanceof Long l) {
-            return ~l;
-        } else if (unary instanceof Integer i) {
-            return ~i;
-        } else if (unary instanceof Short s) {
-            return ~s;
-        } else if (unary instanceof Character c) {
-            return ~c;
-        } else if (unary instanceof Byte b) {
-            return ~b;
+        if (unary instanceof Long) {
+            return ~(Long) unary;
+        } else if (unary instanceof Integer) {
+            return ~(Integer) unary;
+        } else if (unary instanceof Short) {
+            return ~(Short) unary;
+        } else if (unary instanceof Character) {
+            return ~(Character) unary;
+        } else if (unary instanceof Byte) {
+            return ~(Byte) unary;
         }
 
         throw new ClassCastException("Cannot apply [~] operation to type " + "[" + unary.getClass().getCanonicalName() + "].");
@@ -89,21 +89,21 @@ public class DefMath {
         throw new ClassCastException("Cannot apply [-] operation to type [boolean]");
     }
 
-    private static Object neg(Object unary) {
-        if (unary instanceof Double d) {
-            return -d;
-        } else if (unary instanceof Long l) {
-            return -l;
-        } else if (unary instanceof Integer i) {
-            return -i;
-        } else if (unary instanceof Float f) {
-            return -f;
-        } else if (unary instanceof Short s) {
-            return -s;
-        } else if (unary instanceof Character c) {
-            return -c;
-        } else if (unary instanceof Byte b) {
-            return -b;
+    private static Object neg(final Object unary) {
+        if (unary instanceof Double) {
+            return -(double) unary;
+        } else if (unary instanceof Long) {
+            return -(long) unary;
+        } else if (unary instanceof Integer) {
+            return -(int) unary;
+        } else if (unary instanceof Float) {
+            return -(float) unary;
+        } else if (unary instanceof Short) {
+            return -(short) unary;
+        } else if (unary instanceof Character) {
+            return -(char) unary;
+        } else if (unary instanceof Byte) {
+            return -(byte) unary;
         }
 
         throw new ClassCastException("Cannot apply [-] operation to type " + "[" + unary.getClass().getCanonicalName() + "].");
@@ -129,21 +129,21 @@ public class DefMath {
         throw new ClassCastException("Cannot apply [+] operation to type [boolean]");
     }
 
-    private static Object plus(Object unary) {
-        if (unary instanceof Double d) {
-            return +d;
-        } else if (unary instanceof Long l) {
-            return +l;
-        } else if (unary instanceof Integer i) {
-            return +i;
-        } else if (unary instanceof Float f) {
-            return +f;
-        } else if (unary instanceof Short s) {
-            return +s;
-        } else if (unary instanceof Character c) {
-            return +c;
-        } else if (unary instanceof Byte b) {
-            return +b;
+    private static Object plus(final Object unary) {
+        if (unary instanceof Double) {
+            return +(double) unary;
+        } else if (unary instanceof Long) {
+            return +(long) unary;
+        } else if (unary instanceof Integer) {
+            return +(int) unary;
+        } else if (unary instanceof Float) {
+            return +(float) unary;
+        } else if (unary instanceof Short) {
+            return +(short) unary;
+        } else if (unary instanceof Character) {
+            return +(char) unary;
+        } else if (unary instanceof Byte) {
+            return +(byte) unary;
         }
 
         throw new ClassCastException("Cannot apply [+] operation to type " + "[" + unary.getClass().getCanonicalName() + "].");
@@ -172,41 +172,41 @@ public class DefMath {
     }
 
     private static Object mul(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() * r.doubleValue();
+                    return ((Number) left).doubleValue() * ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() * r.floatValue();
+                    return ((Number) left).floatValue() * ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() * r.longValue();
+                    return ((Number) left).longValue() * ((Number) right).longValue();
                 } else {
-                    return l.intValue() * r.intValue();
+                    return ((Number) left).intValue() * ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() * cr;
+                    return ((Number) left).doubleValue() * (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() * cr;
+                    return ((Number) left).longValue() * (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() * cr;
+                    return ((Number) left).floatValue() * (char) right;
                 } else {
-                    return l.intValue() * cr;
+                    return ((Number) left).intValue() * (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl * r.doubleValue();
+                    return (char) left * ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl * r.longValue();
+                    return (char) left * ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl * r.floatValue();
+                    return (char) left * ((Number) right).floatValue();
                 } else {
-                    return cl * r.intValue();
+                    return (char) left * ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl * cr;
+            } else if (right instanceof Character) {
+                return (char) left * (char) right;
             }
         }
 
@@ -241,41 +241,41 @@ public class DefMath {
     }
 
     private static Object div(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() / r.doubleValue();
+                    return ((Number) left).doubleValue() / ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() / r.floatValue();
+                    return ((Number) left).floatValue() / ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() / r.longValue();
+                    return ((Number) left).longValue() / ((Number) right).longValue();
                 } else {
-                    return l.intValue() / r.intValue();
+                    return ((Number) left).intValue() / ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() / cr;
+                    return ((Number) left).doubleValue() / (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() / cr;
+                    return ((Number) left).longValue() / (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() / cr;
+                    return ((Number) left).floatValue() / (char) right;
                 } else {
-                    return l.intValue() / cr;
+                    return ((Number) left).intValue() / (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl / r.doubleValue();
+                    return (char) left / ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl / r.longValue();
+                    return (char) left / ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl / r.floatValue();
+                    return (char) left / ((Number) right).floatValue();
                 } else {
-                    return cl / r.intValue();
+                    return (char) left / ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl / cr;
+            } else if (right instanceof Character) {
+                return (char) left / (char) right;
             }
         }
 
@@ -310,41 +310,41 @@ public class DefMath {
     }
 
     private static Object rem(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() % r.doubleValue();
+                    return ((Number) left).doubleValue() % ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() % r.floatValue();
+                    return ((Number) left).floatValue() % ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() % r.longValue();
+                    return ((Number) left).longValue() % ((Number) right).longValue();
                 } else {
-                    return l.intValue() % r.intValue();
+                    return ((Number) left).intValue() % ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() % cr;
+                    return ((Number) left).doubleValue() % (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() % cr;
+                    return ((Number) left).longValue() % (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() % cr;
+                    return ((Number) left).floatValue() % (char) right;
                 } else {
-                    return l.intValue() % cr;
+                    return ((Number) left).intValue() % (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl % r.doubleValue();
+                    return (char) left % ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl % r.longValue();
+                    return (char) left % ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl % r.floatValue();
+                    return (char) left % ((Number) right).floatValue();
                 } else {
-                    return cl % r.intValue();
+                    return (char) left % ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl % cr;
+            } else if (right instanceof Character) {
+                return (char) left % (char) right;
             }
         }
 
@@ -382,45 +382,45 @@ public class DefMath {
     }
 
     private static Object add(Object left, Object right) {
-        if (left instanceof String sl) {
-            return sl + right;
-        } else if (right instanceof String sr) {
-            return left + sr;
-        } else if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof String) {
+            return (String) left + right;
+        } else if (right instanceof String) {
+            return left + (String) right;
+        } else if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() + r.doubleValue();
+                    return ((Number) left).doubleValue() + ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() + r.floatValue();
+                    return ((Number) left).floatValue() + ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() + r.longValue();
+                    return ((Number) left).longValue() + ((Number) right).longValue();
                 } else {
-                    return l.intValue() + r.intValue();
+                    return ((Number) left).intValue() + ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() + cr;
+                    return ((Number) left).doubleValue() + (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() + cr;
+                    return ((Number) left).longValue() + (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() + cr;
+                    return ((Number) left).floatValue() + (char) right;
                 } else {
-                    return l.intValue() + cr;
+                    return ((Number) left).intValue() + (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl + r.doubleValue();
+                    return (char) left + ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl + r.longValue();
+                    return (char) left + ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl + r.floatValue();
+                    return (char) left + ((Number) right).floatValue();
                 } else {
-                    return cl + r.intValue();
+                    return (char) left + ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl + cr;
+            } else if (right instanceof Character) {
+                return (char) left + (char) right;
             }
         }
 
@@ -455,41 +455,41 @@ public class DefMath {
     }
 
     private static Object sub(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() - r.doubleValue();
+                    return ((Number) left).doubleValue() - ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() - r.floatValue();
+                    return ((Number) left).floatValue() - ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() - r.longValue();
+                    return ((Number) left).longValue() - ((Number) right).longValue();
                 } else {
-                    return l.intValue() - r.intValue();
+                    return ((Number) left).intValue() - ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() - cr;
+                    return ((Number) left).doubleValue() - (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() - cr;
+                    return ((Number) left).longValue() - (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() - cr;
+                    return ((Number) left).floatValue() - (char) right;
                 } else {
-                    return l.intValue() - cr;
+                    return ((Number) left).intValue() - (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl - r.doubleValue();
+                    return (char) left - ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl - r.longValue();
+                    return (char) left - ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl - r.floatValue();
+                    return (char) left - ((Number) right).floatValue();
                 } else {
-                    return cl - r.intValue();
+                    return (char) left - ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl - cr;
+            } else if (right instanceof Character) {
+                return (char) left - (char) right;
             }
         }
 
@@ -528,61 +528,62 @@ public class DefMath {
     private static boolean eq(Object left, Object right) {
         if (left == right) {
             return true;
-        } else if (left != null && right != null) {
+        }
+        else if (left != null && right != null) {
             if (left.getClass() == right.getClass()) {
                 return left.equals(right);
-            } else if (left instanceof Double dl) {
-                if (right instanceof Number r) {
-                    return dl == r.doubleValue();
-                } else if (right instanceof Character cr) {
-                    return (double) dl == cr;
+            } else if (left instanceof Double) {
+                if (right instanceof Number) {
+                    return (double) left == ((Number) right).doubleValue();
+                } else if (right instanceof Character) {
+                    return (double) left == (char) right;
                 }
-            } else if (right instanceof Double dr) {
-                if (left instanceof Number l) {
-                    return l.doubleValue() == dr;
-                } else if (left instanceof Character cl) {
-                    return cl == (double) dr;
+            } else if (right instanceof Double) {
+                if (left instanceof Number) {
+                    return ((Number) left).doubleValue() == (double) right;
+                } else if (left instanceof Character) {
+                    return (char) left == ((Number) right).doubleValue();
                 }
-            } else if (left instanceof Float fl) {
-                if (right instanceof Number r) {
-                    return fl == r.floatValue();
-                } else if (right instanceof Character cr) {
-                    return (float) fl == cr;
+            } else if (left instanceof Float) {
+                if (right instanceof Number) {
+                    return (float) left == ((Number) right).floatValue();
+                } else if (right instanceof Character) {
+                    return (float) left == (char) right;
                 }
-            } else if (right instanceof Float fr) {
-                if (left instanceof Number l) {
-                    return l.floatValue() == fr;
-                } else if (left instanceof Character cl) {
-                    return cl == (float) fr;
+            } else if (right instanceof Float) {
+                if (left instanceof Number) {
+                    return ((Number) left).floatValue() == (float) right;
+                } else if (left instanceof Character) {
+                    return (char) left == ((Number) right).floatValue();
                 }
-            } else if (left instanceof Long ll) {
-                if (right instanceof Number r) {
-                    return ll == r.longValue();
-                } else if (right instanceof Character cr) {
-                    return (long) ll == cr;
+            } else if (left instanceof Long) {
+                if (right instanceof Number) {
+                    return (long) left == ((Number) right).longValue();
+                } else if (right instanceof Character) {
+                    return (long) left == (char) right;
                 }
-            } else if (right instanceof Long lr) {
-                if (left instanceof Number l) {
-                    return l.longValue() == lr;
-                } else if (left instanceof Character cl) {
-                    return cl == (long) lr;
+            } else if (right instanceof Long) {
+                if (left instanceof Number) {
+                    return ((Number) left).longValue() == (long) right;
+                } else if (left instanceof Character) {
+                    return (char) left == ((Number) right).longValue();
                 }
-            } else if (left instanceof Number l) {
-                if (right instanceof Number r) {
-                    return l.intValue() == r.intValue();
-                } else if (right instanceof Character cr) {
-                    return l.intValue() == cr;
+            } else if (left instanceof Number) {
+                if (right instanceof Number) {
+                    return ((Number) left).intValue() == ((Number) right).intValue();
+                } else if (right instanceof Character) {
+                    return ((Number) left).intValue() == (char) right;
                 }
-            } else if (right instanceof Number r && left instanceof Character cl) {
-                return cl == r.intValue();
-            } else if (left instanceof Character cl && right instanceof Character cr) {
-                return (char) cl == cr;
+            } else if (right instanceof Number && left instanceof Character) {
+                return (char) left == ((Number) right).intValue();
+            } else if (left instanceof Character && right instanceof Character) {
+                return (char) left == (char) right;
             }
 
             return left.equals(right);
         }
 
-        return false;
+        return left == null && right == null;
     }
 
     // comparison operators: applicable for any numeric type
@@ -608,41 +609,41 @@ public class DefMath {
     }
 
     private static boolean lt(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() < r.doubleValue();
+                    return ((Number) left).doubleValue() < ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() < r.floatValue();
+                    return ((Number) left).floatValue() < ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() < r.longValue();
+                    return ((Number) left).longValue() < ((Number) right).longValue();
                 } else {
-                    return l.intValue() < r.intValue();
+                    return ((Number) left).intValue() < ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() < cr;
+                    return ((Number) left).doubleValue() < (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() < cr;
+                    return ((Number) left).longValue() < (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() < cr;
+                    return ((Number) left).floatValue() < (char) right;
                 } else {
-                    return l.intValue() < cr;
+                    return ((Number) left).intValue() < (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl < r.doubleValue();
+                    return (char) left < ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl < r.longValue();
+                    return (char) left < ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl < r.floatValue();
+                    return (char) left < ((Number) right).floatValue();
                 } else {
-                    return cl < r.intValue();
+                    return (char) left < ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl < cr;
+            } else if (right instanceof Character) {
+                return (char) left < (char) right;
             }
         }
 
@@ -677,41 +678,41 @@ public class DefMath {
     }
 
     private static boolean lte(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() <= r.doubleValue();
+                    return ((Number) left).doubleValue() <= ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() <= r.floatValue();
+                    return ((Number) left).floatValue() <= ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() <= r.longValue();
+                    return ((Number) left).longValue() <= ((Number) right).longValue();
                 } else {
-                    return l.intValue() <= r.intValue();
+                    return ((Number) left).intValue() <= ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() <= cr;
+                    return ((Number) left).doubleValue() <= (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() <= cr;
+                    return ((Number) left).longValue() <= (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() <= cr;
+                    return ((Number) left).floatValue() <= (char) right;
                 } else {
-                    return l.intValue() <= cr;
+                    return ((Number) left).intValue() <= (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl <= r.doubleValue();
+                    return (char) left <= ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl <= r.longValue();
+                    return (char) left <= ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl <= r.floatValue();
+                    return (char) left <= ((Number) right).floatValue();
                 } else {
-                    return cl <= r.intValue();
+                    return (char) left <= ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl <= cr;
+            } else if (right instanceof Character) {
+                return (char) left <= (char) right;
             }
         }
 
@@ -746,41 +747,41 @@ public class DefMath {
     }
 
     private static boolean gt(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() > r.doubleValue();
+                    return ((Number) left).doubleValue() > ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() > r.floatValue();
+                    return ((Number) left).floatValue() > ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() > r.longValue();
+                    return ((Number) left).longValue() > ((Number) right).longValue();
                 } else {
-                    return l.intValue() > r.intValue();
+                    return ((Number) left).intValue() > ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() > cr;
+                    return ((Number) left).doubleValue() > (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() > cr;
+                    return ((Number) left).longValue() > (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() > cr;
+                    return ((Number) left).floatValue() > (char) right;
                 } else {
-                    return l.intValue() > cr;
+                    return ((Number) left).intValue() > (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl > r.doubleValue();
+                    return (char) left > ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl > r.longValue();
+                    return (char) left > ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl > r.floatValue();
+                    return (char) left > ((Number) right).floatValue();
                 } else {
-                    return cl > r.intValue();
+                    return (char) left > ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl > cr;
+            } else if (right instanceof Character) {
+                return (char) left > (char) right;
             }
         }
 
@@ -815,41 +816,41 @@ public class DefMath {
     }
 
     private static boolean gte(Object left, Object right) {
-        if (left instanceof Number l) {
-            if (right instanceof Number r) {
+        if (left instanceof Number) {
+            if (right instanceof Number) {
                 if (left instanceof Double || right instanceof Double) {
-                    return l.doubleValue() >= r.doubleValue();
+                    return ((Number) left).doubleValue() >= ((Number) right).doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return l.floatValue() >= r.floatValue();
+                    return ((Number) left).floatValue() >= ((Number) right).floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return l.longValue() >= r.longValue();
+                    return ((Number) left).longValue() >= ((Number) right).longValue();
                 } else {
-                    return l.intValue() >= r.intValue();
+                    return ((Number) left).intValue() >= ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
+            } else if (right instanceof Character) {
                 if (left instanceof Double) {
-                    return l.doubleValue() >= cr;
+                    return ((Number) left).doubleValue() >= (char) right;
                 } else if (left instanceof Long) {
-                    return l.longValue() >= cr;
+                    return ((Number) left).longValue() >= (char) right;
                 } else if (left instanceof Float) {
-                    return l.floatValue() >= cr;
+                    return ((Number) left).floatValue() >= (char) right;
                 } else {
-                    return l.intValue() >= cr;
+                    return ((Number) left).intValue() >= (char) right;
                 }
             }
-        } else if (left instanceof Character cl) {
-            if (right instanceof Number r) {
+        } else if (left instanceof Character) {
+            if (right instanceof Number) {
                 if (right instanceof Double) {
-                    return cl >= r.doubleValue();
+                    return (char) left >= ((Number) right).doubleValue();
                 } else if (right instanceof Long) {
-                    return cl >= r.longValue();
+                    return (char) left >= ((Number) right).longValue();
                 } else if (right instanceof Float) {
-                    return cl >= r.floatValue();
+                    return (char) left >= ((Number) right).floatValue();
                 } else {
-                    return cl >= r.intValue();
+                    return (char) left >= ((Number) right).intValue();
                 }
-            } else if (right instanceof Character cr) {
-                return cl >= cr;
+            } else if (right instanceof Character) {
+                return (char) left >= (char) right;
             }
         }
 
@@ -867,12 +868,12 @@ public class DefMath {
     // this is used by the generic code for bitwise and shift operators
 
     private static long longIntegralValue(Object o) {
-        if (o instanceof Long l) {
-            return l;
+        if (o instanceof Long) {
+            return (long) o;
         } else if (o instanceof Integer || o instanceof Short || o instanceof Byte) {
             return ((Number) o).longValue();
-        } else if (o instanceof Character c) {
-            return c;
+        } else if (o instanceof Character) {
+            return (char) o;
         } else {
             throw new ClassCastException("Cannot convert [" + o.getClass().getCanonicalName() + "] to an integral value.");
         }
@@ -881,8 +882,8 @@ public class DefMath {
     private static int intIntegralValue(Object o) {
         if (o instanceof Integer || o instanceof Short || o instanceof Byte) {
             return ((Number) o).intValue();
-        } else if (o instanceof Character c) {
-            return c;
+        } else if (o instanceof Character) {
+            return (char) o;
         } else {
             throw new ClassCastException("Cannot convert [" + o.getClass().getCanonicalName() + "] to an integral value.");
         }
@@ -911,8 +912,8 @@ public class DefMath {
     }
 
     private static Object and(Object left, Object right) {
-        if (left instanceof Boolean bl && right instanceof Boolean br) {
-            return bl & br;
+        if (left instanceof Boolean && right instanceof Boolean) {
+            return (boolean) left & (boolean) right;
         } else if (left instanceof Long || right instanceof Long) {
             return longIntegralValue(left) & longIntegralValue(right);
         } else {
@@ -941,8 +942,8 @@ public class DefMath {
     }
 
     private static Object xor(Object left, Object right) {
-        if (left instanceof Boolean bl && right instanceof Boolean br) {
-            return bl ^ br;
+        if (left instanceof Boolean && right instanceof Boolean) {
+            return (boolean) left ^ (boolean) right;
         } else if (left instanceof Long || right instanceof Long) {
             return longIntegralValue(left) ^ longIntegralValue(right);
         } else {
@@ -971,8 +972,8 @@ public class DefMath {
     }
 
     private static Object or(Object left, Object right) {
-        if (left instanceof Boolean bl && right instanceof Boolean br) {
-            return bl | br;
+        if (left instanceof Boolean && right instanceof Boolean) {
+            return (boolean) left | (boolean) right;
         } else if (left instanceof Long || right instanceof Long) {
             return longIntegralValue(left) | longIntegralValue(right);
         } else {
@@ -1004,8 +1005,8 @@ public class DefMath {
     }
 
     public static Object lsh(Object left, long right) {
-        if (left instanceof Long l) {
-            return l << right;
+        if (left instanceof Long) {
+            return (long) (left) << right;
         } else {
             return intIntegralValue(left) << right;
         }
@@ -1032,8 +1033,8 @@ public class DefMath {
     }
 
     public static Object rsh(Object left, long right) {
-        if (left instanceof Long l) {
-            return l >> right;
+        if (left instanceof Long) {
+            return (long) left >> right;
         } else {
             return intIntegralValue(left) >> right;
         }
@@ -1060,8 +1061,8 @@ public class DefMath {
     }
 
     public static Object ush(Object left, long right) {
-        if (left instanceof Long l) {
-            return l >>> right;
+        if (left instanceof Long) {
+            return (long) (left) >>> right;
         } else {
             return intIntegralValue(left) >>> right;
         }
@@ -1219,10 +1220,10 @@ public class DefMath {
 
     /** Slowly returns a Number for o. Just for supporting dynamicCast */
     static Number getNumber(Object o) {
-        if (o instanceof Number n) {
-            return n;
-        } else if (o instanceof Character c) {
-            return (int) c;
+        if (o instanceof Number) {
+            return (Number) o;
+        } else if (o instanceof Character) {
+            return Integer.valueOf((char) o);
         } else {
             throw new ClassCastException("Cannot convert [" + o.getClass() + "] to a Number");
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
@@ -52,16 +52,16 @@ public class DefMath {
     }
 
     private static Object not(Object unary) {
-        if (unary instanceof Long) {
-            return ~(Long) unary;
-        } else if (unary instanceof Integer) {
-            return ~(Integer) unary;
-        } else if (unary instanceof Short) {
-            return ~(Short) unary;
-        } else if (unary instanceof Character) {
-            return ~(Character) unary;
-        } else if (unary instanceof Byte) {
-            return ~(Byte) unary;
+        if (unary instanceof Long l) {
+            return ~l;
+        } else if (unary instanceof Integer i) {
+            return ~i;
+        } else if (unary instanceof Short s) {
+            return ~s;
+        } else if (unary instanceof Character c) {
+            return ~c;
+        } else if (unary instanceof Byte b) {
+            return ~b;
         }
 
         throw new ClassCastException("Cannot apply [~] operation to type " + "[" + unary.getClass().getCanonicalName() + "].");
@@ -89,21 +89,21 @@ public class DefMath {
         throw new ClassCastException("Cannot apply [-] operation to type [boolean]");
     }
 
-    private static Object neg(final Object unary) {
-        if (unary instanceof Double) {
-            return -(double) unary;
-        } else if (unary instanceof Long) {
-            return -(long) unary;
-        } else if (unary instanceof Integer) {
-            return -(int) unary;
-        } else if (unary instanceof Float) {
-            return -(float) unary;
-        } else if (unary instanceof Short) {
-            return -(short) unary;
-        } else if (unary instanceof Character) {
-            return -(char) unary;
-        } else if (unary instanceof Byte) {
-            return -(byte) unary;
+    private static Object neg(Object unary) {
+        if (unary instanceof Double d) {
+            return -d;
+        } else if (unary instanceof Long l) {
+            return -l;
+        } else if (unary instanceof Integer i) {
+            return -i;
+        } else if (unary instanceof Float f) {
+            return -f;
+        } else if (unary instanceof Short s) {
+            return -s;
+        } else if (unary instanceof Character c) {
+            return -c;
+        } else if (unary instanceof Byte b) {
+            return -b;
         }
 
         throw new ClassCastException("Cannot apply [-] operation to type " + "[" + unary.getClass().getCanonicalName() + "].");
@@ -129,21 +129,21 @@ public class DefMath {
         throw new ClassCastException("Cannot apply [+] operation to type [boolean]");
     }
 
-    private static Object plus(final Object unary) {
-        if (unary instanceof Double) {
-            return +(double) unary;
-        } else if (unary instanceof Long) {
-            return +(long) unary;
-        } else if (unary instanceof Integer) {
-            return +(int) unary;
-        } else if (unary instanceof Float) {
-            return +(float) unary;
-        } else if (unary instanceof Short) {
-            return +(short) unary;
-        } else if (unary instanceof Character) {
-            return +(char) unary;
-        } else if (unary instanceof Byte) {
-            return +(byte) unary;
+    private static Object plus(Object unary) {
+        if (unary instanceof Double d) {
+            return +d;
+        } else if (unary instanceof Long l) {
+            return +l;
+        } else if (unary instanceof Integer i) {
+            return +i;
+        } else if (unary instanceof Float f) {
+            return +f;
+        } else if (unary instanceof Short s) {
+            return +s;
+        } else if (unary instanceof Character c) {
+            return +c;
+        } else if (unary instanceof Byte b) {
+            return +b;
         }
 
         throw new ClassCastException("Cannot apply [+] operation to type " + "[" + unary.getClass().getCanonicalName() + "].");
@@ -172,41 +172,41 @@ public class DefMath {
     }
 
     private static Object mul(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() * ((Number) right).doubleValue();
+                    return l.doubleValue() * r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() * ((Number) right).floatValue();
+                    return l.floatValue() * r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() * ((Number) right).longValue();
+                    return l.longValue() * r.longValue();
                 } else {
-                    return ((Number) left).intValue() * ((Number) right).intValue();
+                    return l.intValue() * r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() * (char) right;
+                    return l.doubleValue() * cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() * (char) right;
+                    return l.longValue() * cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() * (char) right;
+                    return l.floatValue() * cr;
                 } else {
-                    return ((Number) left).intValue() * (char) right;
+                    return l.intValue() * cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left * ((Number) right).doubleValue();
+                    return cl * r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left * ((Number) right).longValue();
+                    return cl * r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left * ((Number) right).floatValue();
+                    return cl * r.floatValue();
                 } else {
-                    return (char) left * ((Number) right).intValue();
+                    return cl * r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left * (char) right;
+            } else if (right instanceof Character cr) {
+                return cl * cr;
             }
         }
 
@@ -241,41 +241,41 @@ public class DefMath {
     }
 
     private static Object div(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() / ((Number) right).doubleValue();
+                    return l.doubleValue() / r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() / ((Number) right).floatValue();
+                    return l.floatValue() / r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() / ((Number) right).longValue();
+                    return l.longValue() / r.longValue();
                 } else {
-                    return ((Number) left).intValue() / ((Number) right).intValue();
+                    return l.intValue() / r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() / (char) right;
+                    return l.doubleValue() / cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() / (char) right;
+                    return l.longValue() / cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() / (char) right;
+                    return l.floatValue() / cr;
                 } else {
-                    return ((Number) left).intValue() / (char) right;
+                    return l.intValue() / cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left / ((Number) right).doubleValue();
+                    return cl / r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left / ((Number) right).longValue();
+                    return cl / r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left / ((Number) right).floatValue();
+                    return cl / r.floatValue();
                 } else {
-                    return (char) left / ((Number) right).intValue();
+                    return cl / r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left / (char) right;
+            } else if (right instanceof Character cr) {
+                return cl / cr;
             }
         }
 
@@ -310,41 +310,41 @@ public class DefMath {
     }
 
     private static Object rem(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() % ((Number) right).doubleValue();
+                    return l.doubleValue() % r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() % ((Number) right).floatValue();
+                    return l.floatValue() % r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() % ((Number) right).longValue();
+                    return l.longValue() % r.longValue();
                 } else {
-                    return ((Number) left).intValue() % ((Number) right).intValue();
+                    return l.intValue() % r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() % (char) right;
+                    return l.doubleValue() % cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() % (char) right;
+                    return l.longValue() % cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() % (char) right;
+                    return l.floatValue() % cr;
                 } else {
-                    return ((Number) left).intValue() % (char) right;
+                    return l.intValue() % cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left % ((Number) right).doubleValue();
+                    return cl % r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left % ((Number) right).longValue();
+                    return cl % r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left % ((Number) right).floatValue();
+                    return cl % r.floatValue();
                 } else {
-                    return (char) left % ((Number) right).intValue();
+                    return cl % r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left % (char) right;
+            } else if (right instanceof Character cr) {
+                return cl % cr;
             }
         }
 
@@ -382,45 +382,45 @@ public class DefMath {
     }
 
     private static Object add(Object left, Object right) {
-        if (left instanceof String) {
-            return (String) left + right;
-        } else if (right instanceof String) {
-            return left + (String) right;
-        } else if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof String sl) {
+            return sl + right;
+        } else if (right instanceof String sr) {
+            return left + sr;
+        } else if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() + ((Number) right).doubleValue();
+                    return l.doubleValue() + r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() + ((Number) right).floatValue();
+                    return l.floatValue() + r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() + ((Number) right).longValue();
+                    return l.longValue() + r.longValue();
                 } else {
-                    return ((Number) left).intValue() + ((Number) right).intValue();
+                    return l.intValue() + r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() + (char) right;
+                    return l.doubleValue() + cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() + (char) right;
+                    return l.longValue() + cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() + (char) right;
+                    return l.floatValue() + cr;
                 } else {
-                    return ((Number) left).intValue() + (char) right;
+                    return l.intValue() + cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left + ((Number) right).doubleValue();
+                    return cl + r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left + ((Number) right).longValue();
+                    return cl + r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left + ((Number) right).floatValue();
+                    return cl + r.floatValue();
                 } else {
-                    return (char) left + ((Number) right).intValue();
+                    return cl + r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left + (char) right;
+            } else if (right instanceof Character cr) {
+                return cl + cr;
             }
         }
 
@@ -455,41 +455,41 @@ public class DefMath {
     }
 
     private static Object sub(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() - ((Number) right).doubleValue();
+                    return l.doubleValue() - r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() - ((Number) right).floatValue();
+                    return l.floatValue() - r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() - ((Number) right).longValue();
+                    return l.longValue() - r.longValue();
                 } else {
-                    return ((Number) left).intValue() - ((Number) right).intValue();
+                    return l.intValue() - r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() - (char) right;
+                    return l.doubleValue() - cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() - (char) right;
+                    return l.longValue() - cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() - (char) right;
+                    return l.floatValue() - cr;
                 } else {
-                    return ((Number) left).intValue() - (char) right;
+                    return l.intValue() - cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left - ((Number) right).doubleValue();
+                    return cl - r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left - ((Number) right).longValue();
+                    return cl - r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left - ((Number) right).floatValue();
+                    return cl - r.floatValue();
                 } else {
-                    return (char) left - ((Number) right).intValue();
+                    return cl - r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left - (char) right;
+            } else if (right instanceof Character cr) {
+                return cl - cr;
             }
         }
 
@@ -527,52 +527,52 @@ public class DefMath {
 
     private static boolean eq(Object left, Object right) {
         if (left != null && right != null) {
-            if (left instanceof Double) {
-                if (right instanceof Number) {
-                    return (double) left == ((Number) right).doubleValue();
-                } else if (right instanceof Character) {
-                    return (double) left == (char) right;
+            if (left instanceof Double dl) {
+                if (right instanceof Number r) {
+                    return dl == r.doubleValue();
+                } else if (right instanceof Character cr) {
+                    return (double)dl == cr;
                 }
-            } else if (right instanceof Double) {
-                if (left instanceof Number) {
-                    return ((Number) left).doubleValue() == (double) right;
-                } else if (left instanceof Character) {
-                    return (char) left == ((Number) right).doubleValue();
+            } else if (right instanceof Double dr) {
+                if (left instanceof Number l) {
+                    return l.doubleValue() == dr;
+                } else if (left instanceof Character cl) {
+                    return cl == (double)dr;
                 }
-            } else if (left instanceof Float) {
-                if (right instanceof Number) {
-                    return (float) left == ((Number) right).floatValue();
-                } else if (right instanceof Character) {
-                    return (float) left == (char) right;
+            } else if (left instanceof Float fl) {
+                if (right instanceof Number r) {
+                    return fl == r.floatValue();
+                } else if (right instanceof Character cr) {
+                    return (float)fl == cr;
                 }
-            } else if (right instanceof Float) {
-                if (left instanceof Number) {
-                    return ((Number) left).floatValue() == (float) right;
-                } else if (left instanceof Character) {
-                    return (char) left == ((Number) right).floatValue();
+            } else if (right instanceof Float fr) {
+                if (left instanceof Number l) {
+                    return l.floatValue() == fr;
+                } else if (left instanceof Character cl) {
+                    return cl == (float)fr;
                 }
-            } else if (left instanceof Long) {
-                if (right instanceof Number) {
-                    return (long) left == ((Number) right).longValue();
-                } else if (right instanceof Character) {
-                    return (long) left == (char) right;
+            } else if (left instanceof Long ll) {
+                if (right instanceof Number r) {
+                    return ll == r.longValue();
+                } else if (right instanceof Character cr) {
+                    return (long)ll == cr;
                 }
-            } else if (right instanceof Long) {
-                if (left instanceof Number) {
-                    return ((Number) left).longValue() == (long) right;
-                } else if (left instanceof Character) {
-                    return (char) left == ((Number) right).longValue();
+            } else if (right instanceof Long lr) {
+                if (left instanceof Number l) {
+                    return l.longValue() == lr;
+                } else if (left instanceof Character cl) {
+                    return cl == (long)lr;
                 }
-            } else if (left instanceof Number) {
-                if (right instanceof Number) {
-                    return ((Number) left).intValue() == ((Number) right).intValue();
-                } else if (right instanceof Character) {
-                    return ((Number) left).intValue() == (char) right;
+            } else if (left instanceof Number l) {
+                if (right instanceof Number r) {
+                    return l.intValue() == r.intValue();
+                } else if (right instanceof Character cr) {
+                    return l.intValue() == cr;
                 }
-            } else if (right instanceof Number && left instanceof Character) {
-                return (char) left == ((Number) right).intValue();
-            } else if (left instanceof Character && right instanceof Character) {
-                return (char) left == (char) right;
+            } else if (right instanceof Number r && left instanceof Character cl) {
+                return cl == r.intValue();
+            } else if (left instanceof Character cl && right instanceof Character cr) {
+                return (char) cl == cr;
             }
 
             return left.equals(right);
@@ -604,41 +604,41 @@ public class DefMath {
     }
 
     private static boolean lt(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() < ((Number) right).doubleValue();
+                    return l.doubleValue() < r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() < ((Number) right).floatValue();
+                    return l.floatValue() < r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() < ((Number) right).longValue();
+                    return l.longValue() < r.longValue();
                 } else {
-                    return ((Number) left).intValue() < ((Number) right).intValue();
+                    return l.intValue() < r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() < (char) right;
+                    return l.doubleValue() < cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() < (char) right;
+                    return l.longValue() < cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() < (char) right;
+                    return l.floatValue() < cr;
                 } else {
-                    return ((Number) left).intValue() < (char) right;
+                    return l.intValue() < cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left < ((Number) right).doubleValue();
+                    return cl < r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left < ((Number) right).longValue();
+                    return cl < r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left < ((Number) right).floatValue();
+                    return cl < r.floatValue();
                 } else {
-                    return (char) left < ((Number) right).intValue();
+                    return cl < r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left < (char) right;
+            } else if (right instanceof Character cr) {
+                return cl < cr;
             }
         }
 
@@ -673,41 +673,41 @@ public class DefMath {
     }
 
     private static boolean lte(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() <= ((Number) right).doubleValue();
+                    return l.doubleValue() <= r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() <= ((Number) right).floatValue();
+                    return l.floatValue() <= r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() <= ((Number) right).longValue();
+                    return l.longValue() <= r.longValue();
                 } else {
-                    return ((Number) left).intValue() <= ((Number) right).intValue();
+                    return l.intValue() <= r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() <= (char) right;
+                    return l.doubleValue() <= cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() <= (char) right;
+                    return l.longValue() <= cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() <= (char) right;
+                    return l.floatValue() <= cr;
                 } else {
-                    return ((Number) left).intValue() <= (char) right;
+                    return l.intValue() <= cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left <= ((Number) right).doubleValue();
+                    return cl <= r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left <= ((Number) right).longValue();
+                    return cl <= r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left <= ((Number) right).floatValue();
+                    return cl <= r.floatValue();
                 } else {
-                    return (char) left <= ((Number) right).intValue();
+                    return cl <= r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left <= (char) right;
+            } else if (right instanceof Character cr) {
+                return cl <= cr;
             }
         }
 
@@ -742,41 +742,41 @@ public class DefMath {
     }
 
     private static boolean gt(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() > ((Number) right).doubleValue();
+                    return l.doubleValue() > r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() > ((Number) right).floatValue();
+                    return l.floatValue() > r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() > ((Number) right).longValue();
+                    return l.longValue() > r.longValue();
                 } else {
-                    return ((Number) left).intValue() > ((Number) right).intValue();
+                    return l.intValue() > r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() > (char) right;
+                    return l.doubleValue() > cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() > (char) right;
+                    return l.longValue() > cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() > (char) right;
+                    return l.floatValue() > cr;
                 } else {
-                    return ((Number) left).intValue() > (char) right;
+                    return l.intValue() > cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left > ((Number) right).doubleValue();
+                    return cl > r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left > ((Number) right).longValue();
+                    return cl > r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left > ((Number) right).floatValue();
+                    return cl > r.floatValue();
                 } else {
-                    return (char) left > ((Number) right).intValue();
+                    return cl > r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left > (char) right;
+            } else if (right instanceof Character cr) {
+                return cl > cr;
             }
         }
 
@@ -811,41 +811,41 @@ public class DefMath {
     }
 
     private static boolean gte(Object left, Object right) {
-        if (left instanceof Number) {
-            if (right instanceof Number) {
+        if (left instanceof Number l) {
+            if (right instanceof Number r) {
                 if (left instanceof Double || right instanceof Double) {
-                    return ((Number) left).doubleValue() >= ((Number) right).doubleValue();
+                    return l.doubleValue() >= r.doubleValue();
                 } else if (left instanceof Float || right instanceof Float) {
-                    return ((Number) left).floatValue() >= ((Number) right).floatValue();
+                    return l.floatValue() >= r.floatValue();
                 } else if (left instanceof Long || right instanceof Long) {
-                    return ((Number) left).longValue() >= ((Number) right).longValue();
+                    return l.longValue() >= r.longValue();
                 } else {
-                    return ((Number) left).intValue() >= ((Number) right).intValue();
+                    return l.intValue() >= r.intValue();
                 }
-            } else if (right instanceof Character) {
+            } else if (right instanceof Character cr) {
                 if (left instanceof Double) {
-                    return ((Number) left).doubleValue() >= (char) right;
+                    return l.doubleValue() >= cr;
                 } else if (left instanceof Long) {
-                    return ((Number) left).longValue() >= (char) right;
+                    return l.longValue() >= cr;
                 } else if (left instanceof Float) {
-                    return ((Number) left).floatValue() >= (char) right;
+                    return l.floatValue() >= cr;
                 } else {
-                    return ((Number) left).intValue() >= (char) right;
+                    return l.intValue() >= cr;
                 }
             }
-        } else if (left instanceof Character) {
-            if (right instanceof Number) {
+        } else if (left instanceof Character cl) {
+            if (right instanceof Number r) {
                 if (right instanceof Double) {
-                    return (char) left >= ((Number) right).doubleValue();
+                    return cl >= r.doubleValue();
                 } else if (right instanceof Long) {
-                    return (char) left >= ((Number) right).longValue();
+                    return cl >= r.longValue();
                 } else if (right instanceof Float) {
-                    return (char) left >= ((Number) right).floatValue();
+                    return cl >= r.floatValue();
                 } else {
-                    return (char) left >= ((Number) right).intValue();
+                    return cl >= r.intValue();
                 }
-            } else if (right instanceof Character) {
-                return (char) left >= (char) right;
+            } else if (right instanceof Character cr) {
+                return cl >= cr;
             }
         }
 
@@ -863,12 +863,12 @@ public class DefMath {
     // this is used by the generic code for bitwise and shift operators
 
     private static long longIntegralValue(Object o) {
-        if (o instanceof Long) {
-            return (long) o;
+        if (o instanceof Long l) {
+            return l;
         } else if (o instanceof Integer || o instanceof Short || o instanceof Byte) {
             return ((Number) o).longValue();
-        } else if (o instanceof Character) {
-            return (char) o;
+        } else if (o instanceof Character c) {
+            return c;
         } else {
             throw new ClassCastException("Cannot convert [" + o.getClass().getCanonicalName() + "] to an integral value.");
         }
@@ -877,8 +877,8 @@ public class DefMath {
     private static int intIntegralValue(Object o) {
         if (o instanceof Integer || o instanceof Short || o instanceof Byte) {
             return ((Number) o).intValue();
-        } else if (o instanceof Character) {
-            return (char) o;
+        } else if (o instanceof Character c) {
+            return c;
         } else {
             throw new ClassCastException("Cannot convert [" + o.getClass().getCanonicalName() + "] to an integral value.");
         }
@@ -907,8 +907,8 @@ public class DefMath {
     }
 
     private static Object and(Object left, Object right) {
-        if (left instanceof Boolean && right instanceof Boolean) {
-            return (boolean) left & (boolean) right;
+        if (left instanceof Boolean bl && right instanceof Boolean br) {
+            return bl & br;
         } else if (left instanceof Long || right instanceof Long) {
             return longIntegralValue(left) & longIntegralValue(right);
         } else {
@@ -937,8 +937,8 @@ public class DefMath {
     }
 
     private static Object xor(Object left, Object right) {
-        if (left instanceof Boolean && right instanceof Boolean) {
-            return (boolean) left ^ (boolean) right;
+        if (left instanceof Boolean bl && right instanceof Boolean br) {
+            return bl ^ br;
         } else if (left instanceof Long || right instanceof Long) {
             return longIntegralValue(left) ^ longIntegralValue(right);
         } else {
@@ -967,8 +967,8 @@ public class DefMath {
     }
 
     private static Object or(Object left, Object right) {
-        if (left instanceof Boolean && right instanceof Boolean) {
-            return (boolean) left | (boolean) right;
+        if (left instanceof Boolean bl && right instanceof Boolean br) {
+            return bl | br;
         } else if (left instanceof Long || right instanceof Long) {
             return longIntegralValue(left) | longIntegralValue(right);
         } else {
@@ -1000,8 +1000,8 @@ public class DefMath {
     }
 
     public static Object lsh(Object left, long right) {
-        if (left instanceof Long) {
-            return (long) (left) << right;
+        if (left instanceof Long l) {
+            return l << right;
         } else {
             return intIntegralValue(left) << right;
         }
@@ -1028,8 +1028,8 @@ public class DefMath {
     }
 
     public static Object rsh(Object left, long right) {
-        if (left instanceof Long) {
-            return (long) left >> right;
+        if (left instanceof Long l) {
+            return l >> right;
         } else {
             return intIntegralValue(left) >> right;
         }
@@ -1056,8 +1056,8 @@ public class DefMath {
     }
 
     public static Object ush(Object left, long right) {
-        if (left instanceof Long) {
-            return (long) (left) >>> right;
+        if (left instanceof Long l) {
+            return l >>> right;
         } else {
             return intIntegralValue(left) >>> right;
         }
@@ -1215,10 +1215,10 @@ public class DefMath {
 
     /** Slowly returns a Number for o. Just for supporting dynamicCast */
     static Number getNumber(Object o) {
-        if (o instanceof Number) {
-            return (Number) o;
-        } else if (o instanceof Character) {
-            return Integer.valueOf((char) o);
+        if (o instanceof Number n) {
+            return n;
+        } else if (o instanceof Character c) {
+            return (int) c;
         } else {
             throw new ClassCastException("Cannot convert [" + o.getClass() + "] to a Number");
         }

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
@@ -528,8 +528,7 @@ public class DefMath {
     private static boolean eq(Object left, Object right) {
         if (left == right) {
             return true;
-        }
-        else if (left != null && right != null) {
+        } else if (left != null && right != null) {
             if (left.getClass() == right.getClass()) {
                 return left.equals(right);
             } else if (left instanceof Double) {

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
@@ -526,42 +526,46 @@ public class DefMath {
     }
 
     private static boolean eq(Object left, Object right) {
-        if (left != null && right != null) {
-            if (left instanceof Double dl) {
+        if (left == right) {
+            return true;
+        } else if (left != null && right != null) {
+            if (left.getClass() == right.getClass()) {
+                return left.equals(right);
+            } else if (left instanceof Double dl) {
                 if (right instanceof Number r) {
                     return dl == r.doubleValue();
                 } else if (right instanceof Character cr) {
-                    return (double)dl == cr;
+                    return (double) dl == cr;
                 }
             } else if (right instanceof Double dr) {
                 if (left instanceof Number l) {
                     return l.doubleValue() == dr;
                 } else if (left instanceof Character cl) {
-                    return cl == (double)dr;
+                    return cl == (double) dr;
                 }
             } else if (left instanceof Float fl) {
                 if (right instanceof Number r) {
                     return fl == r.floatValue();
                 } else if (right instanceof Character cr) {
-                    return (float)fl == cr;
+                    return (float) fl == cr;
                 }
             } else if (right instanceof Float fr) {
                 if (left instanceof Number l) {
                     return l.floatValue() == fr;
                 } else if (left instanceof Character cl) {
-                    return cl == (float)fr;
+                    return cl == (float) fr;
                 }
             } else if (left instanceof Long ll) {
                 if (right instanceof Number r) {
                     return ll == r.longValue();
                 } else if (right instanceof Character cr) {
-                    return (long)ll == cr;
+                    return (long) ll == cr;
                 }
             } else if (right instanceof Long lr) {
                 if (left instanceof Number l) {
                     return l.longValue() == lr;
                 } else if (left instanceof Character cl) {
-                    return cl == (long)lr;
+                    return cl == (long) lr;
                 }
             } else if (left instanceof Number l) {
                 if (right instanceof Number r) {
@@ -578,7 +582,7 @@ public class DefMath {
             return left.equals(right);
         }
 
-        return left == null && right == null;
+        return false;
     }
 
     // comparison operators: applicable for any numeric type

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/DefMath.java
@@ -541,7 +541,7 @@ public class DefMath {
                 if (left instanceof Number) {
                     return ((Number) left).doubleValue() == (double) right;
                 } else if (left instanceof Character) {
-                    return (char) left == ((Number) right).doubleValue();
+                    return (char) left == (double) right;
                 }
             } else if (left instanceof Float) {
                 if (right instanceof Number) {
@@ -553,7 +553,7 @@ public class DefMath {
                 if (left instanceof Number) {
                     return ((Number) left).floatValue() == (float) right;
                 } else if (left instanceof Character) {
-                    return (char) left == ((Number) right).floatValue();
+                    return (char) left == (float) right;
                 }
             } else if (left instanceof Long) {
                 if (right instanceof Number) {
@@ -565,7 +565,7 @@ public class DefMath {
                 if (left instanceof Number) {
                     return ((Number) left).longValue() == (long) right;
                 } else if (left instanceof Character) {
-                    return (char) left == ((Number) right).longValue();
+                    return (char) left == (long) right;
                 }
             } else if (left instanceof Number) {
                 if (right instanceof Number) {
@@ -582,7 +582,7 @@ public class DefMath {
             return left.equals(right);
         }
 
-        return left == null && right == null;
+        return false;
     }
 
     // comparison operators: applicable for any numeric type

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/MethodWriter.java
@@ -61,21 +61,10 @@ import static org.elasticsearch.painless.WriterConstants.DEF_TO_P_SHORT_IMPLICIT
 import static org.elasticsearch.painless.WriterConstants.DEF_TO_STRING_EXPLICIT;
 import static org.elasticsearch.painless.WriterConstants.DEF_TO_STRING_IMPLICIT;
 import static org.elasticsearch.painless.WriterConstants.DEF_UTIL_TYPE;
-import static org.elasticsearch.painless.WriterConstants.INDY_STRING_CONCAT_BOOTSTRAP_HANDLE;
 import static org.elasticsearch.painless.WriterConstants.LAMBDA_BOOTSTRAP_HANDLE;
-import static org.elasticsearch.painless.WriterConstants.MAX_INDY_STRING_CONCAT_ARGS;
+import static org.elasticsearch.painless.WriterConstants.MAX_STRING_CONCAT_ARGS;
 import static org.elasticsearch.painless.WriterConstants.PAINLESS_ERROR_TYPE;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_BOOLEAN;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_CHAR;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_DOUBLE;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_FLOAT;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_INT;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_LONG;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_OBJECT;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_APPEND_STRING;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_CONSTRUCTOR;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_TOSTRING;
-import static org.elasticsearch.painless.WriterConstants.STRINGBUILDER_TYPE;
+import static org.elasticsearch.painless.WriterConstants.STRING_CONCAT_BOOTSTRAP_HANDLE;
 import static org.elasticsearch.painless.WriterConstants.STRING_TO_CHAR;
 import static org.elasticsearch.painless.WriterConstants.STRING_TYPE;
 import static org.elasticsearch.painless.WriterConstants.UTILITY_TYPE;
@@ -90,7 +79,7 @@ public final class MethodWriter extends GeneratorAdapter {
     private final BitSet statements;
     private final CompilerSettings settings;
 
-    private final Deque<List<Type>> stringConcatArgs = (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE == null) ? null : new ArrayDeque<>();
+    private final Deque<List<Type>> stringConcatArgs = new ArrayDeque<>();
 
     public MethodWriter(int access, Method method, ClassVisitor cw, BitSet statements, CompilerSettings settings) {
         super(
@@ -266,57 +255,28 @@ public final class MethodWriter extends GeneratorAdapter {
     /** Starts a new string concat.
      * @return the size of arguments pushed to stack (the object that does string concats, e.g. a StringBuilder)
      */
-    public int writeNewStrings() {
-        if (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE != null) {
-            // Java 9+: we just push our argument collector onto deque
-            stringConcatArgs.push(new ArrayList<>());
-            return 0; // nothing added to stack
-        } else {
-            // Java 8: create a StringBuilder in bytecode
-            newInstance(STRINGBUILDER_TYPE);
-            dup();
-            invokeConstructor(STRINGBUILDER_TYPE, STRINGBUILDER_CONSTRUCTOR);
-            return 1; // StringBuilder on stack
-        }
+    public List<Type> writeNewStrings() {
+        List<Type> list = new ArrayList<>();
+        stringConcatArgs.push(list);
+        return list;
     }
 
     public void writeAppendStrings(Class<?> clazz) {
-        if (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE != null) {
-            // Java 9+: record type information
-            stringConcatArgs.peek().add(getType(clazz));
-            // prevent too many concat args.
-            // If there are too many, do the actual concat:
-            if (stringConcatArgs.peek().size() >= MAX_INDY_STRING_CONCAT_ARGS) {
-                writeToStrings();
-                writeNewStrings();
-                // add the return value type as new first param for next concat:
-                stringConcatArgs.peek().add(STRING_TYPE);
-            }
-        } else {
-            // Java 8: push a StringBuilder append
-            if (clazz == boolean.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_BOOLEAN);
-            else if (clazz == char.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_CHAR);
-            else if (clazz == byte.class || clazz == short.class || clazz == int.class) invokeVirtual(
-                STRINGBUILDER_TYPE,
-                STRINGBUILDER_APPEND_INT
-            );
-            else if (clazz == long.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_LONG);
-            else if (clazz == float.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_FLOAT);
-            else if (clazz == double.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_DOUBLE);
-            else if (clazz == String.class) invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_STRING);
-            else invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_APPEND_OBJECT);
+        List<Type> currentConcat = stringConcatArgs.peek();
+        currentConcat.add(getType(clazz));
+        // prevent too many concat args.
+        // If there are too many, do the actual concat:
+        if (currentConcat.size() >= MAX_STRING_CONCAT_ARGS) {
+            writeToStrings();
+            currentConcat = writeNewStrings();
+            // add the return value type as new first param for next concat:
+            currentConcat.add(STRING_TYPE);
         }
     }
 
     public void writeToStrings() {
-        if (INDY_STRING_CONCAT_BOOTSTRAP_HANDLE != null) {
-            // Java 9+: use type information and push invokeDynamic
-            final String desc = Type.getMethodDescriptor(STRING_TYPE, stringConcatArgs.pop().stream().toArray(Type[]::new));
-            invokeDynamic("concat", desc, INDY_STRING_CONCAT_BOOTSTRAP_HANDLE);
-        } else {
-            // Java 8: call toString() on StringBuilder
-            invokeVirtual(STRINGBUILDER_TYPE, STRINGBUILDER_TOSTRING);
-        }
+        final String desc = Type.getMethodDescriptor(STRING_TYPE, stringConcatArgs.pop().toArray(Type[]::new));
+        invokeDynamic("concat", desc, STRING_CONCAT_BOOTSTRAP_HANDLE);
     }
 
     /** Writes a dynamic binary instruction: returnType, lhs, and rhs can be different */

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/phase/DefaultUserTreeToIRTreePhase.java
@@ -905,7 +905,7 @@ public class DefaultUserTreeToIRTreePhase implements UserTreeVisitor<ScriptScope
                 irCompoundNode = stringConcatenationNode;
 
                 // must handle the StringBuilder case for java version <= 8
-                if (irLoadNode instanceof BinaryImplNode bin && WriterConstants.INDY_STRING_CONCAT_BOOTSTRAP_HANDLE == null) {
+                if (irLoadNode instanceof BinaryImplNode bin && WriterConstants.STRING_CONCAT_BOOTSTRAP_HANDLE == null) {
                     bin.getLeftNode().attachDecoration(new IRDDepth(1));
                 }
                 // handles when the operation is mathematical

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/ArrayTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.painless;
 
-import org.apache.lucene.util.Constants;
 import org.hamcrest.Matcher;
 
 import java.lang.invoke.MethodHandle;
@@ -34,7 +33,6 @@ public class ArrayTests extends ArrayLikeObjectTestCase {
     }
 
     public void testArrayLengthHelper() throws Throwable {
-        assertEquals(Constants.JRE_IS_MINIMUM_JAVA9, Def.JAVA9_ARRAY_LENGTH_MH_FACTORY != null);
         assertArrayLength(2, new int[2]);
         assertArrayLength(3, new long[3]);
         assertArrayLength(4, new byte[4]);

--- a/modules/lang-painless/src/test/java/org/elasticsearch/painless/StringTests.java
+++ b/modules/lang-painless/src/test/java/org/elasticsearch/painless/StringTests.java
@@ -8,13 +8,11 @@
 
 package org.elasticsearch.painless;
 
-import org.apache.lucene.util.Constants;
-
 import java.util.HashMap;
 import java.util.Map;
 
 import static java.util.Collections.singletonMap;
-import static org.elasticsearch.painless.WriterConstants.MAX_INDY_STRING_CONCAT_ARGS;
+import static org.elasticsearch.painless.WriterConstants.MAX_STRING_CONCAT_ARGS;
 
 public class StringTests extends ScriptTestCase {
 
@@ -65,7 +63,7 @@ public class StringTests extends ScriptTestCase {
     }
 
     public void testAppendMany() {
-        for (int i = MAX_INDY_STRING_CONCAT_ARGS - 5; i < MAX_INDY_STRING_CONCAT_ARGS + 5; i++) {
+        for (int i = MAX_STRING_CONCAT_ARGS - 5; i < MAX_STRING_CONCAT_ARGS + 5; i++) {
             doTestAppendMany(i);
         }
     }
@@ -234,18 +232,14 @@ public class StringTests extends ScriptTestCase {
         assertEquals(rando, exec("params.rando.encodeBase64().decodeBase64()", singletonMap("rando", rando), true));
     }
 
-    public void testJava9ConstantStringConcatBytecode() {
-        assumeTrue("Needs Java 9 to test indified String concat", Constants.JRE_IS_MINIMUM_JAVA9);
-        assertNotNull(WriterConstants.INDY_STRING_CONCAT_BOOTSTRAP_HANDLE);
+    public void testConstantStringConcatBytecode() {
         assertBytecodeExists(
             "String s = \"cat\"; return s + true + 'abc' + null;",
             "INVOKEDYNAMIC concat(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"
         );
     }
 
-    public void testJava9StringConcatBytecode() {
-        assumeTrue("Needs Java 9 to test indified String concat", Constants.JRE_IS_MINIMUM_JAVA9);
-        assertNotNull(WriterConstants.INDY_STRING_CONCAT_BOOTSTRAP_HANDLE);
+    public void testStringConcatBytecode() {
         assertBytecodeExists(
             "String s = \"cat\"; boolean t = true; Object u = null; return s + t + 'abc' + u;",
             "INVOKEDYNAMIC concat(Ljava/lang/String;ZLjava/lang/String;Ljava/lang/Object;)Ljava/lang/String;"
@@ -259,11 +253,5 @@ public class StringTests extends ScriptTestCase {
         assertEquals("" + null + null, exec("null + '' + null"));
         assertEquals("" + 2 + null, exec("2 + '' + null"));
         assertEquals("" + null + 2, exec("null + '' + 2"));
-    }
-
-    public void testJava9NullStringConcatBytecode() {
-        assumeTrue("Needs Java 9 to test indified String concat", Constants.JRE_IS_MINIMUM_JAVA9);
-        assertNotNull(WriterConstants.INDY_STRING_CONCAT_BOOTSTRAP_HANDLE);
-        assertEquals("" + null + null, exec("'' + null + null"));
     }
 }


### PR DESCRIPTION
Add short-circuiting checks to `Def.eq` implementation.
Remove some obsoleted code for array handles and string concat.

This shows a 8% increase in throughput in the index-append-with-ingest-baseline-pipeline rally test