### PR TITLE
Revert "Chunked encoding for RestGetIndicesAction (#92016)"

### DIFF
--- a/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
+++ b/modules/transport-netty4/src/javaRestTest/java/org/elasticsearch/rest/Netty4HeadBodyIsEmptyIT.java
@@ -25,7 +25,6 @@ import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
 import static org.elasticsearch.rest.RestStatus.OK;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.nullValue;
 
 public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
     public void testHeadRoot() throws IOException {
@@ -60,8 +59,8 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
 
     public void testIndexExists() throws IOException {
         createTestDoc();
-        headTestCase("/test", emptyMap(), nullValue(Integer.class));
-        headTestCase("/test", singletonMap("pretty", "true"), nullValue(Integer.class));
+        headTestCase("/test", emptyMap(), greaterThan(0));
+        headTestCase("/test", singletonMap("pretty", "true"), greaterThan(0));
     }
 
     public void testAliasExists() throws IOException {
@@ -178,8 +177,7 @@ public class Netty4HeadBodyIsEmptyIT extends ESRestTestCase {
         request.setOptions(expectWarnings(expectedWarnings));
         Response response = client().performRequest(request);
         assertEquals(expectedStatusCode, response.getStatusLine().getStatusCode());
-        final var contentLength = response.getHeader("Content-Length");
-        assertThat(contentLength == null ? null : Integer.valueOf(contentLength), matcher);
+        assertThat(Integer.valueOf(response.getHeader("Content-Length")), matcher);
         assertNull("HEAD requests shouldn't have a response body but " + url + " did", response.getEntity());
     }
 

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -768,7 +768,7 @@ public class ActionModule extends AbstractModule {
         registerHandler.accept(new RestResetFeatureStateAction());
         registerHandler.accept(new RestGetFeatureUpgradeStatusAction());
         registerHandler.accept(new RestPostFeatureUpgradeAction());
-        registerHandler.accept(new RestGetIndicesAction());
+        registerHandler.accept(new RestGetIndicesAction(threadPool));
         registerHandler.accept(new RestIndicesStatsAction());
         registerHandler.accept(new RestIndicesSegmentsAction());
         registerHandler.accept(new RestIndicesShardStoresAction());

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexResponseTests.java
@@ -18,9 +18,7 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.RandomCreateIndexGenerator;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
-import org.elasticsearch.xcontent.ToXContent;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
@@ -28,9 +26,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
-
-import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
-import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public class GetIndexResponseTests extends AbstractWireSerializingTestCase<GetIndexResponse> {
 
@@ -77,19 +72,5 @@ public class GetIndexResponseTests extends AbstractWireSerializingTestCase<GetIn
             }
         }
         return new GetIndexResponse(indices, mappings, aliases, settings, defaultSettings, dataStreams);
-    }
-
-    public void testChunking() throws IOException {
-        final var response = createTestInstance();
-
-        try (var builder = jsonBuilder()) {
-            int chunkCount = 0;
-            final var iterator = response.toXContentChunked(EMPTY_PARAMS);
-            while (iterator.hasNext()) {
-                iterator.next().toXContent(builder, ToXContent.EMPTY_PARAMS);
-                chunkCount += 1;
-            }
-            assertEquals(response.getIndices().length + 2, chunkCount);
-        } // closing the builder verifies that the XContent is well-formed
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/admin/indices/RestGetIndicesActionTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.rest.action.admin.indices;
 
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.test.ESTestCase;
@@ -36,7 +37,7 @@ public class RestGetIndicesActionTests extends ESTestCase {
             Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
         ).withMethod(RestRequest.Method.GET).withPath("/some_index").withParams(params).build();
 
-        RestGetIndicesAction handler = new RestGetIndicesAction();
+        RestGetIndicesAction handler = new RestGetIndicesAction(new DeterministicTaskQueue().getThreadPool());
         handler.prepareRequest(request, mock(NodeClient.class));
         assertCriticalWarnings(RestGetIndicesAction.TYPES_DEPRECATION_MESSAGE);
 
@@ -57,7 +58,7 @@ public class RestGetIndicesActionTests extends ESTestCase {
             Map.of("Content-Type", contentTypeHeader, "Accept", contentTypeHeader)
         ).withMethod(RestRequest.Method.HEAD).withPath("/some_index").withParams(params).build();
 
-        RestGetIndicesAction handler = new RestGetIndicesAction();
+        RestGetIndicesAction handler = new RestGetIndicesAction(new DeterministicTaskQueue().getThreadPool());
         handler.prepareRequest(request, mock(NodeClient.class));
     }
 }


### PR DESCRIPTION
This reverts commit 75de8f85cf41374fcdc5da3a36f86f9098b81951 due to https://github.com/elastic/elasticsearch/issues/92032 and https://github.com/elastic/kibana/issues/146758