### PR TITLE
[CI] Mute MaxDocsLimitIT.testMaxDocsLimit

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -72,6 +72,7 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         restoreIndexWriterMaxDocs();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92037")
     public void testMaxDocsLimit() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(1);
         assertAcked(


### PR DESCRIPTION
See https://github.com/elastic/elasticsearch/issues/92037

