### PR TITLE
[8.6] [CI] Mute MaxDocsLimitIT.testMaxDocsLimit (#92038)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -72,6 +72,7 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         restoreIndexWriterMaxDocs();
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92037")
     public void testMaxDocsLimit() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(1);
         assertAcked(


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [CI] Mute MaxDocsLimitIT.testMaxDocsLimit (#92038)