### PR TITLE
Nested pipeline metrics are now supported

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorTests.java
@@ -478,10 +478,10 @@ public class ForEachProcessorTests extends ESTestCase {
     // executes either sync or async forEach processor
     private static void execProcessor(ForEachProcessor processor, IngestDocument doc, BiConsumer<IngestDocument, Exception> handler) {
         if (processor.isAsync()) {
-            processor.execute(doc, handler);
+            processor.execute(doc, randomAlphaOfLength(5), handler);
         } else {
             try {
-                IngestDocument result = processor.execute(doc);
+                IngestDocument result = processor.execute(doc, randomAlphaOfLength(5));
                 handler.accept(result, null);
             } catch (Exception e) {
                 handler.accept(null, e);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/ingest/IngestMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/ingest/IngestMetricsIT.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.action.ingest;
+
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
+import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsResponse;
+import org.elasticsearch.action.bulk.BulkRequest;
+import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.IngestStats;
+import org.elasticsearch.ingest.PipelineProcessor;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.plugins.IngestPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.RepositoriesService;
+import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.tracing.Tracer;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
+import java.util.function.Supplier;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+
+/**
+ * The purpose of this test is to make sure that ingestion counters are correct.
+ */
+public class IngestMetricsIT extends ESSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(TestPlugin.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testAsyncProcessorImplementation() throws IOException {
+        String innerInnerPipeline = """
+            {
+                "processors": [
+                    {
+                        "test-async-processor": {
+                            "description": "test-async-processor-in-innerInner"
+                        }
+                    }
+                ]
+            }
+            """;
+        BytesReference innerInnerPipelineReference = new BytesArray(innerInnerPipeline);
+        client().admin()
+            .cluster()
+            .putPipeline(new PutPipelineRequest("innerInnerPipeline", innerInnerPipelineReference, XContentType.JSON))
+            .actionGet();
+        String innerPipeline = """
+            {
+                "processors": [
+                    {
+                        "test-async-processor": {
+                            "description": "test-async-processor-in-inner"
+                        },
+                        "pipeline": {
+                            "name": "innerInnerPipeline",
+                            "description": "innerInnerPipeline-in-inner"
+                        }
+                    }
+                ]
+            }
+            """;
+        BytesReference innerPipelineReference = new BytesArray(innerPipeline);
+        client().admin()
+            .cluster()
+            .putPipeline(new PutPipelineRequest("innerPipeline", innerPipelineReference, XContentType.JSON))
+            .actionGet();
+        String outerPipeline = """
+            {
+                "processors": [
+                    {
+                        "pipeline": {
+                            "name": "innerPipeline",
+                            "description": "innerPipeline-in-outer"
+                        }
+                    },
+                    {
+                        "test-async-processor": {
+                            "description": "test-async-processor-in-outer"
+                        },
+                        "pipeline": {
+                            "name": "innerInnerPipeline",
+                            "description": "innerInnerPipeline-in-outer"
+                        }
+                    }
+                ]
+            }
+            """;
+        BytesReference outerPipelineReference = new BytesArray(outerPipeline);
+        client().admin()
+            .cluster()
+            .putPipeline(new PutPipelineRequest("outerPipeline", outerPipelineReference, XContentType.JSON))
+            .actionGet();
+
+        BulkRequest bulkRequest = new BulkRequest();
+        int numDocs = randomIntBetween(1, 200);
+        for (int i = 0; i < numDocs; i++) {
+            bulkRequest.add(
+                new IndexRequest("foobar").id(Integer.toString(i)).source("{}", XContentType.JSON).setPipeline("outerPipeline")
+            );
+        }
+        BulkResponse bulkResponse = client().bulk(bulkRequest).actionGet();
+        assertThat(bulkResponse.getItems().length, equalTo(numDocs));
+        for (int i = 0; i < numDocs; i++) {
+            String id = Integer.toString(i);
+            assertThat(bulkResponse.getItems()[i].getId(), equalTo(id));
+        }
+        NodesStatsResponse nodesStatsResponse = client().admin()
+            .cluster()
+            .nodesStats(new NodesStatsRequest().addMetric("ingest"))
+            .actionGet();
+        IngestStats ingestStats = nodesStatsResponse.getNodes().get(0).getIngestStats();
+        Map<String, Object> ingestStatsMap = xContentToMap(ingestStats);
+        Map<String, Object> ingest = (Map<String, Object>) ingestStatsMap.get("ingest");
+        Map<String, Object> total = (Map<String, Object>) ingest.get("total");
+        int totalCount = (int) total.get("count");
+        assertThat(totalCount, equalTo(numDocs));
+        int totalTime = (int) total.get("time_in_millis");
+        assertThat(totalTime, greaterThan(0));
+        Map<String, Object> pipelines = (Map<String, Object>) ingest.get("pipelines");
+        Map<String, Object> outerPipelineMap = (Map<String, Object>) pipelines.get("outerPipeline");
+        AtomicInteger pipelinesChecked = new AtomicInteger(0);
+        checkPipeline(outerPipelineMap, totalCount, totalTime, pipelinesChecked);
+        assertThat(pipelinesChecked.get(), equalTo(4));
+    }
+
+    /*
+     * Recursively check that the count in each processor is the same, and that the time spent in all processors as a given level is less
+     * than or equal to the time at the previous level.
+     */
+    @SuppressWarnings("unchecked")
+    private void checkPipeline(
+        Map<String, Object> pipelineMap,
+        int previousLevelCount,
+        int previousLevelTime,
+        AtomicInteger pipelinesCheckedAccumulator
+    ) {
+        pipelinesCheckedAccumulator.incrementAndGet();
+        assertThat(pipelineMap.get("count"), equalTo(previousLevelCount)); // We don't have conditionals
+        int time = (int) pipelineMap.get("time_in_millis");
+        assertThat(time, greaterThan(0));
+        assertThat(time, lessThanOrEqualTo(previousLevelTime));
+        List<Map<String, Object>> pipelineProcessors = (List<Map<String, Object>>) pipelineMap.get("processors");
+        int allProcessorsTime = 0;
+        for (Map<String, Object> processorMap : pipelineProcessors) {
+            assertThat(processorMap.size(), equalTo(1));
+            Map<String, Object> innerProcessorMap = (Map<String, Object>) processorMap.values().iterator().next();
+            String type = (String) innerProcessorMap.get("type");
+            Map<String, Object> stats = (Map<String, Object>) innerProcessorMap.get("stats");
+            int processorTime = (int) stats.get("time_in_millis");
+            assertThat(processorTime, greaterThanOrEqualTo(0));
+            allProcessorsTime += processorTime;
+            int count = (int) stats.get("count");
+            assertThat(count, equalTo(previousLevelCount));
+            if (PipelineProcessor.TYPE.equals(type)) {
+                checkPipeline(stats, count, time, pipelinesCheckedAccumulator);
+            }
+        }
+        assertThat(allProcessorsTime, lessThanOrEqualTo(previousLevelTime));
+    }
+
+    private Map<String, Object> xContentToMap(ToXContent xcontent) throws IOException {
+        XContentBuilder builder = XContentFactory.yamlBuilder().prettyPrint();
+        builder.startObject();
+        xcontent.toXContent(builder, ToXContent.EMPTY_PARAMS);
+        builder.endObject();
+        XContentParser parser = XContentType.YAML.xContent()
+            .createParser(xContentRegistry(), LoggingDeprecationHandler.INSTANCE, BytesReference.bytes(builder).streamInput());
+        logger.info(((ByteArrayOutputStream) builder.getOutputStream()).toString(StandardCharsets.UTF_8));
+        return parser.map();
+    }
+
+    public static class TestPlugin extends Plugin implements IngestPlugin {
+
+        private ThreadPool threadPool;
+
+        @Override
+        public Collection<Object> createComponents(
+            Client client,
+            ClusterService clusterService,
+            ThreadPool threadPool,
+            ResourceWatcherService resourceWatcherService,
+            ScriptService scriptService,
+            NamedXContentRegistry xContentRegistry,
+            Environment environment,
+            NodeEnvironment nodeEnvironment,
+            NamedWriteableRegistry namedWriteableRegistry,
+            IndexNameExpressionResolver expressionResolver,
+            Supplier<RepositoriesService> repositoriesServiceSupplier,
+            Tracer tracer,
+            AllocationDeciders allocationDeciders
+        ) {
+            this.threadPool = threadPool;
+            return List.of();
+        }
+
+        @Override
+        public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
+            Map<String, Processor.Factory> procMap = new HashMap<>();
+            procMap.put("test-async-processor", (factories, tag, description, config) -> new AbstractProcessor(tag, description) {
+                @Override
+                public void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
+                    threadPool.generic().execute(() -> {
+                        String id = (String) ingestDocument.getSourceAndMetadata().get("_id");
+                        if (usually()) {
+                            try {
+                                Thread.sleep(10);
+                            } catch (InterruptedException e) {
+                                // ignore
+                            }
+                        }
+                        ingestDocument.setFieldValue(randomAlphaOfLength(5), "bar-" + id);
+                        handler.accept(ingestDocument, null);
+                    });
+                }
+
+                @Override
+                public String getType() {
+                    return "test-async-processor";
+                }
+
+                @Override
+                public boolean isAsync() {
+                    return true;
+                }
+
+            });
+            Processor.Factory pipelineFactory1 = new PipelineProcessor.Factory(parameters.ingestService);
+            procMap.put("pipeline", pipelineFactory1);
+            return procMap;
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulateExecutionService.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulateExecutionService.java
@@ -50,10 +50,11 @@ class SimulateExecutionService {
             );
             ingestDocument.executePipeline(
                 verbosePipeline,
+                "simulation",
                 (result, e) -> { handler.accept(new SimulateDocumentVerboseResult(processorResultList), e); }
             );
         } else {
-            ingestDocument.executePipeline(pipeline, (result, e) -> {
+            ingestDocument.executePipeline(pipeline, "simulation", (result, e) -> {
                 if (e == null) {
                     handler.accept(new SimulateDocumentBaseResult(result), null);
                 } else {

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -178,7 +178,6 @@ public class CompoundProcessor implements Processor {
         while (currentProcessor < processorsWithMetrics.size() && processorsWithMetrics.get(currentProcessor).v1().isAsync() == false) {
             processor = processorsWithMetrics.get(currentProcessor).v1();
             metric = processorsWithMetrics.get(currentProcessor).v2().computeIfAbsent(context, s -> new IngestMetric());
-            // metric = processorWithMetric.v2();
             metric.preIngest();
 
             final long startTimeInNanos = relativeTimeProvider.getAsLong();

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -87,7 +87,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
     }
 
     @Override
-    public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+    public IngestDocument execute(IngestDocument ingestDocument, String context) throws Exception {
         assert isAsync() == false;
 
         final boolean matches = evaluate(ingestDocument);
@@ -95,7 +95,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
             long startTimeInNanos = relativeTimeProvider.getAsLong();
             try {
                 metric.preIngest();
-                return processor.execute(ingestDocument);
+                return processor.execute(ingestDocument, context);
             } catch (Exception e) {
                 metric.ingestFailed();
                 throw e;
@@ -108,7 +108,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
     }
 
     @Override
-    public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+    public void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
         assert isAsync();
         final boolean matches;
         try {
@@ -121,7 +121,7 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
         if (matches) {
             final long startTimeInNanos = relativeTimeProvider.getAsLong();
             metric.preIngest();
-            processor.execute(ingestDocument, (result, e) -> {
+            processor.execute(ingestDocument, context, (result, e) -> {
                 long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
                 metric.postIngest(ingestTimeInNanos);
                 if (e != null) {
@@ -134,6 +134,11 @@ public class ConditionalProcessor extends AbstractProcessor implements WrappingP
         } else {
             handler.accept(ingestDocument, null);
         }
+    }
+
+    @Override
+    public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+        throw new UnsupportedOperationException("Calling execute without context loses context");
     }
 
     boolean evaluate(IngestDocument ingestDocument) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -825,10 +825,10 @@ public final class IngestDocument {
      * @param pipeline the pipeline to execute
      * @param handler handles the result or failure
      */
-    public void executePipeline(Pipeline pipeline, BiConsumer<IngestDocument, Exception> handler) {
+    public void executePipeline(Pipeline pipeline, String context, BiConsumer<IngestDocument, Exception> handler) {
         if (executedPipelines.add(pipeline.getId())) {
             Object previousPipeline = ingestMetadata.put("pipeline", pipeline.getId());
-            pipeline.execute(this, (result, e) -> {
+            pipeline.execute(this, context, (result, e) -> {
                 executedPipelines.remove(pipeline.getId());
                 if (previousPipeline != null) {
                     ingestMetadata.put("pipeline", previousPipeline);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -553,6 +553,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 getProcessorMetrics(cp, processorMetrics);
             } else {
                 Map<String, IngestMetric> contextAwareMetrics = processorWithMetric.v2();
+                // Prefer the conditional's metric since it only includes metrics when the conditional evaluated to true.
                 if (processor instanceof ConditionalProcessor cp) {
                     Map<String, IngestMetric> conditionalContextAwareMetrics = new HashMap<>();
                     for (Map.Entry<String, IngestMetric> entry : contextAwareMetrics.entrySet()) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -553,7 +553,15 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 getProcessorMetrics(cp, processorMetrics);
             } else {
                 Map<String, IngestMetric> contextAwareMetrics = processorWithMetric.v2();
-                processorMetrics.add(new Tuple<>(processor, contextAwareMetrics));
+                if (processor instanceof ConditionalProcessor cp) {
+                    Map<String, IngestMetric> conditionalContextAwareMetrics = new HashMap<>();
+                    for (Map.Entry<String, IngestMetric> entry : contextAwareMetrics.entrySet()) {
+                        conditionalContextAwareMetrics.put(entry.getKey(), cp.getMetric(entry.getKey()));
+                    }
+                    processorMetrics.add(new Tuple<>(processor, conditionalContextAwareMetrics));
+                } else {
+                    processorMetrics.add(new Tuple<>(processor, contextAwareMetrics));
+                }
             }
         }
         return processorMetrics;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -542,22 +542,18 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
      * @param processorMetrics The list of {@link Processor} {@link IngestMetric} tuples.
      * @return the processorMetrics for all non-failure processor that belong to the original compoundProcessor
      */
-    private static List<Tuple<Processor, IngestMetric>> getProcessorMetrics(
+    private static List<Tuple<Processor, Map<String, IngestMetric>>> getProcessorMetrics(
         CompoundProcessor compoundProcessor,
-        List<Tuple<Processor, IngestMetric>> processorMetrics
+        List<Tuple<Processor, Map<String, IngestMetric>>> processorMetrics
     ) {
         // only surface the top level non-failure processors, on-failure processor times will be included in the top level non-failure
-        for (Tuple<Processor, IngestMetric> processorWithMetric : compoundProcessor.getProcessorsWithMetrics()) {
+        for (Tuple<Processor, Map<String, IngestMetric>> processorWithMetric : compoundProcessor.getProcessorsWithMetrics()) {
             Processor processor = processorWithMetric.v1();
-            IngestMetric metric = processorWithMetric.v2();
             if (processor instanceof CompoundProcessor cp) {
                 getProcessorMetrics(cp, processorMetrics);
             } else {
-                // Prefer the conditional's metric since it only includes metrics when the conditional evaluated to true.
-                if (processor instanceof ConditionalProcessor cp) {
-                    metric = (cp.getMetric());
-                }
-                processorMetrics.add(new Tuple<>(processor, metric));
+                Map<String, IngestMetric> contextAwareMetrics = processorWithMetric.v2();
+                processorMetrics.add(new Tuple<>(processor, contextAwareMetrics));
             }
         }
         return processorMetrics;
@@ -841,12 +837,19 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             Pipeline pipeline = holder.pipeline;
             CompoundProcessor rootProcessor = pipeline.getCompoundProcessor();
             statsBuilder.addPipelineMetrics(id, pipeline.getMetrics());
-            List<Tuple<Processor, IngestMetric>> processorMetrics = new ArrayList<>();
+            List<Tuple<Processor, Map<String, IngestMetric>>> processorMetrics = new ArrayList<>();
             getProcessorMetrics(rootProcessor, processorMetrics);
             processorMetrics.forEach(t -> {
                 Processor processor = t.v1();
-                IngestMetric processorMetric = t.v2();
-                statsBuilder.addProcessorMetrics(id, getProcessorName(processor), processor.getType(), processorMetric);
+                Map<String, IngestMetric> contextToMetricMap = t.v2();
+                if (contextToMetricMap.isEmpty()) {
+                    statsBuilder.addProcessorMetrics(id, getProcessorName(processor), processor.getType(), new IngestMetric());
+                } else {
+                    for (Map.Entry<String, IngestMetric> entry : contextToMetricMap.entrySet()) {
+                        IngestMetric processorMetric = entry.getValue();
+                        statsBuilder.addProcessorMetrics(entry.getKey(), getProcessorName(processor), processor.getType(), processorMetric);
+                    }
+                }
             });
         });
         return statsBuilder.build();
@@ -904,7 +907,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         VersionType versionType = indexRequest.versionType();
         Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
         IngestDocument ingestDocument = new IngestDocument(index, id, version, routing, versionType, sourceAsMap);
-        ingestDocument.executePipeline(pipeline, (result, e) -> {
+        ingestDocument.executePipeline(pipeline, pipeline.getId(), (result, e) -> {
             if (e != null) {
                 handler.accept(e);
             } else if (result == null) {
@@ -1029,24 +1032,31 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 }
                 Pipeline oldPipeline = previous.pipeline;
                 newPipeline.getMetrics().add(oldPipeline.getMetrics());
-                List<Tuple<Processor, IngestMetric>> oldPerProcessMetrics = new ArrayList<>();
-                List<Tuple<Processor, IngestMetric>> newPerProcessMetrics = new ArrayList<>();
+                List<Tuple<Processor, Map<String, IngestMetric>>> oldPerProcessMetrics = new ArrayList<>();
+                List<Tuple<Processor, Map<String, IngestMetric>>> newPerProcessMetrics = new ArrayList<>();
                 getProcessorMetrics(oldPipeline.getCompoundProcessor(), oldPerProcessMetrics);
                 getProcessorMetrics(newPipeline.getCompoundProcessor(), newPerProcessMetrics);
                 // Best attempt to populate new processor metrics using a parallel array of the old metrics. This is not ideal since
                 // the per processor metrics may get reset when the arrays don't match. However, to get to an ideal model, unique and
                 // consistent id's per processor and/or semantic equals for each processor will be needed.
                 if (newPerProcessMetrics.size() == oldPerProcessMetrics.size()) {
-                    Iterator<Tuple<Processor, IngestMetric>> oldMetricsIterator = oldPerProcessMetrics.iterator();
-                    for (Tuple<Processor, IngestMetric> compositeMetric : newPerProcessMetrics) {
+                    Iterator<Tuple<Processor, Map<String, IngestMetric>>> oldMetricsIterator = oldPerProcessMetrics.iterator();
+                    for (Tuple<Processor, Map<String, IngestMetric>> compositeMetric : newPerProcessMetrics) {
                         String type = compositeMetric.v1().getType();
-                        IngestMetric metric = compositeMetric.v2();
+                        Map<String, IngestMetric> contextToMetricMap = compositeMetric.v2();
                         if (oldMetricsIterator.hasNext()) {
-                            Tuple<Processor, IngestMetric> oldCompositeMetric = oldMetricsIterator.next();
-                            String oldType = oldCompositeMetric.v1().getType();
-                            IngestMetric oldMetric = oldCompositeMetric.v2();
-                            if (type.equals(oldType)) {
-                                metric.add(oldMetric);
+                            Tuple<Processor, Map<String, IngestMetric>> oldCompositeContextToMetric = oldMetricsIterator.next();
+                            String oldType = oldCompositeContextToMetric.v1().getType();
+                            for (Map.Entry<String, IngestMetric> entry : oldCompositeContextToMetric.v2().entrySet()) {
+                                IngestMetric oldMetric = entry.getValue();
+                                IngestMetric newMetric = contextToMetricMap.get(entry.getKey());
+                                if (type.equals(oldType)) {
+                                    if (newMetric == null) {
+                                        contextToMetricMap.put(entry.getKey(), oldMetric);
+                                    } else {
+                                        newMetric.add(oldMetric);
+                                    }
+                                }
                             }
                         }
                     }
@@ -1154,7 +1164,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         String errorMessage = "pipeline with id [" + id + "] could not be loaded, caused by [" + e.getDetailedMessage() + "]";
         Processor failureProcessor = new AbstractProcessor(tag, "this is a placeholder processor") {
             @Override
-            public IngestDocument execute(IngestDocument ingestDocument) {
+            public IngestDocument execute(IngestDocument ingestDocument, String context) {
                 throw new IllegalStateException(errorMessage);
             }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -104,7 +104,7 @@ public class IngestStats implements Writeable, ToXContentFragment {
         totalStats.toXContent(builder, params);
         builder.endObject();
         builder.startObject("pipelines");
-        String pipelineProcessorPrefix = PipelineProcessor.TYPE + ":";
+        String pipelineProcessorPrefix = PipelineProcessor.TYPE + PipelineProcessor.CONTEXT_DELIMITER;
         Map<String, PipelineStat> pipelineStatMap = pipelineStats.stream()
             .collect(
                 Collectors.toMap(pipelineStat -> pipelineProcessorPrefix + pipelineStat.getPipelineId(), pipelineStat -> pipelineStat)
@@ -143,7 +143,8 @@ public class IngestStats implements Writeable, ToXContentFragment {
                 processorStat.getStats().toXContent(builder, params);
                 if (processorStat.getType().equals(PipelineProcessor.TYPE)) {
                     processorsToXContent(
-                        context + ":" + processorStat.getName().substring(PipelineProcessor.TYPE.length() + 1),
+                        context + PipelineProcessor.CONTEXT_DELIMITER + processorStat.getName()
+                            .substring(PipelineProcessor.TYPE.length() + 1),
                         processorStats,
                         pipelineStatMap,
                         builder,

--- a/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestStats.java
@@ -18,14 +18,11 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -106,7 +106,7 @@ public final class Pipeline {
      * If <code>null</code> is returned then this document will be dropped and not indexed, otherwise
      * this document will be kept and indexed.
      */
-    public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+    public void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
         final long startTimeInNanos = relativeTimeProvider.getAsLong();
         /*
          * Our assumption is that the listener passed to the processor is only ever called once. However, there is no way to enforce
@@ -115,7 +115,7 @@ public final class Pipeline {
          * is only executed once.
          */
         metrics.preIngest();
-        compoundProcessor.execute(ingestDocument, (result, e) -> {
+        compoundProcessor.execute(ingestDocument, context, (result, e) -> {
             long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
             metrics.postIngest(ingestTimeInNanos);
             if (e != null) {

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -114,12 +114,13 @@ public final class Pipeline {
          * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
          * is only executed once.
          */
-        if (context.contains(":") == false) {
+        final boolean isTopLevelPipeline = isTopLevelPipeline(context);
+        if (isTopLevelPipeline) {
             metrics.preIngest();
         }
         compoundProcessor.execute(ingestDocument, context, (result, e) -> {
             long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
-            if (context.contains(":") == false) {
+            if (isTopLevelPipeline) {
                 metrics.postIngest(ingestTimeInNanos);
                 if (e != null) {
                     metrics.ingestFailed();
@@ -127,6 +128,10 @@ public final class Pipeline {
             }
             handler.accept(result, e);
         });
+    }
+
+    private boolean isTopLevelPipeline(String context) {
+        return context.contains(PipelineProcessor.CONTEXT_DELIMITER) == false;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -114,12 +114,16 @@ public final class Pipeline {
          * such as the metrics being wrong. The listenerHasBeenCalled variable is used to make sure that the code in the listener
          * is only executed once.
          */
-        metrics.preIngest();
+        if (context.contains(":") == false) {
+            metrics.preIngest();
+        }
         compoundProcessor.execute(ingestDocument, context, (result, e) -> {
             long ingestTimeInNanos = relativeTimeProvider.getAsLong() - startTimeInNanos;
-            metrics.postIngest(ingestTimeInNanos);
-            if (e != null) {
-                metrics.ingestFailed();
+            if (context.contains(":") == false) {
+                metrics.postIngest(ingestTimeInNanos);
+                if (e != null) {
+                    metrics.ingestFailed();
+                }
             }
             handler.accept(result, e);
         });

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
@@ -35,11 +35,11 @@ public class PipelineProcessor extends AbstractProcessor {
     }
 
     @Override
-    public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+    public void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
         String pipelineName = ingestDocument.renderTemplate(this.pipelineTemplate);
         Pipeline pipeline = ingestService.getPipeline(pipelineName);
         if (pipeline != null) {
-            ingestDocument.executePipeline(pipeline, handler);
+            ingestDocument.executePipeline(pipeline, context + ":" + pipelineName, handler);
         } else {
             if (ignoreMissingPipeline) {
                 handler.accept(ingestDocument, null);
@@ -50,6 +50,11 @@ public class PipelineProcessor extends AbstractProcessor {
                 );
             }
         }
+    }
+
+    @Override
+    public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+        throw new UnsupportedOperationException("Calling execute without context loses context");
     }
 
     Pipeline getPipeline(IngestDocument ingestDocument) {

--- a/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/PipelineProcessor.java
@@ -16,6 +16,7 @@ import java.util.function.BiConsumer;
 public class PipelineProcessor extends AbstractProcessor {
 
     public static final String TYPE = "pipeline";
+    public static final String CONTEXT_DELIMITER = ":";
 
     private final TemplateScript.Factory pipelineTemplate;
     private final boolean ignoreMissingPipeline;
@@ -39,7 +40,7 @@ public class PipelineProcessor extends AbstractProcessor {
         String pipelineName = ingestDocument.renderTemplate(this.pipelineTemplate);
         Pipeline pipeline = ingestService.getPipeline(pipelineName);
         if (pipeline != null) {
-            ingestDocument.executePipeline(pipeline, context + ":" + pipelineName, handler);
+            ingestDocument.executePipeline(pipeline, context + CONTEXT_DELIMITER + pipelineName, handler);
         } else {
             if (ignoreMissingPipeline) {
                 handler.accept(ingestDocument, null);

--- a/server/src/main/java/org/elasticsearch/ingest/Processor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Processor.java
@@ -33,7 +33,7 @@ public interface Processor {
      * Introspect and potentially modify the incoming data.
      *
      * Expert method: only override this method if a processor implementation needs to make an asynchronous call,
-     * otherwise just overwrite {@link #execute(IngestDocument)}.
+     * otherwise just overwrite {@link #execute(IngestDocument, String)}.
      */
     default void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
         if (isAsync() == false) {
@@ -43,6 +43,10 @@ public interface Processor {
             );
         }
         handler.accept(ingestDocument, null);
+    }
+
+    default void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
+        execute(ingestDocument, handler);
     }
 
     /**
@@ -56,6 +60,10 @@ public interface Processor {
             throw new UnsupportedOperationException("synchronous execute method should not be executed for async processors");
         }
         return ingestDocument;
+    }
+
+    default IngestDocument execute(IngestDocument ingestDocument, String context) throws Exception {
+        return execute(ingestDocument);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -126,7 +126,7 @@ public class CompoundProcessorTests extends ESTestCase {
         TestProcessor processor1 = new TestProcessor("id", "first", null, new RuntimeException("error"));
         Processor processor2 = new Processor() {
             @Override
-            public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+            public IngestDocument execute(IngestDocument ingestDocument, String context) throws Exception {
                 // Simulates the drop processor
                 return null;
             }
@@ -368,16 +368,16 @@ public class CompoundProcessorTests extends ESTestCase {
         );
         Pipeline pipeline1 = new Pipeline("1", null, null, null, new CompoundProcessor(false, List.of(new AbstractProcessor(null, null) {
             @Override
-            public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+            public void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
                 throw new AssertionError();
             }
 
             @Override
-            public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+            public IngestDocument execute(IngestDocument ingestDocument, String context) throws Exception {
                 IngestDocument[] result = new IngestDocument[1];
                 Exception[] error = new Exception[1];
 
-                ingestDocument.executePipeline(pipeline2, (document, e) -> {
+                ingestDocument.executePipeline(pipeline2, randomAlphaOfLength(5), (document, e) -> {
                     result[0] = document;
                     error[0] = e;
                 });
@@ -398,7 +398,7 @@ public class CompoundProcessorTests extends ESTestCase {
             }
         }), List.of(onFailureProcessor)));
 
-        ingestDocument.executePipeline(pipeline1, (document, e) -> {
+        ingestDocument.executePipeline(pipeline1, randomAlphaOfLength(5), (document, e) -> {
             assertThat(document, notNullValue());
             assertThat(e, nullValue());
         });
@@ -434,11 +434,11 @@ public class CompoundProcessorTests extends ESTestCase {
         );
         Pipeline pipeline1 = new Pipeline("1", null, null, null, new CompoundProcessor(new AbstractProcessor(null, null) {
             @Override
-            public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
+            public IngestDocument execute(IngestDocument ingestDocument, String context) throws Exception {
                 IngestDocument[] result = new IngestDocument[1];
                 Exception[] error = new Exception[1];
 
-                ingestDocument.executePipeline(pipeline2, (document, e) -> {
+                ingestDocument.executePipeline(pipeline2, randomAlphaOfLength(5), (document, e) -> {
                     result[0] = document;
                     error[0] = e;
                 });
@@ -449,7 +449,7 @@ public class CompoundProcessorTests extends ESTestCase {
             }
 
             @Override
-            public void execute(IngestDocument ingestDocument, BiConsumer<IngestDocument, Exception> handler) {
+            public void execute(IngestDocument ingestDocument, String context, BiConsumer<IngestDocument, Exception> handler) {
                 throw new UnsupportedOperationException();
             }
 
@@ -465,7 +465,7 @@ public class CompoundProcessorTests extends ESTestCase {
         }));
 
         Exception[] holder = new Exception[1];
-        ingestDocument.executePipeline(pipeline1, (document, e) -> holder[0] = e);
+        ingestDocument.executePipeline(pipeline1, randomAlphaOfLength(5), (document, e) -> holder[0] = e);
         IngestProcessorException ingestProcessorException = (IngestProcessorException) holder[0];
         assertThat(ingestProcessorException.getHeader("processor_tag"), equalTo(List.of("my_tag")));
         assertThat(ingestProcessorException.getHeader("processor_type"), equalTo(List.of("my_type")));
@@ -543,10 +543,10 @@ public class CompoundProcessorTests extends ESTestCase {
     // delegates to appropriate sync or async method
     private static void executeCompound(CompoundProcessor cp, IngestDocument doc, BiConsumer<IngestDocument, Exception> handler) {
         if (cp.isAsync()) {
-            cp.execute(doc, handler);
+            cp.execute(doc, randomAlphaOfLength(5), handler);
         } else {
             try {
-                IngestDocument result = cp.execute(doc);
+                IngestDocument result = cp.execute(doc, randomAlphaOfLength(5));
                 handler.accept(result, null);
             } catch (Exception e) {
                 handler.accept(null, e);
@@ -559,7 +559,7 @@ public class CompoundProcessorTests extends ESTestCase {
     }
 
     private void assertStats(int processor, CompoundProcessor compoundProcessor, long current, long count, long failed, long time) {
-        IngestStats.Stats stats = compoundProcessor.getProcessorsWithMetrics().get(processor).v2().createStats();
+        IngestStats.Stats stats = compoundProcessor.getProcessorsWithMetrics().get(processor).v2().values().iterator().next().createStats();
         assertThat(stats.getIngestCount(), equalTo(count));
         assertThat(stats.getIngestCurrent(), equalTo(current));
         assertThat(stats.getIngestFailedCount(), equalTo(failed));

--- a/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
@@ -287,7 +287,7 @@ public class ConditionalProcessorTests extends ESTestCase {
     }
 
     private static void assertStats(ConditionalProcessor conditionalProcessor, long count, long failed, long time) {
-        IngestStats.Stats stats = conditionalProcessor.getMetric().createStats();
+        IngestStats.Stats stats = conditionalProcessor.getMetric(randomAlphaOfLength(5)).createStats();
         assertThat(stats.getIngestCount(), equalTo(count));
         assertThat(stats.getIngestCurrent(), equalTo(0L));
         assertThat(stats.getIngestFailedCount(), equalTo(failed));

--- a/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
@@ -73,7 +73,7 @@ public class ConditionalProcessorTests extends ESTestCase {
             scriptService,
             new Processor() {
                 @Override
-                public IngestDocument execute(final IngestDocument ingestDocument) {
+                public IngestDocument execute(final IngestDocument ingestDocument, String context) {
                     if (ingestDocument.hasField("error")) {
                         throw new RuntimeException("error");
                     }
@@ -170,7 +170,7 @@ public class ConditionalProcessorTests extends ESTestCase {
             scriptService,
             new Processor() {
                 @Override
-                public IngestDocument execute(final IngestDocument ingestDocument) {
+                public IngestDocument execute(final IngestDocument ingestDocument, String context) {
                     return ingestDocument;
                 }
 
@@ -296,10 +296,10 @@ public class ConditionalProcessorTests extends ESTestCase {
 
     private static void execProcessor(Processor processor, IngestDocument doc, BiConsumer<IngestDocument, Exception> handler) {
         if (processor.isAsync()) {
-            processor.execute(doc, handler);
+            processor.execute(doc, randomAlphaOfLength(5), handler);
         } else {
             try {
-                IngestDocument result = processor.execute(doc);
+                IngestDocument result = processor.execute(doc, randomAlphaOfLength(5));
                 handler.accept(result, null);
             } catch (Exception e) {
                 handler.accept(null, e);

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineProcessorTests.java
@@ -211,18 +211,18 @@ public class PipelineProcessorTests extends ESTestCase {
 
         // count
         assertThat(pipeline1Stats.getIngestCount(), equalTo(1L));
-        assertThat(pipeline2Stats.getIngestCount(), equalTo(1L));
-        assertThat(pipeline3Stats.getIngestCount(), equalTo(1L));
+        assertThat(pipeline2Stats.getIngestCount(), equalTo(0L)); // because pipeline1 was the only toplevel pipeline run
+        assertThat(pipeline3Stats.getIngestCount(), equalTo(0L)); // because pipeline1 was the only toplevel pipeline run
 
         // time
         assertThat(pipeline1Stats.getIngestTimeInMillis(), equalTo(0L));
-        assertThat(pipeline2Stats.getIngestTimeInMillis(), equalTo(3L));
-        assertThat(pipeline3Stats.getIngestTimeInMillis(), equalTo(2L));
+        assertThat(pipeline2Stats.getIngestTimeInMillis(), equalTo(0L)); // because pipeline1 was the only toplevel pipeline run
+        assertThat(pipeline3Stats.getIngestTimeInMillis(), equalTo(0L)); // because pipeline1 was the only toplevel pipeline run
 
         // failure
         assertThat(pipeline1Stats.getIngestFailedCount(), equalTo(0L));
-        assertThat(pipeline2Stats.getIngestFailedCount(), equalTo(0L));
-        assertThat(pipeline3Stats.getIngestFailedCount(), equalTo(1L));
+        assertThat(pipeline2Stats.getIngestFailedCount(), equalTo(0L)); // because pipeline1 was the only toplevel pipeline run
+        assertThat(pipeline3Stats.getIngestFailedCount(), equalTo(0L)); // because pipeline1 was the only toplevel pipeline run
     }
 
     public void testIngestPipelineMetadata() {

--- a/server/src/test/java/org/elasticsearch/ingest/TrackingResultProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/TrackingResultProcessorTests.java
@@ -55,7 +55,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
     public void testActualProcessor() throws Exception {
         TestProcessor actualProcessor = new TestProcessor(ingestDocument -> {});
         TrackingResultProcessor trackingProcessor = new TrackingResultProcessor(false, actualProcessor, null, resultList);
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),
@@ -80,7 +80,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
         Exception[] holder = new Exception[1];
-        trackingProcessor.execute(ingestDocument, (result, e) -> holder[0] = e);
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> holder[0] = e);
         assertThat(((IngestProcessorException) holder[0]).getRootCause().getMessage(), equalTo(exception.getMessage()));
 
         SimulateProcessorResult expectedFirstResult = new SimulateProcessorResult(
@@ -113,7 +113,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
             Arrays.asList(onFailureProcessor)
         );
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedFailResult = new SimulateProcessorResult(
             failProcessor.getType(),
@@ -184,7 +184,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
             Arrays.asList(onFailureProcessor)
         );
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedFailResult = new SimulateProcessorResult(
             failProcessor.getType(),
@@ -226,7 +226,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         CompoundProcessor actualProcessor = new CompoundProcessor(true, Collections.singletonList(testProcessor), Collections.emptyList());
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             testProcessor.getType(),
@@ -271,7 +271,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         );
 
         CompoundProcessor trackingProcessor = decorate(compoundProcessor, null, resultList);
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             compoundProcessor.getType(),
             compoundProcessor.getTag(),
@@ -327,7 +327,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
 
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),
@@ -420,7 +420,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
 
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),
@@ -520,7 +520,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
 
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),
@@ -586,7 +586,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
 
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),
@@ -647,7 +647,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
 
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),
@@ -704,7 +704,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
         Exception[] holder = new Exception[1];
-        trackingProcessor.execute(ingestDocument, (result, e) -> holder[0] = e);
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> holder[0] = e);
         IngestProcessorException exception = (IngestProcessorException) holder[0];
         assertThat(exception.getCause(), instanceOf(IllegalStateException.class));
         assertThat(exception.getMessage(), containsString("Cycle detected for pipeline: pipeline1"));
@@ -733,7 +733,7 @@ public class TrackingResultProcessorTests extends ESTestCase {
 
         CompoundProcessor trackingProcessor = decorate(actualProcessor, null, resultList);
 
-        trackingProcessor.execute(ingestDocument, (result, e) -> {});
+        trackingProcessor.execute(ingestDocument, randomAlphaOfLength(5), (result, e) -> {});
 
         SimulateProcessorResult expectedResult = new SimulateProcessorResult(
             actualProcessor.getType(),


### PR DESCRIPTION
The ingest metrics are currently really confusing if you have pipelines that call other pipelines. Say you have
pipeline1:
```
            {
                "processors": [
                    {
                        "pipeline": {
                            "name": "pipeline2",
                            "description": "pipeline2-in-pipeline1"
                        }
                    },
                    {
                        "test-async-processor": {
                            "description": "test-async-processor-in-pipeline1"
                        },
                        "pipeline": {
                            "name": "pipeline3",
                            "description": "pipeline3-in-pipeline1"
                        }
                    }
                ]
            }
```
pipeline2:
```
            {
                "processors": [
                    {
                        "test-async-processor": {
                            "description": "test-async-processor-in-pipeline2"
                        },
                        "pipeline": {
                            "name": "pipeline3",
                            "description": "pipeline3-in-pipeline2"
                        }
                    }
                ]
            }
```
pipeline3:
```
            {
                "processors": [
                    {
                        "test-async-processor": {
                            "description": "test-async-processor-in-pipeline3"
                        }
                    }
                ]
            }
```
So pipeline1 calls pipeline2 and pipeline3, and pipeline2 calls pipeline3. And they all call a "test-async-processor" . Say I send 8 documents directly through pipeline1 and 172 directly through pipeline2. Before, the metrics looked like this:
```
ingest:
  total:
    count: 180
    time_in_millis: 5077
    current: 0
    failed: 0
  pipelines:
    pipeline1:
      count: 8
      time_in_millis: 381
      current: 0
      failed: 0
      processors:
      - pipeline:pipeline2:
          type: "pipeline"
          stats:
            count: 8
            time_in_millis: 205
            current: 0
            failed: 0
      - test-async-processor:
          type: "test-async-processor"
          stats:
            count: 8
            time_in_millis: 90
            current: 0
            failed: 0
      - pipeline:pipeline3:
          type: "pipeline"
          stats:
            count: 8
            time_in_millis: 84
            current: 0
            failed: 0
    pipeline2:
      count: 180
      time_in_millis: 4820
      current: 0
      failed: 0
      processors:
      - test-async-processor:
          type: "test-async-processor"
          stats:
            count: 180
            time_in_millis: 1977
            current: 0
            failed: 0
      - pipeline:pipeline3:
          type: "pipeline"
          stats:
            count: 180
            time_in_millis: 2833
            current: 0
            failed: 0
    pipeline3:
      count: 188
      time_in_millis: 2910
      current: 0
      failed: 0
      processors:
      - test-async-processor:
          type: "test-async-processor"
          stats:
            count: 188
            time_in_millis: 2906
            current: 0
            failed: 0
```
It's really unclear how many times each pipeline was called directly vs part of another pipeline, and how much of a pipeline or processor's runtime contributed to the runtime of the pipeline that ran it. It's really confusing that pipeline3 reports having run 188 documents even though there were only 180 total. I can hardly make sense of that (even though I'm pretty familiar with what's going on). With this PR they look like this:
```
ingest:
  total:
    count: 180
    time_in_millis: 4559
    current: 0
    failed: 0
  pipelines:
    pipeline1:
      count: 8
      time_in_millis: 362
      current: 0
      failed: 0
      processors:
      - pipeline:pipeline2:
          type: "pipeline"
          stats:
            count: 8
            time_in_millis: 194
            current: 0
            failed: 0
            processors:
            - test-async-processor:
                type: "test-async-processor"
                stats:
                  count: 8
                  time_in_millis: 98
                  current: 0
                  failed: 0
            - pipeline:pipeline3:
                type: "pipeline"
                stats:
                  count: 8
                  time_in_millis: 94
                  current: 0
                  failed: 0
                  processors:
                  - test-async-processor:
                      type: "test-async-processor"
                      stats:
                        count: 8
                        time_in_millis: 93
                        current: 0
                        failed: 0
      - test-async-processor:
          type: "test-async-processor"
          stats:
            count: 8
            time_in_millis: 81
            current: 0
            failed: 0
      - pipeline:pipeline3:
          type: "pipeline"
          stats:
            count: 8
            time_in_millis: 85
            current: 0
            failed: 0
            processors:
            - test-async-processor:
                type: "test-async-processor"
                stats:
                  count: 8
                  time_in_millis: 85
                  current: 0
                  failed: 0
    pipeline2:
      count: 172
      time_in_millis: 3774
      current: 0
      failed: 0
      processors:
      - test-async-processor:
          type: "test-async-processor"
          stats:
            count: 172
            time_in_millis: 1873
            current: 0
            failed: 0
      - pipeline:pipeline3:
          type: "pipeline"
          stats:
            count: 172
            time_in_millis: 1898
            current: 0
            failed: 0
            processors:
            - test-async-processor:
                type: "test-async-processor"
                stats:
                  count: 172
                  time_in_millis: 1894
                  current: 0
                  failed: 0
    pipeline3:
      count: 0
      time_in_millis: 0
      current: 0
      failed: 0
```
Structurally, all the changes are only additive (we've just added a "processsors" section to the stats of any processor that was of type "pipeline"). The values that are returned are different now though. All the stats now roll up. So you see that there are 180 total docs. The sum of the top-level pipelines is 8 + 172 + 0 = 180. Then if you drill into the processors for any pipeline, the count is the same for all of them (b/c i have no conditionals, failures, or currents in this example). And the sum of the time_in_millis at any level is just under the time_in_millis at the level above. Everything reconciles and makes sense (to me anyway).