### PR TITLE
Use elasticsearch DRAs in example plugin build

### DIFF
--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -29,7 +29,7 @@ subprojects {
         }
       }
     }
-    if(gradle.includedBuilds.isEmpty()) {
+    if (gradle.includedBuilds.isEmpty()) {
       maven {
         url = "https://artifacts-snapshot.elastic.co/elasticsearch/${elasticsearchVersion}/maven"
         mavenContent {

--- a/plugins/examples/build.gradle
+++ b/plugins/examples/build.gradle
@@ -29,6 +29,14 @@ subprojects {
         }
       }
     }
+    if(gradle.includedBuilds.isEmpty()) {
+      maven {
+        url = "https://artifacts-snapshot.elastic.co/elasticsearch/${elasticsearchVersion}/maven"
+        mavenContent {
+          includeModule 'org.elasticsearch', 'elasticsearch'
+        }
+      }
+    }
 
     // Same for Lucene, add the snapshot repo based on the currently used Lucene version
     def luceneVersion = VersionProperties.getLucene()


### PR DESCRIPTION
This should fix our example build by resolving elasticsearch artifacts from the synced DRA location