### PR TITLE
Update the default `cluster.routing.allocation.balance.disk_usage`

### DIFF
--- a/docs/changelog/92065.yaml
+++ b/docs/changelog/92065.yaml
@@ -1,0 +1,5 @@
+pr: 92065
+summary: Update the default `cluster.routing.allocation.balance.disk_usage`
+area: Allocation
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -101,7 +101,7 @@ public class BalancedShardsAllocator implements ShardsAllocator {
     );
     public static final Setting<Float> DISK_USAGE_BALANCE_FACTOR_SETTING = Setting.floatSetting(
         "cluster.routing.allocation.balance.disk_usage",
-        5e-11f,
+        2e-11f,
         0.0f,
         Property.Dynamic,
         Property.NodeScope


### PR DESCRIPTION
Set the new default to `2e-11f` to make 50GiB count roughly as 1 shard.