### PR TITLE
Fix time unit for connection request timeout of JWKs reload

### DIFF
--- a/docs/changelog/92080.yaml
+++ b/docs/changelog/92080.yaml
@@ -1,0 +1,5 @@
+pr: 92080
+summary: Improve JWKs reloading and fix time unit for connection request timeout
+area: Authentication
+type: bug
+issues: []

--- a/docs/changelog/92080.yaml
+++ b/docs/changelog/92080.yaml
@@ -1,5 +1,5 @@
 pr: 92080
-summary: Improve JWKs reloading and fix time unit for connection request timeout
+summary: Fix time unit for connection request timeout of JWKs reload
 area: Authentication
 type: bug
 issues: []

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
@@ -101,7 +101,7 @@ public class JwkSetLoader implements Releasable {
 
             final ListenableFuture<Boolean> newFuture = new ListenableFuture<>();
             if (this.reloadFutureRef.compareAndSet(null, newFuture)) {
-                loadInternal(ActionListener.runBefore(newFuture, () -> {
+                loadInternal(ActionListener.runAfter(newFuture, () -> {
                     final ListenableFuture<Boolean> oldValue = this.reloadFutureRef.getAndSet(null);
                     assert oldValue == newFuture : "future reference changed unexpectedly";
                 }));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwkSetLoader.java
@@ -101,7 +101,7 @@ public class JwkSetLoader implements Releasable {
 
             final ListenableFuture<Boolean> newFuture = new ListenableFuture<>();
             if (this.reloadFutureRef.compareAndSet(null, newFuture)) {
-                loadInternal(ActionListener.runAfter(newFuture, () -> {
+                loadInternal(ActionListener.runBefore(newFuture, () -> {
                     final ListenableFuture<Boolean> oldValue = this.reloadFutureRef.getAndSet(null);
                     assert oldValue == newFuture : "future reference changed unexpectedly";
                 }));

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/jwt/JwtUtil.java
@@ -251,7 +251,7 @@ public class JwtUtil {
                 final RequestConfig requestConfig = RequestConfig.custom()
                     .setConnectTimeout(Math.toIntExact(realmConfig.getSetting(JwtRealmSettings.HTTP_CONNECT_TIMEOUT).getMillis()))
                     .setConnectionRequestTimeout(
-                        Math.toIntExact(realmConfig.getSetting(JwtRealmSettings.HTTP_CONNECTION_READ_TIMEOUT).getSeconds())
+                        Math.toIntExact(realmConfig.getSetting(JwtRealmSettings.HTTP_CONNECTION_READ_TIMEOUT).getMillis())
                     )
                     .setSocketTimeout(Math.toIntExact(realmConfig.getSetting(JwtRealmSettings.HTTP_SOCKET_TIMEOUT).getMillis()))
                     .build();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtRealmAuthenticateTests.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
 import org.elasticsearch.xpack.core.security.authc.Realm;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
@@ -98,7 +97,6 @@ public class JwtRealmAuthenticateTests extends JwtRealmTestCase {
      * Test with updated/removed/restored JWKs.
      * @throws Exception Unexpected test failure
      */
-    @TestLogging(value = "org.elasticsearch.xpack.security.authc.jwt:trace", reason = "debug")
     public void testJwkSetUpdates() throws Exception {
         this.jwtIssuerAndRealms = this.generateJwtIssuerRealmPairs(
             this.createJwtRealmsSettingsBuilder(),


### PR DESCRIPTION
This PR fixes a bug where connection request timeout is configured using the wrong time unit (it should be milli-second instead of second).

Some test failures have been caused by this issue.

Relates: #90467
Relates: #89509
