### PR TITLE
[Transform][CI] TransformIndexerStateTests testStopAtCheckpointForThrottledTransform debug logging

### DIFF
--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.search.suggest.Suggest;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.test.junit.annotations.TestIssueLogging;
 import org.elasticsearch.threadpool.TestThreadPool;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.indexing.IndexerState;
@@ -501,6 +502,10 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
     }
 
+    @TestIssueLogging(
+        value = "org.elasticsearch.xpack.transform.transforms:DEBUG",
+        issueUrl = "https://github.com/elastic/elasticsearch/issues/92069"
+    )
     public void testStopAtCheckpointForThrottledTransform() throws Exception {
         TransformConfig config = new TransformConfig(
             randomAlphaOfLength(10),


### PR DESCRIPTION
enable debug logging to find the cause of #92069

relates: #92069

Note: The test failure happened on the 7.17 branch. The test hasn't changed, so `main` isn't fundamentally different. It still makes sense to backport to rule out other side-effects like the new scheduler introduced in 8.4.