### PR TITLE
[ML] Free resources where correctly when model loading is cancelled

### DIFF
--- a/docs/changelog/92094.yaml
+++ b/docs/changelog/92094.yaml
@@ -1,0 +1,5 @@
+pr: 92094
+summary: Free resources where correctly when model loading is cancelled
+area: Machine Learning
+type: bug
+issues: []


### PR DESCRIPTION
If a model deployment is stopped during the loading process or the loading fails some resources are held onto and not freed properly. In particular a worker thread can be started but may not be stopped.

There is some refactoring that makes the PR hard to read the main gist of it is:
- If model loading failed stop the process and free resources 
- If the model was stopped during the loading the process then do not start the worker queue thread and free resources 

The PR is raised against the 8.5 branch as that is where the failures in #92001 are occurring and will be forward ported to main.