### PR TITLE
Ensure balance threshold is at least 1

### DIFF
--- a/docs/changelog/92100.yaml
+++ b/docs/changelog/92100.yaml
@@ -1,7 +1,7 @@
 pr: 92100
 summary: Ensure balance threshold is at least 1
 area: Allocation
-type: "bug, deprecation"
+type: deprecation
 issues: []
 deprecation:
   title: Ensure balance threshold is at least 1

--- a/docs/changelog/92100.yaml
+++ b/docs/changelog/92100.yaml
@@ -1,11 +1,12 @@
 pr: 92100
 summary: Ensure balance threshold is at least 1
 area: Allocation
-type: "bug, deprecation"
+type: deprecation
 issues: []
 deprecation:
   title: Ensure balance threshold is at least 1
   area: Allocation
-  details: Please describe the details of this change for the release notes. You can
-    use asciidoc.
-  impact: Please describe the impact of this change to users
+  details: Values for `cluster.routing.allocation.balance.threshold` smaller
+    than `1` are now ignored. Support for values less than `1` for this setting
+    is deprecated and will be forbidden in a future version.
+  impact: Set `cluster.routing.allocation.balance.threshold` to be at least `1`.

--- a/docs/changelog/92100.yaml
+++ b/docs/changelog/92100.yaml
@@ -1,0 +1,11 @@
+pr: 92100
+summary: Ensure balance threshold is at least 1
+area: Allocation
+type: "bug, deprecation"
+issues: []
+deprecation:
+  title: Ensure balance threshold is at least 1
+  area: Allocation
+  details: Please describe the details of this change for the release notes. You can
+    use asciidoc.
+  impact: Please describe the impact of this change to users

--- a/docs/changelog/92100.yaml
+++ b/docs/changelog/92100.yaml
@@ -1,12 +1,12 @@
 pr: 92100
 summary: Ensure balance threshold is at least 1
 area: Allocation
-type: deprecation
+type: "bug, deprecation"
 issues: []
 deprecation:
   title: Ensure balance threshold is at least 1
   area: Cluster and node setting
-  details: Values for `cluster.routing.allocation.balance.threshold` smaller
-    than `1` are now ignored. Support for values less than `1` for this setting
-    is deprecated and will be forbidden in a future version.
+  details: Values for `cluster.routing.allocation.balance.threshold` smaller than
+    `1` are now ignored. Support for values less than `1` for this setting is deprecated
+    and will be forbidden in a future version.
   impact: Set `cluster.routing.allocation.balance.threshold` to be at least `1`.

--- a/docs/changelog/92100.yaml
+++ b/docs/changelog/92100.yaml
@@ -5,7 +5,7 @@ type: deprecation
 issues: []
 deprecation:
   title: Ensure balance threshold is at least 1
-  area: Allocation
+  area: Cluster and node setting
   details: Values for `cluster.routing.allocation.balance.threshold` smaller
     than `1` are now ignored. Support for values less than `1` for this setting
     is deprecated and will be forbidden in a future version.

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocator.java
@@ -34,6 +34,8 @@ import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision.Type;
 import org.elasticsearch.cluster.routing.allocation.decider.DiskThresholdDecider;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.logging.DeprecationCategory;
+import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -132,13 +134,36 @@ public class BalancedShardsAllocator implements ShardsAllocator {
         watchSetting(settings, clusterSettings, SHARD_BALANCE_FACTOR_SETTING, value -> this.shardBalanceFactor = value);
         watchSetting(settings, clusterSettings, WRITE_LOAD_BALANCE_FACTOR_SETTING, value -> this.writeLoadBalanceFactor = value);
         watchSetting(settings, clusterSettings, DISK_USAGE_BALANCE_FACTOR_SETTING, value -> this.diskUsageBalanceFactor = value);
-        watchSetting(settings, clusterSettings, THRESHOLD_SETTING, value -> this.threshold = value);
+        watchSetting(settings, clusterSettings, THRESHOLD_SETTING, value -> this.threshold = ensureValidThreshold(value));
         this.writeLoadForecaster = writeLoadForecaster;
     }
 
     private <T> void watchSetting(Settings settings, ClusterSettings clusterSettings, Setting<T> setting, Consumer<T> consumer) {
         consumer.accept(setting.get(settings));
         clusterSettings.addSettingsUpdateConsumer(setting, consumer);
+    }
+
+    /**
+     * Clamp threshold to be at least 1, and log a critical deprecation warning if smaller values are given.
+     *
+     * Once {@link org.elasticsearch.Version#V_7_17_0} goes out of scope, start to properly reject such bad values.
+     */
+    private static float ensureValidThreshold(float threshold) {
+        if (1.0f <= threshold) {
+            return threshold;
+        } else {
+            DeprecationLogger.getLogger(BalancedShardsAllocator.class)
+                .critical(
+                    DeprecationCategory.SETTINGS,
+                    "balance_threshold_too_small",
+                    "ignoring value [{}] for [{}] since it is smaller than 1.0; "
+                        + "setting [{}] to a value smaller than 1.0 will be forbidden in a future release",
+                    threshold,
+                    THRESHOLD_SETTING.getKey(),
+                    THRESHOLD_SETTING.getKey()
+                );
+            return 1.0f;
+        }
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalancedSingleShardTests.java
@@ -298,6 +298,10 @@ public class BalancedSingleShardTests extends ESAllocationTestCase {
                 assertTrue(nodesWithTwoShards.contains(result.getNode().getId()));
             }
         }
+
+        assertCriticalWarnings("""
+            ignoring value [0.01] for [cluster.routing.allocation.balance.threshold] since it is smaller than 1.0; setting \
+            [cluster.routing.allocation.balance.threshold] to a value smaller than 1.0 will be forbidden in a future release""");
     }
 
     private MoveDecision executeRebalanceFor(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -315,6 +315,27 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
         }
     }
 
+    public void testThresholdLimit() {
+        final var badValue = (float) randomDoubleBetween(0.0, Math.nextDown(1.0f), true);
+        assertEquals(
+            1.0f,
+            new BalancedShardsAllocator(Settings.builder().put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), badValue).build())
+                .getThreshold(),
+            0.0f
+        );
+        assertCriticalWarnings("ignoring value [" + badValue + """
+            ] for [cluster.routing.allocation.balance.threshold] since it is smaller than 1.0; setting \
+            [cluster.routing.allocation.balance.threshold] to a value smaller than 1.0 will be forbidden in a future release""");
+
+        final var goodValue = (float) randomDoubleBetween(1.0, 10.0, true);
+        assertEquals(
+            goodValue,
+            new BalancedShardsAllocator(Settings.builder().put(BalancedShardsAllocator.THRESHOLD_SETTING.getKey(), goodValue).build())
+                .getThreshold(),
+            0.0f
+        );
+    }
+
     private Map<String, Integer> getTargetShardPerNodeCount(IndexRoutingTable indexRoutingTable) {
         var counts = new HashMap<String, Integer>();
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {


### PR DESCRIPTION
The balancer can get into a loop if the balance threshold is less than one. With this commit we force the value to be at least one, and emit a deprecation warning about smaller values so they can be properly rejected in a future version.