### PR TITLE
Don't leak ansi console dir handle

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/ConsoleLoader.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/ConsoleLoader.java
@@ -53,9 +53,8 @@ public class ConsoleLoader {
     private static ClassLoader buildClassLoader(Environment env) {
         final Path libDir = env.libFile().resolve("tools").resolve("ansi-console");
 
-        try {
-            final URL[] urls = Files.list(libDir)
-                .filter(each -> each.getFileName().toString().endsWith(".jar"))
+        try (var libDirFilesStream = Files.list(libDir)) {
+            final URL[] urls = libDirFilesStream.filter(each -> each.getFileName().toString().endsWith(".jar"))
                 .map(ConsoleLoader::pathToURL)
                 .toArray(URL[]::new);
 


### PR DESCRIPTION
Mostly harmless, but we should close properly the
directory list file stream, otherwise it leaks the file handle. I found this while investigating an
issue with CRaC/CRIU snapshots.
