### PR TITLE
only return the attribute values of available datanodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -270,7 +270,11 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
     public Set<String> getAttributeValues(String attributeName) {
         return attributeValuesByAttribute.computeIfAbsent(
             attributeName,
-            ignored -> stream().map(r -> r.node().getAttributes().get(attributeName)).filter(Objects::nonNull).collect(Collectors.toSet())
+            ignored -> stream()
+                .filter(r -> r.node().canContainData())
+                .map(r -> r.node().getAttributes().get(attributeName))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toSet())
         );
     }
 


### PR DESCRIPTION
**My cluster is as follows:**
master node：3（zone1: 1，zone2: 1，zone3: 1）
data node：10（zone1: 5，zone2: 5）

**My index is as follows:**
index1: 1 primary + 9 replicas

**My cluster parameters are set as follows:**
"Cluster. routing. allocation. awareness. attributes": "zone" # zone includes zone1, zone2, zone3

According to normal logic, my index should be a shard allocated to each node. In fact, some shards cannot be allocated.

I looked at the processing logic of AwarenssAllocationDecider. In this line of code, I found that it returns the value set of all nodes' zones (zone1, zone2, zone3)

`final Set<String> actualAttributeValues = allocation.routingNodes().getAttributeValues(awarenessAttribute);`

At this time, the length of actualAttributeValues is 3. There is an occasional problem when calculating the maximum number of shards allocated to each node in the following code

shardCount=10
valueCount=3
maximumShardsPerAttributeValue = (10 + 3 - 1) / 3 = 4

```
final List<String> forcedValues = forcedAwarenessAttributes.get(awarenessAttribute);
final int valueCount = forcedValues == null ? actualAttributeValues.size() : Math.toIntExact(Stream.concat(actualAttributeValues.stream(), forcedValues.stream()).distinct().count());

final int maximumShardsPerAttributeValue = (shardCount + valueCount - 1) / valueCount;
```

Therefore, zone3 should be excluded because the dedicated master node cannot store shards