### PR TITLE
[DOCS] Documents how aggregate_metric_double works in datafeeds

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -439,3 +439,12 @@ the `error` field.
 ----------------------------------
 // NOTCONSOLE
 
+
+[discrete]
+[[aggs-amd-dfeeds]]
+== Using `aggregate_metric_double` field type in {dfeeds}
+
+You can use fields with the 
+<<aggregate-metric-double,`aggregate_metric_double`>> field type in a {dfeed} 
+with aggregations. 
+

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -444,7 +444,78 @@ the `error` field.
 [[aggs-amd-dfeeds]]
 == Using `aggregate_metric_double` field type in {dfeeds}
 
+
+NOTE: It is not currently possible to use `aggregate_metric_double` type fields 
+in {dfeeds} without aggregations. 
+
 You can use fields with the 
 <<aggregate-metric-double,`aggregate_metric_double`>> field type in a {dfeed} 
-with aggregations. 
+with aggregations. It is required to retrieve the `value_count` of the 
+`aggregate_metric_double` filed in an aggregation and then use it as the 
+`summary_count_field_name`. In the following example, `presum` is an 
+`aggregate_metric_double` type field that has all the possible metrics: 
+`[ min, max, sum, value_count ]`. 
 
+
+[source,js]
+----------------------------------
+{
+  "analysis_config": {
+    "bucket_span": "1h",
+    "detectors": [
+      {
+        "function": "avg",
+        "field_name": "my_avg"
+      }
+    ],
+    "summary_count_field_name": "my_count" <1>
+  },
+  "data_description": {
+    "time_field": "timestamp"
+  },
+  "datafeed_config": {
+    "indices": [
+      "my_index"
+    ],
+    "datafeed_id": "datafeed-id",
+    "aggregations": {
+      "buckets": {
+        "date_histogram": {
+          "field": "time",
+          "fixed_interval": "360s",
+          "time_zone": "UTC"
+        },
+        "aggregations": {
+            "timestamp": {  
+                "max": {"field": "timestamp"}
+            },
+            "my_avg": {  <2>
+                "avg": {
+                    "field": "presum" 
+                }
+             },
+             "my_count": { <3>
+                 "value_count": {
+                     "field": "presum" 
+                 }
+             }
+          }
+        }
+     }
+  }
+}
+----------------------------------
+// NOTCONSOLE
+
+<1> The field `my_count` is set as the `summary_count_field_name`. This field 
+contains aggregated values from the `presum` `aggregate_metric_double` type 
+field (refer to <3>). 
+<2> The `avg` aggregation to use on the `presum` `aggregate_metric_double` type 
+field. It is required to use the `value_count` aggregation on the `presum` field 
+and then set that aggregated field as the `summary_count_field_name` in the 
+{dfeed} in order to use any other aggregations on a `aggregate_metric_double` 
+type field.
+<3> The `value_count` aggregation on the `presum` `aggregate_metric_double` type 
+field. This aggregated field must be set as the `summary_count_field_name` 
+(refer to <1>) to make it possible to use the `aggregate_metric_double` type 
+field in another aggregation.

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -513,10 +513,10 @@ on `presum` and then set the field that contains the aggregated values
 
 <1> The field `my_count` is set as the `summary_count_field_name`. This field 
 contains aggregated values from the `presum` `aggregate_metric_double` type 
-field (refer to <3>). 
+field (refer to footnote 3). 
 <2> The `avg` aggregation to use on the `presum` `aggregate_metric_double` type 
 field.
 <3> The `value_count` aggregation on the `presum` `aggregate_metric_double` type 
 field. This aggregated field must be set as the `summary_count_field_name` 
-(refer to <1>) to make it possible to use the `aggregate_metric_double` type 
-field in another aggregation.
+(refer to footnote 1) to make it possible to use the `aggregate_metric_double` 
+type field in another aggregation.

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -449,8 +449,8 @@ NOTE: It is not currently possible to use `aggregate_metric_double` type fields
 in {dfeeds} without aggregations. 
 
 You can use fields with the 
-<<aggregate-metric-double,`aggregate_metric_double`>> field type in a {dfeed} 
-with aggregations. It is required to retrieve the `value_count` of the 
+{ref}/aggregate-metric-double.html[`aggregate_metric_double`] field type in a 
+{dfeed} with aggregations. It is required to retrieve the `value_count` of the 
 `aggregate_metric_double` filed in an aggregation and then use it as the 
 `summary_count_field_name`.
 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -452,7 +452,8 @@ You can use fields with the
 {ref}/aggregate-metric-double.html[`aggregate_metric_double`] field type in a 
 {dfeed} with aggregations. It is required to retrieve the `value_count` of the 
 `aggregate_metric_double` filed in an aggregation and then use it as the 
-`summary_count_field_name`.
+`summary_count_field_name` to provide the correct count that represents the 
+aggregation value.
 
 In the following example, `presum` is an `aggregate_metric_double` type field 
 that has all the possible metrics: `[ min, max, sum, value_count ]`. To use an 

--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -452,9 +452,13 @@ You can use fields with the
 <<aggregate-metric-double,`aggregate_metric_double`>> field type in a {dfeed} 
 with aggregations. It is required to retrieve the `value_count` of the 
 `aggregate_metric_double` filed in an aggregation and then use it as the 
-`summary_count_field_name`. In the following example, `presum` is an 
-`aggregate_metric_double` type field that has all the possible metrics: 
-`[ min, max, sum, value_count ]`. 
+`summary_count_field_name`.
+
+In the following example, `presum` is an `aggregate_metric_double` type field 
+that has all the possible metrics: `[ min, max, sum, value_count ]`. To use an 
+`avg` aggregation on this field, you need to perform a `value_count` aggregation 
+on `presum` and then set the field that contains the aggregated values 
+`my_count` as the `summary_count_field_name`: 
 
 
 [source,js]
@@ -511,10 +515,7 @@ with aggregations. It is required to retrieve the `value_count` of the
 contains aggregated values from the `presum` `aggregate_metric_double` type 
 field (refer to <3>). 
 <2> The `avg` aggregation to use on the `presum` `aggregate_metric_double` type 
-field. It is required to use the `value_count` aggregation on the `presum` field 
-and then set that aggregated field as the `summary_count_field_name` in the 
-{dfeed} in order to use any other aggregations on a `aggregate_metric_double` 
-type field.
+field.
 <3> The `value_count` aggregation on the `presum` `aggregate_metric_double` type 
 field. This aggregated field must be set as the `summary_count_field_name` 
 (refer to <1>) to make it possible to use the `aggregate_metric_double` type 


### PR DESCRIPTION
## Overview

This PR explains how `aggregate_metric_double` type fields work in datafeeds.

### Preview

[Using `aggregate_metric_double` field type in datafeeds](https://elasticsearch_92139.docs-preview.app.elstc.co/guide/en/machine-learning/master/ml-configuring-aggregation.html#aggs-amd-dfeeds)