### PR TITLE
[8.6] Update docs for v8.5.3 release (#92135)

### DIFF
--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -32,6 +32,9 @@ Transform::
 Ingest Node::
 * Refactor enrich maintenance coordination logic {es-pull}90931[#90931]
 
+TLS::
+* Support SAN/dnsName for restricted trust {es-pull}91946[#91946]
+
 [[upgrade-8.5.3]]
 [float]
 === Upgrades


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Update docs for v8.5.3 release (#92135)