### PR TITLE
Mute reference/text-structure/apis/find-structure/line_264 for #92141

### DIFF
--- a/docs/reference/text-structure/apis/find-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-structure.asciidoc
@@ -539,7 +539,7 @@ If the request does not encounter errors, you receive the following result:
 }
 ----
 // TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/92141"]
-// TESTRESPONSE[s/"sample_start" : ".*",/"sample_start" : "$body.sample_start",/]
+// original (put back after unmuting)[s/"sample_start" : ".*",/"sample_start" : "$body.sample_start",/]
 // The substitution is because the text is pre-processed by the test harness,
 // so the fields may get reordered in the JSON the endpoint sees
 

--- a/docs/reference/text-structure/apis/find-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-structure.asciidoc
@@ -538,6 +538,7 @@ If the request does not encounter errors, you receive the following result:
   }
 }
 ----
+// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/92141"]
 // TESTRESPONSE[s/"sample_start" : ".*",/"sample_start" : "$body.sample_start",/]
 // The substitution is because the text is pre-processed by the test harness,
 // so the fields may get reordered in the JSON the endpoint sees


### PR DESCRIPTION
Mutes DocsClientYamlTestSuiteIT test {yaml=reference/text-structure/apis/find-structure/line_264} awaiting a fix for https://github.com/elastic/elasticsearch/issues/92141