### PR TITLE
Update `kibana_system` privileges with access to `.apm-source-map`

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -694,30 +694,23 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .indices(".ml-annotations*", ".ml-notifications*")
                     .privileges("read", "write")
                     .build(),
+                    
                 // APM agent configuration - system index defined in KibanaPlugin
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".apm-agent-configuration")
-                    .privileges("all")
-                    .allowRestrictedIndices(true)
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".apm-agent-configuration").privileges("all").allowRestrictedIndices(true).build(),
+                
                 // APM custom link index creation - system index defined in KibanaPlugin
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".apm-custom-link")
-                    .privileges("all")
-                    .allowRestrictedIndices(true)
-                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices(".apm-custom-link").privileges("all").allowRestrictedIndices(true).build(),
+                
                 // APM source map index creation - system index defined in KibanaPlugin                
-                RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".apm-source-map")
-                    .privileges("all")
-                    .allowRestrictedIndices(true)
-                    .build(),                
+                RoleDescriptor.IndicesPrivileges.builder().indices(".apm-source-map").privileges("all").allowRestrictedIndices(true).build(),                
+                
                 // APM telemetry queries APM indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("apm-*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*").privileges("read", "read_cross_cluster").build(),
+                
                 // Data telemetry reads mappings, metadata and stats of indices
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -694,23 +694,35 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .indices(".ml-annotations*", ".ml-notifications*")
                     .privileges("read", "write")
                     .build(),
-                    
+
                 // APM agent configuration - system index defined in KibanaPlugin
-                RoleDescriptor.IndicesPrivileges.builder().indices(".apm-agent-configuration").privileges("all").allowRestrictedIndices(true).build(),
-                
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".apm-agent-configuration")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+
                 // APM custom link index creation - system index defined in KibanaPlugin
-                RoleDescriptor.IndicesPrivileges.builder().indices(".apm-custom-link").privileges("all").allowRestrictedIndices(true).build(),
-                
-                // APM source map index creation - system index defined in KibanaPlugin                
-                RoleDescriptor.IndicesPrivileges.builder().indices(".apm-source-map").privileges("all").allowRestrictedIndices(true).build(),                
-                
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".apm-custom-link")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+
+                // APM source map index creation - system index defined in KibanaPlugin
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".apm-source-map")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),
+
                 // APM telemetry queries APM indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("apm-*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("metrics-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm.*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("traces-apm-*").privileges("read", "read_cross_cluster").build(),
-                
+
                 // Data telemetry reads mappings, metadata and stats of indices
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -706,6 +706,12 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .privileges("all")
                     .allowRestrictedIndices(true)
                     .build(),
+                // APM source map index creation - system index defined in KibanaPlugin                
+                RoleDescriptor.IndicesPrivileges.builder()
+                    .indices(".apm-source-map")
+                    .privileges("all")
+                    .allowRestrictedIndices(true)
+                    .build(),                
                 // APM telemetry queries APM indices in kibana task runner
                 RoleDescriptor.IndicesPrivileges.builder().indices("apm-*").privileges("read", "read_cross_cluster").build(),
                 RoleDescriptor.IndicesPrivileges.builder().indices("logs-apm.*").privileges("read", "read_cross_cluster").build(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -565,6 +565,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
             ".reporting-" + randomAlphaOfLength(randomIntBetween(0, 13)),
             ".apm-agent-configuration",
             ".apm-custom-link",
+            ".apm-source-map",
             ReservedRolesStore.ALERTS_LEGACY_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.ALERTS_BACKING_INDEX + randomAlphaOfLength(randomIntBetween(0, 13)),
             ReservedRolesStore.ALERTS_INDEX_ALIAS + randomAlphaOfLength(randomIntBetween(0, 13)),


### PR DESCRIPTION
In https://github.com/elastic/kibana/issues/146367 Kibana will create a system index `.apm-source-map` at startup. All access to the index (creation, indexing, reading) will happen through the system user (`kibana_system`).  `kibana_system` already has access to `.apm-agent-configuration` and `.apm-custom-link`. Following this pattern the role should also be granted access to `.apm-source-map`.