### PR TITLE
Start fulfilling-cluster task for the querying-cluster task

### DIFF
--- a/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
@@ -53,8 +54,20 @@ tasks.register('fulfilling-cluster', RestIntegTestTask) {
   systemProperty 'tests.rest.suite', 'fulfilling_cluster'
 }
 
+// the following task is needed to make sure the fulfilling cluster is running before the querying cluster
+// gets configured with the fulfilling cluster seed
+tasks.register('startFulfillingCluster', DefaultTestClustersTask) {
+  useCluster fulfillingCluster
+  doLast {
+    clusters.each { c ->
+      print "Fulfilling cluster transport uri for ccs configuration is: "
+      println c.getAllTransportPortURI().get(0)
+    }
+  }
+}
+
 tasks.register('querying-cluster', RestIntegTestTask) {
-  dependsOn 'fulfilling-cluster'
+  dependsOn 'startFulfillingCluster'
   useCluster queryingCluster
   useCluster fulfillingCluster
   systemProperty 'tests.rest.suite', 'querying_cluster'

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-basic-license/build.gradle
@@ -68,8 +68,8 @@ tasks.register('startFulfillingCluster', DefaultTestClustersTask) {
 
 tasks.register('querying-cluster', RestIntegTestTask) {
   dependsOn 'startFulfillingCluster'
-  useCluster queryingCluster
   useCluster fulfillingCluster
+  useCluster queryingCluster
   systemProperty 'tests.rest.suite', 'querying_cluster'
   if (proxyMode) {
     systemProperty 'tests.rest.blacklist', [

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-full-license/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
@@ -53,10 +54,22 @@ tasks.register('fulfilling-cluster', RestIntegTestTask) {
   systemProperty 'tests.rest.suite', 'fulfilling_cluster'
 }
 
-tasks.register('querying-cluster', RestIntegTestTask) {
-  dependsOn 'fulfilling-cluster'
-  useCluster queryingCluster
+// the following task is needed to make sure the fulfilling cluster is running before the querying cluster
+// gets configured with the fulfilling cluster seed
+tasks.register('startFulfillingCluster', DefaultTestClustersTask) {
   useCluster fulfillingCluster
+  doLast {
+    clusters.each { c ->
+      print "Fulfilling cluster transport uri for ccs configuration is: "
+      println c.getAllTransportPortURI().get(0)
+    }
+  }
+}
+
+tasks.register('querying-cluster', RestIntegTestTask) {
+  dependsOn 'startFulfillingCluster'
+  useCluster fulfillingCluster
+  useCluster queryingCluster
   systemProperty 'tests.rest.suite', 'querying_cluster'
 }
 

--- a/x-pack/qa/multi-cluster-search-security/legacy-with-restricted-trust/build.gradle
+++ b/x-pack/qa/multi-cluster-search-security/legacy-with-restricted-trust/build.gradle
@@ -1,5 +1,6 @@
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.internal.test.RestIntegTestTask
+import org.elasticsearch.gradle.testclusters.DefaultTestClustersTask
 
 apply plugin: 'elasticsearch.standalone-rest-test'
 apply plugin: 'elasticsearch.rest-resources'
@@ -77,11 +78,23 @@ tasks.register('fulfilling-cluster', RestIntegTestTask) {
   systemProperty 'tests.rest.suite', 'fulfilling_cluster'
 }
 
+// the following task is needed to make sure the fulfilling cluster is running before the querying cluster
+// gets configured with the fulfilling cluster seed
+tasks.register('startFulfillingCluster', DefaultTestClustersTask) {
+  useCluster fulfillingCluster
+  doLast {
+    clusters.each { c ->
+      print "Fulfilling cluster transport uri for ccs configuration is: "
+      println c.getAllTransportPortURI().get(0)
+    }
+  }
+}
+
 tasks.register('querying-cluster', RestIntegTestTask) {
   dependsOn 'copyCerts'
-  dependsOn 'fulfilling-cluster'
-  useCluster queryingCluster
+  dependsOn 'startFulfillingCluster'
   useCluster fulfillingCluster
+  useCluster queryingCluster
   systemProperty 'tests.rest.suite', 'querying_cluster'
 }
 


### PR DESCRIPTION
The `querying-cluster` test cluster requires the `fulfilling-cluster` test cluster to be already starting when it itself starts.
Having both clusters specified by a task's `useCluster` property is not enough to express this dependency.
Also, expressing this dependency via a task dependency where the depended-upon task (i.e. `fulfilling-cluster`) uses the depended-upon test cluster sometimes works, but it doesn't work when the depended-upon task is not executed because it is "UP-TO-DATE".

This PR introduces an explicit task to start the `fulfilling-cluster` test cluster when only the `querying-cluster` task is executed.

Without this PR, subsequent invocations of `./gradlew ':x-pack:qa:multi-cluster-search-security:legacy-with-basic-license:querying-cluster' --tests "org.elasticsearch.xpack.security.MultiClusterSearchWithSecurityYamlTestSuiteIT.test {yaml=querying_cluster/10_basic/Search an filtered alias on the remote cluster}" -Dtests.seed=B4A0F28E6AA1D471` error with:
```
Execution failed for task ':x-pack:qa:multi-cluster-search-security:legacy-with-basic-license:querying-cluster'.
> Error while evaluating property 'clusters.querying-cluster$1.nodes.$0.settings.cluster.remote.my_remote_cluster.proxy_address$4.value' of task ':x-pack:qa:multi-cluster-search-security:legacy-with-basic-license:querying-cluster'
   > Can't wait for `node{:x-pack:qa:multi-cluster-search-security:legacy-with-basic-license:fulfilling-cluster-0}` as it's not started. Does the task have `useCluster` ?
```
