### PR TITLE
Make the cranky circuit breaker easier to reuse

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/MockBigArrays.java
@@ -50,6 +50,11 @@ public class MockBigArrays extends BigArrays {
     private static final Logger logger = LogManager.getLogger(MockBigArrays.class);
 
     /**
+     * Error message thrown by {@link BigArrays} produced with {@link MockBigArrays#MockBigArrays(PageCacheRecycler, ByteSizeValue)}.
+     */
+    public static final String ERROR_MESSAGE = "over test limit";
+
+    /**
      * Assert that a function returning a {@link Releasable} runs to completion
      * when allocated a breaker with that breaks when it uses more than {@code max}
      * bytes <strong>and</strong> that the function doesn't leak any
@@ -667,7 +672,7 @@ public class MockBigArrays extends BigArrays {
         public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
             long total = used.addAndGet(bytes);
             if (total > max.getBytes()) {
-                throw new CircuitBreakingException("test error", bytes, max.getBytes(), Durability.TRANSIENT);
+                throw new CircuitBreakingException(ERROR_MESSAGE, bytes, max.getBytes(), Durability.TRANSIENT);
             }
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/indices/CrankyCircuitBreakerService.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/CrankyCircuitBreakerService.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices;
+
+import org.elasticsearch.common.breaker.CircuitBreaker;
+import org.elasticsearch.common.breaker.CircuitBreakingException;
+import org.elasticsearch.indices.breaker.AllCircuitBreakerStats;
+import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.breaker.CircuitBreakerStats;
+import org.elasticsearch.test.ESTestCase;
+
+/**
+ * {@link CircuitBreakerService} that fails every 20th time you add bytes. This
+ * is useful to make sure code responds sensibly to circuit breaks at unpredictable
+ * times.
+ */
+public class CrankyCircuitBreakerService extends CircuitBreakerService {
+    /**
+     * Error message thrown when the breaker randomly trips.
+     */
+    public static final String ERROR_MESSAGE = "cranky breaker";
+
+    private final CircuitBreaker breaker = new CircuitBreaker() {
+        @Override
+        public void circuitBreak(String fieldName, long bytesNeeded) {
+
+        }
+
+        @Override
+        public void addEstimateBytesAndMaybeBreak(long bytes, String label) throws CircuitBreakingException {
+            if (ESTestCase.random().nextInt(20) == 0) {
+                throw new CircuitBreakingException(ERROR_MESSAGE, Durability.PERMANENT);
+            }
+        }
+
+        @Override
+        public void addWithoutBreaking(long bytes) {
+
+        }
+
+        @Override
+        public long getUsed() {
+            return 0;
+        }
+
+        @Override
+        public long getLimit() {
+            return 0;
+        }
+
+        @Override
+        public double getOverhead() {
+            return 0;
+        }
+
+        @Override
+        public long getTrippedCount() {
+            return 0;
+        }
+
+        @Override
+        public String getName() {
+            return CircuitBreaker.FIELDDATA;
+        }
+
+        @Override
+        public Durability getDurability() {
+            return null;
+        }
+
+        @Override
+        public void setLimitAndOverhead(long limit, double overhead) {
+
+        }
+    };
+
+    @Override
+    public CircuitBreaker getBreaker(String name) {
+        return breaker;
+    }
+
+    @Override
+    public AllCircuitBreakerStats stats() {
+        return new AllCircuitBreakerStats(new CircuitBreakerStats[] { stats(CircuitBreaker.FIELDDATA) });
+    }
+
+    @Override
+    public CircuitBreakerStats stats(String name) {
+        return new CircuitBreakerStats(CircuitBreaker.FIELDDATA, -1, -1, 0, 0);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/indices/CrankyCircuitBreakerService.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/CrankyCircuitBreakerService.java
@@ -16,9 +16,9 @@ import org.elasticsearch.indices.breaker.CircuitBreakerStats;
 import org.elasticsearch.test.ESTestCase;
 
 /**
- * {@link CircuitBreakerService} that fails every 20th time you add bytes. This
- * is useful to make sure code responds sensibly to circuit breaks at unpredictable
- * times.
+ * {@link CircuitBreakerService} that fails one twentieth of the time when you
+ * add bytes. This is useful to make sure code responds sensibly to circuit
+ * breaks at unpredictable times.
  */
 public class CrankyCircuitBreakerService extends CircuitBreakerService {
     /**

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregatorTests.java
@@ -435,7 +435,7 @@ public class TopMetricsAggregatorTests extends AggregatorTestCase {
                         }
                     }
                     CircuitBreakingException e = expectThrows(CircuitBreakingException.class, () -> leaf.collect(0, bucketThatBreaks));
-                    assertThat(e.getMessage(), equalTo("test error"));
+                    assertThat(e.getMessage(), equalTo(MockBigArrays.ERROR_MESSAGE));
                     assertThat(e.getByteLimit(), equalTo(max.getBytes()));
                     assertThat(e.getBytesWanted(), equalTo(5872L));
                 }


### PR DESCRIPTION
This moves the `CrankyCircuitBreaker` into a top level class and documents it so it can be used outside of testing `Aggregator`s. It really is generally useful. It also makes constansts for the error messages it throws. And for the error message thrown by `MockBigArrays`. Just so it's easier to know which one throw what exception.
