### PR TITLE
[Test] Avoid randomly generating one of the registered claim names

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtStringClaimValidatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/jwt/JwtStringClaimValidatorTests.java
@@ -36,7 +36,10 @@ public class JwtStringClaimValidatorTests extends ESTestCase {
     }
 
     public void testClaimIsNotSingleValued() throws ParseException {
-        final String claimName = randomAlphaOfLengthBetween(3, 8);
+        final String claimName = randomValueOtherThanMany(
+            name -> JWTClaimsSet.getRegisteredNames().contains(name),
+            () -> randomAlphaOfLengthBetween(3, 8)
+        );
         final JwtStringClaimValidator validator = new JwtStringClaimValidator(claimName, List.of(), true);
 
         final JWTClaimsSet jwtClaimsSet = JWTClaimsSet.parse(Map.of(claimName, List.of("foo", "bar")));


### PR DESCRIPTION
We were randomly generating a claim name which could end up being one of the registered claim names (e.g. `sub`) and cause the test to fail before invoking the `JwtStringClaimValidator`.

Fixes #92184