### PR TITLE
[8.6] Make adding auth info to REST responses more robust (#92168)

### DIFF
--- a/docs/changelog/92168.yaml
+++ b/docs/changelog/92168.yaml
@@ -1,0 +1,5 @@
+pr: 92168
+summary: Make adding auth info to REST responses more robust
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/AuthenticationContextSerializer.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/AuthenticationContextSerializer.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.authc.support;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -22,6 +24,8 @@ import java.util.Base64;
  * {@link org.elasticsearch.common.util.concurrent.ThreadContext} under a specified key
  */
 public class AuthenticationContextSerializer {
+
+    private static final Logger logger = LogManager.getLogger(AuthenticationContextSerializer.class);
 
     private final String contextKey;
 
@@ -57,11 +61,16 @@ public class AuthenticationContextSerializer {
     }
 
     public static Authentication decode(String header) throws IOException {
-        byte[] bytes = Base64.getDecoder().decode(header);
-        StreamInput input = StreamInput.wrap(bytes);
-        Version version = Version.readVersion(input);
-        input.setVersion(version);
-        return new Authentication(input);
+        try {
+            byte[] bytes = Base64.getDecoder().decode(header);
+            StreamInput input = StreamInput.wrap(bytes);
+            Version version = Version.readVersion(input);
+            input.setVersion(version);
+            return new Authentication(input);
+        } catch (IOException | RuntimeException e) {
+            logger.warn("Failed to decode authentication [" + header + "]", e);
+            throw e;
+        }
     }
 
     public Authentication getAuthentication(ThreadContext context) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/xcontent/XContentUtilsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/xcontent/XContentUtilsTests.java
@@ -67,6 +67,11 @@ public class XContentUtilsTests extends ESTestCase {
         assertThat(json, equalTo("{\"authorization\":{\"service_account\":\"" + account + "\"}}"));
     }
 
+    public void testAddAuthorizationInfoWithCorruptData() throws IOException {
+        String json = generateJson(Map.of(AuthenticationField.AUTHENTICATION_KEY, "corrupt"));
+        assertThat(json, equalTo("{}"));
+    }
+
     private String generateJson(Map<String, String> headers) throws IOException {
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Make adding auth info to REST responses more robust (#92168)