### PR TITLE
[ML] Adjust more BWC constants

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -312,7 +312,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public Response(StreamInput in) throws IOException {
             super(in);
             results = in.readNamedWriteable(InferenceResults.class);
-            if (in.getVersion().onOrAfter(Version.V_8_6_0)) {
+            if (in.getVersion().onOrAfter(Version.V_8_7_0)) {
                 tookMillis = in.readVLong();
             }
         }
@@ -329,7 +329,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeNamedWriteable(results);
-            if (out.getVersion().onOrAfter(Version.V_8_6_0)) {
+            if (out.getVersion().onOrAfter(Version.V_8_7_0)) {
                 out.writeVLong(tookMillis);
             }
         }


### PR DESCRIPTION
When semantic search was backed out in #92105 the
`tookMillis` field was removed from 8.6. But the
8.6 BWC constants for `tookMillis` were not changed in #92157. This change corrects that discrepancy.