### PR TITLE
[7.17] 90630: Fix links to Apache HTTP Client doc (#92174)

### DIFF
--- a/docs/java-rest/low-level/configuration.asciidoc
+++ b/docs/java-rest/low-level/configuration.asciidoc
@@ -14,7 +14,7 @@ additional configuration for the low-level Java REST Client.
 Configuring requests timeouts can be done by providing an instance of
 `RequestConfigCallback` while building the `RestClient` through its builder.
 The interface has one method that receives an instance of
-https://hc.apache.org/httpcomponents-client-ga/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html[`org.apache.http.client.config.RequestConfig.Builder`]
+https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html[`org.apache.http.client.config.RequestConfig.Builder`]
  as an argument and has the same return type. The request config builder can
 be modified and then returned. In the following example we increase the
 connect timeout (defaults to 1 second) and the socket timeout (defaults to 30
@@ -50,7 +50,7 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-config-thre
 Configuring basic authentication can be done by providing an
 `HttpClientConfigCallback` while building the `RestClient` through its builder.
 The interface has one method that receives an instance of
-https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html[`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`]
+https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html[`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`]
  as an argument and has the same return type. The http client builder can be
 modified and then returned. In the following example we set a default
 credentials provider that requires basic authentication.
@@ -99,7 +99,7 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-auth-api-ke
 
 Encrypted communication using TLS can also be configured through the
 `HttpClientConfigCallback`. The
-https://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html[`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`]
+https://hc.apache.org/httpcomponents-asyncclient-4.1.x/current/httpasyncclient/apidocs/org/apache/http/impl/nio/client/HttpAsyncClientBuilder.html[`org.apache.http.impl.nio.client.HttpAsyncClientBuilder`]
  received as an argument exposes multiple methods to configure encrypted
  communication: `setSSLContext`, `setSSLSessionStrategy` and
  `setConnectionManager`, in order of precedence from the least important.

--- a/docs/java-rest/low-level/usage.asciidoc
+++ b/docs/java-rest/low-level/usage.asciidoc
@@ -57,7 +57,7 @@ dependencies {
 === Dependencies
 
 The low-level Java REST client internally uses the
-https://hc.apache.org/httpcomponents-asyncclient-dev/[Apache Http Async Client]
+https://hc.apache.org/httpcomponents-asyncclient-4.1.x/[Apache Http Async Client]
  to send http requests. It depends on the following artifacts, namely the async
  http client and its own transitive dependencies:
 
@@ -152,7 +152,7 @@ A `RestClient` instance can be built through the corresponding
 `RestClientBuilder` class, created via `RestClient#builder(HttpHost...)`
 static method. The only required argument is one or more hosts that the
 client will communicate with, provided as instances of
-https://hc.apache.org/httpcomponents-core-5.2.x/current/httpcore5/apidocs/org/apache/hc/core5/http/HttpHost.html[HttpHost]
+https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpHost.html[HttpHost]
  as follows:
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -203,7 +203,7 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-init-reques
 --------------------------------------------------
 <1> Set a callback that allows to modify the default request configuration
 (e.g. request timeouts, authentication, or anything that the
-https://hc.apache.org/httpcomponents-client-5.2.x/current/httpclient5/apidocs/org/apache/hc/client5/http/config/RequestConfig.Builder.html[`org.apache.hc.client5.http.config.RequestConfig.Builder`]
+https://hc.apache.org/httpcomponents-client-4.5.x/current/httpclient/apidocs/org/apache/http/client/config/RequestConfig.Builder.html[`org.apache.http.client.config.RequestConfig.Builder`]
  allows to set)
 
 ["source","java",subs="attributes,callouts,macros"]
@@ -366,7 +366,7 @@ include-tagged::{doc-tests}/RestClientDocumentation.java[rest-client-response2]
 <2> The host that returned the response
 <3> The response status line, from which you can for instance retrieve the status code
 <4> The response headers, which can also be retrieved by name though `getHeader(String)`
-<5> The response body enclosed in an https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/HttpEntity.html[`org.apache.http.HttpEntity`]
+<5> The response body enclosed in an https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpEntity.html[`org.apache.http.HttpEntity`]
  object
 
 When performing a request, an exception is thrown (or received as an argument
@@ -395,13 +395,13 @@ and un-marshalling. Users are free to use the library that they prefer for that
 purpose.
 
 The underlying Apache Async Http Client ships with different
-https://hc.apache.org/httpcomponents-core-ga/httpcore/apidocs/org/apache/http/HttpEntity.html[`org.apache.http.HttpEntity`]
+https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore/apidocs/org/apache/http/HttpEntity.html[`org.apache.http.HttpEntity`]
  implementations that allow to provide the request body in different formats
 (stream, byte array, string etc.). As for reading the response body, the
 `HttpEntity#getContent` method comes handy which returns an `InputStream`
 reading from the previously buffered response body. As an alternative, it is
 possible to provide a custom
-https://hc.apache.org/httpcomponents-core-ga/httpcore-nio/apidocs/org/apache/http/nio/protocol/HttpAsyncResponseConsumer.html[`org.apache.http.nio.protocol.HttpAsyncResponseConsumer`]
+https://hc.apache.org/httpcomponents-core-4.4.x/current/httpcore-nio/apidocs/org/apache/http/nio/protocol/HttpAsyncResponseConsumer.html[`org.apache.http.nio.protocol.HttpAsyncResponseConsumer`]
  that controls how bytes are read and buffered.
 
 [[java-rest-low-usage-logging]]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [90630: Fix links to Apache HTTP Client doc (#92174)](https://github.com/elastic/elasticsearch/pull/92174)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)