### PR TITLE
[8.5] mute snapshot based recovery (#91847)

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
@@ -40,6 +40,7 @@ import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class SnapshotBasedRecoveryIT extends AbstractRollingTestCase {
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91383")
     public void testSnapshotBasedRecovery() throws Exception {
         final String indexName = "snapshot_based_recovery";
         final String repositoryName = "snapshot_based_recovery_repo";


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [mute snapshot based recovery (#91847)](https://github.com/elastic/elasticsearch/pull/91847)

Mute for https://github.com/elastic/elasticsearch/issues/91383