### PR TITLE
Introduce Iterators#flatMap

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
-import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -88,6 +87,10 @@ public class SnapshotsStatusResponse extends ActionResponse implements ChunkedTo
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return ChunkedToXContentHelper.array("snapshots", Iterators.flatMap(snapshots.iterator(), s -> s.toXContentChunked(params)));
+        return Iterators.<ToXContent>concat(
+            Iterators.single((b, p) -> b.startObject().startArray("snapshots")),
+            Iterators.flatMap(snapshots.iterator(), s -> s.toXContentChunked(params)),
+            Iterators.single((b, p) -> b.endArray().endObject())
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -22,9 +23,6 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
@@ -90,14 +88,6 @@ public class SnapshotsStatusResponse extends ActionResponse implements ChunkedTo
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        return Iterators.concat(
-            Iterators.single((ToXContent) (b, p) -> b.startObject().startArray("snapshots")),
-            snapshots.stream()
-                .flatMap(
-                    s -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(s.toXContentChunked(params), Spliterator.ORDERED), false)
-                )
-                .iterator(),
-            Iterators.single((b, p) -> b.endArray().endObject())
-        );
+        return ChunkedToXContentHelper.array("snapshots", Iterators.flatMap(snapshots.iterator(), s -> s.toXContentChunked(params)));
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexGraveyard.java
@@ -127,7 +127,7 @@ public final class IndexGraveyard implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params ignored) {
-        return ChunkedToXContentHelper.array(TOMBSTONES_FIELD.getPreferredName(), tombstones);
+        return ChunkedToXContentHelper.array(TOMBSTONES_FIELD.getPreferredName(), tombstones.iterator());
     }
 
     public static IndexGraveyard fromXContent(final XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -75,8 +75,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.SortedMap;
-import java.util.Spliterator;
-import java.util.Spliterators;
 import java.util.TreeMap;
 import java.util.function.BiPredicate;
 import java.util.function.Consumer;
@@ -84,7 +82,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.cluster.metadata.LifecycleExecutionState.ILM_CUSTOM_METADATA_KEY;
 import static org.elasticsearch.common.settings.Settings.readSettingsFromStream;
@@ -1340,7 +1337,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
             ? ChunkedToXContentHelper.wrapWithObject("indices", indices().values().iterator())
             : Collections.emptyIterator();
 
-        return Iterators.concat(start, Iterators.single((builder, params) -> {
+        return Iterators.concat(start, Iterators.<ToXContent>single((builder, params) -> {
             builder.field("cluster_uuid", clusterUUID);
             builder.field("cluster_uuid_committed", clusterUUIDCommitted);
             builder.startObject("cluster_coordination");
@@ -1362,17 +1359,12 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
                     .iterator()
             ),
             indices,
-            customs().entrySet()
-                .stream()
-                .filter(cursor -> cursor.getValue().context().contains(context))
-                .map(
-                    cursor -> (ChunkedToXContent) params -> ChunkedToXContentHelper.wrapWithObject(
-                        cursor.getKey(),
-                        cursor.getValue().toXContentChunked(params)
-                    )
-                )
-                .flatMap(s -> StreamSupport.stream(Spliterators.spliteratorUnknownSize(s.toXContentChunked(p), Spliterator.ORDERED), false))
-                .iterator(),
+            Iterators.flatMap(
+                customs.entrySet().iterator(),
+                entry -> entry.getValue().context().contains(context)
+                    ? ChunkedToXContentHelper.wrapWithObject(entry.getKey(), entry.getValue().toXContentChunked(p))
+                    : Collections.emptyIterator()
+            ),
             ChunkedToXContentHelper.wrapWithObject("reserved_state", reservedStateMetadata().values().iterator()),
             ChunkedToXContentHelper.endObject()
         );

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentHelper.java
@@ -62,8 +62,8 @@ public enum ChunkedToXContentHelper {
         return Iterators.single(((builder, params) -> builder.field(name, value)));
     }
 
-    public static Iterator<ToXContent> array(String name, Iterable<? extends ToXContent> iterable) {
-        return Iterators.concat(ChunkedToXContentHelper.startArray(name), iterable.iterator(), ChunkedToXContentHelper.endArray());
+    public static Iterator<ToXContent> array(String name, Iterator<? extends ToXContent> contents) {
+        return Iterators.concat(ChunkedToXContentHelper.startArray(name), contents, ChunkedToXContentHelper.endArray());
     }
 
     public static <T extends ToXContent> Iterator<ToXContent> wrapWithObject(String name, Iterator<T> iterator) {

--- a/server/src/main/java/org/elasticsearch/health/Diagnosis.java
+++ b/server/src/main/java/org/elasticsearch/health/Diagnosis.java
@@ -11,6 +11,7 @@ package org.elasticsearch.health;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -19,9 +20,6 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.health.HealthService.HEALTH_API_ID_PREFIX;
 
@@ -78,7 +76,7 @@ public record Diagnosis(Definition definition, @Nullable List<Resource> affected
 
         @Override
         public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
-            Iterator<? extends ToXContent> valuesIterator;
+            final Iterator<? extends ToXContent> valuesIterator;
             if (nodes != null) {
                 valuesIterator = nodes.stream().map(node -> (ToXContent) (builder, params) -> {
                     builder.startObject();
@@ -92,11 +90,7 @@ public record Diagnosis(Definition definition, @Nullable List<Resource> affected
             } else {
                 valuesIterator = values.stream().map(value -> (ToXContent) (builder, params) -> builder.value(value)).iterator();
             }
-            return Iterators.concat(
-                Iterators.single((ToXContent) (builder, params) -> builder.startArray(type.displayValue)),
-                valuesIterator,
-                Iterators.single((builder, params) -> builder.endArray())
-            );
+            return ChunkedToXContentHelper.array(type.displayValue, valuesIterator);
         }
 
         @Override
@@ -148,16 +142,11 @@ public record Diagnosis(Definition definition, @Nullable List<Resource> affected
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
-        Iterator<? extends ToXContent> resourcesIterator = Collections.emptyIterator();
-        if (affectedResources != null && affectedResources.size() > 0) {
-            resourcesIterator = affectedResources.stream()
-                .flatMap(
-                    s -> StreamSupport.stream(
-                        Spliterators.spliteratorUnknownSize(s.toXContentChunked(outerParams), Spliterator.ORDERED),
-                        false
-                    )
-                )
-                .iterator();
+        final Iterator<? extends ToXContent> resourcesIterator;
+        if (affectedResources == null) {
+            resourcesIterator = Collections.emptyIterator();
+        } else {
+            resourcesIterator = Iterators.flatMap(affectedResources.iterator(), s -> s.toXContentChunked(outerParams));
         }
         return Iterators.concat(Iterators.single((ToXContent) (builder, params) -> {
             builder.startObject();

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
@@ -15,9 +15,6 @@ import org.elasticsearch.xcontent.ToXContent;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Spliterator;
-import java.util.Spliterators;
-import java.util.stream.StreamSupport;
 
 public record HealthIndicatorResult(
     String name,
@@ -29,16 +26,11 @@ public record HealthIndicatorResult(
 ) implements ChunkedToXContent {
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
-        Iterator<? extends ToXContent> diagnosisIterator = Collections.emptyIterator();
-        if (diagnosisList != null && diagnosisList.isEmpty() == false) {
-            diagnosisIterator = diagnosisList.stream()
-                .flatMap(
-                    s -> StreamSupport.stream(
-                        Spliterators.spliteratorUnknownSize(s.toXContentChunked(outerParams), Spliterator.ORDERED),
-                        false
-                    )
-                )
-                .iterator();
+        final Iterator<? extends ToXContent> diagnosisIterator;
+        if (diagnosisList.isEmpty()) {
+            diagnosisIterator = Collections.emptyIterator();
+        } else {
+            diagnosisIterator = Iterators.flatMap(diagnosisList.iterator(), s -> s.toXContentChunked(outerParams));
         }
         return Iterators.concat(Iterators.single((ToXContent) (builder, params) -> {
             builder.startObject();

--- a/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
+++ b/server/src/main/java/org/elasticsearch/health/HealthIndicatorResult.java
@@ -27,7 +27,7 @@ public record HealthIndicatorResult(
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
         final Iterator<? extends ToXContent> diagnosisIterator;
-        if (diagnosisList.isEmpty()) {
+        if (diagnosisList == null) {
             diagnosisIterator = Collections.emptyIterator();
         } else {
             diagnosisIterator = Iterators.flatMap(diagnosisList.iterator(), s -> s.toXContentChunked(outerParams));

--- a/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestMetadata.java
@@ -98,7 +98,7 @@ public final class IngestMetadata implements Metadata.Custom {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params ignored) {
-        return ChunkedToXContentHelper.array(PIPELINES_FIELD.getPreferredName(), pipelines.values());
+        return ChunkedToXContentHelper.array(PIPELINES_FIELD.getPreferredName(), pipelines.values().iterator());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -558,7 +558,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params ignored) {
         return Iterators.concat(
             Iterators.single((builder, params) -> builder.field("last_allocation_id", lastAllocationId)),
-            ChunkedToXContentHelper.array("tasks", tasks.values())
+            ChunkedToXContentHelper.array("tasks", tasks.values().iterator())
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/collect/IteratorsTests.java
@@ -18,6 +18,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
 
 public class IteratorsTests extends ESTestCase {
     public void testConcatentation() {
@@ -151,6 +152,35 @@ public class IteratorsTests extends ESTestCase {
 
     public void testArrayIteratorOnNull() {
         expectThrows(NullPointerException.class, "Unable to iterate over a null array", () -> Iterators.forArray(null));
+    }
+
+    public void testFlatMap() {
+        final var array = randomIntegerArray();
+        assertEmptyIterator(Iterators.flatMap(Iterators.forArray(array), i -> Iterators.concat()));
+        assertEmptyIterator(Iterators.flatMap(Iterators.concat(), i -> Iterators.single("foo")));
+
+        final var index = new AtomicInteger();
+        Iterators.flatMap(Iterators.forArray(array), Iterators::single)
+            .forEachRemaining(i -> assertEquals(array[index.getAndIncrement()], i));
+        assertEquals(array.length, index.get());
+
+        index.set(0);
+        Iterators.flatMap(Iterators.forArray(array), i -> Iterators.forArray(new Integer[] { i, i, i }))
+            .forEachRemaining(i -> assertEquals(array[(index.getAndIncrement() / 3)], i));
+        assertEquals(array.length * 3, index.get());
+
+        final var input = new ArrayList<>();
+        for (int i = 1; i <= 4; i++) {
+            IntStream.range(0, between(0, 2)).forEachOrdered(ignored -> input.add(0));
+            input.add(i);
+            IntStream.range(0, between(0, 2)).forEachOrdered(ignored -> input.add(0));
+        }
+
+        index.set(0);
+        final var expectedArray = new Integer[] { 0, 0, 1, 0, 1, 2, 0, 1, 2, 3 };
+        Iterators.flatMap(input.listIterator(), i -> IntStream.range(0, (int) i).iterator())
+            .forEachRemaining(i -> assertEquals(expectedArray[(index.getAndIncrement())], i));
+        assertEquals(expectedArray.length, index.get());
     }
 
     private static Integer[] randomIntegerArray() {


### PR DESCRIPTION
Various places that implement response chunking involving some kind of nested structure (e.g. a list of lists) need to call something like `flatMap`, and today this means they must must convert between iterators and streams to make use of `Stream#flatMap`. This is noisy and awkward, so with this commit we introduce a way to `flatMap` directly on iterators.

Relates #89838