### PR TITLE
[ML] Validate rule filters are present on open anomaly detection api

### DIFF
--- a/docs/changelog/92207.yaml
+++ b/docs/changelog/92207.yaml
@@ -1,0 +1,5 @@
+pr: 92207
+summary: Validate rule filters are present on open anomaly detection api
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/qa/ml-with-security/build.gradle
+++ b/x-pack/plugin/ml/qa/ml-with-security/build.gradle
@@ -185,6 +185,7 @@ tasks.named("yamlRestTest").configure {
     'ml/jobs_crud/Test put job with time field in analysis_config',
     'ml/jobs_crud/Test put job with duplicate detector configurations',
     'ml/jobs_crud/Test job with categorization_analyzer and categorization_filters',
+    'ml/jobs_crud/Test job with rule referencing missing filter',
     'ml/jobs_get/Test get job given missing job_id',
     'ml/jobs_get_result_buckets/Test mutually-exclusive params',
     'ml/jobs_get_result_buckets/Test mutually-exclusive params via body',

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/jobs_crud.yml
@@ -1670,3 +1670,35 @@
           {
             "allow_no_match" : true
           }
+
+---
+"Test job with rule referencing missing filter":
+
+  - do:
+      ml.put_job:
+        job_id: jobs-crud-rule-missing-filter
+        body:  >
+          {
+            "analysis_config": {
+              "detectors": [
+                {
+                  "function": "count",
+                  "by_field_name": "country",
+                  "custom_rules": [
+                    {
+                      "actions": ["skip_result"],
+                      "scope": {
+                        "country": {"filter_id": "safe_countries"}
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            "data_description" : {}
+          }
+
+  - do:
+      catch: /Unable to find filter \[safe_countries\]/
+      ml.open_job:
+        job_id: jobs-crud-rule-missing-filter


### PR DESCRIPTION
When an anomaly detection job is opened and it is refererring a rule filter that is missing, the open action reports successful but the job goes to `failed` state immediately without explaining what the reason was.

This commit improves this behavior by validating that referenced filters are present when the open action is called. If there is a missing filter then an error is returned and the job is not opened.
