### PR TITLE
[8.6] Refactor enrich maintenance coordination logic (#90931)

### DIFF
--- a/docs/changelog/90931.yaml
+++ b/docs/changelog/90931.yaml
@@ -1,0 +1,5 @@
+pr: 90931
+summary: Refactor enrich maintenance coordination logic
+area: Ingest Node
+type: enhancement
+issues: []

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyLocks.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyLocks.java
@@ -7,12 +7,12 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.Releasable;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * A coordination object that allows multiple distinct polices to be executed concurrently, but also makes sure that a single
@@ -23,28 +23,36 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class EnrichPolicyLocks {
 
     /**
-     * A snapshot in time detailing if any policy executions are in flight and total number of local executions that
-     * have been kicked off since the node has started
+     * An instance of a specific lock on a single policy object. Ensures that when unlocking a policy, the policy is only unlocked if this
+     * object is the owner of the held lock. Additionally, this manages the lock lifecycle for any other resources tracked by the policy
+     * coordination logic, such as a policy execution's target index.
      */
-    public static class EnrichPolicyExecutionState {
-        final boolean anyPolicyInFlight;
-        final long executions;
+    public class EnrichPolicyLock implements Releasable {
+        private final String policyName;
+        private final String enrichIndexName;
+        private final Semaphore executionLease;
 
-        EnrichPolicyExecutionState(boolean anyPolicyInFlight, long executions) {
-            this.anyPolicyInFlight = anyPolicyInFlight;
-            this.executions = executions;
+        private EnrichPolicyLock(String policyName, String enrichIndexName, Semaphore executionLease) {
+            this.policyName = policyName;
+            this.enrichIndexName = enrichIndexName;
+            this.executionLease = executionLease;
         }
 
-        public boolean isAnyPolicyInFlight() {
-            return anyPolicyInFlight;
+        /**
+         * Unlocks this policy for execution and maintenance IFF this lock represents the currently held semaphore for a policy name. If
+         * this lock was created for an execution, the target index for the policy execution is also cleared from the locked state.
+         */
+        @Override
+        public void close() {
+            if (enrichIndexName != null) {
+                boolean wasRemoved = workingIndices.remove(enrichIndexName, executionLease);
+                assert wasRemoved
+                    : "Target index [" + enrichIndexName + "] for policy [" + policyName + "] was removed prior to policy unlock";
+            }
+            boolean wasRemoved = policyLocks.remove(policyName, executionLease);
+            assert wasRemoved : "Second attempt was made to unlock policy [" + policyName + "]";
         }
     }
-
-    /**
-     * A read-write lock that allows for policies to be executed concurrently with minimal overhead, but allows for blocking
-     * policy locking operations while capturing the state of policy executions.
-     */
-    private final ReadWriteLock currentStateLock = new ReentrantReadWriteLock(true);
 
     /**
      * A mapping of policy name to a semaphore used for ensuring that a single policy can only have one execution in flight
@@ -53,73 +61,58 @@ public class EnrichPolicyLocks {
     private final ConcurrentHashMap<String, Semaphore> policyLocks = new ConcurrentHashMap<>();
 
     /**
-     * A counter that is used as a sort of policy execution sequence id / dirty bit. This is incremented every time a policy
-     * successfully acquires an execution lock.
+     * When a policy is locked for execution the new index that is created is added to this set to keep it from being accidentally
+     * cleaned up by the maintenance task.
      */
-    private final AtomicLong policyRunCounter = new AtomicLong(0L);
+    private final ConcurrentHashMap<String, Semaphore> workingIndices = new ConcurrentHashMap<>();
 
     /**
      * Locks a policy to prevent concurrent execution. If the policy is currently executing, this method will immediately
      * throw without waiting. This method only blocks if another thread is currently capturing the current policy execution state.
+     * <br/><br/>
+     * If a policy is being executed, use {@link EnrichPolicyLocks#lockPolicy(String, String)} instead in order to properly track the
+     * new enrich index that will be created.
      * @param policyName The policy name to lock for execution
      * @throws EsRejectedExecutionException if the policy is locked already or if the maximum number of concurrent policy executions
      *                                      has been reached
      */
-    public void lockPolicy(String policyName) {
-        currentStateLock.readLock().lock();
-        try {
-            Semaphore runLock = policyLocks.computeIfAbsent(policyName, (name) -> new Semaphore(1));
-            boolean acquired = runLock.tryAcquire();
-            if (acquired == false) {
-                throw new EsRejectedExecutionException(
-                    "Could not obtain lock because policy execution for [" + policyName + "] is already in progress."
-                );
-            }
-            policyRunCounter.incrementAndGet();
-        } finally {
-            currentStateLock.readLock().unlock();
-        }
+    public EnrichPolicyLock lockPolicy(String policyName) {
+        return lockPolicy(policyName, null);
     }
 
     /**
-     * Captures a snapshot of the current policy execution state. This method never blocks, instead assuming that a policy is
-     * currently starting its execution and returns an appropriate state.
-     * @return The current state of in-flight policy executions
+     * Locks a policy to prevent concurrent execution. If the policy is currently executing, this method will immediately
+     * throw without waiting. This method only blocks if another thread is currently capturing the current policy execution state.
+     * <br/><br/>
+     * If a policy needs to be locked just to ensure it is not executing, use {@link EnrichPolicyLocks#lockPolicy(String)} instead since
+     * no new enrich indices need to be maintained.
+     * @param policyName The policy name to lock for execution
+     * @param enrichIndexName If the policy is being executed, this parameter denotes the index that should be protected from maintenance
+     *                  operations.
+     * @throws EsRejectedExecutionException if the policy is locked already or if the maximum number of concurrent policy executions
+     *                                      has been reached
      */
-    public EnrichPolicyExecutionState captureExecutionState() {
-        if (currentStateLock.writeLock().tryLock()) {
-            try {
-                long revision = policyRunCounter.get();
-                long currentPolicyExecutions = policyLocks.mappingCount();
-                return new EnrichPolicyExecutionState(currentPolicyExecutions > 0L, revision);
-            } finally {
-                currentStateLock.writeLock().unlock();
-            }
+    public EnrichPolicyLock lockPolicy(String policyName, String enrichIndexName) {
+        Semaphore runLock = policyLocks.computeIfAbsent(policyName, (name) -> new Semaphore(1));
+        boolean acquired = runLock.tryAcquire();
+        if (acquired == false) {
+            throw new EsRejectedExecutionException(
+                "Could not obtain lock because policy execution for [" + policyName + "] is already in progress."
+            );
         }
-        return new EnrichPolicyExecutionState(true, policyRunCounter.get());
+        if (enrichIndexName != null) {
+            Semaphore previous = workingIndices.putIfAbsent(enrichIndexName, runLock);
+            assert previous == null : "Target index [" + enrichIndexName + "] is already claimed by an execution, or was not cleaned up.";
+        }
+        return new EnrichPolicyLock(policyName, enrichIndexName, runLock);
     }
 
-    /**
-     * Checks if the current execution state matches that of the given execution state. Used to ensure that over a period of time
-     * no changes to the policy execution state have occurred.
-     * @param previousState The previous state to check the current state against
-     * @return true if the current state matches the given previous state, false if policy executions have changed over time.
-     */
-    boolean isSameState(EnrichPolicyExecutionState previousState) {
-        EnrichPolicyExecutionState currentState = captureExecutionState();
-        return currentState.anyPolicyInFlight == previousState.anyPolicyInFlight && currentState.executions == previousState.executions;
+    public Set<String> lockedPolices() {
+        return new HashSet<>(policyLocks.keySet());
     }
 
-    /**
-     * Releases the lock for a given policy name, allowing it to be executed.
-     * @param policyName The policy to release.
-     */
-    public void releasePolicy(String policyName) {
-        currentStateLock.readLock().lock();
-        try {
-            policyLocks.remove(policyName);
-        } finally {
-            currentStateLock.readLock().unlock();
-        }
+    public Set<String> inflightPolicyIndices() {
+        return new HashSet<>(workingIndices.keySet());
     }
+
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
@@ -11,28 +11,29 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
@@ -145,64 +146,55 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
     }
 
     void cleanUpEnrichIndices() {
-        final Map<String, EnrichPolicy> policies = EnrichStore.getPolicies(clusterService.state());
-        GetIndexRequest indices = new GetIndexRequest().indices(EnrichPolicy.ENRICH_INDEX_NAME_BASE + "*")
-            .indicesOptions(IndicesOptions.lenientExpand());
-        // Check that no enrich policies are being executed
-        final EnrichPolicyLocks.EnrichPolicyExecutionState executionState = enrichPolicyLocks.captureExecutionState();
-        if (executionState.isAnyPolicyInFlight() == false) {
-            client.admin().indices().getIndex(indices, new ActionListener<>() {
-                @Override
-                public void onResponse(GetIndexResponse getIndexResponse) {
-                    // Ensure that no enrich policy executions started while we were retrieving the snapshot of index data
-                    // If executions were kicked off, we can't be sure that the indices we are about to process are a
-                    // stable state of the system (they could be new indices created by a policy that hasn't been published yet).
-                    if (enrichPolicyLocks.isSameState(executionState)) {
-                        String[] removeIndices = Arrays.stream(getIndexResponse.getIndices())
-                            .filter(indexName -> shouldRemoveIndex(getIndexResponse, policies, indexName))
-                            .toArray(String[]::new);
-                        deleteIndices(removeIndices);
-                    } else {
-                        logger.debug("Skipping enrich index cleanup since enrich policy was executed while gathering indices");
-                        concludeMaintenance();
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.error("Failed to get indices during enrich index maintenance task", e);
-                    concludeMaintenance();
-                }
-            });
-        } else {
-            concludeMaintenance();
-        }
+        // Get cluster state first because for a new index to exist there then it has to have already been added to the inflight list
+        // If the new index is in the cluster state but not in the inflight list, then that means that the index name was removed from the
+        // list inflight list because it has already been promoted or because the policy execution failed.
+        ClusterState clusterState = clusterService.state();
+        Set<String> inflightPolicyExecutionIndices = enrichPolicyLocks.inflightPolicyIndices();
+        final Map<String, EnrichPolicy> policies = EnrichStore.getPolicies(clusterState);
+        logger.debug(() -> "Working enrich indices excluded from maintenance [" + String.join(", ", inflightPolicyExecutionIndices) + "]");
+        String[] removeIndices = clusterState.metadata()
+            .indices()
+            .values()
+            .stream()
+            .filter(indexMetadata -> indexMetadata.getIndex().getName().startsWith(EnrichPolicy.ENRICH_INDEX_NAME_BASE))
+            .filter(indexMetadata -> indexUsedByPolicy(indexMetadata, policies, inflightPolicyExecutionIndices) == false)
+            .map(IndexMetadata::getIndex)
+            .map(Index::getName)
+            .toArray(String[]::new);
+        deleteIndices(removeIndices);
     }
 
-    private boolean shouldRemoveIndex(GetIndexResponse getIndexResponse, Map<String, EnrichPolicy> policies, String indexName) {
-        // Find the policy on the index
+    private boolean indexUsedByPolicy(IndexMetadata indexMetadata, Map<String, EnrichPolicy> policies, Set<String> inflightPolicyIndices) {
+        String indexName = indexMetadata.getIndex().getName();
         logger.debug("Checking if should remove enrich index [{}]", indexName);
-        MappingMetadata mappingMetadata = getIndexResponse.getMappings().get(indexName);
+        // First ignore the index entirely if it is in the inflightPolicyIndices set as it is actively being worked on
+        if (inflightPolicyIndices.contains(indexName)) {
+            logger.debug("Enrich index [{}] was spared since it is reserved for an active policy execution.", indexName);
+            return true;
+        }
+        // Find the policy on the index
+        MappingMetadata mappingMetadata = indexMetadata.mapping();
         Map<String, Object> mapping = mappingMetadata.getSourceAsMap();
         String policyName = ObjectPath.eval(MAPPING_POLICY_FIELD_PATH, mapping);
         // Check if index has a corresponding policy
         if (policyName == null || policies.containsKey(policyName) == false) {
             // No corresponding policy. Index should be marked for removal.
             logger.debug("Enrich index [{}] does not correspond to any existing policy. Found policy name [{}]", indexName, policyName);
-            return true;
+            return false;
         }
         // Check if index is currently linked to an alias
         final String aliasName = EnrichPolicy.getBaseName(policyName);
-        List<AliasMetadata> aliasMetadata = getIndexResponse.aliases().get(indexName);
+        Map<String, AliasMetadata> aliasMetadata = indexMetadata.getAliases();
         if (aliasMetadata == null) {
             logger.debug("Enrich index [{}] is not marked as a live index since it has no alias information", indexName);
-            return true;
+            return false;
         }
-        boolean hasAlias = aliasMetadata.stream().anyMatch((am -> am.getAlias().equals(aliasName)));
+        boolean hasAlias = aliasMetadata.containsKey(aliasName);
         // Index is not currently published to the enrich alias. Should be marked for removal.
         if (hasAlias == false) {
             logger.debug("Enrich index [{}] is not marked as a live index since it lacks the alias [{}]", indexName, aliasName);
-            return true;
+            return false;
         }
         logger.debug(
             "Enrich index [{}] was spared since it is associated with the valid policy [{}] and references alias [{}]",
@@ -210,7 +202,7 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
             policyName,
             aliasName
         );
-        return false;
+        return true;
     }
 
     private void deleteIndices(String[] removeIndices) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
@@ -19,20 +19,24 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskAwareRequest;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
 import org.elasticsearch.xpack.enrich.EnrichPolicyExecutor;
 import org.elasticsearch.xpack.enrich.ExecuteEnrichPolicyTask;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction.Request;
 import static org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction.Response;
 import static org.elasticsearch.xpack.enrich.EnrichPolicyExecutor.TASK_ACTION;
 
@@ -56,6 +60,45 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
 
     private InternalExecutePolicyAction() {
         super(NAME, Response::new);
+    }
+
+    public static class Request extends ExecuteEnrichPolicyAction.Request {
+
+        private final String enrichIndexName;
+
+        public Request(String name, String enrichIndexName) {
+            super(name);
+            this.enrichIndexName = enrichIndexName;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.enrichIndexName = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(enrichIndexName);
+        }
+
+        public String getEnrichIndexName() {
+            return enrichIndexName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (super.equals(o) == false) return false;
+            Request request = (Request) o;
+            return Objects.equals(enrichIndexName, request.enrichIndexName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), enrichIndexName);
+        }
     }
 
     public static class Transport extends HandledTransportAction<Request, Response> {
@@ -106,7 +149,11 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
 
                     @Override
                     public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-                        String description = "executing enrich policy [" + request.getName() + "]";
+                        String description = "executing enrich policy ["
+                            + request.getName()
+                            + "] creating new enrich index ["
+                            + request.getEnrichIndexName()
+                            + "]";
                         return new ExecuteEnrichPolicyTask(id, type, action, description, parentTaskId, headers);
                     }
                 });
@@ -130,7 +177,7 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
                             }
                         );
                     }
-                    policyExecutor.runPolicyLocally(task, request.getName(), ActionListener.wrap(result -> {
+                    policyExecutor.runPolicyLocally(task, request.getName(), request.getEnrichIndexName(), ActionListener.wrap(result -> {
                         taskManager.unregister(task);
                         listener.onResponse(result);
                     }, e -> {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.AbstractEnrichProcessor;
 import org.elasticsearch.xpack.enrich.EnrichPolicyLocks;
+import org.elasticsearch.xpack.enrich.EnrichPolicyLocks.EnrichPolicyLock;
 import org.elasticsearch.xpack.enrich.EnrichStore;
 
 import java.util.ArrayList;
@@ -82,14 +83,14 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
         DeleteEnrichPolicyAction.Request request,
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
-    ) throws Exception {
+    ) {
         final String policyName = request.getName();
         final EnrichPolicy policy = EnrichStore.getPolicy(policyName, state); // ensure the policy exists first
         if (policy == null) {
             throw new ResourceNotFoundException("policy [{}] not found", policyName);
         }
 
-        enrichPolicyLocks.lockPolicy(policyName);
+        EnrichPolicyLock policyLock = enrichPolicyLocks.lockPolicy(policyName);
         try {
             final List<PipelineConfiguration> pipelines = IngestService.getPipelines(state);
             final List<String> pipelinesWithProcessors = new ArrayList<>();
@@ -115,27 +116,26 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
                 );
             }
         } catch (Exception e) {
-            enrichPolicyLocks.releasePolicy(policyName);
+            policyLock.close();
             listener.onFailure(e);
             return;
         }
 
-        final GetIndexRequest indices = new GetIndexRequest().indices(EnrichPolicy.getBaseName(policyName) + "-*")
-            .indicesOptions(IndicesOptions.lenientExpand());
+        try {
+            final GetIndexRequest indices = new GetIndexRequest().indices(EnrichPolicy.getBaseName(policyName) + "-*")
+                .indicesOptions(IndicesOptions.lenientExpand());
 
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(state, indices);
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(state, indices);
 
-        // the wildcard expansion could be too wide (e.g. in the case of a policy named policy-1 and another named policy-10),
-        // so we need to filter down to just the concrete indices that are actually indices for this policy
-        concreteIndices = Stream.of(concreteIndices).filter(i -> EnrichPolicy.isPolicyForIndex(policyName, i)).toArray(String[]::new);
+            // the wildcard expansion could be too wide (e.g. in the case of a policy named policy-1 and another named policy-10),
+            // so we need to filter down to just the concrete indices that are actually indices for this policy
+            concreteIndices = Stream.of(concreteIndices).filter(i -> EnrichPolicy.isPolicyForIndex(policyName, i)).toArray(String[]::new);
 
-        deleteIndicesAndPolicy(concreteIndices, policyName, ActionListener.wrap((response) -> {
-            enrichPolicyLocks.releasePolicy(policyName);
-            listener.onResponse(response);
-        }, (exc) -> {
-            enrichPolicyLocks.releasePolicy(policyName);
-            listener.onFailure(exc);
-        }));
+            deleteIndicesAndPolicy(concreteIndices, policyName, ActionListener.runBefore(listener, policyLock::close));
+        } catch (Exception e) {
+            policyLock.close();
+            listener.onFailure(e);
+        }
     }
 
     private void deleteIndicesAndPolicy(String[] indices, String name, ActionListener<AcknowledgedResponse> listener) {
@@ -160,7 +160,7 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
             } else {
                 deletePolicy(name, listener);
             }
-        }, (error) -> listener.onFailure(error)));
+        }, listener::onFailure));
     }
 
     private void deletePolicy(String name, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -133,10 +133,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -146,7 +147,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -202,10 +202,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -215,7 +216,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -287,10 +287,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -300,7 +301,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -374,10 +374,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -387,7 +388,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -463,10 +463,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -476,7 +477,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -559,10 +559,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -572,7 +573,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -656,10 +656,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -669,7 +670,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -711,10 +711,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -738,10 +739,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -797,10 +799,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(sourceIndex), "nesting.key", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -860,10 +863,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(sourceIndex), "key", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -947,10 +951,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -960,7 +965,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1058,10 +1062,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1071,7 +1076,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1170,10 +1174,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.subnet", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1183,7 +1188,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1291,10 +1295,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(sourceIndex), "data.fields.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1304,7 +1309,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1418,10 +1422,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.fields.subnet", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1431,7 +1436,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1552,10 +1556,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, List.of(sourceIndex), "data.fields.period", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1565,7 +1570,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1684,10 +1688,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, List.of(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1697,7 +1702,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1823,7 +1827,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             clusterService,
             client(),
             resolver,
-            () -> createTime,
+            createdEnrichIndex,
             randomIntBetween(1, 10000),
             randomIntBetween(3, 10)
         ) {
@@ -1914,6 +1918,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
@@ -1948,7 +1953,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             }
         };
 
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(client, policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(client, policyName, policy, listener, createdEnrichIndex);
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
         latch.await();
@@ -1984,10 +1989,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -2001,9 +2007,9 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName,
         EnrichPolicy policy,
         ActionListener<ExecuteEnrichPolicyStatus> listener,
-        Long createTime
+        String targetIndex
     ) {
-        return createPolicyRunner(client(), policyName, policy, listener, createTime);
+        return createPolicyRunner(client(), policyName, policy, listener, targetIndex);
     }
 
     private EnrichPolicyRunner createPolicyRunner(
@@ -2011,7 +2017,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName,
         EnrichPolicy policy,
         ActionListener<ExecuteEnrichPolicyStatus> listener,
-        Long createTime
+        String targetIndex
     ) {
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         IndexNameExpressionResolver resolver = getInstanceFromNode(IndexNameExpressionResolver.class);
@@ -2059,7 +2065,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             clusterService,
             client,
             resolver,
-            () -> createTime,
+            targetIndex,
             randomIntBetween(1, 10000),
             randomIntBetween(1, 10)
         );

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionRequestTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionRequestTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.enrich.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.enrich.action.InternalExecutePolicyAction.Request;
+
+public class InternalExecutePolicyActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        Request request = new Request(randomAlphaOfLength(3), randomAlphaOfLength(5));
+        if (randomBoolean()) {
+            request.setWaitForCompletion(true);
+        }
+        return request;
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) {
+        String policyName = instance.getName();
+        String enrichIndexName = instance.getEnrichIndexName();
+        boolean waitForCompletion = instance.isWaitForCompletion();
+
+        switch (between(0, 2)) {
+            case 0 -> policyName = randomAlphaOfLength(4);
+            case 1 -> enrichIndexName = randomAlphaOfLength(6);
+            case 2 -> waitForCompletion = waitForCompletion == false;
+            default -> throw new AssertionError("Illegal randomisation branch");
+        }
+
+        Request request = new Request(policyName, enrichIndexName);
+        request.setWaitForCompletion(waitForCompletion);
+        return request;
+    }
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.AbstractEnrichTestCase;
 import org.elasticsearch.xpack.enrich.EnrichPolicyLocks;
+import org.elasticsearch.xpack.enrich.EnrichPolicyLocks.EnrichPolicyLock;
 import org.elasticsearch.xpack.enrich.EnrichStore;
 import org.junit.After;
 
@@ -48,7 +49,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
 
         // fail if the state of this is left locked
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
     }
 
     public void testDeletePolicyDoesNotExistUnlocksPolicy() throws InterruptedException {
@@ -77,7 +78,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
 
         // fail if the state of this is left locked
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
     }
 
     public void testDeleteWithoutIndex() throws Exception {
@@ -107,7 +108,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         assertTrue(reference.get().isAcknowledged());
 
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
 
         assertNull(EnrichStore.getPolicy(name, clusterService.state()));
     }
@@ -170,7 +171,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         }
 
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
 
         assertNull(EnrichStore.getPolicy(name, clusterService.state()));
     }
@@ -187,10 +188,10 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         createIndex(EnrichPolicy.getIndexName(name, 1002));
 
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
 
-        enrichPolicyLocks.lockPolicy(name);
-        assertTrue(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        EnrichPolicyLock policyLock = enrichPolicyLocks.lockPolicy(name);
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(1));
 
         {
             final CountDownLatch latch = new CountDownLatch(1);
@@ -215,8 +216,8 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
             );
         }
         {
-            enrichPolicyLocks.releasePolicy(name);
-            assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+            policyLock.close();
+            assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
 
             final CountDownLatch latch = new CountDownLatch(1);
             final AtomicReference<AcknowledgedResponse> reference = new AtomicReference<>();
@@ -236,7 +237,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
             assertNotNull(reference.get());
             assertTrue(reference.get().isAcknowledged());
 
-            assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+            assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
 
             assertNull(EnrichStore.getPolicy(name, clusterService.state()));
         }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
@@ -60,7 +60,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
 
         // fail if the state of this is left locked
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
     }
 
     public void testListPolicies() throws InterruptedException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Refactor enrich maintenance coordination logic (#90931)](https://github.com/elastic/elasticsearch/pull/90931)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)