### PR TITLE
Ensure reproducible builds and task avoidance when using x-content jar

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -146,6 +146,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
      */
     public static void configureInputNormalization(Project project) {
         project.getNormalization().getRuntimeClasspath().ignore("META-INF/MANIFEST.MF");
+        project.getNormalization().getRuntimeClasspath().ignore("IMPL-JARS/**/META-INF/MANIFEST.MF");
     }
 
     private static Provider<Integer> releaseVersionProviderFromCompileTask(Project project, AbstractCompile compileTask) {

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -74,7 +74,7 @@ def generateProviderManifest = tasks.register("generateProviderManifest") {
   doLast {
     manifestFile.parentFile.mkdirs()
     manifestFile.setText(configurations.providerImpl.files.stream()
-      .map(f -> f.name).collect(Collectors.joining('\n')), 'UTF-8')
+      .map(f -> f.name).sorted().collect(Collectors.joining('\n')), 'UTF-8')
   }
 }
 


### PR DESCRIPTION
The elasticsearch-x-content jar is special in that it embeds other runtime dependencies under an IMPL-JARS folder in the jar. This has side-effects with Gradle runtime classpath normalization. This commit fixes some isssues her by firstly, sorting the content of the jar listing manifest so it's reproducible across filesystems, and secondly ignoreing nested jar manifests for the purposes of runtime classpath normalization, as they often contain things like timestamps and commit hashes.