### PR TITLE
[DOCS] Adds example of better index resolve to transforms at scale

### DIFF
--- a/docs/reference/transform/transforms-at-scale.asciidoc
+++ b/docs/reference/transform/transforms-at-scale.asciidoc
@@ -118,8 +118,8 @@ this date range is re-evaluated at the point of each checkpoint execution.
 
 Consider using <<api-date-math-index-names,date math>> in your index names to 
 reduce the number of indices to resolve in your queries. Add a date pattern 
-- for example, `yyy-MM-dd` - to your index names and use it to limit your query 
-to a specific date. The example below queries indicies only from yesterday and 
+- for example, `yyyy-MM-dd` - to your index names and use it to limit your query 
+to a specific date. The example below queries indices only from yesterday and 
 today: 
 
 [source,js]

--- a/docs/reference/transform/transforms-at-scale.asciidoc
+++ b/docs/reference/transform/transforms-at-scale.asciidoc
@@ -116,6 +116,23 @@ example, greater than `2020-01-01T00:00:00`) to limit which historical indices
 are accessed. If you use a relative time value (for example, `now-30d`) then 
 this date range is re-evaluated at the point of each checkpoint execution.
 
+Consider using <<api-date-math-index-names,date math>> in your index names to 
+reduce the number of indices to resolve in your queries. Add a date pattern 
+- for example, `yyy-MM-dd` - to your index names and use it to limit your query 
+to a specific date. The example below queries indicies only from yesterday and 
+today: 
+
+[source,js]
+----------------------------------
+  "source": {
+    "index": [
+        "<mydata-{now/d-1d{yyyy-MM-dd}}*>", 
+        "<mydata-{now/d{yyyy-MM-dd}}*>"
+    ]
+  },
+----------------------------------
+// NOTCONSOLE
+
 
 [discrete]
 [[optimize-shading-strategy]]


### PR DESCRIPTION
## Overview

This PR expands the `Limit the scope of the source query` section in the Transforms at scale page with an example of using date math in index names and queries.

### Preview

[Limit the scope of the source query](https://elasticsearch_92234.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/transform-scale.html#limit-source-query)