### PR TITLE
[DOCS] Remove coming note from 7.17.8 release notes

### DIFF
--- a/docs/reference/release-notes/7.17.8.asciidoc
+++ b/docs/reference/release-notes/7.17.8.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.17.8]]
 == {es} version 7.17.8
 
-coming[7.17.8]
-
 Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 
 [[bug-7.17.8]]


### PR DESCRIPTION
This PR updates https://www.elastic.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.8.html to remove the "coming" admonition.
