### PR TITLE
Revert 91720

### DIFF
--- a/docs/changelog/91720.yaml
+++ b/docs/changelog/91720.yaml
@@ -1,6 +1,0 @@
-pr: 91720
-summary: Mark empty `_terms_enum` results due to DLS as incomplete
-area: Search
-type: enhancement
-issues:
- - 88321

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/termsenum/action/TransportTermsEnumAction.java
@@ -715,20 +715,7 @@ public class TransportTermsEnumAction extends HandledTransportAction<TermsEnumRe
         ThreadContext threadContext = transportService.getThreadPool().getThreadContext();
         final XPackLicenseState frozenLicenseState = licenseState.copyCurrentLicenseState();
         for (ShardId shardId : request.shardIds().toArray(new ShardId[0])) {
-            if (canAccess(shardId, request, frozenLicenseState, threadContext) == false) {
-                listener.onResponse(
-                    new NodeTermsEnumResponse(
-                        request.nodeId(),
-                        Collections.emptyList(),
-                        "cannot execute [_terms_enum] request on index ["
-                            + shardId.getIndexName()
-                            + "] due to "
-                            + "DLS/FLS security restrictions.",
-                        false
-                    )
-                );
-            }
-            if (canMatchShard(shardId, request) == false) {
+            if (canAccess(shardId, request, frozenLicenseState, threadContext) == false || canMatchShard(shardId, request) == false) {
                 // Permission denied or can't match, remove shardID from request
                 request.remove(shardId);
             }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/terms_enum/10_basic.yml
@@ -549,25 +549,18 @@ teardown:
   - length: { terms: 1 }
 
   - do:
-      headers: { Authorization: "Basic ZGxzX3NvbWVfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # dls_some_user doesn't see all docs
+      headers: { Authorization: "Basic ZGxzX3NvbWVfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # dls_some_user sees selected docs
       terms_enum:
-        index: test_security
-        body: { "field": "foo", "string": "b" }
-
-  - length: { terms: 0 }
-  - match: { complete: false }
-  - match: { _shards.failed: 1 }
-  - match: { _shards.failures.0.reason.type: "broadcast_shard_operation_failed_exception" }
-  - match: { _shards.failures.0.reason.reason: "cannot execute [_terms_enum] request on index [test_security] due to DLS/FLS security restrictions." }
+        index:  test_security
+        body:  {"field": "foo", "string":"b"}
+  - length: {terms: 0}
 
   - do:
       headers: { Authorization: "Basic ZmxzX3VzZXI6eC1wYWNrLXRlc3QtcGFzc3dvcmQ=" } # fls_user can't see field
       terms_enum:
-        index: test_security
-        body: { "field": "foo", "string": "b" }
-  - length: { terms: 0 }
-  - match: { complete: true }
-  - match: { _shards.failed: 0 }
+        index:  test_security
+        body:  {"field": "foo", "string":"b"}
+  - length: {terms: 0}
 
 ---
 "Test security with API keys":
@@ -619,7 +612,7 @@ teardown:
             }
           }
   - match: { name: "dls_all_user_bad_key" }
-  - set: { encoded: login_creds }
+  - set: { encoded: login_creds}
   - do:
       headers:
         Authorization: ApiKey ${login_creds}  # dls_all_user bad API key sees selected docs
@@ -627,9 +620,6 @@ teardown:
         index: test_security
         body: { "field": "foo", "string": "b" }
   - length: { terms: 0 }
-  - match: { complete: false }
-  - match: { _shards.failed: 1 }
-  - match: { _shards.failures.0.reason.type: "broadcast_shard_operation_failed_exception" }
 
   - do:
       headers: { Authorization: "Basic ZGxzX3NvbWVfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" } # dls_some_user
@@ -651,7 +641,7 @@ teardown:
             }
           }
   - match: { name: "dls_some_user_key" }
-  - set: { encoded: login_creds }
+  - set: { encoded: login_creds}
   - do:
       headers:
         Authorization: ApiKey ${login_creds}  # dls_some_user's API key sees selected user regardless of the key's role descriptor
@@ -659,6 +649,3 @@ teardown:
         index: test_security
         body: { "field": "foo", "string": "b" }
   - length: { terms: 0 }
-  - match: { complete: false }
-  - match: { _shards.failed: 1 }
-  - match: { _shards.failures.0.reason.type: "broadcast_shard_operation_failed_exception" }


### PR DESCRIPTION
This reverts the commit from  #91720 that added an enhancement to Mark empty `_terms_enum` 
results due to DLS as incomplete. Unfortunately the solution created potential concurrency issues with 
early returning node request calls. While trying to fix those in https://github.com/elastic/elasticsearch/pull/92134
newly added tests also revealed other problematic edge cases like targeting shards from different indices on the
same node call. If any of these were blocked due to DLS restrictions, the solution from #91720 would also abort
the request for other shards on that node that could be from an index without DLS restrictions. 
Other general concerns were raised around [returning the DLS warning as a shard failure](https://github.com/elastic/elasticsearch/pull/91720#issuecomment-1342802185). For that reason we decided to take a step back, revert the change and reopen the
original issue to re-discuss the goals and come up with a cleaner solution.

