### PR TITLE
Update README.asciidoc

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -48,7 +48,7 @@ https://www.elastic.co/guide/en/elasticsearch/reference/current/install-elastics
 **Start Elasticsearch**
 
 . Install and start https://www.docker.com/products/docker-desktop[Docker
-Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4GB.
+Desktop]. Go to **Preferences > Resources > Advanced** and set Memory to at least 4 GB.
 
 . Start an Elasticsearch container:
 +


### PR DESCRIPTION
very minor suggestion to put a space between value and the GB so making 4GB as 4 GB. You can ignore but this is the proper way to specify RAM.  Thanks for your work and sorry for such a nit of a change

I signed contributing agreement just now