### PR TITLE
Switch the order of the GroupedActionListener args

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -508,8 +508,8 @@ public class CancellableTasksIT extends ESIntegTestCase {
             arrivedLatches.get(request).countDown();
             List<TestRequest> subRequests = request.subRequests;
             GroupedActionListener<TestResponse> groupedListener = new GroupedActionListener<>(
-                listener.map(r -> new TestResponse()),
-                subRequests.size() + 1
+                subRequests.size() + 1,
+                listener.map(r -> new TestResponse())
             );
             transportService.getThreadPool().generic().execute(ActionRunnable.supply(groupedListener, () -> {
                 assertTrue(beforeExecuteLatches.get(request).await(60, TimeUnit.SECONDS));

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -219,7 +219,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> waiting for batched deletes to finish");
         final PlainActionFuture<Collection<AcknowledgedResponse>> allDeletesDone = new PlainActionFuture<>();
-        final ActionListener<AcknowledgedResponse> deletesListener = new GroupedActionListener<>(allDeletesDone, deleteFutures.size());
+        final ActionListener<AcknowledgedResponse> deletesListener = new GroupedActionListener<>(deleteFutures.size(), allDeletesDone);
         for (StepListener<AcknowledgedResponse> deleteFuture : deleteFutures) {
             deleteFuture.addListener(deletesListener);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -661,8 +661,8 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         final var waitForCompletion = randomBoolean();
         final var createsListener = new PlainActionFuture<Void>();
         final var createsGroupedListener = new GroupedActionListener<CreateSnapshotResponse>(
-            createsListener.map(ignored -> null),
-            snapshotNames.length
+            snapshotNames.length,
+            createsListener.map(ignored -> null)
         );
         for (final var snapshotName : snapshotNames) {
             clusterAdmin().prepareCreateSnapshot(repoName, snapshotName)

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/features/TransportResetFeatureStateAction.java
@@ -73,11 +73,11 @@ public class TransportResetFeatureStateAction extends TransportMasterNodeAction<
 
         final int features = systemIndices.getFeatures().size();
         GroupedActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> groupedActionListener = new GroupedActionListener<>(
+            systemIndices.getFeatures().size(),
             listener.map(responses -> {
                 assert features == responses.size();
                 return new ResetFeatureStateResponse(new ArrayList<>(responses));
-            }),
-            systemIndices.getFeatures().size()
+            })
         );
 
         for (SystemIndices.Feature feature : systemIndices.getFeatures()) {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -176,7 +176,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             return;
         }
         final GroupedActionListener<Tuple<Tuple<String, ElasticsearchException>, SnapshotsInRepo>> groupedActionListener =
-            new GroupedActionListener<>(listener.map(responses -> {
+            new GroupedActionListener<>(repos.size(), listener.map(responses -> {
                 assert repos.size() == responses.size();
                 final List<SnapshotInfo> allSnapshots = responses.stream()
                     .map(Tuple::v2)
@@ -203,7 +203,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                     responses.stream().map(Tuple::v2).filter(Objects::nonNull).mapToInt(s -> s.totalCount).sum(),
                     remaining
                 );
-            }), repos.size());
+            }));
 
         for (final RepositoryMetadata repo : repos) {
             final String repoName = repo.name();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/TransportGetShardSnapshotAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/TransportGetShardSnapshotAction.java
@@ -85,8 +85,8 @@ public class TransportGetShardSnapshotAction extends TransportMasterNodeAction<G
         }
 
         GroupedActionListener<Tuple<Optional<ShardSnapshotInfo>, RepositoryException>> groupedActionListener = new GroupedActionListener<>(
-            listener.map(TransportGetShardSnapshotAction::transformToResponse),
-            repositories.size()
+            repositories.size(),
+            listener.map(TransportGetShardSnapshotAction::transformToResponse)
         );
 
         BlockingQueue<String> repositoriesQueue = new LinkedBlockingQueue<>(repositories);

--- a/server/src/main/java/org/elasticsearch/action/search/ClearScrollController.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClearScrollController.java
@@ -170,8 +170,8 @@ public final class ClearScrollController implements Runnable {
         }
         lookupListener.whenComplete(nodeLookup -> {
             final GroupedActionListener<Boolean> groupedListener = new GroupedActionListener<>(
-                listener.map(rs -> Math.toIntExact(rs.stream().filter(r -> r).count())),
-                contextIds.size()
+                contextIds.size(),
+                listener.map(rs -> Math.toIntExact(rs.stream().filter(r -> r).count()))
             );
             for (SearchContextIdForNode contextId : contextIds) {
                 final DiscoveryNode node = nodeLookup.apply(contextId.getClusterAlias(), contextId.getNode());

--- a/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
@@ -31,10 +31,10 @@ public final class GroupedActionListener<T> extends ActionListener.Delegating<T,
 
     /**
      * Creates a new listener
-     * @param delegate the delegate listener
      * @param groupSize the group size
+     * @param delegate the delegate listener
      */
-    public GroupedActionListener(ActionListener<Collection<T>> delegate, int groupSize) {
+    public GroupedActionListener(int groupSize, ActionListener<Collection<T>> delegate) {
         super(delegate);
         if (groupSize <= 0) {
             assert false : "illegal group size [" + groupSize + "]";

--- a/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/NodeConnectionsService.java
@@ -98,8 +98,8 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
         }
 
         final GroupedActionListener<Void> listener = new GroupedActionListener<>(
-            ActionListener.wrap(onCompletion),
-            discoveryNodes.getSize()
+            discoveryNodes.getSize(),
+            ActionListener.wrap(onCompletion)
         );
 
         final List<Runnable> runnables = new ArrayList<>(discoveryNodes.getSize());
@@ -160,8 +160,8 @@ public class NodeConnectionsService extends AbstractLifecycleComponent {
             } else {
                 logger.trace("ensureConnections: {}", targetsByNode);
                 final GroupedActionListener<Void> listener = new GroupedActionListener<>(
-                    ActionListener.wrap(onCompletion),
-                    connectionTargets.size()
+                    connectionTargets.size(),
+                    ActionListener.wrap(onCompletion)
                 );
                 for (final ConnectionTarget connectionTarget : connectionTargets) {
                     runnables.add(connectionTarget.connect(listener));

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -301,7 +301,7 @@ public class DiskThresholdMonitor {
             }
         }
 
-        final ActionListener<Void> listener = new GroupedActionListener<>(ActionListener.wrap(this::checkFinished), 3);
+        final ActionListener<Void> listener = new GroupedActionListener<>(3, ActionListener.wrap(this::checkFinished));
 
         if (reroute) {
             logger.debug("rerouting shards: [{}]", explanation);

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1472,10 +1472,13 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
     public synchronized void createMissingPeerRecoveryRetentionLeases(ActionListener<Void> listener) {
         if (hasAllPeerRecoveryRetentionLeases == false) {
             final List<ShardRouting> shardRoutings = routingTable.assignedShards();
-            final GroupedActionListener<ReplicationResponse> groupedActionListener = new GroupedActionListener<>(ActionListener.wrap(vs -> {
-                setHasAllPeerRecoveryRetentionLeases();
-                listener.onResponse(null);
-            }, listener::onFailure), shardRoutings.size());
+            final GroupedActionListener<ReplicationResponse> groupedActionListener = new GroupedActionListener<>(
+                shardRoutings.size(),
+                ActionListener.wrap(vs -> {
+                    setHasAllPeerRecoveryRetentionLeases();
+                    listener.onResponse(null);
+                }, listener::onFailure)
+            );
             for (ShardRouting shardRouting : shardRoutings) {
                 if (retentionLeases.contains(getPeerRecoveryRetentionLeaseId(shardRouting))) {
                     groupedActionListener.onResponse(null);

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -116,8 +116,8 @@ public class SystemIndexManager implements ClusterStateListener {
                 // Use a GroupedActionListener so that we only release the lock once all upgrade attempts have succeeded or failed.
                 // The failures are logged in upgradeIndexMetadata(), so we don't actually care about them here.
                 ActionListener<AcknowledgedResponse> listener = new GroupedActionListener<>(
-                    ActionListener.wrap(() -> isUpgradeInProgress.set(false)),
-                    descriptors.size()
+                    descriptors.size(),
+                    ActionListener.wrap(() -> isUpgradeInProgress.set(false))
                 );
 
                 descriptors.forEach(descriptor -> upgradeIndexMetadata(descriptor, listener));

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndices.java
@@ -922,6 +922,7 @@ public class SystemIndices {
             }
 
             GroupedActionListener<ResetFeatureStateStatus> groupedListener = new GroupedActionListener<>(
+                taskCount,
                 ActionListener.wrap(listenerResults -> {
                     List<ResetFeatureStateStatus> errors = listenerResults.stream()
                         .filter(status -> status.getStatus() == ResetFeatureStateResponse.ResetFeatureStateStatus.Status.FAILURE)
@@ -936,8 +937,7 @@ public class SystemIndices {
                         errors.forEach(e -> logger.warn(() -> "error while resetting feature [" + name + "]", e.getException()));
                         listener.onResponse(ResetFeatureStateStatus.failure(name, new Exception(exceptions.toString())));
                     }
-                }, listener::onFailure),
-                taskCount
+                }, listener::onFailure)
             );
 
             // Send cleanup for the associated indices, they don't need special origin since they are not protected

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/ReservedClusterStateService.java
@@ -351,17 +351,20 @@ public class ReservedClusterStateService {
             return;
         }
 
-        GroupedActionListener<NonStateTransformResult> postTasksListener = new GroupedActionListener<>(new ActionListener<>() {
-            @Override
-            public void onResponse(Collection<NonStateTransformResult> updateKeyTaskResult) {
-                listener.onResponse(updateKeyTaskResult);
-            }
+        GroupedActionListener<NonStateTransformResult> postTasksListener = new GroupedActionListener<>(
+            nonStateTransforms.size(),
+            new ActionListener<>() {
+                @Override
+                public void onResponse(Collection<NonStateTransformResult> updateKeyTaskResult) {
+                    listener.onResponse(updateKeyTaskResult);
+                }
 
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
             }
-        }, nonStateTransforms.size());
+        );
 
         for (var transform : nonStateTransforms) {
             // non cluster state transforms don't modify the cluster state, they however are given a chance to return a more

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestIndicesAction.java
@@ -217,7 +217,7 @@ public class RestIndicesAction extends AbstractCatAction {
         final int size,
         final ActionListener<Table> listener
     ) {
-        return new GroupedActionListener<>(new ActionListener.Delegating<>(listener) {
+        return new GroupedActionListener<>(size, new ActionListener.Delegating<>(listener) {
             @Override
             public void onResponse(final Collection<ActionResponse> responses) {
                 try {
@@ -242,7 +242,7 @@ public class RestIndicesAction extends AbstractCatAction {
                     onFailure(e);
                 }
             }
-        }, size);
+        });
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotsService.java
@@ -601,8 +601,8 @@ public class SnapshotsService extends AbstractLifecycleComponent implements Clus
 
         final StepListener<Collection<Tuple<IndexId, Integer>>> allShardCountsListener = new StepListener<>();
         final GroupedActionListener<Tuple<IndexId, Integer>> shardCountListener = new GroupedActionListener<>(
-            allShardCountsListener,
-            indices.size()
+            indices.size(),
+            allShardCountsListener
         );
         snapshotInfoListener.whenComplete(snapshotInfo -> {
             for (IndexId indexId : indices) {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteClusterService.java
@@ -339,7 +339,7 @@ public final class RemoteClusterService extends RemoteClusterAware implements Cl
             return;
         }
 
-        GroupedActionListener<Void> listener = new GroupedActionListener<>(future, enabledClusters.size());
+        GroupedActionListener<Void> listener = new GroupedActionListener<>(enabledClusters.size(), future);
         for (String clusterAlias : enabledClusters) {
             updateRemoteCluster(clusterAlias, settings, listener);
         }

--- a/server/src/test/java/org/elasticsearch/action/support/GroupedActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/GroupedActionListenerTests.java
@@ -43,7 +43,7 @@ public class GroupedActionListenerTests extends ESTestCase {
         };
         final int groupSize = randomIntBetween(10, 1000);
         AtomicInteger count = new AtomicInteger();
-        GroupedActionListener<Integer> listener = new GroupedActionListener<>(result, groupSize);
+        GroupedActionListener<Integer> listener = new GroupedActionListener<>(groupSize, result);
         int numThreads = randomIntBetween(2, 5);
         Thread[] threads = new Thread[numThreads];
         CyclicBarrier barrier = new CyclicBarrier(numThreads);
@@ -90,7 +90,7 @@ public class GroupedActionListenerTests extends ESTestCase {
             }
         };
         int size = randomIntBetween(3, 4);
-        GroupedActionListener<Integer> listener = new GroupedActionListener<>(result, size);
+        GroupedActionListener<Integer> listener = new GroupedActionListener<>(size, result);
         listener.onResponse(0);
         IOException ioException = new IOException();
         RuntimeException rtException = new RuntimeException();
@@ -111,7 +111,7 @@ public class GroupedActionListenerTests extends ESTestCase {
     public void testConcurrentFailures() throws InterruptedException {
         AtomicReference<Exception> finalException = new AtomicReference<>();
         int numGroups = randomIntBetween(10, 100);
-        GroupedActionListener<Void> listener = new GroupedActionListener<>(ActionListener.wrap(r -> {}, finalException::set), numGroups);
+        GroupedActionListener<Void> listener = new GroupedActionListener<>(numGroups, ActionListener.wrap(r -> {}, finalException::set));
         ExecutorService executorService = Executors.newFixedThreadPool(numGroups);
         for (int i = 0; i < numGroups; i++) {
             executorService.submit(() -> listener.onFailure(new IOException()));
@@ -133,7 +133,7 @@ public class GroupedActionListenerTests extends ESTestCase {
      */
     public void testRepeatNotificationForTheSameException() {
         final AtomicReference<Exception> finalException = new AtomicReference<>();
-        final GroupedActionListener<Void> listener = new GroupedActionListener<>(ActionListener.wrap(r -> {}, finalException::set), 2);
+        final GroupedActionListener<Void> listener = new GroupedActionListener<>(2, ActionListener.wrap(r -> {}, finalException::set));
         final Exception e = new Exception();
         // repeat notification for the same exception
         listener.onFailure(e);

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/ShardSnapshotTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/ShardSnapshotTaskRunnerTests.java
@@ -73,8 +73,8 @@ public class ShardSnapshotTaskRunnerTests extends ESTestCase {
             } else {
                 expectedFileSnapshotTasks.addAndGet(filesToUpload);
                 ActionListener<Void> uploadListener = new GroupedActionListener<>(
-                    ActionListener.wrap(finishedShardSnapshots::incrementAndGet),
-                    filesToUpload
+                    filesToUpload,
+                    ActionListener.wrap(finishedShardSnapshots::incrementAndGet)
                 );
                 for (int i = 0; i < filesToUpload; i++) {
                     taskRunner.enqueueFileSnapshot(context, ShardSnapshotTaskRunnerTests::dummyFileInfo, uploadListener);

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -665,8 +665,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
         final int inProgressSnapshots = randomIntBetween(1, 5);
         final StepListener<Collection<CreateSnapshotResponse>> createOtherSnapshotResponseStepListener = new StepListener<>();
         final ActionListener<CreateSnapshotResponse> createSnapshotListener = new GroupedActionListener<>(
-            createOtherSnapshotResponseStepListener,
-            inProgressSnapshots
+            inProgressSnapshots,
+            createOtherSnapshotResponseStepListener
         );
 
         continueOrDie(createSnapshotResponseStepListener, createSnapshotResponse -> {
@@ -825,7 +825,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             firstIndex.set(masterNode.clusterService.state().metadata().index(index).getIndex());
             // create a few more indices to make it more likely that the subsequent index delete operation happens before snapshot
             // finalization
-            final GroupedActionListener<CreateIndexResponse> listener = new GroupedActionListener<>(createIndicesListener, indices);
+            final GroupedActionListener<CreateIndexResponse> listener = new GroupedActionListener<>(indices, createIndicesListener);
             for (int i = 0; i < indices; ++i) {
                 client().admin().indices().create(new CreateIndexRequest("index-" + i), listener);
             }
@@ -1172,8 +1172,8 @@ public class SnapshotResiliencyTests extends ESTestCase {
 
         final StepListener<Collection<CreateSnapshotResponse>> allSnapshotsListener = new StepListener<>();
         final ActionListener<CreateSnapshotResponse> snapshotListener = new GroupedActionListener<>(
-            allSnapshotsListener,
-            snapshotNames.size()
+            snapshotNames.size(),
+            allSnapshotsListener
         );
         final AtomicBoolean doneIndexing = new AtomicBoolean(false);
         continueOrDie(createRepoAndIndex(repoName, index, shards), createIndexResponse -> {

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -700,7 +700,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
     public static List<String> createNSnapshots(Logger logger, String repoName, int count) throws Exception {
         final PlainActionFuture<Collection<CreateSnapshotResponse>> allSnapshotsDone = PlainActionFuture.newFuture();
-        final ActionListener<CreateSnapshotResponse> snapshotsListener = new GroupedActionListener<>(allSnapshotsDone, count);
+        final ActionListener<CreateSnapshotResponse> snapshotsListener = new GroupedActionListener<>(count, allSnapshotsDone);
         final List<String> snapshotNames = new ArrayList<>(count);
         final String prefix = RANDOM_SNAPSHOT_NAME_PREFIX + UUIDs.randomBase64UUID(random()).toLowerCase(Locale.ROOT) + "-";
         for (int i = 0; i < count; i++) {

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/AutoFollowCoordinator.java
@@ -594,11 +594,11 @@ public class AutoFollowCoordinator extends AbstractLifecycleComponent implements
             Consumer<AutoFollowResult> resultHandler
         ) {
             final GroupedActionListener<Tuple<Index, Exception>> groupedListener = new GroupedActionListener<>(
+                leaderIndicesToFollow.size(),
                 ActionListener.wrap(
                     rs -> resultHandler.accept(new AutoFollowResult(autoFollowPattenName, new ArrayList<>(rs))),
                     e -> { throw new AssertionError("must never happen", e); }
-                ),
-                leaderIndicesToFollow.size()
+                )
             );
 
             // Loop through all the as-of-yet-unfollowed indices from the leader

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportUnfollowAction.java
@@ -124,23 +124,26 @@ public class TransportUnfollowAction extends AcknowledgedTransportMasterNodeActi
                     return;
                 }
 
-                final GroupedActionListener<ActionResponse.Empty> groupListener = new GroupedActionListener<>(new ActionListener<>() {
+                final GroupedActionListener<ActionResponse.Empty> groupListener = new GroupedActionListener<>(
+                    numberOfShards,
+                    new ActionListener<>() {
 
-                    @Override
-                    public void onResponse(final Collection<ActionResponse.Empty> responses) {
-                        logger.trace(
-                            "[{}] removed retention lease [{}] on all leader primary shards",
-                            indexMetadata.getIndex(),
-                            retentionLeaseId
-                        );
-                        listener.onResponse(AcknowledgedResponse.TRUE);
-                    }
+                        @Override
+                        public void onResponse(final Collection<ActionResponse.Empty> responses) {
+                            logger.trace(
+                                "[{}] removed retention lease [{}] on all leader primary shards",
+                                indexMetadata.getIndex(),
+                                retentionLeaseId
+                            );
+                            listener.onResponse(AcknowledgedResponse.TRUE);
+                        }
 
-                    @Override
-                    public void onFailure(final Exception e) {
-                        onLeaseRemovalFailure(indexMetadata.getIndex(), retentionLeaseId, e);
+                        @Override
+                        public void onFailure(final Exception e) {
+                            onLeaseRemovalFailure(indexMetadata.getIndex(), retentionLeaseId, e);
+                        }
                     }
-                }, numberOfShards);
+                );
                 for (int i = 0; i < numberOfShards; i++) {
                     final ShardId followerShardId = new ShardId(indexMetadata.getIndex(), i);
                     final ShardId leaderShardId = new ShardId(leaderIndex, i);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersection.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersection.java
@@ -37,15 +37,18 @@ public class RoleReferenceIntersection {
     }
 
     public void buildRole(BiConsumer<RoleReference, ActionListener<Role>> singleRoleBuilder, ActionListener<Role> roleActionListener) {
-        final GroupedActionListener<Role> roleGroupedActionListener = new GroupedActionListener<>(ActionListener.wrap(roles -> {
-            assert false == roles.isEmpty();
-            final Iterator<Role> iterator = roles.stream().iterator();
-            Role finalRole = iterator.next();
-            while (iterator.hasNext()) {
-                finalRole = finalRole.limitedBy(iterator.next());
-            }
-            roleActionListener.onResponse(finalRole);
-        }, roleActionListener::onFailure), roleReferences.size());
+        final GroupedActionListener<Role> roleGroupedActionListener = new GroupedActionListener<>(
+            roleReferences.size(),
+            ActionListener.wrap(roles -> {
+                assert false == roles.isEmpty();
+                final Iterator<Role> iterator = roles.stream().iterator();
+                Role finalRole = iterator.next();
+                while (iterator.hasNext()) {
+                    finalRole = finalRole.limitedBy(iterator.next());
+                }
+                roleActionListener.onResponse(finalRole);
+            }, roleActionListener::onFailure)
+        );
 
         roleReferences.forEach(roleReference -> singleRoleBuilder.accept(roleReference, roleGroupedActionListener));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -729,6 +729,7 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
         List<SystemIndexPlugin> systemPlugins = filterPlugins(SystemIndexPlugin.class);
 
         GroupedActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> allListeners = new GroupedActionListener<>(
+            systemPlugins.size(),
             ActionListener.wrap(listenerResults -> {
                 // If the clean-up produced only one result, use that to pass along. In most
                 // cases it should be 1-1 mapping of feature to response. Passing back success
@@ -738,8 +739,7 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
                 } else {
                     finalListener.onResponse(ResetFeatureStateStatus.success(getFeatureName()));
                 }
-            }, finalListener::onFailure),
-            systemPlugins.size()
+            }, finalListener::onFailure)
         );
         systemPlugins.forEach(plugin -> plugin.cleanUpFeature(clusterService, client, allListeners));
     }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/TransportDeprecationInfoAction.java
@@ -162,6 +162,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
             return;
         }
         GroupedActionListener<DeprecationChecker.CheckResult> groupedActionListener = new GroupedActionListener<>(
+            enabledCheckers.size(),
             ActionListener.wrap(
                 checkResults -> listener.onResponse(
                     checkResults.stream()
@@ -170,8 +171,7 @@ public class TransportDeprecationInfoAction extends TransportMasterNodeReadActio
                         )
                 ),
                 listener::onFailure
-            ),
-            enabledCheckers.size()
+            )
         );
         for (DeprecationChecker checker : checkers) {
             checker.check(components, groupedActionListener);

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -329,12 +329,12 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
         final AtomicInteger deleted = new AtomicInteger(0);
         final AtomicInteger failed = new AtomicInteger(0);
         final GroupedActionListener<Void> allDeletesListener = new GroupedActionListener<>(
+            snapshotsToDelete.size(),
             ActionListener.runAfter(listener.map(v -> null), () -> {
                 TimeValue totalElapsedTime = TimeValue.timeValueNanos(nowNanoSupplier.getAsLong() - startTime);
                 logger.debug("total elapsed time for deletion of [{}] snapshots: {}", deleted, totalElapsedTime);
                 slmStats.deletionTime(totalElapsedTime);
-            }),
-            snapshotsToDelete.size()
+            })
         );
         for (Map.Entry<String, List<Tuple<SnapshotId, String>>> entry : snapshotsToDelete.entrySet()) {
             String repo = entry.getKey();
@@ -354,7 +354,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
         ActionListener<Void> listener
     ) {
 
-        final ActionListener<Void> allDeletesListener = new GroupedActionListener<>(listener.map(v -> null), snapshots.size());
+        final ActionListener<Void> allDeletesListener = new GroupedActionListener<>(snapshots.size(), listener.map(v -> null));
         for (Tuple<SnapshotId, String> info : snapshots) {
             final SnapshotId snapshotId = info.v1();
             if (runningDeletions.add(snapshotId) == false) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -342,6 +342,7 @@ public class TransportCloseJobAction extends TransportTasksAction<
     void isolateDatafeeds(List<String> openJobs, List<String> runningDatafeedIds, ActionListener<Void> listener) {
 
         GroupedActionListener<IsolateDatafeedAction.Response> groupedListener = new GroupedActionListener<>(
+            runningDatafeedIds.size(),
             ActionListener.wrap(c -> listener.onResponse(null), e -> {
                 // This is deliberately NOT an error. The reasoning is as follows:
                 // - Isolate datafeed just sets a flag on the datafeed, so cannot fail IF it reaches the running datafeed code
@@ -363,8 +364,7 @@ public class TransportCloseJobAction extends TransportTasksAction<
                 // race condition easier.
                 logger.info("could not isolate all datafeeds while force closing jobs " + openJobs, e);
                 listener.onResponse(null);
-            }),
-            runningDatafeedIds.size()
+            })
         );
 
         for (String runningDatafeedId : runningDatafeedIds) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
@@ -233,7 +233,7 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
         final List<TrainedModelConfig> configs,
         final ActionListener<Table> listener
     ) {
-        return new GroupedActionListener<>(listener.delegateFailure((l, responses) -> {
+        return new GroupedActionListener<>(size, listener.delegateFailure((l, responses) -> {
             GetTrainedModelsStatsAction.Response statsResponse = extractResponse(responses, GetTrainedModelsStatsAction.Response.class);
             GetDataFrameAnalyticsAction.Response analytics = extractResponse(responses, GetDataFrameAnalyticsAction.Response.class);
             l.onResponse(
@@ -244,7 +244,7 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
                     analytics == null ? Collections.emptyList() : analytics.getResources().results()
                 )
             );
-        }), size);
+        }));
     }
 
     private Table buildTable(

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/SparseFileTracker.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/cache/common/SparseFileTracker.java
@@ -258,8 +258,8 @@ public class SparseFileTracker {
             }
             default -> {
                 final GroupedActionListener<Long> groupedActionListener = new GroupedActionListener<>(
-                    wrappedListener.map(progress -> null),
-                    requiredRanges.size()
+                    requiredRanges.size(),
+                    wrappedListener.map(progress -> null)
                 );
                 requiredRanges.forEach(
                     r -> r.completionListener.addListener(groupedActionListener, Math.min(r.completionListener.end, subRange.end()))
@@ -346,8 +346,8 @@ public class SparseFileTracker {
             }
             default -> {
                 final GroupedActionListener<Long> groupedActionListener = new GroupedActionListener<>(
-                    wrappedListener.map(progress -> null),
-                    pendingRanges.size()
+                    pendingRanges.size(),
+                    wrappedListener.map(progress -> null)
                 );
                 pendingRanges.forEach(
                     r -> r.completionListener.addListener(groupedActionListener, Math.min(r.completionListener.end, range.end()))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/InitialNodeSecurityAutoConfiguration.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/InitialNodeSecurityAutoConfiguration.java
@@ -120,6 +120,7 @@ public class InitialNodeSecurityAutoConfiguration {
                         }
                         final String httpsCaFingerprint = fingerprint;
                         GroupedActionListener<Map<String, String>> groupedActionListener = new GroupedActionListener<>(
+                            3,
                             ActionListener.wrap(results -> {
                                 final Map<String, String> allResultsMap = new HashMap<>();
                                 for (Map<String, String> result : results) {
@@ -135,8 +136,7 @@ public class InitialNodeSecurityAutoConfiguration {
                                     httpsCaFingerprint,
                                     console
                                 );
-                            }, e -> LOGGER.error("Unexpected exception during security auto-configuration", e)),
-                            3
+                            }, e -> LOGGER.error("Unexpected exception during security auto-configuration", e))
                         );
                         // we only generate the elastic user password if the node has been auto-configured in a specific way, such that the
                         // first time a node starts it will form a cluster by itself and can hold the .security index (which we assume

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/ReservedRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/ReservedRoleMappingAction.java
@@ -104,7 +104,7 @@ public class ReservedRoleMappingAction implements ReservedClusterStateHandler<Li
             return;
         }
 
-        GroupedActionListener<Boolean> taskListener = new GroupedActionListener<>(new ActionListener<>() {
+        GroupedActionListener<Boolean> taskListener = new GroupedActionListener<>(tasksCount, new ActionListener<>() {
             @Override
             public void onResponse(Collection<Boolean> booleans) {
                 listener.onResponse(new NonStateTransformResult(ReservedRoleMappingAction.NAME, Collections.unmodifiableSet(entities)));
@@ -114,7 +114,7 @@ public class ReservedRoleMappingAction implements ReservedClusterStateHandler<Li
             public void onFailure(Exception e) {
                 listener.onFailure(e);
             }
-        }, tasksCount);
+        });
 
         for (var request : requests) {
             roleMappingStore.putRoleMapping(request, taskListener);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/saml/TransportSamlInvalidateSessionAction.java
@@ -113,8 +113,8 @@ public final class TransportSamlInvalidateSessionAction extends HandledTransport
                 listener.onResponse(0);
             } else {
                 GroupedActionListener<TokensInvalidationResult> groupedListener = new GroupedActionListener<>(
-                    ActionListener.wrap(collection -> listener.onResponse(collection.size()), listener::onFailure),
-                    tokens.size()
+                    tokens.size(),
+                    ActionListener.wrap(collection -> listener.onResponse(collection.size()), listener::onFailure)
                 );
                 tokens.forEach(tuple -> invalidateTokenPair(tuple, groupedListener));
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportGetUsersAction.java
@@ -103,7 +103,7 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
             }
 
         }, listener::onFailure);
-        final GroupedActionListener<Collection<User>> groupListener = new GroupedActionListener<>(sendingListener, 2);
+        final GroupedActionListener<Collection<User>> groupListener = new GroupedActionListener<>(2, sendingListener);
         // We have two sources for the users object, the reservedRealm and the usersStore, we query both at the same time with a
         // GroupedActionListener
         if (realmLookup.isEmpty()) {
@@ -117,7 +117,7 @@ public class TransportGetUsersAction extends HandledTransportAction<GetUsersRequ
         } else {
             // nested group listener action here - for each of the users we got and fetch it concurrently - once we are done we notify
             // the "global" group listener.
-            GroupedActionListener<User> realmGroupListener = new GroupedActionListener<>(groupListener, realmLookup.size());
+            GroupedActionListener<User> realmGroupListener = new GroupedActionListener<>(realmLookup.size(), groupListener);
             for (String user : realmLookup) {
                 reservedRealm.lookupUser(user, realmGroupListener);
             }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
@@ -44,11 +44,11 @@ public class CompositeRoleMapper implements UserRoleMapper {
     @Override
     public void resolveRoles(UserData user, ActionListener<Set<String>> listener) {
         GroupedActionListener<Set<String>> groupListener = new GroupedActionListener<>(
+            delegates.size(),
             ActionListener.wrap(
                 composite -> listener.onResponse(composite.stream().flatMap(Set::stream).collect(Collectors.toSet())),
                 listener::onFailure
-            ),
-            delegates.size()
+            )
         );
         this.delegates.forEach(mapper -> mapper.resolveRoles(user, groupListener));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationService.java
@@ -829,7 +829,7 @@ public class AuthorizationService {
                 listener::onFailure
             );
             final ActionListener<Tuple<String, IndexAuthorizationResult>> groupedActionListener = wrapPreservingContext(
-                new GroupedActionListener<>(bulkAuthzListener, actionToIndicesMap.size()),
+                new GroupedActionListener<>(actionToIndicesMap.size(), bulkAuthzListener),
                 threadContext
             );
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/store/CompositeRolesStore.java
@@ -376,8 +376,8 @@ public class CompositeRolesStore {
             () -> {
                 final List<RoleReference> roleReferences = subject.getRoleReferenceIntersection(anonymousUser).getRoleReferences();
                 final GroupedActionListener<Set<RoleDescriptor>> groupedActionListener = new GroupedActionListener<>(
-                    listener,
-                    roleReferences.size()
+                    roleReferences.size(),
+                    listener
                 );
 
                 roleReferences.forEach(roleReference -> {

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/BlobAnalyzeAction.java
@@ -254,8 +254,8 @@ public class BlobAnalyzeAction extends ActionType<BlobAnalyzeAction.Response> {
 
             final StepListener<Collection<NodeResponse>> readsCompleteStep = new StepListener<>();
             readNodesListener = new GroupedActionListener<>(
-                new ThreadedActionListener<>(logger, transportService.getThreadPool(), ThreadPool.Names.SNAPSHOT, readsCompleteStep, false),
-                earlyReadNodes.size() + readNodes.size()
+                earlyReadNodes.size() + readNodes.size(),
+                new ThreadedActionListener<>(logger, transportService.getThreadPool(), ThreadPool.Names.SNAPSHOT, readsCompleteStep, false)
             );
 
             // The order is important in this chain: if writing fails then we may never even start all the reads, and we want to cancel

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetCheckpointAction.java
@@ -143,6 +143,7 @@ public class TransportGetCheckpointAction extends HandledTransportAction<Request
 
         public void start() {
             GroupedActionListener<GetCheckpointNodeAction.Response> groupedListener = new GroupedActionListener<>(
+                nodesAndShards.size(),
                 ActionListener.wrap(responses -> {
                     // the final list should be ordered by key
                     Map<String, long[]> checkpointsByIndexReduced = new TreeMap<>();
@@ -162,8 +163,7 @@ public class TransportGetCheckpointAction extends HandledTransportAction<Request
                     }
 
                     listener.onResponse(new Response(checkpointsByIndexReduced));
-                }, listener::onFailure),
-                nodesAndShards.size()
+                }, listener::onFailure)
             );
 
             for (Entry<String, Set<ShardId>> oneNodeAndItsShards : nodesAndShards.entrySet()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -483,8 +483,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
     ) {
         final ActionListener<Response> doExecuteListener = ActionListener.wrap(response -> {
             GroupedActionListener<PersistentTask<?>> groupedListener = new GroupedActionListener<>(
-                ActionListener.wrap(r -> { finalListener.onResponse(response); }, finalListener::onFailure),
-                transformNodeAssignments.getWaitingForAssignment().size()
+                transformNodeAssignments.getWaitingForAssignment().size(),
+                ActionListener.wrap(r -> { finalListener.onResponse(response); }, finalListener::onFailure)
             );
 
             for (String unassignedTaskId : transformNodeAssignments.getWaitingForAssignment()) {
@@ -493,8 +493,8 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
 
         }, e -> {
             GroupedActionListener<PersistentTask<?>> groupedListener = new GroupedActionListener<>(
-                ActionListener.wrap(r -> { finalListener.onFailure(e); }, finalListener::onFailure),
-                transformNodeAssignments.getWaitingForAssignment().size()
+                transformNodeAssignments.getWaitingForAssignment().size(),
+                ActionListener.wrap(r -> { finalListener.onFailure(e); }, finalListener::onFailure)
             );
 
             for (String unassignedTaskId : transformNodeAssignments.getWaitingForAssignment()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/checkpoint/DefaultCheckpointProvider.java
@@ -118,7 +118,7 @@ class DefaultCheckpointProvider implements CheckpointProvider {
                     );
                 }, listener::onFailure);
 
-                groupedListener = new GroupedActionListener<>(mergeMapsListener, resolvedIndexes.numClusters());
+                groupedListener = new GroupedActionListener<>(resolvedIndexes.numClusters(), mergeMapsListener);
             }
 
             if (resolvedIndexes.getLocalIndices().isEmpty() == false) {


### PR DESCRIPTION
Switches the order of the arguments to the GroupedActionListener constructor, so that we don't (as frequently) have a big ol' block of code followed by some number (a variable or constant).

Not an especially valuable change when both arguments are variables, but it carries its weight when the listener/delegate is a 40+ line block of logic and stuff:

```diff --git a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
index 1235afc3b86..3df54bc6436 100644
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -176,7 +176,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             return;
         }
         final GroupedActionListener<Tuple<Tuple<String, ElasticsearchException>, SnapshotsInRepo>> groupedActionListener =
-            new GroupedActionListener<>(listener.map(responses -> {
+            new GroupedActionListener<>(repos.size(), listener.map(responses -> {
                 assert repos.size() == responses.size();
                 final List<SnapshotInfo> allSnapshots = responses.stream()
                     .map(Tuple::v2)
@@ -203,7 +203,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                     responses.stream().map(Tuple::v2).filter(Objects::nonNull).mapToInt(s -> s.totalCount).sum(),
                     remaining
                 );
-            }), repos.size());
+            }));

         for (final RepositoryMetadata repo : repos) {
             final String repoName = repo.name();
```

This is a small refactoring on the way to a bigger PR that I'll be putting through soon, it's not just a random little fix out of nowhere. 😄 