### PR TITLE
[8.6] [DOCS] Remove the sentence on deleting document in .tasks (#87310)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -141,8 +141,6 @@ If the request contains `wait_for_completion=false`, {es}
 performs some preflight checks, launches the request, and returns a
 <<tasks,`task`>> you can use to cancel or get the status of the task.
 {es} creates a record of this task as a document at `_tasks/<task_id>`.
-When you are done with a task, you should delete the task document so
-{es} can reclaim the space.
 
 [[docs-reindex-from-multiple-sources]]
 ===== Reindex from multiple sources

--- a/docs/reference/docs/update-by-query.asciidoc
+++ b/docs/reference/docs/update-by-query.asciidoc
@@ -99,8 +99,6 @@ If the request contains `wait_for_completion=false`, {es}
 performs some preflight checks, launches the request, and returns a
 <<tasks,`task`>> you can use to cancel or get the status of the task.
 {es} creates a record of this task as a document at `.tasks/task/${taskId}`.
-When you are done with a task, you should delete the task document so
-{es} can reclaim the space.
 
 ===== Waiting for active shards
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Remove the sentence on deleting document in .tasks (#87310)