### PR TITLE
Minor TSDB parsing speedup.

### DIFF
--- a/docs/changelog/92276.yaml
+++ b/docs/changelog/92276.yaml
@@ -1,0 +1,5 @@
+pr: 92276
+summary: Minor TSDB parsing speedup
+area: TSDB
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/regex/Regex.java
+++ b/server/src/main/java/org/elasticsearch/common/regex/Regex.java
@@ -11,13 +11,17 @@ package org.elasticsearch.common.regex;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.automaton.Automata;
 import org.apache.lucene.util.automaton.Automaton;
+import org.apache.lucene.util.automaton.CharacterRunAutomaton;
 import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.common.Strings;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 
 public class Regex {
@@ -88,6 +92,40 @@ public class Regex {
             automata.add(simpleStringsAutomaton);
         }
         return Operations.union(automata);
+    }
+
+    /**
+     * Create a {@link Predicate} that matches the given patterns. Evaluating
+     * the returned predicate against a {@link String} yields the same result as
+     * running {@link #simpleMatch(String[], String)} but may run faster,
+     * especially in the case when there are multiple patterns.
+     */
+    public static Predicate<String> simpleMatcher(String... patterns) {
+        if (patterns == null || patterns.length == 0) {
+            return str -> false;
+        }
+        boolean hasWildcard = false;
+        for (String pattern : patterns) {
+            if (isMatchAllPattern(pattern)) {
+                return str -> true;
+            }
+            if (isSimpleMatchPattern(pattern)) {
+                hasWildcard = true;
+                break;
+            }
+        }
+        if (patterns.length == 1) {
+            if (hasWildcard) {
+                return str -> simpleMatch(patterns[0], str);
+            } else {
+                return patterns[0]::equals;
+            }
+        } else if (hasWildcard == false) {
+            return Set.copyOf(Arrays.asList(patterns))::contains;
+        } else {
+            Automaton automaton = simpleMatchToAutomaton(patterns);
+            return new CharacterRunAutomaton(automaton)::run;
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentDimensions.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentDimensions.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.apache.lucene.util.BytesRef;
+
 import java.net.InetAddress;
 import java.util.HashSet;
 import java.util.Set;
@@ -16,7 +18,17 @@ import java.util.Set;
  * Collects dimensions from documents.
  */
 public interface DocumentDimensions {
-    void addString(String fieldName, String value);
+
+    /**
+     * This overloaded method tries to take advantage of the fact that the UTF-8
+     * value is already computed in some cases when we want to collect
+     * dimensions, so we can save re-computing the UTF-8 encoding.
+     */
+    void addString(String fieldName, BytesRef utf8Value);
+
+    default void addString(String fieldName, String value) {
+        addString(fieldName, new BytesRef(value));
+    }
 
     void addIp(String fieldName, InetAddress value);
 
@@ -30,6 +42,12 @@ public interface DocumentDimensions {
     class OnlySingleValueAllowed implements DocumentDimensions {
         private final Set<String> names = new HashSet<>();
 
+        @Override
+        public void addString(String fieldName, BytesRef value) {
+            add(fieldName);
+        }
+
+        // Override to skip the UTF-8 conversion that happens in the default implementation
         @Override
         public void addString(String fieldName, String value) {
             add(fieldName);

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -995,12 +995,13 @@ public final class KeywordFieldMapper extends FieldMapper {
         }
 
         value = normalizeValue(fieldType().normalizer(), name(), value);
-        if (fieldType().isDimension()) {
-            context.getDimensions().addString(fieldType().name(), value);
-        }
 
         // convert to utf8 only once before feeding postings/dv/stored fields
         final BytesRef binaryValue = new BytesRef(value);
+
+        if (fieldType().isDimension()) {
+            context.getDimensions().addString(fieldType().name(), binaryValue);
+        }
 
         // If the UTF8 encoding of the field value is bigger than the max length 32766, Lucene fill fail the indexing request and, to roll
         // back the changes, will mark the (possibly partially indexed) document as deleted. This results in deletes, even in an append-only

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesIdFieldMapper.java
@@ -239,7 +239,7 @@ public class TimeSeriesIdFieldMapper extends MetadataFieldMapper {
         }
 
         @Override
-        public void addString(String fieldName, String value) {
+        public void addString(String fieldName, BytesRef utf8Value) {
             try (BytesStreamOutput out = new BytesStreamOutput()) {
                 out.write((byte) 's');
                 /*
@@ -247,17 +247,16 @@ public class TimeSeriesIdFieldMapper extends MetadataFieldMapper {
                  * so it's easier for folks to reason about the space taken up. Mostly
                  * it'll be smaller too.
                  */
-                BytesRef bytes = new BytesRef(value);
-                if (bytes.length > DIMENSION_VALUE_LIMIT) {
+                if (utf8Value.length > DIMENSION_VALUE_LIMIT) {
                     throw new IllegalArgumentException(
-                        "Dimension fields must be less than [" + DIMENSION_VALUE_LIMIT + "] bytes but was [" + bytes.length + "]."
+                        "Dimension fields must be less than [" + DIMENSION_VALUE_LIMIT + "] bytes but was [" + utf8Value.length + "]."
                     );
                 }
-                out.writeBytesRef(bytes);
+                out.writeBytesRef(utf8Value);
                 add(fieldName, out.bytes());
 
                 if (routingBuilder != null) {
-                    routingBuilder.addMatching(fieldName, bytes);
+                    routingBuilder.addMatching(fieldName, utf8Value);
                 }
             } catch (IOException e) {
                 throw new IllegalArgumentException("Dimension field cannot be serialized.", e);

--- a/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
+++ b/server/src/test/java/org/elasticsearch/common/regex/RegexTests.java
@@ -189,4 +189,27 @@ public class RegexTests extends ESTestCase {
             assertFalse(run.run(s));
         }
     }
+
+    public void testSimpleMatcher() {
+        assertFalse(Regex.simpleMatcher((String[]) null).test("abc"));
+        assertFalse(Regex.simpleMatcher().test("abc"));
+        assertTrue(Regex.simpleMatcher("abc").test("abc"));
+        assertFalse(Regex.simpleMatcher("abc").test("abd"));
+
+        assertTrue(Regex.simpleMatcher("abc", "xyz").test("abc"));
+        assertTrue(Regex.simpleMatcher("abc", "xyz").test("xyz"));
+        assertFalse(Regex.simpleMatcher("abc", "xyz").test("abd"));
+        assertFalse(Regex.simpleMatcher("abc", "xyz").test("xyy"));
+
+        assertTrue(Regex.simpleMatcher("abc", "*").test("abc"));
+        assertTrue(Regex.simpleMatcher("abc", "*").test("abd"));
+
+        assertTrue(Regex.simpleMatcher("a*c").test("abc"));
+        assertFalse(Regex.simpleMatcher("a*c").test("abd"));
+
+        assertTrue(Regex.simpleMatcher("a*c", "x*z").test("abc"));
+        assertTrue(Regex.simpleMatcher("a*c", "x*z").test("xyz"));
+        assertFalse(Regex.simpleMatcher("a*c", "x*z").test("abd"));
+        assertFalse(Regex.simpleMatcher("a*c", "x*z").test("xyy"));
+    }
 }


### PR DESCRIPTION
This changes addresses a few minor inefficiences on the TSDB parsing path:
 - The UTF-8 representation of keyword fields that are also dimensions is computed twice.
 - Extraction of the routing path evaluates every pattern in sequence, while it is possible to do better by converting the list of patterns to a set when there are no wildcards, or to an automaton otherwise.