### PR TITLE
[8.5] [DOCS] Remove 'coming' from 8.5.3 release notes (#92283)

### DIFF
--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.5.3]]
 == {es} version 8.5.3
 
-coming[8.5.3]
-
 Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.
 
 [[bug-8.5.3]]


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [DOCS] Remove 'coming' from 8.5.3 release notes (#92283)