### PR TITLE
[8.6] [DOCS] Add missing privilege to bulk prerequisites (#92237)

### DIFF
--- a/docs/reference/docs/bulk.asciidoc
+++ b/docs/reference/docs/bulk.asciidoc
@@ -49,6 +49,9 @@ privilege.
 ** To automatically create a data stream or index with a bulk API request, you
 must have the `auto_configure`, `create_index`, or `manage` index privilege.
 
+** To make the result of a bulk operation visible to search using the `refresh`
+parameter, you must have the `maintenance` or `manage` index privilege.
+
 * Automatic data stream creation requires a matching index template with data
 stream enabled. See <<set-up-a-data-stream>>.
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Add missing privilege to bulk prerequisites (#92237)