### PR TITLE
[DOCS] Move known issues section to top of 8.5.0 release notes

### DIFF
--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -3,6 +3,17 @@
 
 Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.
 
+[[known-issues-8.5.0]]
+[float]
+=== Known issues
+
+* It is possible to inadvertently create an alias with the same name as an
+index in version 8.5.0. This action leaves the cluster in an invalid state in
+which several features will not work correctly, and it may not even be possible
+to restart nodes while in this state. Upgrade to 8.5.1 as soon as possible to
+avoid the risk of this occurring ({es-pull}91456[#91456]). If your cluster is
+affected by this issue, upgrade to 8.5.3 to repair it ({es-pull}91887[#91887]).
+
 [[breaking-8.5.0]]
 [float]
 === Breaking changes
@@ -319,15 +330,3 @@ Client::
 
 Packaging::
 * Upgrade bundled JDK to Java 19 {es-pull}90571[#90571]
-
-
-[[known-issues-8.5.0]]
-[float]
-=== Known issues
-
-* It is possible to inadvertently create an alias with the same name as an
-index in version 8.5.0. This action leaves the cluster in an invalid state in
-which several features will not work correctly, and it may not even be possible
-to restart nodes while in this state. Upgrade to 8.5.1 as soon as possible to
-avoid the risk of this occurring ({es-pull}91456[#91456]). If your cluster is
-affected by this issue, upgrade to 8.5.3 to repair it ({es-pull}91887[#91887]).


### PR DESCRIPTION
This PR moves the "known issues" section of the 8.5.0 release notes to the top of the page for better visibility.