### PR TITLE
Execute blackhole response on correct transport

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -63,7 +62,6 @@ import static org.hamcrest.Matchers.startsWith;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92307")
 public class CoordinationDiagnosticsServiceTests extends AbstractCoordinatorTestCase {
     DiscoveryNode node1;
     DiscoveryNode node2;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.LogEvent;
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
@@ -98,7 +97,6 @@ import static org.hamcrest.Matchers.sameInstance;
 import static org.hamcrest.Matchers.startsWith;
 
 @TestLogging(reason = "these tests do a lot of log-worthy things but we usually don't care", value = "org.elasticsearch:FATAL")
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92307")
 public class CoordinatorTests extends AbstractCoordinatorTestCase {
 
     public void testCanUpdateClusterStateAfterStabilisation() {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StableMasterHealthIndicatorServiceTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -52,7 +51,6 @@ import static org.hamcrest.Matchers.not;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92307")
 public class StableMasterHealthIndicatorServiceTests extends AbstractCoordinatorTestCase {
     DiscoveryNode node1;
     DiscoveryNode node2;

--- a/test/framework/src/main/java/org/elasticsearch/transport/DisruptableMockTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/DisruptableMockTransport.java
@@ -194,7 +194,7 @@ public abstract class DisruptableMockTransport extends MockTransport {
         });
     }
 
-    protected Runnable getDisconnectException(long requestId, String action, DiscoveryNode destination) {
+    private Runnable getDisconnectException(long requestId, String action, DiscoveryNode destination) {
         return new RebootSensitiveRunnable() {
             @Override
             public void ifRebooted() {
@@ -213,11 +213,11 @@ public abstract class DisruptableMockTransport extends MockTransport {
         };
     }
 
-    protected String getRequestDescription(long requestId, String action, DiscoveryNode destination) {
+    private String getRequestDescription(long requestId, String action, DiscoveryNode destination) {
         return format("[%s][%s] from %s to %s", requestId, action, getLocalNode(), destination);
     }
 
-    protected void onBlackholedDuringSend(long requestId, String action, DisruptableMockTransport destinationTransport) {
+    private void onBlackholedDuringSend(long requestId, String action, DisruptableMockTransport destinationTransport) {
         logger.trace("dropping {}", getRequestDescription(requestId, action, destinationTransport.getLocalNode()));
         // Delaying the response until explicitly instructed, to simulate a very long delay
         blackholedRequests.add(new Runnable() {
@@ -233,11 +233,11 @@ public abstract class DisruptableMockTransport extends MockTransport {
         });
     }
 
-    protected void onDisconnectedDuringSend(long requestId, String action, DisruptableMockTransport destinationTransport) {
-        destinationTransport.execute(getDisconnectException(requestId, action, destinationTransport.getLocalNode()));
+    private void onDisconnectedDuringSend(long requestId, String action, DisruptableMockTransport destinationTransport) {
+        execute(getDisconnectException(requestId, action, destinationTransport.getLocalNode()));
     }
 
-    protected void onConnectedDuringSend(
+    private void onConnectedDuringSend(
         long requestId,
         String action,
         TransportRequest request,

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -554,6 +554,7 @@ public class DisruptableMockTransportTests extends ESTestCase {
         deterministicTaskQueue.runAllRunnableTasks();
 
         assertTrue(responseHandlerReleased.get());
+        assertTrue(rebootedNodes.contains(node1) || responseHandlerCalled.get());
     }
 
     public void testBrokenLinkFailsToConnect() {

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -504,7 +504,7 @@ public class DisruptableMockTransportTests extends ESTestCase {
 
         for (Runnable runnable : Stream.concat(
             Stream.of(reboot(node1), reboot(node2), blockTestAction),
-            Stream.of(Tuple.tuple(node1, node2), Tuple.tuple(node2, node2)).map(link -> {
+            Stream.of(Tuple.tuple(node1, node2), Tuple.tuple(node2, node1)).map(link -> {
                 final var disruption = randomFrom(linkDisruptions);
                 return new Runnable() {
                     @Override

--- a/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeCoordinatorTests.java
+++ b/x-pack/plugin/voting-only-node/src/test/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodeCoordinatorTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.cluster.coordination.votingonly;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.coordination.AbstractCoordinatorTestCase;
 import org.elasticsearch.cluster.coordination.ElectionStrategy;
@@ -23,7 +22,6 @@ import java.util.Set;
 
 import static java.util.Collections.emptySet;
 
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92307")
 public class VotingOnlyNodeCoordinatorTests extends AbstractCoordinatorTestCase {
 
     @Override


### PR DESCRIPTION
We simulate sending traffic along a blackholed connection with a disconnection exception that we withold until far into the future. Today this exception is delivered using the transport of the responding node, but it should be the requesting node. This commit fixes that.

Not sure how this _ever_ worked, but we made things stricter in #92245 and that meant this bug led to test failures.

Closes #92307