### PR TITLE
[8.6] [ML] Adding a known issue for the ML datafeed auth header problem (#92274)

### DIFF
--- a/docs/reference/release-notes/8.4.0.asciidoc
+++ b/docs/reference/release-notes/8.4.0.asciidoc
@@ -3,6 +3,23 @@
 
 Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 
+[[known-issues-8.4.0]]
+[float]
+=== Known issues
+
+// tag::ml-pre-7-datafeeds-known-issue[]
+* {ml-cap} {dfeeds} cannot be listed if any are not modified since version 6.x
++
+If you have a {dfeed} that was created in version 5.x or 6.x and has not
+been updated since 7.0, it is not possible to list {dfeeds} in 
+8.4 and 8.5. This means that {anomaly-jobs} cannot be managed using
+{kib}. This issue is fixed in 8.6.
++
+If you upgrade to 8.4 or 8.5 with such a {dfeed}, you need to
+work around the problem by updating each {dfeed}'s authorization information
+using https://support.elastic.dev/knowledge/view/b5a879db[these steps].
+// end::ml-pre-7-datafeeds-known-issue[]
+
 [[bug-8.4.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -18,3 +18,5 @@ Machine Learning::
 * When using date range search with format that does not have all date fields (missing month or day)
 an incorrectly parsed date could be used. The workaround is to use date pattern with all date fields (year, month, day)
 (issue: {es-issue}90187[#90187])
+
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]

--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -20,6 +20,7 @@ This regression was fixed in version 8.4.3.
 an incorrectly parsed date could be used. The workaround is to use date pattern with all date fields (year, month, day)
 (issue: {es-issue}90187[#90187])
 
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 [[bug-8.4.2]]
 [float]

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -28,3 +28,5 @@ Ranking::
 * When using date range search with format that does not have all date fields (missing month or day)
 an incorrectly parsed date could be used. The workaround is to use date pattern with all date fields (year, month, day)
 (issue: {es-issue}90187[#90187])
+
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]

--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -14,6 +14,8 @@ to restart nodes while in this state. Upgrade to 8.5.1 as soon as possible to
 avoid the risk of this occurring ({es-pull}91456[#91456]). If your cluster is
 affected by this issue, upgrade to 8.5.3 to repair it ({es-pull}91887[#91887]).
 
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
+
 [[breaking-8.5.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.5.1.asciidoc
+++ b/docs/reference/release-notes/8.5.1.asciidoc
@@ -4,6 +4,12 @@
 
 Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.
 
+[[known-issues-8.5.1]]
+[float]
+=== Known issues
+
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
+
 [[bug-8.5.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.2.asciidoc
+++ b/docs/reference/release-notes/8.5.2.asciidoc
@@ -4,6 +4,12 @@
 
 Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.
 
+[[known-issues-8.5.2]]
+[float]
+=== Known issues
+
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
+
 [[bug-8.5.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -3,6 +3,12 @@
 
 Also see <<breaking-changes-8.5,Breaking changes in 8.5>>.
 
+[[known-issues-8.5.3]]
+[float]
+=== Known issues
+
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
+
 [[bug-8.5.3]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [ML] Adding a known issue for the ML datafeed auth header problem (#92274)