### PR TITLE
[ML] Frequent items extension pruning

### DIFF
--- a/docs/changelog/92322.yaml
+++ b/docs/changelog/92322.yaml
@@ -1,5 +1,5 @@
 pr: 92322
-summary: Frequent items extension pruning
+summary: implement extension pruning in frequent items to improve runtime
 area: Machine Learning
 type: enhancement
 issues: []

--- a/docs/changelog/92322.yaml
+++ b/docs/changelog/92322.yaml
@@ -1,0 +1,5 @@
+pr: 92322
+summary: Frequent items extension pruning
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
@@ -263,13 +263,10 @@ final class CountingItemSetTraverser implements Releasable {
 
     public void pruneToNextMainBranch() {
         long thisCount = getCount();
-        int thisDepth = getNumberOfItems();
 
         while (getNumberOfItems() > 1 && getCount() == thisCount) {
             topItemSetTraverser.prune();
         }
-
-        logger.trace("skipped from depth {} to depth {}", thisDepth, getNumberOfItems());
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/CountingItemSetTraverser.java
@@ -261,6 +261,17 @@ final class CountingItemSetTraverser implements Releasable {
         topItemSetTraverser.prune();
     }
 
+    public void pruneToNextMainBranch() {
+        long thisCount = getCount();
+        int thisDepth = getNumberOfItems();
+
+        while (getNumberOfItems() > 1 && getCount() == thisCount) {
+            topItemSetTraverser.prune();
+        }
+
+        logger.trace("skipped from depth {} to depth {}", thisDepth, getNumberOfItems());
+    }
+
     /**
      * Return true if the item set tree is on a leaf, which mean no further items can be added to the candidate set.
      */

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
@@ -490,12 +490,12 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
                     logger.debug("adjusting min count to {}", minCount);
                 }
 
+                /**
+                 * Optimization:
+                 *
+                 * If we reached a leaf, go up the branch until the new branch has a higher count than our current leaf.
+                 */
                 if (setTraverser.atLeaf()) {
-                    /**
-                     * Optimization:
-                     *
-                     * If we reached a leaf, go up the branch until the new branch has a higher count than our current leaf.
-                     */
                     setTraverser.prune();
                     setTraverser.pruneToNextMainBranch();
                 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
@@ -424,6 +424,22 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
                         // no need to set visited, as we are on a leaf
                     }
 
+                    /**
+                     * Optimization
+                     *
+                     * a - b - c - d
+                     * |   |    \- h
+                     * |   |\- e - f
+                     * |    \- h - j
+                     *  \- x - y
+                     *
+                     * assume we pruned at d above, if c has the same count as d, we don't need the sub-branches, but go up
+                     * until we find a branch that has a higher count than the pruned one. This allows us to skip over subtrees.
+                     */
+                    if (setTraverser.atLeaf()) {
+                        setTraverser.pruneToNextMainBranch();
+                    }
+
                     continue;
                 }
 
@@ -472,6 +488,16 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
                 if (previousMinCount != minCount) {
                     previousMinCount = minCount;
                     logger.debug("adjusting min count to {}", minCount);
+                }
+
+                if (setTraverser.atLeaf()) {
+                    /**
+                     * Optimization:
+                     *
+                     * If we reached a leaf, go up the branch until the new branch has a higher count than our current leaf.
+                     */
+                    setTraverser.prune();
+                    setTraverser.pruneToNextMainBranch();
                 }
             }
             FrequentItemSet[] topFrequentItems = collector.finalizeAndGetResults(fields);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducerTests.java
@@ -27,7 +27,6 @@ import java.util.stream.Stream;
 import static org.elasticsearch.core.Tuple.tuple;
 import static org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr.ItemSetMapReduceValueSourceTests.createKeywordFieldTestInstance;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducerTests.java
@@ -27,6 +27,9 @@ import java.util.stream.Stream;
 import static org.elasticsearch.core.Tuple.tuple;
 import static org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr.ItemSetMapReduceValueSourceTests.createKeywordFieldTestInstance;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThan;
 
 public class EclatMapReducerTests extends ESTestCase {
 
@@ -240,7 +243,7 @@ public class EclatMapReducerTests extends ESTestCase {
         assertThat(result.getProfilingInfo().get("unique_items_after_reduce"), equalTo(21L));
         assertThat(result.getProfilingInfo().get("total_transactions_after_reduce"), equalTo(12L));
         assertThat(result.getProfilingInfo().get("total_items_after_reduce"), equalTo(72L));
-        assertThat(result.getProfilingInfo().get("item_sets_checked_eclat"), equalTo(63L));
+        assertThat(result.getProfilingInfo().get("item_sets_checked_eclat"), equalTo(47L));
     }
 
     public void testPruneToNextMainBranchAfterMinCountPrune() throws IOException {
@@ -456,7 +459,11 @@ public class EclatMapReducerTests extends ESTestCase {
         assertThat(result.getProfilingInfo().get("total_transactions_after_reduce"), equalTo(12L));
         assertThat(result.getProfilingInfo().get("total_items_after_reduce"), equalTo(96L));
         assertThat(result.getProfilingInfo().get("total_items_after_prune"), equalTo(96L));
-        assertThat(result.getProfilingInfo().get("item_sets_checked_eclat"), equalTo(495L));
+
+        // the number can vary depending on order, so we can only check a range, which is still much lower than without
+        // that optimization
+        assertThat((Long) result.getProfilingInfo().get("item_sets_checked_eclat"), greaterThanOrEqualTo(294L));
+        assertThat((Long) result.getProfilingInfo().get("item_sets_checked_eclat"), lessThan(310L));
     }
 
     private static BigArrays mockBigArrays() {


### PR DESCRIPTION
Especially machine-generated data contains data that always appears together, e.g. a URI and a path which is the same URI but without the protocol. Such a case is called an "extension". This PR implements so called extension pruning, it avoids iterating over those extensions to build all permutations of subsets from a superset. All with the same item counts.

This fixes problems with datasets based on APM and logging. For those a benchmark of the query execution time reduces from `19434198` ms to `103321` ms (factor `188`).

For more "natural" data sets like the ones used for rally-tracks this PR has no effect as pruning doesn't kick in here.