### PR TITLE
[8.4] [ML] Adding a known issue for the ML datafeed auth header problem

### DIFF
--- a/docs/reference/release-notes/8.4.0.asciidoc
+++ b/docs/reference/release-notes/8.4.0.asciidoc
@@ -3,6 +3,23 @@
 
 Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 
+[[known-issues-8.4.0]]
+[float]
+=== Known issues
+
+// tag::ml-pre-7-datafeeds-known-issue[]
+* {ml-cap} {dfeeds} cannot be listed if any are not modified since version 6.x
++
+If you have a {dfeed} that was created in version 5.x or 6.x and has not
+been updated since 7.0, it is not possible to list {dfeeds} in 
+8.4 and 8.5. This means that {anomaly-jobs} cannot be managed using
+{kib}. This issue is fixed in 8.6.
++
+If you upgrade to 8.4 or 8.5 with such a {dfeed}, you need to
+work around the problem by updating each {dfeed}'s authorization information
+using https://support.elastic.dev/knowledge/view/b5a879db[these steps].
+// end::ml-pre-7-datafeeds-known-issue[]
+
 [[bug-8.4.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -10,4 +10,8 @@ Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 Machine Learning::
 * [ML] Validate trained model deployment `queue_capacity` limit {es-pull}89611[#89611] (issue: {es-issue}89555[#89555])
 
+[[known-issues-8.4.1]]
+[float]
+=== Known issues
 
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]

--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -16,6 +16,8 @@ with the message "totalTermFreq must be at least docFreq". If you use the
 `cross_fields` scoring type, it is recommended that you skip version 8.4.2.
 This regression was fixed in version 8.4.3.
 
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
+
 [[bug-8.4.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -20,4 +20,8 @@ Ingest Node::
 Ranking::
 * Ensure `cross_fields` always uses valid term statistics {es-pull}90314[#90314]
 
+[[known-issues-8.4.3]]
+[float]
+=== Known issues
 
+include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]


### PR DESCRIPTION
Due to #41185 datafeeds created prior to 7.0 and not updated since then have unparseable authorization headers in 8.x. In 8.0-8.3 this could easily be a non-issue, as such datafeeds were likely forgotten leftovers and never run. Even if it was a problem, only the datafeed of interest would need updating with any urgency.

Due to #87884 datafeeds with authorization headers older than 7.0 prevent _all_ datafeeds being listed in 8.4 and 8.5. This in turn breaks the anomaly detection job management section of the ML UI.

The problem is alleviated by #92168 and fixed by #92221, but we should warn users that the problem exists in 8.4.0-8.5.3 inclusive.

Backport of #92274