### PR TITLE
Make sure EngineConfig can access whether shard is primary

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -80,7 +80,7 @@ public class IndexingMemoryControllerIT extends ESSingleNodeTestCase {
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
                 config.getIndexCommitListener(),
-                config.getRecoveryState()
+                config.isRecoveringAsPrimary()
             );
         }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -79,7 +79,8 @@ public class IndexingMemoryControllerIT extends ESSingleNodeTestCase {
                 config.getSnapshotCommitSupplier(),
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
-                config.getIndexCommitListener()
+                config.getIndexCommitListener(),
+                config.getRecoveryState()
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -30,7 +30,6 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.indices.IndexingMemoryController;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
-import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -129,8 +128,7 @@ public final class EngineConfig {
     @Nullable
     private final Engine.IndexCommitListener indexCommitListener;
 
-    @Nullable
-    private final RecoveryState recoveryState;
+    private final boolean recoveringAsPrimary;
 
     /**
      * Creates a new {@link org.elasticsearch.index.engine.EngineConfig}
@@ -161,7 +159,7 @@ public final class EngineConfig {
         Comparator<LeafReader> leafSorter,
         LongSupplier relativeTimeInNanosSupplier,
         Engine.IndexCommitListener indexCommitListener,
-        RecoveryState recoveryState
+        boolean recoveringAsPrimary
     ) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
@@ -203,7 +201,7 @@ public final class EngineConfig {
         this.leafSorter = leafSorter;
         this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
         this.indexCommitListener = indexCommitListener;
-        this.recoveryState = recoveryState;
+        this.recoveringAsPrimary = recoveringAsPrimary;
     }
 
     /**
@@ -412,8 +410,7 @@ public final class EngineConfig {
         return indexCommitListener;
     }
 
-    @Nullable
-    public RecoveryState getRecoveryState() {
-        return recoveryState;
+    public boolean isRecoveringAsPrimary() {
+        return recoveringAsPrimary;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -30,6 +30,7 @@ import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.translog.TranslogConfig;
 import org.elasticsearch.indices.IndexingMemoryController;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.plugins.IndexStorePlugin;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -128,6 +129,9 @@ public final class EngineConfig {
     @Nullable
     private final Engine.IndexCommitListener indexCommitListener;
 
+    @Nullable
+    private final RecoveryState recoveryState;
+
     /**
      * Creates a new {@link org.elasticsearch.index.engine.EngineConfig}
      */
@@ -156,7 +160,8 @@ public final class EngineConfig {
         IndexStorePlugin.SnapshotCommitSupplier snapshotCommitSupplier,
         Comparator<LeafReader> leafSorter,
         LongSupplier relativeTimeInNanosSupplier,
-        Engine.IndexCommitListener indexCommitListener
+        Engine.IndexCommitListener indexCommitListener,
+        RecoveryState recoveryState
     ) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
@@ -198,6 +203,7 @@ public final class EngineConfig {
         this.leafSorter = leafSorter;
         this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
         this.indexCommitListener = indexCommitListener;
+        this.recoveryState = recoveryState;
     }
 
     /**
@@ -404,5 +410,10 @@ public final class EngineConfig {
     @Nullable
     public Engine.IndexCommitListener getIndexCommitListener() {
         return indexCommitListener;
+    }
+
+    @Nullable
+    public RecoveryState getRecoveryState() {
+        return recoveryState;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -410,6 +410,10 @@ public final class EngineConfig {
         return indexCommitListener;
     }
 
+    /**
+     * Represents the primary state only in case when a recovery starts.
+     * IMPORTANT: The flag is a temporary solution and should NOT be used outside of Stateless.
+     */
     public boolean isRecoveringAsPrimary() {
         return recoveringAsPrimary;
     }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3274,7 +3274,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             snapshotCommitSupplier,
             isTimeseriesIndex ? TIMESERIES_LEAF_READERS_SORTER : null,
             relativeTimeInNanosSupplier,
-            indexCommitListener
+            indexCommitListener,
+            recoveryState
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3275,7 +3275,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             isTimeseriesIndex ? TIMESERIES_LEAF_READERS_SORTER : null,
             relativeTimeInNanosSupplier,
             indexCommitListener,
-            recoveryState
+            recoveryState != null && recoveryState.getPrimary()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3591,7 +3591,7 @@ public class InternalEngineTests extends EngineTestCase {
             null,
             config.getRelativeTimeInNanosSupplier(),
             null,
-            null
+            false
         );
         expectThrows(EngineCreationFailureException.class, () -> new InternalEngine(brokenConfig));
 
@@ -7262,7 +7262,7 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
                 config.getIndexCommitListener(),
-                config.getRecoveryState()
+                config.isRecoveringAsPrimary()
             );
             try (InternalEngine engine = createEngine(configWithWarmer)) {
                 assertThat(warmedUpReaders, empty());

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3590,6 +3590,7 @@ public class InternalEngineTests extends EngineTestCase {
             IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
             null,
             config.getRelativeTimeInNanosSupplier(),
+            null,
             null
         );
         expectThrows(EngineCreationFailureException.class, () -> new InternalEngine(brokenConfig));
@@ -7260,7 +7261,8 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getSnapshotCommitSupplier(),
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
-                config.getIndexCommitListener()
+                config.getIndexCommitListener(),
+                config.getRecoveryState()
             );
             try (InternalEngine engine = createEngine(configWithWarmer)) {
                 assertThat(warmedUpReaders, empty());

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2915,7 +2915,7 @@ public class IndexShardTests extends IndexShardTestCase {
         // Shard should now be active since we did recover:
         assertTrue(shard.isActive());
         // Recovery state should be propagated to the engine
-        assertEquals(shard.recoveryState(), shard.getEngine().config().getRecoveryState());
+        assertTrue(shard.getEngine().config().isRecoveringAsPrimary());
         closeShards(shard);
     }
 
@@ -4523,7 +4523,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
                 config.getIndexCommitListener(),
-                config.getRecoveryState()
+                config.isRecoveringAsPrimary()
             );
             return new InternalEngine(configWithWarmer);
         });

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2914,6 +2914,8 @@ public class IndexShardTests extends IndexShardTestCase {
         shard.openEngineAndRecoverFromTranslog();
         // Shard should now be active since we did recover:
         assertTrue(shard.isActive());
+        // Recovery state should be propagated to the engine
+        assertEquals(shard.recoveryState(), shard.getEngine().config().getRecoveryState());
         closeShards(shard);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -4520,7 +4520,8 @@ public class IndexShardTests extends IndexShardTestCase {
                 IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
-                config.getIndexCommitListener()
+                config.getIndexCommitListener(),
+                config.getRecoveryState()
             );
             return new InternalEngine(configWithWarmer);
         });

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -153,6 +153,7 @@ public class RefreshListenersTests extends ESTestCase {
             IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
             null,
             System::nanoTime,
+            null,
             null
         );
         engine = new InternalEngine(config);

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -154,7 +154,7 @@ public class RefreshListenersTests extends ESTestCase {
             null,
             System::nanoTime,
             null,
-            null
+            false
         );
         engine = new InternalEngine(config);
         engine.recoverFromTranslog((e, s) -> 0, Long.MAX_VALUE);

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -402,7 +402,8 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             config.getSnapshotCommitSupplier(),
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener()
+            config.getIndexCommitListener(),
+            config.getRecoveryState()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -403,7 +403,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.getRecoveryState()
+            config.isRecoveringAsPrimary()
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -276,7 +276,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.getRecoveryState()
+            config.isRecoveringAsPrimary()
         );
     }
 
@@ -307,7 +307,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.getRecoveryState()
+            config.isRecoveringAsPrimary()
         );
     }
 
@@ -338,7 +338,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.getRecoveryState()
+            config.isRecoveringAsPrimary()
         );
     }
 
@@ -862,7 +862,7 @@ public abstract class EngineTestCase extends ESTestCase {
             null,
             System::nanoTime,
             indexCommitListener,
-            null
+            false
         );
     }
 
@@ -901,7 +901,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.getRecoveryState()
+            config.isRecoveringAsPrimary()
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -275,7 +275,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getSnapshotCommitSupplier(),
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener()
+            config.getIndexCommitListener(),
+            config.getRecoveryState()
         );
     }
 
@@ -305,7 +306,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getSnapshotCommitSupplier(),
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener()
+            config.getIndexCommitListener(),
+            config.getRecoveryState()
         );
     }
 
@@ -335,7 +337,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getSnapshotCommitSupplier(),
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener()
+            config.getIndexCommitListener(),
+            config.getRecoveryState()
         );
     }
 
@@ -858,7 +861,8 @@ public abstract class EngineTestCase extends ESTestCase {
             IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
             null,
             System::nanoTime,
-            indexCommitListener
+            indexCommitListener,
+            null
         );
     }
 
@@ -896,7 +900,8 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getSnapshotCommitSupplier(),
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
-            config.getIndexCommitListener()
+            config.getIndexCommitListener(),
+            config.getRecoveryState()
         );
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -288,6 +288,7 @@ public class FollowingEngineTests extends ESTestCase {
             IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
             null,
             System::nanoTime,
+            null,
             null
         );
     }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -289,7 +289,7 @@ public class FollowingEngineTests extends ESTestCase {
             null,
             System::nanoTime,
             null,
-            null
+            false
         );
     }
 


### PR DESCRIPTION
Make sure engine factories can access the `RecoveryState#primary` flag, so plugins can create different engines for primary and replica indices.
