### PR TITLE
[ML] fix tokenization bug when handling normalization in BERT and MPNet

### DIFF
--- a/docs/changelog/92329.yaml
+++ b/docs/changelog/92329.yaml
@@ -1,0 +1,5 @@
+pr: 92329
+summary: Fix tokenization bug when handling normalization in BERT and MPNet
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizerTests.java
@@ -67,6 +67,35 @@ public class BertTokenizerTests extends ESTestCase {
         }
     }
 
+    public void testTokenizeFailureCaseAccentFilter() {
+        List<String> testingVocab = List.of(
+            "[CLS]",
+            "br",
+            "##ᄎ",
+            "##ᅡ",
+            "##ᆼ",
+            "##n",
+            "'",
+            "s",
+            "[SEP]",
+            BertTokenizer.MASK_TOKEN,
+            BertTokenizer.UNKNOWN_TOKEN,
+            BertTokenizer.PAD_TOKEN
+        );
+        try (
+            BertTokenizer tokenizer = BertTokenizer.builder(
+                testingVocab,
+                new BertTokenization(true, true, 512, Tokenization.Truncate.FIRST, -1)
+            ).build()
+        ) {
+            TokenizationResult.Tokens tokenization = tokenizer.tokenize("Br창n's", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenization.tokenIds(), equalTo(new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 8 }));
+
+            tokenization = tokenizer.tokenize("Br창n", Tokenization.Truncate.NONE, -1, 0).get(0);
+            assertThat(tokenization.tokenIds(), equalTo(new int[] { 0, 1, 2, 3, 4, 5, 8 }));
+        }
+    }
+
     public void testTokenizeLargeInputNoTruncation() {
         try (
             BertTokenizer tokenizer = BertTokenizer.builder(


### PR DESCRIPTION
There is a small bug in how we handle normalization and accent stripping in BERT and MPNet. 

The bug may return something like this:
```
'java.lang.IllegalArgumentException: startOffset must be non-negative, and endOffset must be >= startOffset; got startOffset=553,endOffset=552', 'caused_by': {'type': 'illegal_argument_exception', 'reason': 'startOffset must be non-negative, and endOffset must be >= startOffset; got startOffset=553,endOffset=552'
```

The cause of the bug is when we normalize strings, then attempt to split them on a punctuation mark. Since we don't really handle offset changes on normalization, splitting on punctuation could cause some weirdness. Here is an example token: `Br창n's`. In the old way, we would normalize the string (which decomposes `창` thus increasing the character count), and then split on `'`. Since the decomposition increased the character count, our offsets could break as we calculate them based on character count (which is now increased).

To simplify the logic, I changed normalization to be done AFTER our split on punctuation. This way our offsets still refer to the original input offsets and if we add or even remove characters in normalization, it is of no consequence as our punctuation split is already handled.

closes: https://github.com/elastic/elasticsearch/issues/92243