### PR TITLE
Mark simulate index API non-experimental in documentation

### DIFF
--- a/docs/reference/indices/simulate-index.asciidoc
+++ b/docs/reference/indices/simulate-index.asciidoc
@@ -4,9 +4,7 @@
 <titleabbrev>Simulate index</titleabbrev>
 ++++
 
-experimental[]
-
-Returns the index configuration that would be applied to the specified index from an 
+Returns the index configuration that would be applied to the specified index from an
 existing <<index-templates, index template>>.
 
 ////


### PR DESCRIPTION
This has been stable for a long time, we just missed removing the `experimental[]` tag in the docs.
