### PR TITLE
[DOCS] Add snapshot-related 8.5 release highlight

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-coming::[{minor-version}]
-
 Here are the highlights of what's new and improved in {es} {minor-version}!
 ifeval::[\{release-state}\"!=\"unreleased\"]
 For detailed information about this release, see the <<es-release-notes>> and

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -128,4 +128,14 @@ for the possible causes of a spike in the logs.
 
 {es-pull}83055[#83055]
 
+[discrete]
+[[more-efficient-snapshots]]
+=== More efficient snapshots
+
+The overhead of the snapshot operation has been reduced significantly. Snapshots
+now run in a more efficient order and require much less network traffic than
+before.
+
+{es-pull}89619[#89619]
+
 // end::notable-highlights[]


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/90744 didn't make it into the 8.5 release. This PR adds the snapshot-related release highlight directly to the 8.5 release highlights page.

This PR also removes the "coming" admonition from this page as 8.5 has already been released.