### PR TITLE
[8.6] Mark simulate index API non-experimental in documentation (#92331)

### DIFF
--- a/docs/reference/indices/simulate-index.asciidoc
+++ b/docs/reference/indices/simulate-index.asciidoc
@@ -4,9 +4,7 @@
 <titleabbrev>Simulate index</titleabbrev>
 ++++
 
-experimental[]
-
-Returns the index configuration that would be applied to the specified index from an 
+Returns the index configuration that would be applied to the specified index from an
 existing <<index-templates, index template>>.
 
 ////


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Mark simulate index API non-experimental in documentation (#92331)