### PR TITLE
Redact another HTTP header in APM traces

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -465,7 +465,7 @@ public class RestController implements HttpServerTransport.Dispatcher {
         req.getHeaders().forEach((key, values) -> {
             final String lowerKey = key.toLowerCase(Locale.ROOT).replace('-', '_');
             final String value = switch (lowerKey) {
-                case "authorization", "cookie", "secret", "session", "set_cookie", "token" -> "[REDACTED]";
+                case "authorization", "cookie", "secret", "session", "set_cookie", "token", "x_elastic_app_auth" -> "[REDACTED]";
                 default -> String.join("; ", values);
             };
             attributes.put("http.request.headers." + lowerKey, value);


### PR DESCRIPTION
There's another auth-related header that we need to omit when capturing HTTP spans with APM.