### PR TITLE
[8.6] Ensure reproducible builds and task avoidance when using x-content jar (#92212)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchJavaBasePlugin.java
@@ -146,6 +146,7 @@ public class ElasticsearchJavaBasePlugin implements Plugin<Project> {
      */
     public static void configureInputNormalization(Project project) {
         project.getNormalization().getRuntimeClasspath().ignore("META-INF/MANIFEST.MF");
+        project.getNormalization().getRuntimeClasspath().ignore("IMPL-JARS/**/META-INF/MANIFEST.MF");
     }
 
     private static Provider<Integer> releaseVersionProviderFromCompileTask(Project project, AbstractCompile compileTask) {

--- a/libs/x-content/build.gradle
+++ b/libs/x-content/build.gradle
@@ -74,7 +74,7 @@ def generateProviderManifest = tasks.register("generateProviderManifest") {
   doLast {
     manifestFile.parentFile.mkdirs()
     manifestFile.setText(configurations.providerImpl.files.stream()
-      .map(f -> f.name).collect(Collectors.joining('\n')), 'UTF-8')
+      .map(f -> f.name).sorted().collect(Collectors.joining('\n')), 'UTF-8')
   }
 }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Ensure reproducible builds and task avoidance when using x-content jar (#92212)