### PR TITLE
Deduplicate RetentionLease.source

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
@@ -92,12 +92,14 @@ public final class RetentionLease implements ToXContentObject, Writeable {
         if (timestamp < 0) {
             throw new IllegalArgumentException("retention lease timestamp [" + timestamp + "] out of range");
         }
+        Objects.requireNonNull(source);
         if (source.isEmpty()) {
             throw new IllegalArgumentException("retention lease source can not be empty");
         }
         this.id = id;
         this.retainingSequenceNumber = retainingSequenceNumber;
         this.timestamp = timestamp;
+        // deduplicate the string instances to save memory for the known possible source values
         this.source = switch (source) {
             case "ccr" -> "ccr";
             case ReplicationTracker.PEER_RECOVERY_RETENTION_LEASE_SOURCE -> ReplicationTracker.PEER_RECOVERY_RETENTION_LEASE_SOURCE;

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
@@ -92,14 +92,17 @@ public final class RetentionLease implements ToXContentObject, Writeable {
         if (timestamp < 0) {
             throw new IllegalArgumentException("retention lease timestamp [" + timestamp + "] out of range");
         }
-        Objects.requireNonNull(source);
         if (source.isEmpty()) {
             throw new IllegalArgumentException("retention lease source can not be empty");
         }
         this.id = id;
         this.retainingSequenceNumber = retainingSequenceNumber;
         this.timestamp = timestamp;
-        this.source = source;
+        this.source = switch (source) {
+            case "ccr" -> "ccr";
+            case ReplicationTracker.PEER_RECOVERY_RETENTION_LEASE_SOURCE -> ReplicationTracker.PEER_RECOVERY_RETENTION_LEASE_SOURCE;
+            default -> source;
+        };
     }
 
     /**
@@ -109,10 +112,7 @@ public final class RetentionLease implements ToXContentObject, Writeable {
      * @throws IOException if an I/O exception occurs reading from the stream
      */
     public RetentionLease(final StreamInput in) throws IOException {
-        id = in.readString();
-        retainingSequenceNumber = in.readZLong();
-        timestamp = in.readVLong();
-        source = in.readString();
+        this(in.readString(), in.readZLong(), in.readVLong(), in.readString());
     }
 
     /**


### PR DESCRIPTION
We only ever see the strings "ccr" or "peer recovery" here. A recent experiment with ccr and many follower clusters following one leader, revealed 100s of MB being wasted on duplicate "ccr" strings when fetching index stats -> lets fix this by simple deduplication.

cc @dliappis from last night :) 