### PR TITLE
Make the visitor of the spatial triangle tree a public interface

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
@@ -17,7 +17,7 @@ import org.apache.lucene.index.PointValues;
  * This class supports checking {@link Component2D} relations against a serialized triangle tree.
  * It does not support bounding boxes crossing the dateline.
  */
-class Component2DRelationVisitor extends TriangleTreeReader.DecodedVisitor {
+class Component2DRelationVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
 
     private GeoRelation relation;
     private Component2D component2D;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DRelationVisitor.java
@@ -39,7 +39,7 @@ class Component2DRelationVisitor extends TriangleTreeVisitor.TriangleTreeDecoded
     }
 
     @Override
-    void visitDecodedPoint(double x, double y) {
+    protected void visitDecodedPoint(double x, double y) {
         if (component2D.contains(x, y)) {
             if (canBeContained()) {
                 relation = GeoRelation.QUERY_CONTAINS;
@@ -54,7 +54,7 @@ class Component2DRelationVisitor extends TriangleTreeVisitor.TriangleTreeDecoded
     }
 
     @Override
-    void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
+    protected void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
         if (component2D.intersectsLine(aX, aY, bX, bY)) {
             final boolean ab = (metadata & 1 << 4) == 1 << 4;
             if (canBeContained() && component2D.containsLine(aX, aY, bX, bY)) {
@@ -70,7 +70,7 @@ class Component2DRelationVisitor extends TriangleTreeVisitor.TriangleTreeDecoded
     }
 
     @Override
-    void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
+    protected void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
         if (component2D.intersectsTriangle(aX, aY, bX, bY, cX, cY)) {
             final boolean ab = (metadata & 1 << 4) == 1 << 4;
             final boolean bc = (metadata & 1 << 5) == 1 << 5;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DVisitor.java
@@ -31,23 +31,23 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
     public abstract void reset();
 
     @Override
-    public boolean pushDecodedX(double minX) {
+    protected boolean pushDecodedX(double minX) {
         return component2D.getMaxX() >= minX;
     }
 
     @Override
-    public boolean pushDecodedY(double minY) {
+    protected boolean pushDecodedY(double minY) {
         return component2D.getMaxY() >= minY;
     }
 
     @Override
-    public boolean pushDecoded(double maxX, double maxY) {
+    protected boolean pushDecoded(double maxX, double maxY) {
         return component2D.getMinX() <= maxX && component2D.getMinY() <= maxY;
 
     }
 
     @Override
-    public boolean pushDecoded(double minX, double minY, double maxX, double maxY) {
+    protected boolean pushDecoded(double minX, double minY, double maxX, double maxY) {
         return pushDecoded(component2D.relate(minX, maxX, minY, maxY));
     }
 
@@ -56,7 +56,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
      *
      * @return if true, the visitor keeps traversing the tree, else it stops.
      * */
-    abstract boolean pushDecoded(PointValues.Relation relation);
+    protected abstract boolean pushDecoded(PointValues.Relation relation);
 
     /**
      * Creates a visitor from the provided Component2D and spatial relationship. Visitors are re-usable by
@@ -95,17 +95,17 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        void visitDecodedPoint(double x, double y) {
+        protected void visitDecodedPoint(double x, double y) {
             intersects = component2D.contains(x, y);
         }
 
         @Override
-        void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
+        protected void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
             intersects = component2D.intersectsLine(aX, aY, bX, bY);
         }
 
         @Override
-        void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
+        protected void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
             intersects = component2D.intersectsTriangle(aX, aY, bX, bY, cX, cY);
         }
 
@@ -116,7 +116,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        boolean pushDecoded(PointValues.Relation relation) {
+        protected boolean pushDecoded(PointValues.Relation relation) {
             if (relation == PointValues.Relation.CELL_OUTSIDE_QUERY) {
                 // shapes are disjoint, stop traversing the tree.
                 return false;
@@ -156,17 +156,17 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        void visitDecodedPoint(double x, double y) {
+        protected void visitDecodedPoint(double x, double y) {
             disjoint = component2D.contains(x, y) == false;
         }
 
         @Override
-        void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
+        protected void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
             disjoint = component2D.intersectsLine(aX, aY, bX, bY) == false;
         }
 
         @Override
-        void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
+        protected void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
             disjoint = component2D.intersectsTriangle(aX, aY, bX, bY, cX, cY) == false;
         }
 
@@ -177,7 +177,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        boolean pushDecoded(PointValues.Relation relation) {
+        protected boolean pushDecoded(PointValues.Relation relation) {
             if (relation == PointValues.Relation.CELL_OUTSIDE_QUERY) {
                 // shapes are disjoint, stop traversing the tree.
                 return false;
@@ -217,17 +217,17 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        void visitDecodedPoint(double x, double y) {
+        protected void visitDecodedPoint(double x, double y) {
             within = component2D.contains(x, y);
         }
 
         @Override
-        void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
+        protected void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
             within = component2D.containsLine(aX, aY, bX, bY);
         }
 
         @Override
-        void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
+        protected void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
             within = component2D.containsTriangle(aX, aY, bX, bY, cX, cY);
         }
 
@@ -238,7 +238,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        public boolean pushDecodedX(double minX) {
+        protected boolean pushDecodedX(double minX) {
             // if any part of the tree is skipped, then the doc value is not within the shape,
             // stop traversing the tree
             within = super.pushDecodedX(minX);
@@ -246,7 +246,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        public boolean pushDecodedY(double minY) {
+        protected boolean pushDecodedY(double minY) {
             // if any part of the tree is skipped, then the doc value is not within the shape,
             // stop traversing the tree
             within = super.pushDecodedY(minY);
@@ -254,7 +254,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        public boolean pushDecoded(double maxX, double maxY) {
+        protected boolean pushDecoded(double maxX, double maxY) {
             // if any part of the tree is skipped, then the doc value is not within the shape,
             // stop traversing the tree
             within = super.pushDecoded(maxX, maxY);
@@ -262,7 +262,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        boolean pushDecoded(PointValues.Relation relation) {
+        protected boolean pushDecoded(PointValues.Relation relation) {
             if (relation == PointValues.Relation.CELL_OUTSIDE_QUERY) {
                 // shapes are disjoint, stop traversing the tree.
                 within = false;
@@ -297,7 +297,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        void visitDecodedPoint(double x, double y) {
+        protected void visitDecodedPoint(double x, double y) {
             final Component2D.WithinRelation rel = component2D.withinPoint(x, y);
             if (rel != Component2D.WithinRelation.DISJOINT) {
                 // Only override relationship if different to DISJOINT
@@ -306,7 +306,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
+        protected void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
             final boolean ab = (metadata & 1 << 4) == 1 << 4;
             final Component2D.WithinRelation rel = component2D.withinLine(aX, aY, ab, bX, bY);
             if (rel != Component2D.WithinRelation.DISJOINT) {
@@ -316,7 +316,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
+        protected void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
             final boolean ab = (metadata & 1 << 4) == 1 << 4;
             final boolean bc = (metadata & 1 << 5) == 1 << 5;
             final boolean ca = (metadata & 1 << 6) == 1 << 6;
@@ -334,7 +334,7 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        boolean pushDecoded(PointValues.Relation relation) {
+        protected boolean pushDecoded(PointValues.Relation relation) {
             // Only traverse the tree if the shapes intersects.
             return relation == PointValues.Relation.CELL_CROSSES_QUERY;
         }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DVisitor.java
@@ -238,26 +238,26 @@ public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTre
         }
 
         @Override
-        public boolean pushX(int minX) {
+        public boolean pushDecodedX(double minX) {
             // if any part of the tree is skipped, then the doc value is not within the shape,
             // stop traversing the tree
-            within = super.pushX(minX);
+            within = super.pushDecodedX(minX);
             return within;
         }
 
         @Override
-        public boolean pushY(int minY) {
+        public boolean pushDecodedY(double minY) {
             // if any part of the tree is skipped, then the doc value is not within the shape,
             // stop traversing the tree
-            within = super.pushY(minY);
+            within = super.pushDecodedY(minY);
             return within;
         }
 
         @Override
-        public boolean push(int maxX, int maxY) {
+        public boolean pushDecoded(double maxX, double maxY) {
             // if any part of the tree is skipped, then the doc value is not within the shape,
             // stop traversing the tree
-            within = super.push(maxX, maxY);
+            within = super.pushDecoded(maxX, maxY);
             return within;
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Component2DVisitor.java
@@ -12,10 +12,10 @@ import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.index.PointValues;
 
 /**
- * A {@link TriangleTreeReader.Visitor} implementation for {@link Component2D} geometries.
+ * A {@link TriangleTreeVisitor.TriangleTreeDecodedVisitor} implementation for {@link Component2D} geometries.
  * It can solve spatial relationships against a serialize triangle tree.
  */
-public abstract class Component2DVisitor extends TriangleTreeReader.DecodedVisitor {
+public abstract class Component2DVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
 
     protected final Component2D component2D;
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeoShapeValues.java
@@ -80,7 +80,7 @@ public abstract class GeoShapeValues extends ShapeValues<GeoShapeValues.GeoShape
          */
         public GeoRelation relate(int minX, int maxX, int minY, int maxY) throws IOException {
             tile2DVisitor.reset(minX, minY, maxX, maxY);
-            reader.visit(tile2DVisitor);
+            visit(tile2DVisitor);
             return tile2DVisitor.relation();
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/GeometryDocValueReader.java
@@ -98,7 +98,7 @@ public class GeometryDocValueReader {
     /**
      * Visit the triangle tree with the provided visitor
      */
-    public void visit(TriangleTreeReader.Visitor visitor) throws IOException {
+    public void visit(TriangleTreeVisitor visitor) throws IOException {
         Extent geometryExtent = getExtent();
         int thisMaxX = geometryExtent.maxX();
         int thisMinX = geometryExtent.minX();

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LabelPositionVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LabelPositionVisitor.java
@@ -67,12 +67,6 @@ public class LabelPositionVisitor extends TriangleTreeVisitor.TriangleTreeDecode
     }
 
     @Override
-    public boolean push(int minX, int minY, int maxX, int maxY) {
-        // Always start the traversal
-        return labelPosition == null;
-    }
-
-    @Override
     boolean pushDecoded(double minX, double minY, double maxX, double maxY) {
         return labelPosition == null;
     }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LabelPositionVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LabelPositionVisitor.java
@@ -17,41 +17,41 @@ import java.util.function.BiFunction;
  *
  * TODO: We could instead choose the point closer to the centroid which improves unbalanced trees
  */
-public class LabelPositionVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
+class LabelPositionVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
 
     private SpatialPoint labelPosition;
     private final BiFunction<Double, Double, SpatialPoint> pointMaker;
 
-    public LabelPositionVisitor(CoordinateEncoder encoder, BiFunction<Double, Double, SpatialPoint> pointMaker) {
+    LabelPositionVisitor(CoordinateEncoder encoder, BiFunction<Double, Double, SpatialPoint> pointMaker) {
         super(encoder);
         this.pointMaker = pointMaker;
     }
 
     @Override
-    void visitDecodedPoint(double x, double y) {
+    protected void visitDecodedPoint(double x, double y) {
         assert labelPosition == null;
         labelPosition = pointMaker.apply(x, y);
     }
 
     @Override
-    public void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
+    protected void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata) {
         assert labelPosition == null;
         labelPosition = pointMaker.apply((aX + bX) / 2.0, (aY + bY) / 2.0);
     }
 
     @Override
-    public void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
+    protected void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata) {
         assert labelPosition == null;
         labelPosition = pointMaker.apply((aX + bX + cX) / 3.0, (aY + bY + cY) / 3.0);
     }
 
     @Override
-    boolean pushDecodedX(double minX) {
+    protected boolean pushDecodedX(double minX) {
         return labelPosition == null;
     }
 
     @Override
-    boolean pushDecodedY(double minX) {
+    protected boolean pushDecodedY(double minX) {
         return labelPosition == null;
     }
 
@@ -62,12 +62,12 @@ public class LabelPositionVisitor extends TriangleTreeVisitor.TriangleTreeDecode
     }
 
     @Override
-    boolean pushDecoded(double maxX, double maxY) {
+    protected boolean pushDecoded(double maxX, double maxY) {
         return labelPosition == null;
     }
 
     @Override
-    boolean pushDecoded(double minX, double minY, double maxX, double maxY) {
+    protected boolean pushDecoded(double minX, double minY, double maxX, double maxY) {
         return labelPosition == null;
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LabelPositionVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/LabelPositionVisitor.java
@@ -17,7 +17,7 @@ import java.util.function.BiFunction;
  *
  * TODO: We could instead choose the point closer to the centroid which improves unbalanced trees
  */
-public class LabelPositionVisitor extends TriangleTreeReader.DecodedVisitor {
+public class LabelPositionVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
 
     private SpatialPoint labelPosition;
     private final BiFunction<Double, Double, SpatialPoint> pointMaker;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/ShapeValues.java
@@ -91,9 +91,9 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
      * the provided decoder (could be geo or cartesian)
      */
     protected abstract static class ShapeValue implements ToXContentFragment {
-        protected final GeometryDocValueReader reader;
+        private final GeometryDocValueReader reader;
         private final BoundingBox boundingBox;
-        protected final CoordinateEncoder encoder;
+        private final CoordinateEncoder encoder;
         private final BiFunction<Double, Double, SpatialPoint> pointMaker;
         private final Component2DRelationVisitor component2DRelationVisitor;
 
@@ -115,6 +115,13 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
 
         public BoundingBox boundingBox() {
             return boundingBox;
+        }
+
+        /**
+         * Visit the underlying tree structure using the provided {@link TriangleTreeVisitor}
+         */
+        public void visit(TriangleTreeVisitor visitor) throws IOException {
+            reader.visit(visitor);
         }
 
         protected abstract Component2D centroidAsComponent2D() throws IOException;
@@ -139,7 +146,7 @@ public abstract class ShapeValues<T extends ShapeValues.ShapeValue> {
             }
             // For all other cases, use the first triangle (or line or point) in the tree which will always intersect the shape
             LabelPositionVisitor visitor = new LabelPositionVisitor(this.encoder, pointMaker);
-            reader.visit(visitor);
+            visit(visitor);
             return visitor.labelPosition();
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/Tile2DVisitor.java
@@ -16,7 +16,7 @@ import static org.apache.lucene.geo.GeoUtils.orient;
  * This class supports checking bounding box relations against a serialized triangle tree.
  *
  */
-class Tile2DVisitor implements TriangleTreeReader.Visitor {
+class Tile2DVisitor implements TriangleTreeVisitor {
 
     private GeoRelation relation;
     private int minX;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeVisitor.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.index.fielddata;
+
+/** Visitor for triangle interval tree.
+ *
+ * @see TriangleTreeReader
+ * */
+public interface TriangleTreeVisitor {
+
+    /** visit a node point. */
+    void visitPoint(int x, int y);
+
+    /** visit a node line. */
+    void visitLine(int aX, int aY, int bX, int bY, byte metadata);
+
+    /** visit a node triangle. */
+    void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata);
+
+    /** Should the visitor keep visiting the tree. Called after visiting a node or skipping
+     * a tree branch, if the return value is {@code false}, no more nodes will be visited. */
+    boolean push();
+
+    /** Should the visitor visit nodes that have bounds greater or equal
+     * than the {@code minX} provided. */
+    boolean pushX(int minX);
+
+    /** Should the visitor visit nodes that have bounds greater or equal
+     * than the {@code minY} provided. */
+    boolean pushY(int minY);
+
+    /** Should the visitor visit nodes that have bounds lower or equal than the
+     * {@code maxX} and {@code minX} provided. */
+    boolean push(int maxX, int maxY);
+
+    /** Should the visitor visit the tree given the bounding box of the tree. Called before
+     * visiting the tree. */
+    boolean push(int minX, int minY, int maxX, int maxY);
+
+    /** Visitor for triangle interval tree which decodes the coordinates */
+    abstract class TriangleTreeDecodedVisitor implements TriangleTreeVisitor {
+
+        private final CoordinateEncoder encoder;
+
+        TriangleTreeDecodedVisitor(CoordinateEncoder encoder) {
+            this.encoder = encoder;
+        }
+
+        @Override
+        public void visitPoint(int x, int y) {
+            visitDecodedPoint(encoder.decodeX(x), encoder.decodeY(y));
+        }
+
+        /**
+         * Equivalent to {@link #visitPoint(int, int)} but coordinates are decoded.
+         */
+        abstract void visitDecodedPoint(double x, double y);
+
+        @Override
+        public void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
+            visitDecodedLine(encoder.decodeX(aX), encoder.decodeY(aY), encoder.decodeX(bX), encoder.decodeY(bY), metadata);
+        }
+
+        /**
+         * Equivalent to {@link #visitLine(int, int, int, int, byte)} but coordinates are decoded.
+         */
+        abstract void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata);
+
+        @Override
+        public void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
+            visitDecodedTriangle(
+                encoder.decodeX(aX),
+                encoder.decodeY(aY),
+                encoder.decodeX(bX),
+                encoder.decodeY(bY),
+                encoder.decodeX(cX),
+                encoder.decodeY(cY),
+                metadata
+            );
+        }
+
+        /**
+         * Equivalent to {@link #visitTriangle(int, int, int, int, int, int, byte)} but coordinates are decoded.
+         */
+        abstract void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata);
+
+        @Override
+        public boolean pushX(int minX) {
+            return pushDecodedX(encoder.decodeX(minX));
+        }
+
+        /**
+         * Equivalent to {@link #pushX(int)}  but coordinates are decoded.
+         */
+        abstract boolean pushDecodedX(double minX);
+
+        @Override
+        public boolean pushY(int minY) {
+            return pushDecodedY(encoder.decodeY(minY));
+        }
+
+        /**
+         * Equivalent to {@link #pushY(int)}  but coordinates are decoded.
+         */
+        abstract boolean pushDecodedY(double minX);
+
+        @Override
+        public boolean push(int maxX, int maxY) {
+            return pushDecoded(encoder.decodeX(maxX), encoder.decodeY(maxY));
+        }
+
+        /**
+         * Equivalent to {@link #push(int, int)} but coordinates are decoded.
+         */
+        abstract boolean pushDecoded(double maxX, double maxY);
+
+        @Override
+        public boolean push(int minX, int minY, int maxX, int maxY) {
+            return pushDecoded(encoder.decodeX(minX), encoder.decodeY(minY), encoder.decodeX(maxX), encoder.decodeY(maxY));
+        }
+
+        /**
+         * Equivalent to {@link #push(int, int, int, int)} but coordinates are decoded.
+         */
+        abstract boolean pushDecoded(double minX, double minY, double maxX, double maxY);
+    }
+}

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeVisitor.java
@@ -47,12 +47,12 @@ public interface TriangleTreeVisitor {
 
         private final CoordinateEncoder encoder;
 
-        TriangleTreeDecodedVisitor(CoordinateEncoder encoder) {
+        protected TriangleTreeDecodedVisitor(CoordinateEncoder encoder) {
             this.encoder = encoder;
         }
 
         @Override
-        public void visitPoint(int x, int y) {
+        public final void visitPoint(int x, int y) {
             visitDecodedPoint(encoder.decodeX(x), encoder.decodeY(y));
         }
 
@@ -62,7 +62,7 @@ public interface TriangleTreeVisitor {
         abstract void visitDecodedPoint(double x, double y);
 
         @Override
-        public void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
+        public final void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
             visitDecodedLine(encoder.decodeX(aX), encoder.decodeY(aY), encoder.decodeX(bX), encoder.decodeY(bY), metadata);
         }
 
@@ -72,7 +72,7 @@ public interface TriangleTreeVisitor {
         abstract void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata);
 
         @Override
-        public void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
+        public final void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
             visitDecodedTriangle(
                 encoder.decodeX(aX),
                 encoder.decodeY(aY),
@@ -90,7 +90,7 @@ public interface TriangleTreeVisitor {
         abstract void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata);
 
         @Override
-        public boolean pushX(int minX) {
+        public final boolean pushX(int minX) {
             return pushDecodedX(encoder.decodeX(minX));
         }
 
@@ -100,7 +100,7 @@ public interface TriangleTreeVisitor {
         abstract boolean pushDecodedX(double minX);
 
         @Override
-        public boolean pushY(int minY) {
+        public final boolean pushY(int minY) {
             return pushDecodedY(encoder.decodeY(minY));
         }
 
@@ -110,7 +110,7 @@ public interface TriangleTreeVisitor {
         abstract boolean pushDecodedY(double minX);
 
         @Override
-        public boolean push(int maxX, int maxY) {
+        public final boolean push(int maxX, int maxY) {
             return pushDecoded(encoder.decodeX(maxX), encoder.decodeY(maxY));
         }
 
@@ -120,7 +120,7 @@ public interface TriangleTreeVisitor {
         abstract boolean pushDecoded(double maxX, double maxY);
 
         @Override
-        public boolean push(int minX, int minY, int maxX, int maxY) {
+        public final boolean push(int minX, int minY, int maxX, int maxY) {
             return pushDecoded(encoder.decodeX(minX), encoder.decodeY(minY), encoder.decodeX(maxX), encoder.decodeY(maxY));
         }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeVisitor.java
@@ -59,7 +59,7 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #visitPoint(int, int)} but coordinates are decoded.
          */
-        abstract void visitDecodedPoint(double x, double y);
+        protected abstract void visitDecodedPoint(double x, double y);
 
         @Override
         public final void visitLine(int aX, int aY, int bX, int bY, byte metadata) {
@@ -69,7 +69,7 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #visitLine(int, int, int, int, byte)} but coordinates are decoded.
          */
-        abstract void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata);
+        protected abstract void visitDecodedLine(double aX, double aY, double bX, double bY, byte metadata);
 
         @Override
         public final void visitTriangle(int aX, int aY, int bX, int bY, int cX, int cY, byte metadata) {
@@ -87,7 +87,7 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #visitTriangle(int, int, int, int, int, int, byte)} but coordinates are decoded.
          */
-        abstract void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata);
+        protected abstract void visitDecodedTriangle(double aX, double aY, double bX, double bY, double cX, double cY, byte metadata);
 
         @Override
         public final boolean pushX(int minX) {
@@ -97,7 +97,7 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #pushX(int)}  but coordinates are decoded.
          */
-        abstract boolean pushDecodedX(double minX);
+        protected abstract boolean pushDecodedX(double minX);
 
         @Override
         public final boolean pushY(int minY) {
@@ -107,7 +107,7 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #pushY(int)}  but coordinates are decoded.
          */
-        abstract boolean pushDecodedY(double minX);
+        protected abstract boolean pushDecodedY(double minX);
 
         @Override
         public final boolean push(int maxX, int maxY) {
@@ -117,7 +117,7 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #push(int, int)} but coordinates are decoded.
          */
-        abstract boolean pushDecoded(double maxX, double maxY);
+        protected abstract boolean pushDecoded(double maxX, double maxY);
 
         @Override
         public final boolean push(int minX, int minY, int maxX, int maxY) {
@@ -127,6 +127,6 @@ public interface TriangleTreeVisitor {
         /**
          * Equivalent to {@link #push(int, int, int, int)} but coordinates are decoded.
          */
-        abstract boolean pushDecoded(double minX, double minY, double maxX, double maxY);
+        protected abstract boolean pushDecoded(double minX, double minY, double maxX, double maxY);
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeTests.java
@@ -42,7 +42,7 @@ public class TriangleTreeTests extends ESTestCase {
         assertThat(fieldList.size(), equalTo(visitor.counter));
     }
 
-    private static class TriangleCounterVisitor implements TriangleTreeReader.Visitor {
+    private static class TriangleCounterVisitor implements TriangleTreeVisitor {
 
         int counter;
 


### PR DESCRIPTION
This changes makes the visitor for the geo_shape/ shape triangle tree a public interface so it can be used outside of its package. In addition it adds a method to `ShapeValue` that accepts a visitor.