### PR TITLE
Remove unnecessary thirdPartyAudit exclusions

### DIFF
--- a/docs/changelog/92352.yaml
+++ b/docs/changelog/92352.yaml
@@ -1,0 +1,6 @@
+pr: 92352
+summary: Remove unnecessary `thirdPartyAudit` exclusions
+area: Infra/Core
+type: bug
+issues:
+ - 92346

--- a/plugins/repository-azure/build.gradle
+++ b/plugins/repository-azure/build.gradle
@@ -293,8 +293,6 @@ tasks.named("thirdPartyAudit").configure {
     )
   } else {
     ignoreMissingClasses(
-      'com.sun.org.apache.xml.internal.resolver.Catalog',
-      'com.sun.org.apache.xml.internal.resolver.tools.CatalogResolver',
       'javax.activation.DataHandler',
       'javax.activation.DataSource',
       'javax.xml.bind.JAXBElement',


### PR DESCRIPTION
These are no longer needed after #92120 updated the jackson version along with the azure plugin

This fixes #92346 