### PR TITLE
Enable a custom ReplicationTracker override per index

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/IndexShardIT.java
@@ -51,6 +51,7 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.flush.FlushStats;
 import org.elasticsearch.index.mapper.SourceToParse;
+import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.translog.TestTranslog;
@@ -661,7 +662,8 @@ public class IndexShardIT extends ESSingleNodeTestCase {
             cbs,
             IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
             System::nanoTime,
-            null
+            null,
+            ReplicationTracker.DEFAULT_FACTORY
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -44,6 +44,7 @@ import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexingOperationListener;
 import org.elasticsearch.index.shard.SearchOperationListener;
@@ -166,6 +167,8 @@ public final class IndexModule {
     private final BooleanSupplier allowExpensiveQueries;
     private final Map<String, IndexStorePlugin.RecoveryStateFactory> recoveryStateFactories;
     private final SetOnce<Engine.IndexCommitListener> indexCommitListener = new SetOnce<>();
+
+    private final SetOnce<ReplicationTracker.Factory> replicationTrackerFactory = new SetOnce<>();
 
     /**
      * Construct the index module for the index with the specified index settings. The index module contains extension points for plugins
@@ -376,6 +379,11 @@ public final class IndexModule {
         this.indexCommitListener.set(Objects.requireNonNull(listener));
     }
 
+    public void setReplicationTrackerFactory(ReplicationTracker.Factory factory) {
+        ensureNotFrozen();
+        this.replicationTrackerFactory.set(factory);
+    }
+
     IndexEventListener freeze() { // pkg private for testing
         if (this.frozen.compareAndSet(false, true)) {
             return new CompositeIndexEventListener(indexSettings, indexEventListeners);
@@ -524,7 +532,8 @@ public final class IndexModule {
                 recoveryStateFactory,
                 indexFoldersDeletionListener,
                 snapshotCommitSupplier,
-                indexCommitListener.get()
+                indexCommitListener.get(),
+                Objects.requireNonNullElse(replicationTrackerFactory.get(), ReplicationTracker.DEFAULT_FACTORY)
             );
             success = true;
             return indexService;

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -52,6 +52,8 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
+
 /**
  * This class is responsible for tracking the replication group with its progress and safety markers (local and global checkpoints).
  *
@@ -64,6 +66,28 @@ import java.util.stream.Stream;
  * The global checkpoint is maintained by the primary shard and is replicated to all the replicas (via {@link GlobalCheckpointSyncAction}).
  */
 public class ReplicationTracker extends AbstractIndexShardComponent implements LongSupplier {
+
+    public static final ReplicationTracker.Factory DEFAULT_FACTORY = (
+        shardId,
+        allocationId,
+        indexSettings,
+        operationPrimaryTerm,
+        onGlobalCheckpointUpdated,
+        currentTimeMillisSupplier,
+        onSyncRetentionLeases,
+        safeCommitInfoSupplier,
+        onReplicationGroupUpdated) -> new ReplicationTracker(
+            shardId,
+            allocationId,
+            indexSettings,
+            operationPrimaryTerm,
+            UNASSIGNED_SEQ_NO,
+            onGlobalCheckpointUpdated,
+            currentTimeMillisSupplier,
+            onSyncRetentionLeases,
+            safeCommitInfoSupplier,
+            onReplicationGroupUpdated
+        );
 
     /**
      * The allocation ID for the shard to which this tracker is a component of.
@@ -1626,5 +1650,23 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
             result = 31 * result + routingTable.hashCode();
             return result;
         }
+    }
+
+    /**
+     * Factory interface used by {@link org.elasticsearch.index.IndexModule#setReplicationTrackerFactory(Factory)} to enable custom
+     * overrides of this class.
+     */
+    public interface Factory {
+        ReplicationTracker create(
+            ShardId shardId,
+            String allocationId,
+            IndexSettings indexSettings,
+            long operationPrimaryTerm,
+            LongConsumer onGlobalCheckpointUpdated,
+            LongSupplier currentTimeMillisSupplier,
+            BiConsumer<RetentionLeases, ActionListener<ReplicationResponse>> onSyncRetentionLeases,
+            Supplier<SafeCommitInfo> safeCommitInfoSupplier,
+            Consumer<ReplicationGroup> onReplicationGroupUpdated
+        );
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -313,7 +313,8 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         final CircuitBreakerService circuitBreakerService,
         final IndexStorePlugin.SnapshotCommitSupplier snapshotCommitSupplier,
         final LongSupplier relativeTimeInNanosSupplier,
-        final Engine.IndexCommitListener indexCommitListener
+        final Engine.IndexCommitListener indexCommitListener,
+        final ReplicationTracker.Factory replicationTrackerFactory
     ) throws IOException {
         super(shardRouting.shardId(), indexSettings);
         assert shardRouting.initializing();
@@ -361,12 +362,11 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         this.pendingPrimaryTerm = primaryTerm;
         this.globalCheckpointListeners = new GlobalCheckpointListeners(shardId, threadPool.scheduler(), logger);
         this.pendingReplicationActions = new PendingReplicationActions(shardId, threadPool);
-        this.replicationTracker = new ReplicationTracker(
+        this.replicationTracker = replicationTrackerFactory.create(
             shardId,
             aId,
             indexSettings,
             primaryTerm,
-            UNASSIGNED_SEQ_NO,
             globalCheckpointListeners::globalCheckpointUpdated,
             threadPool::absoluteTimeInMillis,
             (retentionLeases, listener) -> retentionLeaseSyncer.sync(shardId, aId, getPendingPrimaryTerm(), retentionLeases, listener),
@@ -3773,7 +3773,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
     }
 
     // for tests
-    ReplicationTracker getReplicationTracker() {
+    public ReplicationTracker getReplicationTracker() {
         return replicationTracker;
     }
 

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -444,6 +444,7 @@ public class IndexModuleTests extends ESTestCase {
         assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.forceQueryCacheProvider(null)).getMessage());
         assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.setDirectoryWrapper(null)).getMessage());
         assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.setIndexCommitListener(null)).getMessage());
+        assertEquals(msg, expectThrows(IllegalStateException.class, () -> module.setReplicationTrackerFactory(null)).getMessage());
     }
 
     public void testSetupUnknownSimilarity() {
@@ -730,7 +731,7 @@ public class IndexModuleTests extends ESTestCase {
         }
     }
 
-    public void testCustomRecoverySourceFactory() throws IOException {
+    public void testCustomReplicationTrackerFactory() throws IOException {
         IndexModule module = new IndexModule(
             indexSettings,
             emptyAnalysisRegistry,

--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -24,8 +24,10 @@ import org.apache.lucene.store.FilterDirectory;
 import org.apache.lucene.tests.index.AssertingDirectoryReader;
 import org.apache.lucene.util.SetOnce.AlreadySetException;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -58,14 +60,18 @@ import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.engine.EngineTestCase;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.InternalEngineFactory;
+import org.elasticsearch.index.engine.SafeCommitInfo;
 import org.elasticsearch.index.fielddata.IndexFieldDataCache;
 import org.elasticsearch.index.mapper.MapperRegistry;
 import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.Uid;
+import org.elasticsearch.index.seqno.ReplicationTracker;
 import org.elasticsearch.index.seqno.RetentionLeaseSyncer;
+import org.elasticsearch.index.seqno.RetentionLeases;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexingOperationListener;
+import org.elasticsearch.index.shard.ReplicationGroup;
 import org.elasticsearch.index.shard.SearchOperationListener;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardPath;
@@ -106,10 +112,16 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
+import java.util.function.LongConsumer;
+import java.util.function.LongSupplier;
+import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.singletonMap;
 import static org.elasticsearch.index.IndexService.IndexCreationContext.CREATE_INDEX;
+import static org.elasticsearch.index.seqno.SequenceNumbers.UNASSIGNED_SEQ_NO;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
@@ -716,6 +728,79 @@ public class IndexModuleTests extends ESTestCase {
         } finally {
             IOUtils.close(closeables);
         }
+    }
+
+    public void testCustomRecoverySourceFactory() throws IOException {
+        IndexModule module = new IndexModule(
+            indexSettings,
+            emptyAnalysisRegistry,
+            InternalEngine::new,
+            Collections.emptyMap(),
+            () -> true,
+            indexNameExpressionResolver,
+            Collections.emptyMap()
+        );
+
+        class CustomReplicationTracker extends ReplicationTracker {
+            CustomReplicationTracker(
+                ShardId shardId,
+                String allocationId,
+                IndexSettings indexSettings,
+                long operationPrimaryTerm,
+                long globalCheckpoint,
+                LongConsumer onGlobalCheckpointUpdated,
+                LongSupplier currentTimeMillisSupplier,
+                BiConsumer<RetentionLeases, ActionListener<ReplicationResponse>> onSyncRetentionLeases,
+                Supplier<SafeCommitInfo> safeCommitInfoSupplier,
+                Consumer<ReplicationGroup> onReplicationGroupUpdated
+            ) {
+                super(
+                    shardId,
+                    allocationId,
+                    indexSettings,
+                    operationPrimaryTerm,
+                    globalCheckpoint,
+                    onGlobalCheckpointUpdated,
+                    currentTimeMillisSupplier,
+                    onSyncRetentionLeases,
+                    safeCommitInfoSupplier,
+                    onReplicationGroupUpdated
+                );
+            }
+        }
+        module.setReplicationTrackerFactory(
+            (
+                shardId,
+                allocationId,
+                indexSettings,
+                operationPrimaryTerm,
+                onGlobalCheckpointUpdated,
+                currentTimeMillisSupplier,
+                onSyncRetentionLeases,
+                safeCommitInfoSupplier,
+                onReplicationGroupUpdated) -> new CustomReplicationTracker(
+                    shardId,
+                    allocationId,
+                    indexSettings,
+                    operationPrimaryTerm,
+                    UNASSIGNED_SEQ_NO,
+                    onGlobalCheckpointUpdated,
+                    currentTimeMillisSupplier,
+                    onSyncRetentionLeases,
+                    safeCommitInfoSupplier,
+                    onReplicationGroupUpdated
+                )
+        );
+        final IndexService indexService = newIndexService(module);
+        ShardId shardId = new ShardId("index", UUIDs.randomBase64UUID(random()), 0);
+        ShardRouting shardRouting = ShardRouting.newUnassigned(
+            shardId,
+            true,
+            RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+            new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, null)
+        ).initialize("_node_id", null, -1);
+        IndexShard indexShard = indexService.createShard(shardRouting, s -> {}, RetentionLeaseSyncer.EMPTY);
+        assertThat(indexShard.getReplicationTracker(), instanceOf(CustomReplicationTracker.class));
     }
 
     private ShardRouting createInitializedShardRouting() {

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -504,7 +504,8 @@ public abstract class IndexShardTestCase extends ESTestCase {
                 breakerService,
                 IndexModule.DEFAULT_SNAPSHOT_COMMIT_SUPPLIER,
                 relativeTimeSupplier,
-                null
+                null,
+                ReplicationTracker.DEFAULT_FACTORY
             );
             indexShard.addShardFailureCallback(DEFAULT_SHARD_FAILURE_HANDLER);
             success = true;


### PR DESCRIPTION
Necessary to disable writes to replicas via a plugin for stateless.

