### PR TITLE
Make redaction configurable for APM tracing

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APM.java
+++ b/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APM.java
@@ -101,6 +101,7 @@ public class APM extends Plugin implements NetworkPlugin, TracerPlugin {
             APMAgentSettings.APM_ENABLED_SETTING,
             APMAgentSettings.APM_TRACING_NAMES_INCLUDE_SETTING,
             APMAgentSettings.APM_TRACING_NAMES_EXCLUDE_SETTING,
+            APMAgentSettings.APM_TRACING_SANITIZE_FIELD_NAMES,
             APMAgentSettings.APM_AGENT_SETTINGS,
             APMAgentSettings.APM_SECRET_TOKEN_SETTING,
             APMAgentSettings.APM_API_KEY_SETTING

--- a/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMAgentSettings.java
+++ b/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMAgentSettings.java
@@ -57,6 +57,7 @@ class APMAgentSettings {
         });
         clusterSettings.addSettingsUpdateConsumer(APM_TRACING_NAMES_INCLUDE_SETTING, apmTracer::setIncludeNames);
         clusterSettings.addSettingsUpdateConsumer(APM_TRACING_NAMES_EXCLUDE_SETTING, apmTracer::setExcludeNames);
+        clusterSettings.addSettingsUpdateConsumer(APM_TRACING_SANITIZE_FIELD_NAMES, apmTracer::setLabelFilters);
         clusterSettings.addAffixMapUpdateConsumer(APM_AGENT_SETTINGS, map -> map.forEach(this::setAgentSetting), (x, y) -> {});
     }
 
@@ -138,6 +139,27 @@ class APMAgentSettings {
     static final Setting<List<String>> APM_TRACING_NAMES_EXCLUDE_SETTING = Setting.listSetting(
         APM_SETTING_PREFIX + "names.exclude",
         Collections.emptyList(),
+        Function.identity(),
+        OperatorDynamic,
+        NodeScope
+    );
+
+    static final Setting<List<String>> APM_TRACING_SANITIZE_FIELD_NAMES = Setting.listSetting(
+        APM_SETTING_PREFIX + "sanitize_field_names",
+        List.of(
+            "password",
+            "passwd",
+            "pwd",
+            "secret",
+            "*key",
+            "*token*",
+            "*session*",
+            "*credit*",
+            "*card*",
+            "*auth*",
+            "*principal*",
+            "set-cookie"
+        ),
         Function.identity(),
         OperatorDynamic,
         NodeScope

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -461,14 +461,10 @@ public class RestController implements HttpServerTransport.Dispatcher {
             name = restPath;
         }
 
-        Map<String, Object> attributes = Maps.newMapWithExpectedSize(req.getHeaders().size() + 3);
+        final Map<String, Object> attributes = Maps.newMapWithExpectedSize(req.getHeaders().size() + 3);
         req.getHeaders().forEach((key, values) -> {
             final String lowerKey = key.toLowerCase(Locale.ROOT).replace('-', '_');
-            final String value = switch (lowerKey) {
-                case "authorization", "cookie", "secret", "session", "set_cookie", "token", "x_elastic_app_auth" -> "[REDACTED]";
-                default -> String.join("; ", values);
-            };
-            attributes.put("http.request.headers." + lowerKey, value);
+            attributes.put("http.request.headers." + lowerKey, values.size() == 1 ? values.get(0) : String.join("; ", values));
         });
         attributes.put("http.method", method);
         attributes.put("http.url", req.uri());


### PR DESCRIPTION
Closes #92338.

When tracing REST requests with APM, we capture HTTP headers as labels on the trace, but redact sensitive values. However, we can't know ahead of time what are all possible sensitive values.

Push this redaction into the tracer, and make the redaction terms configurable. Switch the defaults to the APM Java agent's defaults.