### PR TITLE
[ML] Relax stratified splitter unfiformity test error bound

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
@@ -214,7 +214,7 @@ public class StratifiedTrainTestSplitterTests extends ESTestCase {
         // should be close to the training percent, which is set to 0.5
         for (int rowTrainingCount : trainingCountPerRow) {
             double meanCount = rowTrainingCount / (double) runCount;
-            assertThat(meanCount, is(closeTo(0.5, 0.13)));
+            assertThat(meanCount, is(closeTo(0.5, 0.14)));
         }
     }
 


### PR DESCRIPTION
Relaxes slightly the error bound on the uniformity test from 0.13 to 0.14 to avoid sporadic test failures.

Closes #92361
