### PR TITLE
Mute find-structure doctest

### DIFF
--- a/docs/reference/text-structure/apis/find-structure.asciidoc
+++ b/docs/reference/text-structure/apis/find-structure.asciidoc
@@ -283,7 +283,7 @@ POST _text_structure/find_structure
 {"name": "The Left Hand of Darkness", "author": "Ursula K. Le Guin", "release_date": "1969-06-01", "page_count": 304}
 {"name": "The Moon is a Harsh Mistress", "author": "Robert A. Heinlein", "release_date": "1966-04-01", "page_count": 288}
 ----
-// TEST
+// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/87591"]
 
 If the request does not encounter errors, you receive the following result:
 


### PR DESCRIPTION
Mute find-structure doc test that is failing due to https://github.com/elastic/elasticsearch/issues/87591, that hasn't been applied to 8.5