### PR TITLE
[8.6] [ML] Relax stratified splitter unfiformity test error bound (#92362)

### DIFF
--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
@@ -214,7 +214,7 @@ public class StratifiedTrainTestSplitterTests extends ESTestCase {
         // should be close to the training percent, which is set to 0.5
         for (int rowTrainingCount : trainingCountPerRow) {
             double meanCount = rowTrainingCount / (double) runCount;
-            assertThat(meanCount, is(closeTo(0.5, 0.13)));
+            assertThat(meanCount, is(closeTo(0.5, 0.14)));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [ML] Relax stratified splitter unfiformity test error bound (#92362)