### PR TITLE
Speed up ingest geoip processors

### DIFF
--- a/docs/changelog/92372.yaml
+++ b/docs/changelog/92372.yaml
@@ -5,17 +5,12 @@ type: bug
 issues: []
 highlight:
   title: Speed up ingest geoip processors
-  body: "Previously, we were running the relatively expensive\n`SpecialPermission.check()`\
-    \ / `AccessController.doPrivileged(...)` pair \non every call to the cache, whether\
-    \ it was a cache hit or a cache miss.\nInverting that code in my second commit\
-    \ made the expensive parts only\nrun where absolutely needed (on cache misses).\n\
-    \nHowever, going still further, it turns out that in version 2.15.0 of the\ngeoip\
-    \ library it stopped interacting with jackson-databind in a way that\nrequired\
-    \ us to have special permissions to begin with -- so we can drop\nthe additional\
-    \ permissions from our policy file and we no longer need\nthe `SpecialPermission.check()`\
-    \ / `AccessController.doPrivileged(...)`\npair for cache misses, either.\n\nIn\
-    \ one of our nightly benchmarks, this speeds up `geoip` processors by\n~50%, but\
-    \ AFAICT those benchmarks use a less-cacheable random\ndistribution of ip addresses\
-    \ -- I would expect the performance bump for\nreal world use of the geoip processor\
-    \ to be even better than that."
+  body: |-
+    The `geoip` ingest processor is significantly faster.
+
+    Previous versions of the geoip library needed special permission to execute
+    databinding code, requiring an expensive permissions check and
+    `AccessController.doPrivileged` call. The current version of the geoip
+    library no longer requires that, however, so the expensive code has been
+    removed, resulting in better performance for the ingest geoip processor.
   notable: true

--- a/docs/changelog/92372.yaml
+++ b/docs/changelog/92372.yaml
@@ -1,5 +1,21 @@
 pr: 92372
 summary: Speed up ingest geoip processors
 area: Ingest Node
-type: feature
+type: bug
 issues: []
+highlight:
+  title: Speed up ingest geoip processors
+  body: "Previously, we were running the relatively expensive\n`SpecialPermission.check()`\
+    \ / `AccessController.doPrivileged(...)` pair \non every call to the cache, whether\
+    \ it was a cache hit or a cache miss.\nInverting that code in my second commit\
+    \ made the expensive parts only\nrun where absolutely needed (on cache misses).\n\
+    \nHowever, going still further, it turns out that in version 2.15.0 of the\ngeoip\
+    \ library it stopped interacting with jackson-databind in a way that\nrequired\
+    \ us to have special permissions to begin with -- so we can drop\nthe additional\
+    \ permissions from our policy file and we no longer need\nthe `SpecialPermission.check()`\
+    \ / `AccessController.doPrivileged(...)`\npair for cache misses, either.\n\nIn\
+    \ one of our nightly benchmarks, this speeds up `geoip` processors by\n~50%, but\
+    \ AFAICT those benchmarks use a less-cacheable random\ndistribution of ip addresses\
+    \ -- I would expect the performance bump for\nreal world use of the geoip processor\
+    \ to be even better than that."
+  notable: true

--- a/docs/changelog/92372.yaml
+++ b/docs/changelog/92372.yaml
@@ -1,0 +1,5 @@
+pr: 92372
+summary: Speed up ingest geoip processors
+area: Ingest Node
+type: feature
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseReaderLazyLoader.java
@@ -19,7 +19,6 @@ import com.maxmind.geoip2.model.CountryResponse;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.Booleans;
@@ -34,8 +33,6 @@ import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -188,14 +185,11 @@ class DatabaseReaderLazyLoader implements Closeable {
         CheckedBiFunction<DatabaseReader, InetAddress, Optional<T>, Exception> responseProvider
     ) {
         return cache.putIfAbsent(ipAddress, databasePath.toString(), ip -> {
-            SpecialPermission.check();
-            return AccessController.doPrivileged((PrivilegedAction<T>) () -> {
-                try {
-                    return responseProvider.apply(get(), ipAddress).orElse(null);
-                } catch (Exception e) {
-                    throw new RuntimeException(e);
-                }
-            });
+            try {
+                return responseProvider.apply(get(), ipAddress).orElse(null);
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
         });
     }
 

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpCache.java
@@ -15,7 +15,6 @@ import org.elasticsearch.common.cache.CacheBuilder;
 
 import java.net.InetAddress;
 import java.nio.file.Path;
-import java.util.Objects;
 import java.util.function.Function;
 
 /**
@@ -82,29 +81,5 @@ final class GeoIpCache {
      * path is needed to be included in the cache key. For example, if we only used the IP address as the key the City and ASN the same
      * IP may be in both with different values and we need to cache both.
      */
-    private static class CacheKey {
-
-        private final InetAddress ip;
-        private final String databasePath;
-
-        private CacheKey(InetAddress ip, String databasePath) {
-            this.ip = ip;
-            this.databasePath = databasePath;
-        }
-
-        // generated
-        @Override
-        public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            CacheKey cacheKey = (CacheKey) o;
-            return Objects.equals(ip, cacheKey.ip) && Objects.equals(databasePath, cacheKey.databasePath);
-        }
-
-        // generated
-        @Override
-        public int hashCode() {
-            return Objects.hash(ip, databasePath);
-        }
-    }
+    private record CacheKey(InetAddress ip, String databasePath) {}
 }

--- a/modules/ingest-geoip/src/main/plugin-metadata/plugin-security.policy
+++ b/modules/ingest-geoip/src/main/plugin-metadata/plugin-security.policy
@@ -7,13 +7,5 @@
  */
 
 grant {
-  // needed because jackson-databind is using Class#getDeclaredConstructors(), Class#getDeclaredMethods() and
-  // Class#getDeclaredAnnotations() to find all public, private, protected, package protected and
-  // private constructors, methods or annotations. Just locating all public constructors, methods and annotations
-  // should be enough, so this permission wouldn't then be needed. Unfortunately this is not what jackson-databind does
-  // or can be configured to do.
-  permission java.lang.RuntimePermission "accessDeclaredMembers";
-  // Also needed because of jackson-databind:
-  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
   permission java.net.SocketPermission "*", "connect";
 };


### PR DESCRIPTION
Previously, we were running the relatively expensive `SpecialPermission.check()` / `AccessController.doPrivileged(...)` pair  on every call to the cache, whether it was a cache hit or a cache miss. Inverting that code in my second commit made the expensive parts only run where absolutely needed (on cache misses).

However, going still further, it turns out that in version 2.15.0 of the geoip library it stopped interacting with jackson-databind in a way that required us to have special permissions to begin with -- so we can drop the additional permissions from our policy file and we no longer need the `SpecialPermission.check()` / `AccessController.doPrivileged(...)` pair for cache misses, either.

In one of our nightly benchmarks, this speeds up `geoip` processors by ~50%, but AFAICT those benchmarks use a less-cacheable random distribution of ip addresses -- I would expect the performance bump for real world use of the geoip processor to be even better than that.