### PR TITLE
[8.6] Move 'Explore by use case' block down (#92231)

### DIFF
--- a/docs/reference/index-custom-title-page.html
+++ b/docs/reference/index-custom-title-page.html
@@ -68,44 +68,6 @@
   </div>
 </div>
 
-<h3>Explore by use case</h3>
-
-<div class="row my-4">
-  <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
-      <div class="card h-100">
-        <h4 class="mt-3">
-          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>
-          Search my data
-        </h4>
-        <p>Create search experiences for your content, wherever it lives.</p>
-      </div>
-    </a>
-  </div>
-  <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
-      <div class="card h-100">
-        <h4 class="mt-3">
-          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
-          Observe my data
-        </h4>
-        <p>Follow our guides to monitor logs, metrics, and traces.</p>
-      </div>
-    </a>
-  </div>
-  <div class="col-md-4 col-12 mb-2">
-    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/security/current/es-overview.html">
-      <div class="card h-100">
-        <h4 class="mt-3">
-          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
-          Protect my environment
-        </h4>
-        <p>Learn how to defend against threats across your environment.</p>
-      </div>
-    </a>
-  </div>
-</div>
-
 <h3>Get to know Elasticsearch</h3>
 
 <div class="my-5">
@@ -229,5 +191,42 @@
   </ul>
 </div>
 
+<h3>Explore by use case</h3>
+
+<div class="row my-4">
+  <div class="col-md-4 col-12 mb-2">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/enterprise-search/current/start.html">
+      <div class="card h-100">
+        <h4 class="mt-3">
+          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt11200907c1c033aa/634d9da119d8652169cf9b2b/enterprise-search-logo-color-32px.png');"></span>
+          Search my data
+        </h4>
+        <p>Create search experiences for your content, wherever it lives.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col-md-4 col-12 mb-2">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/welcome-to-elastic/current/getting-started-observability.html">
+      <div class="card h-100">
+        <h4 class="mt-3">
+          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltaa08b370a00bbecc/634d9da14e565f1cdce27f7c/observability-logo-color-32px.png');"></span>
+          Observe my data
+        </h4>
+        <p>Follow our guides to monitor logs, metrics, and traces.</p>
+      </div>
+    </a>
+  </div>
+  <div class="col-md-4 col-12 mb-2">
+    <a class="no-text-decoration" href="https://www.elastic.co/guide/en/security/current/es-overview.html">
+      <div class="card h-100">
+        <h4 class="mt-3">
+          <span class="inline-block float-left icon mr-2" style="background-image: url('https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt5e0e0ad9a13e6b8c/634d9da18473831f96bbdf1e/security-logo-color-32px.png');"></span>
+          Protect my environment
+        </h4>
+        <p>Learn how to defend against threats across your environment.</p>
+      </div>
+    </a>
+  </div>
+</div>
 
 <p class="my-4"><a href="https://www.elastic.co/guide/index.html">View all Elastic docs</a></p>


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Move 'Explore by use case' block down (#92231)