### PR TITLE
Force init of Unbox in log4j

### DIFF
--- a/docs/changelog/92377.yaml
+++ b/docs/changelog/92377.yaml
@@ -1,0 +1,6 @@
+pr: 92377
+summary: Force init of Unbox in log4j
+area: Infra/Core
+type: bug
+issues:
+ - 91964


### PR DESCRIPTION
Some libaries have static initializers that require security manager permissions. When this initialization occurs during normal operation, it can cause security manager exceptions depending on where a logging call is made.

This commit adds a place for static initialization of log4j utility classes to be run, and specifically adds the Unbox class which wants to read env vars.

closes #91964