### PR TITLE
Adjust H3 azimuth test delta

### DIFF
--- a/libs/h3/src/test/java/org/elasticsearch/h3/AzimuthTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/AzimuthTests.java
@@ -30,7 +30,7 @@ public class AzimuthTests extends ESTestCase {
         for (int i = 0; i < Vec3d.faceCenterPoint.length; i++) {
             final double azVec3d = Vec3d.faceCenterPoint[i].geoAzimuthRads(point.x, point.y, point.z);
             final double azVec2d = Vec2d.faceCenterGeo[i].geoAzimuthRads(point.getLatitude(), point.getLongitude());
-            assertEquals("Face " + i, azVec2d, azVec3d, 1e-14);
+            assertEquals("Face " + i, azVec2d, azVec3d, 1e-12);
         }
     }
 


### PR DESCRIPTION
There is a failure with delta =1e-14. It could be fixed by going with 1e-13 but considering the spatial3d library considers two linear equality to be in 1e-12, let use it here as well.

fixes https://github.com/elastic/elasticsearch/issues/92385