### PR TITLE
Add jdk.internal.reflect permission to es codebase

### DIFF
--- a/docs/changelog/92387.yaml
+++ b/docs/changelog/92387.yaml
@@ -1,0 +1,6 @@
+pr: 92387
+summary: Add `jdk.internal.reflect` permission to es codebase
+area: Infra/Core
+type: bug
+issues:
+ - 92356

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -30,7 +30,7 @@ grant codeBase "${codebase.elasticsearch}" {
   permission java.lang.RuntimePermission "getClassLoader";
 
   // for plugin api dynamic settings instances
-  permission java.lang.RuntimePermission “accessClassInPackage.jdk.internal.reflect”;
+  permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.reflect";
 };
 
 //// Very special jar permissions:

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -28,6 +28,9 @@ grant codeBase "${codebase.elasticsearch}" {
   // for module layer
   permission java.lang.RuntimePermission "createClassLoader";
   permission java.lang.RuntimePermission "getClassLoader";
+
+  // for plugin api dynamic settings instances
+  permission java.lang.RuntimePermission “accessClassInPackage.jdk.internal.reflect”;
 };
 
 //// Very special jar permissions:


### PR DESCRIPTION
Dynamic settings creation is using dynamic proxy which needs this permission. We use UberModuleClassLoader for stable api without module-info. And this classloader ends up on the stacktrace when the proxy is created. Adding this permission to ES code will allow to pass SecurityManager check.

closes #92356

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
