### PR TITLE
Poison CountDown when initialised with zero

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
@@ -19,17 +19,14 @@ import java.util.concurrent.atomic.AtomicInteger;
 public final class CountDown {
 
     private final AtomicInteger countDown;
-
-    // Track originalCount because new CountDown(0) never reports completion which can be a leak if not handled specially
-    // TODO fix the places that create an empty CountDown and then drop this, see #92196
-    private final int originalCount;
+    private final boolean startedZero;
 
     public CountDown(int count) {
         if (count < 0) {
             throw new IllegalArgumentException("count must be greater or equal to 0 but was: " + count);
         }
-        this.originalCount = count;
         this.countDown = new AtomicInteger(count);
+        this.startedZero = count == 0;
     }
 
     /**
@@ -37,7 +34,9 @@ public final class CountDown {
      * reached zero otherwise <code>false</code>
      */
     public boolean countDown() {
-        assert originalCount > 0;
+        if (startedZero) {
+            throw new IllegalStateException("CountDown initialised with zero; should not get any count updates");
+        }
         return countDown.getAndUpdate(current -> {
             assert current >= 0;
             return current == 0 ? 0 : current - 1;
@@ -50,7 +49,9 @@ public final class CountDown {
      * <code>false</code>
      */
     public boolean fastForward() {
-        assert originalCount > 0;
+        if (startedZero) {
+            throw new IllegalStateException("CountDown initialised with zero; should not get any count updates");
+        }
         assert countDown.get() >= 0;
         return countDown.getAndSet(0) > 0;
     }


### PR DESCRIPTION
This is for #92196. If `CountDown` is initialised with zero, it is then a programming error to call `countDown` or `fastForward`. So add an exception to specifically call it out