### PR TITLE
[Transform] Make transform `_stats` request cancellable

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/transform.get_transform_stats.json
@@ -36,6 +36,11 @@
         "required":false,
         "description":"specifies a max number of transform stats to get, defaults to 100"
       },
+      "timeout":{
+        "type":"time",
+        "required":false,
+        "description":"Controls the time to wait for the stats"
+      },
       "allow_no_match":{
         "type":"boolean",
         "required":false,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsAction.java
@@ -17,7 +17,11 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.action.util.PageParams;
@@ -29,9 +33,11 @@ import org.elasticsearch.xpack.core.transform.utils.ExceptionsHelper;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.core.Strings.format;
 
 public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.Response> {
 
@@ -51,7 +57,8 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
         // used internally to expand the queried id expression
         private List<String> expandedIds;
 
-        public Request(String id) {
+        public Request(String id, @Nullable TimeValue timeout) {
+            setTimeout(timeout);
             if (Strings.isNullOrEmpty(id) || id.equals("*")) {
                 this.id = Metadata.ALL;
             } else {
@@ -139,6 +146,11 @@ public class GetTransformStatsAction extends ActionType<GetTransformStatsAction.
             }
             Request other = (Request) obj;
             return Objects.equals(id, other.id) && Objects.equals(pageParams, other.pageParams) && allowNoMatch == other.allowNoMatch;
+        }
+
+        @Override
+        public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
+            return new CancellableTask(id, type, action, format("get_transform_stats[%s]", this.id), parentTaskId, headers);
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/action/GetTransformStatsActionRequestTests.java
@@ -9,17 +9,37 @@ package org.elasticsearch.xpack.core.transform.action;
 
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction.Request;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 
 public class GetTransformStatsActionRequestTests extends AbstractWireSerializingTestCase<Request> {
     @Override
     protected Request createTestInstance() {
-        return new Request(randomBoolean() ? randomAlphaOfLengthBetween(1, 20) : randomBoolean() ? Metadata.ALL : null);
+        return new Request(
+            randomBoolean() ? randomAlphaOfLengthBetween(1, 20) : randomBoolean() ? Metadata.ALL : null,
+            randomBoolean() ? TimeValue.parseTimeValue(randomTimeValue(), "timeout") : null
+        );
     }
 
     @Override
     protected Writeable.Reader<Request> instanceReader() {
         return Request::new;
+    }
+
+    public void testCreateTask() {
+        Request request = new Request("some-transform", null);
+        Task task = request.createTask(123, "type", "action", TaskId.EMPTY_TASK_ID, Map.of());
+        assertThat(task, is(instanceOf(CancellableTask.class)));
+        assertThat(task.getDescription(), is(equalTo("get_transform_stats[some-transform]")));
     }
 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_stats.yml
@@ -91,6 +91,16 @@ teardown:
   - match: { transforms.0.stats.search_failures: 0 }
 
 ---
+"Test get transform stats with timeout":
+  - do:
+      transform.get_transform_stats:
+        transform_id: "airline-transform-stats"
+        timeout: "10s"
+  - match: { count: 1 }
+  - match: { transforms.0.id: "airline-transform-stats" }
+  - match: { transforms.0.state: "/started|indexing|stopping|stopped/" }
+
+---
 "Test get transform stats on missing transform":
   - do:
       transform.get_transform_stats:

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformNoTransformNodeIT.java
@@ -41,7 +41,7 @@ public class TransformNoTransformNodeIT extends TransformSingleNodeTestCase {
     }
 
     public void testGetTransformStats() {
-        GetTransformStatsAction.Request request = new GetTransformStatsAction.Request("_all");
+        GetTransformStatsAction.Request request = new GetTransformStatsAction.Request("_all", AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
         GetTransformStatsAction.Response response = client().execute(GetTransformStatsAction.INSTANCE, request).actionGet();
         assertThat(response.getTransformsStats(), is(empty()));
 

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -233,7 +233,13 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // expand 1 id
         assertAsync(
-            listener -> transformConfigManager.expandTransformIds(transformConfig1.getId(), PageParams.defaultParams(), true, listener),
+            listener -> transformConfigManager.expandTransformIds(
+                transformConfig1.getId(),
+                PageParams.defaultParams(),
+                null,
+                true,
+                listener
+            ),
             tuple(1L, tuple(singletonList("transform1_expand"), singletonList(transformConfig1))),
             null,
             null
@@ -244,6 +250,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             listener -> transformConfigManager.expandTransformIds(
                 "transform1_expand,transform2_expand",
                 PageParams.defaultParams(),
+                null,
                 true,
                 listener
             ),
@@ -257,6 +264,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             listener -> transformConfigManager.expandTransformIds(
                 "transform1*,transform2_expand,transform3_expand",
                 PageParams.defaultParams(),
+                null,
                 true,
                 listener
             ),
@@ -273,7 +281,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // expand 3 ids _all
         assertAsync(
-            listener -> transformConfigManager.expandTransformIds("_all", PageParams.defaultParams(), true, listener),
+            listener -> transformConfigManager.expandTransformIds("_all", PageParams.defaultParams(), null, true, listener),
             tuple(
                 3L,
                 tuple(
@@ -287,7 +295,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // expand 1 id _all with pagination
         assertAsync(
-            listener -> transformConfigManager.expandTransformIds("_all", new PageParams(0, 1), true, listener),
+            listener -> transformConfigManager.expandTransformIds("_all", new PageParams(0, 1), null, true, listener),
             tuple(3L, tuple(singletonList("transform1_expand"), singletonList(transformConfig1))),
             null,
             null
@@ -295,7 +303,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // expand 2 later ids _all with pagination
         assertAsync(
-            listener -> transformConfigManager.expandTransformIds("_all", new PageParams(1, 2), true, listener),
+            listener -> transformConfigManager.expandTransformIds("_all", new PageParams(1, 2), null, true, listener),
             tuple(3L, tuple(Arrays.asList("transform2_expand", "transform3_expand"), Arrays.asList(transformConfig2, transformConfig3))),
             null,
             null
@@ -303,7 +311,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // expand 1 id explicitly that does not exist
         assertAsync(
-            listener -> transformConfigManager.expandTransformIds("unknown,unknown2", new PageParams(1, 2), true, listener),
+            listener -> transformConfigManager.expandTransformIds("unknown,unknown2", new PageParams(1, 2), null, true, listener),
             (Tuple<Long, Tuple<List<String>, List<TransformConfig>>>) null,
             null,
             e -> {
@@ -317,7 +325,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // expand 1 id implicitly that does not exist
         assertAsync(
-            listener -> transformConfigManager.expandTransformIds("unknown*", new PageParams(1, 2), false, listener),
+            listener -> transformConfigManager.expandTransformIds("unknown*", new PageParams(1, 2), null, false, listener),
             (Tuple<Long, Tuple<List<String>, List<TransformConfig>>>) null,
             null,
             e -> {
@@ -348,6 +356,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             listener -> transformConfigManager.expandTransformIds(
                 "transform1_expand,transform2_expand",
                 PageParams.defaultParams(),
+                null,
                 true,
                 listener
             ),
@@ -368,25 +377,25 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             TransformConfig transformConfig = TransformConfigTests.randomTransformConfig(id);
             assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig, listener), true, null, null);
         }
-        assertAsync(listener -> transformConfigManager.getAllTransformIds(listener), transformIds, null, null);
+        assertAsync(listener -> transformConfigManager.getAllTransformIds(null, listener), transformIds, null, null);
 
         // test recursive retrieval
         assertAsync(
-            listener -> transformConfigManager.expandAllTransformIds(false, 10, listener),
+            listener -> transformConfigManager.expandAllTransformIds(false, 10, null, listener),
             tuple(Long.valueOf(numberOfTransformsToGenerate), transformIds),
             null,
             null
         );
 
         assertAsync(
-            listener -> transformConfigManager.getAllOutdatedTransformIds(listener),
+            listener -> transformConfigManager.getAllOutdatedTransformIds(null, listener),
             tuple(Long.valueOf(numberOfTransformsToGenerate), Collections.<String>emptySet()),
             null,
             null
         );
 
         assertAsync(
-            listener -> transformConfigManager.expandAllTransformIds(true, 10, listener),
+            listener -> transformConfigManager.expandAllTransformIds(true, 10, null, listener),
             tuple(Long.valueOf(numberOfTransformsToGenerate), Collections.<String>emptySet()),
             null,
             null
@@ -410,9 +419,9 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             client().index(request).actionGet();
         }
 
-        assertAsync(listener -> transformConfigManager.getAllTransformIds(listener), transformIds, null, null);
+        assertAsync(listener -> transformConfigManager.getAllTransformIds(null, listener), transformIds, null, null);
         assertAsync(
-            listener -> transformConfigManager.getAllOutdatedTransformIds(listener),
+            listener -> transformConfigManager.getAllOutdatedTransformIds(null, listener),
             tuple(Long.valueOf(numberOfTransformsToGenerate), Collections.<String>emptySet()),
             null,
             null
@@ -443,16 +452,16 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         );
 
         transformIds.add(oldTransformId);
-        assertAsync(listener -> transformConfigManager.getAllTransformIds(listener), transformIds, null, null);
+        assertAsync(listener -> transformConfigManager.getAllTransformIds(null, listener), transformIds, null, null);
         assertAsync(
-            listener -> transformConfigManager.getAllOutdatedTransformIds(listener),
+            listener -> transformConfigManager.getAllOutdatedTransformIds(null, listener),
             tuple(Long.valueOf(numberOfTransformsToGenerate + 1), Collections.singleton(oldTransformId)),
             null,
             null
         );
 
         assertAsync(
-            listener -> transformConfigManager.expandAllTransformIds(true, 10, listener),
+            listener -> transformConfigManager.expandAllTransformIds(true, 10, null, listener),
             tuple(Long.valueOf(numberOfTransformsToGenerate + 1), Collections.singleton(oldTransformId)),
             null,
             null
@@ -517,7 +526,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         // returned docs will be ordered by id
         expectedDocs.sort(Comparator.comparing(TransformStoredDoc::getId));
-        assertAsync(listener -> transformConfigManager.getTransformStoredDocs(ids, listener), expectedDocs, null, null);
+        assertAsync(listener -> transformConfigManager.getTransformStoredDocs(ids, null, listener), expectedDocs, null, null);
     }
 
     public void testDeleteOldTransformConfigurations() throws Exception {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -27,6 +28,7 @@ import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.Assignment;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.transform.action.GetTransformStatsAction;
@@ -138,12 +140,15 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
 
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> finalListener) {
+        TaskId parentTaskId = new TaskId(clusterService.localNode().getId(), task.getId());
+
         final ClusterState clusterState = clusterService.state();
         TransformNodes.warnIfNoTransformNodes(clusterState);
 
         transformConfigManager.expandTransformIds(
             request.getId(),
             request.getPageParams(),
+            request.getTimeout(),
             request.isAllowNoMatch(),
             ActionListener.wrap(hitsAndIds -> {
                 boolean hasAnyTransformNode = TransformNodes.hasAnyTransformNode(clusterState.getNodes());
@@ -175,6 +180,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                         response.getTransformsStats().forEach(dtsasi -> setNodeAttributes(dtsasi, tasksInProgress, clusterState));
                     }
                     collectStatsForTransformsWithoutTasks(
+                        parentTaskId,
                         request,
                         response,
                         transformNodeAssignments.getWaitingForAssignment(),
@@ -246,6 +252,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
     }
 
     private void collectStatsForTransformsWithoutTasks(
+        TaskId parentTaskId,
         Request request,
         Response response,
         Set<String> transformsWaitingForAssignment,
@@ -270,6 +277,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
             // copy the list as it might be immutable
             List<TransformStats> allStateAndStats = new ArrayList<>(response.getTransformsStats());
             addCheckpointingInfoForTransformsWithoutTasks(
+                parentTaskId,
                 allStateAndStats,
                 statsForTransformsWithoutTasks,
                 transformsWaitingForAssignment,
@@ -299,12 +307,16 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
             }
         });
 
-        transformConfigManager.getTransformStoredDocs(transformsWithoutTasks, searchStatsListener);
+        transformConfigManager.getTransformStoredDocs(transformsWithoutTasks, request.getTimeout(), searchStatsListener);
     }
 
-    private void populateSingleStoppedTransformStat(TransformStoredDoc transform, ActionListener<TransformCheckpointingInfo> listener) {
+    private void populateSingleStoppedTransformStat(
+        TransformStoredDoc transform,
+        TaskId parentTaskId,
+        ActionListener<TransformCheckpointingInfo> listener
+    ) {
         transformCheckpointService.getCheckpointingInfo(
-            client,
+            new ParentTaskAssigningClient(client, parentTaskId),
             transform.getId(),
             transform.getTransformState().getCheckpoint(),
             transform.getTransformState().getPosition(),
@@ -317,6 +329,7 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
     }
 
     private void addCheckpointingInfoForTransformsWithoutTasks(
+        TaskId parentTaskId,
         List<TransformStats> allStateAndStats,
         List<TransformStoredDoc> statsForTransformsWithoutTasks,
         Set<String> transformsWaitingForAssignment,
@@ -333,42 +346,44 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
         AtomicInteger numberRemaining = new AtomicInteger(statsForTransformsWithoutTasks.size());
         AtomicBoolean isExceptionReported = new AtomicBoolean(false);
 
-        statsForTransformsWithoutTasks.forEach(stat -> populateSingleStoppedTransformStat(stat, ActionListener.wrap(checkpointingInfo -> {
-            synchronized (allStateAndStats) {
-                if (transformsWaitingForAssignment.contains(stat.getId())) {
-                    Assignment assignment = TransformNodes.getAssignment(stat.getId(), clusterState);
-                    allStateAndStats.add(
-                        new TransformStats(
-                            stat.getId(),
-                            TransformStats.State.WAITING,
-                            assignment.getExplanation(),
-                            null,
-                            stat.getTransformStats(),
-                            checkpointingInfo,
-                            TransformHealthChecker.checkUnassignedTransform(stat.getId(), clusterState)
-                        )
-                    );
-                } else {
-                    allStateAndStats.add(
-                        new TransformStats(
-                            stat.getId(),
-                            TransformStats.State.STOPPED,
-                            null,
-                            null,
-                            stat.getTransformStats(),
-                            checkpointingInfo,
-                            TransformHealth.GREEN
-                        )
-                    );
+        statsForTransformsWithoutTasks.forEach(
+            stat -> populateSingleStoppedTransformStat(stat, parentTaskId, ActionListener.wrap(checkpointingInfo -> {
+                synchronized (allStateAndStats) {
+                    if (transformsWaitingForAssignment.contains(stat.getId())) {
+                        Assignment assignment = TransformNodes.getAssignment(stat.getId(), clusterState);
+                        allStateAndStats.add(
+                            new TransformStats(
+                                stat.getId(),
+                                TransformStats.State.WAITING,
+                                assignment.getExplanation(),
+                                null,
+                                stat.getTransformStats(),
+                                checkpointingInfo,
+                                TransformHealthChecker.checkUnassignedTransform(stat.getId(), clusterState)
+                            )
+                        );
+                    } else {
+                        allStateAndStats.add(
+                            new TransformStats(
+                                stat.getId(),
+                                TransformStats.State.STOPPED,
+                                null,
+                                null,
+                                stat.getTransformStats(),
+                                checkpointingInfo,
+                                TransformHealth.GREEN
+                            )
+                        );
+                    }
                 }
-            }
-            if (numberRemaining.decrementAndGet() == 0) {
-                listener.onResponse(null);
-            }
-        }, e -> {
-            if (isExceptionReported.compareAndSet(false, true)) {
-                listener.onFailure(e);
-            }
-        })));
+                if (numberRemaining.decrementAndGet() == 0) {
+                    listener.onResponse(null);
+                }
+            }, e -> {
+                if (isExceptionReported.compareAndSet(false, true)) {
+                    listener.onFailure(e);
+                }
+            }))
+        );
     }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStopTransformAction.java
@@ -150,6 +150,7 @@ public class TransportStopTransformAction extends TransportTasksAction<Transform
             transformConfigManager.expandTransformIds(
                 request.getId(),
                 new PageParams(0, 10_000),
+                request.getTimeout(),
                 request.isAllowNoMatch(),
                 ActionListener.wrap(hitsAndIds -> {
                     validateTaskState(state, hitsAndIds.v2().v1(), request.isForce());

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpgradeTransformsAction.java
@@ -211,7 +211,7 @@ public class TransportUpgradeTransformsAction extends TransportMasterNodeAction<
         TimeValue timeout,
         ActionListener<Map<UpdateResult.Status, Long>> listener
     ) {
-        transformConfigManager.getAllOutdatedTransformIds(ActionListener.wrap(totalAndIds -> {
+        transformConfigManager.getAllOutdatedTransformIds(timeout, ActionListener.wrap(totalAndIds -> {
 
             // exit quickly if there is nothing to do
             if (totalAndIds.v2().isEmpty()) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -37,6 +37,7 @@ import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.engine.VersionConflictEngineException;
@@ -518,6 +519,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
     public void expandTransformIds(
         String transformIdsExpression,
         PageParams pageParams,
+        TimeValue timeout,
         boolean allowNoMatch,
         ActionListener<Tuple<Long, Tuple<List<String>, List<TransformConfig>>>> foundConfigsListener
     ) {
@@ -533,6 +535,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
             .setFrom(pageParams.getFrom())
             .setTrackTotalHits(true)
             .setSize(pageParams.getSize())
+            .setTimeout(timeout)
             .setQuery(queryBuilder)
             .request();
 
@@ -588,13 +591,18 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
     }
 
     @Override
-    public void getAllTransformIds(ActionListener<Set<String>> listener) {
-        expandAllTransformIds(false, MAX_RESULTS_WINDOW, ActionListener.wrap(r -> listener.onResponse(r.v2()), listener::onFailure));
+    public void getAllTransformIds(TimeValue timeout, ActionListener<Set<String>> listener) {
+        expandAllTransformIds(
+            false,
+            MAX_RESULTS_WINDOW,
+            timeout,
+            ActionListener.wrap(r -> listener.onResponse(r.v2()), listener::onFailure)
+        );
     }
 
     @Override
-    public void getAllOutdatedTransformIds(ActionListener<Tuple<Long, Set<String>>> listener) {
-        expandAllTransformIds(true, MAX_RESULTS_WINDOW, listener);
+    public void getAllOutdatedTransformIds(TimeValue timeout, ActionListener<Tuple<Long, Set<String>>> listener) {
+        expandAllTransformIds(true, MAX_RESULTS_WINDOW, timeout, listener);
     }
 
     @Override
@@ -781,7 +789,11 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
     }
 
     @Override
-    public void getTransformStoredDocs(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener) {
+    public void getTransformStoredDocs(
+        Collection<String> transformIds,
+        TimeValue timeout,
+        ActionListener<List<TransformStoredDoc>> listener
+    ) {
         QueryBuilder builder = QueryBuilders.constantScoreQuery(
             QueryBuilders.boolQuery()
                 .filter(QueryBuilders.termsQuery(TransformField.ID.getPreferredName(), transformIds))
@@ -797,6 +809,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
             .setQuery(builder)
             // the limit for getting stats and transforms is 1000, as long as we do not have 10 indices this works
             .setSize(Math.min(transformIds.size(), 10_000))
+            .setTimeout(timeout)
             .request();
 
         executeAsyncWithOrigin(
@@ -904,13 +917,19 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
      *
      * @param filterForOutdated if true, only returns outdated ids (after de-duplication)
      * @param maxResultWindow the max result window size (exposed for testing)
+     * @param timeout timeout applied to all the spawned requests
      * @param listener listener to call containing transform ids
      */
-    void expandAllTransformIds(boolean filterForOutdated, int maxResultWindow, ActionListener<Tuple<Long, Set<String>>> listener) {
+    void expandAllTransformIds(
+        boolean filterForOutdated,
+        int maxResultWindow,
+        TimeValue timeout,
+        ActionListener<Tuple<Long, Set<String>>> listener
+    ) {
         PageParams startPage = new PageParams(0, maxResultWindow);
 
         Set<String> collectedIds = new HashSet<>();
-        recursiveExpandAllTransformIds(collectedIds, 0, filterForOutdated, maxResultWindow, null, startPage, listener);
+        recursiveExpandAllTransformIds(collectedIds, 0, filterForOutdated, maxResultWindow, null, startPage, timeout, listener);
     }
 
     private void recursiveExpandAllTransformIds(
@@ -920,6 +939,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
         int maxResultWindow,
         String lastId,
         PageParams page,
+        TimeValue timeout,
         ActionListener<Tuple<Long, Set<String>>> listener
     ) {
         SearchRequest request = client.prepareSearch(
@@ -930,6 +950,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
             .addSort("_index", SortOrder.DESC)
             .setFrom(page.getFrom())
             .setSize(page.getSize())
+            .setTimeout(timeout)
             .setFetchSource(false)
             .addDocValueField(TransformField.ID.getPreferredName())
             .setQuery(
@@ -973,6 +994,7 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
                         maxResultWindow,
                         idOfLastHit,
                         nextPage,
+                        timeout,
                         listener
                     );
                     return;

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.persistence;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.transform.TransformField;
@@ -146,11 +147,13 @@ public interface TransformConfigManager {
      *
      * @param transformIdsExpression The id expression. Can be _all, *, or comma delimited list of simple regex strings
      * @param pageParams             The paging params
+     * @param timeout                The timeout applied to all the spawned requests
      * @param foundConfigsListener   The listener on signal on success or failure
      */
     void expandTransformIds(
         String transformIdsExpression,
         PageParams pageParams,
+        TimeValue timeout,
         boolean allowNoMatch,
         ActionListener<Tuple<Long, Tuple<List<String>, List<TransformConfig>>>> foundConfigsListener
     );
@@ -158,16 +161,18 @@ public interface TransformConfigManager {
     /**
      * Get all transform ids
      *
+     * @param timeout  The timeout applied to all the spawned requests
      * @param listener The listener to call with the collected ids
      */
-    void getAllTransformIds(ActionListener<Set<String>> listener);
+    void getAllTransformIds(TimeValue timeout, ActionListener<Set<String>> listener);
 
     /**
      * Get all transform ids that aren't using the latest index.
      *
+     * @param timeout  The timeout applied to all the spawned requests
      * @param listener The listener to call with total number of transforms and the list of transform ids.
      */
-    void getAllOutdatedTransformIds(ActionListener<Tuple<Long, Set<String>>> listener);
+    void getAllOutdatedTransformIds(TimeValue timeout, ActionListener<Tuple<Long, Set<String>>> listener);
 
     /**
      * This deletes documents corresponding to the transform id (e.g. checkpoints).
@@ -198,7 +203,7 @@ public interface TransformConfigManager {
         ActionListener<Tuple<TransformStoredDoc, SeqNoPrimaryTermAndIndex>> resultListener
     );
 
-    void getTransformStoredDocs(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener);
+    void getTransformStoredDocs(Collection<String> transformIds, TimeValue timeout, ActionListener<List<TransformStoredDoc>> listener);
 
     void refresh(ActionListener<Boolean> listener);
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestCatTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestCatTransformAction.java
@@ -59,7 +59,7 @@ public class RestCatTransformAction extends AbstractCatAction {
         GetTransformAction.Request request = new GetTransformAction.Request(id);
         request.setAllowNoResources(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
 
-        GetTransformStatsAction.Request statsRequest = new GetTransformStatsAction.Request(id);
+        GetTransformStatsAction.Request statsRequest = new GetTransformStatsAction.Request(id, null);
         statsRequest.setAllowNoMatch(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
 
         if (restRequest.hasParam(PageParams.FROM.getPreferredName()) || restRequest.hasParam(PageParams.SIZE.getPreferredName())) {

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/rest/action/RestGetTransformStatsAction.java
@@ -7,9 +7,13 @@
 
 package org.elasticsearch.xpack.transform.rest.action;
 
+import org.elasticsearch.action.support.master.AcknowledgedRequest;
+import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.transform.TransformField;
@@ -31,9 +35,10 @@ public class RestGetTransformStatsAction extends BaseRestHandler {
     }
 
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient nodeClient) {
         String id = restRequest.param(TransformField.ID.getPreferredName());
-        GetTransformStatsAction.Request request = new GetTransformStatsAction.Request(id);
+        TimeValue timeout = restRequest.paramAsTime(TransformField.TIMEOUT.getPreferredName(), AcknowledgedRequest.DEFAULT_ACK_TIMEOUT);
+        GetTransformStatsAction.Request request = new GetTransformStatsAction.Request(id, timeout);
         request.setAllowNoMatch(restRequest.paramAsBoolean(ALLOW_NO_MATCH.getPreferredName(), true));
         if (restRequest.hasParam(PageParams.FROM.getPreferredName()) || restRequest.hasParam(PageParams.SIZE.getPreferredName())) {
             request.setPageParams(
@@ -43,6 +48,7 @@ public class RestGetTransformStatsAction extends BaseRestHandler {
                 )
             );
         }
+        Client client = new RestCancellableNodeClient(nodeClient, restRequest.getHttpChannel());
         return channel -> client.execute(GetTransformStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.persistence;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.regex.Regex;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
@@ -243,6 +244,7 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
     public void expandTransformIds(
         String transformIdsExpression,
         PageParams pageParams,
+        TimeValue timeout,
         boolean allowNoMatch,
         ActionListener<Tuple<Long, Tuple<List<String>, List<TransformConfig>>>> foundConfigsListener
     ) {
@@ -359,7 +361,11 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
     }
 
     @Override
-    public void getTransformStoredDocs(Collection<String> transformIds, ActionListener<List<TransformStoredDoc>> listener) {
+    public void getTransformStoredDocs(
+        Collection<String> transformIds,
+        TimeValue timeout,
+        ActionListener<List<TransformStoredDoc>> listener
+    ) {
         List<TransformStoredDoc> docs = new ArrayList<>();
         for (String transformId : transformIds) {
             TransformStoredDoc storedDoc = transformStoredDocs.get(transformId);
@@ -381,17 +387,16 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
     }
 
     @Override
-    public void getAllTransformIds(ActionListener<Set<String>> listener) {
+    public void getAllTransformIds(TimeValue timeout, ActionListener<Set<String>> listener) {
         Set<String> allIds = new HashSet<>(configs.keySet());
         allIds.addAll(oldConfigs.keySet());
         listener.onResponse(allIds);
     }
 
     @Override
-    public void getAllOutdatedTransformIds(ActionListener<Tuple<Long, Set<String>>> listener) {
+    public void getAllOutdatedTransformIds(TimeValue timeout, ActionListener<Tuple<Long, Set<String>>> listener) {
         Set<String> outdatedIds = new HashSet<>(oldConfigs.keySet());
         outdatedIds.removeAll(configs.keySet());
         listener.onResponse(new Tuple<>(Long.valueOf(configs.size() + outdatedIds.size()), outdatedIds));
     }
-
 }


### PR DESCRIPTION
This PR improves the way `_stats` request is handled in Transform API:
- makes the `_stats` call cancellable by passing parent task id around
- makes the `_stats` time-bounded by passing timeout parameter around

Relates https://github.com/elastic/elasticsearch/issues/91616