### PR TITLE
Ensure final_pipeline is executed once

### DIFF
--- a/docs/changelog/92400.yaml
+++ b/docs/changelog/92400.yaml
@@ -1,0 +1,6 @@
+pr: 92400
+summary: Ensure `final_pipeline` is executed once
+area: Ingest Node
+type: bug
+issues:
+ - 83653

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
@@ -1,3 +1,29 @@
+setup:
+  - do:
+      indices.put_template:
+        name: add_final_pipeline
+        body:
+          index_patterns: foo
+          settings:
+            final_pipeline: "final_pipeline"
+
+  - do:
+      ingest.put_pipeline:
+        id: "final_pipeline"
+        body:  >
+          {
+            "processors": [
+              {
+                "append" : {
+                  "field" : "accumulator",
+                  "value" : [
+                    "non-repeated-value"
+                  ]
+                }
+              }
+            ]
+          }
+
 ---
 teardown:
 - do:
@@ -8,6 +34,11 @@ teardown:
 - do:
     indices.delete:
       index: foo
+
+- do:
+    ingest.delete_pipeline:
+      id: final_pipeline
+      ignore: 404
 
 ---
 "Test Change Target Index with Explicit Pipeline":
@@ -49,7 +80,7 @@ teardown:
     get:
       index: foo
       id: "1"
-- match: { _source.a: true }
+- match: { _source: { a: true, accumulator: ["non-repeated-value"]} }
 
 # only the foo index
 - do:
@@ -107,7 +138,7 @@ teardown:
     get:
       index: foo
       id: "1"
-- match: { _source.a: true }
+- match: { _source: { a: true, accumulator: ["non-repeated-value"]} }
 
 # only the foo index
 - do:

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -230,7 +230,11 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
                 // Each index request needs to be evaluated, because this method also modifies the IndexRequest
-                boolean indexRequestHasPipeline = IngestService.resolvePipelines(actionRequest, indexRequest, metadata);
+                boolean indexRequestHasPipeline = IngestService.resolvePipelinesAndUpdateIndexRequest(
+                    actionRequest,
+                    indexRequest,
+                    metadata
+                );
                 hasIndexRequestsWithPipelines |= indexRequestHasPipeline;
             }
 


### PR DESCRIPTION
In case, a processor changes the index of a request and the new index has a final_pipeline, this pipeline is executed twice. This happens because `IngestService` overwrites the pipeline information, but it never cleans it up later. This change ensures that `IngestService` does not change the pipeline information for this case using methods without side effects


Closes #83653
