### PR TITLE
[8.6] Revert back to S3 repository for ML snapshot artifacts (#92381)

### DIFF
--- a/x-pack/plugin/ml/build.gradle
+++ b/x-pack/plugin/ml/build.gradle
@@ -1,6 +1,3 @@
-import org.elasticsearch.gradle.VersionProperties
-import org.elasticsearch.gradle.internal.dra.DraResolvePlugin
-
 apply plugin: 'elasticsearch.internal-es-plugin'
 apply plugin: 'elasticsearch.internal-cluster-test'
 apply plugin: 'elasticsearch.internal-test-artifact'
@@ -14,42 +11,27 @@ esplugin {
   extendedPlugins = ['x-pack-autoscaling', 'lang-painless']
 }
 
-def localRepo = providers.systemProperty('build.ml_cpp.repo').orNull
 if (useDra == false) {
   repositories {
     exclusiveContent {
-      filter {
-        includeGroup 'org.elasticsearch.ml'
-      }
       forRepository {
         ivy {
           name "ml-cpp"
+          url providers.systemProperty('build.ml_cpp.repo').orElse('https://prelert-artifacts.s3.amazonaws.com').get()
           metadataSources {
             // no repository metadata, look directly for the artifact
             artifact()
           }
-          if (localRepo) {
-            url localRepo
-            patternLayout {
-              artifact "maven/[orgPath]/[module]/[revision]/[module]-[revision](-[classifier]).[ext]"
-            }
-          } else {
-            url "https://artifacts-snapshot.elastic.co/"
-            patternLayout {
-              if (VersionProperties.isElasticsearchSnapshot()) {
-                artifact '/ml-cpp/[revision]/downloads/ml-cpp/[module]-[revision]-[classifier].[ext]'
-              } else {
-                // When building locally we always use snapshot artifacts even if passing `-Dbuild.snapshot=false`.
-                // Release builds are always done with a local repo.
-                artifact '/ml-cpp/[revision]-SNAPSHOT/downloads/ml-cpp/[module]-[revision]-SNAPSHOT-[classifier].[ext]'
-              }
-            }
+          patternLayout {
+            artifact "maven/org/elasticsearch/ml/ml-cpp/[revision]/[module]-[revision](-[classifier]).[ext]"
           }
         }
       }
+      filter {
+        includeGroup 'org.elasticsearch.ml'
+      }
     }
   }
-
 }
 
 configurations {


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Revert back to S3 repository for ML snapshot artifacts (#92381)