### PR TITLE
[8.6] Use smaller snapshot threadpool size on small nodes (#92392)

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -15,6 +15,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.SizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
@@ -203,7 +205,9 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         builders.put(Names.FLUSH, new ScalingExecutorBuilder(Names.FLUSH, 1, halfProcMaxAt5, TimeValue.timeValueMinutes(5), false));
         builders.put(Names.REFRESH, new ScalingExecutorBuilder(Names.REFRESH, 1, halfProcMaxAt10, TimeValue.timeValueMinutes(5), false));
         builders.put(Names.WARMER, new ScalingExecutorBuilder(Names.WARMER, 1, halfProcMaxAt5, TimeValue.timeValueMinutes(5), false));
-        builders.put(Names.SNAPSHOT, new ScalingExecutorBuilder(Names.SNAPSHOT, 1, 10, TimeValue.timeValueMinutes(5), false));
+        ByteSizeValue maxHeapSize = ByteSizeValue.ofBytes(Runtime.getRuntime().maxMemory());
+        final int maxSnapshotCores = getMaxSnapshotCores(allocatedProcessors, maxHeapSize);
+        builders.put(Names.SNAPSHOT, new ScalingExecutorBuilder(Names.SNAPSHOT, 1, maxSnapshotCores, TimeValue.timeValueMinutes(5), false));
         builders.put(
             Names.SNAPSHOT_META,
             new ScalingExecutorBuilder(
@@ -559,6 +563,15 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
 
     public static int searchThreadPoolSize(final int allocatedProcessors) {
         return ((allocatedProcessors * 3) / 2) + 1;
+    }
+
+    static int getMaxSnapshotCores(int allocatedProcessors, final ByteSizeValue maxHeapSize) {
+        // While on larger data nodes, larger snapshot threadpool size improves snapshotting on high latency blob stores,
+        // smaller instances can run into OOM issues and need a smaller snapshot threadpool size.
+        if (maxHeapSize.compareTo(new ByteSizeValue(750, ByteSizeUnit.MB)) < 0) {
+            return halfAllocatedProcessorsMaxFive(allocatedProcessors);
+        }
+        return 10;
     }
 
     static class ThreadedRunnable implements Runnable {

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.FutureUtils;
 import org.elasticsearch.core.TimeValue;
@@ -25,6 +26,8 @@ import java.util.concurrent.ExecutorService;
 import static org.elasticsearch.threadpool.ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING;
 import static org.elasticsearch.threadpool.ThreadPool.LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING;
 import static org.elasticsearch.threadpool.ThreadPool.assertCurrentMethodIsNotCalledRecursively;
+import static org.elasticsearch.threadpool.ThreadPool.getMaxSnapshotCores;
+import static org.elasticsearch.threadpool.ThreadPool.halfAllocatedProcessorsMaxFive;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 
@@ -327,5 +330,22 @@ public class ThreadPoolTests extends ESTestCase {
         } finally {
             assertTrue(terminate(threadPool));
         }
+    }
+
+    public void testGetMaxSnapshotCores() {
+        int allocatedProcessors = randomIntBetween(1, 16);
+        assertThat(
+            getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofMb(400)),
+            equalTo(halfAllocatedProcessorsMaxFive(allocatedProcessors))
+        );
+        allocatedProcessors = randomIntBetween(1, 16);
+        assertThat(
+            getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofMb(749)),
+            equalTo(halfAllocatedProcessorsMaxFive(allocatedProcessors))
+        );
+        allocatedProcessors = randomIntBetween(1, 16);
+        assertThat(getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofMb(750)), equalTo(10));
+        allocatedProcessors = randomIntBetween(1, 16);
+        assertThat(getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofGb(4)), equalTo(10));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Use smaller snapshot threadpool size on small nodes (#92392)