### PR TITLE
Don't account for the unassigned reason when diagnosing NO_VALID_SHARD_COPY

### DIFF
--- a/docs/changelog/92416.yaml
+++ b/docs/changelog/92416.yaml
@@ -1,0 +1,5 @@
+pr: 92416
+summary: Don't account for the unassigned reason when diagnosing NO_VALID_SHARD_COPY
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -441,9 +441,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         LOGGER.trace("Diagnosing unassigned shard [{}] due to reason [{}]", shardRouting.shardId(), shardRouting.unassignedInfo());
         switch (shardRouting.unassignedInfo().getLastAllocationStatus()) {
             case NO_VALID_SHARD_COPY:
-                if (UnassignedInfo.Reason.NODE_LEFT == shardRouting.unassignedInfo().getReason()) {
-                    diagnosisDefs.add(ACTION_RESTORE_FROM_SNAPSHOT);
-                }
+                diagnosisDefs.add(ACTION_RESTORE_FROM_SNAPSHOT);
                 break;
             case NO_ATTEMPT:
                 if (shardRouting.unassignedInfo().isDelayed()) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -1407,7 +1407,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
 
     private static UnassignedInfo noShardCopy() {
         return new UnassignedInfo(
-            UnassignedInfo.Reason.NODE_LEFT,
+            randomBoolean() ? UnassignedInfo.Reason.NODE_LEFT : UnassignedInfo.Reason.CLUSTER_RECOVERED,
             null,
             null,
             0,


### PR DESCRIPTION
The UnassignedInfo.Reason indicates what triggered the shard unassignment, as opposed to what the course of action should be.

This extends the `restore-from-snapshot` diagnosis to not take the shard unassigned info reason into account.