### PR TITLE
Make FilterStreamInput less trappy

### DIFF
--- a/docs/changelog/92422.yaml
+++ b/docs/changelog/92422.yaml
@@ -1,0 +1,5 @@
+pr: 92422
+summary: Make `FilterStreamInput` less trappy
+area: Infra/Core
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -93,6 +93,8 @@ public abstract class FilterStreamInput extends StreamInput {
     @Override
     public void setVersion(Version version) {
         delegate.setVersion(version);
+        // also set the version on this stream directly, so that any uses of this.version are still correct
+        super.setVersion(version);
     }
 
     @Override


### PR DESCRIPTION
When version is set on FilterStreamInput, it is passed to the delegate stream. However, any uses of this.version directly on the stream are not correct. While it would be better to force using getVersion() consistently, this commit makes the situation less trappy by also setting the version on the wrapper stream.

relates #88686