### PR TITLE
Improve H3 Vec2d#v2dIntersect method

### DIFF
--- a/libs/h3/src/main/java/org/elasticsearch/h3/FaceIJK.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/FaceIJK.java
@@ -628,7 +628,7 @@ final class FaceIJK {
                 adjacent hexagon edge will lie completely on a single icosahedron
                 face, and no additional vertex is required.
                 */
-                final boolean isIntersectionAtVertex = orig2d0.equals(inter) || orig2d1.equals(inter);
+                final boolean isIntersectionAtVertex = orig2d0.numericallyIdentical(inter) || orig2d1.numericallyIdentical(inter);
                 if (isIntersectionAtVertex == false) {
                     final LatLng point = inter.hex2dToGeo(this.face, adjRes, true);
                     boundary.add(point);

--- a/libs/h3/src/main/java/org/elasticsearch/h3/Vec2d.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/Vec2d.java
@@ -280,16 +280,14 @@ final class Vec2d {
      * @param p3 The second endpoint of the second line.
      */
     public static Vec2d v2dIntersect(Vec2d p0, Vec2d p1, Vec2d p2, Vec2d p3) {
-        double[] s1 = new double[2], s2 = new double[2];
-        s1[0] = p1.x - p0.x;
-        s1[1] = p1.y - p0.y;
-        s2[0] = p3.x - p2.x;
-        s2[1] = p3.y - p2.y;
+        final double s1x = p1.x - p0.x;
+        final double s1y = p1.y - p0.y;
+        final double s2x = p3.x - p2.x;
+        final double s2y = p3.y - p2.y;
 
-        float t;
-        t = (float) ((s2[0] * (p0.y - p2.y) - s2[1] * (p0.x - p2.x)) / (-s2[0] * s1[1] + s1[0] * s2[1]));
+        final double t = ((s2x * (p0.y - p2.y) - s2y * (p0.x - p2.x)) / (-s2x * s1y + s1x * s2y));
 
-        return new Vec2d(p0.x + (t * s1[0]), p0.y + (t * s1[1]));
+        return new Vec2d(p0.x + (t * s1x), p0.y + (t * s1y));
     }
 
     /**

--- a/libs/h3/src/main/java/org/elasticsearch/h3/Vec2d.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/Vec2d.java
@@ -32,6 +32,8 @@ final class Vec2d {
     /** sin(60') */
     private static final double M_SIN60 = Constants.M_SQRT3_2;
 
+    private static final double VEC2D_RESOLUTION = 1e-7;
+
     /**
      * icosahedron face centers in lat/lng radians
      */
@@ -255,6 +257,10 @@ final class Vec2d {
         final CoordIJK coordIJK = new CoordIJK(i, j, k);
         coordIJK.ijkNormalize();
         return coordIJK;
+    }
+
+    public boolean numericallyIdentical(Vec2d vec2d) {
+        return Math.abs(vec2d.x - x) < VEC2D_RESOLUTION && Math.abs(vec2d.y - y) < VEC2D_RESOLUTION;
     }
 
     @Override

--- a/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
@@ -21,7 +21,6 @@ package org.elasticsearch.h3;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.tests.geo.GeoTestUtil;
 import org.elasticsearch.test.ESTestCase;
-import org.hamcrest.Matchers;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -32,6 +31,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
+
+import static org.hamcrest.Matchers.either;
+import static org.hamcrest.Matchers.equalTo;
 
 public class CellBoundaryTests extends ESTestCase {
 
@@ -187,8 +189,8 @@ public class CellBoundaryTests extends ESTestCase {
             int count = 0;
             CellBoundary ringBoundary = H3.h3ToGeoBoundary(r);
             for (int i = 0; i < boundary.numPoints(); i++) {
-                LatLng latLng1 = boundary.getLatLon(getIndex(i, boundary.numPoints()));
-                LatLng latLng2 = boundary.getLatLon(getIndex(i + 1, boundary.numPoints()));
+                LatLng latLng1 = boundary.getLatLon(i % boundary.numPoints());
+                LatLng latLng2 = boundary.getLatLon((i + 1) % boundary.numPoints());
                 int lon1 = GeoEncodingUtils.encodeLongitude(latLng1.getLonDeg());
                 int lat1 = GeoEncodingUtils.encodeLatitude(latLng1.getLatDeg());
                 int lon2 = GeoEncodingUtils.encodeLongitude(latLng2.getLonDeg());
@@ -197,14 +199,14 @@ public class CellBoundaryTests extends ESTestCase {
                     count++;
                 }
             }
-            assertThat(count, Matchers.greaterThan(0));
+            assertThat("For cell " + H3.h3ToString(h3), count, either(equalTo(1)).or(equalTo(2)));
         }
     }
 
     private boolean isSharedBoundary(int clon1, int clat1, int clon2, int clat2, CellBoundary boundary) {
         for (int i = 0; i < boundary.numPoints(); i++) {
-            LatLng latLng1 = boundary.getLatLon(getIndex(i, boundary.numPoints()));
-            LatLng latLng2 = boundary.getLatLon(getIndex(i + 1, boundary.numPoints()));
+            LatLng latLng1 = boundary.getLatLon(i % boundary.numPoints());
+            LatLng latLng2 = boundary.getLatLon((i + 1) % boundary.numPoints());
             int lon1 = GeoEncodingUtils.encodeLongitude(latLng1.getLonDeg());
             int lat1 = GeoEncodingUtils.encodeLatitude(latLng1.getLatDeg());
             int lon2 = GeoEncodingUtils.encodeLongitude(latLng2.getLonDeg());
@@ -215,12 +217,5 @@ public class CellBoundaryTests extends ESTestCase {
             }
         }
         return false;
-    }
-
-    private int getIndex(int i, int numPoints) {
-        if (i < numPoints) {
-            return i;
-        }
-        return i - numPoints;
     }
 }

--- a/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
 
+import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 
 public class CellBoundaryTests extends ESTestCase {
@@ -198,14 +199,7 @@ public class CellBoundaryTests extends ESTestCase {
                     count++;
                 }
             }
-            if (boundary.numPoints() <= 6) {
-                // it is either a pentagon or a hexagon
-                assertThat("For cell " + H3.h3ToString(h3), count, equalTo(1));
-            } else {
-                // the cell crosses the edges of the icosahedron triangle,
-                // therefore it can share more than one edge
-                assertThat("For cell " + H3.h3ToString(h3), count, equalTo(2));
-            }
+            assertThat("For cell " + H3.h3ToString(h3), count, either(equalTo(1)).or(equalTo(2)));
         }
     }
 

--- a/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
@@ -32,8 +32,8 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
 
-import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class CellBoundaryTests extends ESTestCase {
 
@@ -199,7 +199,14 @@ public class CellBoundaryTests extends ESTestCase {
                     count++;
                 }
             }
-            assertThat("For cell " + H3.h3ToString(h3), count, either(equalTo(1)).or(equalTo(2)));
+            if (boundary.numPoints() <= 6) {
+                // it is either a pentagon or a hexagon
+                assertThat("For cell " + H3.h3ToString(h3), count, equalTo(1));
+            } else {
+                // the cell crosses the edges of the icosahedron triangle,
+                // therefore it can share more than one edge
+                assertThat("For cell " + H3.h3ToString(h3), count, greaterThan(0));
+            }
         }
     }
 

--- a/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
@@ -33,7 +33,6 @@ import java.util.StringTokenizer;
 import java.util.zip.GZIPInputStream;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThan;
 
 public class CellBoundaryTests extends ESTestCase {
 
@@ -205,7 +204,7 @@ public class CellBoundaryTests extends ESTestCase {
             } else {
                 // the cell crosses the edges of the icosahedron triangle,
                 // therefore it can share more than one edge
-                assertThat("For cell " + H3.h3ToString(h3), count, greaterThan(0));
+                assertThat("For cell " + H3.h3ToString(h3), count, equalTo(2));
             }
         }
     }

--- a/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/CellBoundaryTests.java
@@ -171,8 +171,8 @@ public class CellBoundaryTests extends ESTestCase {
         CellBoundary boundary = H3.h3ToGeoBoundary(h3Address);
         assert boundary.numPoints() == points.size();
         for (int i = 0; i < boundary.numPoints(); i++) {
-            assertEquals(h3Address, points.get(i)[0], boundary.getLatLon(i).getLatDeg(), 1e-8);
-            assertEquals(h3Address, points.get(i)[1], boundary.getLatLon(i).getLonDeg(), 1e-8);
+            assertEquals(h3Address, points.get(i)[0], boundary.getLatLon(i).getLatDeg(), 5e-7);
+            assertEquals(h3Address, points.get(i)[1], boundary.getLatLon(i).getLonDeg(), 5e-7);
         }
     }
 }


### PR DESCRIPTION
This PR removes the unnecessary use of double arrays and improves the computation of the intersection point by removing an unnecessary casting to float when computing the slope.