### PR TITLE
[8.6] Clarify use of S3 lifecycle policies (#92427)

### DIFF
--- a/docs/reference/snapshot-restore/repository-s3.asciidoc
+++ b/docs/reference/snapshot-restore/repository-s3.asciidoc
@@ -327,13 +327,14 @@ include::repository-shared-settings.asciidoc[]
 
     Sets the S3 storage class for objects stored in the snapshot repository.
     Values may be `standard`, `reduced_redundancy`, `standard_ia`, `onezone_ia`
-    and `intelligent_tiering`. Defaults to `standard`.
-    Changing this setting on an existing repository only affects the
-    storage class for newly created objects, resulting in a mixed usage of
-    storage classes. Additionally, S3 Lifecycle Policies can be used to manage
-    the storage class of existing objects. Due to the extra complexity with the
-    Glacier class lifecycle, it is not currently supported by this
-    repository type. For more information about the different classes, see
+    and `intelligent_tiering`. Defaults to `standard`. Changing this setting on
+    an existing repository only affects the storage class for newly created
+    objects, resulting in a mixed usage of storage classes. You may use an S3
+    Lifecycle Policy to adjust the storage class of existing objects in your
+    repository, but you must not transition objects to Glacier classes and you
+    must not expire objects. If you use Glacier storage classes or object
+    expiry then you may permanently lose access to your repository contents.
+    For more information about S3 storage classes, see
     https://docs.aws.amazon.com/AmazonS3/latest/dev/storage-class-intro.html[AWS
     Storage Classes Guide]
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Clarify use of S3 lifecycle policies (#92427)