### PR TITLE
Fix ScalingThreadPoolTests testScalingThreadPoolConfiguration

### DIFF
--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPool.java
@@ -208,8 +208,7 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         builders.put(Names.FLUSH, new ScalingExecutorBuilder(Names.FLUSH, 1, halfProcMaxAt5, TimeValue.timeValueMinutes(5), false));
         builders.put(Names.REFRESH, new ScalingExecutorBuilder(Names.REFRESH, 1, halfProcMaxAt10, TimeValue.timeValueMinutes(5), false));
         builders.put(Names.WARMER, new ScalingExecutorBuilder(Names.WARMER, 1, halfProcMaxAt5, TimeValue.timeValueMinutes(5), false));
-        ByteSizeValue maxHeapSize = ByteSizeValue.ofBytes(Runtime.getRuntime().maxMemory());
-        final int maxSnapshotCores = getMaxSnapshotCores(allocatedProcessors, maxHeapSize);
+        final int maxSnapshotCores = getMaxSnapshotThreadPoolSize(allocatedProcessors);
         builders.put(Names.SNAPSHOT, new ScalingExecutorBuilder(Names.SNAPSHOT, 1, maxSnapshotCores, TimeValue.timeValueMinutes(5), false));
         builders.put(
             Names.SNAPSHOT_META,
@@ -568,7 +567,12 @@ public class ThreadPool implements ReportingService<ThreadPoolInfo>, Scheduler {
         return ((allocatedProcessors * 3) / 2) + 1;
     }
 
-    static int getMaxSnapshotCores(int allocatedProcessors, final ByteSizeValue maxHeapSize) {
+    static int getMaxSnapshotThreadPoolSize(int allocatedProcessors) {
+        final ByteSizeValue maxHeapSize = ByteSizeValue.ofBytes(Runtime.getRuntime().maxMemory());
+        return getMaxSnapshotThreadPoolSize(allocatedProcessors, maxHeapSize);
+    }
+
+    static int getMaxSnapshotThreadPoolSize(int allocatedProcessors, final ByteSizeValue maxHeapSize) {
         // While on larger data nodes, larger snapshot threadpool size improves snapshotting on high latency blob stores,
         // smaller instances can run into OOM issues and need a smaller snapshot threadpool size.
         if (maxHeapSize.compareTo(new ByteSizeValue(750, ByteSizeUnit.MB)) < 0) {

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
+import static org.elasticsearch.threadpool.ThreadPool.getMaxSnapshotThreadPoolSize;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -73,7 +74,9 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             expectedMax = randomIntBetween(Math.max(1, core), 16);
             builder.put("thread_pool." + threadPoolName + ".max", expectedMax);
         } else {
-            expectedMax = threadPoolName.equals(ThreadPool.Names.SNAPSHOT) ? 10 : maxBasedOnNumberOfProcessors;
+            expectedMax = threadPoolName.equals(ThreadPool.Names.SNAPSHOT)
+                ? getMaxSnapshotThreadPoolSize(processors)
+                : maxBasedOnNumberOfProcessors;
         }
 
         final long keepAlive;

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolTests.java
@@ -26,7 +26,7 @@ import java.util.concurrent.ExecutorService;
 import static org.elasticsearch.threadpool.ThreadPool.ESTIMATED_TIME_INTERVAL_SETTING;
 import static org.elasticsearch.threadpool.ThreadPool.LATE_TIME_INTERVAL_WARN_THRESHOLD_SETTING;
 import static org.elasticsearch.threadpool.ThreadPool.assertCurrentMethodIsNotCalledRecursively;
-import static org.elasticsearch.threadpool.ThreadPool.getMaxSnapshotCores;
+import static org.elasticsearch.threadpool.ThreadPool.getMaxSnapshotThreadPoolSize;
 import static org.elasticsearch.threadpool.ThreadPool.halfAllocatedProcessorsMaxFive;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
@@ -335,17 +335,17 @@ public class ThreadPoolTests extends ESTestCase {
     public void testGetMaxSnapshotCores() {
         int allocatedProcessors = randomIntBetween(1, 16);
         assertThat(
-            getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofMb(400)),
+            getMaxSnapshotThreadPoolSize(allocatedProcessors, ByteSizeValue.ofMb(400)),
             equalTo(halfAllocatedProcessorsMaxFive(allocatedProcessors))
         );
         allocatedProcessors = randomIntBetween(1, 16);
         assertThat(
-            getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofMb(749)),
+            getMaxSnapshotThreadPoolSize(allocatedProcessors, ByteSizeValue.ofMb(749)),
             equalTo(halfAllocatedProcessorsMaxFive(allocatedProcessors))
         );
         allocatedProcessors = randomIntBetween(1, 16);
-        assertThat(getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofMb(750)), equalTo(10));
+        assertThat(getMaxSnapshotThreadPoolSize(allocatedProcessors, ByteSizeValue.ofMb(750)), equalTo(10));
         allocatedProcessors = randomIntBetween(1, 16);
-        assertThat(getMaxSnapshotCores(allocatedProcessors, ByteSizeValue.ofGb(4)), equalTo(10));
+        assertThat(getMaxSnapshotThreadPoolSize(allocatedProcessors, ByteSizeValue.ofGb(4)), equalTo(10));
     }
 }


### PR DESCRIPTION
Adjust scaling threadpool configuration tests to reflect changed Snapshot threadpool size in https://github.com/elastic/elasticsearch/pull/92392.

Closes https://github.com/elastic/elasticsearch/issues/92419