### PR TITLE
Ensure fetching a random threadpool is reproducible 

### DIFF
--- a/server/src/test/java/org/elasticsearch/threadpool/ESThreadPoolTestCase.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ESThreadPoolTestCase.java
@@ -41,7 +41,7 @@ public abstract class ESThreadPoolTestCase extends ESTestCase {
 
     static String randomThreadPool(final ThreadPool.ThreadPoolType type) {
         return randomFrom(
-            ThreadPool.THREAD_POOL_TYPES.entrySet().stream().filter(t -> t.getValue().equals(type)).map(Map.Entry::getKey).toList()
+            ThreadPool.THREAD_POOL_TYPES.entrySet().stream().filter(t -> t.getValue().equals(type)).map(Map.Entry::getKey).sorted().toList()
         );
     }
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/issues/92419, we've noticed
that the test seed doesn't always reproduce the issue, even though it
should. The issue seems to be some randomness resulting from listing the
`Map` entries.