### PR TITLE
[8.6] SQL: fix NPE on logging when not tracking total hits (#92425)

### DIFF
--- a/docs/changelog/92425.yaml
+++ b/docs/changelog/92425.yaml
@@ -1,0 +1,5 @@
+pr: 92425
+summary: Fix NPE on logging when not tracking total hits
+area: SQL
+type: bug
+issues: []

--- a/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
+++ b/x-pack/plugin/sql/src/main/java/org/elasticsearch/xpack/sql/execution/search/Querier.java
@@ -216,11 +216,12 @@ public class Querier {
             aggsNames.append(aggs.get(i).getName() + (i + 1 == aggs.size() ? "" : ", "));
         }
 
+        var totalHits = response.getHits().getTotalHits();
+        var hits = totalHits != null ? "hits " + totalHits.relation + " " + totalHits.value + ", " : "";
         logger.trace(
-            "Got search response [hits {} {}, {} aggregations: [{}], {} failed shards, {} skipped shards, "
+            "Got search response [{}{} aggregations: [{}], {} failed shards, {} skipped shards, "
                 + "{} successful shards, {} total shards, took {}, timed out [{}]]",
-            response.getHits().getTotalHits().relation.toString(),
-            response.getHits().getTotalHits().value,
+            hits,
             aggs.size(),
             aggsNames,
             response.getFailedShards(),


### PR DESCRIPTION
Backports the following commits to 8.6:
 - SQL: fix NPE on logging when not tracking total hits (#92425)