### PR TITLE
Check GeohexGrid bounds on geopoint using spherical coordinates

### DIFF
--- a/docs/changelog/92460.yaml
+++ b/docs/changelog/92460.yaml
@@ -1,0 +1,5 @@
+pr: 92460
+summary: Check `GeohexGrid` bounds on geopoint using spherical coordinates
+area: Geo
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/CellIdSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/CellIdSource.java
@@ -99,7 +99,7 @@ public abstract class CellIdSource extends ValuesSource.Numeric {
      *
      * This method maybe faster than having to compute the bounding box for each point grid.
      * */
-    protected boolean validPoint(double lon, double lat) {
+    protected boolean pointInBounds(double lon, double lat) {
         if (geoBoundingBox.top() > lat && geoBoundingBox.bottom() < lat) {
             if (crossesDateline) {
                 return geoBoundingBox.left() < lon || geoBoundingBox.right() > lon;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashCellIdSource.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoHashCellIdSource.java
@@ -42,7 +42,7 @@ public class GeoHashCellIdSource extends CellIdSource {
             @Override
             protected boolean advance(org.elasticsearch.common.geo.GeoPoint target) {
                 final String hash = Geohash.stringEncode(target.getLon(), target.getLat(), precision);
-                if (validPoint(target.getLon(), target.getLat()) || predicate.validHash(hash)) {
+                if (pointInBounds(target.getLon(), target.getLat()) || predicate.validHash(hash)) {
                     value = Geohash.longEncode(hash);
                     return true;
                 }
@@ -69,7 +69,7 @@ public class GeoHashCellIdSource extends CellIdSource {
             @Override
             protected int advanceValue(org.elasticsearch.common.geo.GeoPoint target, int valuesIdx) {
                 final String hash = Geohash.stringEncode(target.getLon(), target.getLat(), precision);
-                if (validPoint(target.getLon(), target.getLat()) || predicate.validHash(hash)) {
+                if (pointInBounds(target.getLon(), target.getLat()) || predicate.validHash(hash)) {
                     values[valuesIdx] = Geohash.longEncode(hash);
                     return valuesIdx + 1;
                 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
@@ -6,11 +6,17 @@
  */
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
+import org.apache.lucene.geo.GeoUtils;
 import org.apache.lucene.index.NumericDocValues;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.spatial3d.geom.LatLonBounds;
+import org.apache.lucene.spatial3d.geom.Plane;
+import org.apache.lucene.spatial3d.geom.PlanetModel;
+import org.apache.lucene.spatial3d.geom.SidedPlane;
 import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.h3.CellBoundary;
 import org.elasticsearch.h3.H3;
+import org.elasticsearch.h3.LatLng;
 import org.elasticsearch.index.fielddata.GeoPointValues;
 import org.elasticsearch.index.fielddata.MultiGeoPointValues;
 import org.elasticsearch.search.aggregations.bucket.geogrid.CellIdSource;
@@ -46,6 +52,7 @@ public class GeoHexCellIdSource extends CellIdSource {
                 final long hex = H3.geoToH3(lat, lon, precision);
                 // validPoint is a fast check, validHex is slow
                 if (validPoint(lon, lat) || predicate.validHex(hex)) {
+                    assert predicate.validHex(hex) : H3.h3ToString(hex) + " should be valid but it is not";
                     value = hex;
                     return true;
                 }
@@ -98,28 +105,45 @@ public class GeoHexCellIdSource extends CellIdSource {
         }
 
         public boolean validHex(long hex) {
-            CellBoundary boundary = H3.h3ToGeoBoundary(hex);
-            double minLat = Double.POSITIVE_INFINITY;
-            double minLon = Double.POSITIVE_INFINITY;
-            double maxLat = Double.NEGATIVE_INFINITY;
-            double maxLon = Double.NEGATIVE_INFINITY;
-            for (int i = 0; i < boundary.numPoints(); i++) {
-                double boundaryLat = boundary.getLatLon(i).getLatDeg();
-                double boundaryLon = boundary.getLatLon(i).getLonDeg();
-                minLon = Math.min(minLon, boundaryLon);
-                maxLon = Math.max(maxLon, boundaryLon);
-                minLat = Math.min(minLat, boundaryLat);
-                maxLat = Math.max(maxLat, boundaryLat);
+            final LatLonBounds bounds = getGeoBounds(H3.h3ToGeoBoundary(hex));
+            final double minLat = bounds.checkNoBottomLatitudeBound() ? GeoUtils.MIN_LAT_INCL : Math.toDegrees(bounds.getMinLatitude());
+            final double maxLat = bounds.checkNoTopLatitudeBound() ? GeoUtils.MAX_LAT_INCL : Math.toDegrees(bounds.getMaxLatitude());
+            final double minLon;
+            final double maxLon;
+            if (bounds.checkNoLongitudeBound()) {
+                assert northPoleHex == hex || southPoleHex == hex;
+                minLon = GeoUtils.MIN_LON_INCL;
+                maxLon = GeoUtils.MAX_LON_INCL;
+            } else {
+                minLon = Math.toDegrees(bounds.getLeftLongitude());
+                maxLon = Math.toDegrees(bounds.getRightLongitude());
             }
             if (northPoleHex == hex) {
                 return minLat < bbox.top();
             } else if (southPoleHex == hex) {
                 return maxLat > bbox.bottom();
-            } else if (maxLon - minLon > 180) {
+            } else if (maxLon < minLon) {
                 return intersects(-180, minLon, minLat, maxLat) || intersects(maxLon, 180, minLat, maxLat);
             } else {
                 return intersects(minLon, maxLon, minLat, maxLat);
             }
+        }
+
+        private static LatLonBounds getGeoBounds(CellBoundary cellBoundary) {
+            final LatLonBounds bounds = new LatLonBounds();
+            org.apache.lucene.spatial3d.geom.GeoPoint A = getGeoPoint(cellBoundary.getLatLon(cellBoundary.numPoints() - 1));
+            for (int i = 0; i < cellBoundary.numPoints(); i++) {
+                final org.apache.lucene.spatial3d.geom.GeoPoint B = getGeoPoint(cellBoundary.getLatLon(i));
+                bounds.addPoint(B);
+                final Plane plane = new Plane(A, B);
+                bounds.addPlane(PlanetModel.SPHERE, new Plane(A, B), new SidedPlane(A, plane, B), new SidedPlane(B, A, plane));
+                A = B;
+            }
+            return bounds;
+        }
+
+        private static org.apache.lucene.spatial3d.geom.GeoPoint getGeoPoint(LatLng latLng) {
+            return new org.apache.lucene.spatial3d.geom.GeoPoint(PlanetModel.SPHERE, latLng.getLatRad(), latLng.getLonRad());
         }
 
         private boolean intersects(double minLon, double maxLon, double minLat, double maxLat) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
@@ -50,7 +50,7 @@ public class GeoHexCellIdSource extends CellIdSource {
                 final double lat = target.getLat();
                 final double lon = target.getLon();
                 final long hex = H3.geoToH3(lat, lon, precision);
-                // validPoint is a fast check, validHex is slow
+                // pointInBounds is a fast check, validHex is slow
                 if (pointInBounds(lon, lat) || predicate.validHex(hex)) {
                     assert predicate.validHex(hex) : H3.h3ToString(hex) + " should be valid but it is not";
                     value = hex;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexCellIdSource.java
@@ -51,7 +51,7 @@ public class GeoHexCellIdSource extends CellIdSource {
                 final double lon = target.getLon();
                 final long hex = H3.geoToH3(lat, lon, precision);
                 // validPoint is a fast check, validHex is slow
-                if (validPoint(lon, lat) || predicate.validHex(hex)) {
+                if (pointInBounds(lon, lat) || predicate.validHex(hex)) {
                     assert predicate.validHex(hex) : H3.h3ToString(hex) + " should be valid but it is not";
                     value = hex;
                     return true;
@@ -82,7 +82,7 @@ public class GeoHexCellIdSource extends CellIdSource {
                 final double lon = target.getLon();
                 final long hex = H3.geoToH3(lat, lon, precision);
                 // validPoint is a fast check, validHex is slow
-                if (validPoint(lon, lat) || predicate.validHex(hex)) {
+                if (pointInBounds(lon, lat) || predicate.validHex(hex)) {
                     values[valuesIdx] = hex;
                     return valuesIdx + 1;
                 }
@@ -94,13 +94,13 @@ public class GeoHexCellIdSource extends CellIdSource {
     // package private for testing
     static LatLonBounds getGeoBounds(CellBoundary cellBoundary) {
         final LatLonBounds bounds = new LatLonBounds();
-        org.apache.lucene.spatial3d.geom.GeoPoint A = getGeoPoint(cellBoundary.getLatLon(cellBoundary.numPoints() - 1));
+        org.apache.lucene.spatial3d.geom.GeoPoint start = getGeoPoint(cellBoundary.getLatLon(cellBoundary.numPoints() - 1));
         for (int i = 0; i < cellBoundary.numPoints(); i++) {
-            final org.apache.lucene.spatial3d.geom.GeoPoint B = getGeoPoint(cellBoundary.getLatLon(i));
-            bounds.addPoint(B);
-            final Plane plane = new Plane(A, B);
-            bounds.addPlane(PlanetModel.SPHERE, new Plane(A, B), new SidedPlane(A, plane, B), new SidedPlane(B, A, plane));
-            A = B;
+            final org.apache.lucene.spatial3d.geom.GeoPoint end = getGeoPoint(cellBoundary.getLatLon(i));
+            bounds.addPoint(end);
+            final Plane plane = new Plane(start, end);
+            bounds.addPlane(PlanetModel.SPHERE, plane, new SidedPlane(start, plane, end), new SidedPlane(end, start, plane));
+            start = end;
         }
         return bounds;
     }


### PR DESCRIPTION
It is easy to demonstrate that are currently case in the bounded GeohexGrid aggregation where a point is inside bounds but the method `GeoHexPredicate#validHex` returns false. The issue is that we are using cartesian mathematics to compute the bounding box of a h3 bin which is pretty off for low resolutions.

This PR propose to compute the bounding box in spherical coordinates  which makes sure we return the correct answer.