### PR TITLE
[8.6] Fix numOpenOutputs and modCount in ByteSizeCachingDirectory (#92440)

### DIFF
--- a/docs/changelog/92440.yaml
+++ b/docs/changelog/92440.yaml
@@ -1,0 +1,6 @@
+pr: 92440
+summary: Fix numOpenOutputs and modCount in ByteSizeCachingDirectory
+area: Store
+type: bug
+issues:
+  - 92434

--- a/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/ByteSizeCachingDirectory.java
@@ -128,6 +128,8 @@ final class ByteSizeCachingDirectory extends FilterDirectory {
             numOpenOutputs++;
         }
         return new FilterIndexOutput(out.toString(), out) {
+            private boolean closed;
+
             @Override
             public void writeBytes(byte[] b, int length) throws IOException {
                 // Don't write to atomicXXX here since it might be called in
@@ -168,8 +170,11 @@ final class ByteSizeCachingDirectory extends FilterDirectory {
                     super.close();
                 } finally {
                     synchronized (ByteSizeCachingDirectory.this) {
-                        numOpenOutputs--;
-                        modCount++;
+                        if (closed == false) {
+                            closed = true;
+                            numOpenOutputs--;
+                            modCount++;
+                        }
                     }
                 }
             }

--- a/server/src/test/java/org/elasticsearch/index/store/ByteSizeCachingDirectoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/ByteSizeCachingDirectoryTests.java
@@ -87,6 +87,26 @@ public class ByteSizeCachingDirectoryTests extends ESTestCase {
             assertEquals(18, countingDir.numFileLengthCalls);
             assertEquals(15, cachingDir.estimateSizeInBytes());
             assertEquals(18, countingDir.numFileLengthCalls);
+
+            // Close more than once
+            IndexOutput out = cachingDir.createOutput("foo", IOContext.DEFAULT);
+            try {
+                out.writeBytes(new byte[5], 5);
+
+                cachingDir.estimateSizeInBytes();
+                // +3 because there are 3 files
+                assertEquals(21, countingDir.numFileLengthCalls);
+                // An index output is open so no caching
+                cachingDir.estimateSizeInBytes();
+                assertEquals(24, countingDir.numFileLengthCalls);
+            } finally {
+                out.close();
+                assertEquals(20, cachingDir.estimateSizeInBytes());
+                assertEquals(27, countingDir.numFileLengthCalls);
+            }
+            out.close();
+            assertEquals(20, cachingDir.estimateSizeInBytes());
+            assertEquals(27, countingDir.numFileLengthCalls);
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix numOpenOutputs and modCount in ByteSizeCachingDirectory (#92440)