### PR TITLE
DLS role query validator to validate query while parsing

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/support/DLSRoleQueryValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/support/DLSRoleQueryValidator.java
@@ -34,6 +34,7 @@ import org.elasticsearch.xpack.core.security.user.User;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -156,10 +157,38 @@ public final class DLSRoleQueryValidator {
     @Nullable
     public static QueryBuilder evaluateAndVerifyRoleQuery(String query, NamedXContentRegistry xContentRegistry) throws IOException {
         if (query != null) {
-            try (XContentParser parser = XContentFactory.xContent(query).createParser(parserConfig(xContentRegistry), query)) {
-                QueryBuilder queryBuilder = AbstractQueryBuilder.parseTopLevelQuery(parser);
-                verifyRoleQuery(queryBuilder);
-                return queryBuilder;
+            NamedXContentRegistry registryWrapper = new NamedXContentRegistry(Collections.emptyList()) {
+                @Override
+                public <T, C> T parseNamedObject(Class<T> categoryClass, String name, XContentParser parser, C context) throws IOException {
+                    T namedObject = xContentRegistry.parseNamedObject(categoryClass, name, parser, context);
+                    if (categoryClass.equals(QueryBuilder.class)) {
+                        if (namedObject instanceof TermsQueryBuilder termsQueryBuilder) {
+                            if (termsQueryBuilder.termsLookup() != null) {
+                                throw new IllegalArgumentException("terms query with terms lookup isn't supported as part of a role query");
+                            }
+                        } else if (namedObject instanceof GeoShapeQueryBuilder geoShapeQueryBuilder) {
+                            if (geoShapeQueryBuilder.shape() == null) {
+                                throw new IllegalArgumentException(
+                                    "geoshape query referring to indexed shapes isn't supported as part of a role query"
+                                );
+                            }
+                        }
+                    }
+                    return namedObject;
+                }
+            };
+            try (XContentParser parser = XContentFactory.xContent(query).createParser(parserConfig(registryWrapper), query)) {
+                return AbstractQueryBuilder.parseTopLevelQuery(parser, queryName -> {
+                    switch (queryName) {
+                        // actually only if percolate query is referring to an existing document then this is problematic,
+                        // a normal percolate query does work. However we can't check that here as this query builder is inside
+                        // another module. So we don't allow the entire percolate query. I don't think users would ever use
+                        // a percolate query as role query, so this restriction shouldn't prohibit anyone from using dls.
+                        case "percolate", "has_child", "has_parent" -> throw new IllegalArgumentException(
+                            queryName + " query isn't supported as part of a role query"
+                        );
+                    }
+                });
             }
         }
         return null;
@@ -167,49 +196,5 @@ public final class DLSRoleQueryValidator {
 
     private static XContentParserConfiguration parserConfig(NamedXContentRegistry xContentRegistry) {
         return XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry).withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
-    }
-
-    /**
-     * Checks whether the role query contains queries we know can't be used as DLS role query.
-     *
-     * @param queryBuilder {@link QueryBuilder} for given query
-     */
-    // pkg protected for testing
-    static void verifyRoleQuery(QueryBuilder queryBuilder) {
-        if (queryBuilder instanceof TermsQueryBuilder termsQueryBuilder) {
-            if (termsQueryBuilder.termsLookup() != null) {
-                throw new IllegalArgumentException("terms query with terms lookup isn't supported as part of a role query");
-            }
-        } else if (queryBuilder instanceof GeoShapeQueryBuilder geoShapeQueryBuilder) {
-            if (geoShapeQueryBuilder.shape() == null) {
-                throw new IllegalArgumentException("geoshape query referring to indexed shapes isn't supported as part of a role query");
-            }
-        } else if (queryBuilder.getName().equals("percolate")) {
-            // actually only if percolate query is referring to an existing document then this is problematic,
-            // a normal percolate query does work. However we can't check that here as this query builder is inside
-            // another module. So we don't allow the entire percolate query. I don't think users would ever use
-            // a percolate query as role query, so this restriction shouldn't prohibit anyone from using dls.
-            throw new IllegalArgumentException("percolate query isn't supported as part of a role query");
-        } else if (queryBuilder.getName().equals("has_child")) {
-            throw new IllegalArgumentException("has_child query isn't supported as part of a role query");
-        } else if (queryBuilder.getName().equals("has_parent")) {
-            throw new IllegalArgumentException("has_parent query isn't supported as part of a role query");
-        } else if (queryBuilder instanceof BoolQueryBuilder boolQueryBuilder) {
-            List<QueryBuilder> clauses = new ArrayList<>();
-            clauses.addAll(boolQueryBuilder.filter());
-            clauses.addAll(boolQueryBuilder.must());
-            clauses.addAll(boolQueryBuilder.mustNot());
-            clauses.addAll(boolQueryBuilder.should());
-            for (QueryBuilder clause : clauses) {
-                verifyRoleQuery(clause);
-            }
-        } else if (queryBuilder instanceof ConstantScoreQueryBuilder) {
-            verifyRoleQuery(((ConstantScoreQueryBuilder) queryBuilder).innerQuery());
-        } else if (queryBuilder instanceof FunctionScoreQueryBuilder) {
-            verifyRoleQuery(((FunctionScoreQueryBuilder) queryBuilder).query());
-        } else if (queryBuilder instanceof BoostingQueryBuilder) {
-            verifyRoleQuery(((BoostingQueryBuilder) queryBuilder).negativeQuery());
-            verifyRoleQuery(((BoostingQueryBuilder) queryBuilder).positiveQuery());
-        }
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/support/DLSRoleQueryValidator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/support/DLSRoleQueryValidator.java
@@ -13,13 +13,9 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.query.AbstractQueryBuilder;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.BoostingQueryBuilder;
-import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
 import org.elasticsearch.index.query.GeoShapeQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
-import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
@@ -33,9 +29,7 @@ import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 /**
  * This class helps in evaluating the query field if it is template,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/support/DLSRoleQueryValidatorTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/support/DLSRoleQueryValidatorTests.java
@@ -7,7 +7,9 @@
 package org.elasticsearch.xpack.core.security.authz.support;
 
 import org.apache.lucene.search.join.ScoreMode;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.query.BoolQueryBuilder;
 import org.elasticsearch.index.query.BoostingQueryBuilder;
 import org.elasticsearch.index.query.ConstantScoreQueryBuilder;
@@ -17,52 +19,86 @@ import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.TermsQueryBuilder;
 import org.elasticsearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.elasticsearch.indices.TermsLookup;
+import org.elasticsearch.join.ParentJoinPlugin;
 import org.elasticsearch.join.query.HasChildQueryBuilder;
 import org.elasticsearch.join.query.HasParentQueryBuilder;
+import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class DLSRoleQueryValidatorTests extends ESTestCase {
 
+    private static final NamedXContentRegistry XCONTENT_REGISTRY = new NamedXContentRegistry(
+        new SearchModule(Settings.EMPTY, List.of(new ParentJoinPlugin())).getNamedXContents()
+    );
+
     public void testVerifyRoleQuery() throws Exception {
         QueryBuilder queryBuilder1 = new TermsQueryBuilder("field", "val1", "val2");
-        DLSRoleQueryValidator.verifyRoleQuery(queryBuilder1);
+        DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder1), XCONTENT_REGISTRY);
 
         QueryBuilder queryBuilder2 = new TermsQueryBuilder("field", new TermsLookup("_index", "_id", "_path"));
-        Exception e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder2));
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder2), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("terms query with terms lookup isn't supported as part of a role query"));
 
         QueryBuilder queryBuilder3 = new GeoShapeQueryBuilder("field", "_id");
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder3));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder3), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("geoshape query referring to indexed shapes isn't supported as part of a role query"));
 
         QueryBuilder queryBuilder4 = new HasChildQueryBuilder("_type", new MatchAllQueryBuilder(), ScoreMode.None);
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder4));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder4), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("has_child query isn't supported as part of a role query"));
 
         QueryBuilder queryBuilder5 = new HasParentQueryBuilder("_type", new MatchAllQueryBuilder(), false);
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder5));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder5), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("has_parent query isn't supported as part of a role query"));
 
         QueryBuilder queryBuilder6 = new BoolQueryBuilder().must(new GeoShapeQueryBuilder("field", "_id"));
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder6));
-        assertThat(e.getMessage(), equalTo("geoshape query referring to indexed shapes isn't supported as part of a role query"));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder6), XCONTENT_REGISTRY)
+        );
+        assertThat(
+            e.getCause().getMessage(),
+            equalTo("geoshape query referring to indexed shapes isn't supported as part of a role query")
+        );
 
         QueryBuilder queryBuilder7 = new ConstantScoreQueryBuilder(new GeoShapeQueryBuilder("field", "_id"));
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder7));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder7), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("geoshape query referring to indexed shapes isn't supported as part of a role query"));
 
         QueryBuilder queryBuilder8 = new FunctionScoreQueryBuilder(new GeoShapeQueryBuilder("field", "_id"));
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder8));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder8), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("geoshape query referring to indexed shapes isn't supported as part of a role query"));
 
         QueryBuilder queryBuilder9 = new BoostingQueryBuilder(new GeoShapeQueryBuilder("field", "_id"), new MatchAllQueryBuilder());
-        e = expectThrows(IllegalArgumentException.class, () -> DLSRoleQueryValidator.verifyRoleQuery(queryBuilder9));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> DLSRoleQueryValidator.evaluateAndVerifyRoleQuery(Strings.toString(queryBuilder9), XCONTENT_REGISTRY)
+        );
         assertThat(e.getMessage(), equalTo("geoshape query referring to indexed shapes isn't supported as part of a role query"));
     }
 
@@ -76,5 +112,4 @@ public class DLSRoleQueryValidatorTests extends ESTestCase {
             is(false)
         );
     }
-
 }


### PR DESCRIPTION
DLSRoleQueryValidator validates the role query by parsing it and then recursively visiting all the branches of the query tree. Instead, validation can happen directly while parsing. This way there is no recursion needed to visit the query tree after parsing, and all compound queries are supported out-of-the-box as each inner query needs to be looked up in the named xcontent registry.
