### PR TITLE
[Tests] Timeout 1s when creating a red index

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/40_diagnosis.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/40_diagnosis.yml
@@ -7,6 +7,8 @@
   - do:
       indices.create:
         index: red_index
+        master_timeout: 1s
+        timeout: 1s
         body:
           settings:
             number_of_shards: 1


### PR DESCRIPTION
This configures a `1s` timeout when creating a red index in the yaml test 
(to avoid waiting for the default `30s`).

Fixes #92482