### PR TITLE
[8.6] [DOCS] Fix typo (#92481)

### DIFF
--- a/docs/reference/analysis/token-graphs.asciidoc
+++ b/docs/reference/analysis/token-graphs.asciidoc
@@ -34,7 +34,7 @@ include tokens for multi-word synonyms, such as using "atm" as a synonym for
 "automatic teller machine."
 
 However, only some token filters, known as _graph token filters_, accurately
-record the `positionLength` for multi-position tokens. This filters include:
+record the `positionLength` for multi-position tokens. These filters include:
 
 * <<analysis-synonym-graph-tokenfilter,`synonym_graph`>>
 * <<analysis-word-delimiter-graph-tokenfilter,`word_delimiter_graph`>>


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Fix typo (#92481)