### PR TITLE
Make RecoveryPlannerService optional

### DIFF
--- a/docs/changelog/92489.yaml
+++ b/docs/changelog/92489.yaml
@@ -1,0 +1,5 @@
+pr: 92489
+summary: Make `RecoveryPlannerService` optional
+area: Snapshot/Restore
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -574,6 +574,7 @@ public class RecoverySourceHandler {
                     translogOps.getAsInt(),
                     getRequest().targetNode().getVersion(),
                     canUseSnapshots,
+                    request.isPrimaryRelocation(),
                     ActionListener.wrap(plan -> recoverFilesFromSourceAndSnapshot(plan, store, stopWatch, listener), listener::onFailure)
                 );
             } else {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/PeerOnlyRecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/PeerOnlyRecoveryPlannerService.java
@@ -35,6 +35,7 @@ public class PeerOnlyRecoveryPlannerService implements RecoveryPlannerService {
         int translogOps,
         Version targetVersion,
         boolean useSnapshots,
+        boolean primaryRelocation,
         ActionListener<ShardRecoveryPlan> listener
     ) {
         ActionListener.completeWith(listener, () -> {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/plan/RecoveryPlannerService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/plan/RecoveryPlannerService.java
@@ -23,6 +23,7 @@ public interface RecoveryPlannerService {
         int translogOps,
         Version targetVersion,
         boolean useSnapshots,
+        boolean primaryRelocation,
         ActionListener<ShardRecoveryPlan> listener
     );
 }

--- a/server/src/main/java/org/elasticsearch/plugins/RecoveryPlannerPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/RecoveryPlannerPlugin.java
@@ -11,10 +11,12 @@ package org.elasticsearch.plugins;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.ShardSnapshotsService;
 
+import java.util.Optional;
+
 /**
- * A plugin that allows creating custom {@code RecoveryPlannerService}. Only one plugin of this type
- * is allowed to be installed at once.
+ * A plugin that allows creating custom {@code RecoveryPlannerService}. Only one {@code RecoveryPlannerService} is allowed to be active
+ * at once.
  */
 public interface RecoveryPlannerPlugin {
-    RecoveryPlannerService createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService);
+    Optional<RecoveryPlannerService> createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService);
 }

--- a/server/src/test/java/org/elasticsearch/node/NodeTests.java
+++ b/server/src/test/java/org/elasticsearch/node/NodeTests.java
@@ -55,6 +55,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -370,8 +371,8 @@ public class NodeTests extends ESTestCase {
         public MockRecoveryPlannerPlugin() {}
 
         @Override
-        public RecoveryPlannerService createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService) {
-            return mock(RecoveryPlannerService.class);
+        public Optional<RecoveryPlannerService> createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService) {
+            return Optional.of(mock(RecoveryPlannerService.class));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/plugins/PluginIntrospectorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginIntrospectorTests.java
@@ -151,8 +151,8 @@ public class PluginIntrospectorTests extends ESTestCase {
             }
 
             @Override
-            public RecoveryPlannerService createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService) {
-                return null;
+            public Optional<RecoveryPlannerService> createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService) {
+                return Optional.empty();
             }
 
             @Override

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -351,6 +351,11 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
     }
 
     public static class LicensedSnapshotBasedRecoveriesPlugin extends SnapshotBasedRecoveriesPlugin {
+
+        public LicensedSnapshotBasedRecoveriesPlugin(Settings settings) {
+            super(settings);
+        }
+
         @Override
         public boolean isLicenseEnabled() {
             return true;

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/ConfigurableMockSnapshotBasedRecoveriesPlugin.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/ConfigurableMockSnapshotBasedRecoveriesPlugin.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.snapshotbasedrecoveries.recovery;
 
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.CheckedRunnable;
 import org.elasticsearch.xpack.snapshotbasedrecoveries.SnapshotBasedRecoveriesPlugin;
 
@@ -15,7 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class ConfigurableMockSnapshotBasedRecoveriesPlugin extends SnapshotBasedRecoveriesPlugin {
     private static final AtomicBoolean recoveryFromSnapshotAllowed = new AtomicBoolean(true);
 
-    public ConfigurableMockSnapshotBasedRecoveriesPlugin() {}
+    public ConfigurableMockSnapshotBasedRecoveriesPlugin(Settings settings) {
+        super(settings);
+    }
 
     @Override
     public boolean isLicenseEnabled() {

--- a/x-pack/plugin/snapshot-based-recoveries/src/main/java/org/elasticsearch/xpack/snapshotbasedrecoveries/SnapshotBasedRecoveriesPlugin.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/main/java/org/elasticsearch/xpack/snapshotbasedrecoveries/SnapshotBasedRecoveriesPlugin.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.snapshotbasedrecoveries;
 
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.recovery.plan.RecoveryPlannerService;
 import org.elasticsearch.indices.recovery.plan.ShardSnapshotsService;
 import org.elasticsearch.license.License;
@@ -16,18 +18,28 @@ import org.elasticsearch.plugins.RecoveryPlannerPlugin;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.snapshotbasedrecoveries.recovery.plan.SnapshotsRecoveryPlannerService;
 
+import java.util.Optional;
+
 public class SnapshotBasedRecoveriesPlugin extends Plugin implements RecoveryPlannerPlugin {
+
     public static final LicensedFeature.Momentary SNAPSHOT_BASED_RECOVERIES_FEATURE = LicensedFeature.momentary(
         null,
         "snapshot-based-recoveries",
         License.OperationMode.ENTERPRISE
     );
 
-    public SnapshotBasedRecoveriesPlugin() {}
+    private final Settings settings;
+
+    public SnapshotBasedRecoveriesPlugin(Settings settings) {
+        this.settings = settings;
+    }
 
     @Override
-    public RecoveryPlannerService createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService) {
-        return new SnapshotsRecoveryPlannerService(shardSnapshotsService, this::isLicenseEnabled);
+    public Optional<RecoveryPlannerService> createRecoveryPlannerService(ShardSnapshotsService shardSnapshotsService) {
+        if (DiscoveryNode.isStateless(settings)) {
+            return Optional.empty();
+        }
+        return Optional.of(new SnapshotsRecoveryPlannerService(shardSnapshotsService, this::isLicenseEnabled));
     }
 
     // Overridable for tests

--- a/x-pack/plugin/snapshot-based-recoveries/src/main/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerService.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/main/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerService.java
@@ -54,6 +54,7 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
         int translogOps,
         Version targetVersion,
         boolean useSnapshots,
+        boolean primaryRelocation,
         ActionListener<ShardRecoveryPlan> listener
     ) {
         // Fallback to source only recovery if the target node is in an incompatible version

--- a/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
@@ -105,7 +105,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                         assert false : "Unexpected call";
                     }
                 },
-                false
+                false,
+                randomBoolean()
             );
             assertPlanIsValid(shardRecoveryPlan, sourceMetadata);
             assertAllSourceFilesAreAvailableInSource(shardRecoveryPlan, sourceMetadata);
@@ -143,7 +144,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                         }
                     }
                 },
-                true
+                true,
+                randomBoolean()
             );
 
             assertPlanIsValid(shardRecoveryPlan, sourceMetadata);
@@ -183,7 +185,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                         listener.onResponse(Optional.of(shardSnapshotData));
                     }
                 },
-                true
+                true,
+                randomBoolean()
             );
 
             assertPlanIsValid(shardRecoveryPlan, sourceMetadata);
@@ -245,7 +248,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                         listener.onResponse(Optional.of(latestSnapshot));
                     }
                 },
-                true
+                true,
+                randomBoolean()
             );
 
             if (shareFilesWithSource || compatibleVersion == false) {
@@ -313,7 +317,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                         }
                     }
                 },
-                true
+                true,
+                randomBoolean()
             );
 
             assertPlanIsValid(shardRecoveryPlan, latestSourceMetadata);
@@ -365,7 +370,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                         listener.onResponse(Optional.of(availableSnapshots.get(availableSnapshots.size() - 1)));
                     }
                 },
-                true
+                true,
+                randomBoolean()
             );
 
             assertPlanIsValid(shardRecoveryPlan, latestSourceMetadata);
@@ -403,7 +409,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                     }
                 },
                 true,
-                Version.V_7_14_0 // Unsupported version
+                Version.V_7_14_0, // Unsupported version,
+                randomBoolean()
             );
 
             assertPlanIsValid(shardRecoveryPlan, sourceMetadata);
@@ -424,7 +431,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
         long startingSeqNo,
         int translogOps,
         ShardSnapshotsService shardSnapshotsService,
-        boolean snapshotRecoveriesEnabled
+        boolean snapshotRecoveriesEnabled,
+        boolean primaryRelocation
     ) throws Exception {
         return computeShardRecoveryPlan(
             shardIdentifier,
@@ -434,7 +442,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
             translogOps,
             shardSnapshotsService,
             snapshotRecoveriesEnabled,
-            Version.CURRENT
+            Version.CURRENT,
+            primaryRelocation
         );
     }
 
@@ -446,7 +455,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
         int translogOps,
         ShardSnapshotsService shardSnapshotsService,
         boolean snapshotRecoveriesEnabled,
-        Version version
+        Version version,
+        boolean primaryRelocation
     ) throws Exception {
         SnapshotsRecoveryPlannerService recoveryPlannerService = new SnapshotsRecoveryPlannerService(shardSnapshotsService, () -> true);
 
@@ -460,6 +470,7 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
             translogOps,
             version,
             snapshotRecoveriesEnabled,
+            primaryRelocation,
             planFuture
         );
         final ShardRecoveryPlan shardRecoveryPlan = planFuture.get();


### PR DESCRIPTION
This pull request contains changes related to recovery planners:

- it changes the `RecoveryPlannerPlugin` to allow more than 1 plugin to be installed at a time
- it makes the instantiation of the `RecoveryPlannerService` optional, so that plugins can decide to create or not a recovery service but still checks that only 1 recovery planner service is present at a time
- it makes the `SnapshotBasedRecoveriesPlugin` returns an empty service when stateless is enabled
- it adjust the `computeRecoveryPlan()` method to add a boolean parameter indicating if the plan is computed for a primary relocation