### PR TITLE
Make clean up files step configurable for peer-recovery of replicas

### DIFF
--- a/docs/changelog/92490.yaml
+++ b/docs/changelog/92490.yaml
@@ -1,0 +1,5 @@
+pr: 92490
+summary: Make clean up files step configurable for peer-recovery of replicas
+area: Recovery
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -495,7 +495,9 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
             final Store store = store();
             store.incRef();
             try {
-                store.cleanupAndVerify("recovery CleanFilesRequestHandler", sourceMetadata);
+                if (DiscoveryNode.isStateless(indexShard.indexSettings().getSettings()) == false || indexShard.routingEntry().primary()) {
+                    store.cleanupAndVerify("recovery CleanFilesRequestHandler", sourceMetadata);
+                }
                 final String translogUUID = Translog.createEmptyTranslog(
                     indexShard.shardPath().resolveTranslog(),
                     globalCheckpoint,

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -495,7 +495,8 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
             final Store store = store();
             store.incRef();
             try {
-                if (DiscoveryNode.isStateless(indexShard.indexSettings().getSettings()) == false || indexShard.routingEntry().primary()) {
+                if (DiscoveryNode.isStateless(indexShard.indexSettings().getNodeSettings()) == false
+                    || indexShard.routingEntry().primary()) {
                     store.cleanupAndVerify("recovery CleanFilesRequestHandler", sourceMetadata);
                 }
                 final String translogUUID = Translog.createEmptyTranslog(


### PR DESCRIPTION
Skip the "clean up and verify" step at the end of files based peer-recovery for replicas.