### PR TITLE
[8.6] Unsafe bootstrap memory optimization (#92493)

### DIFF
--- a/docs/changelog/92493.yaml
+++ b/docs/changelog/92493.yaml
@@ -1,0 +1,5 @@
+pr: 92493
+summary: Unsafe bootstrap memory optimization
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/UnsafeBootstrapMasterCommand.java
@@ -116,10 +116,12 @@ public class UnsafeBootstrapMasterCommand extends ElasticsearchNodeCommand {
 
         final ClusterState newClusterState = ClusterState.builder(oldClusterState).metadata(newMetadata).build();
 
-        terminal.println(
-            Terminal.Verbosity.VERBOSE,
-            "[old cluster state = " + oldClusterState + ", new cluster state = " + newClusterState + "]"
-        );
+        if (terminal.isPrintable(Terminal.Verbosity.VERBOSE)) {
+            terminal.println(
+                Terminal.Verbosity.VERBOSE,
+                "[old cluster state = " + oldClusterState + ", new cluster state = " + newClusterState + "]"
+            );
+        }
 
         confirm(terminal, CONFIRMATION_MSG);
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Unsafe bootstrap memory optimization (#92493)