### PR TITLE
[8.6] Reject connection attempts while closing (#92465)

### DIFF
--- a/docs/changelog/92465.yaml
+++ b/docs/changelog/92465.yaml
@@ -1,0 +1,5 @@
+pr: 92465
+summary: Reject connection attempts while closing
+area: Network
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -19,6 +19,9 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+import org.elasticsearch.common.util.concurrent.RunOnce;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -42,6 +45,7 @@ import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -49,6 +53,7 @@ import java.util.function.Supplier;
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -344,6 +349,128 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         for (Transport.Connection connection : connections) {
             assertTrue(connection.isClosed());
         }
+    }
+
+    public void testConcurrentConnectsDuringClose() throws Exception {
+
+        // This test ensures that closing the connection manager doesn't block forever, even if there's a constant stream of attempts to
+        // open connections. Note that closing the connection manager _does_ block while there are in-flight connection attempts, and in
+        // practice each attempt will (eventually) finish, so we're just trying to test that constant open attempts do not cause starvation.
+        //
+        // It works by spawning connection-open attempts in several concurrent loops, putting a Runnable to complete each attempt into a
+        // queue, and then consuming and completing the enqueued runnables in a separate thread. The consuming thread is throttled via a
+        // Semaphore, from which the main thread steals a permit which ensures that there's always at least one pending connection while the
+        // close is ongoing even though no connection attempt blocks forever.
+
+        final var pendingConnectionPermits = new Semaphore(0);
+        final var pendingConnections = ConcurrentCollections.<Runnable>newQueue();
+
+        // transport#openConnection enqueues a Runnable to complete the connection attempt
+        doAnswer(invocationOnMock -> {
+            @SuppressWarnings("unchecked")
+            final var listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
+            final var targetNode = (DiscoveryNode) invocationOnMock.getArguments()[0];
+            pendingConnections.add(() -> listener.onResponse(new TestConnect(targetNode)));
+            pendingConnectionPermits.release();
+            return null;
+        }).when(transport).openConnection(any(), eq(connectionProfile), anyActionListener());
+
+        final ConnectionManager.ConnectionValidator validator = (c, p, l) -> l.onResponse(null);
+
+        // Once we start to see connections being rejected, we give back the stolen permit so that the last connection can complete
+        final var onConnectException = new RunOnce(pendingConnectionPermits::release);
+
+        // Create a few threads which open connections in a loop. Must be at least 2 so that there's always more connections incoming.
+        final var connectionLoops = between(2, 4);
+        final var connectionLoopCountDown = new CountDownLatch(connectionLoops);
+        final var expectConnectionFailures = new AtomicBoolean(); // unexpected failures would make this test pass vacuously
+
+        class ConnectionLoop extends AbstractRunnable {
+            private final boolean useConnectToNode = randomBoolean();
+
+            @Override
+            public void onFailure(Exception e) {
+                assert false : e;
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                final var discoveryNode = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+                final var listener = new ActionListener<Releasable>() {
+                    @Override
+                    public void onResponse(Releasable releasable) {
+                        releasable.close();
+                        threadPool.generic().execute(ConnectionLoop.this);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        assertTrue(expectConnectionFailures.get());
+                        assertThat(e, instanceOf(ConnectTransportException.class));
+                        assertThat(e.getMessage(), containsString("connection manager is closed"));
+                        onConnectException.run();
+                        connectionLoopCountDown.countDown();
+                    }
+                };
+
+                if (useConnectToNode) {
+                    connectionManager.connectToNode(discoveryNode, connectionProfile, validator, listener);
+                } else {
+                    connectionManager.openConnection(discoveryNode, connectionProfile, listener.map(c -> c::close));
+                }
+            }
+        }
+
+        for (int i = 0; i < connectionLoops; i++) {
+            threadPool.generic().execute(new ConnectionLoop());
+        }
+
+        // Create a separate thread to complete pending connection attempts, throttled by the pendingConnectionPermits semaphore
+        final var completionThread = new Thread(() -> {
+            while (true) {
+                try {
+                    assertTrue(pendingConnectionPermits.tryAcquire(10, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    // There could still be items in the queue when we are interrupted, so drain the queue before exiting:
+                    while (pendingConnectionPermits.tryAcquire()) {
+                        // noinspection ConstantConditions
+                        pendingConnections.poll().run();
+                    }
+                    return;
+                }
+                // noinspection ConstantConditions
+                pendingConnections.poll().run();
+            }
+        });
+        completionThread.start();
+
+        // Steal a permit so that the consumer lags behind the producers ...
+        assertTrue(pendingConnectionPermits.tryAcquire(10, TimeUnit.SECONDS));
+        // ... and then send a connection attempt through the system to ensure that the lagging has started
+        Releasables.closeExpectNoException(
+            PlainActionFuture.<Releasable, RuntimeException>get(
+                fut -> connectionManager.connectToNode(
+                    new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT),
+                    connectionProfile,
+                    validator,
+                    fut
+                ),
+                30,
+                TimeUnit.SECONDS
+            )
+        );
+
+        // Now close the connection manager
+        expectConnectionFailures.set(true);
+        connectionManager.close();
+        // Success! The close call returned
+
+        // Clean up and check everything completed properly
+        assertTrue(connectionLoopCountDown.await(10, TimeUnit.SECONDS));
+        completionThread.interrupt();
+        completionThread.join();
+        assertTrue(pendingConnections.isEmpty());
     }
 
     public void testConcurrentConnectsAndDisconnects() throws Exception {


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Reject connection attempts while closing (#92465)