### PR TITLE
Prevent usage of time series aggregations with some parent aggs

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -79,3 +79,91 @@ setup:
   - match: { aggregations.ts.buckets.0.key: { "key": "foo" } }
   - match: { aggregations.ts.buckets.0.doc_count: 1 }
 
+---
+"Sampler aggregation with nested time series aggregation failure":
+  - skip:
+      version: " - 8.6.99"
+      reason: "Handling for time series aggregation failures introduced in 8.7.0"
+
+  - do:
+      catch: '/\[random_sampler\] aggregation \[sample\] does not support sampling \[time_series\] aggregation \[ts\]/'
+      search:
+        index: tsdb
+        body:
+          aggs:
+            sample:
+              random_sampler:
+                probability: 1.0
+              aggs:
+                by_timestamp:
+                  date_histogram:
+                    field: "@timestamp"
+                    fixed_interval: 1h
+                  aggs:
+                    ts:
+                      time_series:
+                        keyed: false
+                      aggs:
+                        sum:
+                          sum:
+                            field: val
+
+---
+"Composite aggregation with nested time series aggregation failure":
+  - skip:
+      version: " - 8.6.99"
+      reason: "Handling for time series aggregation failures introduced in 8.7.0"
+
+  - do:
+      catch: '/\[composite] aggregation cannot be used with a child aggregation of type: \[time_series\]/'
+      search:
+        index: tsdb
+        body:
+          aggs:
+            by_key:
+              composite:
+                sources: [
+                  {
+                    "key": {
+                      "terms": {
+                        "field": "key"
+                      }
+                    }
+                  }
+                ]
+              aggs:
+                date:
+                  date_histogram:
+                    field: "@timestamp"
+                    fixed_interval: "1h"
+                  aggs:
+                    ts:
+                      time_series:
+                        keyed: false
+                      aggs:
+                        sum:
+                          sum:
+                            field: val
+
+---
+"Global aggregation with nested time series aggregation failure":
+  - skip:
+      version: " - 8.6.99"
+      reason: "Handling for time series aggregation failures introduced in 8.7.0"
+
+  - do:
+      catch: '/Time series aggregations cannot be used inside global aggregation./'
+      search:
+        index: tsdb
+        body:
+          aggs:
+            global:
+              global: {}
+              aggs:
+                ts:
+                  time_series:
+                    keyed: false
+                  aggs:
+                    sum:
+                      sum:
+                        field: val

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -115,7 +115,7 @@ setup:
       reason: "Handling for time series aggregation failures introduced in 8.7.0"
 
   - do:
-      catch: '/\[composite] aggregation cannot be used with a child aggregation of type: \[time_series\]/'
+      catch: '/\[composite\] aggregation is incompatible with time series execution mode/'
       search:
         index: tsdb
         body:

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -27,10 +27,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -185,23 +183,6 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
             }
     }
 
-    private static String validateSubAggregations(Collection<AggregationBuilder> builders) {
-        if (builders == null || builders.isEmpty()) {
-            return null;
-        }
-
-        for (final AggregationBuilder builder : builders) {
-            if ("time_series".equals(builder.getType().toLowerCase(Locale.ROOT))) {
-                return builder.getType();
-            }
-            final String subAggregations = validateSubAggregations(builder.getSubAggregations());
-            if (subAggregations != null) {
-                return subAggregations;
-            }
-        }
-        return null;
-    }
-
     private static void validateSources(List<CompositeValuesSourceBuilder<?>> sources) {
         if (sources == null || sources.isEmpty()) {
             throw new IllegalArgumentException("Composite [" + SOURCES_FIELD_NAME.getPreferredName() + "] cannot be null or empty");
@@ -240,12 +221,7 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
             );
         }
         if (context.isInSortOrderExecutionRequired()) {
-            final String invalidSubAggregation = validateSubAggregations(subfactoriesBuilder.getAggregatorFactories());
-            if (invalidSubAggregation != null) {
-                throw new IllegalArgumentException(
-                    "[composite] aggregation cannot be used with a child aggregation of" + " type: [" + invalidSubAggregation + "]"
-                );
-            }
+            throw new IllegalArgumentException("[composite] aggregation is incompatible with time series execution mode");
         }
         CompositeValuesSourceConfig[] configs = new CompositeValuesSourceConfig[sources.size()];
         for (int i = 0; i < configs.length; i++) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -211,6 +211,9 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
         AggregatorFactory parent,
         AggregatorFactories.Builder subfactoriesBuilder
     ) throws IOException {
+        if (context.isInSortOrderExecutionRequired()) {
+            throw new IllegalArgumentException("[composite] aggregation is incompatible with time series execution mode");
+        }
         AggregatorFactory invalid = validateParentAggregations(parent);
         if (invalid != null) {
             throw new IllegalArgumentException(
@@ -219,9 +222,6 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
                     + invalid.getClass().getSimpleName()
                     + "]"
             );
-        }
-        if (context.isInSortOrderExecutionRequired()) {
-            throw new IllegalArgumentException("[composite] aggregation is incompatible with time series execution mode");
         }
         CompositeValuesSourceConfig[] configs = new CompositeValuesSourceConfig[sources.size()];
         for (int i = 0; i < configs.length; i++) {


### PR DESCRIPTION
Fail composite aggregation query execution when in time series mode.
`TimeSeriesIndexSearcher` does not support it, so we fail with a proper
exception rather than using a `NO_OP_COLLECTOR` triggering a 
`CollectionTerminatedException`.

Resolves #92390 