### PR TITLE
Use default text for preview warning with tcp readiness port

### DIFF
--- a/docs/reference/setup/advanced-configuration.asciidoc
+++ b/docs/reference/setup/advanced-configuration.asciidoc
@@ -158,9 +158,7 @@ using the service manager. See <<windows-service>>.
 [[readiness-tcp-port]]
 ===== Enable the Elasticsearch TCP readiness port
 
-preview::["This functionality is in technical preview and may be changed or removed in a future release.
-It is intended for internal, experimental use. Features in technical preview are not subject to the support
-SLA of official GA features."]
+preview::[]
 
 If configured, a node can open a TCP port when the node is in a ready state. A node is deemed
 ready when it has successfully joined a cluster. In a single node configuration, the node is


### PR DESCRIPTION
The docs for the TCP readiness port have a preview warning, with custom text. However, this doesn't render correctly in the docs. Rather than figure out why the custom text doesn't render, this commit simply removes the custom text in favor of the default preview text.