### PR TITLE
[8.6] [Tests] Timeout 1s when creating a red index (#92486)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/40_diagnosis.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/40_diagnosis.yml
@@ -7,6 +7,8 @@
   - do:
       indices.create:
         index: red_index
+        master_timeout: 1s
+        timeout: 1s
         body:
           settings:
             number_of_shards: 1


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [Tests] Timeout 1s when creating a red index (#92486)