### PR TITLE
Document jvm options for cli tools

### DIFF
--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by ``elasticsearch-````{tool-name}`` to 1GB.
+the following increases the heap size used by the ``{tool-name}`` tool to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by the `{tool-name}` tool to 1GB.
+the following increases the heap size used by the `+{tool-name}+` tool to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by the `+{tool-name}+` tool to 1GB.
+the following increases the heap size used by the `pass:a[{tool-name}]` tool to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by `elasticsearch-+{tool-name}+` to 1GB.
+the following increases the heap size used by `elasticsearch-{tool-name}` to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by `elasticsearch-{tool-name}` to 1GB.
+the following increases the heap size used by ``elasticsearch-````{tool-name}`` to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -1,0 +1,12 @@
+[[cli-tool-jvm-options]]
+=== JVM options for CLI tools
+
+CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
+this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
+the following increases the heap size used by `elasticsearch-{tool-name}` to 1GB.
+
+[source,shell,subs=attributes+]
+--------------------------------------------------
+export CLI_JAVA_OPTS="-Xmx1g"
+bin/elasticsearch-{tool-name} ...
+--------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -1,9 +1,10 @@
 [[cli-tool-jvm-options-{tool-name}]]
+[float]
 ==== JVM options
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by `elasticsearch-{tool-name}` to 1GB.
+the following increases the heap size used by `elasticsearch-``+{tool-name}+` to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -1,5 +1,5 @@
-[[cli-tool-jvm-options]]
-=== JVM options for CLI tools
+[[cli-tool-jvm-options-{tool-name}]]
+==== JVM options
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by the ``{tool-name}`` tool to 1GB.
+the following increases the heap size used by the `{tool-name}` tool to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/cli-jvm-options.asciidoc
+++ b/docs/reference/commands/cli-jvm-options.asciidoc
@@ -4,7 +4,7 @@
 
 CLI tools run with 64MB of heap. For most tools, this value is fine. However, if needed
 this can be overriden by setting the CLI_JAVA_OPTS environment variable. For example,
-the following increases the heap size used by `elasticsearch-``+{tool-name}+` to 1GB.
+the following increases the heap size used by `elasticsearch-+{tool-name}+` to 1GB.
 
 [source,shell,subs=attributes+]
 --------------------------------------------------

--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -50,7 +50,7 @@ This tool has a number of modes:
   {es}. This may sometimes allow you to downgrade to an earlier version of
   {es}.
 
-:tool-name node
+:tool-name: node
 include::cli-jvm-options.asciidoc[]
 :!tool-name:
 

--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -50,6 +50,10 @@ This tool has a number of modes:
   {es}. This may sometimes allow you to downgrade to an earlier version of
   {es}.
 
+:tool-name node
+include::cli-jvm-options.asciidoc[]
+:!tool-name:
+
 [[node-tool-repurpose]]
 [discrete]
 ==== Changing the role of a node

--- a/docs/reference/commands/reconfigure-node.asciidoc
+++ b/docs/reference/commands/reconfigure-node.asciidoc
@@ -54,6 +54,11 @@ nodes in an existing, secured cluster.
 
 `-v, --verbose`:: Shows verbose output.
 
+
+:tool-name: reconfigure-node
+include::cli-jvm-options.asciidoc[]
+:!tool-name:
+
 [discrete]
 === Examples
 

--- a/docs/reference/commands/shard-tool.asciidoc
+++ b/docs/reference/commands/shard-tool.asciidoc
@@ -44,6 +44,10 @@ There are two ways to specify the path:
 * Use the `--dir` option to specify the full path to the corrupted index or
   translog files.
 
+:tool-name: shard
+include::cli-jvm-options.asciidoc[]
+:!tool-name:
+
 [discrete]
 ==== Removing corrupted data
 


### PR DESCRIPTION
This commit adds documentation for the CLI_JAVA_OPTS environment variable.

closes #92503
