### PR TITLE
Avoiding geoip downloader race conditions

### DIFF
--- a/docs/changelog/92514.yaml
+++ b/docs/changelog/92514.yaml
@@ -1,0 +1,5 @@
+pr: 92514
+summary: Avoiding geoip downloader race conditions
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderTaskExecutor.java
@@ -173,7 +173,7 @@ public final class GeoIpDownloaderTaskExecutor extends PersistentTasksExecutor<G
                 })
             );
         } else {
-            throw new IllegalStateException("Cannot start geoip downloader task because one is already running");
+            logger.error("Cannot start geoip downloader task because one is already running");
         }
     }
 


### PR DESCRIPTION
This PR fixes two race conditions I ran into while testing another PR:
(1) If you start and stop the GeopIpDownloader frequently, you can wind up having `.geoip_databases` being deleted while stopping an old task when a new task is being started. It results in an exception like this:
```
  1> org.elasticsearch.index.IndexNotFoundException: no such index [.geoip_databases]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.notFoundException(IndexNameExpressionResolver.java:456) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.ensureAliasOrIndexExists(IndexNameExpressionResolver.java:469) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.innerResolve(IndexNameExpressionResolver.java:1224) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver$WildcardExpressionResolver.resolve(IndexNameExpressionResolver.java:1130) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.resolveExpressions(IndexNameExpressionResolver.java:247) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndices(IndexNameExpressionResolver.java:323) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:313) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.cluster.metadata.IndexNameExpressionResolver.concreteIndexNames(IndexNameExpressionResolver.java:86) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.action.support.replication.TransportBroadcastReplicationAction.shards(TransportBroadcastReplicationAction.java:131) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.action.support.replication.TransportBroadcastReplicationAction.doExecute(TransportBroadcastReplicationAction.java:73) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.action.support.replication.TransportBroadcastReplicationAction.doExecute(TransportBroadcastReplicationAction.java:42) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.action.support.TransportAction$RequestFilterChain.proceed(TransportAction.java:86) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.action.support.TransportAction.execute(TransportAction.java:61) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.tasks.TaskManager.registerAndExecute(TaskManager.java:202) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.node.NodeClient.executeLocally(NodeClient.java:112) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.node.NodeClient.doExecute(NodeClient.java:90) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.support.AbstractClient.execute(AbstractClient.java:380) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.FilterClient.doExecute(FilterClient.java:57) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.OriginSettingClient.doExecute(OriginSettingClient.java:43) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.support.AbstractClient.execute(AbstractClient.java:380) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.support.AbstractClient.execute(AbstractClient.java:366) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.support.AbstractClient$IndicesAdmin.execute(AbstractClient.java:1262) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.client.internal.support.AbstractClient$IndicesAdmin.refresh(AbstractClient.java:1486) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloader.indexChunks(GeoIpDownloader.java:289) ~[main/:?]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloader.processDatabase(GeoIpDownloader.java:216) ~[main/:?]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloader.updateDatabases(GeoIpDownloader.java:178) ~[main/:?]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloader.runDownloader(GeoIpDownloader.java:328) ~[main/:?]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloader.runDownloader(GeoIpDownloader.java:320) ~[main/:?]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloaderTaskExecutor.nodeOperation(GeoIpDownloaderTaskExecutor.java:102) ~[main/:?]
  1> 	at org.elasticsearch.ingest.geoip.GeoIpDownloaderTaskExecutor.nodeOperation(GeoIpDownloaderTaskExecutor.java:48) ~[main/:?]
  1> 	at org.elasticsearch.persistent.NodePersistentTasksExecutor$1.doRun(NodePersistentTasksExecutor.java:42) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingAbstractRunnable.doRun(ThreadContext.java:917) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26) ~[elasticsearch-8.7.0-SNAPSHOT.jar:8.7.0-SNAPSHOT]
  1> 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
  1> 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
  1> 	at java.lang.Thread.run(Thread.java:833) ~[?:?]
```
The fix for this is to use a semaphore to only allow GeoIpDownloaderTaskExecutor to run one task at a time. It waits up to 100 ms for the semaphore (we can't wait long since this is always done on the cluster state update thread, but we're really only waiting on the response to a delete request that has already been made).

(2) If you start the download and stop it quickly, it's possible for the download to be running before cancel is called (stopping the task calls cancel asynchronously). So you get an exception like this:
```
org.elasticsearch.ResourceNotFoundException: the task with id geoip-downloader and allocation id 5 doesn't exist
	at org.elasticsearch.persistent.PersistentTasksClusterService$4.execute(PersistentTasksClusterService.java:263)
	at org.elasticsearch.cluster.service.MasterService$UnbatchedExecutor.execute(MasterService.java:551)
	at org.elasticsearch.cluster.service.MasterService.innerExecuteTasks(MasterService.java:1052)
	at org.elasticsearch.cluster.service.MasterService.executeTasks(MasterService.java:1017)
	at org.elasticsearch.cluster.service.MasterService.runTasks(MasterService.java:278)
	at org.elasticsearch.cluster.service.MasterService$Batcher.run(MasterService.java:170)
	at org.elasticsearch.cluster.service.TaskBatcher.runIfNotProcessed(TaskBatcher.java:110)
	at org.elasticsearch.cluster.service.TaskBatcher$BatchedTask.run(TaskBatcher.java:148)
	at org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:850)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.runAndClean(PrioritizedEsThreadPoolExecutor.java:257)
	at org.elasticsearch.common.util.concurrent.PrioritizedEsThreadPoolExecutor$TieBreakingPrioritizedRunnable.run(PrioritizedEsThreadPoolExecutor.java:223)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1589)
```
The fix for this is to just log when it happens rather than throwing an exception.
I doubt that either of these happen in production much since people aren't typically rapidly turning the downloader off and on, but they are annoying in tests.