### PR TITLE
Use MockDirectoryWrapper in MultiFileWriterTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/MultiFileWriterTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/MultiFileWriterTests.java
@@ -42,7 +42,7 @@ public class MultiFileWriterTests extends IndexShardTestCase {
     public void setUp() throws Exception {
         super.setUp();
         indexShard = newShard(true);
-        directory = newFSDirectory(indexShard.shardPath().resolveIndex());
+        directory = newMockFSDirectory(indexShard.shardPath().resolveIndex());
         directorySpy = spy(directory);
         store = createStore(indexShard.shardId(), indexShard.indexSettings(), directorySpy);
     }


### PR DESCRIPTION
The underlying Lucene test setup `rarely()` chooses a `RawDirectoryWrapper` which is a final class. 

Closes https://github.com/elastic/elasticsearch/issues/92497.
