### PR TITLE
Repo test kit to use more than 1 snapshot thread

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/rest/build.gradle
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/rest/build.gradle
@@ -16,6 +16,7 @@ testClusters.matching { it.name == "yamlRestTest" }.configureEach {
   testDistribution = 'DEFAULT'
   setting 'path.repo', repoDir.absolutePath
   setting 'xpack.security.enabled', 'false'
+  setting 'thread_pool.snapshot.max', '2'
 }
 
 tasks.named('yamlRestTestTestingConventions').configure {


### PR DESCRIPTION
Fixes #90353

The original issue surfaced when we started testing with 1 processor in 8.5+. It resulted in 1 SNAPSHOT thread and made the timeout of test as explained in [this comment](https://github.com/elastic/elasticsearch/issues/90353#issuecomment-1270432548).

In 8.6 at some point the SNAPSHOT threads were turned to max 10, so this issue stopped. The issue was solved for the 8.5 branch with https://github.com/elastic/elasticsearch/pull/91226 that made the test use 2 SNAPSHOT threads.

But https://github.com/elastic/elasticsearch/pull/92392 made it so that there can be 1 SNAPSHOT thread in cases of low max memory, so the issue resurfaced in 8.6 branch and main. This PR makes the test use 2 SNAPSHOT threads in 8.6 and main.