### PR TITLE
Chunked encoding for CCR APIs

### DIFF
--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
@@ -7,10 +7,14 @@
 
 package org.elasticsearch.xpack.ccr.rest;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
 
 import java.util.List;
@@ -18,6 +22,8 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestCcrStatsAction extends BaseRestHandler {
+
+    private static final Logger logger = LogManager.getLogger(RestCcrStatsAction.class);
 
     @Override
     public List<Route> routes() {
@@ -32,7 +38,17 @@ public class RestCcrStatsAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) {
         final CcrStatsAction.Request request = new CcrStatsAction.Request();
-        return channel -> client.execute(CcrStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> client.execute(
+            CcrStatsAction.INSTANCE,
+            request,
+            new ThreadedActionListener<>(
+                logger,
+                client.threadPool(),
+                ThreadPool.Names.MANAGEMENT,
+                new RestChunkedToXContentListener<>(channel),
+                false
+            )
+        );
     }
 
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestCcrStatsAction.java
@@ -14,7 +14,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestChunkedToXContentListener;
-import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.ccr.Ccr;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
 
 import java.util.List;
@@ -44,7 +44,7 @@ public class RestCcrStatsAction extends BaseRestHandler {
             new ThreadedActionListener<>(
                 logger,
                 client.threadPool(),
-                ThreadPool.Names.MANAGEMENT,
+                Ccr.CCR_THREAD_POOL_NAME,
                 new RestChunkedToXContentListener<>(channel),
                 false
             )

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowInfoAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowInfoAction.java
@@ -11,7 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 import org.elasticsearch.xpack.core.ccr.action.FollowInfoAction;
 
 import java.util.List;
@@ -34,7 +34,7 @@ public class RestFollowInfoAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) {
         final FollowInfoAction.Request request = new FollowInfoAction.Request();
         request.setFollowerIndices(Strings.splitStringByCommaToArray(restRequest.param("index")));
-        return channel -> client.execute(FollowInfoAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> client.execute(FollowInfoAction.INSTANCE, request, new RestChunkedToXContentListener<>(channel));
     }
 
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
@@ -7,11 +7,15 @@
 
 package org.elasticsearch.xpack.ccr.rest;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
 import java.util.List;
@@ -19,6 +23,8 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class RestFollowStatsAction extends BaseRestHandler {
+
+    private static final Logger logger = LogManager.getLogger(RestFollowStatsAction.class);
 
     @Override
     public List<Route> routes() {
@@ -34,7 +40,17 @@ public class RestFollowStatsAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(final RestRequest restRequest, final NodeClient client) {
         final FollowStatsAction.StatsRequest request = new FollowStatsAction.StatsRequest();
         request.setIndices(Strings.splitStringByCommaToArray(restRequest.param("index")));
-        return channel -> client.execute(FollowStatsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> client.execute(
+            FollowStatsAction.INSTANCE,
+            request,
+            new ThreadedActionListener<>(
+                logger,
+                client.threadPool(),
+                ThreadPool.Names.MANAGEMENT,
+                new RestChunkedToXContentListener<>(channel),
+                false
+            )
+        );
     }
 
 }

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/rest/RestFollowStatsAction.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestChunkedToXContentListener;
-import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.ccr.Ccr;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
 import java.util.List;
@@ -46,7 +46,7 @@ public class RestFollowStatsAction extends BaseRestHandler {
             new ThreadedActionListener<>(
                 logger,
                 client.threadPool(),
-                ThreadPool.Names.MANAGEMENT,
+                Ccr.CCR_THREAD_POOL_NAME,
                 new RestChunkedToXContentListener<>(channel),
                 false
             )

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowStatsResponseTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/AutoFollowStatsResponseTests.java
@@ -8,10 +8,15 @@ package org.elasticsearch.xpack.ccr.action;
 
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.ccr.AutoFollowStats;
 import org.elasticsearch.xpack.core.ccr.action.CcrStatsAction;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
+import java.io.IOException;
+
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xpack.ccr.action.AutoFollowStatsTests.randomReadExceptions;
 import static org.elasticsearch.xpack.ccr.action.AutoFollowStatsTests.randomTrackingClusters;
 import static org.elasticsearch.xpack.ccr.action.StatsResponsesTests.createStatsResponse;
@@ -34,5 +39,20 @@ public class AutoFollowStatsResponseTests extends AbstractWireSerializingTestCas
         );
         FollowStatsAction.StatsResponses statsResponse = createStatsResponse();
         return new CcrStatsAction.Response(autoFollowStats, statsResponse);
+    }
+
+    public void testChunking() throws IOException {
+        final var instance = createTestInstance();
+        int chunkCount = 0;
+        try (var builder = jsonBuilder()) {
+            final var iterator = instance.toXContentChunked(EMPTY_PARAMS);
+            while (iterator.hasNext()) {
+                iterator.next().toXContent(builder, ToXContent.EMPTY_PARAMS);
+                chunkCount += 1;
+            }
+        } // closing the builder verifies that the XContent is well-formed
+
+        var indexCount = instance.getFollowStats().getStatsResponses().stream().map(s -> s.status().followerIndex()).distinct().count();
+        assertEquals(instance.getFollowStats().getStatsResponses().size() + indexCount * 2 + 4, chunkCount);
     }
 }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/StatsResponsesTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/StatsResponsesTests.java
@@ -9,12 +9,17 @@ package org.elasticsearch.xpack.ccr.action;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+
+import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 
 public class StatsResponsesTests extends AbstractWireSerializingTestCase<FollowStatsAction.StatsResponses> {
 
@@ -66,5 +71,20 @@ public class StatsResponsesTests extends AbstractWireSerializingTestCase<FollowS
             responses.add(new FollowStatsAction.StatsResponse(status));
         }
         return new FollowStatsAction.StatsResponses(Collections.emptyList(), Collections.emptyList(), responses);
+    }
+
+    public void testChunking() throws IOException {
+        final var instance = createTestInstance();
+        int chunkCount = 0;
+        try (var builder = jsonBuilder()) {
+            final var iterator = instance.toXContentChunked(EMPTY_PARAMS);
+            while (iterator.hasNext()) {
+                iterator.next().toXContent(builder, ToXContent.EMPTY_PARAMS);
+                chunkCount += 1;
+            }
+        } // closing the builder verifies that the XContent is well-formed
+
+        var indexCount = instance.getStatsResponses().stream().map(s -> s.status().followerIndex()).distinct().count();
+        assertEquals(instance.getStatsResponses().size() + indexCount * 2 + 2, chunkCount);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsAction.java
@@ -11,13 +11,15 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.xcontent.ToXContentObject;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.ccr.AutoFollowStats;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Objects;
 
 public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
@@ -48,7 +50,7 @@ public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
         }
     }
 
-    public static class Response extends ActionResponse implements ToXContentObject {
+    public static class Response extends ActionResponse implements ChunkedToXContent {
 
         private final AutoFollowStats autoFollowStats;
         private final FollowStatsAction.StatsResponses followStats;
@@ -79,14 +81,14 @@ public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            {
-                builder.field("auto_follow_stats", autoFollowStats, params);
-                builder.field("follow_stats", followStats, params);
-            }
-            builder.endObject();
-            return builder;
+        public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
+            return Iterators.concat(
+                Iterators.single(
+                    (builder, params) -> builder.startObject().field("auto_follow_stats", autoFollowStats, params).field("follow_stats")
+                ),
+                followStats.toXContentChunked(outerParams),
+                Iterators.single((builder, params) -> builder.endObject())
+            );
         }
 
         @Override
@@ -101,6 +103,7 @@ public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
         public int hashCode() {
             return Objects.hash(autoFollowStats, followStats);
         }
+
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/CcrStatsAction.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xpack.core.ccr.AutoFollowStats;
 
@@ -87,7 +88,7 @@ public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
                     (builder, params) -> builder.startObject().field("auto_follow_stats", autoFollowStats, params).field("follow_stats")
                 ),
                 followStats.toXContentChunked(outerParams),
-                Iterators.single((builder, params) -> builder.endObject())
+                ChunkedToXContentHelper.endObject()
             );
         }
 
@@ -103,7 +104,6 @@ public class CcrStatsAction extends ActionType<CcrStatsAction.Response> {
         public int hashCode() {
             return Objects.hash(autoFollowStats, followStats);
         }
-
     }
 
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
@@ -11,15 +11,19 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.master.MasterNodeReadRequest;
 import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
 
@@ -77,7 +81,7 @@ public class FollowInfoAction extends ActionType<FollowInfoAction.Response> {
         }
     }
 
-    public static class Response extends ActionResponse implements ToXContentObject {
+    public static class Response extends ActionResponse implements ChunkedToXContent {
 
         public static final ParseField FOLLOWER_INDICES_FIELD = new ParseField("follower_indices");
 
@@ -102,15 +106,12 @@ public class FollowInfoAction extends ActionType<FollowInfoAction.Response> {
         }
 
         @Override
-        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.startArray(FOLLOWER_INDICES_FIELD.getPreferredName());
-            for (FollowerInfo followInfo : followInfos) {
-                followInfo.toXContent(builder, params);
-            }
-            builder.endArray();
-            builder.endObject();
-            return builder;
+        public Iterator<ToXContent> toXContentChunked(ToXContent.Params outerParams) {
+            return Iterators.concat(
+                Iterators.single((builder, params) -> builder.startObject().startArray(FOLLOWER_INDICES_FIELD.getPreferredName())),
+                followInfos.iterator(),
+                Iterators.single((builder, params) -> builder.endArray().endObject())
+            );
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowStatsAction.java
@@ -15,16 +15,21 @@ import org.elasticsearch.action.TaskOperationFailure;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.tasks.BaseTasksRequest;
 import org.elasticsearch.action.support.tasks.BaseTasksResponse;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.Transports;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ccr.ShardFollowNodeTaskStatus;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -40,7 +45,7 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
         super(NAME, FollowStatsAction.StatsResponses::new);
     }
 
-    public static class StatsResponses extends BaseTasksResponse implements ToXContentObject {
+    public static class StatsResponses extends BaseTasksResponse implements ChunkedToXContent {
 
         private final List<StatsResponse> statsResponse;
 
@@ -69,36 +74,32 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
         }
 
         @Override
-        public XContentBuilder toXContent(final XContentBuilder builder, final Params params) throws IOException {
+        public Iterator<ToXContent> toXContentChunked(ToXContent.Params outerParams) {
             // sort by index name, then shard ID
+            Transports.assertNotTransportThread("collecting responses into a map may be expensive");
             final Map<String, Map<Integer, StatsResponse>> taskResponsesByIndex = new TreeMap<>();
             for (final StatsResponse response : statsResponse) {
                 taskResponsesByIndex.computeIfAbsent(response.status().followerIndex(), k -> new TreeMap<>())
                     .put(response.status().getShardId(), response);
             }
-            builder.startObject();
-            {
-                builder.startArray("indices");
-                {
-                    for (final Map.Entry<String, Map<Integer, StatsResponse>> index : taskResponsesByIndex.entrySet()) {
-                        builder.startObject();
-                        {
-                            builder.field("index", index.getKey());
-                            builder.startArray("shards");
-                            {
-                                for (final Map.Entry<Integer, StatsResponse> shard : index.getValue().entrySet()) {
-                                    shard.getValue().status().toXContent(builder, params);
-                                }
-                            }
-                            builder.endArray();
-                        }
-                        builder.endObject();
-                    }
-                }
-                builder.endArray();
-            }
-            builder.endObject();
-            return builder;
+            return innerToXContentChunked(taskResponsesByIndex);
+        }
+
+        private static Iterator<ToXContent> innerToXContentChunked(Map<String, Map<Integer, StatsResponse>> taskResponsesByIndex) {
+            return Iterators.concat(
+                Iterators.single((builder, params) -> builder.startObject().startArray("indices")),
+                Iterators.flatMap(
+                    taskResponsesByIndex.entrySet().iterator(),
+                    indexEntry -> Iterators.concat(
+                        Iterators.<ToXContent>single(
+                            (builder, params) -> builder.startObject().field("index", indexEntry.getKey()).startArray("shards")
+                        ),
+                        indexEntry.getValue().values().iterator(),
+                        Iterators.single((builder, params) -> builder.endArray().endObject())
+                    )
+                ),
+                Iterators.single((builder, params) -> builder.endArray().endObject())
+            );
         }
 
         @Override
@@ -178,7 +179,7 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
         }
     }
 
-    public static class StatsResponse implements Writeable {
+    public static class StatsResponse implements Writeable, ToXContentObject {
 
         private final ShardFollowNodeTaskStatus status;
 
@@ -210,6 +211,11 @@ public class FollowStatsAction extends ActionType<FollowStatsAction.StatsRespons
         @Override
         public int hashCode() {
             return Objects.hash(status);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
+            return status.toXContent(builder, params);
         }
     }
 


### PR DESCRIPTION
The CCR info and stats APIs can send fairly sizeable responses that scale as `O(#shards)`. This commit makes them chunked.

Relates #89838