### PR TITLE
Fixes for module projects in new tests clusters and auto security config

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -165,11 +165,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             .withPathSensitivity(PathSensitivity.RELATIVE);
 
         task.getInputs()
-            .files(
-                providerFactory.provider(
-                    () -> configuration.getAsFileTree().filter(f -> f.getName().endsWith(".jar")).getFiles().stream().sorted().toList()
-                )
-            )
+            .files(providerFactory.provider(() -> configuration.filter(f -> f.getName().endsWith(".jar"))))
             .withPropertyName(configuration.getName() + "-classpath")
             .withNormalizer(ClasspathNormalizer.class);
     }
@@ -181,11 +177,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             .withPathSensitivity(PathSensitivity.RELATIVE);
 
         task.getInputs()
-            .files(
-                providerFactory.provider(
-                    () -> getDistributionFiles(distribution, filter -> filter.include("**/*.jar")).getFiles().stream().sorted().toList()
-                )
-            )
+            .files(providerFactory.provider(() -> getDistributionFiles(distribution, filter -> filter.include("**/*.jar"))))
             .withPropertyName(distribution.getName() + "-classpath")
             .withNormalizer(ClasspathNormalizer.class);
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -18,6 +18,7 @@ import org.elasticsearch.gradle.distribution.ElasticsearchDistributionTypes;
 import org.elasticsearch.gradle.internal.ElasticsearchJavaPlugin;
 import org.elasticsearch.gradle.internal.InternalDistributionDownloadPlugin;
 import org.elasticsearch.gradle.internal.info.BuildParams;
+import org.elasticsearch.gradle.plugin.BasePluginBuildPlugin;
 import org.elasticsearch.gradle.plugin.PluginBuildPlugin;
 import org.elasticsearch.gradle.plugin.PluginPropertiesExtension;
 import org.elasticsearch.gradle.test.SystemPropertyCommandLineArgumentProvider;
@@ -99,9 +100,17 @@ public class RestTestBasePlugin implements Plugin<Project> {
         project.getPluginManager().withPlugin("elasticsearch.esplugin", plugin -> {
             if (GradleUtils.isModuleProject(project.getPath())) {
                 project.getDependencies()
-                    .add(modulesConfiguration.getName(), project.getDependencies().project(Map.of("path", project.getPath())));
+                    .add(
+                        modulesConfiguration.getName(),
+                        project.getDependencies()
+                            .project(Map.of("path", project.getPath(), "configuration", BasePluginBuildPlugin.EXPLODED_BUNDLE_CONFIG))
+                    );
             } else {
-                project.getDependencies().add(pluginsConfiguration.getName(), project.files(project.getTasks().named("bundlePlugin")));
+                project.getDependencies()
+                    .add(
+                        pluginsConfiguration.getName(),
+                        project.files(project.getTasks().named(BasePluginBuildPlugin.BUNDLE_PLUGIN_TASK_NAME))
+                    );
             }
 
         });

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -42,8 +42,8 @@ import org.gradle.api.tasks.PathSensitivity;
 import org.gradle.api.tasks.util.PatternFilterable;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -165,7 +165,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             .withPathSensitivity(PathSensitivity.RELATIVE);
 
         task.getInputs()
-            .files(providerFactory.provider(() -> configuration.filter(f -> f.getName().endsWith(".jar"))))
+            .files(providerFactory.provider(() -> configuration.getAsFileTree().filter(f -> f.getName().endsWith(".jar"))))
             .withPropertyName(configuration.getName() + "-classpath")
             .withNormalizer(ClasspathNormalizer.class);
     }
@@ -203,7 +203,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             if (isExtended == false) {
                 c.withDependencies(dependencies -> {
                     // Add dependencies of any modules
-                    Collection<Dependency> additionalDependencies = new HashSet<>();
+                    Collection<Dependency> additionalDependencies = new LinkedHashSet<>();
                     for (Iterator<Dependency> iterator = dependencies.iterator(); iterator.hasNext();) {
                         Dependency dependency = iterator.next();
                         if (dependency instanceof ProjectDependency projectDependency) {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -47,6 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+
 import javax.inject.Inject;
 
 /**
@@ -159,14 +160,18 @@ public class RestTestBasePlugin implements Plugin<Project> {
 
     private void registerConfigurationInputs(Task task, Configuration configuration) {
         task.getInputs()
-            .files(providerFactory.provider(() -> configuration.getAsFileTree().filter(f -> f.getName().endsWith(".jar"))))
-            .withPropertyName(configuration.getName() + "-classpath")
-            .withNormalizer(ClasspathNormalizer.class);
-
-        task.getInputs()
             .files(providerFactory.provider(() -> configuration.getAsFileTree().filter(f -> f.getName().endsWith(".jar") == false)))
             .withPropertyName(configuration.getName() + "-files")
             .withPathSensitivity(PathSensitivity.RELATIVE);
+
+        task.getInputs()
+            .files(
+                providerFactory.provider(
+                    () -> configuration.getAsFileTree().filter(f -> f.getName().endsWith(".jar")).getFiles().stream().sorted().toList()
+                )
+            )
+            .withPropertyName(configuration.getName() + "-classpath")
+            .withNormalizer(ClasspathNormalizer.class);
     }
 
     private void registerDistributionInputs(Task task, ElasticsearchDistribution distribution) {
@@ -176,7 +181,11 @@ public class RestTestBasePlugin implements Plugin<Project> {
             .withPathSensitivity(PathSensitivity.RELATIVE);
 
         task.getInputs()
-            .files(providerFactory.provider(() -> getDistributionFiles(distribution, filter -> filter.include("**/*.jar"))))
+            .files(
+                providerFactory.provider(
+                    () -> getDistributionFiles(distribution, filter -> filter.include("**/*.jar")).getFiles().stream().sorted().toList()
+                )
+            )
             .withPropertyName(distribution.getName() + "-classpath")
             .withNormalizer(ClasspathNormalizer.class);
     }

--- a/modules/aggregations/build.gradle
+++ b/modules/aggregations/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 /*
@@ -8,8 +7,8 @@ import org.elasticsearch.gradle.internal.info.BuildParams
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
+apply plugin: 'elasticsearch.yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
 
 esplugin {
@@ -52,11 +51,7 @@ artifacts {
   restTests(new File(projectDir, "src/yamlRestTest/resources/rest-api-spec/test"))
 }
 
-testClusters.configureEach {
-  module ':modules:lang-painless'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
-}
-
 dependencies {
   compileOnly(project(':modules:lang-painless:spi'))
+  clusterModules(project(':modules:lang-painless'))
 }

--- a/modules/aggregations/src/yamlRestTest/java/org/elasticsearch/aggregations/AggregationsClientYamlTestSuiteIT.java
+++ b/modules/aggregations/src/yamlRestTest/java/org/elasticsearch/aggregations/AggregationsClientYamlTestSuiteIT.java
@@ -10,10 +10,20 @@ package org.elasticsearch.aggregations;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 public class AggregationsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("aggregations")
+        .module("lang-painless")
+        .feature(FeatureFlag.TIME_SERIES_MODE)
+        .build();
+
     public AggregationsClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
     }
@@ -21,5 +31,10 @@ public class AggregationsClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -26,6 +26,7 @@ public class DefaultSettingsProvider implements SettingsProvider {
         settings.put("node.portsfile", "true");
         settings.put("http.port", "0");
         settings.put("transport.port", "0");
+        settings.put("network.host", "_local_");
 
         if (nodeSpec.getDistributionType() == DistributionType.INTEG_TEST) {
             settings.put("xpack.security.enabled", "false");

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -341,7 +341,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                                         + project
                                         + "':\n\n"
                                         + "dependencies {\n"
-                                        + "  clusterModules "
+                                        + "  clusterPlugins "
                                         + "project(':plugins:"
                                         + pluginName
                                         + "')"

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -147,8 +147,8 @@ public class LocalClusterSpec implements ClusterSpec {
             );
         }
 
-        public boolean isSettingTrue(String setting) {
-            return Boolean.parseBoolean(resolveSettings().getOrDefault(setting, "false"));
+        public String getSetting(String setting, String defaultValue) {
+            return resolveSettings().getOrDefault(setting, defaultValue);
         }
 
         /**

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/LocalDistributionResolver.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/LocalDistributionResolver.java
@@ -37,7 +37,7 @@ public class LocalDistributionResolver implements DistributionResolver {
                             + "':\n\n"
                             + "tasks.named('"
                             + taskName
-                            + "').configure {\n"
+                            + "') {\n"
                             + "  usesDefaultDistribution()\n"
                             + "}"
                     );


### PR DESCRIPTION
Fix an issue where the build cannot resolve a module dependency for the current module project. Also add partial support for security auto- configuration in test clusters.