### PR TITLE
Fix mutation function in JoinStatusTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
@@ -56,7 +56,7 @@ public class JoinStatusTests extends ESTestCase {
                     originalJoinStatus.remoteNode(),
                     originalJoinStatus.term(),
                     originalJoinStatus.message(),
-                    ESTestCase.randomValueOtherThan(originalJoinStatus.age(), this::randomNonNegativeTimeValue)
+                    randomValueOtherThan(originalJoinStatus.age(), this::randomNonNegativeTimeValue)
                 );
             }
             case 4 -> {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
@@ -47,7 +47,7 @@ public class JoinStatusTests extends ESTestCase {
                 return new JoinStatus(
                     originalJoinStatus.remoteNode(),
                     originalJoinStatus.term(),
-                    randomAlphaOfLengthBetween(0, 30),
+                    randomValueOtherThan(originalJoinStatus.message(), () -> randomAlphaOfLengthBetween(0, 30)),
                     originalJoinStatus.age()
                 );
             }
@@ -55,8 +55,8 @@ public class JoinStatusTests extends ESTestCase {
                 return new JoinStatus(
                     originalJoinStatus.remoteNode(),
                     originalJoinStatus.term(),
-                    randomAlphaOfLength(30),
-                    randomNonNegativeTimeValue()
+                    originalJoinStatus.message(),
+                    ESTestCase.randomValueOtherThan(originalJoinStatus.age(), this::randomNonNegativeTimeValue)
                 );
             }
             case 4 -> {


### PR DESCRIPTION
Sometimes `mutateJoinStatus()` would fail to return a different object, e.g. if the message was very short. Also in case 4 it was mutating both the message and the age, but should not have been mutating the message.