### PR TITLE
Release delegate ref in Releasables#releaseOnce

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -10,7 +10,7 @@ package org.elasticsearch.core;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 /** Utility methods to work with {@link Releasable}s. */
 public enum Releasables {
@@ -98,13 +98,14 @@ public enum Releasables {
     }
 
     /**
-     * Wraps a {@link Releasable} such that its {@link Releasable#close()} method can be called multiple times without double releasing.
+     * Wraps a {@link Releasable} such that its {@link Releasable#close()} method can be called multiple times without double-releasing.
      */
     public static Releasable releaseOnce(final Releasable releasable) {
-        final AtomicBoolean released = new AtomicBoolean(false);
+        final var ref = new AtomicReference<>(releasable);
         return () -> {
-            if (released.compareAndSet(false, true)) {
-                releasable.close();
+            final var acquired = ref.getAndSet(null);
+            if (acquired != null) {
+                acquired.close();
             }
         };
     }


### PR DESCRIPTION
Like #92452 and #92507 but for `Releasables#releaseOnce`: there's no need to keep hold of the wrapped releasable after closing it, and in some cases this might hold on to excessive heap. With this commit we drop the reference to the delegate when it's complete.