### PR TITLE
improve strategy for filtering h3 cells

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
@@ -82,13 +82,6 @@ public class GeoHexTilerTests extends GeoGridTilerTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92541")
-    @Override
-    public void testGeoGridSetValuesBoundingBoxes_BoundedGeoShapeCellValues() throws Exception {
-        super.testGeoGridSetValuesBoundingBoxes_BoundedGeoShapeCellValues();
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92540")
     public void testLargeShapeWithBounds() throws Exception {
         // We have a shape covering all space
         Rectangle shapeRectangle = new Rectangle(-180, 180, 90, -90);


### PR DESCRIPTION
The current strategy seems not to be correct. Test are showing the we should have a different strategy (different inflated bbox at each resolution) which seems to help as well with performance. Running the failing test 1k times show no errors.

set as non issue as it has not been released.

fixes https://github.com/elastic/elasticsearch/issues/92540
fixes https://github.com/elastic/elasticsearch/issues/92541