### PR TITLE
Introduce chunked version of ToXContentObject

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/migration/GetFeatureUpgradeStatusResponse.java
@@ -335,7 +335,7 @@ public class GetFeatureUpgradeStatusResponse extends ActionResponse implements T
                 + version
                 + '\''
                 + ", exception='"
-                + exception.getMessage()
+                + (exception == null ? "null" : exception.getMessage())
                 + "'"
                 + '}';
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -156,7 +157,7 @@ public class ListTasksResponse extends BaseTasksResponse {
     /**
      * Convert this task response to XContent grouping by executing nodes.
      */
-    public ChunkedToXContent groupedByNode(Supplier<DiscoveryNodes> nodesInCluster) {
+    public ChunkedToXContentObject groupedByNode(Supplier<DiscoveryNodes> nodesInCluster) {
         return ignored -> {
             final var discoveryNodes = nodesInCluster.get();
             return Iterators.concat(Iterators.single((builder, params) -> {
@@ -212,7 +213,7 @@ public class ListTasksResponse extends BaseTasksResponse {
     /**
      * Convert this response to XContent grouping by parent tasks.
      */
-    public ChunkedToXContent groupedByParent() {
+    public ChunkedToXContentObject groupedByParent() {
         return ignored -> Iterators.concat(Iterators.single((builder, params) -> {
             builder.startObject();
             toXContentCommon(builder, params);
@@ -232,7 +233,7 @@ public class ListTasksResponse extends BaseTasksResponse {
     /**
      * Presents a flat list of tasks
      */
-    public ChunkedToXContent groupedByNone() {
+    public ChunkedToXContentObject groupedByNone() {
         return ignored -> Iterators.concat(Iterators.single((builder, params) -> {
             builder.startObject();
             toXContentCommon(builder, params);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/ListTasksResponse.java
@@ -257,7 +257,7 @@ public class ListTasksResponse extends BaseTasksResponse {
 
     @Override
     public String toString() {
-        return Strings.toString(ChunkedToXContent.wrapAsXContentObject(groupedByNone()), true, true);
+        return Strings.toString(ChunkedToXContent.wrapAsToXContent(groupedByNone()), true, true);
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/repositories/get/GetRepositoriesResponse.java
@@ -56,7 +56,7 @@ public class GetRepositoriesResponse extends ActionResponse implements ToXConten
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(repositories)
+        ChunkedToXContent.wrapAsToXContent(repositories)
             .toXContent(builder, new DelegatingMapParams(Map.of(RepositoriesMetadata.HIDE_GENERATIONS_PARAM, "true"), params));
         builder.endObject();
         return builder;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.snapshots.SnapshotInfo;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -33,7 +33,7 @@ import java.util.Objects;
 /**
  * Get snapshots response
  */
-public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXContent {
+public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXContentObject {
 
     private static final int UNKNOWN_COUNT = -1;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotStatus.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.Maps;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotId;
@@ -43,7 +43,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 /**
  * Status of a snapshot
  */
-public class SnapshotStatus implements ChunkedToXContent, Writeable {
+public class SnapshotStatus implements ChunkedToXContentObject, Writeable {
 
     private final Snapshot snapshot;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/status/SnapshotsStatusResponse.java
@@ -12,7 +12,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
@@ -28,7 +28,7 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg
 /**
  * Snapshot status response
  */
-public class SnapshotsStatusResponse extends ActionResponse implements ChunkedToXContent {
+public class SnapshotsStatusResponse extends ActionResponse implements ChunkedToXContentObject {
 
     private final List<SnapshotStatus> snapshots;
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -14,7 +14,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
 
-public class GetSettingsResponse extends ActionResponse implements ChunkedToXContent {
+public class GetSettingsResponse extends ActionResponse implements ChunkedToXContentObject {
 
     private final Map<String, Settings> indexToSettings;
     private final Map<String, Settings> indexToDefaultSettings;

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -13,7 +13,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.common.xcontent.XContentParserUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -34,7 +34,7 @@ import java.util.stream.Collectors;
 /**
  * Response for {@link FieldCapabilitiesRequest} requests.
  */
-public class FieldCapabilitiesResponse extends ActionResponse implements ChunkedToXContent {
+public class FieldCapabilitiesResponse extends ActionResponse implements ChunkedToXContentObject {
     private static final ParseField INDICES_FIELD = new ParseField("indices");
     private static final ParseField FIELDS_FIELD = new ParseField("fields");
     private static final ParseField FAILED_INDICES_FIELD = new ParseField("failed_indices");
@@ -241,6 +241,9 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
 
     @Override
     public String toString() {
+        if (indexResponses.size() > 0) {
+            return "FieldCapabilitiesResponse{unmerged}";
+        }
         return Strings.toString(this);
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -573,7 +573,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
 
         // meta data
         if (metrics.contains(Metric.METADATA)) {
-            ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, params);
+            ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, params);
         }
 
         // routing table
@@ -622,7 +622,7 @@ public class ClusterState implements ToXContentFragment, Diffable<ClusterState> 
         if (metrics.contains(Metric.CUSTOMS)) {
             for (Map.Entry<String, Custom> cursor : customs.entrySet()) {
                 builder.startObject(cursor.getKey());
-                ChunkedToXContent.wrapAsXContentObject(cursor.getValue()).toXContent(builder, params);
+                ChunkedToXContent.wrapAsToXContent(cursor.getValue()).toXContent(builder, params);
                 builder.endObject();
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Metadata.java
@@ -2687,7 +2687,7 @@ public class Metadata extends AbstractCollection<IndexMetadata> implements Diffa
 
         @Override
         public void toXContent(XContentBuilder builder, Metadata state) throws IOException {
-            ChunkedToXContent.wrapAsXContentObject(state).toXContent(builder, FORMAT_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(state).toXContent(builder, FORMAT_PARAMS);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -12,8 +12,10 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -756,7 +758,7 @@ public class Strings {
      */
     @Deprecated
     public static String toString(ChunkedToXContent chunkedToXContent) {
-        return toString(ChunkedToXContent.wrapAsXContentObject(chunkedToXContent));
+        return toString(chunkedToXContent, false, false);
     }
 
     /**
@@ -795,7 +797,14 @@ public class Strings {
      */
     @Deprecated
     public static String toString(ChunkedToXContent chunkedToXContent, boolean pretty, boolean human) {
-        return toString(ChunkedToXContent.wrapAsXContentObject(chunkedToXContent), pretty, human);
+        final ChunkedToXContent wrapped = chunkedToXContent.isFragment()
+            ? params -> Iterators.concat(
+                ChunkedToXContentHelper.startObject(),
+                chunkedToXContent.toXContentChunked(params),
+                ChunkedToXContentHelper.endObject()
+            )
+            : chunkedToXContent;
+        return toString(ChunkedToXContent.wrapAsXContentObject(wrapped), pretty, human);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -795,7 +795,7 @@ public class Strings {
      */
     @Deprecated
     public static String toString(ChunkedToXContent chunkedToXContent, boolean pretty, boolean human) {
-        return toString(ChunkedToXContent.wrapAsXContentObject(chunkedToXContent), pretty, human);
+        return toString(ChunkedToXContent.wrapAsToXContent(chunkedToXContent), pretty, human);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/Strings.java
+++ b/server/src/main/java/org/elasticsearch/common/Strings.java
@@ -12,10 +12,8 @@ import org.apache.lucene.util.BytesRefBuilder;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
-import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -797,14 +795,7 @@ public class Strings {
      */
     @Deprecated
     public static String toString(ChunkedToXContent chunkedToXContent, boolean pretty, boolean human) {
-        final ChunkedToXContent wrapped = chunkedToXContent.isFragment()
-            ? params -> Iterators.concat(
-                ChunkedToXContentHelper.startObject(),
-                chunkedToXContent.toXContentChunked(params),
-                ChunkedToXContentHelper.endObject()
-            )
-            : chunkedToXContent;
-        return toString(ChunkedToXContent.wrapAsXContentObject(wrapped), pretty, human);
+        return toString(ChunkedToXContent.wrapAsXContentObject(chunkedToXContent), pretty, human);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -42,4 +42,8 @@ public interface ChunkedToXContent {
             return builder;
         };
     }
+
+    default boolean isFragment() {
+        return true;
+    }
 }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -43,6 +43,9 @@ public interface ChunkedToXContent {
         };
     }
 
+    /**
+     * @return true if this instances serializes as an x-content fragment. See {@link ToXContentObject} for additional details.
+     */
     default boolean isFragment() {
         return true;
     }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -12,6 +12,7 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
+import java.io.IOException;
 import java.util.Iterator;
 
 /**
@@ -29,17 +30,25 @@ public interface ChunkedToXContent {
     Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params);
 
     /**
-     * Wraps the given instance in a {@link ToXContentObject} that will fully serialize the instance when serialized.
+     * Wraps the given instance in a {@link ToXContent} that will fully serialize the instance when serialized.
      * @param chunkedToXContent instance to wrap
-     * @return x-content object
+     * @return x-content instance
      */
-    static ToXContentObject wrapAsXContentObject(ChunkedToXContent chunkedToXContent) {
-        return (builder, params) -> {
-            Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked(params);
-            while (serialization.hasNext()) {
-                serialization.next().toXContent(builder, params);
+    static ToXContent wrapAsXContentObject(ChunkedToXContent chunkedToXContent) {
+        return new ToXContent() {
+            @Override
+            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+                Iterator<? extends ToXContent> serialization = chunkedToXContent.toXContentChunked(params);
+                while (serialization.hasNext()) {
+                    serialization.next().toXContent(builder, params);
+                }
+                return builder;
             }
-            return builder;
+
+            @Override
+            public boolean isFragment() {
+                return chunkedToXContent.isFragment();
+            }
         };
     }
 

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -34,7 +34,7 @@ public interface ChunkedToXContent {
      * @param chunkedToXContent instance to wrap
      * @return x-content instance
      */
-    static ToXContent wrapAsXContentObject(ChunkedToXContent chunkedToXContent) {
+    static ToXContent wrapAsToXContent(ChunkedToXContent chunkedToXContent) {
         return new ToXContent() {
             @Override
             public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentObject.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentObject.java
@@ -7,6 +7,9 @@
  */
 package org.elasticsearch.common.xcontent;
 
+/**
+ * Chunked equivalent of {@link org.elasticsearch.xcontent.ToXContentObject} that serializes as a full object.
+ */
 public interface ChunkedToXContentObject extends ChunkedToXContent {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentObject.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContentObject.java
@@ -1,0 +1,16 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.common.xcontent;
+
+public interface ChunkedToXContentObject extends ChunkedToXContent {
+
+    @Override
+    default boolean isFragment() {
+        return false;
+    }
+}

--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -1082,7 +1082,7 @@ public class PersistedClusterStateService {
 
         private void addGlobalMetadataDocuments(Metadata metadata) throws IOException {
             logger.trace("updating global metadata doc");
-            writePages(ChunkedToXContent.wrapAsXContentObject(metadata), (bytesRef, pageIndex, isLastPage) -> {
+            writePages(ChunkedToXContent.wrapAsToXContent(metadata), (bytesRef, pageIndex, isLastPage) -> {
                 final Document document = new Document();
                 document.add(new StringField(TYPE_FIELD_NAME, GLOBAL_TYPE_NAME, Field.Store.NO));
                 document.add(new StoredField(PAGE_FIELD_NAME, pageIndex));

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -275,7 +275,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         "metadata",
         METADATA_NAME_FORMAT,
         (repoName, parser) -> Metadata.fromXContent(parser),
-        ChunkedToXContent::wrapAsXContentObject
+        ChunkedToXContent::wrapAsToXContent
     );
 
     public static final ChecksumBlobStoreFormat<IndexMetadata> INDEX_METADATA_FORMAT = new ChecksumBlobStoreFormat<>(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalScriptedMetric.java
@@ -162,4 +162,8 @@ public class InternalScriptedMetric extends InternalAggregation implements Scrip
         return Objects.hash(super.hashCode(), reduceScript, aggregations);
     }
 
+    @Override
+    public String toString() {
+        return "InternalScriptedMetric{" + reduceScript + "}";
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
@@ -106,7 +106,7 @@ public class DesiredBalanceResponseTests extends AbstractWireSerializingTestCase
         DesiredBalanceResponse response = new DesiredBalanceResponse(randomStats(), randomRoutingTable());
 
         Map<String, Object> json = createParser(
-            ChunkedToXContent.wrapAsXContentObject(response).toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
+            ChunkedToXContent.wrapAsToXContent(response).toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS)
         ).map();
         assertEquals(Set.of("stats", "routing_table"), json.keySet());
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -892,9 +892,9 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         XContentBuilder builder = XContentFactory.contentBuilder(XContentType.JSON);
         if (byParents) {
             DiscoveryNodes nodes = testNodes[0].clusterService.state().nodes();
-            ChunkedToXContent.wrapAsXContentObject(response.groupedByNode(() -> nodes)).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(response.groupedByNode(() -> nodes)).toXContent(builder, ToXContent.EMPTY_PARAMS);
         } else {
-            ChunkedToXContent.wrapAsXContentObject(response.groupedByParent()).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(response.groupedByParent()).toXContent(builder, ToXContent.EMPTY_PARAMS);
         }
         builder.flush();
         logger.info(Strings.toString(builder));

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponseTests.java
@@ -165,8 +165,9 @@ public class GetSnapshotsResponseTests extends ESTestCase {
             .asMatchPredicate()
             .or(Pattern.compile("snapshots\\.\\d+\\.index_details").asMatchPredicate())
             .or(Pattern.compile("failures\\.*").asMatchPredicate());
-        chunkedXContentTester(this::createParser, (XContentType t) -> createTestInstance(), params, this::doParseInstance, false)
-            .numberOfTestRuns(1)
+        chunkedXContentTester(this::createParser, (XContentType t) -> createTestInstance(), params, this::doParseInstance).numberOfTestRuns(
+            1
+        )
             .supportsUnknownFields(true)
             .shuffleFieldsExceptions(Strings.EMPTY_ARRAY)
             .randomFieldsExcludeFilter(predicate)

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponseTests.java
@@ -112,7 +112,7 @@ public class FieldCapabilitiesResponseTests extends AbstractWireSerializingTestC
         boolean humanReadable = randomBoolean();
         XContentType xContentType = randomFrom(XContentType.values());
         BytesReference originalBytes = toShuffledXContent(
-            ChunkedToXContent.wrapAsXContentObject(randomResponse),
+            ChunkedToXContent.wrapAsToXContent(randomResponse),
             xContentType,
             ToXContent.EMPTY_PARAMS,
             humanReadable

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterInfoTests.java
@@ -44,12 +44,13 @@ public class ClusterInfoTests extends AbstractWireSerializingTestCase<ClusterInf
         Map<String, DiskUsage> builder = new HashMap<>(numEntries);
         for (int i = 0; i < numEntries; i++) {
             String key = randomAlphaOfLength(32);
+            final int totalBytes = randomIntBetween(0, Integer.MAX_VALUE);
             DiskUsage diskUsage = new DiskUsage(
                 randomAlphaOfLength(4),
                 randomAlphaOfLength(4),
                 randomAlphaOfLength(4),
-                randomIntBetween(0, Integer.MAX_VALUE),
-                randomIntBetween(0, Integer.MAX_VALUE)
+                totalBytes,
+                randomIntBetween(0, totalBytes)
             );
             builder.put(key, diskUsage);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/SnapshotDeletionsInProgressTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/SnapshotDeletionsInProgressTests.java
@@ -40,7 +40,7 @@ public class SnapshotDeletionsInProgressTests extends ESTestCase {
         try (XContentBuilder builder = jsonBuilder()) {
             builder.humanReadable(true);
             builder.startObject();
-            ChunkedToXContent.wrapAsXContentObject(sdip).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(sdip).toXContent(builder, ToXContent.EMPTY_PARAMS);
             builder.endObject();
             String json = Strings.toString(builder);
             assertThat(json, equalTo(XContentHelper.stripWhitespace("""

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -62,9 +62,4 @@ public class DataStreamMetadataTests extends AbstractChunkedSerializingTestCase<
     protected Writeable.Reader<DataStreamMetadata> instanceReader() {
         return DataStreamMetadata::new;
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodesMetadataSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodesMetadataSerializationTests.java
@@ -65,9 +65,4 @@ public class DesiredNodesMetadataSerializationTests extends ChunkedToXContentDif
     private DesiredNodesMetadata mutate(DesiredNodesMetadata base) {
         return new DesiredNodesMetadata(mutateDesiredNodes(base.getLatestDesiredNodes()));
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexGraveyardTests.java
@@ -11,10 +11,8 @@ package org.elasticsearch.cluster.metadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.common.xcontent.XContentElasticsearchExtension;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.test.ESTestCase;
@@ -70,15 +68,7 @@ public class IndexGraveyardTests extends ESTestCase {
         if (graveyard.getTombstones().size() > 0) {
             // check that date properly printed
             assertThat(
-                Strings.toString(
-                    ignored -> Iterators.concat(
-                        ChunkedToXContentHelper.startObject(),
-                        graveyard.toXContentChunked(ToXContent.EMPTY_PARAMS),
-                        ChunkedToXContentHelper.endObject()
-                    ),
-                    false,
-                    true
-                ),
+                Strings.toString(graveyard, false, true),
                 containsString(
                     XContentElasticsearchExtension.DEFAULT_FORMATTER.format(
                         Instant.ofEpochMilli(graveyard.getTombstones().get(0).getDeleteDateInMillis())

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
@@ -142,9 +142,4 @@ public class NodesShutdownMetadataTests extends ChunkedToXContentDiffableSeriali
     protected Metadata.Custom mutateInstance(Metadata.Custom instance) throws IOException {
         return makeTestChanges(instance);
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/ToAndFromJsonMetadataTests.java
@@ -227,7 +227,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
         Metadata metadata = buildMetadata();
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
+        ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
         builder.endObject();
 
         assertEquals(formatted("""
@@ -315,7 +315,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
             .build();
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
+        ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
         builder.endObject();
 
         assertEquals(formatted("""
@@ -386,7 +386,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
         Metadata metadata = buildMetadata();
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
+        ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
         builder.endObject();
 
         assertEquals(formatted("""
@@ -452,7 +452,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
 
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
+        ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
         builder.endObject();
 
         assertEquals(formatted("""
@@ -555,7 +555,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
 
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
+        ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
         builder.endObject();
 
         assertEquals(formatted("""
@@ -690,7 +690,7 @@ public class ToAndFromJsonMetadataTests extends ESTestCase {
 
         XContentBuilder builder = JsonXContent.contentBuilder().prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
+        ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, new ToXContent.MapParams(mapParams));
         builder.endObject();
 
         assertEquals(formatted("""

--- a/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestMetadataTests.java
@@ -49,7 +49,7 @@ public class IngestMetadataTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.contentBuilder(randomFrom(XContentType.values()));
         builder.prettyPrint();
         builder.startObject();
-        ChunkedToXContent.wrapAsXContentObject(ingestMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        ChunkedToXContent.wrapAsToXContent(ingestMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         XContentBuilder shuffled = shuffleXContent(builder);
         try (XContentParser parser = createParser(shuffled)) {

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
@@ -396,9 +396,4 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
         }
         return new Assignment(randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/ScriptMetadataTests.java
@@ -170,9 +170,4 @@ public class ScriptMetadataTests extends AbstractChunkedSerializingTestCase<Scri
             throw new UncheckedIOException(ioe);
         }
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/aggregation/AggregationProfileShardResultTests.java
@@ -27,8 +27,6 @@ import java.util.Map;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
-import static org.hamcrest.Matchers.emptyString;
-import static org.hamcrest.Matchers.not;
 
 public class AggregationProfileShardResultTests extends AbstractXContentSerializingTestCase<AggregationProfileShardResult> {
 
@@ -118,12 +116,6 @@ public class AggregationProfileShardResultTests extends AbstractXContentSerializ
                 }
               ]
             }"""), xContent.utf8ToString());
-    }
-
-    public void testToString() {
-        final String toString = createTestInstance().toString();
-        assertNotNull(toString);
-        assertThat(toString, not(emptyString()));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
+++ b/server/src/test/java/org/elasticsearch/search/sort/SortValueTests.java
@@ -242,4 +242,10 @@ public class SortValueTests extends AbstractNamedWriteableTestCase<SortValue> {
             }
         });
     }
+
+    @Override
+    public void testToString() throws Exception {
+        // override parent since empty sort value serializes to empty string
+        assertNotNull(createTestInstance().toString());
+    }
 }

--- a/server/src/test/java/org/elasticsearch/snapshots/RepositoriesMetadataSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/RepositoriesMetadataSerializationTests.java
@@ -116,9 +116,4 @@ public class RepositoriesMetadataSerializationTests extends ChunkedToXContentDif
         repos.sort(Comparator.comparing(RepositoryMetadata::name));
         return new RepositoriesMetadata(repos);
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/server/src/test/java/org/elasticsearch/tasks/CancelTasksResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/CancelTasksResponseTests.java
@@ -36,7 +36,7 @@ public class CancelTasksResponseTests extends AbstractXContentTestCase<CancelTas
     public record CancelTasksResponseWrapper(CancelTasksResponse in) implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, ToXContent.Params params) throws IOException {
-            return ChunkedToXContent.wrapAsXContentObject(in.groupedByNone()).toXContent(builder, params);
+            return ChunkedToXContent.wrapAsToXContent(in.groupedByNone()).toXContent(builder, params);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/tasks/ListTasksResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/ListTasksResponseTests.java
@@ -42,7 +42,7 @@ public class ListTasksResponseTests extends AbstractXContentTestCase<ListTasksRe
     public record ListTasksResponseWrapper(ListTasksResponse in) implements ToXContentObject {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return ChunkedToXContent.wrapAsXContentObject(in.groupedByNone()).toXContent(builder, params);
+            return ChunkedToXContent.wrapAsToXContent(in.groupedByNone()).toXContent(builder, params);
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/upgrades/FeatureMigrationResultsTests.java
+++ b/server/src/test/java/org/elasticsearch/upgrades/FeatureMigrationResultsTests.java
@@ -72,9 +72,4 @@ public class FeatureMigrationResultsTests extends ChunkedToXContentDiffableSeria
     protected Writeable.Reader<Diff<Metadata.Custom>> diffReader() {
         return FeatureMigrationResults.ResultsDiff::new;
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
@@ -27,7 +27,7 @@ public abstract class AbstractChunkedSerializingTestCase<T extends ChunkedToXCon
 
     @Override
     protected ToXContent asXContent(T instance) {
-        return ChunkedToXContent.wrapAsXContentObject(instance);
+        return ChunkedToXContent.wrapAsToXContent(instance);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
@@ -23,18 +23,12 @@ public abstract class AbstractChunkedSerializingTestCase<T extends ChunkedToXCon
 
     @Override
     protected AbstractXContentTestCase.XContentTester<T> createXContentTester() {
-        return chunkedXContentTester(
-            this::createParser,
-            this::createXContextTestInstance,
-            getToXContentParams(),
-            this::doParseInstance,
-            isFragment()
-        );
+        return chunkedXContentTester(this::createParser, this::createXContextTestInstance, getToXContentParams(), this::doParseInstance);
     }
 
     @Override
     protected ToXContent asXContent(T instance) {
-        if (isFragment()) {
+        if (instance.isFragment()) {
             return (ToXContentObject) ((builder, params) -> {
                 builder.startObject();
                 ChunkedToXContent.wrapAsXContentObject(instance).toXContent(builder, params);
@@ -53,8 +47,4 @@ public abstract class AbstractChunkedSerializingTestCase<T extends ChunkedToXCon
      * Parses to a new instance using the provided {@link XContentParser}
      */
     protected abstract T doParseInstance(XContentParser parser) throws IOException;
-
-    protected boolean isFragment() {
-        return false;
-    }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractChunkedSerializingTestCase.java
@@ -11,7 +11,6 @@ package org.elasticsearch.test;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -28,13 +27,6 @@ public abstract class AbstractChunkedSerializingTestCase<T extends ChunkedToXCon
 
     @Override
     protected ToXContent asXContent(T instance) {
-        if (instance.isFragment()) {
-            return (ToXContentObject) ((builder, params) -> {
-                builder.startObject();
-                ChunkedToXContent.wrapAsXContentObject(instance).toXContent(builder, params);
-                return builder.endObject();
-            });
-        }
         return ChunkedToXContent.wrapAsXContentObject(instance);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractWireTestCase.java
@@ -23,7 +23,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
+import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
 
 /**
  * Standard test case for testing wire serialization. If the class being tested
@@ -110,7 +112,7 @@ public abstract class AbstractWireTestCase<T> extends ESTestCase {
      * some hashCode implementations violate this assumption and it's very
      * surprising. This tries to fail when that assumption is violated.
      */
-    public final void testConcurrentHashCode() throws IOException, InterruptedException, ExecutionException {
+    public final void testConcurrentHashCode() throws InterruptedException, ExecutionException {
         T testInstance = createTestInstance();
         int firstHashCode = testInstance.hashCode();
 
@@ -125,6 +127,12 @@ public abstract class AbstractWireTestCase<T> extends ESTestCase {
                 assertEquals(firstHashCode, testInstance.hashCode());
             }
         });
+    }
+
+    public void testToString() throws Exception {
+        final String toString = createTestInstance().toString();
+        assertNotNull(toString);
+        assertThat(toString, not(emptyString()));
     }
 
     /**
@@ -148,7 +156,7 @@ public abstract class AbstractWireTestCase<T> extends ESTestCase {
      * operations like {@link ToXContent#toXContent}. This doesn't
      * check that exactly, but it's close.
      */
-    public final void testConcurrentSerialization() throws IOException, InterruptedException, ExecutionException {
+    public final void testConcurrentSerialization() throws InterruptedException, ExecutionException {
         T testInstance = createTestInstance();
 
         /*

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractXContentTestCase.java
@@ -87,19 +87,18 @@ public abstract class AbstractXContentTestCase<T extends ToXContent> extends EST
         CheckedBiFunction<XContent, BytesReference, XContentParser, IOException> createParser,
         Function<XContentType, T> instanceSupplier,
         ToXContent.Params toXContentParams,
-        CheckedFunction<XContentParser, T, IOException> fromXContent,
-        boolean fragment
+        CheckedFunction<XContentParser, T, IOException> fromXContent
     ) {
         return new XContentTester<>(createParser, instanceSupplier, (testInstance, xContentType) -> {
             try (XContentBuilder builder = XContentBuilder.builder(xContentType.xContent())) {
                 var serialization = testInstance.toXContentChunked(toXContentParams);
-                if (fragment) {
+                if (testInstance.isFragment()) {
                     builder.startObject();
                 }
                 while (serialization.hasNext()) {
                     serialization.next().toXContent(builder, toXContentParams);
                 }
-                if (fragment) {
+                if (testInstance.isFragment()) {
                     builder.endObject();
                 }
                 return BytesReference.bytes(builder);

--- a/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESIntegTestCase.java
@@ -1162,13 +1162,13 @@ public abstract class ESIntegTestCase extends ESTestCase {
 
                 XContentBuilder builder = SmileXContent.contentBuilder();
                 builder.startObject();
-                ChunkedToXContent.wrapAsXContentObject(metadataWithoutIndices).toXContent(builder, serializationFormatParams);
+                ChunkedToXContent.wrapAsToXContent(metadataWithoutIndices).toXContent(builder, serializationFormatParams);
                 builder.endObject();
                 final BytesReference originalBytes = BytesReference.bytes(builder);
 
                 XContentBuilder compareBuilder = SmileXContent.contentBuilder();
                 compareBuilder.startObject();
-                ChunkedToXContent.wrapAsXContentObject(metadataWithoutIndices).toXContent(compareBuilder, compareFormatParams);
+                ChunkedToXContent.wrapAsToXContent(metadataWithoutIndices).toXContent(compareBuilder, compareFormatParams);
                 compareBuilder.endObject();
                 final BytesReference compareOriginalBytes = BytesReference.bytes(compareBuilder);
 
@@ -1184,7 +1184,7 @@ public abstract class ESIntegTestCase extends ESTestCase {
                 }
                 builder = SmileXContent.contentBuilder();
                 builder.startObject();
-                ChunkedToXContent.wrapAsXContentObject(loadedMetadata).toXContent(builder, compareFormatParams);
+                ChunkedToXContent.wrapAsToXContent(loadedMetadata).toXContent(builder, compareFormatParams);
                 builder.endObject();
                 final BytesReference parsedBytes = BytesReference.bytes(builder);
 

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadataDiffableSerializationTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/AutoscalingMetadataDiffableSerializationTests.java
@@ -77,9 +77,4 @@ public class AutoscalingMetadataDiffableSerializationTests extends ChunkedToXCon
     protected Writeable.Reader<Diff<Metadata.Custom>> diffReader() {
         return AutoscalingMetadata.AutoscalingMetadataDiff::new;
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/AutoFollowMetadataTests.java
@@ -80,9 +80,4 @@ public class AutoFollowMetadataTests extends AbstractChunkedSerializingTestCase<
     protected Writeable.Reader<AutoFollowMetadata> instanceReader() {
         return AutoFollowMetadata::new;
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/FollowInfoAction.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentObject;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.ToXContentObject;
@@ -81,7 +81,7 @@ public class FollowInfoAction extends ActionType<FollowInfoAction.Response> {
         }
     }
 
-    public static class Response extends ActionResponse implements ChunkedToXContent {
+    public static class Response extends ActionResponse implements ChunkedToXContentObject {
 
         public static final ParseField FOLLOWER_INDICES_FIELD = new ParseField("follower_indices");
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/transport/actions/stats/WatcherStatsResponse.java
@@ -64,7 +64,7 @@ public class WatcherStatsResponse extends BaseNodesResponse<WatcherStatsResponse
 
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        ChunkedToXContent.wrapAsXContentObject(watcherMetadata).toXContent(builder, params);
+        ChunkedToXContent.wrapAsToXContent(watcherMetadata).toXContent(builder, params);
         builder.startArray("stats");
         for (Node node : getNodes()) {
             node.toXContent(builder, params);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesMetadataSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/license/LicensesMetadataSerializationTests.java
@@ -39,7 +39,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject("licenses");
-        ChunkedToXContent.wrapAsXContentObject(licensesMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        ChunkedToXContent.wrapAsToXContent(licensesMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         builder.endObject();
         LicensesMetadata licensesMetadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));
@@ -53,7 +53,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject("licenses");
-        ChunkedToXContent.wrapAsXContentObject(licensesMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        ChunkedToXContent.wrapAsToXContent(licensesMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         builder.endObject();
         LicensesMetadata licensesMetadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));
@@ -79,7 +79,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         Params params = new ToXContent.MapParams(Collections.singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY));
         builder.startObject();
-        builder = ChunkedToXContent.wrapAsXContentObject(metadataBuilder.build()).toXContent(builder, params);
+        builder = ChunkedToXContent.wrapAsToXContent(metadataBuilder.build()).toXContent(builder, params);
         builder.endObject();
         // deserialize metadata again
         Metadata metadata = Metadata.Builder.fromXContent(createParser(builder));
@@ -102,7 +102,7 @@ public class LicensesMetadataSerializationTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject("licenses");
-        ChunkedToXContent.wrapAsXContentObject(licensesMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        ChunkedToXContent.wrapAsToXContent(licensesMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         builder.endObject();
         LicensesMetadata licensesMetadataFromXContent = getLicensesMetadataFromXContent(createParser(builder));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleOperationMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleOperationMetadataTests.java
@@ -51,11 +51,6 @@ public class LifecycleOperationMetadataTests extends AbstractChunkedSerializingT
         }
     }
 
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
-
     public void testMinimumSupportedVersion() {
         Version min = createTestInstance().getMinimalSupportedVersion();
         assertTrue(min.onOrBefore(VersionUtils.randomVersionBetween(random(), Version.V_8_7_0, Version.CURRENT)));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadataTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadataTests.java
@@ -41,9 +41,4 @@ public class SnapshotLifecycleMetadataTests extends AbstractChunkedSerializingTe
     protected Writeable.Reader<SnapshotLifecycleMetadata> instanceReader() {
         return SnapshotLifecycleMetadata::new;
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichMetadataTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichMetadataTests.java
@@ -61,9 +61,4 @@ public class EnrichMetadataTests extends AbstractChunkedSerializingTestCase<Enri
             EnrichPolicyTests.assertEqualPolicies(expected, actual);
         }
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleMetadataTests.java
@@ -212,9 +212,4 @@ public class IndexLifecycleMetadataTests extends ChunkedToXContentDiffableSerial
         }
         return new IndexLifecycleMetadata(policies, mode);
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/PolicyStepsRegistryTests.java
@@ -238,7 +238,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             .build();
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();
-            ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
             builder.endObject();
             logger.info("--> metadata: {}", Strings.toString(builder));
         }
@@ -407,7 +407,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
             .build();
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();
-            ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
             builder.endObject();
             logger.info("--> metadata: {}", Strings.toString(builder));
         }
@@ -448,7 +448,7 @@ public class PolicyStepsRegistryTests extends ESTestCase {
         metadata = Metadata.builder(metadata).putCustom(IndexLifecycleMetadata.TYPE, lifecycleMetadata).build();
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             builder.startObject();
-            ChunkedToXContent.wrapAsXContentObject(metadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+            ChunkedToXContent.wrapAsToXContent(metadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
             builder.endObject();
             logger.info("--> metadata: {}", Strings.toString(builder));
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetadataTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlMetadataTests.java
@@ -71,9 +71,4 @@ public class MlMetadataTests extends AbstractChunkedSerializingTestCase<MlMetada
 
         return metadataBuilder.build();
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadataTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadataTests.java
@@ -71,9 +71,4 @@ public class TrainedModelAssignmentMetadataTests extends AbstractChunkedSerializ
             randomFrom(Priority.values())
         );
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformMetadataTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/TransformMetadataTests.java
@@ -33,9 +33,4 @@ public class TransformMetadataTests extends AbstractChunkedSerializingTestCase<T
     protected TransformMetadata mutateInstance(TransformMetadata instance) {
         return new TransformMetadata.Builder().isResetMode(instance.isResetMode() == false).build();
     }
-
-    @Override
-    protected boolean isFragment() {
-        return true;
-    }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherMetadataSerializationTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherMetadataSerializationTests.java
@@ -36,7 +36,7 @@ public class WatcherMetadataSerializationTests extends ESTestCase {
         XContentBuilder builder = XContentFactory.jsonBuilder();
         builder.startObject();
         builder.startObject("watcher");
-        ChunkedToXContent.wrapAsXContentObject(watcherMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
+        ChunkedToXContent.wrapAsToXContent(watcherMetadata).toXContent(builder, ToXContent.EMPTY_PARAMS);
         builder.endObject();
         builder.endObject();
         WatcherMetadata watchersMetadataFromXContent = getWatcherMetadataFromXContent(createParser(builder));
@@ -64,7 +64,7 @@ public class WatcherMetadataSerializationTests extends ESTestCase {
             Collections.singletonMap(Metadata.CONTEXT_MODE_PARAM, Metadata.CONTEXT_MODE_GATEWAY)
         );
         builder.startObject();
-        builder = ChunkedToXContent.wrapAsXContentObject(metadataBuilder.build()).toXContent(builder, params);
+        builder = ChunkedToXContent.wrapAsToXContent(metadataBuilder.build()).toXContent(builder, params);
         builder.endObject();
         // deserialize metadata again
         Metadata metadata = Metadata.Builder.fromXContent(createParser(builder));


### PR DESCRIPTION
Aligning how chunked and normal `ToXContent` work here and simplifying spots where it matters whether or not something is a fragment or not.
This fixes broken `toString` for all kinds of classes and adds a test that makes sure the implementation at least produces a result and doesn't throw. 
