### PR TITLE
Reuse scripted runtime fields error handling in script-less runtime fields

### DIFF
--- a/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/AbstractFieldScript.java
@@ -119,7 +119,9 @@ public abstract class AbstractFieldScript extends DocBasedScript {
 
     protected final void emitFromSource() {
         for (Object v : extractFromSource(fieldName)) {
-            emitFromObject(v);
+            if (v != null) {
+                emitFromObject(v);
+            }
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
@@ -113,12 +113,8 @@ public abstract class BooleanFieldScript extends AbstractFieldScript {
     protected final void emitFromObject(Object v) {
         if (v instanceof Boolean) {
             emit((Boolean) v);
-        } else if (v instanceof String) {
-            try {
-                emit(Booleans.parseBoolean((String) v));
-            } catch (IllegalArgumentException e) {
-                // ignore
-            }
+        } else {
+            emit(Booleans.parseBoolean(v.toString()));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/BooleanFieldScript.java
@@ -24,7 +24,7 @@ public abstract class BooleanFieldScript extends AbstractFieldScript {
     public static final Factory PARSE_FROM_SOURCE = new Factory() {
         @Override
         public LeafFactory newFactory(String field, Map<String, Object> params, SearchLookup lookup, OnScriptError onScriptError) {
-            return ctx -> new BooleanFieldScript(field, params, lookup, OnScriptError.FAIL, ctx) {
+            return ctx -> new BooleanFieldScript(field, params, lookup, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();

--- a/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DateFieldScript.java
@@ -14,7 +14,6 @@ import org.elasticsearch.index.mapper.OnScriptError;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.util.Map;
-import java.util.Objects;
 import java.util.function.Function;
 
 public abstract class DateFieldScript extends AbstractLongFieldScript {
@@ -29,7 +28,7 @@ public abstract class DateFieldScript extends AbstractLongFieldScript {
             DateFormatter formatter,
             OnScriptError onScriptError
         ) {
-            return ctx -> new DateFieldScript(field, params, lookup, formatter, OnScriptError.FAIL, ctx) {
+            return ctx -> new DateFieldScript(field, params, lookup, formatter, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();
@@ -96,11 +95,7 @@ public abstract class DateFieldScript extends AbstractLongFieldScript {
 
     @Override
     protected void emitFromObject(Object v) {
-        try {
-            emit(formatter.parseMillis(Objects.toString(v)));
-        } catch (Exception e) {
-            // ignore
-        }
+        emit(formatter.parseMillis(v.toString()));
     }
 
     public static class Emit {

--- a/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/DoubleFieldScript.java
@@ -23,7 +23,7 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
     public static final Factory PARSE_FROM_SOURCE = new Factory() {
         @Override
         public LeafFactory newFactory(String field, Map<String, Object> params, SearchLookup lookup, OnScriptError onScriptError) {
-            return ctx -> new DoubleFieldScript(field, params, lookup, OnScriptError.FAIL, ctx) {
+            return ctx -> new DoubleFieldScript(field, params, lookup, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();
@@ -117,12 +117,8 @@ public abstract class DoubleFieldScript extends AbstractFieldScript {
     protected void emitFromObject(Object v) {
         if (v instanceof Number) {
             emit(((Number) v).doubleValue());
-        } else if (v instanceof String) {
-            try {
-                emit(Double.parseDouble((String) v));
-            } catch (NumberFormatException e) {
-                // ignore
-            }
+        } else {
+            emit(Double.parseDouble(v.toString()));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/GeoPointFieldScript.java
@@ -33,7 +33,7 @@ public abstract class GeoPointFieldScript extends AbstractFieldScript {
     public static final Factory PARSE_FROM_SOURCE = new Factory() {
         @Override
         public LeafFactory newFactory(String field, Map<String, Object> params, SearchLookup lookup, OnScriptError onScriptError) {
-            return ctx -> new GeoPointFieldScript(field, params, lookup, OnScriptError.FAIL, ctx) {
+            return ctx -> new GeoPointFieldScript(field, params, lookup, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();
@@ -169,14 +169,8 @@ public abstract class GeoPointFieldScript extends AbstractFieldScript {
     }
 
     private void emitPoint(Object point) {
-        if (point != null) {
-            try {
-                GeoPoint geoPoint = GeoUtils.parseGeoPoint(point, true);
-                emit(geoPoint.lat(), geoPoint.lon());
-            } catch (Exception e) {
-                emit(0, 0);
-            }
-        }
+        GeoPoint geoPoint = GeoUtils.parseGeoPoint(point, true);
+        emit(geoPoint.lat(), geoPoint.lon());
     }
 
     protected final void emit(double lat, double lon) {

--- a/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/IpFieldScript.java
@@ -44,7 +44,7 @@ public abstract class IpFieldScript extends AbstractFieldScript {
     public static final Factory PARSE_FROM_SOURCE = new Factory() {
         @Override
         public LeafFactory newFactory(String field, Map<String, Object> params, SearchLookup lookup, OnScriptError onScriptError) {
-            return ctx -> new IpFieldScript(field, params, lookup, OnScriptError.FAIL, ctx) {
+            return ctx -> new IpFieldScript(field, params, lookup, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();
@@ -136,13 +136,7 @@ public abstract class IpFieldScript extends AbstractFieldScript {
 
     @Override
     protected void emitFromObject(Object v) {
-        if (v instanceof String) {
-            try {
-                emit((String) v);
-            } catch (Exception e) {
-                // ignore parsing exceptions
-            }
-        }
+        emit(v.toString());
     }
 
     public final void emit(String v) {

--- a/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/LongFieldScript.java
@@ -22,7 +22,7 @@ public abstract class LongFieldScript extends AbstractLongFieldScript {
     public static final Factory PARSE_FROM_SOURCE = new Factory() {
         @Override
         public LeafFactory newFactory(String field, Map<String, Object> params, SearchLookup lookup, OnScriptError onScriptError) {
-            return ctx -> new LongFieldScript(field, params, lookup, OnScriptError.FAIL, ctx) {
+            return ctx -> new LongFieldScript(field, params, lookup, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();
@@ -79,11 +79,7 @@ public abstract class LongFieldScript extends AbstractLongFieldScript {
 
     @Override
     protected void emitFromObject(Object v) {
-        try {
-            emit(NumberFieldMapper.NumberType.objectToLong(v, true));
-        } catch (Exception e) {
-            // ignore;
-        }
+        emit(NumberFieldMapper.NumberType.objectToLong(v, true));
     }
 
     public static class Emit {

--- a/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
+++ b/server/src/main/java/org/elasticsearch/script/StringFieldScript.java
@@ -30,7 +30,7 @@ public abstract class StringFieldScript extends AbstractFieldScript {
     public static final StringFieldScript.Factory PARSE_FROM_SOURCE = new Factory() {
         @Override
         public LeafFactory newFactory(String field, Map<String, Object> params, SearchLookup lookup, OnScriptError onScriptError) {
-            return ctx -> new StringFieldScript(field, params, lookup, OnScriptError.FAIL, ctx) {
+            return ctx -> new StringFieldScript(field, params, lookup, OnScriptError.CONTINUE, ctx) {
                 @Override
                 public void execute() {
                     emitFromSource();


### PR DESCRIPTION
We recently introduced configurable error handling for runtime fields through the `on_script_error` mappings parameter (see #92380). Script-less runtime fields are though lenient by definition and non-configurable. That means that whenever there is an error in loading the field value from _source, the value will be ignored (equivalent behaviour to `on_script_error: continue` for scripted runtime fields).

This commit removes the error handling code that's specific for script-less runtime fields, in favour of reusing the common runtime fields error handling mechanism and harcoding `continue` as the only option for script-less runtime fields.

Note that this change does not change anything from a user perspective: script-less runtime fields don't support configuring `on_script_error` and all that matters is that errors are ignored for them at all times.
