### PR TITLE
[8.6] Add support for keystore secure settings to test clusters (#92554)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -30,6 +30,7 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
     private final Set<String> modules = new HashSet<>();
     private final Set<String> plugins = new HashSet<>();
     private final Set<FeatureFlag> features = new HashSet<>();
+    private final Map<String, String> keystoreSettings = new HashMap<>();
     private DistributionType distributionType;
 
     protected AbstractLocalSpecBuilder(AbstractLocalSpecBuilder<?> parent) {
@@ -121,6 +122,16 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
 
     Set<FeatureFlag> getFeatures() {
         return inherit(() -> parent.getFeatures(), features);
+    }
+
+    @Override
+    public T keystore(String key, String value) {
+        this.keystoreSettings.put(key, value);
+        return cast(this);
+    }
+
+    public Map<String, String> getKeystoreSettings() {
+        return inherit(() -> parent.getKeystoreSettings(), keystoreSettings);
     }
 
     private <T> List<T> inherit(Supplier<List<T>> parent, List<T> child) {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -145,7 +145,8 @@ public class DefaultLocalClusterSpecBuilder extends AbstractLocalSpecBuilder<Loc
                 getModules(),
                 getPlugins(),
                 Optional.ofNullable(getDistributionType()).orElse(DistributionType.INTEG_TEST),
-                getFeatures()
+                getFeatures(),
+                getKeystoreSettings()
             );
         }
     }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -78,6 +78,7 @@ public class LocalClusterSpec implements ClusterSpec {
         private final Set<String> plugins;
         private final DistributionType distributionType;
         private final Set<FeatureFlag> features;
+        private final Map<String, String> keystoreSettings;
 
         public LocalNodeSpec(
             LocalClusterSpec cluster,
@@ -90,7 +91,8 @@ public class LocalClusterSpec implements ClusterSpec {
             Set<String> modules,
             Set<String> plugins,
             DistributionType distributionType,
-            Set<FeatureFlag> features
+            Set<FeatureFlag> features,
+            Map<String, String> keystoreSettings
         ) {
             this.cluster = cluster;
             this.name = name;
@@ -103,6 +105,7 @@ public class LocalClusterSpec implements ClusterSpec {
             this.plugins = plugins;
             this.distributionType = distributionType;
             this.features = features;
+            this.keystoreSettings = keystoreSettings;
         }
 
         public LocalClusterSpec getCluster() {
@@ -139,6 +142,10 @@ public class LocalClusterSpec implements ClusterSpec {
 
         public Set<FeatureFlag> getFeatures() {
             return features;
+        }
+
+        public Map<String, String> getKeystoreSettings() {
+            return keystoreSettings;
         }
 
         public boolean isSecurityEnabled() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
@@ -61,4 +61,9 @@ interface LocalSpecBuilder<T extends LocalSpecBuilder<?>> {
      * Require feature to be enabled in the cluster.
      */
     T feature(FeatureFlag feature);
+
+    /**
+     * Adds a secure setting to the node keystore.
+     */
+    T keystore(String key, String value);
 }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Add support for keystore secure settings to test clusters (#92554)