### PR TITLE
Fix tokenization bug in tests random seed

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
@@ -112,7 +112,7 @@ public class BuildParams {
     }
 
     public static Random getRandom() {
-        return new Random(Long.parseUnsignedLong(testSeed.split(":", 1)[0], 16));
+        return new Random(Long.parseUnsignedLong(testSeed.split(":")[0], 16));
     }
 
     public static Boolean isCi() {


### PR DESCRIPTION
In the PR https://github.com/elastic/elasticsearch/pull/91674, the code `testSeed.tokenize(":").get(0)` was replaced by `testSeed.split(":", 1)[0]`. While this looks similar, the additional `limit=1` parameter causes the split to not split seeds that contain the `:` character.

So the behaviour changed. Previously we could pass a seed like:

    -Dtests.seed="B0B1C513BDAD728B:B58532497A958B86"

obtained from running tests with `-Dtests.iters=100`, and this would be understood correctly and reproduce the failure. However, with the move to `split(":", 1)[0]`, the entire string (including the `:` character) is used in the next function call (eg. `Long .parseUnsignedLong()` which causes a parse error.

We do not need to revert to using `tokenize` to get the original behaviour, we simply need to remove the `limit=1` parameter.
