### PR TITLE
Trace log level for remote access check

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -295,7 +295,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
                 }
 
                 if (false == REMOTE_ACCESS_ACTION_ALLOWLIST.contains(action)) {
-                    logger.info("Action [{}] towards remote cluster [{}] is not allow-listed", action, remoteClusterAlias);
+                    logger.trace("Action [{}] towards remote cluster [{}] is not allow-listed", action, remoteClusterAlias);
                     return Optional.empty();
                 }
 


### PR DESCRIPTION
Fixing the log level for a log line that should be `TRACE`, not `INFO`.