### PR TITLE
Refactor Watcher webhook execution into WebhookService

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -131,6 +131,7 @@ import org.elasticsearch.xpack.watcher.input.simple.SimpleInputFactory;
 import org.elasticsearch.xpack.watcher.input.transform.TransformInput;
 import org.elasticsearch.xpack.watcher.input.transform.TransformInputFactory;
 import org.elasticsearch.xpack.watcher.notification.NotificationService;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 import org.elasticsearch.xpack.watcher.notification.email.Account;
 import org.elasticsearch.xpack.watcher.notification.email.EmailService;
 import org.elasticsearch.xpack.watcher.notification.email.HtmlSanitizer;
@@ -341,11 +342,13 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         JiraService jiraService = new JiraService(settings, httpClient, clusterService.getClusterSettings());
         SlackService slackService = new SlackService(settings, httpClient, clusterService.getClusterSettings());
         PagerDutyService pagerDutyService = new PagerDutyService(settings, httpClient, clusterService.getClusterSettings());
+        WebhookService webhookService = new WebhookService(settings, httpClient, clusterService.getClusterSettings());
 
         reloadableServices.add(emailService);
         reloadableServices.add(jiraService);
         reloadableServices.add(slackService);
         reloadableServices.add(pagerDutyService);
+        reloadableServices.add(webhookService);
 
         TextTemplateEngine templateEngine = new TextTemplateEngine(scriptService);
         Map<String, EmailAttachmentParser<?>> emailAttachmentParsers = new HashMap<>();
@@ -386,7 +389,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         // actions
         final Map<String, ActionFactory> actionFactoryMap = new HashMap<>();
         actionFactoryMap.put(EmailAction.TYPE, new EmailActionFactory(settings, emailService, templateEngine, emailAttachmentsParser));
-        actionFactoryMap.put(WebhookAction.TYPE, new WebhookActionFactory(httpClient, templateEngine));
+        actionFactoryMap.put(WebhookAction.TYPE, new WebhookActionFactory(webhookService, templateEngine));
         actionFactoryMap.put(IndexAction.TYPE, new IndexActionFactory(settings, client));
         actionFactoryMap.put(LoggingAction.TYPE, new LoggingActionFactory(templateEngine));
         actionFactoryMap.put(JiraAction.TYPE, new JiraActionFactory(templateEngine, jiraService));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/webhook/ExecutableWebhookAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/webhook/ExecutableWebhookAction.java
@@ -11,41 +11,22 @@ import org.elasticsearch.xpack.core.watcher.actions.Action;
 import org.elasticsearch.xpack.core.watcher.actions.ExecutableAction;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
-import org.elasticsearch.xpack.watcher.common.http.HttpClient;
-import org.elasticsearch.xpack.watcher.common.http.HttpRequest;
-import org.elasticsearch.xpack.watcher.common.http.HttpResponse;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
-import org.elasticsearch.xpack.watcher.support.Variables;
-
-import java.util.Map;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 
 public class ExecutableWebhookAction extends ExecutableAction<WebhookAction> {
 
-    private final HttpClient httpClient;
+    private final WebhookService webhookService;
     private final TextTemplateEngine templateEngine;
 
-    public ExecutableWebhookAction(WebhookAction action, Logger logger, HttpClient httpClient, TextTemplateEngine templateEngine) {
+    public ExecutableWebhookAction(WebhookAction action, Logger logger, WebhookService webhookService, TextTemplateEngine templateEngine) {
         super(action, logger);
-        this.httpClient = httpClient;
+        this.webhookService = webhookService;
         this.templateEngine = templateEngine;
     }
 
     @Override
     public Action.Result execute(String actionId, WatchExecutionContext ctx, Payload payload) throws Exception {
-        Map<String, Object> model = Variables.createCtxParamsMap(ctx, payload);
-
-        HttpRequest request = action.requestTemplate.render(templateEngine, model);
-
-        if (ctx.simulateAction(actionId)) {
-            return new WebhookAction.Result.Simulated(request);
-        }
-
-        HttpResponse response = httpClient.execute(request);
-
-        if (response.status() >= 400) {
-            return new WebhookAction.Result.Failure(request, response);
-        } else {
-            return new WebhookAction.Result.Success(request, response);
-        }
+        return webhookService.execute(actionId, action, templateEngine, ctx, payload);
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookActionFactory.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookActionFactory.java
@@ -9,25 +9,25 @@ package org.elasticsearch.xpack.watcher.actions.webhook;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.watcher.actions.ActionFactory;
-import org.elasticsearch.xpack.watcher.common.http.HttpClient;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 
 import java.io.IOException;
 
 public class WebhookActionFactory extends ActionFactory {
 
-    private final HttpClient httpClient;
     private final TextTemplateEngine templateEngine;
+    private final WebhookService webhookService;
 
-    public WebhookActionFactory(HttpClient httpClient, TextTemplateEngine templateEngine) {
+    public WebhookActionFactory(WebhookService webhookService, TextTemplateEngine templateEngine) {
         super(LogManager.getLogger(ExecutableWebhookAction.class));
-        this.httpClient = httpClient;
         this.templateEngine = templateEngine;
+        this.webhookService = webhookService;
     }
 
     @Override
     public ExecutableWebhookAction parseExecutable(String watchId, String actionId, XContentParser parser) throws IOException {
-        return new ExecutableWebhookAction(WebhookAction.parse(watchId, actionId, parser), actionLogger, httpClient, templateEngine);
+        return new ExecutableWebhookAction(WebhookAction.parse(watchId, actionId, parser), actionLogger, webhookService, templateEngine);
 
     }
 }

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.watcher.notification;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Setting;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.core.watcher.actions.Action;
+import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
+import org.elasticsearch.xpack.core.watcher.watch.Payload;
+import org.elasticsearch.xpack.watcher.actions.webhook.WebhookAction;
+import org.elasticsearch.xpack.watcher.common.http.HttpClient;
+import org.elasticsearch.xpack.watcher.common.http.HttpRequest;
+import org.elasticsearch.xpack.watcher.common.http.HttpResponse;
+import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.support.Variables;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * The WebhookService class handles executing webhook requests for Watcher actions. These can be
+ * regular "webhook" actions as well as parts of an "email" action with attachments that make HTTP
+ * requests.
+ */
+public class WebhookService extends NotificationService<WebhookService.WebhookAccount> {
+
+    private final HttpClient httpClient;
+
+    public WebhookService(Settings settings, HttpClient httpClient, ClusterSettings clusterSettings) {
+        super("webhook", settings, clusterSettings, List.of(), getSecureSettings());
+        this.httpClient = httpClient;
+        // do an initial load
+        reload(settings);
+    }
+
+    private static List<Setting<?>> getSecureSettings() {
+        return List.of();
+    }
+
+    @Override
+    protected WebhookAccount createAccount(String name, Settings accountSettings) {
+        return new WebhookAccount();
+    }
+
+    public Action.Result execute(
+        String actionId,
+        WebhookAction action,
+        TextTemplateEngine templateEngine,
+        WatchExecutionContext ctx,
+        Payload payload
+    ) throws IOException {
+        Map<String, Object> model = Variables.createCtxParamsMap(ctx, payload);
+
+        HttpRequest request = action.getRequest().render(templateEngine, model);
+
+        if (ctx.simulateAction(actionId)) {
+            return new WebhookAction.Result.Simulated(request);
+        }
+
+        HttpResponse response = httpClient.execute(request);
+
+        if (response.status() >= 400) {
+            return new WebhookAction.Result.Failure(request, response);
+        } else {
+            return new WebhookAction.Result.Success(request, response);
+        }
+    }
+
+    public static final class WebhookAccount {}
+}

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatcherTestUtils.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/WatcherTestUtils.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.TimeValue;
@@ -43,6 +44,7 @@ import org.elasticsearch.xpack.watcher.condition.InternalAlwaysCondition;
 import org.elasticsearch.xpack.watcher.execution.TriggeredExecutionContext;
 import org.elasticsearch.xpack.watcher.input.simple.ExecutableSimpleInput;
 import org.elasticsearch.xpack.watcher.input.simple.SimpleInput;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 import org.elasticsearch.xpack.watcher.notification.email.Authentication;
 import org.elasticsearch.xpack.watcher.notification.email.EmailService;
 import org.elasticsearch.xpack.watcher.notification.email.EmailTemplate;
@@ -179,13 +181,19 @@ public final class WatcherTestUtils {
         httpRequest.method(HttpMethod.POST);
         httpRequest.path(new TextTemplate("/foobarbaz/{{ctx.watch_id}}"));
         httpRequest.body(new TextTemplate("{{ctx.watch_id}} executed with {{ctx.payload.response.hits.total_hits}} hits"));
+
+        WebhookService webhookService = new WebhookService(
+            Settings.EMPTY,
+            httpClient,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
+        );
         actions.add(
             new ActionWrapper(
                 "_webhook",
                 actionThrottler,
                 null,
                 null,
-                new ExecutableWebhookAction(new WebhookAction(httpRequest.build()), logger, httpClient, engine),
+                new ExecutableWebhookAction(new WebhookAction(httpRequest.build()), logger, webhookService, engine),
                 null,
                 null
             )

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/watch/WatchTests.java
@@ -79,6 +79,7 @@ import org.elasticsearch.xpack.watcher.input.search.SearchInputFactory;
 import org.elasticsearch.xpack.watcher.input.simple.ExecutableSimpleInput;
 import org.elasticsearch.xpack.watcher.input.simple.SimpleInput;
 import org.elasticsearch.xpack.watcher.input.simple.SimpleInputFactory;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 import org.elasticsearch.xpack.watcher.notification.email.DataAttachment;
 import org.elasticsearch.xpack.watcher.notification.email.EmailService;
 import org.elasticsearch.xpack.watcher.notification.email.EmailTemplate;
@@ -153,6 +154,7 @@ public class WatchTests extends ESTestCase {
     private Client client;
     private HttpClient httpClient;
     private EmailService emailService;
+    private WebhookService webhookService;
     private TextTemplateEngine templateEngine;
     private HtmlSanitizer htmlSanitizer;
     private XPackLicenseState licenseState;
@@ -166,6 +168,7 @@ public class WatchTests extends ESTestCase {
         client = mock(Client.class);
         httpClient = mock(HttpClient.class);
         emailService = mock(EmailService.class);
+        webhookService = mock(WebhookService.class);
         templateEngine = mock(TextTemplateEngine.class);
         htmlSanitizer = mock(HtmlSanitizer.class);
         licenseState = mock(XPackLicenseState.class);
@@ -658,7 +661,7 @@ public class WatchTests extends ESTestCase {
                     randomThrottler(),
                     AlwaysConditionTests.randomCondition(scriptService),
                     randomTransform(),
-                    new ExecutableWebhookAction(action, logger, httpClient, templateEngine),
+                    new ExecutableWebhookAction(action, logger, webhookService, templateEngine),
                     null,
                     null
                 )
@@ -676,7 +679,7 @@ public class WatchTests extends ESTestCase {
                     new EmailActionFactory(settings, emailService, templateEngine, new EmailAttachmentsParser(Collections.emptyMap()))
                 );
                 case IndexAction.TYPE -> parsers.put(IndexAction.TYPE, new IndexActionFactory(settings, client));
-                case WebhookAction.TYPE -> parsers.put(WebhookAction.TYPE, new WebhookActionFactory(httpClient, templateEngine));
+                case WebhookAction.TYPE -> parsers.put(WebhookAction.TYPE, new WebhookActionFactory(webhookService, templateEngine));
                 case LoggingAction.TYPE -> parsers.put(LoggingAction.TYPE, new LoggingActionFactory(new MockTextTemplateEngine()));
             }
         }


### PR DESCRIPTION
This commit creates a new `WebhookService` which encapsulates the action of executing Watcher's webhook actions. Currently the functionality of webhook is unchanged from its existing behavior, however, this refactoring allows us to extend webhook actions, from both the "webhook" action as well as other actions that use webhooks like the "email" action, to add functionality for adding additional injected tokens.
