### PR TITLE
[8.6] [CI] Mute SnapshotRepoTestKitClientYamlTestSuiteIT (#92589)

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/10_analyze.yml
+++ b/x-pack/plugin/snapshot-repo-test-kit/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/10_analyze.yml
@@ -158,8 +158,8 @@ setup:
 ---
 "Timeout with large blobs":
   - skip:
-      version: "- 7.13.99"
-      reason: "abortWrites flag introduced in 7.14, and mixed-cluster support not required"
+      version: all
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/90353"
 
   - do:
       catch: request


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [CI] Mute SnapshotRepoTestKitClientYamlTestSuiteIT (#92589)