### PR TITLE
[Security Solution] [Fleet] Update file data mappings with new fields for transit hash and persisting uploads

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-file-data.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-file-data.json
@@ -26,6 +26,10 @@
             "type": "keyword",
             "index": false
           },
+          "sha2": {
+            "type": "keyword",
+            "index": false
+          },
           "last": {
             "type": "boolean",
             "index": false

--- a/x-pack/plugin/core/src/main/resources/fleet-file-data.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-file-data.json
@@ -23,8 +23,7 @@
             "type": "binary"
           },
           "bid": {
-            "type": "keyword",
-            "index": false
+            "type": "keyword"
           },
           "sha2": {
             "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/fleet-files.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-files.json
@@ -21,7 +21,7 @@
         "dynamic": false,
         "properties": {
           "upload_start": {
-            "type": "keyword"
+            "type": "date"
           },
           "agent_id": {
             "type": "keyword"

--- a/x-pack/plugin/core/src/main/resources/fleet-files.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-files.json
@@ -20,6 +20,9 @@
         },
         "dynamic": false,
         "properties": {
+          "upload_start": {
+            "type": "keyword"
+          },
           "agent_id": {
             "type": "keyword"
           },
@@ -27,6 +30,9 @@
             "type": "keyword"
           },
           "source": {
+            "type": "keyword"
+          },
+          "upload_id": {
             "type": "keyword"
           },
           "file": {


### PR DESCRIPTION
This PR updates the mappings for the fleet file data to include new fields needed for persisting in progress uploads to ES and for calculating a transit hash.

This PR is working in conjunction with an upcoming Fleet Server API: https://github.com/elastic/fleet-server/pull/1902
