### PR TITLE
Fixes 92541 and 92562

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHexGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHexGridTiler.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid;
 
 import org.elasticsearch.h3.H3;
+import org.elasticsearch.xpack.spatial.common.H3CartesianUtil;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
@@ -19,15 +20,6 @@ import java.io.IOException;
 abstract class AbstractGeoHexGridTiler extends GeoGridTiler {
 
     private static final long[] RES0CELLS = H3.getLongRes0Cells();
-    // The hexRing neighbours optimization is insufficient at the Poles, so we do a little extra checking
-    private static final long[] NORTH_POLAR_CELLS = new long[H3.MAX_H3_RES + 1];
-    private static final long[] SOUTH_POLAR_CELLS = new long[H3.MAX_H3_RES + 1];
-    static {
-        for (int res = 0; res <= H3.MAX_H3_RES; res++) {
-            NORTH_POLAR_CELLS[res] = H3.geoToH3(90, 0, res);
-            SOUTH_POLAR_CELLS[res] = H3.geoToH3(-90, 0, res);
-        }
-    }
 
     AbstractGeoHexGridTiler(int precision) {
         super(precision);
@@ -100,7 +92,7 @@ abstract class AbstractGeoHexGridTiler extends GeoGridTiler {
             // Normally sufficient to check only bottom-left against top-right
             return -1;
         }
-        if (minH3 == NORTH_POLAR_CELLS[res] || minH3 == SOUTH_POLAR_CELLS[res]) {
+        if (H3CartesianUtil.isPolar(minH3)) {
             // But with polar cells we must check the other two corners too
             final long minMax = H3.geoToH3(bounds.minY(), bounds.maxX(), res);
             final long maxMin = H3.geoToH3(bounds.maxY(), bounds.minX(), res);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHexGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHexGridTiler.java
@@ -20,10 +20,10 @@ abstract class AbstractGeoHexGridTiler extends GeoGridTiler {
 
     private static final long[] RES0CELLS = H3.getLongRes0Cells();
     // The hexRing neighbours optimization is insufficient at the Poles, so we do a little extra checking
-    private static final long[] NORTH_POLAR_CELLS = new long[H3.MAX_H3_RES];
-    private static final long[] SOUTH_POLAR_CELLS = new long[H3.MAX_H3_RES];
+    private static final long[] NORTH_POLAR_CELLS = new long[H3.MAX_H3_RES + 1];
+    private static final long[] SOUTH_POLAR_CELLS = new long[H3.MAX_H3_RES + 1];
     static {
-        for (int res = 0; res < H3.MAX_H3_RES; res++) {
+        for (int res = 0; res <= H3.MAX_H3_RES; res++) {
             NORTH_POLAR_CELLS[res] = H3.geoToH3(90, 0, res);
             SOUTH_POLAR_CELLS[res] = H3.geoToH3(-90, 0, res);
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.h3.H3;
 import org.elasticsearch.xpack.spatial.common.H3CartesianUtil;
@@ -57,16 +58,6 @@ public class GeoHexTilerTests extends GeoGridTilerTestCase {
     @Override
     protected long getCellsForDiffPrecision(int precisionDiff) {
         return UnboundedGeoHexGridTiler.calcMaxAddresses(precisionDiff);
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92541")
-    public void testGeoGridSetValuesBoundingBoxes_BoundedGeoShapeCellValues() throws Exception {
-        super.testGeoGridSetValuesBoundingBoxes_BoundedGeoShapeCellValues();
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92562")
-    public void testGeoGridSetValuesBoundingBoxes_UnboundedGeoShapeCellValues() throws Exception {
-        super.testGeoGridSetValuesBoundingBoxes_UnboundedGeoShapeCellValues();
     }
 
     public void testLargeShape() throws Exception {
@@ -126,6 +117,70 @@ public class GeoHexTilerTests extends GeoGridTilerTestCase {
             assertCorner(h3bins, new Point(tile.getMinLon(), tile.getMaxLat()), precision, msg);
             assertCorner(h3bins, new Point(tile.getMaxLon(), tile.getMaxLat()), precision, msg);
         }
+    }
+
+    // Polygons with bounds inside the South Pole cell break a tiler optimization
+    public void testTroublesomeShapeAlmostWithinSouthPole_BoundedGeoShapeCellValues() throws Exception {
+        int precision = 1;
+        String polygon = """
+            POLYGON((180.0 -90.0, 180.0 -73.80002960532788, 1.401298464324817E-45 -73.80002960532788,
+            1.401298464324817E-45 -90.0, 180.0 -90.0))""";
+        GeoBoundingBox geoBoundingBox = new GeoBoundingBox(
+            new GeoPoint(19.585157879020088, 0.9999999403953552),
+            new GeoPoint(-90.0, -26.405694642531472)
+        );
+        Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, polygon);
+        GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
+        GeoShapeCellValues cellValues = new GeoShapeCellValues(
+            makeGeoShapeValues(value),
+            getBoundedGridTiler(geoBoundingBox, precision),
+            NOOP_BREAKER
+        );
+
+        assertTrue(cellValues.advanceExact(0));
+        int numBuckets = cellValues.docValueCount();
+        int expected = expectedBuckets(value, precision, geoBoundingBox);
+        assertThat("[" + precision + "] bucket count", numBuckets, equalTo(expected));
+    }
+
+    // Polygons with bounds inside the South Pole cell break a tiler optimization
+    public void testTroublesomeShapeAlmostWithinSouthPoleCell_UnboundedGeoShapeCellValues() throws Exception {
+        int precision = 0;
+        String polygon = """
+            POLYGON((1.7481549674935762E-110 -90.0, 180.0 -90.0, 180.0 -75.113250736563,
+            1.7481549674935762E-110 -75.113250736563, 1.7481549674935762E-110 -90.0))""";
+        Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, polygon);
+        GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
+        GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(
+            makeGeoShapeValues(value),
+            getUnboundedGridTiler(precision),
+            NOOP_BREAKER
+        );
+
+        assertTrue(unboundedCellValues.advanceExact(0));
+        int numBuckets = unboundedCellValues.docValueCount();
+        int expected = expectedBuckets(value, precision, null);
+        assertThat("[" + precision + "] bucket count", numBuckets, equalTo(expected));
+    }
+
+    // Polygons with bounds inside the North Pole cell break a tiler optimization
+    public void testTroublesomeShapeAlmostWithinNorthPoleCell_UnboundedGeoShapeCellValues() throws Exception {
+        int precision = 1;
+        String polygon = """
+            POLYGON((36.98661841690625 69.44049730644747, 180.0 69.44049730644747,
+            180.0 90.0, 36.98661841690625 90.0, 36.98661841690625 69.44049730644747))""";
+        Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, polygon);
+        GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
+        GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(
+            makeGeoShapeValues(value),
+            getUnboundedGridTiler(precision),
+            NOOP_BREAKER
+        );
+
+        assertTrue(unboundedCellValues.advanceExact(0));
+        int numBuckets = unboundedCellValues.docValueCount();
+        int expected = expectedBuckets(value, precision, null);
+        assertThat("[" + precision + "] bucket count", numBuckets, equalTo(expected));
     }
 
     private void assertCorner(long[] h3bins, Point point, int precision, String msg) throws IOException {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
@@ -13,24 +13,17 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
-import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.Point;
-import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
-import org.elasticsearch.h3.CellBoundary;
 import org.elasticsearch.h3.H3;
-import org.elasticsearch.h3.LatLng;
 import org.elasticsearch.xpack.spatial.common.H3CartesianUtil;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
 
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.geoShapeValue;
 import static org.hamcrest.Matchers.equalTo;

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexTilerTests.java
@@ -13,17 +13,24 @@ import org.elasticsearch.common.geo.GeoBoundingBox;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.StandardValidator;
 import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.h3.CellBoundary;
 import org.elasticsearch.h3.H3;
+import org.elasticsearch.h3.LatLng;
 import org.elasticsearch.xpack.spatial.common.H3CartesianUtil;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 
 import static org.elasticsearch.xpack.spatial.util.GeoTestUtils.geoShapeValue;
 import static org.hamcrest.Matchers.equalTo;
@@ -169,6 +176,23 @@ public class GeoHexTilerTests extends GeoGridTilerTestCase {
         String polygon = """
             POLYGON((36.98661841690625 69.44049730644747, 180.0 69.44049730644747,
             180.0 90.0, 36.98661841690625 90.0, 36.98661841690625 69.44049730644747))""";
+        Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, polygon);
+        GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
+        GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(
+            makeGeoShapeValues(value),
+            getUnboundedGridTiler(precision),
+            NOOP_BREAKER
+        );
+
+        assertTrue(unboundedCellValues.advanceExact(0));
+        int numBuckets = unboundedCellValues.docValueCount();
+        int expected = expectedBuckets(value, precision, null);
+        assertThat("[" + precision + "] bucket count", numBuckets, equalTo(expected));
+    }
+
+    public void testTroublesomePolarCellLevel1_UnboundedGeoShapeCellValues() throws Exception {
+        int precision = 1;
+        String polygon = "BBOX (-84.24596376729815, 43.36113427778119, 90.0, 83.51476833522361)";
         Geometry geometry = WellKnownText.fromWKT(StandardValidator.instance(true), true, polygon);
         GeoShapeValues.GeoShapeValue value = geoShapeValue(geometry);
         GeoShapeCellValues unboundedCellValues = new GeoShapeCellValues(


### PR DESCRIPTION
An optimization in the GeoHexGridTiler has exceptions for polygons
with two bounding points within the polar cells, but not all points
within those cells. So when the cells are polar we do an additional
check for the other two bounds.

Fixes https://github.com/elastic/elasticsearch/issues/92541
Fixes https://github.com/elastic/elasticsearch/issues/92562
