### PR TITLE
Fix Failure in ShardSearchRequestTests.testClone

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/phrase/PhraseSuggestionBuilderTests.java
@@ -28,7 +28,7 @@ public class PhraseSuggestionBuilderTests extends AbstractSuggestionBuilderTestC
     public static PhraseSuggestionBuilder randomPhraseSuggestionBuilder() {
         PhraseSuggestionBuilder testBuilder = new PhraseSuggestionBuilder(randomAlphaOfLengthBetween(2, 20));
         setCommonPropertiesOnRandomBuilder(testBuilder);
-        maybeSet(testBuilder::maxErrors, randomFloat());
+        maybeSet(testBuilder::maxErrors, Math.max(randomFloat(), Float.MIN_NORMAL));
         maybeSet(testBuilder::separator, randomAlphaOfLengthBetween(1, 10));
         maybeSet(testBuilder::realWordErrorLikelihood, randomFloat());
         maybeSet(testBuilder::confidence, randomFloat());


### PR DESCRIPTION
For some (very rare) seeds we run into the exact float 0.0f but don't allow zero for the `maxErrors` value.
