### PR TITLE
Fix testMaxDocsLimit

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -70,7 +70,7 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(
                 PersistedClusterStateService.DOCUMENT_PAGE_SIZE.getKey(),
-                ByteSizeValue.ofBytes(randomIntBetween(1000, randomFrom(10000, 100000, 1000000)))
+                PersistedClusterStateService.DOCUMENT_PAGE_SIZE.get(Settings.EMPTY)
             )
             .build();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -12,7 +12,9 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.translog.Translog;
@@ -61,6 +63,18 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         return CollectionUtils.appendToCopy(super.nodePlugins(), TestEnginePlugin.class);
     }
 
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        // Document page size should not be too small, else we can fail to write the cluster state for small max doc values
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(
+                PersistedClusterStateService.DOCUMENT_PAGE_SIZE.getKey(),
+                ByteSizeValue.ofBytes(randomIntBetween(1000, randomFrom(10000, 100000, 1000000)))
+            )
+            .build();
+    }
+
     @Before
     public void setMaxDocs() {
         maxDocs.set(randomIntBetween(10, 100)); // Do not set this too low as we can fail to write the cluster state
@@ -72,7 +86,6 @@ public class MaxDocsLimitIT extends ESIntegTestCase {
         restoreIndexWriterMaxDocs();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92037")
     public void testMaxDocsLimit() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(1);
         assertAcked(

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/MaxDocsLimitIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.gateway.PersistedClusterStateService;
 import org.elasticsearch.index.IndexSettings;


### PR DESCRIPTION
The issue was that the DOCUMENT_PAGE_SIZE setting could randomly get a very low value, which resulted in multiple pages for the cluster state update, which was prohibited by a randomly low max docs value.

Fixes #92037