### PR TITLE
Mute DataStreamIT.testWriteLoadAndAvgShardSizeIsStoredInABestEffort

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -2052,6 +2052,7 @@ public class DataStreamIT extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91967")
     public void testWriteLoadAndAvgShardSizeIsStoredInABestEffort() throws Exception {
         // This test simulates the scenario where some nodes fail to respond
         // to the IndicesStatsRequest and therefore only a partial view of the


### PR DESCRIPTION
Relates to #91967
