### PR TITLE
[8.6] Mute DataStreamIT.testWriteLoadAndAvgShardSizeIsStoredInABestEffort (#92601)

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -2068,6 +2068,7 @@ public class DataStreamIT extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/91967")
     public void testWriteLoadAndAvgShardSizeIsStoredInABestEffort() throws Exception {
         // This test simulates the scenario where some nodes fail to respond
         // to the IndicesStatsRequest and therefore only a partial view of the


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Mute DataStreamIT.testWriteLoadAndAvgShardSizeIsStoredInABestEffort (#92601)