### PR TITLE
Convert ServiceAccountIT to new test clusters framework

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -161,8 +161,20 @@ public class LocalClusterSpec implements ClusterSpec {
             );
         }
 
+        /**
+         * Return node configured setting or the provided default if no explicit value has been configured. This method returns all
+         * settings, to include security settings provided to the keystore
+         *
+         * @param setting the setting name
+         * @param defaultValue a default value
+         * @return the configured setting value or provided default
+         */
         public String getSetting(String setting, String defaultValue) {
-            return resolveSettings().getOrDefault(setting, defaultValue);
+            Map<String, String> allSettings = new HashMap<>();
+            allSettings.putAll(resolveSettings());
+            allSettings.putAll(keystoreSettings);
+
+            return allSettings.getOrDefault(setting, defaultValue);
         }
 
         /**

--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -1,44 +1,8 @@
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation project(':x-pack:plugin:core')
   javaRestTestImplementation project(':client:rest-high-level')
   javaRestTestImplementation project(':x-pack:plugin:security')
-}
-
-testClusters.matching { it.name == 'javaRestTest' }.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 2
-
-  extraConfigFile 'node.key', file('src/javaRestTest/resources/ssl/node.key')
-  extraConfigFile 'node.crt', file('src/javaRestTest/resources/ssl/node.crt')
-  extraConfigFile 'ca.crt', file('src/javaRestTest/resources/ssl/ca.crt')
-  extraConfigFile 'service_tokens', file('src/javaRestTest/resources/service_tokens')
-
-  setting 'xpack.ml.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
-
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.security.authc.token.enabled', 'true'
-  setting 'xpack.security.authc.api_key.enabled', 'true'
-
-  setting 'xpack.security.http.ssl.enabled', 'true'
-  setting 'xpack.security.http.ssl.certificate', 'node.crt'
-  setting 'xpack.security.http.ssl.key', 'node.key'
-  setting 'xpack.security.http.ssl.certificate_authorities', 'ca.crt'
-
-  setting 'xpack.security.transport.ssl.enabled', 'true'
-  setting 'xpack.security.transport.ssl.certificate', 'node.crt'
-  setting 'xpack.security.transport.ssl.key', 'node.key'
-  setting 'xpack.security.transport.ssl.certificate_authorities', 'ca.crt'
-  setting 'xpack.security.transport.ssl.verification_mode', 'certificate'
-
-  keystore 'bootstrap.password', 'x-pack-test-password'
-  keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'node-password'
-  keystore 'xpack.security.http.ssl.secure_key_passphrase', 'node-password'
-
-  rolesFile file('src/javaRestTest/resources/roles.yml')
-  user username: "test_admin", password: 'x-pack-test-password'
-  user username: "elastic/fleet-server", password: 'x-pack-test-password', role: "superuser"
-  user username: "service_account_manager", password: 'x-pack-test-password', role: "service_account_manager"
+  clusterModules(project(":modules:analysis-common"))
 }

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -19,6 +19,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentType;
@@ -26,6 +28,7 @@ import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.security.authz.store.ReservedRolesStore;
 import org.elasticsearch.xpack.core.security.user.KibanaSystemUser;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -197,6 +200,36 @@ public class ServiceAccountIT extends ESRestTestCase {
             }
         }""";
 
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .nodes(2)
+        .module("analysis-common")
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.security.authc.token.enabled", "true")
+        .setting("xpack.security.authc.api_key.enabled", "true")
+        .setting("xpack.security.http.ssl.enabled", "true")
+        .setting("xpack.security.http.ssl.certificate", "node.crt")
+        .setting("xpack.security.http.ssl.key", "node.key")
+        .setting("xpack.security.http.ssl.certificate_authorities", "ca.crt")
+        .setting("xpack.security.transport.ssl.enabled", "true")
+        .setting("xpack.security.transport.ssl.certificate", "node.crt")
+        .setting("xpack.security.transport.ssl.key", "node.key")
+        .setting("xpack.security.transport.ssl.certificate_authorities", "ca.crt")
+        .setting("xpack.security.transport.ssl.verification_mode", "certificate")
+        .keystore("bootstrap.password", "x-pack-test-password")
+        .keystore("xpack.security.transport.ssl.secure_key_passphrase", "node-password")
+        .keystore("xpack.security.http.ssl.secure_key_passphrase", "node-password")
+        .configFile("node.key", Resource.fromClasspath("ssl/node.key"))
+        .configFile("node.crt", Resource.fromClasspath("ssl/node.crt"))
+        .configFile("ca.crt", Resource.fromClasspath("ssl/ca.crt"))
+        .configFile("service_tokens", Resource.fromClasspath("service_tokens"))
+        .rolesFile(Resource.fromClasspath("roles.yml"))
+        .user("test_admin", "x-pack-test-password")
+        .user("elastic/fleet-server", "x-pack-test-password", "superuser")
+        .user("service_account_manager", "x-pack-test-password", "service_account_manager")
+        .build();
+
     @BeforeClass
     public static void init() throws URISyntaxException, FileNotFoundException {
         URL resource = ServiceAccountIT.class.getResource("/ssl/ca.crt");
@@ -204,6 +237,11 @@ public class ServiceAccountIT extends ESRestTestCase {
             throw new FileNotFoundException("Cannot find classpath resource /ssl/ca.crt");
         }
         caPath = PathUtils.get(resource.toURI());
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 
     @Override
@@ -574,6 +612,6 @@ public class ServiceAccountIT extends ESRestTestCase {
         final Map<String, Object> fileTokens = (Map<String, Object>) nodes.get("file_tokens");
         assertThat(fileTokens, hasKey("token1"));
         final Map<String, Object> token1 = (Map<String, Object>) fileTokens.get("token1");
-        assertThat((List<String>) token1.get("nodes"), equalTo(List.of("javaRestTest-0", "javaRestTest-1")));
+        assertThat((List<String>) token1.get("nodes"), equalTo(List.of("test-cluster-0", "test-cluster-1")));
     }
 }


### PR DESCRIPTION
Converts a security with SSL-enabled test to the new test clusters framework. Plumbs up the last remaining bits to support testing with TLS.