### PR TITLE
[Docs] Add more details to the `index` option docs

### DIFF
--- a/docs/reference/mapping/params/index.asciidoc
+++ b/docs/reference/mapping/params/index.asciidoc
@@ -2,7 +2,10 @@
 === `index`
 
 The `index` option controls whether field values are indexed. It accepts `true`
-or `false` and defaults to `true`. <<number,Numeric types>>, <<date,date types>>,
+or `false` and defaults to `true`. 
+
+Indexing a field creates data structures that enable the field to be queried 
+efficiently. <<number,Numeric types>>, <<date,date types>>,
 the <<boolean,boolean type>>, <<ip,ip type>>, <<geo-point,geo_point type>> and the
 <<keyword,keyword type>> can also be queried when they are not <<mapping-index,indexed>>
  but only have doc values enabled. Queries on these fields are slow as a full scan

--- a/docs/reference/mapping/params/index.asciidoc
+++ b/docs/reference/mapping/params/index.asciidoc
@@ -2,6 +2,9 @@
 === `index`
 
 The `index` option controls whether field values are indexed. It accepts `true`
-or `false` and defaults to `true`. Fields that are not indexed are typically
-not queryable.
+or `false` and defaults to `true`. <<number,Numeric types>>, <<date,date types>>,
+the <<boolean,boolean type>>, <<ip,ip type>>, <<geo-point,geo_point type>> and the
+<<keyword,keyword type>> can also be queried when they are not <<mapping-index,indexed>>
+ but only have doc values enabled. Queries on these fields are slow as a full scan
+ of the index has to be made. All other fields are not queryable.
 


### PR DESCRIPTION
Docs around the `index` option were not very precise. The term "typical" was used without describing for which fields querying is still available when `index: false` is set. But more precise docs existed in the `doc_values` documentation found here for the index option: https://www.elastic.co/guide/en/elasticsearch/reference/current/doc-values.html These docs were mostly copied over.
