### PR TITLE
Misc improvements to AbstractRefCounted

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/AbstractRefCounted.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/AbstractRefCounted.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.core;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -94,11 +95,18 @@ public abstract class AbstractRefCounted implements RefCounted {
      * Construct an {@link AbstractRefCounted} which runs the given {@link Runnable} when all references are released.
      */
     public static AbstractRefCounted of(Runnable onClose) {
+        Objects.requireNonNull(onClose);
         return new AbstractRefCounted() {
             @Override
             protected void closeInternal() {
                 onClose.run();
             }
+
+            @Override
+            public String toString() {
+                return "refCounted[" + onClose + "]";
+            }
         };
     }
+
 }


### PR DESCRIPTION
Adds a null check and a `toString()` implementation which passes through to the wrapped runnable. Also renames `RefCountedTests` to `AbstractRefCountedTests` since they're really all about testing this specific implementation.