### PR TITLE
Fix GeoShapeGeoGridTestCase#testGeoShapeBounds after adding support for geohex aggregation on geoshape

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileUtils.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/geogrid/GeoTileUtils.java
@@ -197,7 +197,7 @@ public final class GeoTileUtils {
     /**
      * Parse geotile String hash format in "zoom/x/y" into an array of integers
      */
-    private static int[] parseHash(String hashAsString) {
+    public static int[] parseHash(String hashAsString) {
         final String[] parts = hashAsString.split("/", 4);
         if (parts.length != 3) {
             throw new IllegalArgumentException(

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -63,7 +63,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
     /**
      * Convert geo point into a hash string (bucket string ID)
      */
-    protected abstract String hashAsString(double lng, double lat, int precision);
+    protected abstract String[] hashAsStrings(double lng, double lat, int precision);
 
     /**
      * Return a point within the bounds of the tile grid
@@ -76,14 +76,14 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
     protected abstract GeoBoundingBox randomBBox();
 
     /**
-     * Return true if the point intersects the given shape value
+     * Return true if the hash intersects the given shape value
      */
-    protected abstract boolean intersects(double lng, double lat, int precision, GeoShapeValues.GeoShapeValue value) throws IOException;
+    protected abstract boolean intersects(String hash, GeoShapeValues.GeoShapeValue value) throws IOException;
 
     /**
-     * Return true if the point intersects the given bounding box
+     * Return true if the hash intersects the given bounding box
      */
-    protected abstract boolean intersectsBounds(double lng, double lat, int precision, GeoBoundingBox box);
+    protected abstract boolean intersectsBounds(String hash, GeoBoundingBox box);
 
     /**
      * Create a new named {@link GeoGridAggregationBuilder}-derived builder
@@ -163,8 +163,11 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
             double lon = GeoTestUtils.encodeDecodeLon(p.getX());
             double lat = GeoTestUtils.encodeDecodeLat(p.getY());
             GeoShapeValues.GeoShapeValue value = geoShapeValue(p);
-            if (intersects(lon, lat, precision, value) && intersectsBounds(lon, lat, precision, bbox)) {
-                numDocsWithin += 1;
+            String[] hashes = hashAsStrings(lon, lat, precision);
+            for (String hash : hashes) {
+                if (intersects(hash, value) && intersectsBounds(hash, bbox)) {
+                    numDocsWithin += 1;
+                }
             }
 
             docs.add(binaryGeoShapeDocValuesField(FIELD_NAME, p));
@@ -206,11 +209,13 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
                 lat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(lat));
 
                 shapes.add(new Point(lng, lat));
-                String hash = hashAsString(lng, lat, precision);
-                if (distinctHashesPerDoc.contains(hash) == false) {
-                    expectedCountPerGeoHash.put(hash, expectedCountPerGeoHash.getOrDefault(hash, 0) + 1);
+                String[] hashes = hashAsStrings(lng, lat, precision);
+                for (String hash : hashes) {
+                    if (distinctHashesPerDoc.contains(hash) == false) {
+                        expectedCountPerGeoHash.put(hash, expectedCountPerGeoHash.getOrDefault(hash, 0) + 1);
+                    }
+                    distinctHashesPerDoc.add(hash);
                 }
-                distinctHashesPerDoc.add(hash);
                 if (usually()) {
                     Geometry geometry = new MultiPoint(new ArrayList<>(shapes));
                     document.add(binaryGeoShapeDocValuesField(FIELD_NAME, geometry));

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoGridTestCase.java
@@ -61,7 +61,7 @@ public abstract class GeoShapeGeoGridTestCase<T extends InternalGeoGridBucket> e
     protected abstract int randomPrecision();
 
     /**
-     * Convert geo point into a hash string (bucket string ID)
+     * Convert geo point into an array of hash string (bucket string ID).
      */
     protected abstract String[] hashAsStrings(double lng, double lat, int precision);
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHashGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHashGridAggregatorTests.java
@@ -33,8 +33,8 @@ public class GeoShapeGeoHashGridAggregatorTests extends GeoShapeGeoGridTestCase<
     }
 
     @Override
-    protected String hashAsString(double lng, double lat, int precision) {
-        return stringEncode(lng, lat, precision);
+    protected String[] hashAsStrings(double lng, double lat, int precision) {
+        return new String[] { stringEncode(lng, lat, precision) };
     }
 
     @Override
@@ -48,8 +48,8 @@ public class GeoShapeGeoHashGridAggregatorTests extends GeoShapeGeoGridTestCase<
     }
 
     @Override
-    protected boolean intersects(double lng, double lat, int precision, GeoShapeValues.GeoShapeValue value) throws IOException {
-        Rectangle boundingBox = GeoGridQueryBuilder.getQueryHash(hashAsString(lng, lat, precision));
+    protected boolean intersects(String hash, GeoShapeValues.GeoShapeValue value) throws IOException {
+        final Rectangle boundingBox = GeoGridQueryBuilder.getQueryHash(hash);
         return value.relate(
             GeoEncodingUtils.encodeLongitude(boundingBox.getMinLon()),
             GeoEncodingUtils.encodeLongitude(boundingBox.getMaxLon()),
@@ -59,9 +59,9 @@ public class GeoShapeGeoHashGridAggregatorTests extends GeoShapeGeoGridTestCase<
     }
 
     @Override
-    protected boolean intersectsBounds(double lng, double lat, int precision, GeoBoundingBox box) {
-        GeoHashBoundedPredicate predicate = new GeoHashBoundedPredicate(precision, box);
-        return predicate.validHash(stringEncode(lng, lat, precision));
+    protected boolean intersectsBounds(String hash, GeoBoundingBox box) {
+        final GeoHashBoundedPredicate predicate = new GeoHashBoundedPredicate(hash.length(), box);
+        return predicate.validHash(hash);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHexGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoHexGridAggregatorTests.java
@@ -22,7 +22,9 @@ import org.elasticsearch.xpack.spatial.index.fielddata.GeoShapeValues;
 import org.elasticsearch.xpack.spatial.util.GeoTestUtils;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 public class GeoShapeGeoHexGridAggregatorTests extends GeoShapeGeoGridTestCase<InternalGeoHexGridBucket> {
     @Override
@@ -31,19 +33,19 @@ public class GeoShapeGeoHexGridAggregatorTests extends GeoShapeGeoGridTestCase<I
     }
 
     @Override
-    protected String hashAsString(double lng, double lat, int precision) {
-        // TODO: In theory we can have more than one hash per point?
+    protected String[] hashAsStrings(double lng, double lat, int precision) {
+        final List<String> strings = new ArrayList<>();
         final long h3 = H3.geoToH3(lat, lng, precision);
         if (LatLonGeometry.create(H3CartesianUtil.getLatLonGeometry(h3)).contains(lng, lat)) {
-            return H3.h3ToString(h3);
+            strings.add(H3.h3ToString(h3));
         }
         for (long n : H3.hexRing(h3)) {
             if (LatLonGeometry.create(H3CartesianUtil.getLatLonGeometry(n)).contains(lng, lat)) {
-                return H3.h3ToString(n);
+                strings.add(H3.h3ToString(n));
             }
         }
-        fail("Could not find valid h3 bin");
-        return null;
+        assertTrue("did not find any hash for point", strings.size() > 0);
+        return strings.toArray(new String[0]);
     }
 
     @Override
@@ -57,14 +59,17 @@ public class GeoShapeGeoHexGridAggregatorTests extends GeoShapeGeoGridTestCase<I
     }
 
     @Override
-    protected boolean intersects(double lng, double lat, int precision, GeoShapeValues.GeoShapeValue value) throws IOException {
-        return value.relate(new org.apache.lucene.geo.Point(lat, lng)) != GeoRelation.QUERY_DISJOINT;
+    protected boolean intersects(String hash, GeoShapeValues.GeoShapeValue value) throws IOException {
+        final GeoHexVisitor visitor = new GeoHexVisitor();
+        visitor.reset(H3.stringToH3(hash));
+        value.visit(visitor);
+        return visitor.relation() != GeoRelation.QUERY_DISJOINT;
     }
 
     @Override
-    protected boolean intersectsBounds(double lng, double lat, int precision, GeoBoundingBox box) {
-        final BoundedGeoHexGridTiler tiler = new BoundedGeoHexGridTiler(precision, box);
-        return tiler.h3IntersectsBounds(H3.stringToH3(hashAsString(lng, lat, precision)));
+    protected boolean intersectsBounds(String hash, GeoBoundingBox box) {
+        final BoundedGeoHexGridTiler tiler = new BoundedGeoHexGridTiler(H3.getResolution(hash), box);
+        return tiler.h3IntersectsBounds(H3.stringToH3(hash));
     }
 
     @Override
@@ -84,10 +89,5 @@ public class GeoShapeGeoHexGridAggregatorTests extends GeoShapeGeoGridTestCase<I
             geoGrid -> { assertEquals(8, geoGrid.getBuckets().size()); },
             builder
         );
-    }
-
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92563")
-    public void testGeoShapeBounds() throws IOException {
-        super.testGeoShapeBounds();
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoTileGridAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoShapeGeoTileGridAggregatorTests.java
@@ -32,8 +32,8 @@ public class GeoShapeGeoTileGridAggregatorTests extends GeoShapeGeoGridTestCase<
     }
 
     @Override
-    protected String hashAsString(double lng, double lat, int precision) {
-        return GeoTileUtils.stringEncode(GeoTileUtils.longEncode(lng, lat, precision));
+    protected String[] hashAsStrings(double lng, double lat, int precision) {
+        return new String[] { GeoTileUtils.stringEncode(GeoTileUtils.longEncode(lng, lat, precision)) };
     }
 
     @Override
@@ -61,8 +61,8 @@ public class GeoShapeGeoTileGridAggregatorTests extends GeoShapeGeoGridTestCase<
     }
 
     @Override
-    protected boolean intersects(double lng, double lat, int precision, GeoShapeValues.GeoShapeValue value) throws IOException {
-        Rectangle r = GeoGridQueryBuilder.getQueryTile(GeoTileUtils.stringEncode(GeoTileUtils.longEncode(lng, lat, precision)));
+    protected boolean intersects(String hash, GeoShapeValues.GeoShapeValue value) throws IOException {
+        final Rectangle r = GeoGridQueryBuilder.getQueryTile(GeoTileUtils.stringEncode(GeoTileUtils.longEncode(hash)));
         return value.relate(
             GeoEncodingUtils.encodeLongitude(r.getMinLon()),
             GeoEncodingUtils.encodeLongitude(r.getMaxLon()),
@@ -72,9 +72,10 @@ public class GeoShapeGeoTileGridAggregatorTests extends GeoShapeGeoGridTestCase<
     }
 
     @Override
-    protected boolean intersectsBounds(double lng, double lat, int precision, GeoBoundingBox box) {
-        GeoTileBoundedPredicate predicate = new GeoTileBoundedPredicate(precision, box);
-        return predicate.validTile(GeoTileUtils.getXTile(lng, 1L << precision), GeoTileUtils.getYTile(lat, 1L << precision), precision);
+    protected boolean intersectsBounds(String hash, GeoBoundingBox box) {
+        final int[] values = GeoTileUtils.parseHash(hash);
+        final GeoTileBoundedPredicate predicate = new GeoTileBoundedPredicate(values[0], box);
+        return predicate.validTile(values[1], values[2], values[0]);
     }
 
     @Override


### PR DESCRIPTION
This PR updates the test to take into account that for the new aggregation it is possible that a point resolves in more than one bucket.

fixes #92563