### PR TITLE
Minor improvements to PrioritizedThrottledTaskRunnerTests

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunner.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunner.java
@@ -51,8 +51,7 @@ public class PrioritizedThrottledTaskRunner<T extends AbstractRunnable & Compara
         pollAndSpawn();
     }
 
-    // visible for testing
-    protected void pollAndSpawn() {
+    private void pollAndSpawn() {
         // A pollAndSpawn attempts to run a new task. There could be many concurrent pollAndSpawn calls competing
         // to get a "free slot", since we attempt to run a new task on every enqueueTask call and every time an
         // existing task is finished.

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
@@ -11,35 +11,39 @@ package org.elasticsearch.common.util.concurrent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.TestThreadPool;
-import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 
 public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
-    private ThreadPool threadPool;
-    private Executor executor;
+
+    private static final ThreadFactory threadFactory = EsExecutors.daemonThreadFactory("test");
+    private static final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+
+    private ExecutorService executor;
+    private int maxThreads;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        threadPool = new TestThreadPool("test");
-        executor = threadPool.executor(ThreadPool.Names.GENERIC);
+        maxThreads = between(1, 10);
+        executor = EsExecutors.newScaling("test", 1, maxThreads, 0, TimeUnit.MILLISECONDS, false, threadFactory, threadContext);
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        TestThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS);
+        TestThreadPool.terminate(executor, 30, TimeUnit.SECONDS);
     }
 
     static class TestTask extends AbstractRunnable implements Comparable<TestTask> {
@@ -69,81 +73,88 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
     }
 
     public void testMultiThreadedEnqueue() throws Exception {
-        final int maxTasks = randomIntBetween(1, threadPool.info(ThreadPool.Names.GENERIC).getMax());
+        final int maxTasks = randomIntBetween(1, maxThreads);
         PrioritizedThrottledTaskRunner<TestTask> taskRunner = new PrioritizedThrottledTaskRunner<>("test", maxTasks, executor);
         final int enqueued = randomIntBetween(2 * maxTasks, 10 * maxTasks);
-        AtomicInteger executed = new AtomicInteger();
-        CountDownLatch threadBlocker = new CountDownLatch(enqueued);
+        final var threadBlocker = new CyclicBarrier(enqueued);
+        final var executedCountDown = new CountDownLatch(enqueued);
         for (int i = 0; i < enqueued; i++) {
             new Thread(() -> {
-                try {
-                    threadBlocker.countDown();
-                    threadBlocker.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
+                awaitBarrier(threadBlocker);
                 taskRunner.enqueueTask(new TestTask(() -> {
                     try {
                         Thread.sleep(randomLongBetween(0, 10));
                     } catch (InterruptedException e) {
-                        throw new RuntimeException(e);
+                        throw new AssertionError(e);
                     }
-                    executed.incrementAndGet();
+                    executedCountDown.countDown();
                 }, getRandomPriority()));
                 assertThat(taskRunner.runningTasks(), lessThanOrEqualTo(maxTasks));
             }).start();
         }
         // Eventually all tasks are executed
-        assertBusy(() -> {
-            assertThat(executed.get(), equalTo(enqueued));
-            assertThat(taskRunner.runningTasks(), equalTo(0));
-        });
+        assertTrue(executedCountDown.await(10, TimeUnit.SECONDS));
         assertThat(taskRunner.queueSize(), equalTo(0));
+        assertNoRunningTasks(taskRunner);
     }
 
     public void testTasksRunInOrder() throws Exception {
-        final int n = randomIntBetween(1, threadPool.info(ThreadPool.Names.GENERIC).getMax());
-        final int enqueued = randomIntBetween(2 * n, 10 * n);
+        final int n = randomIntBetween(1, maxThreads);
         // To check that tasks are run in the order (based on their priority), limit max running tasks to 1
         // and wait until all tasks are enqueued.
-        CountDownLatch workerBlocker = new CountDownLatch(1);
-        PrioritizedThrottledTaskRunner<TestTask> taskRunner = new PrioritizedThrottledTaskRunner<>("test", 1, executor) {
-            @Override
-            protected void pollAndSpawn() {
-                try {
-                    workerBlocker.await();
-                } catch (InterruptedException e) {
-                    throw new RuntimeException(e);
-                }
-                super.pollAndSpawn();
+        final var barrier = new CyclicBarrier(2);
+        final var taskRunner = new PrioritizedThrottledTaskRunner<TestTask>("test", 1, executor);
+
+        taskRunner.enqueueTask(new TestTask(() -> {
+            try {
+                barrier.await(10, TimeUnit.SECONDS);
+                barrier.await(10, TimeUnit.SECONDS);
+            } catch (Exception e) {
+                throw new AssertionError("unexpected", e);
             }
-        };
+        }, getRandomPriority()));
+
+        barrier.await(10, TimeUnit.SECONDS);
+
+        final int enqueued = randomIntBetween(2 * n, 10 * n);
         List<Integer> taskPriorities = new ArrayList<>(enqueued);
         List<Integer> executedPriorities = new ArrayList<>(enqueued);
+        final var enqueuedBarrier = new CyclicBarrier(enqueued + 1);
+        final var executedCountDown = new CountDownLatch(enqueued);
         for (int i = 0; i < enqueued; i++) {
             final int priority = getRandomPriority();
             taskPriorities.add(priority);
-            new Thread(() -> taskRunner.enqueueTask(new TestTask(() -> executedPriorities.add(priority), priority))).start();
+            new Thread(() -> {
+                awaitBarrier(enqueuedBarrier);
+                taskRunner.enqueueTask(new TestTask(() -> {
+                    executedPriorities.add(priority);
+                    executedCountDown.countDown();
+                }, priority));
+                awaitBarrier(enqueuedBarrier);
+            }).start();
         }
-        assertBusy(() -> assertThat(taskRunner.queueSize(), equalTo(enqueued)));
-        assertThat(taskRunner.runningTasks(), equalTo(0));
-        workerBlocker.countDown();
+        awaitBarrier(enqueuedBarrier);
+        awaitBarrier(enqueuedBarrier);
+        assertThat(taskRunner.queueSize(), equalTo(enqueued));
+        barrier.await(10, TimeUnit.SECONDS);
+
         // Eventually all tasks are executed
-        assertBusy(() -> {
-            assertThat(executedPriorities.size(), equalTo(enqueued));
-            assertThat(taskRunner.runningTasks(), equalTo(0));
-        });
+        assertTrue(executedCountDown.await(10, TimeUnit.SECONDS));
+        assertThat(executedPriorities.size(), equalTo(enqueued));
         assertThat(taskRunner.queueSize(), equalTo(0));
         Collections.sort(taskPriorities);
         assertThat(executedPriorities, equalTo(taskPriorities));
+        assertNoRunningTasks(taskRunner);
     }
 
     public void testEnqueueSpawnsNewTasksUpToMax() throws Exception {
-        int maxTasks = randomIntBetween(1, threadPool.info(ThreadPool.Names.GENERIC).getMax());
-        CountDownLatch taskBlocker = new CountDownLatch(1);
-        AtomicInteger executed = new AtomicInteger();
-        PrioritizedThrottledTaskRunner<TestTask> taskRunner = new PrioritizedThrottledTaskRunner<>("test", maxTasks, executor);
+        int maxTasks = randomIntBetween(1, maxThreads);
         final int enqueued = maxTasks - 1; // So that it is possible to run at least one more task
+        final int newTasks = randomIntBetween(1, 10);
+
+        CountDownLatch taskBlocker = new CountDownLatch(1);
+        CountDownLatch executedCountDown = new CountDownLatch(enqueued + newTasks);
+        PrioritizedThrottledTaskRunner<TestTask> taskRunner = new PrioritizedThrottledTaskRunner<>("test", maxTasks, executor);
         for (int i = 0; i < enqueued; i++) {
             taskRunner.enqueueTask(new TestTask(() -> {
                 try {
@@ -151,12 +162,11 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                executed.incrementAndGet();
+                executedCountDown.countDown();
             }, getRandomPriority()));
             assertThat(taskRunner.runningTasks(), equalTo(i + 1));
         }
         // Enqueueing one or more new tasks would create only one new running task
-        final int newTasks = randomIntBetween(1, 10);
         for (int i = 0; i < newTasks; i++) {
             taskRunner.enqueueTask(new TestTask(() -> {
                 try {
@@ -164,24 +174,19 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
                 } catch (InterruptedException e) {
                     throw new RuntimeException(e);
                 }
-                executed.incrementAndGet();
+                executedCountDown.countDown();
             }, getRandomPriority()));
             assertThat(taskRunner.runningTasks(), equalTo(maxTasks));
         }
         assertThat(taskRunner.queueSize(), equalTo(newTasks - 1));
         taskBlocker.countDown();
         /// Eventually all tasks are executed
-        assertBusy(() -> {
-            assertThat(executed.get(), equalTo(enqueued + newTasks));
-            assertThat(taskRunner.runningTasks(), equalTo(0));
-        });
+        assertTrue(executedCountDown.await(10, TimeUnit.SECONDS));
         assertThat(taskRunner.queueSize(), equalTo(0));
+        assertNoRunningTasks(taskRunner);
     }
 
     public void testFailsTasksOnRejectionOrShutdown() throws Exception {
-        final var maxThreads = between(1, 5);
-        final var threadFactory = EsExecutors.daemonThreadFactory("test");
-        final var threadContext = new ThreadContext(Settings.EMPTY);
         final var executor = randomBoolean()
             ? EsExecutors.newScaling("test", 1, maxThreads, 0, TimeUnit.MILLISECONDS, true, threadFactory, threadContext)
             : EsExecutors.newFixed("test", maxThreads, between(1, 5), threadFactory, threadContext, false);
@@ -225,5 +230,22 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
 
     private int getRandomPriority() {
         return randomIntBetween(-1000, 1000);
+    }
+
+    private void assertNoRunningTasks(PrioritizedThrottledTaskRunner<TestTask> taskRunner) {
+        final var barrier = new CyclicBarrier(maxThreads + 1);
+        for (int i = 0; i < maxThreads; i++) {
+            executor.execute(() -> awaitBarrier(barrier));
+        }
+        awaitBarrier(barrier);
+        assertThat(taskRunner.runningTasks(), equalTo(0));
+    }
+
+    private static void awaitBarrier(CyclicBarrier barrier) {
+        try {
+            barrier.await(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            throw new AssertionError("unexpected", e);
+        }
     }
 }


### PR DESCRIPTION
- Makes the conditions on which we're waiting a little more precise, so there's no need to `assertBusy()`.

- Makes the tests a little lighter by not using the large `GENERIC` threadpool executor.

- Adjusts `testTasksRunInOrder` to wait for the enqueueing to finish using a task rather than overriding the (now-private) `pollAndSpawn()` method.