### PR TITLE
Adjust documentation of CCR fatal exceptions

### DIFF
--- a/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
+++ b/docs/reference/ccr/apis/follow/get-follow-stats.asciidoc
@@ -68,9 +68,12 @@ following tasks associated with each shard for the specified indices.
 [%collapsible%open]
 ====
 `fatal_exception`::
-(object) An object representing a fatal exception that cancelled the following
-task. In this situation, the following task must be resumed manually with the
-<<ccr-post-resume-follow,resume follower API>>.
+(object) An object representing a fatal exception that stopped the task in charge
+of replicating operations. In this situation, the following task must be paused manually
+with the <<ccr-post-pause-follow,pause follower API>> and then resumed with the
+<<ccr-post-resume-follow,resume follower API>>. If the index has been stopped by a fatal
+exception during a period long enough for the retention leases to expire,
+the <<ccr-recreate-follower-index,follower index must be recreated>>.
 
 `index`::
 (string) The name of the follower index.


### PR DESCRIPTION
Advise to pause and resume follower indices that stopped due to a fatal exception, and only fall back to recreate the follower index if the retention leases are expired.

Relates https://github.com/elastic/elasticsearch/pull/92522#issuecomment-1362805973