### PR TITLE
[8.6] Fix thirdpartyAudit check for graalvm runtime (#92635)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/BuildParams.java
@@ -114,6 +114,10 @@ public class BuildParams {
         return value(isCi);
     }
 
+    public static Boolean isGraalVmRuntime() {
+        return value(runtimeJavaDetails.toLowerCase().contains("graalvm"));
+    }
+
     public static Integer getDefaultParallel() {
         return value(defaultParallel);
     }

--- a/modules/repository-gcs/build.gradle
+++ b/modules/repository-gcs/build.gradle
@@ -180,16 +180,22 @@ tasks.named("thirdPartyAudit").configure {
     'org.apache.http.protocol.HttpContext',
     'org.apache.http.protocol.HttpProcessor',
     'org.apache.http.protocol.HttpRequestExecutor',
-    // com.google.api.gax optional dependencies
-    'org.graalvm.nativeimage.hosted.Feature',
-    'org.graalvm.nativeimage.hosted.Feature$BeforeAnalysisAccess',
-    'org.graalvm.nativeimage.hosted.Feature$DuringAnalysisAccess',
-    'org.graalvm.nativeimage.hosted.Feature$FeatureAccess',
-    'org.graalvm.nativeimage.hosted.RuntimeReflection',
+
     // commons-logging provided dependencies
     'javax.servlet.ServletContextEvent',
     'javax.servlet.ServletContextListener'
   )
+
+
+  if(BuildParams.graalVmRuntime == false) {
+    ignoreMissingClasses(
+        'org.graalvm.nativeimage.hosted.Feature',
+        'org.graalvm.nativeimage.hosted.Feature$BeforeAnalysisAccess',
+        'org.graalvm.nativeimage.hosted.Feature$DuringAnalysisAccess',
+        'org.graalvm.nativeimage.hosted.Feature$FeatureAccess',
+        'org.graalvm.nativeimage.hosted.RuntimeReflection'
+    )
+  }
 }
 
 boolean useFixture = false


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix thirdpartyAudit check for graalvm runtime (#92635)