### PR TITLE
Fix NPE when evaluating the disk health for non-data nodes

### DIFF
--- a/docs/changelog/92643.yaml
+++ b/docs/changelog/92643.yaml
@@ -1,0 +1,5 @@
+pr: 92643
+summary: Fix NPE when evaluating the disk health for non-data nodes
+area: Health
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/health/node/LocalHealthMonitor.java
+++ b/server/src/main/java/org/elasticsearch/health/node/LocalHealthMonitor.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -433,9 +434,18 @@ public class LocalHealthMonitor implements ClusterStateListener {
             }
 
             long highThreshold = diskMetadata.getFreeBytesHighWatermark(totalBytes).getBytes();
-            if (usage.getFreeBytes() < highThreshold && hasRelocatingShards(clusterState, node.getId()) == false) {
-                logger.debug("High disk watermark [{}] exceeded on {}", highThreshold, usage);
-                return new DiskHealthInfo(HealthStatus.YELLOW, DiskHealthInfo.Cause.NODE_OVER_HIGH_THRESHOLD);
+            if (usage.getFreeBytes() < highThreshold) {
+                if (node.canContainData()) {
+                    // for data nodes only report YELLOW if shards can't move away from the node
+                    if (DiskCheck.hasRelocatingShards(clusterState, node) == false) {
+                        logger.debug("High disk watermark [{}] exceeded on {}", highThreshold, usage);
+                        return new DiskHealthInfo(HealthStatus.YELLOW, DiskHealthInfo.Cause.NODE_OVER_HIGH_THRESHOLD);
+                    }
+                } else {
+                    // for non-data nodes report YELLOW when the disk high watermark is breached
+                    logger.debug("High disk watermark [{}] exceeded on {}", highThreshold, usage);
+                    return new DiskHealthInfo(HealthStatus.YELLOW, DiskHealthInfo.Cause.NODE_OVER_HIGH_THRESHOLD);
+                }
             }
             return new DiskHealthInfo(HealthStatus.GREEN);
         }
@@ -461,8 +471,13 @@ public class LocalHealthMonitor implements ClusterStateListener {
             return DiskUsage.findLeastAvailablePath(nodeStats);
         }
 
-        private boolean hasRelocatingShards(ClusterState clusterState, String nodeId) {
-            return clusterState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.RELOCATING) > 0;
+        static boolean hasRelocatingShards(ClusterState clusterState, DiscoveryNode node) {
+            RoutingNode routingNode = clusterState.getRoutingNodes().node(node.getId());
+            if (routingNode == null) {
+                // routing node will be null for non-data nodes
+                return false;
+            }
+            return routingNode.numberOfShardsWithState(ShardRoutingState.RELOCATING) > 0;
         }
     }
 }


### PR DESCRIPTION
Non-data nodes are not part of the `RoutingTable` so the expression
```
clusterState.getRoutingNodes().node(nodeId).numberOfShardsWithState(ShardRoutingState.RELOCATING) > 0
```
would yield NPE for dedicated non-data nodes:
```
java.lang.NullPointerException: Cannot invoke "org.elasticsearch.cluster.routing.RoutingNode.shardsWithState(org.elasticsearch.cluster.routing.ShardRoutingState)" because the return value of "org.elasticsearch.cluster.routing.RoutingNodes.node(String)" is null
	at org.elasticsearch.server@8.5.0/org.elasticsearch.health.node.LocalHealthMonitor$DiskCheck.hasRelocatingShards(LocalHealthMonitor.java:465)
	at org.elasticsearch.server@8.5.0/org.elasticsearch.health.node.LocalHealthMonitor$DiskCheck.getHealth(LocalHealthMonitor.java:436)
	at org.elasticsearch.server@8.5.0/org.elasticsearch.health.node.LocalHealthMonitor$Monitoring.run(LocalHealthMonitor.java:340)
	at org.elasticsearch.server@8.5.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:825)
```