### PR TITLE
Remove Lister param from AsyncShardFetch

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -291,6 +291,33 @@ public interface ActionListener<Response> {
     }
 
     /**
+     * Adds a wrapper around a listener which catches exceptions thrown by its {@link #onResponse} method and feeds them to its
+     * {@link #onFailure}.
+     */
+    static <Response, BaseResponse extends Response> ActionListener<BaseResponse> wrap(ActionListener<Response> delegate) {
+        return new ActionListener<>() {
+            @Override
+            public void onResponse(BaseResponse response) {
+                try {
+                    delegate.onResponse(response);
+                } catch (Exception e) {
+                    onFailure(e);
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                delegate.onFailure(e);
+            }
+
+            @Override
+            public String toString() {
+                return "wrapped{" + delegate + "}";
+            }
+        };
+    }
+
+    /**
      * Notifies every given listener with the response passed to {@link #onResponse(Object)}. If a listener itself throws an exception
      * the exception is forwarded to {@link #onFailure(Exception)}. If in turn {@link #onFailure(Exception)} fails all remaining
      * listeners will be processed and the caught exception will be re-thrown.

--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -49,36 +49,21 @@ import static org.elasticsearch.core.Strings.format;
  */
 public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Releasable {
 
-    /**
-     * An action that lists the relevant shard data that needs to be fetched.
-     */
-    public interface Lister<NodesResponse extends BaseNodesResponse<NodeResponse>, NodeResponse extends BaseNodeResponse> {
-        void list(ShardId shardId, @Nullable String customDataPath, DiscoveryNode[] nodes, ActionListener<NodesResponse> listener);
-    }
-
     protected final Logger logger;
     protected final String type;
     protected final ShardId shardId;
     protected final String customDataPath;
-    private final Lister<BaseNodesResponse<T>, T> action;
     private final Map<String, NodeEntry<T>> cache = new HashMap<>();
     private final Set<String> nodesToIgnore = new HashSet<>();
     private final AtomicLong round = new AtomicLong();
     private boolean closed;
 
     @SuppressWarnings("unchecked")
-    protected AsyncShardFetch(
-        Logger logger,
-        String type,
-        ShardId shardId,
-        String customDataPath,
-        Lister<? extends BaseNodesResponse<T>, T> action
-    ) {
+    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, String customDataPath) {
         this.logger = logger;
         this.type = type;
         this.shardId = Objects.requireNonNull(shardId);
         this.customDataPath = Objects.requireNonNull(customDataPath);
-        this.action = (Lister<BaseNodesResponse<T>, T>) action;
     }
 
     @Override
@@ -307,7 +292,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     // visible for testing
     void asyncFetch(final DiscoveryNode[] nodes, long fetchingRound) {
         logger.trace("{} fetching [{}] from {}", shardId, type, nodes);
-        action.list(shardId, customDataPath, nodes, new ActionListener<BaseNodesResponse<T>>() {
+        list(shardId, customDataPath, nodes, new ActionListener<BaseNodesResponse<T>>() {
             @Override
             public void onResponse(BaseNodesResponse<T> response) {
                 assert assertSameNodes(response);
@@ -335,6 +320,13 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
             }
         });
     }
+
+    protected abstract void list(
+        ShardId shardId,
+        @Nullable String customDataPath,
+        DiscoveryNode[] nodes,
+        ActionListener<BaseNodesResponse<T>> listener
+    );
 
     /**
      * The result of a fetch operation. Make sure to first check {@link #hasData()} before

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -27,7 +27,6 @@ import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.Releasables;
-import org.elasticsearch.gateway.AsyncShardFetch.Lister;
 import org.elasticsearch.gateway.TransportNodesListGatewayStartedShards.NodeGatewayStartedShards;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.store.TransportNodesListShardStoreMetadata;
@@ -212,16 +211,10 @@ public class GatewayAllocator implements ExistingShardsAllocator {
         return false;
     }
 
-    class InternalAsyncFetch<T extends BaseNodeResponse> extends AsyncShardFetch<T> {
+    abstract class InternalAsyncFetch<T extends BaseNodeResponse> extends AsyncShardFetch<T> {
 
-        InternalAsyncFetch(
-            Logger logger,
-            String type,
-            ShardId shardId,
-            String customDataPath,
-            Lister<? extends BaseNodesResponse<T>, T> action
-        ) {
-            super(logger, type, shardId, customDataPath, action);
+        InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath) {
+            super(logger, type, shardId, customDataPath);
         }
 
         @Override
@@ -250,16 +243,28 @@ public class GatewayAllocator implements ExistingShardsAllocator {
         @Override
         protected AsyncShardFetch.FetchResult<NodeGatewayStartedShards> fetchData(ShardRouting shard, RoutingAllocation allocation) {
             // explicitly type lister, some IDEs (Eclipse) are not able to correctly infer the function type
-            Lister<BaseNodesResponse<NodeGatewayStartedShards>, NodeGatewayStartedShards> lister = this::listStartedShards;
             AsyncShardFetch<NodeGatewayStartedShards> fetch = asyncFetchStarted.computeIfAbsent(
                 shard.shardId(),
                 shardId -> new InternalAsyncFetch<>(
                     logger,
                     "shard_started",
                     shardId,
-                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings()),
-                    lister
-                )
+                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings())
+                ) {
+                    @Override
+                    protected void list(
+                        ShardId shardId,
+                        String customDataPath,
+                        DiscoveryNode[] nodes,
+                        ActionListener<BaseNodesResponse<NodeGatewayStartedShards>> listener
+                    ) {
+                        client.executeLocally(
+                            TransportNodesListGatewayStartedShards.TYPE,
+                            new TransportNodesListGatewayStartedShards.Request(shardId, customDataPath, nodes),
+                            ActionListener.wrap(listener)
+                        );
+                    }
+                }
             );
             AsyncShardFetch.FetchResult<NodeGatewayStartedShards> shardState = fetch.fetchData(
                 allocation.nodes(),
@@ -272,19 +277,6 @@ public class GatewayAllocator implements ExistingShardsAllocator {
             return shardState;
         }
 
-        private void listStartedShards(
-            ShardId shardId,
-            String customDataPath,
-            DiscoveryNode[] nodes,
-            ActionListener<BaseNodesResponse<NodeGatewayStartedShards>> listener
-        ) {
-            var request = new TransportNodesListGatewayStartedShards.Request(shardId, customDataPath, nodes);
-            client.executeLocally(
-                TransportNodesListGatewayStartedShards.TYPE,
-                request,
-                ActionListener.wrap(listener::onResponse, listener::onFailure)
-            );
-        }
     }
 
     class InternalReplicaShardAllocator extends ReplicaShardAllocator {
@@ -297,17 +289,28 @@ public class GatewayAllocator implements ExistingShardsAllocator {
 
         @Override
         protected AsyncShardFetch.FetchResult<NodeStoreFilesMetadata> fetchData(ShardRouting shard, RoutingAllocation allocation) {
-            // explicitly type lister, some IDEs (Eclipse) are not able to correctly infer the function type
-            Lister<BaseNodesResponse<NodeStoreFilesMetadata>, NodeStoreFilesMetadata> lister = this::listStoreFilesMetadata;
             AsyncShardFetch<NodeStoreFilesMetadata> fetch = asyncFetchStore.computeIfAbsent(
                 shard.shardId(),
                 shardId -> new InternalAsyncFetch<>(
                     logger,
                     "shard_store",
                     shard.shardId(),
-                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings()),
-                    lister
-                )
+                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings())
+                ) {
+                    @Override
+                    protected void list(
+                        ShardId shardId,
+                        String customDataPath,
+                        DiscoveryNode[] nodes,
+                        ActionListener<BaseNodesResponse<NodeStoreFilesMetadata>> listener
+                    ) {
+                        client.executeLocally(
+                            TransportNodesListShardStoreMetadata.TYPE,
+                            new TransportNodesListShardStoreMetadata.Request(shardId, customDataPath, nodes),
+                            ActionListener.wrap(listener)
+                        );
+                    }
+                }
             );
             AsyncShardFetch.FetchResult<NodeStoreFilesMetadata> shardStores = fetch.fetchData(
                 allocation.nodes(),
@@ -317,20 +320,6 @@ public class GatewayAllocator implements ExistingShardsAllocator {
                 shardStores.processAllocation(allocation);
             }
             return shardStores;
-        }
-
-        private void listStoreFilesMetadata(
-            ShardId shardId,
-            String customDataPath,
-            DiscoveryNode[] nodes,
-            ActionListener<BaseNodesResponse<NodeStoreFilesMetadata>> listener
-        ) {
-            var request = new TransportNodesListShardStoreMetadata.Request(shardId, customDataPath, nodes);
-            client.executeLocally(
-                TransportNodesListShardStoreMetadata.TYPE,
-                request,
-                ActionListener.wrap(listener::onResponse, listener::onFailure)
-            );
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
@@ -20,32 +20,126 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class ActionListenerTests extends ESTestCase {
 
-    public void testWrap() {
+    public void testWrapConsumers() {
         AtomicReference<Boolean> reference = new AtomicReference<>();
         AtomicReference<Exception> exReference = new AtomicReference<>();
 
-        CheckedConsumer<Boolean, ? extends Exception> handler = (o) -> {
-            if (Boolean.FALSE.equals(o)) {
-                throw new IllegalArgumentException("must not be false");
+        ActionListener<Boolean> wrap = ActionListener.wrap(new CheckedConsumer<>() {
+            @Override
+            public void accept(Boolean o) {
+                if (Boolean.FALSE.equals(o)) {
+                    throw new IllegalArgumentException("must not be false");
+                }
+                reference.set(o);
             }
-            reference.set(o);
-        };
-        ActionListener<Boolean> wrap = ActionListener.wrap(handler, exReference::set);
+
+            @Override
+            public String toString() {
+                return "test handler";
+            }
+        }, new Consumer<>() {
+            @Override
+            public void accept(Exception newValue) {
+                exReference.set(newValue);
+            }
+
+            @Override
+            public String toString() {
+                return "test exception handler";
+            }
+        });
+
+        assertEquals("WrappedActionListener{test handler}{test exception handler}", wrap.toString());
+
         wrap.onResponse(Boolean.FALSE);
-        assertNull(reference.get());
-        assertNotNull(exReference.get());
-        assertEquals("must not be false", exReference.get().getMessage());
-        exReference.set(null);
+        assertNull(reference.getAndSet(null));
+        assertEquals("must not be false", exReference.getAndSet(null).getMessage());
 
         wrap.onResponse(Boolean.TRUE);
-        assertTrue(reference.get());
-        assertNull(exReference.get());
+        assertTrue(reference.getAndSet(null));
+        assertNull(exReference.getAndSet(null));
+
+        wrap.onFailure(new RuntimeException("test exception"));
+        assertNull(reference.getAndSet(null));
+        assertEquals("test exception", exReference.getAndSet(null).getMessage());
+    }
+
+    public void testWrapRunnable() {
+        var executed = new AtomicBoolean();
+        var listener = ActionListener.wrap(new Runnable() {
+            @Override
+            public void run() {
+                assertTrue(executed.compareAndSet(false, true));
+            }
+
+            @Override
+            public String toString() {
+                return "test runnable";
+            }
+        });
+
+        assertEquals("RunnableWrappingActionListener{test runnable}", listener.toString());
+
+        listener.onResponse(new Object());
+        assertTrue(executed.getAndSet(false));
+
+        listener.onFailure(new Exception("simulated"));
+        assertTrue(executed.getAndSet(false));
+
+        expectThrows(
+            AssertionError.class,
+            () -> ActionListener.wrap(() -> { throw new UnsupportedOperationException(); }).onResponse(null)
+        );
+    }
+
+    public void testWrapListener() {
+        var succeeded = new AtomicBoolean();
+        var failed = new AtomicBoolean();
+
+        var listener = ActionListener.wrap(new ActionListener<>() {
+            @Override
+            public void onResponse(Object o) {
+                assertTrue(succeeded.compareAndSet(false, true));
+                if (o instanceof RuntimeException e) {
+                    throw e;
+                }
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                assertTrue(failed.compareAndSet(false, true));
+                assertEquals("test exception", e.getMessage());
+                if (e instanceof UnsupportedOperationException uoe) {
+                    throw uoe;
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "test listener";
+            }
+        });
+
+        assertEquals("wrapped{test listener}", listener.toString());
+
+        listener.onResponse(new Object());
+        assertTrue(succeeded.getAndSet(false));
+        assertFalse(failed.getAndSet(false));
+
+        listener.onFailure(new RuntimeException("test exception"));
+        assertFalse(succeeded.getAndSet(false));
+        assertTrue(failed.getAndSet(false));
+
+        listener.onResponse(new RuntimeException("test exception"));
+        assertTrue(succeeded.getAndSet(false));
+        assertTrue(failed.getAndSet(false));
     }
 
     public void testOnResponse() {

--- a/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -9,8 +9,10 @@ package org.elasticsearch.gateway;
 
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
+import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
@@ -372,11 +374,21 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         private final ThreadPool threadPool;
         private final Map<String, Entry> simulations = new ConcurrentHashMap<>();
-        private AtomicInteger reroute = new AtomicInteger();
+        private final AtomicInteger reroute = new AtomicInteger();
 
         TestFetch(ThreadPool threadPool) {
-            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "", null);
+            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "");
             this.threadPool = threadPool;
+        }
+
+        @Override
+        protected void list(
+            ShardId shardId,
+            String customDataPath,
+            DiscoveryNode[] nodes,
+            ActionListener<BaseNodesResponse<Response>> listener
+        ) {
+            fail("should not call list()");
         }
 
         public void addSimulation(String nodeId, Response response) {


### PR DESCRIPTION
The `Lister` constructor parameter to `AsyncShardFetch` is essentially just an abstract method with extra steps. This commit removes those unnecessary extra steps in favour of a plain old abstract method.