### PR TITLE
docs: use valid settings in examples

### DIFF
--- a/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
@@ -55,8 +55,7 @@ PUT _logstash/pipeline/my_pipeline
     "pipeline.batch.size": 125,
     "pipeline.batch.delay": 50,
     "queue.type": "memory",
-    "queue.max_bytes.number": 1,
-    "queue.max_bytes.units": "gb",
+    "queue.max_bytes": "1gb",
     "queue.checkpoint.writes": 1024
   }
 }

--- a/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
@@ -57,8 +57,7 @@ PUT _logstash/pipeline/my_pipeline
     "pipeline.batch.size": 125,
     "pipeline.batch.delay": 50,
     "queue.type": "memory",
-    "queue.max_bytes.number": 1,
-    "queue.max_bytes.units": "gb",
+    "queue.max_bytes": "1gb",
     "queue.checkpoint.writes": 1024
   }
 }
@@ -92,8 +91,7 @@ If the request succeeds, the body of the response contains the pipeline definiti
       "pipeline.batch.size": 125,
       "pipeline.batch.delay": 50,
       "queue.type": "memory",
-      "queue.max_bytes.number": 1,
-      "queue.max_bytes.units": "gb",
+      "queue.max_bytes": "1gb",
       "queue.checkpoint.writes": 1024
     }
   }

--- a/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
@@ -87,8 +87,7 @@ PUT _logstash/pipeline/my_pipeline
     "pipeline.batch.size": 125,
     "pipeline.batch.delay": 50,
     "queue.type": "memory",
-    "queue.max_bytes.number": 1,
-    "queue.max_bytes.units": "gb",
+    "queue.max_bytes": "1gb",
     "queue.checkpoint.writes": 1024
   }
 }


### PR DESCRIPTION
Logstash Central Management allows key/value map for `pipeline_settings`, but the Elasticsearch API does not perform validation of the provided settings.

Here, we remove from our examples introduced in https://github.com/elastic/elasticsearch/pull/67788 settings that have no semantic meaning to Logstash, and replace them with a key/value pair [`"queue.max_bytes": "1gb"`](https://www.elastic.co/guide/en/logstash/current/logstash-settings-file.html) that has been valid since [at least Logstash 6.0](https://www.elastic.co/guide/en/logstash/6.0/logstash-settings-file.html),