### PR TITLE
Remove CompoundProcessor constructor

### DIFF
--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/ForEachProcessorFactoryTests.java
@@ -18,7 +18,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.notNullValue;
@@ -28,7 +27,6 @@ import static org.mockito.Mockito.mock;
 public class ForEachProcessorFactoryTests extends ESTestCase {
 
     private final ScriptService scriptService = mock(ScriptService.class);
-    private final Consumer<Runnable> genericExecutor = Runnable::run;
 
     public void testCreate() throws Exception {
         Processor processor = new TestProcessor(ingestDocument -> {});

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -53,7 +53,6 @@ public class CompoundProcessor implements Processor {
         List<Processor> onFailureProcessors,
         LongSupplier relativeTimeProvider
     ) {
-        super();
         this.ignoreFailure = ignoreFailure;
         this.processors = List.copyOf(processors);
         this.onFailureProcessors = List.copyOf(onFailureProcessors);

--- a/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/CompoundProcessor.java
@@ -35,10 +35,6 @@ public class CompoundProcessor implements Processor {
     private final LongSupplier relativeTimeProvider;
     private final boolean isAsync;
 
-    CompoundProcessor(LongSupplier relativeTimeProvider, boolean ignoreFailure, Processor... processors) {
-        this(ignoreFailure, List.of(processors), List.of(), relativeTimeProvider);
-    }
-
     public CompoundProcessor(Processor... processors) {
         this(false, List.of(processors), List.of());
     }

--- a/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/ConditionalProcessor.java
@@ -33,6 +33,9 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
 
+/**
+ * A wrapping processor that adds 'if' logic around the wrapped processor.
+ */
 public class ConditionalProcessor extends AbstractProcessor implements WrappingProcessor {
 
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(DynamicMap.class);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -251,11 +251,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                     Settings settings = MetadataIndexTemplateService.resolveSettings(metadata, v2Template);
                     if (IndexSettings.DEFAULT_PIPELINE.exists(settings)) {
                         defaultPipeline = IndexSettings.DEFAULT_PIPELINE.get(settings);
-                        // we can not break in case a lower-order template has a final pipeline that we need to collect
                     }
                     if (IndexSettings.FINAL_PIPELINE.exists(settings)) {
                         finalPipeline = IndexSettings.FINAL_PIPELINE.get(settings);
-                        // we can not break in case a lower-order template has a default pipeline that we need to collect
                     }
                     indexRequest.setPipeline(Objects.requireNonNullElse(defaultPipeline, NOOP_PIPELINE_NAME));
                     indexRequest.setFinalPipeline(Objects.requireNonNullElse(finalPipeline, NOOP_PIPELINE_NAME));

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -830,7 +830,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     /**
      * Adds a listener that gets invoked with the current cluster state before processor factories
      * get invoked.
-     *
+     * <p>
      * This is useful for components that are used by ingest processors, so that they have the opportunity to update
      * before these components get used by the ingest processor factory.
      */

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -211,7 +211,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             String defaultPipeline = null;
             String finalPipeline = null;
             IndexMetadata indexMetadata = null;
-            // start to look for default or final pipelines via settings found in the index meta data
+            // start to look for default or final pipelines via settings found in the index metadata
             if (originalRequest != null) {
                 indexMetadata = metadata.indices()
                     .get(IndexNameExpressionResolver.resolveDateMathExpression(originalRequest.index(), epochMillis));

--- a/server/src/main/java/org/elasticsearch/ingest/WrappingProcessor.java
+++ b/server/src/main/java/org/elasticsearch/ingest/WrappingProcessor.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.ingest;
 
 /**
- * A srapping processor is one that encapsulates an inner processor, or a processor that the wrapped processor acts upon. All processors
+ * A wrapping processor is one that encapsulates an inner processor, or a processor that the wrapped processor acts upon. All processors
  * that contain an "inner" processor should implement this interface, such that the actual processor can be obtained.
  */
 public interface WrappingProcessor extends Processor {

--- a/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/CompoundProcessorTests.java
@@ -60,7 +60,7 @@ public class CompoundProcessorTests extends ESTestCase {
                 return isAsync;
             }
         };
-        CompoundProcessor compoundProcessor = new CompoundProcessor(relativeTimeProvider, false, processor);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(false, List.of(processor), List.of(), relativeTimeProvider);
         ingestDocument.setFieldValue("compoundProcessor", compoundProcessor); // ugly hack to assert current count = 1
         assertThat(compoundProcessor.getProcessors().size(), equalTo(1));
         assertThat(compoundProcessor.getProcessors().get(0), sameInstance(processor));
@@ -76,7 +76,7 @@ public class CompoundProcessorTests extends ESTestCase {
         TestProcessor processor = new TestProcessor(new RuntimeException("error"));
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
-        CompoundProcessor compoundProcessor = new CompoundProcessor(relativeTimeProvider, false, processor);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(false, List.of(processor), List.of(), relativeTimeProvider);
         assertThat(compoundProcessor.getProcessors().size(), equalTo(1));
         assertThat(compoundProcessor.getProcessors().get(0), sameInstance(processor));
         assertThat(compoundProcessor.getOnFailureProcessors().isEmpty(), is(true));
@@ -249,7 +249,7 @@ public class CompoundProcessorTests extends ESTestCase {
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L);
 
-        CompoundProcessor failCompoundProcessor = new CompoundProcessor(relativeTimeProvider, false, firstProcessor);
+        CompoundProcessor failCompoundProcessor = new CompoundProcessor(false, List.of(firstProcessor), List.of(), relativeTimeProvider);
 
         CompoundProcessor compoundProcessor = new CompoundProcessor(
             false,
@@ -313,7 +313,7 @@ public class CompoundProcessorTests extends ESTestCase {
         CompoundProcessor failCompoundProcessor = new CompoundProcessor(
             false,
             List.of(firstProcessor),
-            List.of(new CompoundProcessor(relativeTimeProvider, false, failProcessor))
+            List.of(new CompoundProcessor(false, List.of(failProcessor), List.of(), relativeTimeProvider))
         );
 
         CompoundProcessor compoundProcessor = new CompoundProcessor(
@@ -480,7 +480,7 @@ public class CompoundProcessorTests extends ESTestCase {
         for (int i = 0; i < processorsCount; i++) {
             processors[i] = getTestProcessor(Integer.toString(i), randomBoolean(), randomBoolean());
         }
-        CompoundProcessor compoundProcessor = new CompoundProcessor(relativeTimeProvider, true, processors);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(true, List.of(processors), List.of(), relativeTimeProvider);
         executeCompound(
             compoundProcessor,
             ingestDocument,
@@ -508,7 +508,7 @@ public class CompoundProcessorTests extends ESTestCase {
         for (int i = goodProcessorsCount + 1; i < totalProcessorsCount; i++) {
             processors[i] = getTestProcessor(Integer.toString(i), randomBoolean(), false);
         }
-        CompoundProcessor compoundProcessor = new CompoundProcessor(relativeTimeProvider, false, processors);
+        CompoundProcessor compoundProcessor = new CompoundProcessor(false, List.of(processors), List.of(), relativeTimeProvider);
         executeCompound(compoundProcessor, ingestDocument, (result, e) -> {});
         for (int i = 0; i < goodProcessorsCount + 1; i++) {
             assertThat(

--- a/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
@@ -265,7 +265,7 @@ public class ConditionalProcessorTests extends ESTestCase {
         Map<String, Object> document = new HashMap<>();
         ConditionalProcessor processor = new ConditionalProcessor(
             randomAlphaOfLength(10),
-            "desription",
+            "description",
             new Script(ScriptType.INLINE, Script.DEFAULT_SCRIPT_LANG, scriptName, Map.of()),
             scriptService,
             new FakeProcessor(null, null, null, null)


### PR DESCRIPTION
`CompoundProcessor` has two public constructors that are used from production code, and two package-private constructors that are used from tests. This PR removes one of the package-private constructors and rewrites all callers of it to instead use the other package-private constructor. Nothing too exciting, just a small task that was in my way on the path to greater things.

This PR also has a bunch of small ingest-related cleanup commits that I've been accumulating in various branches and stashes, none of them seem like 'a thing' enough to warrant their own PRs, but I would actually like to get some of this WIP off my box and merged into main, so here they are.