### PR TITLE
[TEST] Fix FileSettingsRoleMappingsStartupIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnapshotsAndFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnapshotsAndFileSettingsIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.reservedstate.service;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.action.admin.cluster.settings.ClusterGetSettingsAction;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -44,6 +45,7 @@ import static org.hamcrest.Matchers.equalTo;
  * Tests that snapshot restore behaves correctly when we have file based settings that reserve part of the
  * cluster state
  */
+@LuceneTestCase.SuppressFileSystems("*")
 public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
     private static AtomicLong versionCounter = new AtomicLong(1);
 
@@ -279,7 +281,6 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
         String masterNode = internalCluster().getMasterName();
 
         var savedClusterState = setupClusterStateListener(masterNode);
-        FileSettingsService fs = internalCluster().getInstance(FileSettingsService.class, masterNode);
 
         logger.info("--> write some file based settings, putting some reserved state");
         writeJSONFile(masterNode, testFileSettingsJSON);
@@ -351,5 +352,4 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
                 )
         );
     }
-
 }


### PR DESCRIPTION
Disable mock lucene file systems that throw an error where IOException is expected.

FileSettingsService uses the Java WatchService to detect when the file settings have been modified. While processing the current file settings, the file can get replaced on the file system which might cause an IOException at various places when we are in the process of reading the file. 

Throwing an IOException because of an overwritten file is harmless. We'll simply abandon the current file settings processing and we'll process the next event from the watcher service.

However, the mock file systems that we use by default from lucene turn this IOException into a j.l.AssertionError, which isn't an Exception but extends from j.l.Error. Since we only handle Exceptions in the catch block, the Error is propagated all the way to the watcher thread and effectively the file settings service thread terminates.

With this PR I'm disabling the mock file systems, we should be testing the actual file system functionality. If this PR fixes the issue, I'll apply the same fix to the other similar FileSettingsService tests.

Closes #92242
