### PR TITLE
[8.6] Limit test port range to below the Linux default ephemeral port range (#92666)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1730,7 +1730,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     /**
      * Defines the maximum port that test workers should use. See also [NOTE: Port ranges for tests].
      */
-    private static final int MAX_PRIVATE_PORT = 36600;
+    private static final int MAX_PRIVATE_PORT = 32767;
 
     /**
      * Wrap around after reaching this worker ID.


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Limit test port range to below the Linux default ephemeral port range (#92666)