### PR TITLE
Simplify sharding guidelines.

### DIFF
--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -415,6 +415,47 @@ While this would help reduce index and shard counts, the combined index would
 have larger mappings and be less search-efficient.
 
 [discrete]
+[[shard-sizing-considerations]]
+=== Sizing considerations
+
+Keep the following things in mind when building your sharding strategy.
+
+[discrete]
+[[single-thread-per-shard]]
+==== Searches run on a single thread per shard
+
+Most searches hit multiple shards. Each shard runs the search on a single
+CPU thread. While a shard can run multiple concurrent searches, searches across a
+large number of shards can deplete a node's <<modules-threadpool,search
+thread pool>>. This can result in low throughput and slow search speeds.
+
+[discrete]
+[[each-shard-has-overhead]]
+==== Each index, shard, segment and field has overhead
+
+Every index and every shard requires some memory and CPU resources. In most
+cases, a small set of large shards uses fewer resources than many small shards.
+
+Segments play a big role in a shard's resource usage. Most shards contain
+several segments, which store its index data. {es} keeps some segment metadata
+in heap memory so it can be quickly retrieved for searches. As a shard grows,
+its segments are <<index-modules-merge,merged>> into fewer, larger segments.
+This decreases the number of segments, which means less metadata is kept in
+heap memory.
+
+Every mapped field also carries some overhead in terms of memory usage and disk
+space. By default {es} will automatically create a mapping for every field in
+every document it indexes, but you can switch off this behaviour to
+<<explicit-mapping,take control of your mappings>>.
+
+Moreover every segment requires a small amount of heap memory for each mapped
+field. This per-segment-per-field heap overhead includes a copy of the field
+name, encoded using ISO-8859-1 if applicable or UTF-16 otherwise. Usually this
+is not noticeable, but you may need to account for this overhead if your shards
+have high segment counts and the corresponding mappings contain high field
+counts and/or very long field names.
+
+[discrete]
 [[troubleshoot-shard-related-errors]]
 === Troubleshoot shard-related errors
 

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -7,105 +7,18 @@ are using <<data-streams>> then each data stream is backed by a sequence of
 indices. There is a limit to the amount of data you can store on a single node
 so you can increase the capacity of your cluster by adding nodes and increasing
 the number of indices and shards to match. However, each index and shard has
-some overhead and if you divide your data across too many shards then the
-overhead can become overwhelming. A cluster with too many indices or shards is
-said to suffer from _oversharding_. An oversharded cluster will be less
-efficient at responding to searches and in extreme cases it may even become
-unstable.
-
-[discrete]
-[[create-a-sharding-strategy]]
-=== Create a sharding strategy
-
-The best way to prevent oversharding and other shard-related issues is to
-create a sharding strategy. A sharding strategy helps you determine and
-maintain the optimal number of shards for your cluster while limiting the size
-of those shards.
-
-Unfortunately, there is no one-size-fits-all sharding strategy. A strategy that
-works in one environment may not scale in another. A good sharding strategy
-must account for your infrastructure, use case, and performance expectations.
-
-The best way to create a sharding strategy is to benchmark your production data
-on production hardware using the same queries and indexing loads you'd see in
-production. For our recommended methodology, watch the
-https://www.elastic.co/elasticon/conf/2016/sf/quantitative-cluster-sizing[quantitative
-cluster sizing video]. As you test different shard configurations, use {kib}'s
-{kibana-ref}/elasticsearch-metrics.html[{es} monitoring tools] to track your
-cluster's stability and performance.
-
-The following sections provide some reminders and guidelines you should
-consider when designing your sharding strategy. If your cluster is already
-oversharded, see <<reduce-cluster-shard-count>>.
-
-[discrete]
-[[shard-sizing-considerations]]
-=== Sizing considerations
-
-Keep the following things in mind when building your sharding strategy.
-
-[discrete]
-[[single-thread-per-shard]]
-==== Searches run on a single thread per shard
-
-Most searches hit multiple shards. Each shard runs the search on a single
-CPU thread. While a shard can run multiple concurrent searches, searches across a
-large number of shards can deplete a node's <<modules-threadpool,search
-thread pool>>. This can result in low throughput and slow search speeds.
-
-[discrete]
-[[each-shard-has-overhead]]
-==== Each index, shard, segment and field has overhead
-
-Every index and every shard requires some memory and CPU resources. In most
-cases, a small set of large shards uses fewer resources than many small shards.
-
-Segments play a big role in a shard's resource usage. Most shards contain
-several segments, which store its index data. {es} keeps some segment metadata
-in heap memory so it can be quickly retrieved for searches. As a shard grows,
-its segments are <<index-modules-merge,merged>> into fewer, larger segments.
-This decreases the number of segments, which means less metadata is kept in
-heap memory.
-
-Every mapped field also carries some overhead in terms of memory usage and disk
-space. By default {es} will automatically create a mapping for every field in
-every document it indexes, but you can switch off this behaviour to
-<<explicit-mapping,take control of your mappings>>.
-
-Moreover every segment requires a small amount of heap memory for each mapped
-field. This per-segment-per-field heap overhead includes a copy of the field
-name, encoded using ISO-8859-1 if applicable or UTF-16 otherwise. Usually this
-is not noticeable, but you may need to account for this overhead if your shards
-have high segment counts and the corresponding mappings contain high field
-counts and/or very long field names.
-
-[discrete]
-[[shard-auto-balance]]
-==== {es} automatically balances shards within a data tier
-
-A cluster's nodes are grouped into <<data-tiers,data tiers>>. Within each tier,
-{es} attempts to spread an index's shards across as many nodes as possible. When
-you add a new node or a node fails, {es} automatically rebalances the index's
-shards across the tier's remaining nodes.
+some overhead and if shards do not store enough data on average then this
+overhead becomes the scalability bottleneck of the cluster. A cluster with too
+many indices or shards for the amount of data that it manages is said to suffer
+from _oversharding_. An oversharded cluster will be less efficient at
+responding to searches and in extreme cases it may even become unstable.
 
 [discrete]
 [[shard-size-best-practices]]
 === Best practices
 
-Where applicable, use the following best practices as starting points for your
-sharding strategy.
-
-[discrete]
-[[delete-indices-not-documents]]
-==== Delete indices, not documents
-
-Deleted documents aren't immediately removed from {es}'s file system.
-Instead, {es} marks the document as deleted on each related shard. The marked
-document will continue to use resources until it's removed during a periodic
-<<index-modules-merge,segment merge>>.
-
-When possible, delete entire indices instead. {es} can immediately remove
-deleted indices directly from the file system and free up resources.
+The best way to avoid oversharding issues is to follow some best practices
+regarding data organization and cluster sizing.
 
 [discrete]
 [[use-ds-ilm-for-time-series]]
@@ -121,7 +34,7 @@ a new write index when the current one meets a defined `max_primary_shard_size`,
 `max_age`, `max_docs`, or `max_size` threshold. When an index is no longer
 needed, you can use {ilm-init} to automatically delete it and free up resources.
 
-{ilm-init} also makes it easy to change your sharding strategy over time:
+{ilm-init} also makes it easy to change your number of shards over time:
 
 * *Want to decrease the shard count for new indices?* +
 Change the <<index-number-of-shards,`index.number_of_shards`>> setting in the
@@ -136,7 +49,7 @@ Offset the increased shard count by deleting older indices sooner. You can do
 this by lowering the `min_age` threshold for your policy's
 <<ilm-index-lifecycle,delete phase>>.
 
-Every new backing index is an opportunity to further tune your strategy.
+Every new backing index is an opportunity to further tune sharding.
 
 [discrete]
 [[shard-size-recommendation]]
@@ -158,6 +71,9 @@ Smaller shards may be appropriate for
 
 If you use {ilm-init}, set the <<ilm-rollover,rollover action>>'s
 `max_primary_shard_size` threshold to `50gb` to avoid shards larger than 50GB.
+If you configure a `max_age`, it is recommended to also configure a
+`min_primary_shard_size` of e.g. `1gb` to prevent age-based rollovers from
+producing too small indices.
 
 To see the current size of your shards, use the <<cat-shards,cat shards API>>.
 
@@ -181,6 +97,20 @@ index                                 prirep shard store
 // TESTRESPONSE[s/50gb/.*/]
 
 [discrete]
+[[delete-indices-not-documents]]
+==== Delete indices, not documents
+
+Deleted documents aren't immediately removed from {es}'s file system.
+Instead, {es} marks the document as deleted on each related shard. The marked
+document will continue to use resources until it's removed during a periodic
+<<index-modules-merge,segment merge>>.
+
+When possible, delete entire indices instead. {es} can immediately remove
+deleted indices directly from the file system and free up resources. This is
+how the {ilm} delete action works under the hood, so if you are using data
+streams and {ilm}, this is taken care of for you.
+
+[discrete]
 [[shard-count-recommendation]]
 ==== Master-eligible nodes should have at least 1GB of heap per 3000 indices
 
@@ -198,9 +128,7 @@ for every 3000 indices in your cluster.
 Note that this rule defines the absolute maximum number of indices that a
 master node can manage, but does not guarantee the performance of searches or
 indexing involving this many indices. You must also ensure that your data nodes
-have adequate resources for your workload and that your overall sharding
-strategy meets all your performance requirements. See also
-<<single-thread-per-shard>> and <<each-shard-has-overhead>>.
+have adequate resources for your workload.
 
 To check the configured size of each node's heap, use the <<cat-nodes,cat nodes
 API>>.
@@ -341,9 +269,7 @@ or scaling up the cluster, or redistributing index shards.
 
 Note that the above rules do not necessarily guarantee the performance of
 searches or indexing involving a very high number of indices. You must also
-ensure that your data nodes have adequate resources for your workload and
-that your overall sharding strategy meets all your performance requirements.
-See also <<single-thread-per-shard>> and <<each-shard-has-overhead>>.
+ensure that your data nodes have adequate resources.
 
 [discrete]
 [[avoid-node-hotspots]]
@@ -483,6 +409,10 @@ POST _reindex
   }
 }
 ----
+
+Note that it is discouraged to combine indices that have different mappings.
+While this would help reduce index and shard counts, the combined index would
+have larger mappings and be less search-efficient.
 
 [discrete]
 [[troubleshoot-shard-related-errors]]

--- a/docs/reference/how-to/size-your-shards.asciidoc
+++ b/docs/reference/how-to/size-your-shards.asciidoc
@@ -418,7 +418,7 @@ have larger mappings and be less search-efficient.
 [[shard-sizing-considerations]]
 === Sizing considerations
 
-Keep the following things in mind when building your sharding strategy.
+Keep the following things in mind when sizing your shards.
 
 [discrete]
 [[single-thread-per-shard]]


### PR DESCRIPTION
Our current sharding guidelines are complicated and emphasize that there is no one-size-fits-all sharding strategy. I think it makes it sound more complicated than it should be: while figuring out the optimal way to organize shards can be involved, figuring out an approach that works should be very simple and mostly consist of following some best practices.

From this perspective I made the following changes:
 - Removed parts that make it sound like "it's complicated" and mentions of "sharding strategy".
 - Move best practices closer to the top, especially the most relevant best practices.
 - Mention rollover's `min_primary_shard_size`.
 - Rephrased the description of oversharding to highlight that it's not as much about the number of shards as it is about the average shard size.