### PR TITLE
[8.6] Migrate core rest tests with security to new testing framework (#92575)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ElasticsearchTestBasePlugin.java
@@ -54,7 +54,8 @@ public class ElasticsearchTestBasePlugin implements Plugin<Project> {
         project.getTasks().withType(Test.class).configureEach(test -> {
             File testOutputDir = new File(test.getReports().getJunitXml().getOutputLocation().getAsFile().get(), "output");
 
-            ErrorReportingTestListener listener = new ErrorReportingTestListener(test.getTestLogging(), test.getLogger(), testOutputDir);
+            ErrorReportingTestListener listener = new ErrorReportingTestListener(test, testOutputDir);
+            test.getExtensions().getExtraProperties().set("dumpOutputOnFailure", true);
             test.getExtensions().add("errorReportingTestListener", listener);
             test.addTestOutputListener(listener);
             test.addTestListener(listener);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/ErrorReportingTestListener.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/ErrorReportingTestListener.java
@@ -10,12 +10,12 @@ package org.elasticsearch.gradle.internal.test;
 import org.gradle.api.internal.tasks.testing.logging.FullExceptionFormatter;
 import org.gradle.api.internal.tasks.testing.logging.TestExceptionFormatter;
 import org.gradle.api.logging.Logger;
+import org.gradle.api.tasks.testing.Test;
 import org.gradle.api.tasks.testing.TestDescriptor;
 import org.gradle.api.tasks.testing.TestListener;
 import org.gradle.api.tasks.testing.TestOutputEvent;
 import org.gradle.api.tasks.testing.TestOutputListener;
 import org.gradle.api.tasks.testing.TestResult;
-import org.gradle.api.tasks.testing.logging.TestLogging;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -38,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
 public class ErrorReportingTestListener implements TestOutputListener, TestListener {
     private static final String REPRODUCE_WITH_PREFIX = "REPRODUCE WITH";
 
+    private final Test testTask;
     private final TestExceptionFormatter formatter;
     private final File outputDirectory;
     private final Logger taskLogger;
@@ -45,9 +46,10 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
     private Map<Descriptor, Deque<String>> reproductionLines = new ConcurrentHashMap<>();
     private Set<Descriptor> failedTests = new LinkedHashSet<>();
 
-    public ErrorReportingTestListener(TestLogging testLogging, Logger taskLogger, File outputDirectory) {
-        this.formatter = new FullExceptionFormatter(testLogging);
-        this.taskLogger = taskLogger;
+    public ErrorReportingTestListener(Test testTask, File outputDirectory) {
+        this.testTask = testTask;
+        this.formatter = new FullExceptionFormatter(testTask.getTestLogging());
+        this.taskLogger = testTask.getLogger();
         this.outputDirectory = outputDirectory;
     }
 
@@ -80,34 +82,37 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
         Descriptor descriptor = Descriptor.of(suite);
 
         try {
-            // if the test suite failed, report all captured output
-            if (result.getResultType().equals(TestResult.ResultType.FAILURE)) {
-                EventWriter eventWriter = eventWriters.get(descriptor);
+            if (isDumpOutputEnabled()) {
+                // if the test suite failed, report all captured output
+                if (result.getResultType().equals(TestResult.ResultType.FAILURE)) {
+                    EventWriter eventWriter = eventWriters.get(descriptor);
 
-                if (eventWriter != null) {
-                    // It's not explicit what the threading guarantees are for TestListener method execution so we'll
-                    // be explicitly safe here to avoid interleaving output from multiple test suites
-                    synchronized (this) {
-                        // make sure we've flushed everything to disk before reading
-                        eventWriter.flush();
+                    if (eventWriter != null) {
+                        // It's not explicit what the threading guarantees are for TestListener method execution so we'll
+                        // be explicitly safe here to avoid interleaving output from multiple test suites
+                        synchronized (this) {
+                            // make sure we've flushed everything to disk before reading
+                            eventWriter.flush();
 
-                        System.err.println("\n\nSuite: " + suite);
+                            System.err.println("\n\nSuite: " + suite);
 
-                        try (BufferedReader reader = eventWriter.reader()) {
-                            PrintStream out = System.out;
-                            for (String message = reader.readLine(); message != null; message = reader.readLine()) {
-                                if (message.startsWith("  1> ")) {
-                                    out = System.out;
-                                } else if (message.startsWith("  2> ")) {
-                                    out = System.err;
+                            try (BufferedReader reader = eventWriter.reader()) {
+                                PrintStream out = System.out;
+                                for (String message = reader.readLine(); message != null; message = reader.readLine()) {
+                                    if (message.startsWith("  1> ")) {
+                                        out = System.out;
+                                    } else if (message.startsWith("  2> ")) {
+                                        out = System.err;
+                                    }
+
+                                    out.println(message);
                                 }
-
-                                out.println(message);
                             }
                         }
                     }
                 }
             }
+
             if (suite.getParent() == null) {
                 // per test task top level gradle test run suite finished
                 if (getFailedTests().size() > 0) {
@@ -249,5 +254,10 @@ public class ErrorReportingTestListener implements TestOutputListener, TestListe
             // there's no need to keep this stuff on disk after suite execution
             outputFile.delete();
         }
+    }
+
+    private boolean isDumpOutputEnabled() {
+        Object errorReportingEnabled = testTask.getExtensions().getExtraProperties().get("dumpOutputOnFailure");
+        return errorReportingEnabled == null || (boolean) errorReportingEnabled;
     }
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -114,7 +114,11 @@ public class RestTestBasePlugin implements Plugin<Project> {
             task.dependsOn(integTestDistro, modulesConfiguration);
             registerDistributionInputs(task, integTestDistro);
 
+            // Enable parallel execution for these tests since each test gets its own cluster
             task.setMaxParallelForks(task.getProject().getGradle().getStartParameter().getMaxWorkerCount() / 2);
+
+            // Disable test failure reporting since this stuff is now captured in build scans
+            task.getExtensions().getExtraProperties().set("dumpOutputOnFailure", false);
 
             // Disable the security manager and syscall filter since the test framework needs to fork processes
             task.systemProperty("tests.security.manager", "false");

--- a/x-pack/qa/core-rest-tests-with-security/build.gradle
+++ b/x-pack/qa/core-rest-tests-with-security/build.gradle
@@ -1,11 +1,12 @@
-import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.internal.info.BuildParams
-
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
-apply plugin: 'elasticsearch.authenticated-testclusters'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 dependencies {
   testImplementation project(':x-pack:qa')
+  clusterModules project(':modules:mapper-extras')
+  clusterModules project(':modules:rank-eval')
+  clusterModules project(xpackModule('stack'))
+  clusterModules project(xpackModule('ilm'))
+  clusterModules project(xpackModule('mapper-constant-keyword'))
 }
 
 restResources {
@@ -20,14 +21,4 @@ tasks.named("yamlRestTest").configure {
         'index/10_with_id/Index with ID',
         'indices.get_alias/10_basic/Get alias against closed indices'
       ].join(',')
-}
-
-testClusters.matching { it.name == "yamlRestTest" }.configureEach {
-  testDistribution = 'DEFAULT'
-  setting 'xpack.watcher.enabled', 'false'
-  setting 'xpack.ml.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
-  setting 'indices.lifecycle.history_index_enabled', 'false'
-  setting 'xpack.security.autoconfiguration.enabled', 'false'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
 }

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
@@ -15,16 +15,34 @@ import org.apache.lucene.tests.util.TimeUnits;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
 
 import java.util.Objects;
 
 @TimeoutSuite(millis = 30 * TimeUnits.MINUTE) // as default timeout seems not enough on the jenkins VMs
 public class CoreWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+    private static final String USER = Objects.requireNonNull(System.getProperty("tests.rest.cluster.username", "test_admin"));
+    private static final String PASS = Objects.requireNonNull(System.getProperty("tests.rest.cluster.password", "x-pack-test-password"));
 
-    private static final String USER = Objects.requireNonNull(System.getProperty("tests.rest.cluster.username"));
-    private static final String PASS = Objects.requireNonNull(System.getProperty("tests.rest.cluster.password"));
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .module("constant-keyword")
+        .module("mapper-extras")
+        .module("rank-eval")
+        .module("x-pack-ilm")
+        .module("x-pack-stack")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.watcher.enabled", "false")
+        .setting("xpack.ml.enabled", "false")
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("xpack.security.autoconfiguration.enabled", "false")
+        .user(USER, PASS)
+        .feature(FeatureFlag.TIME_SERIES_MODE)
+        .build();
 
     public CoreWithSecurityClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -39,5 +57,10 @@ public class CoreWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteTest
     protected Settings restClientSettings() {
         String token = basicAuthHeaderValue(USER, new SecureString(PASS.toCharArray()));
         return Settings.builder().put(super.restClientSettings()).put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Migrate core rest tests with security to new testing framework (#92575)