### PR TITLE
Fix _bulk api dynamic_templates and explicit op_type

### DIFF
--- a/docs/changelog/92687.yaml
+++ b/docs/changelog/92687.yaml
@@ -1,5 +1,5 @@
 pr: 92687
-summary: '`_bulk` api `dynamic_templates` and explicit `op_type`'
+summary: 'Fix `_bulk` api `dynamic_templates` and explicit `op_type`'
 area: Mapping
 type: bug
 issues: []

--- a/docs/changelog/92687.yaml
+++ b/docs/changelog/92687.yaml
@@ -1,0 +1,5 @@
+pr: 92687
+summary: '`_bulk` api `dynamic_templates` and explicit `op_type`'
+area: Mapping
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -24,15 +24,13 @@
       bulk:
         refresh: true
         body:
-          - index:
+          - create:
               _index: test_index
               _id: id_1
-              op_type: create
               dynamic_templates:
                 location: location
           - { "location": "41.12,-71.34"}
           - index:
-              op_type: index
               _index: test_index
               _id: id_2
               dynamic_templates:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -27,17 +27,19 @@
           - index:
               _index: test_index
               _id: id_1
+              op_type: create
               dynamic_templates:
                 location: location
           - { "location": "41.12,-71.34"}
           - index:
+              op_type: index
               _index: test_index
               _id: id_2
               dynamic_templates:
                 location: location
           - { "location": [ -71.34, 41.12 ]}
   - match: { errors: false }
-  - match: { items.0.index.result: created }
+  - match: { items.0.create.result: created }
   - match: { items.1.index.result: created }
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -169,3 +169,64 @@
   - match: { items.0.index.error.reason: "failed to parse field [foo] of type [keyword] in document with id 'id_11'. Preview of field's value: '{bar=hello world}'"}
   - match: { items.1.index.status: 201 }
   - match: { items.1.index.result: created }
+
+---
+"Dynamic templates with op_type":
+  - skip:
+      version: " - 8.6.99"
+      reason: "bug fixed in 8.7.0"
+
+  - do:
+      indices.create:
+        index: test_index
+        body:
+          mappings:
+            dynamic_templates:
+              - location:
+                  mapping:
+                    type: geo_point
+              - my_location:
+                  match: my*
+                  mapping:
+                    type: geo_point
+              - string:
+                  mapping:
+                    type: keyword
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_index
+              _id: id_1
+              op_type: create
+              dynamic_templates:
+                location: location
+          - { "location": "41.12,-71.34"}
+          - index:
+              _index: test_index
+              _id: id_2
+              op_type: index
+              dynamic_templates:
+                location: location
+          - { "location": [ -71.34, 41.12 ]}
+  - match: { errors: false }
+  - match: { items.0.create.result: created }
+  - match: { items.1.index.result: created }
+
+  - do:
+      search:
+        index: test_index
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                top_left:
+                  lat: 42
+                  lon: -72
+                bottom_right:
+                  lat: 40
+                  lon: -74
+  - match: { hits.total.value: 2 }
+  - match: { hits.hits.0._id: id_1 }
+  - match: { hits.hits.1._id: id_2 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -67,7 +67,7 @@
               _index: test_index
               _id: id_3
           - { "my_location": "41.12,-71.34" } # matches the field name defined in the `my_location` template
-          - index:
+          - create:
               _index: test_index
               _id: id_4
               dynamic_templates:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -29,13 +29,13 @@
               _id: id_1
               dynamic_templates:
                 location: location
-          - { "location": [ -71.34, 41.12 ]}
+          - { "location": "41.12,-71.34"}
           - index:
               _index: test_index
               _id: id_2
               dynamic_templates:
                 location: location
-          - { "location": "41.12,-71.34"}
+          - { "location": [ -71.34, 41.12 ]}
   - match: { errors: false }
   - match: { items.0.index.result: created }
   - match: { items.1.index.result: created }

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java
@@ -357,6 +357,7 @@ public final class BulkRequestParser {
                                     .setIfSeqNo(ifSeqNo)
                                     .setIfPrimaryTerm(ifPrimaryTerm)
                                     .source(sliceTrimmingCarriageReturn(data, from, nextMarker, xContentType), xContentType)
+                                    .setDynamicTemplates(dynamicTemplates)
                                     .setRequireAlias(requireAlias),
                                 type
                             );

--- a/server/src/main/java/org/elasticsearch/ingest/IngestCtxMap.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestCtxMap.java
@@ -22,7 +22,7 @@ import java.util.Map;
  * _index, _id and _routing must be a String or null
  * _version_type must be a lower case VersionType or null
  * _version must be representable as a long without loss of precision or null
- * _dyanmic_templates must be a map
+ * _dynamic_templates must be a map
  * _if_seq_no must be a long or null
  * _if_primary_term must be a long or null
  *


### PR DESCRIPTION
There are three branches in `BulkRequestParser`, the first for explicit `index` actions without an `opType`, the last for explicit `create` actions (which don't have an `opType`), and the middle for `index` actions that have an `opType` (of `create` or `index`). 

https://github.com/elastic/elasticsearch/blob/217ba2cc7e147796cc1a6f4f688a8a22308a4df0/server/src/main/java/org/elasticsearch/action/bulk/BulkRequestParser.java#L334-L378

That middle one should have a `.setDynamicTemplates(dynamicTemplates)` call like the other two already do.

That is, consider the following:

```
PUT myindex
{
  "mappings": {
    "dynamic_templates": [{
      "time_histograms": {
        "mapping": {
          "type": "histogram",
          "meta": {
            "unit": "s"
          }
        }
      }
    }]
  }
}

POST myindex/_bulk
{ "index": { "dynamic_templates": { "response_times": "time_histograms" } } }
{ "@timestamp": "2020-08-12", "response_times": { "values": [1, 10], "counts": [5, 1] }}
{ "create": { "dynamic_templates": { "response_times": "time_histograms" } } }
{ "@timestamp": "2020-08-12", "response_times": { "values": [1, 10], "counts": [5, 1] }}
{ "index": { "dynamic_templates": { "response_times": "time_histograms" }, "op_type": "create" } }
{ "@timestamp": "2020-08-12", "response_times": { "values": [1, 10], "counts": [5, 1] }}
{ "index": { "dynamic_templates": { "response_times": "time_histograms" }, "op_type": "index" } }
{ "@timestamp": "2020-08-12", "response_times": { "values": [1, 10], "counts": [5, 1] }}
```

The last two operations should also be participating in the `dynamic_templates`, but without the `.setDynamicTemplates(dynamicTemplates)` call they weren't.