### PR TITLE
Allow different filters per DataStream in a DataStreamAlias

### DIFF
--- a/docs/changelog/92692.yaml
+++ b/docs/changelog/92692.yaml
@@ -1,0 +1,6 @@
+pr: 92692
+summary: Allow different filters per `DataStream` in a `DataStreamAlias`
+area: Data streams
+type: bug
+issues:
+ - 92050

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -180,7 +180,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").size(), equalTo(1));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getName(), equalTo("my-alias"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getWriteDataStream(), equalTo("other-ds"));
@@ -188,7 +188,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getName(), equalTo("my-alias"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
     }
@@ -419,7 +419,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getDataStreams(), containsInAnyOrder("ds", "other-ds"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").size(), equalTo(1));
@@ -427,7 +427,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getDataStreams(), containsInAnyOrder("ds", "other-ds"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
 
@@ -473,7 +473,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getDataStreams(), containsInAnyOrder("ds", "other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
 
@@ -482,7 +482,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getDataStreams(), containsInAnyOrder("ds", "other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
 
@@ -567,21 +567,21 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds2").size(), equalTo(1));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds2").get(0).getName(), equalTo("my-alias"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("ds2").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("ds2").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").size(), equalTo(1));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getName(), equalTo("my-alias"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").size(), equalTo(1));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getName(), equalTo("my-alias"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getWriteDataStream(), equalTo("other-ds"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
     }
@@ -621,21 +621,21 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds2").get(0).getName(), equalTo("my-alias"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds2").get(0).getWriteDataStream(), equalTo("other-ds2"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("other-ds2").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("other-ds2").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").size(), equalTo(1));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getName(), equalTo("my-alias"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("ds").get(0).getWriteDataStream(), equalTo("other-ds2"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").size(), equalTo(1));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getName(), equalTo("my-alias"));
         assertThat(getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getWriteDataStream(), equalTo("other-ds2"));
         assertThat(
-            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter().string(),
+            getAliasesResponse.getDataStreamAliases().get("other-ds").get(0).getFilter("ds").string(),
             equalTo("{\"match_all\":{\"boost\":1.0}}")
         );
     }

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -371,7 +371,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
                         "my-alias",
                         List.of(dataStreamToSnapshot),
                         "other-ds".equals(dataStreamToSnapshot) ? "other-ds" : null,
-                        Map.of("match_all", Map.of("boost", 1f))
+                        Map.of("other-ds", Map.of("match_all", Map.of("boost", 1f)), "ds", Map.of("match_all", Map.of("boost", 1f)))
                     )
                 )
             )

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -16,7 +16,6 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
-import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -25,30 +24,32 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXContentFragment {
 
     public static final ParseField DATA_STREAMS_FIELD = new ParseField("data_streams");
     public static final ParseField WRITE_DATA_STREAM_FIELD = new ParseField("write_data_stream");
-    public static final ParseField FILTER_FIELD = new ParseField("filter");
+    public static final ParseField FILTERS_FIELD = new ParseField("filters");
 
     @SuppressWarnings("unchecked")
     private static final ConstructingObjectParser<DataStreamAlias, String> PARSER = new ConstructingObjectParser<>(
         "data_stream_alias",
         false,
-        (args, name) -> new DataStreamAlias(name, (List<String>) args[0], (String) args[1], (CompressedXContent) args[2])
+        (args, name) -> new DataStreamAlias(name, (List<String>) args[0], (Map<String, CompressedXContent>) args[2], (String) args[1])
     );
 
     static {
         PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), DATA_STREAMS_FIELD);
         PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), WRITE_DATA_STREAM_FIELD);
-        PARSER.declareField(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
+        PARSER.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> p.map(HashMap::new, xContentParser -> {
             if (p.currentToken() == XContentParser.Token.VALUE_EMBEDDED_OBJECT || p.currentToken() == XContentParser.Token.VALUE_STRING) {
                 return new CompressedXContent(p.binaryValue());
             } else if (p.currentToken() == XContentParser.Token.START_OBJECT) {
@@ -58,24 +59,44 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
                 assert false : "unexpected token [" + p.currentToken() + " ]";
                 return null;
             }
-        }, FILTER_FIELD, ObjectParser.ValueType.VALUE_OBJECT_ARRAY);
+        }), FILTERS_FIELD);
     }
 
     private final String name;
     private final List<String> dataStreams;
     private final String writeDataStream;
-    private final CompressedXContent filter;
 
-    private DataStreamAlias(String name, List<String> dataStreams, String writeDataStream, CompressedXContent filter) {
+    private final Map<String, CompressedXContent> dataStreamToFilterMap;
+
+    private DataStreamAlias(
+        String name,
+        List<String> dataStreams,
+        Map<String, CompressedXContent> dataStreamsToFilters,
+        String writeDataStream
+    ) {
         this.name = Objects.requireNonNull(name);
         this.dataStreams = List.copyOf(dataStreams);
         this.writeDataStream = writeDataStream;
-        this.filter = filter;
+        this.dataStreamToFilterMap = new HashMap<>(dataStreamsToFilters);
         assert writeDataStream == null || dataStreams.contains(writeDataStream);
     }
 
-    public DataStreamAlias(String name, List<String> dataStreams, String writeDataStream, Map<String, Object> filter) {
-        this(name, dataStreams, writeDataStream, compress(filter));
+    public DataStreamAlias(
+        String name,
+        List<String> dataStreams,
+        String writeDataStream,
+        Map<String, Map<String, Object>> dataStreamsToFilters
+    ) {
+        this(name, dataStreams, compressFiltersMap(dataStreamsToFilters), writeDataStream);
+    }
+
+    private static Map<String, CompressedXContent> compressFiltersMap(Map<String, Map<String, Object>> dataStreamToUncompressedFilterMap) {
+        if (dataStreamToUncompressedFilterMap == null) {
+            return Map.of();
+        }
+        return dataStreamToUncompressedFilterMap.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, entry -> compress(entry.getValue())));
     }
 
     private static CompressedXContent compress(Map<String, Object> filterAsMap) {
@@ -100,7 +121,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         this.name = in.readString();
         this.dataStreams = in.readStringList();
         this.writeDataStream = in.readOptionalString();
-        this.filter = in.readBoolean() ? CompressedXContent.readCompressedString(in) : null;
+        this.dataStreamToFilterMap = in.readMap(StreamInput::readString, CompressedXContent::readCompressedString);
     }
 
     /**
@@ -128,12 +149,12 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         return writeDataStream;
     }
 
-    public CompressedXContent getFilter() {
-        return filter;
+    public CompressedXContent getFilter(String dataStreamName) {
+        return dataStreamToFilterMap.get(dataStreamName);
     }
 
     public boolean filteringRequired() {
-        return filter != null;
+        return dataStreamToFilterMap.isEmpty() == false;
     }
 
     /**
@@ -158,23 +179,25 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         }
 
         boolean filterUpdated;
-        CompressedXContent filter;
         if (filterAsMap != null) {
-            filter = compress(filterAsMap);
-            if (this.filter == null) {
+            CompressedXContent previousFilter = dataStreamToFilterMap.get(dataStream);
+            if (previousFilter == null) {
                 filterUpdated = true;
             } else {
-                filterUpdated = filterAsMap.equals(decompress(this.filter)) == false;
+                filterUpdated = filterAsMap.equals(decompress(previousFilter)) == false;
             }
         } else {
-            filter = this.filter;
             filterUpdated = false;
         }
 
         Set<String> dataStreams = new HashSet<>(this.dataStreams);
         boolean added = dataStreams.add(dataStream);
         if (added || Objects.equals(this.writeDataStream, writeDataStream) == false || filterUpdated) {
-            return new DataStreamAlias(name, List.copyOf(dataStreams), writeDataStream, filter);
+            Map<String, CompressedXContent> newDataStreamToFilterMap = new HashMap<>(dataStreamToFilterMap);
+            if (filterAsMap != null) {
+                newDataStreamToFilterMap.put(dataStream, compress(filterAsMap));
+            }
+            return new DataStreamAlias(name, List.copyOf(dataStreams), newDataStreamToFilterMap, writeDataStream);
         } else {
             return this;
         }
@@ -199,7 +222,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
             if (dataStream.equals(writeDataStream)) {
                 writeDataStream = null;
             }
-            return new DataStreamAlias(name, List.copyOf(dataStreams), writeDataStream, filter);
+            return new DataStreamAlias(name, List.copyOf(dataStreams), dataStreamToFilterMap, writeDataStream);
         }
     }
 
@@ -216,7 +239,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         if (intersectingDataStreams.contains(writeDataStream) == false) {
             writeDataStream = null;
         }
-        return new DataStreamAlias(this.name, intersectingDataStreams, writeDataStream, this.filter);
+        return new DataStreamAlias(this.name, intersectingDataStreams, this.dataStreamToFilterMap, writeDataStream);
     }
 
     /**
@@ -273,7 +296,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
             }
         }
 
-        return new DataStreamAlias(this.name, List.copyOf(mergedDataStreams), writeDataStream, filter);
+        return new DataStreamAlias(this.name, List.copyOf(mergedDataStreams), dataStreamToFilterMap, writeDataStream);
     }
 
     public static Diff<DataStreamAlias> readDiffFrom(StreamInput in) throws IOException {
@@ -296,14 +319,16 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         if (writeDataStream != null) {
             builder.field(WRITE_DATA_STREAM_FIELD.getPreferredName(), writeDataStream);
         }
-        if (filter != null) {
-            boolean binary = params.paramAsBoolean("binary", false);
+        boolean binary = params.paramAsBoolean("binary", false);
+        builder.startObject("filters");
+        for (Map.Entry<String, CompressedXContent> entry : dataStreamToFilterMap.entrySet()) {
             if (binary) {
-                builder.field("filter", filter.compressed());
+                builder.field(entry.getKey(), entry.getValue().compressed());
             } else {
-                builder.field("filter", XContentHelper.convertToMap(filter.uncompressed(), true).v2());
+                builder.field(entry.getKey(), XContentHelper.convertToMap(entry.getValue().uncompressed(), true).v2());
             }
         }
+        builder.endObject();
         builder.endObject();
         return builder;
     }
@@ -313,12 +338,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         out.writeString(name);
         out.writeStringCollection(dataStreams);
         out.writeOptionalString(writeDataStream);
-        if (filter != null) {
-            out.writeBoolean(true);
-            filter.writeTo(out);
-        } else {
-            out.writeBoolean(false);
-        }
+        out.writeMap(dataStreamToFilterMap, StreamOutput::writeString, (out1, filter) -> filter.writeTo(out1));
     }
 
     @Override
@@ -329,12 +349,12 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         return Objects.equals(name, that.name)
             && Objects.equals(dataStreams, that.dataStreams)
             && Objects.equals(writeDataStream, that.writeDataStream)
-            && Objects.equals(filter, that.filter);
+            && Objects.equals(dataStreamToFilterMap, that.dataStreamToFilterMap);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(name, dataStreams, writeDataStream, filter);
+        return Objects.hash(name, dataStreams, writeDataStream, dataStreamToFilterMap);
     }
 
     @Override
@@ -348,8 +368,11 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
             + ", writeDataStream='"
             + writeDataStream
             + '\''
-            + ", filter="
-            + (filter != null ? filter.string() : "null")
+            + ", dataStreamToFilterMap="
+            + dataStreamToFilterMap.keySet()
+                .stream()
+                .map(key -> key + "=" + dataStreamToFilterMap.get(key))
+                .collect(Collectors.joining(", ", "{", "}"))
             + '}';
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -64,8 +64,8 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
             List<String> dataStreamNames = (List<String>) args[0];
             if (dataStreamsToFilters == null && oldFilter != null && dataStreamNames != null) {
                 logger.info(
-                    "Reading in DataStreamAlias {} with a pre-8.7.0-style DataStream filter and using it for all DataStreams in "
-                        + "the DataStreamAlias",
+                    "Reading in data stream alias [{}] with a pre-8.7.0-style data stream filter and using it for all data streams in "
+                        + "the data stream alias",
                     name
                 );
                 dataStreamsToFilters = new HashMap<>();
@@ -173,10 +173,10 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
             this.dataStreamToFilterMap = new HashMap<>();
             CompressedXContent filter = in.readBoolean() ? CompressedXContent.readCompressedString(in) : null;
             if (filter != null) {
-                logger.info(
-                    "Reading in DataStreamAlias {} from before 8.7.0, which did not correctly associate filters with DataStreams.",
-                    name
-                );
+                /*
+                 * Here we're reading in a DataStreamAlias from before 8.7.0, which did not correctly associate filters with DataStreams.
+                 * So we associated the same filter with all DataStreams in the alias to replicate the old behavior.
+                 */
                 for (String dataStream : dataStreams) {
                     dataStreamToFilterMap.put(dataStream, filter);
                 }
@@ -409,11 +409,6 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
                  * replicate that buggy behavior here if we have to write to an older node because there is no way to send multipole
                  * filters to an older node.
                  */
-                logger.info(
-                    "Sending DataStreamAlias {} to a node with version earlier than 8.7.0. Versions before 8.7.0 do not support "
-                        + "separate filters for each DataStream.",
-                    name
-                );
                 dataStreamToFilterMap.values().iterator().next().writeTo(out);
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamMetadata.java
@@ -117,7 +117,12 @@ public class DataStreamMetadata implements Metadata.Custom {
         DataStreamAlias alias = dataStreamAliases.get(aliasName);
         if (alias == null) {
             String writeDataStream = isWriteDataStream != null && isWriteDataStream ? dataStream : null;
-            alias = new DataStreamAlias(aliasName, List.of(dataStream), writeDataStream, filterAsMap);
+            alias = new DataStreamAlias(
+                aliasName,
+                List.of(dataStream),
+                writeDataStream,
+                filterAsMap == null ? null : Map.of(dataStream, filterAsMap)
+            );
         } else {
             DataStreamAlias copy = alias.update(dataStream, isWriteDataStream, filterAsMap);
             if (copy == alias) {

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1648,13 +1648,15 @@ public class IndicesService extends AbstractLifecycleComponent
 
         Metadata metadata = state.metadata();
         IndexAbstraction ia = state.metadata().getIndicesLookup().get(index);
-        if (ia.getParentDataStream() != null) {
+        IndexAbstraction.DataStream dataStream = ia.getParentDataStream();
+        if (dataStream != null) {
+            String dataStreamName = dataStream.getName();
             List<QueryBuilder> filters = Arrays.stream(aliases)
                 .map(name -> metadata.dataStreamAliases().get(name))
-                .filter(dataStreamAlias -> dataStreamAlias.getFilter(ia.getParentDataStream().getName()) != null)
+                .filter(dataStreamAlias -> dataStreamAlias.getFilter(dataStreamName) != null)
                 .map(dataStreamAlias -> {
                     try {
-                        return filterParser.apply(dataStreamAlias.getFilter(ia.getParentDataStream().getName()).uncompressed());
+                        return filterParser.apply(dataStreamAlias.getFilter(dataStreamName).uncompressed());
                     } catch (IOException e) {
                         throw new UncheckedIOException(e);
                     }

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestGetAliasesAction.java
@@ -168,8 +168,11 @@ public class RestGetAliasesAction extends BaseRestHandler {
                             if (entry.getKey().equals(alias.getWriteDataStream())) {
                                 builder.field("is_write_index", true);
                             }
-                            if (alias.getFilter() != null) {
-                                builder.field("filter", XContentHelper.convertToMap(alias.getFilter().uncompressed(), true).v2());
+                            if (alias.getFilter(entry.getKey()) != null) {
+                                builder.field(
+                                    "filter",
+                                    XContentHelper.convertToMap(alias.getFilter(entry.getKey()).uncompressed(), true).v2()
+                                );
                             }
                             builder.endObject();
                         }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
@@ -87,8 +87,9 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
             assertThat(result, not(sameInstance(alias)));
             assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2"));
             assertThat(result.getWriteDataStream(), nullValue());
-            assertThat(result.getFilter(), notNullValue());
-            assertThat(result.getFilter().string(), equalTo("""
+            assertThat(result.getFilter("ds-1"), nullValue());
+            assertThat(result.getFilter("ds-2"), notNullValue());
+            assertThat(result.getFilter("ds-2").string(), equalTo("""
                 {"term":{"field":"value"}}"""));
         }
         // noop update to filter:
@@ -97,7 +98,7 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
                 "my-alias",
                 List.of("ds-1", "ds-2"),
                 null,
-                Map.of("term", Map.of("field", "value"))
+                Map.of("ds-2", Map.of("term", Map.of("field", "value")))
             );
             DataStreamAlias result = alias.update("ds-2", null, Map.of("term", Map.of("field", "value")));
             assertThat(result, sameInstance(alias));
@@ -108,14 +109,15 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
                 "my-alias",
                 List.of("ds-1", "ds-2"),
                 null,
-                Map.of("term", Map.of("field", "value"))
+                Map.of("ds-2", Map.of("term", Map.of("field", "value")))
             );
             DataStreamAlias result = alias.update("ds-2", null, Map.of("term", Map.of("field", "value1")));
             assertThat(result, not(sameInstance(alias)));
             assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2"));
             assertThat(result.getWriteDataStream(), nullValue());
-            assertThat(result.getFilter(), notNullValue());
-            assertThat(result.getFilter().string(), equalTo("""
+            assertThat(result.getFilter("ds-1"), nullValue());
+            assertThat(result.getFilter("ds-2"), notNullValue());
+            assertThat(result.getFilter("ds-2").string(), equalTo("""
                 {"term":{"field":"value1"}}"""));
         }
         // Filter not specified, keep existing filter:
@@ -124,13 +126,14 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
                 "my-alias",
                 List.of("ds-1", "ds-2"),
                 null,
-                Map.of("term", Map.of("field", "value"))
+                Map.of("ds-2", Map.of("term", Map.of("field", "value")))
             );
             DataStreamAlias result = alias.update("ds-2", null, null);
             assertThat(result, sameInstance(alias));
             assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2"));
             assertThat(result.getWriteDataStream(), nullValue());
-            assertThat(result.getFilter().string(), equalTo("""
+            assertThat(result.getFilter("ds-1"), nullValue());
+            assertThat(result.getFilter("ds-2").string(), equalTo("""
                 {"term":{"field":"value"}}"""));
         }
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamAliasTests.java
@@ -8,15 +8,24 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.json.JsonXContent;
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.cluster.metadata.DataStreamAlias.DATA_STREAMS_FIELD;
+import static org.elasticsearch.cluster.metadata.DataStreamAlias.OLD_FILTER_FIELD;
+import static org.elasticsearch.cluster.metadata.DataStreamAlias.WRITE_DATA_STREAM_FIELD;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
@@ -270,5 +279,54 @@ public class DataStreamAliasTests extends AbstractXContentSerializingTestCase<Da
         DataStreamAlias result = alias1.restore(alias2, "ds-3", null);
         assertThat(result.getDataStreams(), containsInAnyOrder("ds-1", "ds-2", "ds-3"));
         assertThat(result.getWriteDataStream(), equalTo("ds-3"));
+    }
+
+    public void testSupportsXContentWithSingleFilter() throws IOException {
+        /*
+         * Before 8.7.0, DataStreamAlias only supported a single filter shared by all DataStreams. As of 8.7.0 the "filter" XContent field
+         * is no longer written, but this tests that we can still read it (needed when the cluster state is read on a cluster upgrade).
+         */
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        XContentBuilder builder = new XContentBuilder(JsonXContent.jsonXContent, baos);
+        builder.startObject();
+        String aliasName = randomAlphaOfLength(20);
+        builder.startObject(aliasName);
+        List<String> dataStreams = randomList(10, () -> randomAlphaOfLength(20));
+        builder.stringListField(DATA_STREAMS_FIELD.getPreferredName(), dataStreams);
+        String writeDataStream = dataStreams.isEmpty() ? null : randomFrom(dataStreams);
+        if (writeDataStream != null) {
+            builder.field(WRITE_DATA_STREAM_FIELD.getPreferredName(), writeDataStream);
+        }
+        boolean binary = randomBoolean();
+        Map<String, Object> filterMap = new HashMap<>();
+        filterMap.put(randomAlphaOfLength(10), randomAlphaOfLength(20));
+        CompressedXContent filter = randomBoolean() ? null : new CompressedXContent(filterMap);
+        if (filter != null) {
+            if (binary) {
+                builder.field(OLD_FILTER_FIELD.getPreferredName(), filter.compressed());
+            } else {
+                builder.field(OLD_FILTER_FIELD.getPreferredName(), XContentHelper.convertToMap(filter.uncompressed(), true).v2());
+            }
+        }
+        builder.endObject();
+        builder.endObject();
+        builder.close();
+        try (XContentParser parser = createParser(JsonXContent.jsonXContent, baos.toByteArray())) {
+            parser.nextToken();
+            parser.nextToken();
+            DataStreamAlias outputAlias = DataStreamAlias.fromXContent(parser);
+            assertNotNull(outputAlias);
+            assertThat(outputAlias.getName(), equalTo(aliasName));
+            assertThat(outputAlias.getDataStreams(), equalTo(dataStreams));
+            assertThat(outputAlias.getWriteDataStream(), equalTo(writeDataStream));
+            if (filter == null) {
+                assertTrue(outputAlias.dataStreamToFilterMap.isEmpty());
+            } else {
+                assertThat(outputAlias.dataStreamToFilterMap.size(), equalTo(dataStreams.size()));
+                for (String dataStreamName : dataStreams) {
+                    assertThat(outputAlias.getFilter(dataStreamName), equalTo(filter));
+                }
+            }
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamMetadataTests.java
@@ -11,15 +11,20 @@ package org.elasticsearch.cluster.metadata;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+
+import static org.hamcrest.Matchers.equalTo;
 
 public class DataStreamMetadataTests extends AbstractChunkedSerializingTestCase<DataStreamMetadata> {
 
@@ -61,5 +66,61 @@ public class DataStreamMetadataTests extends AbstractChunkedSerializingTestCase<
     @Override
     protected Writeable.Reader<DataStreamMetadata> instanceReader() {
         return DataStreamMetadata::new;
+    }
+
+    public void testWithAlias() {
+        Index index1 = new Index("data-stream-1-index", "1");
+        Index index2 = new Index("data-stream-2-index", "2");
+        DataStream dataStream1 = new DataStream(
+            "data-stream-1",
+            List.of(index1),
+            1,
+            Map.of(),
+            false,
+            false,
+            false,
+            false,
+            IndexMode.STANDARD
+        );
+        DataStream dataStream2 = new DataStream(
+            "data-stream-2",
+            List.of(index2),
+            1,
+            Map.of(),
+            false,
+            false,
+            false,
+            false,
+            IndexMode.STANDARD
+        );
+        ImmutableOpenMap<String, DataStream> dataStreams = new ImmutableOpenMap.Builder<String, DataStream>().fPut(
+            "data-stream-1",
+            dataStream1
+        ).fPut("data-stream-2", dataStream2).build();
+        ImmutableOpenMap<String, DataStreamAlias> dataStreamAliases = new ImmutableOpenMap.Builder<String, DataStreamAlias>().build();
+        DataStreamMetadata dataStreamMetadata = new DataStreamMetadata(dataStreams, dataStreamAliases);
+        dataStreamMetadata = dataStreamMetadata.withAlias("alias1", "data-stream-2", false, null);
+        dataStreamMetadata = dataStreamMetadata.withAlias("alias1", "data-stream-1", false, """
+            {
+                "term": {
+                    "reaction": "report"
+                }
+                }""");
+
+        Map<String, DataStreamAlias> aliasMap = dataStreamMetadata.getDataStreamAliases();
+        assertNotNull(aliasMap);
+        assertThat(aliasMap.size(), equalTo(1));
+        DataStreamAlias alias1 = aliasMap.get("alias1");
+        assertNotNull(alias1);
+        Map<String, DataStream> dataStreamMap = dataStreamMetadata.dataStreams();
+        assertNotNull(dataStreamMap);
+        assertThat(dataStreamMap.size(), equalTo(2));
+        DataStream resultDataStream1 = dataStreamMap.get("data-stream-1");
+        assertNotNull(resultDataStream1);
+        DataStream resultDataStream2 = dataStreamMap.get("data-stream-2");
+        assertNotNull(resultDataStream2);
+
+        assertNotNull(alias1.getFilter(resultDataStream1.getName()));
+        assertNull(alias1.getFilter(resultDataStream2.getName()));
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexNameExpressionResolverTests.java
@@ -1672,6 +1672,21 @@ public class IndexNameExpressionResolverTests extends ESTestCase {
             String[] result = indexNameExpressionResolver.indexAliases(state, index, x -> true, x -> true, false, resolvedExpressions);
             assertThat(result, nullValue());
         }
+
+        {
+            // Only resolve aliases that refer to dataStreamName1 where the filter is not null
+            Set<String> resolvedExpressions = indexNameExpressionResolver.resolveExpressions(state, "l*");
+            String index = backingIndex1.getIndex().getName();
+            String[] result = indexNameExpressionResolver.indexAliases(
+                state,
+                index,
+                x -> true,
+                DataStreamAlias::filteringRequired,
+                true,
+                resolvedExpressions
+            );
+            assertThat(result, arrayContainingInAnyOrder("logs", "logs_foo"));
+        }
     }
 
     public void testIndexAliasesSkipIdentity() {

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataCreateDataStreamServiceTests.java
@@ -109,7 +109,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
             var actualAlias = newState.metadata().dataStreamAliases().get(aliasName);
             assertThat(actualAlias, is(notNullValue()));
             assertThat(actualAlias.getName(), equalTo(expectedAlias.alias()));
-            assertThat(actualAlias.getFilter(), equalTo(expectedAlias.filter()));
+            assertThat(actualAlias.getFilter(dataStreamName), equalTo(expectedAlias.filter()));
             assertThat(actualAlias.getWriteDataStream(), equalTo(expectedAlias.writeIndex() ? dataStreamName : null));
         }
 
@@ -183,7 +183,7 @@ public class MetadataCreateDataStreamServiceTests extends ESTestCase {
                 var actualAlias = newState.metadata().dataStreamAliases().get(alias.alias());
                 assertThat(actualAlias, is(notNullValue()));
                 assertThat(actualAlias.getName(), equalTo(alias.alias()));
-                assertThat(actualAlias.getFilter(), equalTo(alias.filter()));
+                assertThat(actualAlias.getFilter(dataStreamName), equalTo(alias.filter()));
                 assertThat(actualAlias.getWriteDataStream(), equalTo(alias.writeIndex() ? dataStreamName : null));
             }
         }

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -610,12 +610,17 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
 
     public void testBuildAliasFilter() {
         var indicesService = getIndicesService();
-
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(
                 indexBuilder("test-0").state(IndexMetadata.State.OPEN)
                     .putAlias(AliasMetadata.builder("test-alias-0").filter(Strings.toString(QueryBuilders.termQuery("foo", "bar"))))
                     .putAlias(AliasMetadata.builder("test-alias-1").filter(Strings.toString(QueryBuilders.termQuery("foo", "baz"))))
+                    .putAlias(AliasMetadata.builder("test-alias-non-filtering"))
+            )
+            .put(
+                indexBuilder("test-1").state(IndexMetadata.State.OPEN)
+                    .putAlias(AliasMetadata.builder("test-alias-0").filter(Strings.toString(QueryBuilders.termQuery("foo", "bar"))))
+                    .putAlias(AliasMetadata.builder("test-alias-1").filter(Strings.toString(QueryBuilders.termQuery("foo", "bax"))))
                     .putAlias(AliasMetadata.builder("test-alias-non-filtering"))
             );
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
@@ -625,9 +630,19 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             assertThat(result.getQueryBuilder(), equalTo(QueryBuilders.termQuery("foo", "bar")));
         }
         {
+            AliasFilter result = indicesService.buildAliasFilter(state, "test-1", Set.of("test-alias-0"));
+            assertThat(result.getAliases(), arrayContainingInAnyOrder("test-alias-0"));
+            assertThat(result.getQueryBuilder(), equalTo(QueryBuilders.termQuery("foo", "bar")));
+        }
+        {
             AliasFilter result = indicesService.buildAliasFilter(state, "test-0", Set.of("test-alias-1"));
             assertThat(result.getAliases(), arrayContainingInAnyOrder("test-alias-1"));
             assertThat(result.getQueryBuilder(), equalTo(QueryBuilders.termQuery("foo", "baz")));
+        }
+        {
+            AliasFilter result = indicesService.buildAliasFilter(state, "test-1", Set.of("test-alias-1"));
+            assertThat(result.getAliases(), arrayContainingInAnyOrder("test-alias-1"));
+            assertThat(result.getQueryBuilder(), equalTo(QueryBuilders.termQuery("foo", "bax")));
         }
         {
             AliasFilter result = indicesService.buildAliasFilter(state, "test-0", Set.of("test-alias-0", "test-alias-1"));
@@ -639,9 +654,27 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             assertThat(filter.should(), containsInAnyOrder(QueryBuilders.termQuery("foo", "baz"), QueryBuilders.termQuery("foo", "bar")));
         }
         {
+            AliasFilter result = indicesService.buildAliasFilter(state, "test-1", Set.of("test-alias-0", "test-alias-1"));
+            assertThat(result.getAliases(), arrayContainingInAnyOrder("test-alias-0", "test-alias-1"));
+            BoolQueryBuilder filter = (BoolQueryBuilder) result.getQueryBuilder();
+            assertThat(filter.filter(), empty());
+            assertThat(filter.must(), empty());
+            assertThat(filter.mustNot(), empty());
+            assertThat(filter.should(), containsInAnyOrder(QueryBuilders.termQuery("foo", "bax"), QueryBuilders.termQuery("foo", "bar")));
+        }
+        {
             AliasFilter result = indicesService.buildAliasFilter(
                 state,
                 "test-0",
+                Set.of("test-alias-0", "test-alias-1", "test-alias-non-filtering")
+            );
+            assertThat(result.getAliases(), emptyArray());
+            assertThat(result.getQueryBuilder(), nullValue());
+        }
+        {
+            AliasFilter result = indicesService.buildAliasFilter(
+                state,
+                "test-1",
                 Set.of("test-alias-0", "test-alias-1", "test-alias-non-filtering")
             );
             assertThat(result.getAliases(), emptyArray());
@@ -653,12 +686,18 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
         var indicesService = getIndicesService();
 
         final String dataStreamName1 = "logs-foobar";
+        final String dataStreamName2 = "logs-foobaz";
         IndexMetadata backingIndex1 = createBackingIndex(dataStreamName1, 1).build();
+        IndexMetadata backingIndex2 = createBackingIndex(dataStreamName2, 1).build();
         Metadata.Builder mdBuilder = Metadata.builder()
             .put(backingIndex1, false)
-            .put(DataStreamTestHelper.newInstance(dataStreamName1, List.of(backingIndex1.getIndex())));
+            .put(backingIndex2, false)
+            .put(DataStreamTestHelper.newInstance(dataStreamName1, List.of(backingIndex1.getIndex())))
+            .put(DataStreamTestHelper.newInstance(dataStreamName2, List.of(backingIndex2.getIndex())));
         mdBuilder.put("logs_foo", dataStreamName1, null, Strings.toString(QueryBuilders.termQuery("foo", "bar")));
+        mdBuilder.put("logs_foo", dataStreamName2, null, Strings.toString(QueryBuilders.termQuery("foo", "baz")));
         mdBuilder.put("logs", dataStreamName1, null, Strings.toString(QueryBuilders.termQuery("foo", "baz")));
+        mdBuilder.put("logs", dataStreamName2, null, Strings.toString(QueryBuilders.termQuery("foo", "bax")));
         mdBuilder.put("logs_bar", dataStreamName1, null, null);
         ClusterState state = ClusterState.builder(new ClusterName("_name")).metadata(mdBuilder).build();
         {
@@ -666,6 +705,12 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             AliasFilter result = indicesService.buildAliasFilter(state, index, Set.of("logs_foo"));
             assertThat(result.getAliases(), arrayContainingInAnyOrder("logs_foo"));
             assertThat(result.getQueryBuilder(), equalTo(QueryBuilders.termQuery("foo", "bar")));
+        }
+        {
+            String index = backingIndex2.getIndex().getName();
+            AliasFilter result = indicesService.buildAliasFilter(state, index, Set.of("logs_foo"));
+            assertThat(result.getAliases(), arrayContainingInAnyOrder("logs_foo"));
+            assertThat(result.getQueryBuilder(), equalTo(QueryBuilders.termQuery("foo", "baz")));
         }
         {
             String index = backingIndex1.getIndex().getName();
@@ -676,6 +721,16 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             assertThat(filter.must(), empty());
             assertThat(filter.mustNot(), empty());
             assertThat(filter.should(), containsInAnyOrder(QueryBuilders.termQuery("foo", "baz"), QueryBuilders.termQuery("foo", "bar")));
+        }
+        {
+            String index = backingIndex2.getIndex().getName();
+            AliasFilter result = indicesService.buildAliasFilter(state, index, Set.of("logs_foo", "logs"));
+            assertThat(result.getAliases(), arrayContainingInAnyOrder("logs_foo", "logs"));
+            BoolQueryBuilder filter = (BoolQueryBuilder) result.getQueryBuilder();
+            assertThat(filter.filter(), empty());
+            assertThat(filter.must(), empty());
+            assertThat(filter.mustNot(), empty());
+            assertThat(filter.should(), containsInAnyOrder(QueryBuilders.termQuery("foo", "baz"), QueryBuilders.termQuery("foo", "bax")));
         }
         {
             String index = backingIndex1.getIndex().getName();


### PR DESCRIPTION
Index aliases allow each index in the alias to have a different filter. Data stream aliases appear to do this, but in reality they do not. That is, if you ask to add two data streams to a data stream alias, each with a different filter, the API allows it but only keeps one of the filters. This PR makes it so that the DataStreamAlias keeps a map of DataStreams to filters so that the different filters are respected.
Closes https://github.com/elastic/elasticsearch/issues/92050