### PR TITLE
Delay master task failure notifications until commit

### DIFF
--- a/docs/changelog/92693.yaml
+++ b/docs/changelog/92693.yaml
@@ -2,4 +2,5 @@ pr: 92693
 summary: Delay master task failure notifications until commit
 area: Cluster Coordination
 type: bug
-issues: []
+issues:
+ - 92677

--- a/docs/changelog/92693.yaml
+++ b/docs/changelog/92693.yaml
@@ -1,0 +1,5 @@
+pr: 92693
+summary: Delay master task failure notifications until commit
+area: Cluster Coordination
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -33,7 +33,7 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
      * should do that instead.
      * <p>
      * Returning {@code batchExecutionContext.initialState()} is an important and useful optimisation in most cases, but note that this
-     * fast-path exposes APIs to the risk of dirty reads in the vicinity of a master failover: a node {@code N} that handles such a no-op
+     * fast-path exposes APIs to the risk of stale reads in the vicinity of a master failover: a node {@code N} that handles such a no-op
      * task batch does not verify with its peers that it's still the master, and if it's not the master then another node {@code M} may
      * already have become master and updated the state in a way that would be inconsistent with the response that {@code N} sends back to
      * clients.

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -38,7 +38,8 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
      * already have become master and updated the state in a way that would be inconsistent with the response that {@code N} sends back to
      * clients.
      *
-     * @return The resulting cluster state after executing all the tasks. If {code initialState} is returned then no update is published.
+     * @return The resulting cluster state after executing all the tasks. If {code batchExecutionContext.initialState()} is returned then no
+     * update is published.
      */
     ClusterState execute(BatchExecutionContext<T> batchExecutionContext) throws Exception;
 

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateTaskExecutor.java
@@ -21,7 +21,8 @@ import java.util.function.Supplier;
  */
 public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
     /**
-     * Update the cluster state based on the current state and the given tasks. Return the *same instance* if no update should be published.
+     * Update the cluster state based on the current state and the given tasks. Return {@code batchExecutionContext.initialState()} to avoid
+     * publishing any update.
      * <p>
      * If this method throws an exception then the cluster state is unchanged and every task's {@link ClusterStateTaskListener#onFailure}
      * method is called.
@@ -30,6 +31,12 @@ public interface ClusterStateTaskExecutor<T extends ClusterStateTaskListener> {
      * This works ok but beware that constructing a whole new {@link ClusterState} can be somewhat expensive, and there may sometimes be
      * surprisingly many tasks to process in the batch. If it's possible to accumulate the effects of the tasks at a lower level then you
      * should do that instead.
+     * <p>
+     * Returning {@code batchExecutionContext.initialState()} is an important and useful optimisation in most cases, but note that this
+     * fast-path exposes APIs to the risk of dirty reads in the vicinity of a master failover: a node {@code N} that handles such a no-op
+     * task batch does not verify with its peers that it's still the master, and if it's not the master then another node {@code M} may
+     * already have become master and updated the state in a way that would be inconsistent with the response that {@code N} sends back to
+     * clients.
      *
      * @return The resulting cluster state after executing all the tasks. If {code initialState} is returned then no update is published.
      */

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -277,12 +277,6 @@ public class MasterService extends AbstractLifecycleComponent {
             previousClusterState,
             executeTasks(previousClusterState, executionResults, executor, summary, threadPool.getThreadContext())
         );
-        // fail all tasks that have failed
-        for (final var executionResult : executionResults) {
-            if (executionResult.failure != null) {
-                executionResult.updateTask.onFailure(executionResult.failure, executionResult::restoreResponseHeaders);
-            }
-        }
         final TimeValue computationTime = getTimeSince(computationStartTime);
         logExecutionTime(computationTime, "compute cluster state update", summary);
 
@@ -950,7 +944,7 @@ public class MasterService extends AbstractLifecycleComponent {
 
         void onPublishSuccess(ClusterState newClusterState) {
             if (publishedStateConsumer == null && onPublicationSuccess == null) {
-                assert failure != null;
+                notifyFailure();
                 return;
             }
             try (ThreadContext.StoredContext ignored = updateTask.threadContextSupplier.get()) {
@@ -967,7 +961,7 @@ public class MasterService extends AbstractLifecycleComponent {
 
         void onClusterStateUnchanged(ClusterState clusterState) {
             if (publishedStateConsumer == null && onPublicationSuccess == null) {
-                assert failure != null;
+                notifyFailure();
                 return;
             }
             try (ThreadContext.StoredContext ignored = updateTask.threadContextSupplier.get()) {
@@ -984,7 +978,7 @@ public class MasterService extends AbstractLifecycleComponent {
 
         void onPublishFailure(FailedToCommitClusterStateException e) {
             if (publishedStateConsumer == null && onPublicationSuccess == null) {
-                assert failure != null;
+                notifyFailure();
                 return;
             }
             try (ThreadContext.StoredContext ignored = updateTask.threadContextSupplier.get()) {
@@ -996,9 +990,14 @@ public class MasterService extends AbstractLifecycleComponent {
             }
         }
 
+        void notifyFailure() {
+            assert failure != null;
+            this.updateTask.onFailure(this.failure, this::restoreResponseHeaders);
+        }
+
         ContextPreservingAckListener getContextPreservingAckListener() {
             assert incomplete() == false;
-            return updateTask.wrapInTaskContext(clusterStateAckListener, this::restoreResponseHeaders);
+            return failure == null ? updateTask.wrapInTaskContext(clusterStateAckListener, this::restoreResponseHeaders) : null;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/MasterService.java
@@ -978,6 +978,10 @@ public class MasterService extends AbstractLifecycleComponent {
 
         void onPublishFailure(FailedToCommitClusterStateException e) {
             if (publishedStateConsumer == null && onPublicationSuccess == null) {
+                assert failure != null;
+                var taskFailure = failure;
+                failure = new FailedToCommitClusterStateException(e.getMessage(), e);
+                failure.addSuppressed(taskFailure);
                 notifyFailure();
                 return;
             }


### PR DESCRIPTION
Today when the master service processes a batch of tasks in which some tasks fail and others succeed, the failure notifications occur straight away. However, the tasks may have failed because earlier tasks in the batch succeeded, and the effects of those successful tasks will not be visible to clients straight away. This commit delays all notifications until the publication is complete.

Closes #92677