### PR TITLE
[7.17] docs: use valid settings in examples

### DIFF
--- a/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/delete-pipeline.asciidoc
@@ -55,8 +55,7 @@ PUT _logstash/pipeline/my_pipeline
     "pipeline.batch.size": 125,
     "pipeline.batch.delay": 50,
     "queue.type": "memory",
-    "queue.max_bytes.number": 1,
-    "queue.max_bytes.units": "gb",
+    "queue.max_bytes": "1gb",
     "queue.checkpoint.writes": 1024
   }
 }

--- a/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/get-pipeline.asciidoc
@@ -57,8 +57,7 @@ PUT _logstash/pipeline/my_pipeline
     "pipeline.batch.size": 125,
     "pipeline.batch.delay": 50,
     "queue.type": "memory",
-    "queue.max_bytes.number": 1,
-    "queue.max_bytes.units": "gb",
+    "queue.max_bytes": "1gb",
     "queue.checkpoint.writes": 1024
   }
 }
@@ -92,8 +91,7 @@ If the request succeeds, the body of the response contains the pipeline definiti
       "pipeline.batch.size": 125,
       "pipeline.batch.delay": 50,
       "queue.type": "memory",
-      "queue.max_bytes.number": 1,
-      "queue.max_bytes.units": "gb",
+      "queue.max_bytes": "1gb",
       "queue.checkpoint.writes": 1024
     }
   }

--- a/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
+++ b/x-pack/docs/en/rest-api/logstash/put-pipeline.asciidoc
@@ -87,8 +87,7 @@ PUT _logstash/pipeline/my_pipeline
     "pipeline.batch.size": 125,
     "pipeline.batch.delay": 50,
     "queue.type": "memory",
-    "queue.max_bytes.number": 1,
-    "queue.max_bytes.units": "gb",
+    "queue.max_bytes": "1gb",
     "queue.checkpoint.writes": 1024
   }
 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - docs: use valid settings in examples (#92651)