### PR TITLE
[Rest Api Compatibility] Format response media type with parameters

### DIFF
--- a/docs/changelog/92695.yaml
+++ b/docs/changelog/92695.yaml
@@ -1,0 +1,5 @@
+pr: 92695
+summary: "[Rest Api Compatibility] Format response media type with parameters"
+area: Infra/REST API
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -122,7 +122,7 @@ public class RestResponse {
         try (XContentBuilder builder = channel.newErrorBuilder()) {
             build(builder, params, status, channel.detailedErrorsEnabled(), e);
             this.content = BytesReference.bytes(builder);
-            this.responseMediaType = builder.contentType().mediaType();
+            this.responseMediaType = builder.getResponseContentTypeString();
         }
         if (e instanceof ElasticsearchException) {
             copyHeaders(((ElasticsearchException) e));

--- a/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestResponseTests.java
@@ -19,11 +19,13 @@ import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchShardTarget;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.rest.FakeRestRequest;
 import org.elasticsearch.transport.RemoteTransportException;
+import org.elasticsearch.xcontent.MediaType;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentType;
@@ -31,11 +33,13 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.ElasticsearchExceptionTests.assertDeepEquals;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -355,6 +359,21 @@ public class RestResponseTests extends ESTestCase {
             }
         });
         assertEquals("Failed to parse elasticsearch status exception: no exception was found", e.getMessage());
+    }
+
+    public void testResponseContentTypeUponException() throws Exception {
+        String mediaType = XContentType.VND_JSON.toParsedMediaType()
+            .responseContentTypeHeader(
+                Map.of(MediaType.COMPATIBLE_WITH_PARAMETER_NAME, String.valueOf(RestApiVersion.minimumSupported().major))
+            );
+        List<String> mediaTypeList = Collections.singletonList(mediaType);
+
+        RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withHeaders(Map.of("Accept", mediaTypeList)).build();
+        RestChannel channel = new SimpleExceptionRestChannel(request);
+
+        Exception t = new ElasticsearchException("an error occurred reading data", new FileNotFoundException("/foo/bar"));
+        RestResponse response = new RestResponse(channel, t);
+        assertThat(response.contentType(), equalTo(mediaType));
     }
 
     public static class WithHeadersException extends ElasticsearchException {


### PR DESCRIPTION
Currently a response media type when returning an exception to user was taken from XContentType.mediaType - hardcoded values. For instance: `application/json;charset=utf-8` or `application/json` - even though the vendor specific content type was used on a request's Accept header.

Response media type should be formatted with parameters (when provided).
For instance: `application/vnd.elasticsearch+json;compatible-with=8`

relates #92658

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
