### PR TITLE
[ML] Remove invalid assertion on model deployment thread count

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -260,13 +260,6 @@ public class DeploymentManager {
         Task parentActionTask,
         ActionListener<InferenceResults> listener
     ) {
-        assert ((EsThreadPoolExecutor) executorServiceForProcess).getPoolSize() % 3 == 0
-            : "Thread pool size ["
-                + ((EsThreadPoolExecutor) executorServiceForProcess).getPoolSize()
-                + "] should be a multiple of 3. Num contexts = ["
-                + processContextByAllocation.size()
-                + "]";
-
         var processContext = getProcessContext(task, listener::onFailure);
         if (processContext == null) {
             // error reporting handled in the call to getProcessContext

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
-import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.query.IdsQueryBuilder;


### PR DESCRIPTION
The assertion added in #92204 on the number of threads used by a trained model deployment can fail if it is evaluated while another model is starting or stopping. 


Closes #92701