### PR TITLE
Add more invariant checks to ISRT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -291,7 +291,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
                         nodeId,
                         null,
                         j == 0,
-                        ShardRoutingState.fromValue((byte) randomIntBetween(2, 3)),
+                        j == 0 ? ShardRoutingState.STARTED : randomFrom(ShardRoutingState.INITIALIZING, ShardRoutingState.STARTED),
                         unassignedInfo
                     )
                 );

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -590,9 +590,7 @@ public class IndexShardRoutingTable {
                     seenPrimary = true;
                 }
             }
-            // We should be able to return seenPrimary here, but in tests there are many empty routing tables so for now we leniently allow
-            // this case too. TODO fix those tests and stop being lenient here.
-            return shards.isEmpty() || seenPrimary;
+            return seenPrimary;
         }
 
         static boolean noAssignedReplicaWithoutActivePrimary(List<ShardRouting> shards) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -559,6 +559,7 @@ public class IndexShardRoutingTable {
             // don't allow more than one shard copy with same id to be allocated to same node
             assert distinctNodes(shards) : "more than one shard with same id assigned to same node (shards: " + shards + ")";
             assert noDuplicatePrimary(shards) : "expected but did not find unique primary in shard routing table: " + shards;
+            assert noAssignedReplicaWithoutActivePrimary(shards) : "unexpected assigned replica with no active primary: " + shards;
             return new IndexShardRoutingTable(shardId, shards);
         }
 
@@ -592,6 +593,23 @@ public class IndexShardRoutingTable {
             // We should be able to return seenPrimary here, but in tests there are many routing tables with no primary (e.g. empty) so for
             // now we leniently allow there to be no primary as well. TODO fix those tests and stop being lenient here.
             return true;
+        }
+
+        static boolean noAssignedReplicaWithoutActivePrimary(List<ShardRouting> shards) {
+            boolean seenAssignedReplica = false;
+            for (final var shard : shards) {
+                if (shard.currentNodeId() != null) {
+                    if (shard.primary()) {
+                        if (shard.active()) {
+                            return true;
+                        }
+                    } else {
+                        seenAssignedReplica = true;
+                    }
+                }
+            }
+
+            return seenAssignedReplica == false;
         }
 
         public static IndexShardRoutingTable.Builder readFrom(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -590,9 +590,9 @@ public class IndexShardRoutingTable {
                     seenPrimary = true;
                 }
             }
-            // We should be able to return seenPrimary here, but in tests there are many routing tables with no primary (e.g. empty) so for
-            // now we leniently allow there to be no primary as well. TODO fix those tests and stop being lenient here.
-            return true;
+            // We should be able to return seenPrimary here, but in tests there are many empty routing tables so for now we leniently allow
+            // this case too. TODO fix those tests and stop being lenient here.
+            return shards.isEmpty() || seenPrimary;
         }
 
         static boolean noAssignedReplicaWithoutActivePrimary(List<ShardRouting> shards) {

--- a/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
+++ b/server/src/main/java/org/elasticsearch/indices/store/IndicesStore.java
@@ -184,6 +184,8 @@ public class IndicesStore implements ClusterStateListener, Closeable {
     }
 
     static boolean shardCanBeDeleted(String localNodeId, IndexShardRoutingTable indexShardRoutingTable) {
+        assert indexShardRoutingTable.size() > 0;
+
         // a shard can be deleted if all its copies are active, and its not allocated on this node
         if (indexShardRoutingTable.size() == 0) {
             // should not really happen, there should always be at least 1 (primary) shard in a

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
@@ -26,7 +26,6 @@ import org.elasticsearch.index.shard.IndexLongFieldRange;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.shard.ShardLongFieldRange;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
@@ -142,9 +141,9 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
         assertSame(clusterState, executeTasks(clusterState, tasks));
     }
 
-    public void testStartedShards() throws Exception {
+    public void testStartPrimary() throws Exception {
         final String indexName = "test";
-        final ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.INITIALIZING, ShardRoutingState.INITIALIZING);
+        final ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.INITIALIZING);
 
         final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
         final ShardId shardId = new ShardId(indexMetadata.getIndex(), 0);
@@ -152,35 +151,47 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
         final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
         final String primaryAllocationId = primaryShard.allocationId().getId();
 
-        final List<StartedShardUpdateTask> tasks = new ArrayList<>();
-        tasks.add(
-            new StartedShardUpdateTask(
-                new StartedShardEntry(shardId, primaryAllocationId, primaryTerm, "test", ShardLongFieldRange.UNKNOWN),
-                createTestListener()
-            )
+        final var task = new StartedShardUpdateTask(
+            new StartedShardEntry(shardId, primaryAllocationId, primaryTerm, "test", ShardLongFieldRange.UNKNOWN),
+            createTestListener()
         );
-        if (randomBoolean()) {
-            final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().iterator().next();
-            final String replicaAllocationId = replicaShard.allocationId().getId();
-            tasks.add(
-                new StartedShardUpdateTask(
-                    new StartedShardEntry(shardId, replicaAllocationId, primaryTerm, "test", ShardLongFieldRange.UNKNOWN),
-                    createTestListener()
-                )
-            );
-        }
 
-        final var resultingState = executeTasks(clusterState, tasks);
+        final var resultingState = executeTasks(clusterState, List.of(task));
         assertNotSame(clusterState, resultingState);
-        for (final var task : tasks) {
-            assertThat(
-                resultingState.routingTable()
-                    .shardRoutingTable(task.getEntry().shardId)
-                    .getByAllocationId(task.getEntry().allocationId)
-                    .state(),
-                is(ShardRoutingState.STARTED)
-            );
-        }
+        assertThat(
+            resultingState.routingTable()
+                .shardRoutingTable(task.getEntry().shardId)
+                .getByAllocationId(task.getEntry().allocationId)
+                .state(),
+            is(ShardRoutingState.STARTED)
+        );
+    }
+
+    public void testStartReplica() throws Exception {
+        final String indexName = "test";
+        final ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING);
+
+        final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
+        final ShardId shardId = new ShardId(indexMetadata.getIndex(), 0);
+        final long primaryTerm = indexMetadata.primaryTerm(shardId.id());
+        final ShardRouting primaryShard = clusterState.routingTable().shardRoutingTable(shardId).primaryShard();
+
+        final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().iterator().next();
+        final String replicaAllocationId = replicaShard.allocationId().getId();
+        final var task = new StartedShardUpdateTask(
+            new StartedShardEntry(shardId, replicaAllocationId, primaryTerm, "test", ShardLongFieldRange.UNKNOWN),
+            createTestListener()
+        );
+
+        final var resultingState = executeTasks(clusterState, List.of(task));
+        assertNotSame(clusterState, resultingState);
+        assertThat(
+            resultingState.routingTable()
+                .shardRoutingTable(task.getEntry().shardId)
+                .getByAllocationId(task.getEntry().allocationId)
+                .state(),
+            is(ShardRoutingState.STARTED)
+        );
     }
 
     public void testDuplicateStartsAreOkay() throws Exception {
@@ -215,12 +226,12 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
         }
     }
 
-    public void testPrimaryTermsMismatch() throws Exception {
+    public void testPrimaryTermsMismatchOnPrimary() throws Exception {
         final String indexName = "test";
         final int shard = 0;
         final int primaryTerm = 2 + randomInt(200);
 
-        ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.INITIALIZING, ShardRoutingState.INITIALIZING);
+        ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.INITIALIZING);
         clusterState = ClusterState.builder(clusterState)
             .metadata(
                 Metadata.builder(clusterState.metadata())
@@ -272,8 +283,23 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
                     .state(),
                 is(ShardRoutingState.STARTED)
             );
-            clusterState = resultingState;
         }
+    }
+
+    public void testPrimaryTermsMismatchOnReplica() throws Exception {
+        final String indexName = "test";
+        final int shard = 0;
+        final int primaryTerm = 2 + randomInt(200);
+
+        ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING);
+        clusterState = ClusterState.builder(clusterState)
+            .metadata(
+                Metadata.builder(clusterState.metadata())
+                    .put(IndexMetadata.builder(clusterState.metadata().index(indexName)).primaryTerm(shard, primaryTerm).build(), true)
+                    .build()
+            )
+            .build();
+        final ShardId shardId = new ShardId(clusterState.metadata().index(indexName).getIndex(), shard);
         {
             final long replicaPrimaryTerm = randomBoolean() ? primaryTerm : primaryTerm - 1;
             final String replicaAllocationId = clusterState.routingTable()
@@ -301,9 +327,9 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
         }
     }
 
-    public void testExpandsTimestampRange() throws Exception {
+    public void testExpandsTimestampRangeForPrimary() throws Exception {
         final String indexName = "test";
-        final ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.INITIALIZING, ShardRoutingState.INITIALIZING);
+        final ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.INITIALIZING);
 
         final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
         final ShardId shardId = new ShardId(indexMetadata.getIndex(), 0);
@@ -317,45 +343,64 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
             : randomBoolean() ? ShardLongFieldRange.EMPTY
             : ShardLongFieldRange.of(1606407943000L, 1606407944000L);
 
-        final List<StartedShardUpdateTask> tasks = new ArrayList<>();
-        tasks.add(
-            new StartedShardUpdateTask(
-                new StartedShardEntry(shardId, primaryAllocationId, primaryTerm, "test", shardTimestampRange),
-                createTestListener()
-            )
+        final var task = new StartedShardUpdateTask(
+            new StartedShardEntry(shardId, primaryAllocationId, primaryTerm, "test", shardTimestampRange),
+            createTestListener()
         );
-        if (randomBoolean()) {
-            final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().iterator().next();
-            final String replicaAllocationId = replicaShard.allocationId().getId();
-            tasks.add(
-                new StartedShardUpdateTask(
-                    new StartedShardEntry(shardId, replicaAllocationId, primaryTerm, "test", shardTimestampRange),
-                    createTestListener()
-                )
-            );
-        }
-        final var resultingState = executeTasks(clusterState, tasks);
-        assertNotSame(clusterState, resultingState);
-        for (final var task : tasks) {
-            assertThat(
-                resultingState.routingTable()
-                    .shardRoutingTable(task.getEntry().shardId)
-                    .getByAllocationId(task.getEntry().allocationId)
-                    .state(),
-                is(ShardRoutingState.STARTED)
-            );
 
-            final var timestampRange = resultingState.metadata().index(indexName).getTimestampRange();
-            if (shardTimestampRange == ShardLongFieldRange.UNKNOWN) {
-                assertThat(timestampRange, sameInstance(IndexLongFieldRange.UNKNOWN));
-            } else if (shardTimestampRange == ShardLongFieldRange.EMPTY) {
-                assertThat(timestampRange, sameInstance(IndexLongFieldRange.EMPTY));
-            } else {
-                assertTrue(timestampRange.isComplete());
-                assertThat(timestampRange.getMin(), equalTo(shardTimestampRange.getMin()));
-                assertThat(timestampRange.getMax(), equalTo(shardTimestampRange.getMax()));
-            }
+        final var resultingState = executeTasks(clusterState, List.of(task));
+        assertNotSame(clusterState, resultingState);
+        assertThat(
+            resultingState.routingTable()
+                .shardRoutingTable(task.getEntry().shardId)
+                .getByAllocationId(task.getEntry().allocationId)
+                .state(),
+            is(ShardRoutingState.STARTED)
+        );
+
+        final var timestampRange = resultingState.metadata().index(indexName).getTimestampRange();
+        if (shardTimestampRange == ShardLongFieldRange.UNKNOWN) {
+            assertThat(timestampRange, sameInstance(IndexLongFieldRange.UNKNOWN));
+        } else if (shardTimestampRange == ShardLongFieldRange.EMPTY) {
+            assertThat(timestampRange, sameInstance(IndexLongFieldRange.EMPTY));
+        } else {
+            assertTrue(timestampRange.isComplete());
+            assertThat(timestampRange.getMin(), equalTo(shardTimestampRange.getMin()));
+            assertThat(timestampRange.getMax(), equalTo(shardTimestampRange.getMax()));
         }
+    }
+
+    public void testExpandsTimestampRangeForReplica() throws Exception {
+        final String indexName = "test";
+        final ClusterState clusterState = state(indexName, randomBoolean(), ShardRoutingState.STARTED, ShardRoutingState.INITIALIZING);
+
+        final IndexMetadata indexMetadata = clusterState.metadata().index(indexName);
+        final ShardId shardId = new ShardId(indexMetadata.getIndex(), 0);
+        final long primaryTerm = indexMetadata.primaryTerm(shardId.id());
+
+        assertThat(indexMetadata.getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
+
+        final ShardLongFieldRange shardTimestampRange = randomBoolean() ? ShardLongFieldRange.UNKNOWN
+            : randomBoolean() ? ShardLongFieldRange.EMPTY
+            : ShardLongFieldRange.of(1606407943000L, 1606407944000L);
+
+        final ShardRouting replicaShard = clusterState.routingTable().shardRoutingTable(shardId).replicaShards().iterator().next();
+        final String replicaAllocationId = replicaShard.allocationId().getId();
+        final var task = new StartedShardUpdateTask(
+            new StartedShardEntry(shardId, replicaAllocationId, primaryTerm, "test", shardTimestampRange),
+            createTestListener()
+        );
+        final var resultingState = executeTasks(clusterState, List.of(task));
+        assertNotSame(clusterState, resultingState);
+        assertThat(
+            resultingState.routingTable()
+                .shardRoutingTable(task.getEntry().shardId)
+                .getByAllocationId(task.getEntry().allocationId)
+                .state(),
+            is(ShardRoutingState.STARTED)
+        );
+
+        assertThat(resultingState.metadata().index(indexName).getTimestampRange(), sameInstance(IndexLongFieldRange.UNKNOWN));
     }
 
     private ClusterState executeTasks(final ClusterState state, final List<StartedShardUpdateTask> tasks) throws Exception {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableGenerator.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/RoutingTableGenerator.java
@@ -26,7 +26,7 @@ public class RoutingTableGenerator {
         int stateRandomizer = RandomizedContext.current().getRandom().nextInt(40);
         if (stateRandomizer > 5) {
             state = ShardRoutingState.STARTED;
-        } else if (stateRandomizer > 3) {
+        } else if (stateRandomizer > 3 || primary) {
             state = ShardRoutingState.RELOCATING;
         } else {
             state = ShardRoutingState.INITIALIZING;
@@ -36,7 +36,7 @@ public class RoutingTableGenerator {
             case STARTED -> TestShardRouting.newShardRouting(
                 index,
                 shardId,
-                "node_" + Integer.toString(node_id++),
+                "node_" + (node_id++),
                 null,
                 primary,
                 ShardRoutingState.STARTED
@@ -44,7 +44,7 @@ public class RoutingTableGenerator {
             case INITIALIZING -> TestShardRouting.newShardRouting(
                 index,
                 shardId,
-                "node_" + Integer.toString(node_id++),
+                "node_" + (node_id++),
                 null,
                 primary,
                 ShardRoutingState.INITIALIZING
@@ -52,8 +52,8 @@ public class RoutingTableGenerator {
             case RELOCATING -> TestShardRouting.newShardRouting(
                 index,
                 shardId,
-                "node_" + Integer.toString(node_id++),
-                "node_" + Integer.toString(node_id++),
+                "node_" + (node_id++),
+                "node_" + (node_id++),
                 primary,
                 ShardRoutingState.RELOCATING
             );
@@ -65,13 +65,13 @@ public class RoutingTableGenerator {
     public IndexShardRoutingTable.Builder genShardRoutingTable(IndexMetadata indexMetadata, int shardId, ShardCounter counter) {
         final String index = indexMetadata.getIndex().getName();
         IndexShardRoutingTable.Builder builder = new IndexShardRoutingTable.Builder(new ShardId(index, "_na_", shardId));
-        ShardRouting shardRouting = genShardRouting(index, shardId, true);
-        counter.update(shardRouting);
-        builder.addShard(shardRouting);
+        final ShardRouting primary = genShardRouting(index, shardId, true);
+        counter.update(primary);
+        builder.addShard(primary);
         for (int replicas = indexMetadata.getNumberOfReplicas(); replicas > 0; replicas--) {
-            shardRouting = genShardRouting(index, shardId, false);
-            counter.update(shardRouting);
-            builder.addShard(shardRouting);
+            final ShardRouting replica = genShardRouting(index, shardId, false);
+            counter.update(replica);
+            builder.addShard(replica);
         }
 
         return builder;

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/BalanceConfigurationTests.java
@@ -10,27 +10,21 @@ package org.elasticsearch.cluster.routing.allocation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.ArrayUtil;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
-import org.elasticsearch.cluster.EmptyClusterInfoService;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
-import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllocator;
-import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 import org.hamcrest.Matchers;
 
@@ -318,155 +312,4 @@ public class BalanceConfigurationTests extends ESAllocationTestCase {
         assertThat(allocator.getShardBalance(), Matchers.equalTo(0.1f));
         assertThat(allocator.getThreshold(), Matchers.equalTo(3.0f));
     }
-
-    public void testNoRebalanceOnPrimaryOverload() {
-        Settings.Builder settings = Settings.builder();
-        AllocationService strategy = new AllocationService(
-            randomAllocationDeciders(
-                settings.build(),
-                new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
-                random()
-            ),
-            new TestGatewayAllocator(),
-            new ShardsAllocator() {
-                /*
-                 *  // this allocator tries to rebuild this scenario where a rebalance is
-                 *  // triggered solely by the primary overload on node [1] where a shard
-                 *  // is rebalanced to node 0
-                    routing_nodes:
-                    -----node_id[0][V]
-                    --------[test][0], node[0], [R], s[STARTED]
-                    --------[test][4], node[0], [R], s[STARTED]
-                    -----node_id[1][V]
-                    --------[test][0], node[1], [P], s[STARTED]
-                    --------[test][1], node[1], [P], s[STARTED]
-                    --------[test][3], node[1], [R], s[STARTED]
-                    -----node_id[2][V]
-                    --------[test][1], node[2], [R], s[STARTED]
-                    --------[test][2], node[2], [R], s[STARTED]
-                    --------[test][4], node[2], [P], s[STARTED]
-                    -----node_id[3][V]
-                    --------[test][2], node[3], [P], s[STARTED]
-                    --------[test][3], node[3], [P], s[STARTED]
-                    ---- unassigned
-                */
-                public void allocate(RoutingAllocation allocation) {
-                    RoutingNodes.UnassignedShards unassigned = allocation.routingNodes().unassigned();
-                    ShardRouting[] drain = unassigned.drain();
-                    ArrayUtil.timSort(drain, (a, b) -> { return a.primary() ? -1 : 1; }); // we have to allocate primaries first
-                    for (ShardRouting sr : drain) {
-                        switch (sr.id()) {
-                            case 0:
-                                if (sr.primary()) {
-                                    allocation.routingNodes().initializeShard(sr, "node1", null, -1, allocation.changes());
-                                } else {
-                                    allocation.routingNodes().initializeShard(sr, "node0", null, -1, allocation.changes());
-                                }
-                                break;
-                            case 1:
-                                if (sr.primary()) {
-                                    allocation.routingNodes().initializeShard(sr, "node1", null, -1, allocation.changes());
-                                } else {
-                                    allocation.routingNodes().initializeShard(sr, "node2", null, -1, allocation.changes());
-                                }
-                                break;
-                            case 2:
-                                if (sr.primary()) {
-                                    allocation.routingNodes().initializeShard(sr, "node3", null, -1, allocation.changes());
-                                } else {
-                                    allocation.routingNodes().initializeShard(sr, "node2", null, -1, allocation.changes());
-                                }
-                                break;
-                            case 3:
-                                if (sr.primary()) {
-                                    allocation.routingNodes().initializeShard(sr, "node3", null, -1, allocation.changes());
-                                } else {
-                                    allocation.routingNodes().initializeShard(sr, "node1", null, -1, allocation.changes());
-                                }
-                                break;
-                            case 4:
-                                if (sr.primary()) {
-                                    allocation.routingNodes().initializeShard(sr, "node2", null, -1, allocation.changes());
-                                } else {
-                                    allocation.routingNodes().initializeShard(sr, "node0", null, -1, allocation.changes());
-                                }
-                                break;
-                        }
-
-                    }
-                }
-
-                @Override
-                public ShardAllocationDecision decideShardAllocation(ShardRouting shard, RoutingAllocation allocation) {
-                    throw new UnsupportedOperationException("explain not supported");
-                }
-            },
-            EmptyClusterInfoService.INSTANCE,
-            EmptySnapshotsInfoService.INSTANCE
-        );
-        Metadata.Builder metadataBuilder = Metadata.builder();
-        RoutingTable.Builder routingTableBuilder = RoutingTable.builder();
-        IndexMetadata.Builder indexMeta = IndexMetadata.builder("test")
-            .settings(settings(Version.CURRENT))
-            .numberOfShards(5)
-            .numberOfReplicas(1);
-        metadataBuilder = metadataBuilder.put(indexMeta);
-        Metadata metadata = metadataBuilder.build();
-        for (IndexMetadata indexMetadata : metadata.indices().values()) {
-            routingTableBuilder.addAsNew(indexMetadata);
-        }
-        RoutingTable routingTable = routingTableBuilder.build();
-        DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
-        for (int i = 0; i < 4; i++) {
-            DiscoveryNode node = newNode("node" + i);
-            nodes.add(node);
-        }
-
-        ClusterState clusterState = ClusterState.builder(
-            org.elasticsearch.cluster.ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY)
-        ).nodes(nodes).metadata(metadata).routingTable(routingTable).build();
-        routingTable = strategy.reroute(clusterState, "reroute", ActionListener.noop()).routingTable();
-        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
-        RoutingNodes routingNodes = clusterState.getRoutingNodes();
-
-        for (RoutingNode routingNode : routingNodes) {
-            for (ShardRouting shardRouting : routingNode) {
-                assertThat(shardRouting.state(), Matchers.equalTo(ShardRoutingState.INITIALIZING));
-            }
-        }
-        strategy = createAllocationService(settings.build(), new TestGatewayAllocator());
-
-        logger.info("use the new allocator and check if it moves shards");
-        routingTable = startInitializingShardsAndReroute(strategy, clusterState).routingTable();
-        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
-        routingNodes = clusterState.getRoutingNodes();
-        for (RoutingNode routingNode : routingNodes) {
-            for (ShardRouting shardRouting : routingNode) {
-                assertThat(shardRouting.state(), Matchers.equalTo(ShardRoutingState.STARTED));
-            }
-        }
-
-        logger.info("start the replica shards");
-        routingTable = startInitializingShardsAndReroute(strategy, clusterState).routingTable();
-        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
-        routingNodes = clusterState.getRoutingNodes();
-
-        for (RoutingNode routingNode : routingNodes) {
-            for (ShardRouting shardRouting : routingNode) {
-                assertThat(shardRouting.state(), Matchers.equalTo(ShardRoutingState.STARTED));
-            }
-        }
-
-        logger.info("rebalancing");
-        routingTable = strategy.reroute(clusterState, "reroute", ActionListener.noop()).routingTable();
-        clusterState = ClusterState.builder(clusterState).routingTable(routingTable).build();
-        routingNodes = clusterState.getRoutingNodes();
-
-        for (RoutingNode routingNode : routingNodes) {
-            for (ShardRouting shardRouting : routingNode) {
-                assertThat(shardRouting.state(), Matchers.equalTo(ShardRoutingState.STARTED));
-            }
-        }
-    }
-
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/CatAllocationTestCase.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/CatAllocationTestCase.java
@@ -108,16 +108,12 @@ public abstract class CatAllocationTestCase extends ESAllocationTestCase {
             IndexMetadata idxMeta = idxMetaBuilder.build();
             builder.put(idxMeta, false);
             IndexRoutingTable.Builder tableBuilder = new IndexRoutingTable.Builder(idxMeta.getIndex()).initializeAsRecovery(idxMeta);
-            Map<Integer, IndexShardRoutingTable> shardIdToRouting = new HashMap<>();
+            Map<Integer, IndexShardRoutingTable.Builder> shardIdToRouting = new HashMap<>();
             for (ShardRouting r : idx.routing) {
-                IndexShardRoutingTable refData = new IndexShardRoutingTable.Builder(r.shardId()).addShard(r).build();
-                if (shardIdToRouting.containsKey(r.getId())) {
-                    refData = new IndexShardRoutingTable.Builder(shardIdToRouting.get(r.getId())).addShard(r).build();
-                }
-                shardIdToRouting.put(r.getId(), refData);
+                shardIdToRouting.computeIfAbsent(r.shardId().getId(), i -> new IndexShardRoutingTable.Builder(r.shardId())).addShard(r);
             }
-            for (IndexShardRoutingTable t : shardIdToRouting.values()) {
-                tableBuilder.addIndexShard(new IndexShardRoutingTable.Builder(t));
+            for (IndexShardRoutingTable.Builder t : shardIdToRouting.values()) {
+                tableBuilder.addIndexShard(t);
             }
             IndexRoutingTable table = tableBuilder.build();
             routingTableBuilder.add(table);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DecisionsImpactOnClusterHealthTests.java
@@ -27,14 +27,14 @@ import org.elasticsearch.cluster.routing.allocation.allocator.BalancedShardsAllo
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDecider;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
+import org.elasticsearch.cluster.routing.allocation.decider.ReplicaAfterPrimaryActiveAllocationDecider;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.snapshots.EmptySnapshotsInfoService;
 import org.elasticsearch.test.gateway.TestGatewayAllocator;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Set;
+import java.util.List;
 
 import static org.hamcrest.Matchers.equalTo;
 
@@ -52,7 +52,7 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
             .build();
         AllocationDecider decider = new TestAllocateDecision(Decision.NO);
         // if deciders say NO to allocating a primary shard, then the cluster health should be RED
-        runAllocationTest(settings, indexName, Collections.singleton(decider), ClusterHealthStatus.RED);
+        runAllocationTest(settings, indexName, decider, ClusterHealthStatus.RED);
     }
 
     public void testPrimaryShardThrottleDecisionOnIndexCreation() throws IOException {
@@ -62,7 +62,7 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
             .build();
         AllocationDecider decider = new TestAllocateDecision(Decision.THROTTLE);
         // if deciders THROTTLE allocating a primary shard, stay in YELLOW state
-        runAllocationTest(settings, indexName, Collections.singleton(decider), ClusterHealthStatus.YELLOW);
+        runAllocationTest(settings, indexName, decider, ClusterHealthStatus.YELLOW);
     }
 
     public void testPrimaryShardYesDecisionOnIndexCreation() throws IOException {
@@ -81,7 +81,7 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
             }
         };
         // if deciders say YES to allocating primary shards, stay in YELLOW state
-        ClusterState clusterState = runAllocationTest(settings, indexName, Collections.singleton(decider), ClusterHealthStatus.YELLOW);
+        ClusterState clusterState = runAllocationTest(settings, indexName, decider, ClusterHealthStatus.YELLOW);
         // make sure primaries are initialized
         final IndexRoutingTable indexRoutingTable = clusterState.routingTable().index(indexName);
         for (int i = 0; i < indexRoutingTable.size(); i++) {
@@ -92,12 +92,12 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
     private ClusterState runAllocationTest(
         final Settings settings,
         final String indexName,
-        final Set<AllocationDecider> allocationDeciders,
+        final AllocationDecider allocationDecider,
         final ClusterHealthStatus expectedStatus
     ) throws IOException {
 
         final String clusterName = "test-cluster";
-        final AllocationService allocationService = newAllocationService(settings, allocationDeciders);
+        final AllocationService allocationService = newAllocationService(settings, allocationDecider);
 
         logger.info("Building initial routing table");
         final int numShards = randomIntBetween(1, 5);
@@ -133,9 +133,9 @@ public class DecisionsImpactOnClusterHealthTests extends ESAllocationTestCase {
         return clusterState;
     }
 
-    private static AllocationService newAllocationService(Settings settings, Set<AllocationDecider> deciders) {
+    private static AllocationService newAllocationService(Settings settings, AllocationDecider decider) {
         return new AllocationService(
-            new AllocationDeciders(deciders),
+            new AllocationDeciders(List.of(decider, new ReplicaAfterPrimaryActiveAllocationDecider())),
             new TestGatewayAllocator(),
             new BalancedShardsAllocator(settings),
             EmptyClusterInfoService.INSTANCE,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -184,9 +184,9 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         );
     }
 
-    public void testShouldBeRedWhenThereAreUnassignedPrimariesAndAssignedReplicas() {
+    public void testShouldBeRedWhenThereAreUnassignedPrimariesAndUnassignedReplicas() {
         var clusterState = createClusterStateWith(
-            List.of(index("red-index", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE))),
+            List.of(index("red-index", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), UNAVAILABLE))),
             List.of()
         );
         var service = createShardsAvailabilityIndicatorService(clusterState);
@@ -196,8 +196,8 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             equalTo(
                 createExpectedResult(
                     RED,
-                    "This cluster has 1 unavailable primary shard.",
-                    Map.of("unassigned_primaries", 1, "started_replicas", 1),
+                    "This cluster has 1 unavailable primary shard, 1 unavailable replica shard.",
+                    Map.of("unassigned_primaries", 1, "unassigned_replicas", 1),
                     List.of(
                         new HealthIndicatorImpact(
                             NAME,
@@ -273,7 +273,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
         var clusterState = createClusterStateWith(
             indexMetadataList,
             List.of(
-                index("red-index", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE)),
+                index("red-index", new ShardAllocation(randomNodeId(), UNAVAILABLE)),
                 index("yellow-index-1", new ShardAllocation(randomNodeId(), AVAILABLE), new ShardAllocation(randomNodeId(), UNAVAILABLE)),
                 index("yellow-index-2", new ShardAllocation(randomNodeId(), AVAILABLE), new ShardAllocation(randomNodeId(), UNAVAILABLE))
             ),
@@ -1343,11 +1343,11 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
     public void testLimitNumberOfAffectedResources() {
         var clusterState = createClusterStateWith(
             List.of(
-                index("red-index1", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE)),
-                index("red-index2", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE)),
-                index("red-index3", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE)),
-                index("red-index4", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE)),
-                index("red-index5", new ShardAllocation(randomNodeId(), UNAVAILABLE), new ShardAllocation(randomNodeId(), AVAILABLE))
+                index("red-index1", new ShardAllocation(randomNodeId(), UNAVAILABLE)),
+                index("red-index2", new ShardAllocation(randomNodeId(), UNAVAILABLE)),
+                index("red-index3", new ShardAllocation(randomNodeId(), UNAVAILABLE)),
+                index("red-index4", new ShardAllocation(randomNodeId(), UNAVAILABLE)),
+                index("red-index5", new ShardAllocation(randomNodeId(), UNAVAILABLE))
             ),
             List.of()
         );
@@ -1361,7 +1361,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     createExpectedResult(
                         RED,
                         "This cluster has 5 unavailable primary shards.",
-                        Map.of("unassigned_primaries", 5, "started_replicas", 5),
+                        Map.of("unassigned_primaries", 5),
                         List.of(
                             new HealthIndicatorImpact(
                                 NAME,

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -630,7 +630,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
                     )
                 );
                 for (int replica = 0; replica < replicas; replica++) {
-                    var replicaNodeId = pickAndRemoveRandomValueFrom(remainingNodeIds);
+                    var replicaNodeId = primaryNodeId == null ? null : pickAndRemoveRandomValueFrom(remainingNodeIds);
                     indexRoutingTableBuilder.addShard(
                         newShardRouting(
                             shardId,

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -482,7 +482,9 @@ public class IndexShardTests extends IndexShardTestCase {
         promoteReplica(
             indexShard,
             Collections.singleton(replicaRouting.allocationId().getId()),
-            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(replicaRouting).build()
+            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(
+                TestShardRouting.newShardRouting(replicaRouting.shardId(), "ignored", true, ShardRoutingState.STARTED)
+            ).addShard(replicaRouting).build()
         );
 
         final int delayedOperations = scaledRandomIntBetween(1, 64);
@@ -570,7 +572,9 @@ public class IndexShardTests extends IndexShardTestCase {
         promoteReplica(
             indexShard,
             Collections.singleton(replicaRouting.allocationId().getId()),
-            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(replicaRouting).build()
+            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(
+                TestShardRouting.newShardRouting(replicaRouting.shardId(), "ignored", true, ShardRoutingState.STARTED)
+            ).addShard(replicaRouting).build()
         );
 
         stop.set(true);
@@ -593,7 +597,9 @@ public class IndexShardTests extends IndexShardTestCase {
         promoteReplica(
             indexShard,
             Collections.singleton(replicaRouting.allocationId().getId()),
-            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(replicaRouting).build()
+            new IndexShardRoutingTable.Builder(replicaRouting.shardId()).addShard(
+                TestShardRouting.newShardRouting(replicaRouting.shardId(), "ignored", true, ShardRoutingState.STARTED)
+            ).addShard(replicaRouting).build()
         );
 
         /*

--- a/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/IndicesClusterStateServiceRandomUpdatesTests.java
@@ -157,7 +157,7 @@ public class IndicesClusterStateServiceRandomUpdatesTests extends AbstractIndice
         // a cluster state derived from the initial state that includes a created index
         String name = "index_" + randomAlphaOfLength(8).toLowerCase(Locale.ROOT);
         ShardRoutingState[] replicaStates = new ShardRoutingState[randomIntBetween(0, 3)];
-        Arrays.fill(replicaStates, ShardRoutingState.INITIALIZING);
+        Arrays.fill(replicaStates, ShardRoutingState.UNASSIGNED);
         ClusterState stateWithIndex = ClusterStateCreationUtils.state(name, randomBoolean(), ShardRoutingState.INITIALIZING, replicaStates);
 
         // the initial state which is derived from the newly created cluster state but doesn't contain the index

--- a/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -42,11 +42,6 @@ public class IndicesStoreTests extends ESTestCase {
         localNode = new DiscoveryNode("abc", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
     }
 
-    public void testShardCanBeDeletedNoShardRouting() {
-        IndexShardRoutingTable.Builder routingTable = new IndexShardRoutingTable.Builder(new ShardId("test", "_na_", 1));
-        assertFalse(IndicesStore.shardCanBeDeleted(localNode.getId(), routingTable.build()));
-    }
-
     public void testShardCanBeDeletedNoShardStarted() {
         final var numShardCopies = randomInt(3);
         final var shardId = new ShardId("test", "_na_", 0);

--- a/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/store/IndicesStoreTests.java
@@ -52,12 +52,18 @@ public class IndicesStoreTests extends ESTestCase {
         final var shardId = new ShardId("test", "_na_", 0);
         final var routingTable = new IndexShardRoutingTable.Builder(shardId);
         final var unStartedShard = randomInt(numShardCopies);
+        boolean activePrimary = false;
         for (int j = 0; j <= numShardCopies; j++) {
             ShardRoutingState state;
             if (j == unStartedShard) {
                 state = randomFrom(NOT_STARTED_STATES);
             } else {
                 state = randomFrom(ShardRoutingState.values());
+            }
+            if (j == 0) {
+                activePrimary = state == ShardRoutingState.STARTED || state == ShardRoutingState.RELOCATING;
+            } else if (activePrimary == false) {
+                state = ShardRoutingState.UNASSIGNED;
             }
             UnassignedInfo unassignedInfo = null;
             if (state == ShardRoutingState.UNASSIGNED) {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -19,9 +19,12 @@ import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
+import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
+import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -467,7 +470,21 @@ public class SnapshotsServiceTests extends ESTestCase {
         final RoutingTable.Builder routingTable = RoutingTable.builder();
         for (String index : indexNames) {
             final Index idx = metaBuilder.get(index).getIndex();
-            routingTable.add(IndexRoutingTable.builder(idx).addIndexShard(IndexShardRoutingTable.builder(new ShardId(idx, 0))));
+            final ShardId shardId = new ShardId(idx, 0);
+            routingTable.add(
+                IndexRoutingTable.builder(idx)
+                    .addIndexShard(
+                        IndexShardRoutingTable.builder(shardId)
+                            .addShard(
+                                ShardRouting.newUnassigned(
+                                    shardId,
+                                    true,
+                                    RecoverySource.EmptyStoreRecoverySource.INSTANCE,
+                                    new UnassignedInfo(UnassignedInfo.Reason.INDEX_CREATED, "test")
+                                )
+                            )
+                    )
+            );
         }
         return ClusterState.builder(ClusterState.EMPTY_STATE).metadata(metaBuilder).routingTable(routingTable.build()).build();
     }

--- a/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/action/support/replication/ClusterStateCreationUtils.java
@@ -34,6 +34,7 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -67,6 +68,11 @@ public class ClusterStateCreationUtils {
         ShardRoutingState primaryState,
         ShardRoutingState... replicaStates
     ) {
+        assert primaryState == ShardRoutingState.STARTED
+            || primaryState == ShardRoutingState.RELOCATING
+            || Arrays.stream(replicaStates).allMatch(s -> s == ShardRoutingState.UNASSIGNED)
+            : "invalid shard states [" + primaryState + "] vs [" + Arrays.toString(replicaStates) + "]";
+
         final int numberOfReplicas = replicaStates.length;
 
         int numberOfNodes = numberOfReplicas + 1;

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -572,7 +572,9 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
                 null,
                 currentClusterStateVersion.incrementAndGet(),
                 activeIds(),
-                routingTable(Function.identity())
+                primary.routingEntry().initializing()
+                    ? IndexShardRoutingTable.builder(primary.shardId()).addShard(primary.routingEntry()).build()
+                    : routingTable(Function.identity())
             );
         }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -677,7 +677,11 @@ public abstract class IndexShardTestCase extends ESTestCase {
 
     public static void updateRoutingEntry(IndexShard shard, ShardRouting shardRouting) throws IOException {
         Set<String> inSyncIds = shardRouting.active() ? Collections.singleton(shardRouting.allocationId().getId()) : Collections.emptySet();
-        IndexShardRoutingTable newRoutingTable = new IndexShardRoutingTable.Builder(shardRouting.shardId()).addShard(shardRouting).build();
+        final var builder = new IndexShardRoutingTable.Builder(shardRouting.shardId());
+        if (shardRouting.primary() == false) {
+            builder.addShard(TestShardRouting.newShardRouting(shardRouting.shardId(), "ignored", true, ShardRoutingState.STARTED));
+        }
+        IndexShardRoutingTable newRoutingTable = builder.addShard(shardRouting).build();
         shard.updateShardState(
             shardRouting,
             shard.getPendingPrimaryTerm(),
@@ -858,9 +862,9 @@ public abstract class IndexShardTestCase extends ESTestCase {
             replica.routingEntry().allocationId()
         );
 
-        final IndexShardRoutingTable newRoutingTable = new IndexShardRoutingTable.Builder(routingTable).removeShard(replica.routingEntry())
-            .addShard(routingEntry)
-            .build();
+        final IndexShardRoutingTable newRoutingTable = new IndexShardRoutingTable.Builder(routingTable).removeShard(
+            routingTable.primaryShard()
+        ).removeShard(replica.routingEntry()).addShard(routingEntry).build();
         replica.updateShardState(
             routingEntry,
             replica.getPendingPrimaryTerm() + 1,


### PR DESCRIPTION
Today there are two invariants of all realistic `IndexShardRoutingTable`
instances which are not enforced, nor are they satisfied by all instances
created by tests:

- every `IndexShardRoutingTable` must have exactly one primary shard
- if the primary shard is not active (`STARTED` or `RELOCATING`) then the
  replicas must all be `UNASSIGNED`

This commit adds assertions to enforce these invariants, and fixes up the tests
which create instances that do not satisfy them.