### PR TITLE
Fix version range after backport

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/bulk/11_dynamic_templates.yml
@@ -173,8 +173,8 @@
 ---
 "Dynamic templates with op_type":
   - skip:
-      version: " - 8.6.99"
-      reason: "bug fixed in 8.7.0"
+      version: " - 8.6.0"
+      reason: "bug fixed in 8.6.1"
 
   - do:
       indices.create:


### PR DESCRIPTION
Fixing the version range on this bwc-ish test, now that I've backported #92687 to 8.6.