### PR TITLE
Add methods to H3#hexRing to prevent allocating long arrays

### DIFF
--- a/docs/changelog/92711.yaml
+++ b/docs/changelog/92711.yaml
@@ -1,0 +1,5 @@
+pr: 92711
+summary: Add methods to H3#hexRing to prevent allocating long arrays
+area: Geo
+type: enhancement
+issues: []

--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -348,7 +348,7 @@ public final class H3 {
      * Returns the neighbor indexes.
      *
      * @param h3 Origin index
-     *  @return All neighbor indexes from the origin
+     * @return All neighbor indexes from the origin
      */
     public static long[] hexRing(long h3) {
         final long[] ring = new long[hexRingSize(h3)];

--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -348,10 +348,70 @@ public final class H3 {
      * Returns the neighbor indexes.
      *
      * @param h3 Origin index
-     * @return All neighbor indexes from the origin
+     *  @return All neighbor indexes from the origin
      */
     public static long[] hexRing(long h3) {
-        return HexRing.hexRing(h3);
+        final long[] ring = new long[hexRingSize(h3)];
+        for (int i = 0; i < ring.length; i++) {
+            ring[i] = hexRingPosToH3(h3, i);
+            assert ring[i] >= 0;
+        }
+        return ring;
+    }
+
+    /**
+     * Returns the number of neighbor indexes.
+     *
+     * @param h3 Origin index
+     * @return the number of neighbor indexes from the origin
+     */
+    public static int hexRingSize(long h3) {
+        return H3Index.H3_is_pentagon(h3) ? 5 : 6;
+    }
+
+    /**
+     * Returns the number of neighbor indexes.
+     *
+     * @param h3Address Origin index
+     * @return the number of neighbor indexes from the origin
+     */
+    public static int hexRingSize(String h3Address) {
+        return hexRingSize(stringToH3(h3Address));
+    }
+
+    /**
+     * Returns the neighbor index at the given position.
+     *
+     * @param h3 Origin index
+     * @param ringPos position of the neighbour index
+     * @return the actual neighbour at the given position
+     */
+    public static long hexRingPosToH3(long h3, int ringPos) {
+        if (ringPos < 2) {
+            return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[ringPos].digit());
+        }
+        if (H3Index.H3_is_pentagon(h3)) {
+            if (ringPos > 4) {
+                throw new IllegalArgumentException("invalid ring position");
+            }
+            return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[ringPos + 1].digit());
+        } else {
+            if (ringPos > 5) {
+                throw new IllegalArgumentException("invalid ring position");
+            }
+            return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[ringPos].digit());
+        }
+    }
+
+    /**
+     * Returns the neighbor index at the given position.
+     *
+     * @param h3Address Origin index
+     * @param ringPos position of the neighbour index
+     * @return the actual neighbour at the given position
+     */
+    public static String hexRingPosToH3(String h3Address, int ringPos) {
+        return h3ToString(hexRingPosToH3(stringToH3(h3Address), ringPos));
     }
 
     /**

--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -389,7 +389,7 @@ public final class H3 {
     public static long hexRingPosToH3(long h3, int ringPos) {
         // for pentagons, we skip direction at position 2
         final int pos = H3Index.H3_is_pentagon(h3) && ringPos >= 2 ? ringPos + 1 : ringPos;
-        if (ringPos < 0 || ringPos > 5) {
+        if (pos < 0 || pos > 5) {
             throw new IllegalArgumentException("invalid ring position");
         }
         return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[pos].digit());

--- a/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/H3.java
@@ -387,20 +387,12 @@ public final class H3 {
      * @return the actual neighbour at the given position
      */
     public static long hexRingPosToH3(long h3, int ringPos) {
-        if (ringPos < 2) {
-            return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[ringPos].digit());
+        // for pentagons, we skip direction at position 2
+        final int pos = H3Index.H3_is_pentagon(h3) && ringPos >= 2 ? ringPos + 1 : ringPos;
+        if (ringPos < 0 || ringPos > 5) {
+            throw new IllegalArgumentException("invalid ring position");
         }
-        if (H3Index.H3_is_pentagon(h3)) {
-            if (ringPos > 4) {
-                throw new IllegalArgumentException("invalid ring position");
-            }
-            return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[ringPos + 1].digit());
-        } else {
-            if (ringPos > 5) {
-                throw new IllegalArgumentException("invalid ring position");
-            }
-            return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[ringPos].digit());
-        }
+        return HexRing.h3NeighborInDirection(h3, HexRing.DIRECTIONS[pos].digit());
     }
 
     /**

--- a/libs/h3/src/main/java/org/elasticsearch/h3/HexRing.java
+++ b/libs/h3/src/main/java/org/elasticsearch/h3/HexRing.java
@@ -309,7 +309,7 @@ final class HexRing {
      *     \\2/
      * </pre>
      */
-    private static final CoordIJK.Direction[] DIRECTIONS = new CoordIJK.Direction[] {
+    static final CoordIJK.Direction[] DIRECTIONS = new CoordIJK.Direction[] {
         CoordIJK.Direction.J_AXES_DIGIT,
         CoordIJK.Direction.JK_AXES_DIGIT,
         CoordIJK.Direction.K_AXES_DIGIT,
@@ -586,31 +586,6 @@ final class HexRing {
         CoordIJK.Direction.IJ_AXES_DIGIT,
         CoordIJK.Direction.I_AXES_DIGIT,
         CoordIJK.Direction.J_AXES_DIGIT };
-
-    /**
-     * Produce all neighboring cells. For Hexagons there will be 6 neighbors while
-     * for pentagon just 5.
-     * Output is placed in the provided array in no particular order.
-     *
-     * @param  origin   origin cell
-     */
-    public static long[] hexRing(long origin) {
-        final long[] out = H3Index.H3_is_pentagon(origin) ? new long[5] : new long[6];
-        int idx = 0;
-        long previous = -1;
-        for (int i = 0; i < 6; i++) {
-            long neighbor = h3NeighborInDirection(origin, DIRECTIONS[i].digit());
-            if (neighbor != -1) {
-                // -1 is an expected case when trying to traverse off of pentagons.
-                if (previous != neighbor) {
-                    out[idx++] = neighbor;
-                    previous = neighbor;
-                }
-            }
-        }
-        assert idx == out.length;
-        return out;
-    }
 
     /**
      * Returns whether or not the provided H3Indexes are neighbors.

--- a/libs/h3/src/test/java/org/elasticsearch/h3/HexRingTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/HexRingTests.java
@@ -25,6 +25,15 @@ import java.util.Arrays;
 
 public class HexRingTests extends ESTestCase {
 
+    public void testInvalidHexRingPos() {
+        long h3 = H3.geoToH3(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude(), randomIntBetween(0, H3.MAX_H3_RES));
+        IllegalArgumentException ex = expectThrows(IllegalArgumentException.class, () -> H3.hexRingPosToH3(h3, -1));
+        assertEquals(ex.getMessage(), "invalid ring position");
+        int pos = H3.isPentagon(h3) ? 5 : 6;
+        ex = expectThrows(IllegalArgumentException.class, () -> H3.hexRingPosToH3(h3, pos));
+        assertEquals(ex.getMessage(), "invalid ring position");
+    }
+
     public void testHexRing() {
         for (int i = 0; i < 500; i++) {
             double lat = GeoTestUtil.nextLatitude();

--- a/libs/h3/src/test/java/org/elasticsearch/h3/ParentChildNavigationTests.java
+++ b/libs/h3/src/test/java/org/elasticsearch/h3/ParentChildNavigationTests.java
@@ -173,4 +173,21 @@ public class ParentChildNavigationTests extends ESTestCase {
         }
         return GeoPolygonFactory.makeGeoPolygon(PlanetModel.SPHERE, points);
     }
+
+    public void testHexRingPos() {
+        String[] h3Addresses = H3.getStringRes0Cells();
+        for (int i = 0; i < H3.MAX_H3_RES; i++) {
+            String h3Address = RandomPicks.randomFrom(random(), h3Addresses);
+            assertHexRing3(h3Address);
+            h3Addresses = H3.h3ToChildren(h3Address);
+        }
+    }
+
+    private void assertHexRing3(String h3Address) {
+        String[] ring = H3.hexRing(h3Address);
+        assertEquals(ring.length, H3.hexRingSize(h3Address));
+        for (int i = 0; i < H3.hexRingSize(h3Address); i++) {
+            assertEquals(ring[i], H3.hexRingPosToH3(h3Address, i));
+        }
+    }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHexGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/AbstractGeoHexGridTiler.java
@@ -74,7 +74,9 @@ abstract class AbstractGeoHexGridTiler extends GeoGridTiler {
         // Point resolution is done using H3 library which uses spherical geometry. It might happen that in cartesian, the
         // actual point value is in a neighbour cell as well.
         {
-            for (long n : H3.hexRing(h3)) {
+            final int ringSize = H3.hexRingSize(h3);
+            for (int i = 0; i < ringSize; i++) {
+                final long n = H3.hexRingPosToH3(h3, i);
                 final GeoRelation relation = relateTile(geoValue, n);
                 valueIndex = maybeAdd(n, relation, values, valueIndex);
                 if (relation == GeoRelation.QUERY_CONTAINS) {
@@ -130,8 +132,9 @@ abstract class AbstractGeoHexGridTiler extends GeoGridTiler {
             if (singleCell > 0) {
                 // When the level 0 bounds are within a single cell, we can search that cell and its immediate neighbours
                 valueIndex = setValuesByRecursion(values, geoValue, singleCell, 0, valueIndex);
-                for (long n : H3.hexRing(singleCell)) {
-                    valueIndex = setValuesByRecursion(values, geoValue, n, 0, valueIndex);
+                final int ringSize = H3.hexRingSize(singleCell);
+                for (int i = 0; i < ringSize; i++) {
+                    valueIndex = setValuesByRecursion(values, geoValue, H3.hexRingPosToH3(singleCell, i), 0, valueIndex);
                 }
                 return valueIndex;
             }


### PR DESCRIPTION
Similarly to https://github.com/elastic/elasticsearch/pull/92099, this PR adds the following methods to H3 API:

```
int hexRingSize(long h3) 
int hexRingSize(String h3Address)

long  hexRingPosToH3(long h3, int ringPos)
String hexRingPosToH3(lString h3Address, int ringPos) 
```