### PR TITLE
Fix URL of Semantic Search API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/semantic_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/semantic_search.json
@@ -1,7 +1,7 @@
 {
   "semantic_search":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-search-api.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search-api.html",
       "description":"Semantic search API using dense vector similarity"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/semantic_search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/semantic_search.json
@@ -1,7 +1,7 @@
 {
   "semantic_search":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/semantic-search.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/semantic-search-api.html",
       "description":"Semantic search API using dense vector similarity"
     },
     "stability":"experimental",


### PR DESCRIPTION
Current URL leads to a 404 which will be an issue once documentation for clients is generated.