### PR TITLE
Cleanup ilm+slm text block indentation

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCacheManagementTests.java
@@ -62,21 +62,21 @@ public class PhaseCacheManagementTests extends ESTestCase {
             .setStep("check-rollover-ready")
             .setPhaseDefinition("""
                 {
-                        "policy" : "my-policy",
-                        "phase_definition" : {
-                          "min_age" : "20m",
-                          "actions" : {
-                            "rollover" : {
-                              "max_age" : "5s"
-                            },
-                            "set_priority" : {
-                              "priority" : 150
-                            }
-                          }
-                        },
-                        "version" : 1,
-                        "modified_date_in_millis" : 1578521007076
-                      }""");
+                  "policy" : "my-policy",
+                  "phase_definition" : {
+                    "min_age" : "20m",
+                    "actions" : {
+                      "rollover" : {
+                        "max_age" : "5s"
+                      },
+                      "set_priority" : {
+                        "priority" : 150
+                      }
+                    }
+                  },
+                  "version" : 1,
+                  "modified_date_in_millis" : 1578521007076
+                }""");
 
         IndexMetadata meta = buildIndexMetadata("my-policy", exState);
         String indexName = meta.getIndex().getName();
@@ -216,17 +216,17 @@ public class PhaseCacheManagementTests extends ESTestCase {
         assertThat(
             readStepKeys(REGISTRY, client, """
                 {
-                        "policy": "my_lifecycle3",
-                        "phase_definition": {
-                          "min_age": "0ms",
-                          "actions": {
-                            "rollover": {
-                              "max_age": "30s"
-                            }
-                          }
-                        },
-                        "version": 3,
-                        "modified_date_in_millis": 1539609701576
+                  "policy": "my_lifecycle3",
+                  "phase_definition": {
+                    "min_age": "0ms",
+                    "actions": {
+                      "rollover": {
+                        "max_age": "30s"
+                      }
+                    }
+                  },
+                  "version": 3,
+                  "modified_date_in_millis": 1539609701576
                 }""", "phase", null),
             contains(
                 new Step.StepKey("phase", "rollover", WaitForRolloverReadyStep.NAME),
@@ -240,20 +240,20 @@ public class PhaseCacheManagementTests extends ESTestCase {
         assertThat(
             readStepKeys(REGISTRY, client, """
                 {
-                        "policy" : "my_lifecycle3",
-                        "phase_definition" : {
-                          "min_age" : "20m",
-                          "actions" : {
-                            "rollover" : {
-                              "max_age" : "5s"
-                            },
-                            "set_priority" : {
-                              "priority" : 150
-                            }
-                          }
-                        },
-                        "version" : 1,
-                        "modified_date_in_millis" : 1578521007076
+                  "policy" : "my_lifecycle3",
+                  "phase_definition" : {
+                    "min_age" : "20m",
+                    "actions" : {
+                      "rollover" : {
+                        "max_age" : "5s"
+                      },
+                      "set_priority" : {
+                        "priority" : 150
+                      }
+                    }
+                  },
+                  "version" : 1,
+                  "modified_date_in_millis" : 1578521007076
                 }""", "phase", null),
             containsInAnyOrder(
                 new Step.StepKey("phase", "rollover", WaitForRolloverReadyStep.NAME),
@@ -298,21 +298,21 @@ public class PhaseCacheManagementTests extends ESTestCase {
                 .setStep("check-rollover-ready")
                 .setPhaseDefinition("""
                     {
-                            "policy" : "my-policy",
-                            "phase_definition" : {
-                              "min_age" : "20m",
-                              "actions" : {
-                                "rollover" : {
-                                  "max_age" : "5s"
-                                },
-                                "set_priority" : {
-                                  "priority" : 150
-                                }
-                              }
-                            },
-                            "version" : 1,
-                            "modified_date_in_millis" : 1578521007076
-                          }""")
+                      "policy" : "my-policy",
+                      "phase_definition" : {
+                        "min_age" : "20m",
+                        "actions" : {
+                          "rollover" : {
+                            "max_age" : "5s"
+                          },
+                          "set_priority" : {
+                            "priority" : 150
+                          }
+                        }
+                      },
+                      "version" : 1,
+                      "modified_date_in_millis" : 1578521007076
+                    }""")
                 .build();
 
             IndexMetadata meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, exState.asMap()).build();
@@ -335,21 +335,21 @@ public class PhaseCacheManagementTests extends ESTestCase {
                 .setStep("check-rollover-ready")
                 .setPhaseDefinition("""
                     {
-                            "policy" : "my-policy",
-                            "phase_definition" : {
-                              "min_age" : "20m",
-                              "actions" : {
-                                "rollover" : {
-                                  "max_age" : "5s"
-                                },
-                                "set_priority" : {
-                                  "priority" : 150
-                                }
-                              }
-                            },
-                            "version" : 1,
-                            "modified_date_in_millis" : 1578521007076
-                          }""")
+                      "policy" : "my-policy",
+                      "phase_definition" : {
+                        "min_age" : "20m",
+                        "actions" : {
+                          "rollover" : {
+                            "max_age" : "5s"
+                          },
+                          "set_priority" : {
+                            "priority" : 150
+                          }
+                        }
+                      },
+                      "version" : 1,
+                      "modified_date_in_millis" : 1578521007076
+                    }""")
                 .build();
 
             IndexMetadata meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, exState.asMap()).build();
@@ -371,21 +371,21 @@ public class PhaseCacheManagementTests extends ESTestCase {
                 .setStep("check-rollover-ready")
                 .setPhaseDefinition("""
                     {
-                            "policy" : "my-policy",
-                            "phase_definition" : {
-                              "min_age" : "20m",
-                              "actions" : {
-                                "rollover" : {
-                                  "max_age" : "5s"
-                                },
-                                "set_priority" : {
-                                  "priority" : 150
-                                }
-                              }
-                            },
-                            "version" : 1,
-                            "modified_date_in_millis" : 1578521007076
-                          }""")
+                      "policy" : "my-policy",
+                      "phase_definition" : {
+                        "min_age" : "20m",
+                        "actions" : {
+                          "rollover" : {
+                            "max_age" : "5s"
+                          },
+                          "set_priority" : {
+                            "priority" : 150
+                          }
+                        }
+                      },
+                      "version" : 1,
+                      "modified_date_in_millis" : 1578521007076
+                    }""")
                 .build();
 
             IndexMetadata meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, exState.asMap()).build();
@@ -406,21 +406,21 @@ public class PhaseCacheManagementTests extends ESTestCase {
         {
             LifecycleExecutionState exState = LifecycleExecutionState.builder().setPhaseDefinition("""
                 {
-                        "policy" : "my-policy",
-                        "phase_definition" : {
-                          "min_age" : "20m",
-                          "actions" : {
-                            "rollover" : {
-                              "max_age" : "5s"
-                            },
-                            "set_priority" : {
-                              "priority" : 150
-                            }
-                          }
-                        },
-                        "version" : 1,
-                        "modified_date_in_millis" : 1578521007076
-                      }""").build();
+                  "policy" : "my-policy",
+                  "phase_definition" : {
+                    "min_age" : "20m",
+                    "actions" : {
+                      "rollover" : {
+                        "max_age" : "5s"
+                      },
+                      "set_priority" : {
+                        "priority" : 150
+                      }
+                    }
+                  },
+                  "version" : 1,
+                  "modified_date_in_millis" : 1578521007076
+                }""").build();
 
             IndexMetadata meta = mkMeta().putCustom(ILM_CUSTOM_METADATA_KEY, exState.asMap()).build();
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -572,21 +572,21 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             .setStep("check-rollover-ready")
             .setPhaseDefinition("""
                 {
-                        "policy" : "my-policy",
-                        "phase_definition" : {
-                          "min_age" : "20m",
-                          "actions" : {
-                            "rollover" : {
-                              "max_age" : "5s"
-                            },
-                            "set_priority" : {
-                              "priority" : 150
-                            }
-                          }
-                        },
-                        "version" : 1,
-                        "modified_date_in_millis" : 1578521007076
-                      }""");
+                  "policy" : "my-policy",
+                  "phase_definition" : {
+                    "min_age" : "20m",
+                    "actions" : {
+                      "rollover" : {
+                        "max_age" : "5s"
+                      },
+                      "set_priority" : {
+                        "priority" : 150
+                      }
+                    }
+                  },
+                  "version" : 1,
+                  "modified_date_in_millis" : 1578521007076
+                }""");
 
         IndexMetadata meta = buildIndexMetadata("my-policy", executionState);
 
@@ -829,21 +829,21 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
     public void testMoveToFailedStepDoesntRefreshCachedPhaseWhenUnsafe() {
         String initialPhaseDefinition = """
             {
-                    "policy" : "my-policy",
-                    "phase_definition" : {
-                      "min_age" : "20m",
-                      "actions" : {
-                        "rollover" : {
-                          "max_age" : "5s"
-                        },
-                        "set_priority" : {
-                          "priority" : 150
-                        }
-                      }
-                    },
-                    "version" : 1,
-                    "modified_date_in_millis" : 1578521007076
-                  }""";
+              "policy" : "my-policy",
+              "phase_definition" : {
+                "min_age" : "20m",
+                "actions" : {
+                  "rollover" : {
+                    "max_age" : "5s"
+                  },
+                  "set_priority" : {
+                    "priority" : 150
+                  }
+                }
+              },
+              "version" : 1,
+              "modified_date_in_millis" : 1578521007076
+            }""";
         String failedStep = "check-rollover-ready";
         LifecycleExecutionState.Builder currentExecutionState = LifecycleExecutionState.builder()
             .setPhase("hot")
@@ -900,21 +900,21 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             .setStep("check-rollover-ready")
             .setPhaseDefinition("""
                 {
-                        "policy" : "my-policy",
-                        "phase_definition" : {
-                          "min_age" : "20m",
-                          "actions" : {
-                            "rollover" : {
-                              "max_age" : "5s"
-                            },
-                            "set_priority" : {
-                              "priority" : 150
-                            }
-                          }
-                        },
-                        "version" : 1,
-                        "modified_date_in_millis" : 1578521007076
-                      }""");
+                  "policy" : "my-policy",
+                  "phase_definition" : {
+                    "min_age" : "20m",
+                    "actions" : {
+                      "rollover" : {
+                        "max_age" : "5s"
+                      },
+                      "set_priority" : {
+                        "priority" : 150
+                      }
+                    }
+                  },
+                  "version" : 1,
+                  "modified_date_in_millis" : 1578521007076
+                }""");
 
         IndexMetadata meta = buildIndexMetadata("my-policy", exState);
         String index = meta.getIndex().getName();
@@ -1052,21 +1052,21 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
             .setStep("check-rollover-ready")
             .setPhaseDefinition("""
                 {
-                        "policy" : "my-policy",
-                        "phase_definition" : {
-                          "min_age" : "20m",
-                          "actions" : {
-                            "rollover" : {
-                              "max_age" : "5s"
-                            },
-                            "set_priority" : {
-                              "priority" : 150
-                            }
-                          }
-                        },
-                        "version" : 1,
-                        "modified_date_in_millis" : 1578521007076
-                      }""");
+                  "policy" : "my-policy",
+                  "phase_definition" : {
+                    "min_age" : "20m",
+                    "actions" : {
+                      "rollover" : {
+                        "max_age" : "5s"
+                      },
+                      "set_priority" : {
+                        "priority" : 150
+                      }
+                    }
+                  },
+                  "version" : 1,
+                  "modified_date_in_millis" : 1578521007076
+                }""");
 
         IndexMetadata meta = buildIndexMetadata("my-policy", currentExecutionState);
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleStateServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/ReservedLifecycleStateServiceTests.java
@@ -133,15 +133,15 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
 
         String badPolicyJSON = """
             {
-                "my_timeseries_lifecycle": {
-                    "phase": {
-                        "warm": {
-                            "min_age": "10s",
-                            "actions": {
-                            }
-                        }
+              "my_timeseries_lifecycle": {
+                "phase": {
+                  "warm": {
+                    "min_age": "10s",
+                    "actions": {
                     }
+                  }
                 }
+              }
             }""";
 
         assertEquals(
@@ -169,29 +169,29 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
 
         String twoPoliciesJSON = """
             {
-                "my_timeseries_lifecycle": {
-                    "phases": {
-                        "warm": {
-                            "min_age": "10s",
-                            "actions": {
-                            }
-                        }
+              "my_timeseries_lifecycle": {
+                "phases": {
+                  "warm": {
+                    "min_age": "10s",
+                    "actions": {
                     }
-                },
-                "my_timeseries_lifecycle1": {
-                    "phases": {
-                        "warm": {
-                            "min_age": "10s",
-                            "actions": {
-                            }
-                        },
-                        "delete": {
-                            "min_age": "30s",
-                            "actions": {
-                            }
-                        }
-                    }
+                  }
                 }
+              },
+              "my_timeseries_lifecycle1": {
+                "phases": {
+                  "warm": {
+                    "min_age": "10s",
+                    "actions": {
+                    }
+                  },
+                  "delete": {
+                    "min_age": "30s",
+                    "actions": {
+                    }
+                  }
+                }
+              }
             }""";
 
         prevState = updatedState;
@@ -204,15 +204,15 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
 
         String onePolicyRemovedJSON = """
             {
-                "my_timeseries_lifecycle": {
-                    "phases": {
-                        "warm": {
-                            "min_age": "10s",
-                            "actions": {
-                            }
-                        }
+              "my_timeseries_lifecycle": {
+                "phases": {
+                  "warm": {
+                    "min_age": "10s",
+                    "actions": {
                     }
+                  }
                 }
+              }
             }""";
 
         prevState = updatedState;
@@ -223,15 +223,15 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
 
         String onePolicyRenamedJSON = """
             {
-                "my_timeseries_lifecycle2": {
-                    "phases": {
-                        "warm": {
-                            "min_age": "10s",
-                            "actions": {
-                            }
-                        }
+              "my_timeseries_lifecycle2": {
+                "phases": {
+                  "warm": {
+                    "min_age": "10s",
+                    "actions": {
                     }
+                  }
                 }
+              }
             }""";
 
         prevState = updatedState;
@@ -301,55 +301,55 @@ public class ReservedLifecycleStateServiceTests extends ESTestCase {
 
         String testJSON = """
             {
-                 "metadata": {
-                     "version": "1234",
-                     "compatibility": "8.4.0"
-                 },
-                 "state": {
-                     "cluster_settings": {
-                         "indices.recovery.max_bytes_per_sec": "50mb"
-                     },
-                     "ilm": {
-                         "my_timeseries_lifecycle": {
-                             "phases": {
-                                 "hot": {
-                                     "min_age": "10s",
-                                     "actions": {
-                                        "rollover": {
-                                           "max_primary_shard_size": "50gb",
-                                           "max_age": "30d"
-                                        }
-                                     }
-                                 },
-                                 "delete": {
-                                     "min_age": "30s",
-                                     "actions": {
-                                     }
-                                 }
-                             }
-                         },
-                         "my_timeseries_lifecycle1": {
-                             "phases": {
-                                 "warm": {
-                                     "min_age": "10s",
-                                     "actions": {
-                                        "shrink": {
-                                          "number_of_shards": 1
-                                        },
-                                        "forcemerge": {
-                                          "max_num_segments": 1
-                                        }
-                                     }
-                                 },
-                                 "delete": {
-                                     "min_age": "30s",
-                                     "actions": {
-                                     }
-                                 }
-                             }
-                         }
-                     }
-                 }
+              "metadata": {
+                "version": "1234",
+                "compatibility": "8.4.0"
+              },
+              "state": {
+                "cluster_settings": {
+                  "indices.recovery.max_bytes_per_sec": "50mb"
+                },
+                "ilm": {
+                  "my_timeseries_lifecycle": {
+                    "phases": {
+                      "hot": {
+                        "min_age": "10s",
+                        "actions": {
+                           "rollover": {
+                              "max_primary_shard_size": "50gb",
+                              "max_age": "30d"
+                           }
+                        }
+                      },
+                      "delete": {
+                        "min_age": "30s",
+                        "actions": {
+                        }
+                      }
+                    }
+                  },
+                  "my_timeseries_lifecycle1": {
+                    "phases": {
+                      "warm": {
+                        "min_age": "10s",
+                        "actions": {
+                          "shrink": {
+                            "number_of_shards": 1
+                          },
+                          "forcemerge": {
+                            "max_num_segments": 1
+                          }
+                        }
+                      },
+                      "delete": {
+                        "min_age": "30s",
+                        "actions": {
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }""";
 
         AtomicReference<Exception> x = new AtomicReference<>();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportExplainLifecycleActionTests.java
@@ -37,18 +37,18 @@ public class TransportExplainLifecycleActionTests extends ESTestCase {
 
     public static final String PHASE_DEFINITION = """
         {
-                "policy" : "my-policy",
-                "phase_definition" : {
-                  "min_age" : "20m",
-                  "actions" : {
-                    "rollover" : {
-                      "max_age" : "5s"
-                    }
-                  }
-                },
-                "version" : 1,
-                "modified_date_in_millis" : 1578521007076
-              }""";
+          "policy" : "my-policy",
+          "phase_definition" : {
+            "min_age" : "20m",
+            "actions" : {
+              "rollover" : {
+                "max_age" : "5s"
+              }
+            }
+          },
+          "version" : 1,
+          "modified_date_in_millis" : 1578521007076
+        }""";
 
     private static final NamedXContentRegistry REGISTRY;
 

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/action/TransportPutLifecycleActionTests.java
@@ -60,15 +60,15 @@ public class TransportPutLifecycleActionTests extends ESTestCase {
 
         String json = """
             {
-                "policy": {
-                    "phases": {
-                        "warm": {
-                            "min_age": "10s",
-                            "actions": {
-                            }
-                        }
+              "policy": {
+                "phases": {
+                  "warm": {
+                    "min_age": "10s",
+                    "actions": {
                     }
+                  }
                 }
+              }
             }""";
 
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, json)) {

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleTaskTests.java
@@ -149,26 +149,26 @@ public class SnapshotLifecycleTaskTests extends ESTestCase {
         );
         final String createSnapResponse = Strings.format("""
             {
-                "snapshot": {
-                    "snapshot": "snapshot_1",
-                    "uuid": "bcP3ClgCSYO_TP7_FCBbBw",
-                    "version_id": %s,
-                    "version": "%s",
-                    "indices": [],
-                    "include_global_state": true,
-                    "state": "SUCCESS",
-                    "start_time": "2019-03-19T22:19:53.542Z",
-                    "start_time_in_millis": 1553033993542,
-                    "end_time": "2019-03-19T22:19:53.567Z",
-                    "end_time_in_millis": 1553033993567,
-                    "duration_in_millis": 25,
-                    "failures": [],
-                    "shards": {
-                        "total": 0,
-                        "failed": 0,
-                        "successful": 0
-                    }
+              "snapshot": {
+                "snapshot": "snapshot_1",
+                "uuid": "bcP3ClgCSYO_TP7_FCBbBw",
+                "version_id": %s,
+                "version": "%s",
+                "indices": [],
+                "include_global_state": true,
+                "state": "SUCCESS",
+                "start_time": "2019-03-19T22:19:53.542Z",
+                "start_time_in_millis": 1553033993542,
+                "end_time": "2019-03-19T22:19:53.567Z",
+                "end_time_in_millis": 1553033993567,
+                "duration_in_millis": 25,
+                "failures": [],
+                "shards": {
+                  "total": 0,
+                  "failed": 0,
+                  "successful": 0
                 }
+              }
             }""", Version.CURRENT.id, Version.CURRENT);
 
         final AtomicBoolean clientCalled = new AtomicBoolean(false);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/action/ReservedSnapshotLifecycleStateServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/action/ReservedSnapshotLifecycleStateServiceTests.java
@@ -81,21 +81,21 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
 
         String badPolicyJSON = """
             {
-                "daily-snapshots": {
-                    "no_schedule": "0 1 2 3 4 ?",
-                    "name": "<production-snap-{now/d}>",
-                    "repository": "repo",
-                    "config": {
-                        "indices": ["foo-*", "important"],
-                        "ignore_unavailable": true,
-                        "include_global_state": false
-                    },
-                    "retention": {
-                        "expire_after": "30d",
-                        "min_count": 1,
-                        "max_count": 50
-                    }
+              "daily-snapshots": {
+                "no_schedule": "0 1 2 3 4 ?",
+                "name": "<production-snap-{now/d}>",
+                "repository": "repo",
+                "config": {
+                  "indices": ["foo-*", "important"],
+                  "ignore_unavailable": true,
+                  "include_global_state": false
+                },
+                "retention": {
+                  "expire_after": "30d",
+                  "min_count": 1,
+                  "max_count": 50
                 }
+              }
             }""";
 
         assertEquals(
@@ -127,36 +127,36 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
 
         String twoPoliciesJSON = """
             {
-                "daily-snapshots": {
-                    "schedule": "0 1 2 3 4 ?",
-                    "name": "<production-snap-{now/d}>",
-                    "repository": "repo",
-                    "config": {
-                        "indices": ["foo-*", "important"],
-                        "ignore_unavailable": true,
-                        "include_global_state": false
-                    },
-                    "retention": {
-                        "expire_after": "30d",
-                        "min_count": 1,
-                        "max_count": 50
-                    }
+              "daily-snapshots": {
+                "schedule": "0 1 2 3 4 ?",
+                "name": "<production-snap-{now/d}>",
+                "repository": "repo",
+                "config": {
+                  "indices": ["foo-*", "important"],
+                  "ignore_unavailable": true,
+                  "include_global_state": false
                 },
-                "daily-snapshots1": {
-                    "schedule": "0 1 2 3 4 ?",
-                    "name": "<production-snap-{now/d}>",
-                    "repository": "repo",
-                    "config": {
-                        "indices": ["bar-*", "not-important"],
-                        "ignore_unavailable": true,
-                        "include_global_state": false
-                    },
-                    "retention": {
-                        "expire_after": "30d",
-                        "min_count": 1,
-                        "max_count": 50
-                    }
+                "retention": {
+                  "expire_after": "30d",
+                  "min_count": 1,
+                  "max_count": 50
                 }
+              },
+              "daily-snapshots1": {
+                "schedule": "0 1 2 3 4 ?",
+                "name": "<production-snap-{now/d}>",
+                "repository": "repo",
+                "config": {
+                  "indices": ["bar-*", "not-important"],
+                  "ignore_unavailable": true,
+                  "include_global_state": false
+                },
+                "retention": {
+                  "expire_after": "30d",
+                  "min_count": 1,
+                  "max_count": 50
+                }
+              }
             }""";
 
         prevState = updatedState;
@@ -167,21 +167,21 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
 
         String onePolicyRemovedJSON = """
             {
-                "daily-snapshots": {
-                    "schedule": "0 1 2 3 4 ?",
-                    "name": "<production-snap-{now/d}>",
-                    "repository": "repo",
-                    "config": {
-                        "indices": ["foo-*", "important"],
-                        "ignore_unavailable": true,
-                        "include_global_state": false
-                    },
-                    "retention": {
-                        "expire_after": "30d",
-                        "min_count": 1,
-                        "max_count": 50
-                    }
+              "daily-snapshots": {
+                "schedule": "0 1 2 3 4 ?",
+                "name": "<production-snap-{now/d}>",
+                "repository": "repo",
+                "config": {
+                  "indices": ["foo-*", "important"],
+                  "ignore_unavailable": true,
+                  "include_global_state": false
+                },
+                "retention": {
+                  "expire_after": "30d",
+                  "min_count": 1,
+                  "max_count": 50
                 }
+              }
             }""";
 
         prevState = updatedState;
@@ -192,21 +192,21 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
 
         String onePolicyRenamedJSON = """
             {
-                "daily-snapshots-2": {
-                    "schedule": "0 1 2 3 4 ?",
-                    "name": "<production-snap-{now/d}>",
-                    "repository": "repo",
-                    "config": {
-                        "indices": ["foo-*", "important"],
-                        "ignore_unavailable": true,
-                        "include_global_state": false
-                    },
-                    "retention": {
-                        "expire_after": "30d",
-                        "min_count": 1,
-                        "max_count": 50
-                    }
+              "daily-snapshots-2": {
+                "schedule": "0 1 2 3 4 ?",
+                "name": "<production-snap-{now/d}>",
+                "repository": "repo",
+                "config": {
+                  "indices": ["foo-*", "important"],
+                  "ignore_unavailable": true,
+                  "include_global_state": false
+                },
+                "retention": {
+                  "expire_after": "30d",
+                  "min_count": 1,
+                  "max_count": 50
                 }
+              }
             }""";
 
         prevState = updatedState;
@@ -278,55 +278,55 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
 
         String testJSON = """
             {
-                 "metadata": {
-                     "version": "1234",
-                     "compatibility": "8.4.0"
-                 },
-                 "state": {
-                     "cluster_settings": {
-                         "indices.recovery.max_bytes_per_sec": "50mb"
-                     },
-                     "snapshot_repositories": {
-                        "repo": {
-                           "type": "fs",
-                           "settings": {
-                              "location": "my_backup_location"
-                           }
-                        }
-                     },
-                     "slm": {
-                        "daily-snapshots": {
-                            "schedule": "0 1 2 3 4 ?",
-                            "name": "<production-snap-{now/d}>",
-                            "repository": "repo",
-                            "config": {
-                                "indices": ["foo-*", "important"],
-                                "ignore_unavailable": true,
-                                "include_global_state": false
-                            },
-                            "retention": {
-                                "expire_after": "30d",
-                                "min_count": 1,
-                                "max_count": 50
-                            }
-                        },
-                        "daily-snapshots1": {
-                            "schedule": "0 1 2 3 4 ?",
-                            "name": "<production-snap-{now/d}>",
-                            "repository": "repo",
-                            "config": {
-                                "indices": ["bar-*", "not-important"],
-                                "ignore_unavailable": true,
-                                "include_global_state": false
-                            },
-                            "retention": {
-                                "expire_after": "30d",
-                                "min_count": 1,
-                                "max_count": 50
-                            }
-                        }
+              "metadata": {
+                "version": "1234",
+                "compatibility": "8.4.0"
+              },
+              "state": {
+                "cluster_settings": {
+                  "indices.recovery.max_bytes_per_sec": "50mb"
+                },
+                "snapshot_repositories": {
+                  "repo": {
+                    "type": "fs",
+                    "settings": {
+                      "location": "my_backup_location"
                     }
-                 }
+                  }
+                },
+                "slm": {
+                  "daily-snapshots": {
+                    "schedule": "0 1 2 3 4 ?",
+                    "name": "<production-snap-{now/d}>",
+                    "repository": "repo",
+                    "config": {
+                      "indices": ["foo-*", "important"],
+                      "ignore_unavailable": true,
+                      "include_global_state": false
+                    },
+                    "retention": {
+                      "expire_after": "30d",
+                      "min_count": 1,
+                      "max_count": 50
+                    }
+                  },
+                  "daily-snapshots1": {
+                    "schedule": "0 1 2 3 4 ?",
+                    "name": "<production-snap-{now/d}>",
+                    "repository": "repo",
+                    "config": {
+                      "indices": ["bar-*", "not-important"],
+                      "ignore_unavailable": true,
+                      "include_global_state": false
+                    },
+                    "retention": {
+                      "expire_after": "30d",
+                      "min_count": 1,
+                      "max_count": 50
+                    }
+                  }
+                }
+              }
             }""";
 
         AtomicReference<Exception> x = new AtomicReference<>();
@@ -387,19 +387,19 @@ public class ReservedSnapshotLifecycleStateServiceTests extends ESTestCase {
 
         String json = """
             {
-                "schedule": "0 1 2 3 4 ?",
-                "name": "<production-snap-{now/d}>",
-                "repository": "repo",
-                "config": {
-                    "indices": ["foo-*", "important"],
-                    "ignore_unavailable": true,
-                    "include_global_state": false
-                },
-                "retention": {
-                    "expire_after": "30d",
-                    "min_count": 1,
-                    "max_count": 50
-                }
+              "schedule": "0 1 2 3 4 ?",
+              "name": "<production-snap-{now/d}>",
+              "repository": "repo",
+              "config": {
+                "indices": ["foo-*", "important"],
+                "ignore_unavailable": true,
+                "include_global_state": false
+              },
+              "retention": {
+                "expire_after": "30d",
+                "min_count": 1,
+                "max_count": 50
+              }
             }""";
 
         try (XContentParser parser = XContentType.JSON.xContent().createParser(XContentParserConfiguration.EMPTY, json)) {


### PR DESCRIPTION
I was taking 10d6 of unblockable psychic damage from the indentation of these text blocks, so I cleaned them up.

See [here](https://github.com/elastic/elasticsearch/pull/92713/files?w=1), it's all just whitespace changes, I promise. ;)