### PR TITLE
Fix wildcard expansion for update-by-query on data streams

### DIFF
--- a/docs/changelog/92717.yaml
+++ b/docs/changelog/92717.yaml
@@ -1,0 +1,6 @@
+pr: 92717
+summary: Fix wildcard expansion for update-by-query on data streams
+area: Data streams
+type: bug
+issues:
+ - 90272

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/110_update_by_query.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/110_update_by_query.yml
@@ -104,3 +104,91 @@
       indices.delete_data_stream:
         name: simple-data-stream1
   - is_true: acknowledged
+
+---
+"Update by query for multiple data streams":
+  - skip:
+      features: allowed_warnings
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template2] has index patterns [simple-stream*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template2
+        body:
+          index_patterns: [simple-stream*]
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: simple-stream1
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:   simple-stream1
+        id:      "1"
+        op_type: create
+        body:    { "number": 4, '@timestamp': '2020-12-12' }
+
+  - do:
+      index:
+        index:   simple-stream2
+        id:      "2"
+        op_type: create
+        body:    { "number": 4, '@timestamp': '2020-12-12' }
+
+  - do:
+      index:
+        index:   simple-stream2
+        id:      "3"
+        op_type: create
+        body:    { "number": 6, '@timestamp': '2020-12-12' }
+
+  - do:
+      indices.refresh:
+        index: simple-stream1,simple-stream2
+
+  # increment by one any docs with number <= 4
+  - do:
+      update_by_query:
+        index: simple-stream*
+        body:
+          script:
+            source: "ctx._source.number++"
+            lang: "painless"
+          query:
+            range:
+              number:
+                lte: 4
+
+  - match: {updated: 2}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {noops: 0}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+
+  - do:
+      indices.refresh:
+        index: simple-stream1,simple-stream2
+
+  # verify that both numbers originally <= 4 have been incremented by one
+  - do:
+      search:
+        index: simple-stream*
+        body: { query: { range: { number: { lte: 5 } } } }
+  - length:   { hits.hits: 2  }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-stream2
+  - is_true: acknowledged

--- a/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/UpdateByQueryRequest.java
@@ -127,6 +127,11 @@ public class UpdateByQueryRequest extends AbstractBulkIndexByScrollRequest<Updat
     }
 
     @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
+    @Override
     public UpdateByQueryRequest forSlice(TaskId slicingTask, SearchRequest slice, int totalSlices) {
         UpdateByQueryRequest request = doForSlice(new UpdateByQueryRequest(slice, false), slicingTask, totalSlices);
         request.setPipeline(pipeline);


### PR DESCRIPTION
This commit allows wildcards for data streams to be used for update-by-query. We always allowed multiple data streams (comma-separated), but the expansion did not include wildcards.

Resolves #90272
