### PR TITLE
[8.6] Make rest resources plugin extension dsl methods public (#92718)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestResourcesExtension.java
@@ -27,11 +27,11 @@ public class RestResourcesExtension {
         restTests = new XpackRestResourcesSpec(objects);
     }
 
-    void restApi(Action<? super RestResourcesSpec> spec) {
+    public void restApi(Action<? super RestResourcesSpec> spec) {
         spec.execute(restApi);
     }
 
-    void restTests(Action<? super XpackRestResourcesSpec> spec) {
+    public void restTests(Action<? super XpackRestResourcesSpec> spec) {
         spec.execute(restTests);
     }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Make rest resources plugin extension dsl methods public (#92718)