### PR TITLE
Make engine components public for plugins

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/engine/CompletionStatsCache.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CompletionStatsCache.java
@@ -25,7 +25,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-class CompletionStatsCache implements ReferenceManager.RefreshListener {
+public class CompletionStatsCache implements ReferenceManager.RefreshListener {
 
     private final Supplier<Engine.Searcher> searcherSupplier;
 
@@ -37,11 +37,11 @@ class CompletionStatsCache implements ReferenceManager.RefreshListener {
      */
     private final AtomicReference<PlainActionFuture<CompletionStats>> completionStatsFutureRef = new AtomicReference<>();
 
-    CompletionStatsCache(Supplier<Engine.Searcher> searcherSupplier) {
+    public CompletionStatsCache(Supplier<Engine.Searcher> searcherSupplier) {
         this.searcherSupplier = searcherSupplier;
     }
 
-    CompletionStats get(String... fieldNamePatterns) {
+    public CompletionStats get(String... fieldNamePatterns) {
         final PlainActionFuture<CompletionStats> newFuture = new PlainActionFuture<>();
         final PlainActionFuture<CompletionStats> oldFuture = completionStatsFutureRef.compareAndExchange(null, newFuture);
 

--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchReaderManager.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchReaderManager.java
@@ -25,6 +25,7 @@ import java.io.IOException;
  *
  */
 @SuppressForbidden(reason = "reference counting is required here")
+public
 class ElasticsearchReaderManager extends ReferenceManager<ElasticsearchDirectoryReader> {
 
     /**
@@ -34,7 +35,7 @@ class ElasticsearchReaderManager extends ReferenceManager<ElasticsearchDirectory
      *
      * @param reader            the directoryReader to use for future reopens
      */
-    ElasticsearchReaderManager(ElasticsearchDirectoryReader reader) {
+    public ElasticsearchReaderManager(ElasticsearchDirectoryReader reader) {
         this.current = reader;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchReaderManager.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ElasticsearchReaderManager.java
@@ -25,8 +25,7 @@ import java.io.IOException;
  *
  */
 @SuppressForbidden(reason = "reference counting is required here")
-public
-class ElasticsearchReaderManager extends ReferenceManager<ElasticsearchDirectoryReader> {
+public class ElasticsearchReaderManager extends ReferenceManager<ElasticsearchDirectoryReader> {
 
     /**
      * Creates and returns a new ElasticsearchReaderManager from the given


### PR DESCRIPTION
Some plugins require certain engine components (fetching the engine and creating completion stats) public for extending index shard and the underlying engine. This commit makes these components public.