### PR TITLE
Fix H3 cartesian bounding box over the dateline

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtil.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtil.java
@@ -187,8 +187,8 @@ public final class H3CartesianUtil {
         double maxNegLon = Double.NEGATIVE_INFINITY;
         double minPosLon = Double.POSITIVE_INFINITY;
         for (int i = 0; i < boundary.numPoints(); i++) {
-            final double lon = boundary.getLatLon(i).getLonDeg();
-            final double lat = boundary.getLatLon(i).getLatDeg();
+            final double lon = GeoEncodingUtils.decodeLongitude(GeoEncodingUtils.encodeLongitude(boundary.getLatLon(i).getLonDeg()));
+            final double lat = GeoEncodingUtils.decodeLatitude(GeoEncodingUtils.encodeLatitude(boundary.getLatLon(i).getLatDeg()));
             minLat = Math.min(minLat, lat);
             minLon = Math.min(minLon, lon);
             maxLat = Math.max(maxLat, lat);

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtil.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtil.java
@@ -184,12 +184,20 @@ public final class H3CartesianUtil {
         double minLon = Double.POSITIVE_INFINITY;
         double maxLat = Double.NEGATIVE_INFINITY;
         double maxLon = Double.NEGATIVE_INFINITY;
+        double maxNegLon = Double.NEGATIVE_INFINITY;
+        double minPosLon = Double.POSITIVE_INFINITY;
         for (int i = 0; i < boundary.numPoints(); i++) {
-            final LatLng latLng = boundary.getLatLon(i);
-            minLat = Math.min(minLat, latLng.getLatDeg());
-            minLon = Math.min(minLon, latLng.getLonDeg());
-            maxLat = Math.max(maxLat, latLng.getLatDeg());
-            maxLon = Math.max(maxLon, latLng.getLonDeg());
+            final double lon = boundary.getLatLon(i).getLonDeg();
+            final double lat = boundary.getLatLon(i).getLatDeg();
+            minLat = Math.min(minLat, lat);
+            minLon = Math.min(minLon, lon);
+            maxLat = Math.max(maxLat, lat);
+            maxLon = Math.max(maxLon, lon);
+            if (lon < 0) {
+                maxNegLon = Math.max(maxNegLon, lon);
+            } else {
+                minPosLon = Math.min(minPosLon, lon);
+            }
         }
         final int res = H3.getResolution(h3);
         if (h3 == NORTH[res]) {
@@ -197,7 +205,7 @@ public final class H3CartesianUtil {
         } else if (h3 == SOUTH[res]) {
             return new org.elasticsearch.geometry.Rectangle(-180d, 180d, maxLat, -90d);
         } else if (maxLon - minLon > 180d) {
-            return new org.elasticsearch.geometry.Rectangle(maxLon, minLon, maxLat, minLat);
+            return new org.elasticsearch.geometry.Rectangle(minPosLon, maxNegLon, maxLat, minLat);
         } else {
             return new org.elasticsearch.geometry.Rectangle(minLon, maxLon, maxLat, minLat);
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtilTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtilTests.java
@@ -20,7 +20,6 @@ import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.WellKnownText;
-import org.elasticsearch.h3.CellBoundary;
 import org.elasticsearch.h3.H3;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
@@ -242,13 +241,15 @@ public class H3CartesianUtilTests extends ESTestCase {
     }
 
     public void testBoundingBox() {
+        final double[] xs = new double[H3CartesianUtil.MAX_ARRAY_SIZE];
+        final double[] ys = new double[H3CartesianUtil.MAX_ARRAY_SIZE];
         for (int res = 0; res <= H3.MAX_H3_RES; res++) {
             final long h3 = H3.geoToH3(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude(), res);
             final Rectangle rectangle = H3CartesianUtil.toBoundingBox(h3);
-            final CellBoundary boundary = H3.h3ToGeoBoundary(h3);
-            for (int i = 0; i < boundary.numPoints(); i++) {
-                final double lat = boundary.getLatLon(i).getLatDeg();
-                final double lon = boundary.getLatLon(i).getLonDeg();
+            final int points = H3CartesianUtil.computePoints(h3, xs, ys);
+            for (int i = 0; i < points; i++) {
+                final double lat = ys[i];
+                final double lon = xs[i];
                 assertTrue(rectangle.getMaxY() >= lat && rectangle.getMinY() <= lat);
                 if (rectangle.getMinX() > rectangle.getMaxX()) {
                     assertTrue(rectangle.getMaxX() >= lon || rectangle.getMinX() <= lon);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtilTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtilTests.java
@@ -18,7 +18,9 @@ import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.Point;
 import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.h3.CellBoundary;
 import org.elasticsearch.h3.H3;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.spatial.index.fielddata.GeoRelation;
@@ -236,6 +238,24 @@ public class H3CartesianUtilTests extends ESTestCase {
             return geometry;
         } else {
             return polygon;
+        }
+    }
+
+    public void testBoundingBox() {
+        for (int res = 0; res <= H3.MAX_H3_RES; res++) {
+            final long h3 = H3.geoToH3(GeoTestUtil.nextLatitude(), GeoTestUtil.nextLongitude(), res);
+            final Rectangle rectangle = H3CartesianUtil.toBoundingBox(h3);
+            final CellBoundary boundary = H3.h3ToGeoBoundary(h3);
+            for (int i = 0; i < boundary.numPoints(); i++) {
+                final double lat = boundary.getLatLon(i).getLatDeg();
+                final double lon = boundary.getLatLon(i).getLonDeg();
+                assertTrue(rectangle.getMaxY() >= lat && rectangle.getMinY() <= lat);
+                if (rectangle.getMinX() > rectangle.getMaxX()) {
+                    assertTrue(rectangle.getMaxX() >= lon || rectangle.getMinX() <= lon);
+                } else {
+                    assertTrue(rectangle.getMaxX() >= lon && rectangle.getMinX() <= lon);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
The current implementation of `H3CartesianUtil#toBoundingBox` does not handle properly h3 cells that crosses the dateline. In such a case we need to compute the minimum positive longitude and the maximum negative longitude in order to compute properly the bounding box. This PR changes that.

Label the PR as non issue as it is an unreleased change.