### PR TITLE
[META] Add links to cluster coordination troubleshooting docs

### DIFF
--- a/docs/reference/modules/discovery/fault-detection.asciidoc
+++ b/docs/reference/modules/discovery/fault-detection.asciidoc
@@ -52,7 +52,7 @@ logs.
 * The master may appear busy due to frequent cluster state updates.
 
 To troubleshoot a cluster in this state, first ensure the cluster has a
-<<modules-discovery-troubleshooting,stable master>>. Next, focus on the nodes
+<<discovery-troubleshooting,stable master>>. Next, focus on the nodes
 unexpectedly leaving the cluster ahead of all other issues. It will not be
 possible to solve other issues until the cluster has a stable master node and
 stable node membership.
@@ -62,23 +62,33 @@ tools only offer a view of the state of the cluster at a single point in time.
 Instead, look at the cluster logs to see the pattern of behaviour over time.
 Focus particularly on logs from the elected master. When a node leaves the
 cluster, logs for the elected master include a message like this (with line
-breaks added for clarity):
+breaks added to make it easier to read):
 
 [source,text]
 ----
-[2022-03-21T11:02:35,513][INFO ][o.e.c.s.MasterService    ]
-    [instance-0000000000] node-left[
-        {instance-0000000004}{bfcMDTiDRkietFb9v_di7w}{aNlyORLASam1ammv2DzYXA}{172.27.47.21}{172.27.47.21:19054}{m}
-            reason: disconnected,
-        {tiebreaker-0000000003}{UNw_RuazQCSBskWZV8ID_w}{bltyVOQ-RNu20OQfTHSLtA}{172.27.161.154}{172.27.161.154:19251}{mv}
-            reason: disconnected
-        ], term: 14, version: 1653415, ...
+[2022-03-21T11:02:35,513][INFO ][o.e.c.c.NodeLeftExecutor] [instance-0000000000] node-left:
+    removed [{instance-0000000004}{bfcMDTiDRkietFb9v_di7w}{aNlyORLASam1ammv2DzYXA}{172.27.47.21}{172.27.47.21:19054}{m}]
+    with reason [test reason]
 ----
 
-This message says that the `MasterService` on the elected master
-(`instance-0000000000`) is processing a `node-left` task. It lists the nodes
-that are being removed and the reasons for their removal. Other nodes may log
-similar messages, but report fewer details:
+This message says that the `NodeLeftExecutor` on the elected master
+(`instance-0000000000`) processed a `node-left` task, identifying the node that
+was removed and the reason for its removal. When the node joins the cluster
+again, logs for the elected master will include a message like this (with line
+breaks added to make it easier to read):
+
+[source,text]
+----
+[2022-03-21T11:02:59,892][INFO ][o.e.c.c.NodeJoinExecutor] [instance-0000000000] node-join:
+    added [{instance-0000000004}{bfcMDTiDRkietFb9v_di7w}{UNw_RuazQCSBskWZV8ID_w}{172.27.47.21}{172.27.47.21:19054}{m}]
+    with reason [joining after restart, removed [24s] ago with reason [disconnected]]
+----
+
+This message says that the `NodeJoinExecutor` on the elected master
+(`instance-0000000000`) processed a `node-join` task, identifying the node that
+was added to the cluster and the reason for the task.
+
+Other nodes may log similar messages, but report fewer details:
 
 [source,text]
 ----
@@ -89,9 +99,10 @@ similar messages, but report fewer details:
     }, term: 14, version: 1653415, reason: Publication{term=14, version=1653415}
 ----
 
-Focus on the one from the `MasterService` which is only emitted on the elected
-master, since it contains more details. If you don't see the messages from the
-`MasterService`, check that:
+These messages are not especially useful for troubleshooting, so focus on the
+ones from the `NodeLeftExecutor` and `NodeJoinExecutor` which are only emitted
+on the elected master and which contain more details. If you don't see the
+messages from the `NodeLeftExecutor` and `NodeJoinExecutor`, check that:
 
 * You're looking at the logs for the elected master node.
 
@@ -104,18 +115,14 @@ start or stop following the elected master. You can use these messages to
 determine each node's view of the state of the master over time.
 
 If a node restarts, it will leave the cluster and then join the cluster again.
-When it rejoins, the `MasterService` will log that it is processing a
-`node-join` task. You can tell from the master logs that the node was restarted
-because the `node-join` message will indicate that it is
-`joining after restart`. In older {es} versions, you can also determine that a
-node restarted by looking at the second "ephemeral" ID in the `node-left` and
-subsequent `node-join` messages. This ephemeral ID is different each time the
-node starts up. If a node is unexpectedly restarting, you'll need to look at
-the node's logs to see why it is shutting down.
+When it rejoins, the `NodeJoinExecutor` will log that it processed a
+`node-join` task indicating that the node is `joining after restart`. If a node
+is unexpectedly restarting, look at the node's logs to see why it is shutting
+down.
 
 If the node did not restart then you should look at the reason for its
-departure in the `node-left` message, which is reported after each node. There
-are three possible reasons:
+departure more closely. Each reason has different troubleshooting steps,
+described below. There are three possible reasons:
 
 * `disconnected`: The connection from the master node to the removed node was
 closed.
@@ -133,6 +140,10 @@ to <<modules-discovery-settings>> for information about the settings which
 control this mechanism.
 
 ===== Diagnosing `disconnected` nodes
+
+Nodes typically leave the cluster with reason `disconnected` when they shut
+down, but if they rejoin the cluster without restarting then there is some
+other problem.
 
 {es} is designed to run on a fairly reliable network. It opens a number of TCP
 connections between nodes and expects these connections to remain open forever.
@@ -193,6 +204,10 @@ When this logger is enabled, {es} will attempt to run the
 the logs on the elected master.
 
 ===== Diagnosing `follower check retry count exceeded` nodes
+
+Nodes sometimes leave the cluster with reason `follower check retry count
+exceeded` when they shut down, but if they rejoin the cluster without
+restarting then there is some other problem.
 
 {es} needs every node to respond to network messages successfully and
 reasonably quickly. If a node rejects requests or does not respond at all then

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterBootstrapService.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
@@ -146,10 +147,12 @@ public class ClusterBootstrapService implements Coordinator.PeerFinderListener {
         logger.warn(
             """
                 this node is locked into cluster UUID [{}] but [{}] is set to {}; \
-                remove this setting to avoid possible data loss caused by subsequent cluster bootstrap attempts""",
+                remove this setting to avoid possible data loss caused by subsequent cluster bootstrap attempts; \
+                for further information see {}""",
             clusterUUID,
             INITIAL_MASTER_NODES_SETTING.getKey(),
-            bootstrapRequirements
+            bootstrapRequirements,
+            ReferenceDocs.INITIAL_MASTER_NODES
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfigu
 import org.elasticsearch.cluster.coordination.CoordinationState.VoteCollection;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -100,7 +101,11 @@ public class ClusterFormationFailureHelper {
                 protected void doRun() {
                     if (isActive()) {
                         logLastFailedJoinAttempt.run();
-                        logger.warn(clusterFormationStateSupplier.get().getDescription());
+                        logger.warn(
+                            "{}; for troubleshooting guidance, see {}",
+                            clusterFormationStateSupplier.get().getDescription(),
+                            ReferenceDocs.DISCOVERY_TROUBLESHOOTING
+                        );
                     }
                 }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReason.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReason.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+/**
+ * @param message Message describing the reason for the node joining
+ */
+public record JoinReason(String message) {}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReason.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReason.java
@@ -8,7 +8,11 @@
 
 package org.elasticsearch.cluster.coordination;
 
+import org.elasticsearch.common.ReferenceDocs;
+import org.elasticsearch.core.Nullable;
+
 /**
- * @param message Message describing the reason for the node joining
+ * @param message      Message describing the reason for the node joining
+ * @param guidanceDocs An optional link to troubleshooting guidance docs
  */
-public record JoinReason(String message) {}
+public record JoinReason(String message, @Nullable ReferenceDocs guidanceDocs) {}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
@@ -107,9 +107,9 @@ public class JoinReasonService {
      * @param currentMode   The current mode of the master that the node is joining.
      * @return              A description of the reason for the join, possibly including some details of its earlier removal.
      */
-    public String getJoinReason(DiscoveryNode discoveryNode, Coordinator.Mode currentMode) {
+    public JoinReason getJoinReason(DiscoveryNode discoveryNode, Coordinator.Mode currentMode) {
         return trackedNodes.getOrDefault(discoveryNode.getId(), UNKNOWN_NODE)
-            .getDescription(relativeTimeInMillisSupplier.getAsLong(), discoveryNode.getEphemeralId(), currentMode);
+            .getJoinReason(relativeTimeInMillisSupplier.getAsLong(), discoveryNode.getEphemeralId(), currentMode);
     }
 
     /**
@@ -134,7 +134,7 @@ public class JoinReasonService {
 
         TrackedNode withRemovalReason(String removalReason);
 
-        String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode);
+        JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode);
 
         long getRemovalAgeMillis(long currentTimeMillis);
     }
@@ -161,11 +161,11 @@ public class JoinReasonService {
         }
 
         @Override
-        public String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
+        public JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
             if (currentMode == CANDIDATE) {
-                return "completing election";
+                return COMPLETING_ELECTION;
             } else {
-                return "joining";
+                return NEW_NODE_JOINING;
             }
         }
 
@@ -193,11 +193,11 @@ public class JoinReasonService {
         }
 
         @Override
-        public String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
+        public JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
             if (currentMode == CANDIDATE) {
-                return "completing election";
+                return COMPLETING_ELECTION;
             } else {
-                return "rejoining";
+                return KNOWN_NODE_REJOINING;
             }
         }
 
@@ -231,7 +231,7 @@ public class JoinReasonService {
         }
 
         @Override
-        public String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
+        public JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
             final StringBuilder description = new StringBuilder();
             if (currentMode == CANDIDATE) {
                 description.append("completing election");
@@ -261,7 +261,7 @@ public class JoinReasonService {
                 description.append(", [").append(removalCount).append("] total removals");
             }
 
-            return description.toString();
+            return new JoinReason(description.toString());
         }
 
         @Override
@@ -270,4 +270,7 @@ public class JoinReasonService {
         }
     }
 
+    private static final JoinReason COMPLETING_ELECTION = new JoinReason("completing election");
+    private static final JoinReason NEW_NODE_JOINING = new JoinReason("joining");
+    private static final JoinReason KNOWN_NODE_REJOINING = new JoinReason("rejoining");
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
@@ -12,6 +12,7 @@ import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.MasterService;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.Nullable;
@@ -261,7 +262,7 @@ public class JoinReasonService {
                 description.append(", [").append(removalCount).append("] total removals");
             }
 
-            return new JoinReason(description.toString());
+            return new JoinReason(description.toString(), isRestarted ? null : ReferenceDocs.UNSTABLE_CLUSTER_TROUBLESHOOTING);
         }
 
         @Override
@@ -270,7 +271,7 @@ public class JoinReasonService {
         }
     }
 
-    private static final JoinReason COMPLETING_ELECTION = new JoinReason("completing election");
-    private static final JoinReason NEW_NODE_JOINING = new JoinReason("joining");
-    private static final JoinReason KNOWN_NODE_REJOINING = new JoinReason("rejoining");
+    private static final JoinReason COMPLETING_ELECTION = new JoinReason("completing election", null);
+    private static final JoinReason NEW_NODE_JOINING = new JoinReason("joining", null);
+    private static final JoinReason KNOWN_NODE_REJOINING = new JoinReason("rejoining", null);
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTask.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 
 public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaster, long term) implements ClusterStateTaskListener {
 
-    public static JoinTask singleNode(DiscoveryNode node, String reason, ActionListener<Void> listener, long term) {
+    public static JoinTask singleNode(DiscoveryNode node, JoinReason reason, ActionListener<Void> listener, long term) {
         return new JoinTask(List.of(new NodeJoinTask(node, reason, listener)), false, term);
     }
 
@@ -59,9 +59,9 @@ public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaste
         return () -> nodeJoinTasks.stream().map(j -> j.node).iterator();
     }
 
-    public record NodeJoinTask(DiscoveryNode node, String reason, ActionListener<Void> listener) {
+    public record NodeJoinTask(DiscoveryNode node, JoinReason reason, ActionListener<Void> listener) {
 
-        public NodeJoinTask(DiscoveryNode node, String reason, ActionListener<Void> listener) {
+        public NodeJoinTask(DiscoveryNode node, JoinReason reason, ActionListener<Void> listener) {
             this.node = Objects.requireNonNull(node);
             this.reason = reason;
             this.listener = listener;
@@ -76,7 +76,7 @@ public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaste
 
         public void appendDescription(StringBuilder stringBuilder) {
             node.appendDescriptionWithoutAttributes(stringBuilder);
-            stringBuilder.append(' ').append(reason);
+            stringBuilder.append(' ').append(reason.message());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
@@ -136,11 +136,21 @@ public class NodeJoinExecutor implements ClusterStateTaskExecutor<JoinTask> {
                     }
                 }
                 onTaskSuccess.add(() -> {
-                    logger.info(
-                        "node-join: added [{}] with reason [{}]",
-                        nodeJoinTask.node().descriptionWithoutAttributes(),
-                        nodeJoinTask.reason().message()
-                    );
+                    final var reason = nodeJoinTask.reason();
+                    if (reason.guidanceDocs() == null) {
+                        logger.info(
+                            "node-join: added [{}] with reason [{}]",
+                            nodeJoinTask.node().descriptionWithoutAttributes(),
+                            reason.message()
+                        );
+                    } else {
+                        logger.warn(
+                            "node-join: added [{}] with reason [{}]; for troubleshooting guidance, see {}",
+                            nodeJoinTask.node().descriptionWithoutAttributes(),
+                            reason.message(),
+                            reason.guidanceDocs()
+                        );
+                    }
                     nodeJoinTask.listener().onResponse(null);
                 });
             }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
@@ -36,14 +36,14 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.gateway.GatewayService.STATE_NOT_RECOVERED_BLOCK;
 
-public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
+public class NodeJoinExecutor implements ClusterStateTaskExecutor<JoinTask> {
 
-    private static final Logger logger = LogManager.getLogger(JoinTaskExecutor.class);
+    private static final Logger logger = LogManager.getLogger(NodeJoinExecutor.class);
 
     private final AllocationService allocationService;
     private final RerouteService rerouteService;
 
-    public JoinTaskExecutor(AllocationService allocationService, RerouteService rerouteService) {
+    public NodeJoinExecutor(AllocationService allocationService, RerouteService rerouteService) {
         this.allocationService = allocationService;
         this.rerouteService = rerouteService;
     }
@@ -135,7 +135,14 @@ public class JoinTaskExecutor implements ClusterStateTaskExecutor<JoinTask> {
                         continue;
                     }
                 }
-                onTaskSuccess.add(() -> nodeJoinTask.listener().onResponse(null));
+                onTaskSuccess.add(() -> {
+                    logger.info(
+                        "node-join: added [{}] with reason [{}]",
+                        nodeJoinTask.node().descriptionWithoutAttributes(),
+                        nodeJoinTask.reason()
+                    );
+                    nodeJoinTask.listener().onResponse(null);
+                });
             }
             joinTaskContext.success(() -> {
                 for (Runnable joinCompleter : onTaskSuccess) {

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
@@ -139,7 +139,7 @@ public class NodeJoinExecutor implements ClusterStateTaskExecutor<JoinTask> {
                     logger.info(
                         "node-join: added [{}] with reason [{}]",
                         nodeJoinTask.node().descriptionWithoutAttributes(),
-                        nodeJoinTask.reason()
+                        nodeJoinTask.reason().message()
                     );
                     nodeJoinTask.listener().onResponse(null);
                 });

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeLeftExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeLeftExecutor.java
@@ -19,9 +19,9 @@ import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 
-public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExecutor<NodeRemovalClusterStateTaskExecutor.Task> {
+public class NodeLeftExecutor implements ClusterStateTaskExecutor<NodeLeftExecutor.Task> {
 
-    private static final Logger logger = LogManager.getLogger(NodeRemovalClusterStateTaskExecutor.class);
+    private static final Logger logger = LogManager.getLogger(NodeLeftExecutor.class);
 
     private final AllocationService allocationService;
 
@@ -41,7 +41,7 @@ public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExec
         }
     }
 
-    public NodeRemovalClusterStateTaskExecutor(AllocationService allocationService) {
+    public NodeLeftExecutor(AllocationService allocationService) {
         this.allocationService = allocationService;
     }
 
@@ -52,13 +52,21 @@ public class NodeRemovalClusterStateTaskExecutor implements ClusterStateTaskExec
         boolean removed = false;
         for (final var taskContext : batchExecutionContext.taskContexts()) {
             final var task = taskContext.getTask();
+            final String reason;
             if (initialState.nodes().nodeExists(task.node())) {
                 remainingNodesBuilder.remove(task.node());
                 removed = true;
+                reason = task.reason();
             } else {
                 logger.debug("node [{}] does not exist in cluster state, ignoring", task);
+                reason = null;
             }
-            taskContext.success(task.onClusterStateProcessed::run);
+            taskContext.success(() -> {
+                if (reason != null) {
+                    logger.info("node-left: removed [{}] with reason [{}]", task.node().descriptionWithoutAttributes(), reason);
+                }
+                task.onClusterStateProcessed.run();
+            });
         }
 
         if (removed == false) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodeWithStatus.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodeWithStatus.java
@@ -47,7 +47,7 @@ public record DesiredNodeWithStatus(DesiredNode desiredNode, Status status)
             ),
             // An unknown status is expected during upgrades to versions >= STATUS_TRACKING_SUPPORT_VERSION
             // the desired node status would be populated when a node in the newer version is elected as
-            // master, the desired nodes status update happens in JoinTaskExecutor.
+            // master, the desired nodes status update happens in NodeJoinExecutor.
             args[6] == null ? Status.PENDING : (Status) args[6]
         )
     );
@@ -84,7 +84,7 @@ public record DesiredNodeWithStatus(DesiredNode desiredNode, Status status)
             // since it's impossible to know if a node that was supposed to
             // join the cluster, it joined. The status will be updated
             // once the master node is upgraded to a version >= STATUS_TRACKING_SUPPORT_VERSION
-            // in JoinTaskExecutor or when the desired nodes are upgraded to a new version.
+            // in NodeJoinExecutor or when the desired nodes are upgraded to a new version.
             status = Status.PENDING;
         }
         return new DesiredNodeWithStatus(desiredNode, status);

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DesiredNodes.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.cluster.metadata;
 
+import org.elasticsearch.action.admin.cluster.desirednodes.TransportUpdateDesiredNodesAction;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.NodeJoinExecutor;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -97,8 +99,7 @@ import static org.elasticsearch.node.Node.NODE_EXTERNAL_ID_SETTING;
  *  </ul>
  *
  * <p>
- *  See {@code JoinTaskExecutor} and {@code TransportUpdateDesiredNodesAction} for more details about
- *  desired nodes status tracking.
+ *  See {@link NodeJoinExecutor} and {@link TransportUpdateDesiredNodesAction} for more details about desired nodes status tracking.
  * </p>
  *
  * <p>

--- a/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
+++ b/server/src/main/java/org/elasticsearch/common/ReferenceDocs.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Encapsulates links to pages in the reference docs, so that for example we can include URLs in logs and API outputs.
+ */
+public enum ReferenceDocs {
+    INITIAL_MASTER_NODES("important-settings.html#initial_master_nodes"),
+    DISCOVERY_TROUBLESHOOTING("discovery-troubleshooting.html"),
+    UNSTABLE_CLUSTER_TROUBLESHOOTING("cluster-fault-detection.html#cluster-fault-detection-troubleshooting");
+
+    private final String relativePath;
+
+    ReferenceDocs(String relativePath) {
+        this.relativePath = relativePath;
+    }
+
+    static final String UNRELEASED_VERSION_COMPONENT = "master";
+    static final String VERSION_COMPONENT = getVersionComponent(Version.CURRENT, Build.CURRENT.isSnapshot());
+
+    static String getVersionComponent(Version currentVersion, boolean isSnapshot) {
+        return isSnapshot && currentVersion.revision == 0
+            ? UNRELEASED_VERSION_COMPONENT
+            : currentVersion.major + "." + currentVersion.minor;
+    }
+
+    @Override
+    public String toString() {
+        return "https://www.elastic.co/guide/en/elasticsearch/reference/" + VERSION_COMPONENT + "/" + relativePath;
+    }
+
+    public static List<ReferenceDocs> linksToVerify(Version currentVersion, boolean isSnapshot) {
+        if (currentVersion.revision == 0 && isSnapshot == false) {
+            return List.of();
+        }
+        return Arrays.stream(values()).toList();
+    }
+}

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -707,7 +707,9 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
 
             final var warningMessagePattern = """
                 this node is locked into cluster UUID [test-uuid] but [cluster.initial_master_nodes] is set to [node1, node2]; \
-                remove this setting to avoid possible data loss caused by subsequent cluster bootstrap attempts""";
+                remove this setting to avoid possible data loss caused by subsequent cluster bootstrap attempts; \
+                for further information see \
+                https://www.elastic.co/guide/en/elasticsearch/reference/*/important-settings.html#initial_master_nodes""";
 
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -8,16 +8,15 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.Level;
-import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
@@ -661,13 +660,9 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
         );
     }
 
-    public void testBootstrapStateLogging() throws IllegalAccessException {
+    public void testBootstrapStateLogging() {
         final var mockAppender = new MockLogAppender();
-        mockAppender.start();
-        final var serviceLogger = LogManager.getLogger(ClusterBootstrapService.class);
-        Loggers.addAppender(serviceLogger, mockAppender);
-
-        try {
+        try (var ignored = mockAppender.capturing(ClusterBootstrapService.class)) {
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "fresh node message",
@@ -710,14 +705,16 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
 
             mockAppender.assertAllExpectationsMatched();
 
+            final var warningMessagePattern = """
+                this node is locked into cluster UUID [test-uuid] but [cluster.initial_master_nodes] is set to [node1, node2]; \
+                remove this setting to avoid possible data loss caused by subsequent cluster bootstrap attempts""";
+
             mockAppender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "bootstrapped node message if bootstrapping still configured",
                     ClusterBootstrapService.class.getCanonicalName(),
                     Level.WARN,
-                    """
-                        this node is locked into cluster UUID [test-uuid] but [cluster.initial_master_nodes] is set to [node1, node2]; \
-                        remove this setting to avoid possible data loss caused by subsequent cluster bootstrap attempts"""
+                    warningMessagePattern
                 )
             );
 
@@ -731,9 +728,22 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
 
             mockAppender.assertAllExpectationsMatched();
 
-        } finally {
-            Loggers.removeAppender(serviceLogger, mockAppender);
-            mockAppender.stop();
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "bootstrapped node message if bootstrapping still configured",
+                    ClusterBootstrapService.class.getCanonicalName(),
+                    Level.WARN,
+                    warningMessagePattern
+                )
+            );
+
+            var startTime = deterministicTaskQueue.getCurrentTimeMillis();
+            while (deterministicTaskQueue.getCurrentTimeMillis() <= startTime + TimeValue.timeValueHours(12).millis()) {
+                deterministicTaskQueue.runAllRunnableTasks();
+                deterministicTaskQueue.advanceTime();
+            }
+
+            mockAppender.assertAllExpectationsMatched();
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.cluster.coordination;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -25,6 +26,7 @@ import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.monitor.StatusInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
+import org.elasticsearch.test.MockLogAppender;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -53,6 +55,9 @@ import static org.hamcrest.Matchers.oneOf;
 public class ClusterFormationFailureHelperTests extends ESTestCase {
 
     private static final ElectionStrategy electionStrategy = ElectionStrategy.DEFAULT_INSTANCE;
+
+    // Hard-coding the class name here because it is also mentioned in the troubleshooting docs, so should not be renamed without care.
+    private static final String LOGGER_NAME = "org.elasticsearch.cluster.coordination.ClusterFormationFailureHelper";
 
     public void testScheduling() {
         final long expectedDelayMillis;
@@ -103,16 +108,23 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final long startTimeMillis = deterministicTaskQueue.getCurrentTimeMillis();
         clusterFormationFailureHelper.start();
 
-        while (warningCount.get() == 0) {
-            assertTrue(clusterFormationFailureHelper.isRunning());
-            if (deterministicTaskQueue.hasRunnableTasks()) {
-                deterministicTaskQueue.runRandomTask();
-            } else {
-                deterministicTaskQueue.advanceTime();
+        var mockLogAppender = new MockLogAppender();
+        mockLogAppender.addExpectation(
+            new MockLogAppender.SeenEventExpectation("master not discovered", LOGGER_NAME, Level.WARN, "master not discovered")
+        );
+        try (var ignored = mockLogAppender.capturing(ClusterFormationFailureHelper.class)) {
+            while (warningCount.get() == 0) {
+                assertTrue(clusterFormationFailureHelper.isRunning());
+                if (deterministicTaskQueue.hasRunnableTasks()) {
+                    deterministicTaskQueue.runRandomTask();
+                } else {
+                    deterministicTaskQueue.advanceTime();
+                }
             }
         }
         assertThat(warningCount.get(), is(1L));
         assertThat(deterministicTaskQueue.getCurrentTimeMillis() - startTimeMillis, is(expectedDelayMillis));
+        mockLogAppender.assertAllExpectationsMatched();
 
         while (warningCount.get() < 5) {
             assertTrue(clusterFormationFailureHelper.isRunning());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -112,6 +112,15 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         mockLogAppender.addExpectation(
             new MockLogAppender.SeenEventExpectation("master not discovered", LOGGER_NAME, Level.WARN, "master not discovered")
         );
+        mockLogAppender.addExpectation(
+            new MockLogAppender.SeenEventExpectation(
+                "troubleshooting link",
+                LOGGER_NAME,
+                Level.WARN,
+                "* for troubleshooting guidance, see "
+                    + "https://www.elastic.co/guide/en/elasticsearch/reference/*/discovery-troubleshooting.html*"
+            )
+        );
         try (var ignored = mockLogAppender.capturing(ClusterFormationFailureHelper.class)) {
             while (warningCount.get() == 0) {
                 assertTrue(clusterFormationFailureHelper.isRunning());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -7,10 +7,13 @@
  */
 package org.elasticsearch.cluster.coordination;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.DesiredNodeWithStatus;
@@ -24,16 +27,22 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.metadata.DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect;
@@ -54,7 +63,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-public class JoinTaskExecutorTests extends ESTestCase {
+public class NodeJoinExecutorTests extends ESTestCase {
 
     private static final ActionListener<Void> NOT_COMPLETED_LISTENER = ActionListener.wrap(
         () -> { throw new AssertionError("should not complete publication"); }
@@ -70,11 +79,11 @@ public class JoinTaskExecutorTests extends ESTestCase {
             .build();
         metaBuilder.put(indexMetadata, false);
         Metadata metadata = metaBuilder.build();
-        JoinTaskExecutor.ensureIndexCompatibility(Version.CURRENT, metadata);
+        NodeJoinExecutor.ensureIndexCompatibility(Version.CURRENT, metadata);
 
         expectThrows(
             IllegalStateException.class,
-            () -> JoinTaskExecutor.ensureIndexCompatibility(VersionUtils.getPreviousVersion(Version.CURRENT), metadata)
+            () -> NodeJoinExecutor.ensureIndexCompatibility(VersionUtils.getPreviousVersion(Version.CURRENT), metadata)
         );
     }
 
@@ -88,7 +97,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
             .build();
         metaBuilder.put(indexMetadata, false);
         Metadata metadata = metaBuilder.build();
-        expectThrows(IllegalStateException.class, () -> JoinTaskExecutor.ensureIndexCompatibility(Version.CURRENT, metadata));
+        expectThrows(IllegalStateException.class, () -> NodeJoinExecutor.ensureIndexCompatibility(Version.CURRENT, metadata));
     }
 
     public void testPreventJoinClusterWithUnsupportedNodeVersions() {
@@ -104,9 +113,9 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final Version tooLow = Version.fromId(maxNodeVersion.minimumCompatibilityVersion().id - 100);
         expectThrows(IllegalStateException.class, () -> {
             if (randomBoolean()) {
-                JoinTaskExecutor.ensureNodesCompatibility(tooLow, nodes);
+                NodeJoinExecutor.ensureNodesCompatibility(tooLow, nodes);
             } else {
-                JoinTaskExecutor.ensureNodesCompatibility(tooLow, minNodeVersion, maxNodeVersion);
+                NodeJoinExecutor.ensureNodesCompatibility(tooLow, minNodeVersion, maxNodeVersion);
             }
         });
 
@@ -114,7 +123,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
             v -> v.onOrAfter(minNodeVersion),
             () -> rarely() ? Version.fromId(minNodeVersion.id - 1) : randomVersion(random())
         );
-        expectThrows(IllegalStateException.class, () -> JoinTaskExecutor.ensureVersionBarrier(oldVersion, minNodeVersion));
+        expectThrows(IllegalStateException.class, () -> NodeJoinExecutor.ensureVersionBarrier(oldVersion, minNodeVersion));
 
         final Version minGoodVersion = maxNodeVersion.major == minNodeVersion.major ?
         // we have to stick with the same major
@@ -122,9 +131,9 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final Version justGood = randomVersionBetween(random(), minGoodVersion, maxCompatibleVersion(minNodeVersion));
 
         if (randomBoolean()) {
-            JoinTaskExecutor.ensureNodesCompatibility(justGood, nodes);
+            NodeJoinExecutor.ensureNodesCompatibility(justGood, nodes);
         } else {
-            JoinTaskExecutor.ensureNodesCompatibility(justGood, minNodeVersion, maxNodeVersion);
+            NodeJoinExecutor.ensureNodesCompatibility(justGood, minNodeVersion, maxNodeVersion);
         }
     }
 
@@ -144,7 +153,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
             .build();
         metaBuilder.put(indexMetadata, false);
         Metadata metadata = metaBuilder.build();
-        JoinTaskExecutor.ensureIndexCompatibility(Version.CURRENT, metadata);
+        NodeJoinExecutor.ensureIndexCompatibility(Version.CURRENT, metadata);
     }
 
     public static Settings.Builder randomCompatibleVersionSettings() {
@@ -165,6 +174,8 @@ public class JoinTaskExecutorTests extends ESTestCase {
         return VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumIndexCompatibilityVersion(), Version.CURRENT);
     }
 
+    private static final String TEST_REASON = "test";
+
     public void testUpdatesNodeWithNewRoles() throws Exception {
         // Node roles vary by version, and new roles are suppressed for BWC. This means we can receive a join from a node that's already
         // in the cluster but with a different set of roles: the node didn't change roles, but the cluster state came via an older master.
@@ -174,7 +185,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
-        final JoinTaskExecutor joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final NodeJoinExecutor executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final DiscoveryNode masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
 
@@ -196,8 +207,8 @@ public class JoinTaskExecutorTests extends ESTestCase {
 
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterState,
-            joinTaskExecutor,
-            List.of(JoinTask.singleNode(actualNode, "test", NOT_COMPLETED_LISTENER, 0L))
+            executor,
+            List.of(JoinTask.singleNode(actualNode, TEST_REASON, NOT_COMPLETED_LISTENER, 0L))
         );
 
         assertThat(resultingState.getNodes().get(actualNode.getId()).getRoles(), equalTo(actualNode.getRoles()));
@@ -208,7 +219,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
         final long executorTerm = randomLongBetween(0L, Long.MAX_VALUE - 1);
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
@@ -225,12 +236,12 @@ public class JoinTaskExecutorTests extends ESTestCase {
                 NotMasterException.class,
                 () -> ClusterStateTaskExecutorUtils.executeHandlingResults(
                     clusterState,
-                    joinTaskExecutor,
+                    executor,
                     randomBoolean()
-                        ? List.of(JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER, executorTerm))
+                        ? List.of(JoinTask.singleNode(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER, executorTerm))
                         : List.of(
                             JoinTask.completingElection(
-                                Stream.of(new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER)),
+                                Stream.of(new JoinTask.NodeJoinTask(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER)),
                                 executorTerm
                             )
                         ),
@@ -247,7 +258,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
         final long executorTerm = randomNonNegativeLong();
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
         final var localNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
@@ -272,12 +283,12 @@ public class JoinTaskExecutorTests extends ESTestCase {
                 NotMasterException.class,
                 () -> ClusterStateTaskExecutorUtils.executeHandlingResults(
                     clusterState,
-                    joinTaskExecutor,
+                    executor,
                     randomBoolean()
-                        ? List.of(JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER, executorTerm))
+                        ? List.of(JoinTask.singleNode(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER, executorTerm))
                         : List.of(
                             JoinTask.completingElection(
-                                Stream.of(new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER)),
+                                Stream.of(new JoinTask.NodeJoinTask(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER)),
                                 executorTerm
                             )
                         ),
@@ -294,7 +305,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
         final long executorTerm = randomNonNegativeLong();
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
@@ -311,8 +322,8 @@ public class JoinTaskExecutorTests extends ESTestCase {
                 NotMasterException.class,
                 () -> ClusterStateTaskExecutorUtils.executeHandlingResults(
                     clusterState,
-                    joinTaskExecutor,
-                    List.of(JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER, executorTerm)),
+                    executor,
+                    List.of(JoinTask.singleNode(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER, executorTerm)),
                     t -> fail("should not succeed"),
                     (t, e) -> assertThat(e, instanceOf(NotMasterException.class))
                 )
@@ -326,7 +337,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
         final long executorTerm = randomLongBetween(1, Long.MAX_VALUE);
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
         final var otherNodeOld = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
@@ -352,12 +363,12 @@ public class JoinTaskExecutorTests extends ESTestCase {
                         .build()
                 )
                 .build(),
-            joinTaskExecutor,
+            executor,
             List.of(
                 JoinTask.completingElection(
                     Stream.of(
-                        new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER),
-                        new JoinTask.NodeJoinTask(otherNodeNew, "test", NOT_COMPLETED_LISTENER)
+                        new JoinTask.NodeJoinTask(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER),
+                        new JoinTask.NodeJoinTask(otherNodeNew, TEST_REASON, NOT_COMPLETED_LISTENER)
                     ),
                     executorTerm
                 )
@@ -376,10 +387,10 @@ public class JoinTaskExecutorTests extends ESTestCase {
             "existing node should not be replaced if not completing an election",
             ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
                 afterElectionClusterState,
-                joinTaskExecutor,
+                executor,
                 List.of(
-                    JoinTask.singleNode(masterNode, "test", NOT_COMPLETED_LISTENER, executorTerm),
-                    JoinTask.singleNode(otherNodeOld, "test", NOT_COMPLETED_LISTENER, executorTerm)
+                    JoinTask.singleNode(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER, executorTerm),
+                    JoinTask.singleNode(otherNodeOld, TEST_REASON, NOT_COMPLETED_LISTENER, executorTerm)
                 )
             ).nodes().get(otherNodeNew.getId()).getEphemeralId(),
             equalTo(otherNodeNew.getEphemeralId())
@@ -391,7 +402,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
         final long executorTerm = randomLongBetween(1, Long.MAX_VALUE);
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
         final var otherNode = new DiscoveryNode(
@@ -429,12 +440,12 @@ public class JoinTaskExecutorTests extends ESTestCase {
         if (randomBoolean()) {
             clusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
                 clusterState,
-                joinTaskExecutor,
+                executor,
                 List.of(
                     JoinTask.completingElection(
                         Stream.of(
-                            new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER),
-                            new JoinTask.NodeJoinTask(otherNode, "test", NOT_COMPLETED_LISTENER)
+                            new JoinTask.NodeJoinTask(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER),
+                            new JoinTask.NodeJoinTask(otherNode, TEST_REASON, NOT_COMPLETED_LISTENER)
                         ),
                         executorTerm
                     )
@@ -443,18 +454,18 @@ public class JoinTaskExecutorTests extends ESTestCase {
         } else {
             clusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
                 clusterState,
-                joinTaskExecutor,
+                executor,
                 List.of(
                     JoinTask.completingElection(
-                        Stream.of(new JoinTask.NodeJoinTask(masterNode, "test", NOT_COMPLETED_LISTENER)),
+                        Stream.of(new JoinTask.NodeJoinTask(masterNode, TEST_REASON, NOT_COMPLETED_LISTENER)),
                         executorTerm
                     )
                 )
             );
             clusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
                 clusterState,
-                joinTaskExecutor,
-                List.of(JoinTask.singleNode(otherNode, "test", NOT_COMPLETED_LISTENER, executorTerm))
+                executor,
+                List.of(JoinTask.singleNode(otherNode, TEST_REASON, NOT_COMPLETED_LISTENER, executorTerm))
             );
         }
 
@@ -471,7 +482,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
 
         final long currentTerm = randomLongBetween(100, 1000);
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
@@ -480,14 +491,13 @@ public class JoinTaskExecutorTests extends ESTestCase {
             .build();
 
         var tasks = Stream.concat(
-            Stream.generate(() -> createRandomTask(masterNode, "outdated", randomLongBetween(0, currentTerm - 1)))
-                .limit(randomLongBetween(1, 10)),
-            Stream.of(createRandomTask(masterNode, "current", currentTerm))
+            Stream.generate(() -> createRandomTask(masterNode, randomLongBetween(0, currentTerm - 1))).limit(randomLongBetween(1, 10)),
+            Stream.of(createRandomTask(masterNode, currentTerm))
         ).toList();
 
         ClusterStateTaskExecutorUtils.executeHandlingResults(
             clusterState,
-            joinTaskExecutor,
+            executor,
             tasks,
             t -> assertThat(t.term(), equalTo(currentTerm)),
             (t, e) -> {
@@ -500,7 +510,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
     public void testDesiredNodesMembershipIsUpgradedWhenNewNodesJoin() throws Exception {
         final var allocationService = createAllocationService();
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var actualizedDesiredNodes = randomList(0, 5, this::createActualizedDesiredNode);
         final var pendingDesiredNodes = randomList(0, 5, this::createPendingDesiredNode);
@@ -519,9 +529,9 @@ public class JoinTaskExecutorTests extends ESTestCase {
         );
         final var desiredNodes = DesiredNodes.latestFromClusterState(clusterState);
 
-        var tasks = joiningNodes.stream().map(node -> JoinTask.singleNode(node, "join", NOT_COMPLETED_LISTENER, 0L)).toList();
+        var tasks = joiningNodes.stream().map(node -> JoinTask.singleNode(node, TEST_REASON, NOT_COMPLETED_LISTENER, 0L)).toList();
 
-        final var updatedClusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(clusterState, joinTaskExecutor, tasks);
+        final var updatedClusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(clusterState, executor, tasks);
 
         final var updatedDesiredNodes = DesiredNodes.latestFromClusterState(clusterState);
         assertThat(updatedDesiredNodes, is(notNullValue()));
@@ -537,7 +547,7 @@ public class JoinTaskExecutorTests extends ESTestCase {
     public void testDesiredNodesMembershipIsUpgradedWhenANewMasterIsElected() throws Exception {
         final var allocationService = createAllocationService();
         final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
-        final var joinTaskExecutor = new JoinTaskExecutor(allocationService, rerouteService);
+        final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
         final var actualizedDesiredNodes = randomList(1, 5, this::createPendingDesiredNode);
         final var pendingDesiredNodes = randomList(0, 5, this::createPendingDesiredNode);
@@ -552,13 +562,13 @@ public class JoinTaskExecutorTests extends ESTestCase {
         final var desiredNodes = DesiredNodes.latestFromClusterState(clusterState);
 
         final var completingElectionTask = JoinTask.completingElection(
-            clusterState.nodes().stream().map(node -> new JoinTask.NodeJoinTask(node, "test", NOT_COMPLETED_LISTENER)),
+            clusterState.nodes().stream().map(node -> new JoinTask.NodeJoinTask(node, TEST_REASON, NOT_COMPLETED_LISTENER)),
             1L
         );
 
         final var updatedClusterState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterState,
-            joinTaskExecutor,
+            executor,
             List.of(completingElectionTask)
         );
 
@@ -573,6 +583,50 @@ public class JoinTaskExecutorTests extends ESTestCase {
         );
     }
 
+    public void testPerNodeLogging() {
+        final AllocationService allocationService = createAllocationService();
+        when(allocationService.adaptAutoExpandReplicas(any())).then(invocationOnMock -> invocationOnMock.getArguments()[0]);
+        final RerouteService rerouteService = (reason, priority, listener) -> listener.onResponse(null);
+
+        final NodeJoinExecutor executor = new NodeJoinExecutor(allocationService, rerouteService);
+
+        final DiscoveryNode masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).masterNodeId(masterNode.getId()))
+            .build();
+
+        final MockLogAppender appender = new MockLogAppender();
+        final ThreadPool threadPool = new TestThreadPool("test");
+        try (
+            var ignored = appender.capturing(NodeJoinExecutor.class);
+            var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
+        ) {
+            final var node1 = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "info message",
+                    LOGGER_NAME,
+                    Level.INFO,
+                    "node-join: added [" + node1.descriptionWithoutAttributes() + "] with reason [" + TEST_REASON + "]"
+                )
+            );
+            assertNull(
+                PlainActionFuture.<Void, RuntimeException>get(
+                    future -> clusterService.getMasterService()
+                        .submitStateUpdateTask(
+                            "test",
+                            JoinTask.singleNode(node1, TEST_REASON, future, 0L),
+                            ClusterStateTaskConfig.build(Priority.NORMAL),
+                            executor
+                        )
+                )
+            );
+            appender.assertAllExpectationsMatched();
+        } finally {
+            TestThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
     private DesiredNodeWithStatus createActualizedDesiredNode() {
         return new DesiredNodeWithStatus(randomDesiredNode(), DesiredNodeWithStatus.Status.ACTUALIZED);
     }
@@ -581,10 +635,10 @@ public class JoinTaskExecutorTests extends ESTestCase {
         return new DesiredNodeWithStatus(randomDesiredNode(), DesiredNodeWithStatus.Status.PENDING);
     }
 
-    private static JoinTask createRandomTask(DiscoveryNode node, String reason, long term) {
+    private static JoinTask createRandomTask(DiscoveryNode node, long term) {
         return randomBoolean()
-            ? JoinTask.singleNode(node, reason, NOT_COMPLETED_LISTENER, term)
-            : JoinTask.completingElection(Stream.of(new JoinTask.NodeJoinTask(node, reason, NOT_COMPLETED_LISTENER)), term);
+            ? JoinTask.singleNode(node, TEST_REASON, NOT_COMPLETED_LISTENER, term)
+            : JoinTask.completingElection(Stream.of(new JoinTask.NodeJoinTask(node, TEST_REASON, NOT_COMPLETED_LISTENER)), term);
     }
 
     private static AllocationService createAllocationService() {
@@ -595,4 +649,8 @@ public class JoinTaskExecutorTests extends ESTestCase {
         );
         return allocationService;
     }
+
+    // Hard-coding the class name here because it is also mentioned in the troubleshooting docs, so should not be renamed without care.
+    private static final String LOGGER_NAME = "org.elasticsearch.cluster.coordination.NodeJoinExecutor";
+
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -28,6 +28,7 @@ import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ClusterServiceUtils;
@@ -174,7 +175,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         return VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumIndexCompatibilityVersion(), Version.CURRENT);
     }
 
-    private static final JoinReason TEST_REASON = new JoinReason("test");
+    private static final JoinReason TEST_REASON = new JoinReason("test", null);
 
     public void testUpdatesNodeWithNewRoles() throws Exception {
         // Node roles vary by version, and new roles are suppressed for BWC. This means we can receive a join from a node that's already
@@ -616,6 +617,35 @@ public class NodeJoinExecutorTests extends ESTestCase {
                         .submitStateUpdateTask(
                             "test",
                             JoinTask.singleNode(node1, TEST_REASON, future, 0L),
+                            ClusterStateTaskConfig.build(Priority.NORMAL),
+                            executor
+                        ),
+                    10,
+                    TimeUnit.SECONDS
+                )
+            );
+            appender.assertAllExpectationsMatched();
+
+            final var node2 = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+            final var testReasonWithLink = new JoinReason("test", ReferenceDocs.UNSTABLE_CLUSTER_TROUBLESHOOTING);
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "warn message with troubleshooting link",
+                    LOGGER_NAME,
+                    Level.WARN,
+                    "node-join: added ["
+                        + node2.descriptionWithoutAttributes()
+                        + "] with reason ["
+                        + testReasonWithLink.message()
+                        + "]; for troubleshooting guidance, see https://www.elastic.co/guide/en/elasticsearch/reference/*"
+                )
+            );
+            assertNull(
+                PlainActionFuture.<Void, RuntimeException>get(
+                    future -> clusterService.getMasterService()
+                        .submitStateUpdateTask(
+                            "test",
+                            JoinTask.singleNode(node2, testReasonWithLink, future, 0L),
                             ClusterStateTaskConfig.build(Priority.NORMAL),
                             executor
                         ),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -174,7 +174,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         return VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumIndexCompatibilityVersion(), Version.CURRENT);
     }
 
-    private static final String TEST_REASON = "test";
+    private static final JoinReason TEST_REASON = new JoinReason("test");
 
     public void testUpdatesNodeWithNewRoles() throws Exception {
         // Node roles vary by version, and new roles are suppressed for BWC. This means we can receive a join from a node that's already
@@ -607,7 +607,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     "info message",
                     LOGGER_NAME,
                     Level.INFO,
-                    "node-join: added [" + node1.descriptionWithoutAttributes() + "] with reason [" + TEST_REASON + "]"
+                    "node-join: added [" + node1.descriptionWithoutAttributes() + "] with reason [" + TEST_REASON.message() + "]"
                 )
             );
             assertNull(
@@ -618,7 +618,9 @@ public class NodeJoinExecutorTests extends ESTestCase {
                             JoinTask.singleNode(node1, TEST_REASON, future, 0L),
                             ClusterStateTaskConfig.build(Priority.NORMAL),
                             executor
-                        )
+                        ),
+                    10,
+                    TimeUnit.SECONDS
                 )
             );
             appender.assertAllExpectationsMatched();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
@@ -8,17 +8,26 @@
 
 package org.elasticsearch.cluster.coordination;
 
+import org.apache.logging.log4j.Level;
 import org.elasticsearch.Version;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateTaskConfig;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -27,10 +36,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class NodeRemovalClusterStateTaskExecutorTests extends ESTestCase {
+public class NodeLeftExecutorTests extends ESTestCase {
 
     public void testRemovingNonExistentNodes() throws Exception {
-        final NodeRemovalClusterStateTaskExecutor executor = new NodeRemovalClusterStateTaskExecutor(null);
+        final NodeLeftExecutor executor = new NodeLeftExecutor(null);
         final DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
         final int nodes = randomIntBetween(2, 16);
         for (int i = 0; i < nodes; i++) {
@@ -42,9 +51,9 @@ public class NodeRemovalClusterStateTaskExecutorTests extends ESTestCase {
         for (int i = nodes; i < nodes + randomIntBetween(1, 16); i++) {
             removeBuilder.add(node(i));
         }
-        final List<NodeRemovalClusterStateTaskExecutor.Task> tasks = removeBuilder.build()
+        final List<NodeLeftExecutor.Task> tasks = removeBuilder.build()
             .stream()
-            .map(node -> new NodeRemovalClusterStateTaskExecutor.Task(node, randomBoolean() ? "left" : "failed", () -> {}))
+            .map(node -> new NodeLeftExecutor.Task(node, randomBoolean() ? "left" : "failed", () -> {}))
             .toList();
 
         assertSame(clusterState, ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(clusterState, executor, tasks));
@@ -57,7 +66,7 @@ public class NodeRemovalClusterStateTaskExecutorTests extends ESTestCase {
         );
 
         final AtomicReference<ClusterState> remainingNodesClusterState = new AtomicReference<>();
-        final NodeRemovalClusterStateTaskExecutor executor = new NodeRemovalClusterStateTaskExecutor(allocationService) {
+        final NodeLeftExecutor executor = new NodeLeftExecutor(allocationService) {
             @Override
             protected ClusterState remainingNodesClusterState(ClusterState currentState, DiscoveryNodes.Builder remainingNodesBuilder) {
                 remainingNodesClusterState.set(super.remainingNodesClusterState(currentState, remainingNodesBuilder));
@@ -67,14 +76,14 @@ public class NodeRemovalClusterStateTaskExecutorTests extends ESTestCase {
 
         final DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
         final int nodes = randomIntBetween(2, 16);
-        final List<NodeRemovalClusterStateTaskExecutor.Task> tasks = new ArrayList<>();
+        final List<NodeLeftExecutor.Task> tasks = new ArrayList<>();
         // to ensure that there is at least one removal
         boolean first = true;
         for (int i = 0; i < nodes; i++) {
             final DiscoveryNode node = node(i);
             builder.add(node);
             if (first || randomBoolean()) {
-                tasks.add(new NodeRemovalClusterStateTaskExecutor.Task(node, randomBoolean() ? "left" : "failed", () -> {}));
+                tasks.add(new NodeLeftExecutor.Task(node, randomBoolean() ? "left" : "failed", () -> {}));
             }
             first = false;
         }
@@ -84,13 +93,66 @@ public class NodeRemovalClusterStateTaskExecutorTests extends ESTestCase {
 
         verify(allocationService).disassociateDeadNodes(eq(remainingNodesClusterState.get()), eq(true), any(String.class));
 
-        for (final NodeRemovalClusterStateTaskExecutor.Task task : tasks) {
+        for (final NodeLeftExecutor.Task task : tasks) {
             assertNull(resultingState.nodes().get(task.node().getId()));
         }
     }
 
-    private DiscoveryNode node(final int id) {
+    public void testPerNodeLogging() {
+        final AllocationService allocationService = mock(AllocationService.class);
+        when(allocationService.disassociateDeadNodes(any(ClusterState.class), eq(true), any(String.class))).thenAnswer(
+            im -> im.getArguments()[0]
+        );
+        final var executor = new NodeLeftExecutor(allocationService);
+
+        final DiscoveryNode masterNode = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
+            .nodes(
+                DiscoveryNodes.builder()
+                    .add(masterNode)
+                    .localNodeId("master")
+                    .masterNodeId("master")
+                    .add(new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT))
+            )
+            .build();
+
+        final MockLogAppender appender = new MockLogAppender();
+        final ThreadPool threadPool = new TestThreadPool("test");
+        try (
+            var ignored = appender.capturing(NodeLeftExecutor.class);
+            var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
+        ) {
+            final var nodeToRemove = clusterState.nodes().get("other");
+            appender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "info message",
+                    LOGGER_NAME,
+                    Level.INFO,
+                    "node-left: removed [" + nodeToRemove.descriptionWithoutAttributes() + "] with reason [test reason]"
+                )
+            );
+            assertNull(
+                PlainActionFuture.<Void, RuntimeException>get(
+                    future -> clusterService.getMasterService()
+                        .submitStateUpdateTask(
+                            "test",
+                            new NodeLeftExecutor.Task(nodeToRemove, "test reason", () -> future.onResponse(null)),
+                            ClusterStateTaskConfig.build(Priority.NORMAL),
+                            executor
+                        )
+                )
+            );
+            appender.assertAllExpectationsMatched();
+        } finally {
+            TestThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
+        }
+    }
+
+    private static DiscoveryNode node(final int id) {
         return new DiscoveryNode(Integer.toString(id), buildNewFakeTransportAddress(), Version.CURRENT);
     }
+
+    // Hard-coding the class name here because it is also mentioned in the troubleshooting docs, so should not be renamed without care.
+    private static final String LOGGER_NAME = "org.elasticsearch.cluster.coordination.NodeLeftExecutor";
 
 }

--- a/server/src/test/java/org/elasticsearch/common/ReferenceDocsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/ReferenceDocsTests.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.common;
+
+import org.elasticsearch.Build;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.io.Streams;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.net.URL;
+
+import static org.elasticsearch.common.ReferenceDocs.getVersionComponent;
+import static org.elasticsearch.common.ReferenceDocs.linksToVerify;
+
+public class ReferenceDocsTests extends ESTestCase {
+
+    public void testVersionComponent() {
+        // Snapshot x.y.0 versions are unreleased so link to master
+        assertEquals("master", getVersionComponent(Version.V_8_7_0, true));
+
+        // Snapshot x.y.z versions with z>0 mean that x.y.0 is released so have a properly versioned docs link
+        assertEquals("8.5", getVersionComponent(Version.V_8_5_1, true));
+
+        // Non-snapshot versions are to be released so have a properly versioned docs link
+        assertEquals("8.7", getVersionComponent(Version.V_8_7_0, false));
+    }
+
+    public void testLinksToVerify() {
+        // Snapshot x.y.0 versions are unreleased so we link to master and these links are expected to exist
+        assertFalse(linksToVerify(Version.V_8_7_0, true).isEmpty());
+
+        // Snapshot x.y.z versions with z>0 mean that x.y.0 is released so links are expected to exist
+        assertFalse(linksToVerify(Version.V_8_5_1, true).isEmpty());
+
+        // Non-snapshot x.y.0 versions may not be released yet, and the docs are published on release, so we cannot verify these links
+        assertTrue(linksToVerify(Version.V_8_7_0, false).isEmpty());
+    }
+
+    @AwaitsFix(bugUrl = "TODO")
+    @SuppressForbidden(reason = "never executed")
+    public void testDocsExist() throws IOException {
+        // cannot run as a unit test due to security manager restrictions - TODO create a separate Gradle task for this
+        for (ReferenceDocs docsLink : linksToVerify(Version.CURRENT, Build.CURRENT.isSnapshot())) {
+            try (var stream = new URL(docsLink.toString()).openStream()) {
+                Streams.readFully(stream);
+                // TODO also for URLs that contain a fragment id, verify that the fragment exists
+            }
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -397,7 +397,7 @@ public class ClusterStateChanges {
         return execute(transportClusterRerouteAction, request, state);
     }
 
-    private static final JoinReason DUMMY_REASON = new JoinReason("dummy reason");
+    private static final JoinReason DUMMY_REASON = new JoinReason("dummy reason", null);
 
     public ClusterState addNode(ClusterState clusterState, DiscoveryNode discoveryNode) {
         return runTasks(

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -45,6 +45,7 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction.FailedShardUpdate
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardEntry;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.coordination.JoinReason;
 import org.elasticsearch.cluster.coordination.JoinTask;
 import org.elasticsearch.cluster.coordination.NodeJoinExecutor;
 import org.elasticsearch.cluster.coordination.NodeLeftExecutor;
@@ -396,7 +397,7 @@ public class ClusterStateChanges {
         return execute(transportClusterRerouteAction, request, state);
     }
 
-    private static final String DUMMY_REASON = "dummy reason";
+    private static final JoinReason DUMMY_REASON = new JoinReason("dummy reason");
 
     public ClusterState addNode(ClusterState clusterState, DiscoveryNode discoveryNode) {
         return runTasks(


### PR DESCRIPTION
This is a meta issue showing a sequence of commits that move us towards including links to reference docs in error messages, particularly on the subject of cluster coordination troubleshooting. I do not intend to merge it as-is - instead I will open PRs for the individual steps, since they will each want a different reviewer:

- [x] #92742
- [x] #92750
- [x] #92743
- [x] #92744
- [x] #92755