### PR TITLE
Encapsulate JoinReason

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReason.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReason.java
@@ -1,0 +1,14 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.coordination;
+
+/**
+ * @param message Message describing the reason for the node joining
+ */
+public record JoinReason(String message) {}

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinReasonService.java
@@ -107,9 +107,9 @@ public class JoinReasonService {
      * @param currentMode   The current mode of the master that the node is joining.
      * @return              A description of the reason for the join, possibly including some details of its earlier removal.
      */
-    public String getJoinReason(DiscoveryNode discoveryNode, Coordinator.Mode currentMode) {
+    public JoinReason getJoinReason(DiscoveryNode discoveryNode, Coordinator.Mode currentMode) {
         return trackedNodes.getOrDefault(discoveryNode.getId(), UNKNOWN_NODE)
-            .getDescription(relativeTimeInMillisSupplier.getAsLong(), discoveryNode.getEphemeralId(), currentMode);
+            .getJoinReason(relativeTimeInMillisSupplier.getAsLong(), discoveryNode.getEphemeralId(), currentMode);
     }
 
     /**
@@ -134,7 +134,7 @@ public class JoinReasonService {
 
         TrackedNode withRemovalReason(String removalReason);
 
-        String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode);
+        JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode);
 
         long getRemovalAgeMillis(long currentTimeMillis);
     }
@@ -161,11 +161,11 @@ public class JoinReasonService {
         }
 
         @Override
-        public String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
+        public JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
             if (currentMode == CANDIDATE) {
-                return "completing election";
+                return COMPLETING_ELECTION;
             } else {
-                return "joining";
+                return NEW_NODE_JOINING;
             }
         }
 
@@ -193,11 +193,11 @@ public class JoinReasonService {
         }
 
         @Override
-        public String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
+        public JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
             if (currentMode == CANDIDATE) {
-                return "completing election";
+                return COMPLETING_ELECTION;
             } else {
-                return "rejoining";
+                return KNOWN_NODE_REJOINING;
             }
         }
 
@@ -231,7 +231,7 @@ public class JoinReasonService {
         }
 
         @Override
-        public String getDescription(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
+        public JoinReason getJoinReason(long currentTimeMillis, String joiningNodeEphemeralId, Coordinator.Mode currentMode) {
             final StringBuilder description = new StringBuilder();
             if (currentMode == CANDIDATE) {
                 description.append("completing election");
@@ -261,7 +261,7 @@ public class JoinReasonService {
                 description.append(", [").append(removalCount).append("] total removals");
             }
 
-            return description.toString();
+            return new JoinReason(description.toString());
         }
 
         @Override
@@ -270,4 +270,7 @@ public class JoinReasonService {
         }
     }
 
+    private static final JoinReason COMPLETING_ELECTION = new JoinReason("completing election");
+    private static final JoinReason NEW_NODE_JOINING = new JoinReason("joining");
+    private static final JoinReason KNOWN_NODE_REJOINING = new JoinReason("rejoining");
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTask.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinTask.java
@@ -18,7 +18,7 @@ import java.util.stream.Stream;
 
 public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaster, long term) implements ClusterStateTaskListener {
 
-    public static JoinTask singleNode(DiscoveryNode node, String reason, ActionListener<Void> listener, long term) {
+    public static JoinTask singleNode(DiscoveryNode node, JoinReason reason, ActionListener<Void> listener, long term) {
         return new JoinTask(List.of(new NodeJoinTask(node, reason, listener)), false, term);
     }
 
@@ -59,9 +59,9 @@ public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaste
         return () -> nodeJoinTasks.stream().map(j -> j.node).iterator();
     }
 
-    public record NodeJoinTask(DiscoveryNode node, String reason, ActionListener<Void> listener) {
+    public record NodeJoinTask(DiscoveryNode node, JoinReason reason, ActionListener<Void> listener) {
 
-        public NodeJoinTask(DiscoveryNode node, String reason, ActionListener<Void> listener) {
+        public NodeJoinTask(DiscoveryNode node, JoinReason reason, ActionListener<Void> listener) {
             this.node = Objects.requireNonNull(node);
             this.reason = reason;
             this.listener = listener;
@@ -76,7 +76,7 @@ public record JoinTask(List<NodeJoinTask> nodeJoinTasks, boolean isBecomingMaste
 
         public void appendDescription(StringBuilder stringBuilder) {
             node.appendDescriptionWithoutAttributes(stringBuilder);
-            stringBuilder.append(' ').append(reason);
+            stringBuilder.append(' ').append(reason.message());
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/NodeJoinExecutor.java
@@ -139,7 +139,7 @@ public class NodeJoinExecutor implements ClusterStateTaskExecutor<JoinTask> {
                     logger.info(
                         "node-join: [{}] with reason [{}]",
                         nodeJoinTask.node().descriptionWithoutAttributes(),
-                        nodeJoinTask.reason()
+                        nodeJoinTask.reason().message()
                     );
                     nodeJoinTask.listener().onResponse(null);
                 });

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -174,7 +174,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         return VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumIndexCompatibilityVersion(), Version.CURRENT);
     }
 
-    private static final String TEST_REASON = "test";
+    private static final JoinReason TEST_REASON = new JoinReason("test");
 
     public void testUpdatesNodeWithNewRoles() throws Exception {
         // Node roles vary by version, and new roles are suppressed for BWC. This means we can receive a join from a node that's already
@@ -607,7 +607,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
                     "info message",
                     LOGGER_NAME,
                     Level.INFO,
-                    "node-join: [" + node1.descriptionWithoutAttributes() + "] with reason [" + TEST_REASON + "]"
+                    "node-join: [" + node1.descriptionWithoutAttributes() + "] with reason [" + TEST_REASON.message() + "]"
                 )
             );
             assertNull(
@@ -618,7 +618,9 @@ public class NodeJoinExecutorTests extends ESTestCase {
                             JoinTask.singleNode(node1, TEST_REASON, future, 0L),
                             ClusterStateTaskConfig.build(Priority.NORMAL),
                             executor
-                        )
+                        ),
+                    10,
+                    TimeUnit.SECONDS
                 )
             );
             appender.assertAllExpectationsMatched();

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -45,6 +45,7 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction.FailedShardUpdate
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardEntry;
 import org.elasticsearch.cluster.action.shard.ShardStateAction.StartedShardUpdateTask;
 import org.elasticsearch.cluster.block.ClusterBlock;
+import org.elasticsearch.cluster.coordination.JoinReason;
 import org.elasticsearch.cluster.coordination.JoinTask;
 import org.elasticsearch.cluster.coordination.NodeJoinExecutor;
 import org.elasticsearch.cluster.coordination.NodeLeftExecutor;
@@ -396,7 +397,7 @@ public class ClusterStateChanges {
         return execute(transportClusterRerouteAction, request, state);
     }
 
-    private static final String DUMMY_REASON = "dummy reason";
+    private static final JoinReason DUMMY_REASON = new JoinReason("dummy reason");
 
     public ClusterState addNode(ClusterState clusterState, DiscoveryNode discoveryNode) {
         return runTasks(


### PR DESCRIPTION
Today the reason attached to a `node-join` event is just a string, but we'd rather it be a proper object so we can attach some extra metadata in future. This refactors things to encapsulate the string within a dedicated record.

Relates #92741