### PR TITLE
[DOCS] Fine-tunes documentation on exclude/include in frequent items

### DIFF
--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -160,11 +160,7 @@ POST /kibana_sample_data_ecommerce/_async_search
                   "exclude":"other"
                }
             ],
-            "size":3,
-            "terms":{
-               "field":"products.discount_amount",
-               "include":0
-            }
+            "size":3
          }
       }
    }

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -257,7 +257,7 @@ mostly from New York. Finally, the item set with the third highest support is
 ==== Aggregation with two analyzed fields and a filter
 
 We take the first example, but want to narrow the item sets to places in Europe.
-For that we add a filter:
+For that we add a filter and this time, we don't use the `exclude` parameter:
 
 [source,console]
 -------------------------------------------------

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -257,7 +257,7 @@ mostly from New York. Finally, the item set with the third highest support is
 ==== Aggregation with two analyzed fields and a filter
 
 We take the first example, but want to narrow the item sets to places in Europe.
-For that we add a filter and this time, we don't use the `exclude` parameter:
+For that, we add a filter, and this time, we don't use the `exclude` parameter:
 
 [source,console]
 -------------------------------------------------

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -146,27 +146,28 @@ example.
 -------------------------------------------------
 POST /kibana_sample_data_ecommerce/_async_search
 {
-  "size": 0,
-  "aggs": {
-    "my_agg": {
-      "frequent_items": {
-        "minimum_set_size": 3,
-        "fields": [
-          { "field": "category.keyword" }, 
-          { "field": 
-            "geoip.city_name",
-              "exclude": "other"
-          }
-        ],
-        "size": 3,
-        "terms": {
-          "field": "products.discount_amount",
-          "include": 0
-          }
-        }
+   "size":0,
+   "aggs":{
+      "my_agg":{
+         "frequent_items":{
+            "minimum_set_size":3,
+            "fields":[
+               {
+                  "field":"category.keyword"
+               },
+               {
+                  "field":"geoip.city_name",
+                  "exclude":"other"
+               }
+            ],
+            "size":3,
+            "terms":{
+               "field":"products.discount_amount",
+               "include":0
+            }
+         }
       }
-    }
-  }
+   }
 }
 -------------------------------------------------
 // TEST[skip:setup kibana sample data]

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -63,14 +63,15 @@ Supported field types for the analyzed fields are keyword, numeric, ip, date,
 and arrays of these types. You can also add runtime fields to your analyzed 
 fields.
 
-If the combined cardinality of the analyzed fields are high, then the 
-aggregation might require a significant amount of system resources.
+If the combined cardinality of the analyzed fields are high, the aggregation 
+might require a significant amount of system resources.
 
-It is possible to filter the values for each field. This can be done using the
-`include` and `exclude` parameters which are based on a regular expression string
-or arrays of exact terms. This functionality mirrors the features described in the
-<<search-aggregations-bucket-terms-aggregation,terms aggregation>> documentation.
-Filtered values are removed from the analysis and therefore reduce the runtime.
+You can filter the values for each field by using the `include` and `exclude` 
+parameters. The parameters can be regular expression strings or arrays of 
+strings of exact terms. The filtered values are removed from the analysis and 
+therefore reduce the runtime. If both `include` and `exclude` are defined, 
+`exclude` takes precedence; it means `include` is evaluated first and then 
+`exclude`.
 
 [discrete]
 [[frequent-items-minimum-set-size]]
@@ -129,13 +130,14 @@ In the following examples, we use the e-commerce {kib} sample data set.
 
 
 [discrete]
-==== Aggregation with two analyzed fields
+==== Aggregation with two analyzed fields and an `exclude` parameter
 
 In the first example, the goal is to find out based on transaction data (1.) 
 from what product categories the customers purchase products frequently together 
-and (2.) from which cities they make those purchases. We are interested in sets 
-with three or more items, and want to see the first three frequent item sets 
-with the highest support.
+and (2.) from which cities they make those purchases. We want to exclude results 
+where location information is not available (where the city name is `other`). 
+Finally, we are interested in sets with three or more items, and want to see the 
+first three frequent item sets with the highest support.
 
 Note that we use the <<async-search,async search>> endpoint in this first 
 example.
@@ -151,9 +153,17 @@ POST /kibana_sample_data_ecommerce/_async_search
         "minimum_set_size": 3,
         "fields": [
           { "field": "category.keyword" }, 
-          { "field": "geoip.city_name" }
+          { "field": 
+            "geoip.city_name",
+              "exclude": "other"
+          }
         ],
-        "size": 3
+        "size": 3,
+        "terms": {
+          "field": "products.discount_amount",
+          "include": 0
+          }
+        }
       }
     }
   }
@@ -235,10 +245,10 @@ The response shows that the categories customers purchase from most frequently
 together are `Women's Clothing` and `Women's Shoes` and customers from New York 
 tend to buy items from these categories frequently togeher. In other words, 
 customers who buy products labelled `Women's Clothing` more likely buy products 
-also from the `Women's Shoes` category and customers from New York most likely buy 
-products from these categories together. The item set with the second highest 
-support is `Women's Clothing` and `Women's Accessories` with customers mostly 
-from New York. Finally, the item set with the third highest support is 
+also from the `Women's Shoes` category and customers from New York most likely 
+buy products from these categories together. The item set with the second 
+highest support is `Women's Clothing` and `Women's Accessories` with customers 
+mostly from New York. Finally, the item set with the third highest support is 
 `Men's Clothing` and `Men's Shoes` with customers mostly from Cairo.
 
 
@@ -275,9 +285,10 @@ POST /kibana_sample_data_ecommerce/_async_search
 // TEST[skip:setup kibana sample data]
 
 The result will only show item sets that created from documents matching the
-filter, namely purchases in Europe. Using `filter`, the calculated `support` still
-takes all purchases into acount. That's different than specifying a query at the
-top-level, in which case `support` gets calculated only from purchases in Europe.
+filter, namely purchases in Europe. Using `filter`, the calculated `support` 
+still takes all purchases into acount. That's different than specifying a query 
+at the top-level, in which case `support` gets calculated only from purchases in 
+Europe.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR slightly re-words the documentation of include/exclude filtering in frequent items and adds more details about the behavior. This way, it is not necessary to link out to another page, so users can get the relevant information on one page.

It also expands the first example to demonstrate how to use the `exclude` parameter. I used an existing example because a new example would require a great amount of real estate on the page for demonstrating a relatively simple syntax. (@hendrikmuhs please let me know if you think a separate example would be better.)

### Preview

[Frequent items](https://elasticsearch_92758.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-frequent-items-aggregation.html)