### PR TITLE
[DOCS] Remove coming tag from 8.6.0 release notes

### DIFF
--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.6.0]]
 == {es} version 8.6.0
 
-coming[8.6.0]
-
 Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 


### PR DESCRIPTION
This PR removes the "Coming in 8.6.0" text from the 8.6.0 release notes.