### PR TITLE
[Transform] Integrate "sourceHasChanged" call into failure handling and retry logic.

### DIFF
--- a/docs/changelog/92762.yaml
+++ b/docs/changelog/92762.yaml
@@ -1,0 +1,6 @@
+pr: 92762
+summary: Integrate "sourceHasChanged" call into failure handling and retry logic
+area: Transform
+type: bug
+issues:
+ - 92133


### PR DESCRIPTION
If there is an exception thrown in the `sourceHasChanged` method call, the exception gets caught and log message is generated.
This PR makes it so that the exception is not caught at that level but fall through to the proper failure handler. This naturally reduces log spam because in `TransformFailureHandler` the log messages are throttled.

Closes https://github.com/elastic/elasticsearch/issues/92133