### PR TITLE
Ensure that expectations are evaluated before closing a MockLogAppender.capturing

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -121,10 +121,10 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
                     deterministicTaskQueue.advanceTime();
                 }
             }
+            assertThat(warningCount.get(), is(1L));
+            assertThat(deterministicTaskQueue.getCurrentTimeMillis() - startTimeMillis, is(expectedDelayMillis));
+            mockLogAppender.assertAllExpectationsMatched();
         }
-        assertThat(warningCount.get(), is(1L));
-        assertThat(deterministicTaskQueue.getCurrentTimeMillis() - startTimeMillis, is(expectedDelayMillis));
-        mockLogAppender.assertAllExpectationsMatched();
 
         while (warningCount.get() < 5) {
             assertTrue(clusterFormationFailureHelper.isRunning());

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -1556,8 +1556,8 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
 
             try (var ignored = mockAppender.capturing(PersistedClusterStateService.class)) {
                 persistedClusterStateService.loadBestOnDiskState();
+                mockAppender.assertAllExpectationsMatched();
             }
-            mockAppender.assertAllExpectationsMatched();
         }
     }
 
@@ -1851,8 +1851,8 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
             } else {
                 writer.writeIncrementalStateAndCommit(currentTerm, previousState, clusterState);
             }
+            mockAppender.assertAllExpectationsMatched();
         }
-        mockAppender.assertAllExpectationsMatched();
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -19,11 +19,14 @@ import org.elasticsearch.core.Releasable;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
 /**
  * Test appender that can be used to verify that certain events were logged correctly
@@ -32,7 +35,7 @@ public class MockLogAppender extends AbstractAppender {
 
     private static final String COMMON_PREFIX = System.getProperty("es.logger.prefix", "org.elasticsearch.");
 
-    private final List<LoggingExpectation> expectations;
+    private final List<WrappedLoggingExpectation> expectations;
 
     public MockLogAppender() {
         super("mock", null, null, false, Property.EMPTY_ARRAY);
@@ -45,7 +48,7 @@ public class MockLogAppender extends AbstractAppender {
     }
 
     public void addExpectation(LoggingExpectation expectation) {
-        expectations.add(expectation);
+        expectations.add(new WrappedLoggingExpectation(expectation));
     }
 
     @Override
@@ -214,6 +217,38 @@ public class MockLogAppender extends AbstractAppender {
         return COMMON_PREFIX + name;
     }
 
+    /**
+     * A wrapper around {@link LoggingExpectation} to detect if the assertMatched method has been called
+     */
+    private static class WrappedLoggingExpectation implements LoggingExpectation {
+
+        private final AtomicBoolean assertMatchedCalled = new AtomicBoolean(false);
+        private final LoggingExpectation delegate;
+
+        private WrappedLoggingExpectation(LoggingExpectation delegate) {
+            this.delegate = Objects.requireNonNull(delegate);
+        }
+
+        @Override
+        public void match(LogEvent event) {
+            delegate.match(event);
+        }
+
+        @Override
+        public void assertMatched() {
+            try {
+                delegate.assertMatched();
+            } finally {
+                assertMatchedCalled.set(true);
+            }
+        }
+
+        @Override
+        public String toString() {
+            return delegate.toString();
+        }
+    }
+
     public Releasable capturing(Class<?>... classes) {
         start();
         final var loggers = Arrays.stream(classes).map(LogManager::getLogger).toArray(Logger[]::new);
@@ -225,6 +260,14 @@ public class MockLogAppender extends AbstractAppender {
                 Loggers.removeAppender(logger, this);
             }
             stop();
+            // check that all expectations have been evaluated before this is released
+            for (WrappedLoggingExpectation expectation : expectations) {
+                assertThat(
+                    "Method assertMatched() not called on LoggingExpectation instance before release: " + expectation,
+                    expectation.assertMatchedCalled.get(),
+                    is(true)
+                );
+            }
         };
     }
 }


### PR DESCRIPTION
Since #92748 `MockLogAppender` provides a nice `capturing` method that helps removing and stopping log appenders in try-catch-with-resources statements, but it's also easy to forget to evaluate all expectations before closing the MockLogAppender.

This change ensure that all expectations have been evaluated before the `Releasable` instance returns by `MockLogAppender.capturing()` is effectively released.

Relates https://github.com/elastic/elasticsearch/pull/92748#discussion_r1064437577