### PR TITLE
Fix 92551 with point touching edge

### DIFF
--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
@@ -137,6 +137,53 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
         }
     }
 
+    public void testKnownIssueWithCellIntersectingPolygonAndBoundingBox() throws IOException {
+        XContentBuilder xcb = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("properties")
+            .startObject("geometry")
+            .field("type", "geo_shape")
+            .endObject()
+            .endObject()
+            .endObject();
+        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
+
+        BulkRequestBuilder builder = client().prepareBulk();
+        builder.add(
+            new IndexRequest("test").source("{\"geometry\" : \"POINT (169.12088680200193 86.17678739494652)\"}", XContentType.JSON)
+        );
+        builder.add(
+            new IndexRequest("test").source("{\"geometry\" : \"POINT (169.12088680200193 86.17678739494652)\"}", XContentType.JSON)
+        );
+        String mp = "POLYGON ((150.0 70.0, 150.0 85.91811374669217, 168.77544806565834 85.91811374669217, 150.0 70.0))";
+        builder.add(new IndexRequest("test").source("{\"geometry\" : \"" + mp + "\"}", XContentType.JSON));
+
+        assertFalse(builder.get().hasFailures());
+        client().admin().indices().prepareRefresh("test").get();
+
+        // BBOX (172.21916569181505, -173.17785081207947, 86.17678739494652, 83.01600086049713)
+        GeoBoundingBox boundingBox = new GeoBoundingBox(
+            new GeoPoint(86.17678739494652, 172.21916569181505),
+            new GeoPoint(83.01600086049713, 179)
+        );
+        int precision = 4;
+        GeoGridAggregationBuilder builderPoint = new GeoHexGridAggregationBuilder("geometry").field("geometry")
+            .precision(precision)
+            .setGeoBoundingBox(boundingBox)
+            .size(256 * 256);
+        SearchResponse response = client().prepareSearch("test").addAggregation(builderPoint).setSize(0).get();
+        InternalGeoGrid<?> gridPoint = response.getAggregations().get("geometry");
+        for (InternalGeoGridBucket bucket : gridPoint.getBuckets()) {
+            assertThat(bucket.getDocCount(), Matchers.greaterThan(0L));
+            QueryBuilder queryBuilder = new GeoGridQueryBuilder("geometry").setGridId(
+                GeoGridQueryBuilder.Grid.GEOHEX,
+                bucket.getKeyAsString()
+            );
+            response = client().prepareSearch("test").setTrackTotalHits(true).setQuery(queryBuilder).get();
+            assertThat(response.getHits().getTotalHits().value, Matchers.equalTo(bucket.getDocCount()));
+        }
+    }
+
     private void doTestGeohashGrid(String fieldType, Supplier<Geometry> randomGeometriesSupplier) throws IOException {
         doTestGrid(
             1,
@@ -267,7 +314,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
             QueryBuilder queryBuilder = queryFunction.apply("geometry", bucket.getKeyAsString());
             SearchResponse response = client().prepareSearch("test").setTrackTotalHits(true).setQuery(queryBuilder).get();
             assertThat(
-                "Expected hits at precision " + precision,
+                "Expected hits at precision " + precision + " for H3 cell " + bucket.getKeyAsString(),
                 response.getHits().getTotalHits().value,
                 Matchers.equalTo(bucket.getDocCount())
             );

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitor.java
@@ -297,21 +297,21 @@ class GeoHexVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
         }
 
         boolean within = false;
-        if (edgeIntersectsQuery(aX, aY, bX, bY, false)) {
+        if (edgeIntersectsQuery(aX, aY, bX, bY, ab)) {
             if (ab) {
                 return GeoRelation.QUERY_CROSSES;
             }
             within = true;
         }
 
-        if (edgeIntersectsQuery(bX, bY, cX, cY, false)) {
+        if (edgeIntersectsQuery(bX, bY, cX, cY, bc)) {
             if (bc) {
                 return GeoRelation.QUERY_CROSSES;
             }
             within = true;
         }
 
-        if (edgeIntersectsQuery(cX, cY, aX, aY, false)) {
+        if (edgeIntersectsQuery(cX, cY, aX, aY, ca)) {
             if (ca) {
                 return GeoRelation.QUERY_CROSSES;
             }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexVisitor.java
@@ -234,7 +234,7 @@ class GeoHexVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
             return GeoRelation.QUERY_CONTAINS;
         }
         // 2. check crossings
-        if (edgeIntersectsQuery(aX, aY, bX, bY, true)) {
+        if (edgeIntersectsQuery(aX, aY, bX, bY)) {
             return GeoRelation.QUERY_CROSSES;
         }
         return GeoRelation.QUERY_DISJOINT;
@@ -297,21 +297,21 @@ class GeoHexVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
         }
 
         boolean within = false;
-        if (edgeIntersectsQuery(aX, aY, bX, bY, ab)) {
+        if (edgeIntersectsQuery(aX, aY, bX, bY)) {
             if (ab) {
                 return GeoRelation.QUERY_CROSSES;
             }
             within = true;
         }
 
-        if (edgeIntersectsQuery(bX, bY, cX, cY, bc)) {
+        if (edgeIntersectsQuery(bX, bY, cX, cY)) {
             if (bc) {
                 return GeoRelation.QUERY_CROSSES;
             }
             within = true;
         }
 
-        if (edgeIntersectsQuery(cX, cY, aX, aY, ca)) {
+        if (edgeIntersectsQuery(cX, cY, aX, aY)) {
             if (ca) {
                 return GeoRelation.QUERY_CROSSES;
             }
@@ -328,13 +328,13 @@ class GeoHexVisitor extends TriangleTreeVisitor.TriangleTreeDecodedVisitor {
     /**
      * returns true if the edge (defined by (ax, ay) (bx, by)) intersects the query
      */
-    private boolean edgeIntersectsQuery(double ax, double ay, double bx, double by, boolean includeBoundary) {
+    private boolean edgeIntersectsQuery(double ax, double ay, double bx, double by) {
         final double minX = Math.min(ax, bx);
         final double maxX = Math.max(ax, bx);
         final double minY = Math.min(ay, by);
         final double maxY = Math.max(ay, by);
         return boxesAreDisjoint(minX, maxX, minY, maxY) == false
-            && H3CartesianUtil.crossesLine(xs, ys, numPoints, crossesDateline, minX, maxX, minY, maxY, ax, ay, bx, by, includeBoundary);
+            && H3CartesianUtil.crossesLine(xs, ys, numPoints, crossesDateline, minX, maxX, minY, maxY, ax, ay, bx, by, true);
     }
 
     /**

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianGeometryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianGeometryTests.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.spatial.common;
+
+import org.apache.lucene.geo.Component2D;
+import org.apache.lucene.geo.LatLonGeometry;
+import org.apache.lucene.index.PointValues;
+import org.elasticsearch.h3.H3;
+import org.elasticsearch.test.ESTestCase;
+
+public class H3CartesianGeometryTests extends ESTestCase {
+    public void testPolarH3Crossing() {
+        long h3 = H3.geoToH3(-90, 0, 2);
+        Component2D component2D = LatLonGeometry.create(H3CartesianUtil.getLatLonGeometry(h3));
+        assertEquals(
+            PointValues.Relation.CELL_CROSSES_QUERY,
+            component2D.relate(-155.15317029319704, 163.99789148010314, -88.69673718698323, -88.26949733309448)
+        );
+    }
+}


### PR DESCRIPTION
If an H3 cell touches an outside polygon edge, it should be considered intersecting.
(labeled `non-issue` because this is a fix to an unreleased feature)

Fixes #92551 