### PR TITLE
Not propagating TimeoutException from Retry2::awaitClose

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
@@ -25,7 +25,6 @@ import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
 
@@ -237,7 +236,7 @@ public class BulkProcessor2 {
      * @param unit    The time unit of the {@code timeout} argument
      * @throws InterruptedException If the current thread is interrupted
      */
-    public void awaitClose(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+    public void awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
         synchronized (mutex) {
             if (closed) {
                 return;

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry2.java
@@ -119,14 +119,18 @@ class Retry2 {
      * @param timeout
      * @param unit
      */
-    void awaitClose(long timeout, TimeUnit unit) throws InterruptedException, TimeoutException {
+    void awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
         isClosing = true;
         /*
          * This removes the party that was placed in the phaser at initialization so that the phaser will terminate once all in-flight
          * requests have been completed (i.e. this makes it possible that the number of parties can become 0).
          */
         inFlightRequestsPhaser.arriveAndDeregister();
-        inFlightRequestsPhaser.awaitAdvanceInterruptibly(0, timeout, unit);
+        try {
+            inFlightRequestsPhaser.awaitAdvanceInterruptibly(0, timeout, unit);
+        } catch (TimeoutException e) {
+            logger.debug("Timed out waiting for all requests to complete during awaitClose");
+        }
     }
 
     /**

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.joining;
@@ -196,8 +195,6 @@ public class ILMHistoryStore implements Closeable {
         } catch (InterruptedException e) {
             logger.warn("failed to shut down ILM history bulk processor after 10 seconds", e);
             Thread.currentThread().interrupt();
-        } catch (TimeoutException e) {
-            logger.warn("failed to shut down ILM history bulk processor after 10 seconds", e);
         }
     }
 


### PR DESCRIPTION
The Retry2::awaitClose waits for the given amount of time for all requests to complete. If they don't, it currently throws a TimeoutException (through the call to inFlightRequestsPhaser.awaitAdvanceInterruptibly()). This is probably excessive, and could cause problems upstream since callers aren't expecting it and might not finish closing other resources. This PR changes Retry2::awaitClose so that it catches that TimeoutException and logs a message instead.