### PR TITLE
Convert smoke test multinode

### DIFF
--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -15,6 +15,7 @@ restResources {
 
 dependencies {
   clusterModules project(":modules:mapper-extras")
+  clusterModules project(":modules:ingest-common")
 }
 
 tasks.named("yamlRestTest").configure {

--- a/qa/smoke-test-multinode/build.gradle
+++ b/qa/smoke-test-multinode/build.gradle
@@ -5,12 +5,7 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
-
-
-import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.internal.info.BuildParams
-
-apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.internal-yaml-rest-test'
 
 restResources {
   restTests {
@@ -18,24 +13,11 @@ restResources {
   }
 }
 
-File repo = file("$buildDir/testclusters/repo")
-testClusters.matching { it.name == "yamlRestTest" }.configureEach {
-  numberOfNodes = 2
-  setting 'path.repo', repo.absolutePath
-  // The first node does not have the ingest role so we're sure ingest requests are forwarded:
-  nodes."yamlRestTest-0".setting 'node.roles', '[master,data,ml,remote_cluster_client,transform]'
-}
-
-testClusters.configureEach {
-  setting 'xpack.security.enabled', 'false'
-  requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
+dependencies {
+  clusterModules project(":modules:mapper-extras")
 }
 
 tasks.named("yamlRestTest").configure {
-  doFirst {
-    project.delete(repo)
-    repo.mkdirs()
-  }
   systemProperty 'tests.rest.blacklist', [
     'cat.templates/10_basic/No templates',
     'cat.templates/10_basic/Sort templates',

--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -30,6 +30,7 @@ public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTe
     private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .nodes(2)
         .module("mapper-extras")
+        .module("ingest-common")
         .setting("path.repo", () -> repoDirectory.getRoot().getPath())
         // The first node does not have the ingest role so we're sure ingest requests are forwarded:
         .node(0, n -> n.setting("node.roles", "[master,data,ml,remote_cluster_client,transform]"))

--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -13,11 +13,32 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 import com.carrotsearch.randomizedtesting.annotations.TimeoutSuite;
 
 import org.apache.lucene.tests.util.TimeUnits;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TemporaryFolder;
+import org.junit.rules.TestRule;
 
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
 public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
+
+    private static TemporaryFolder repoDirectory = new TemporaryFolder();
+
+    private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+        .nodes(2)
+        .module("mapper-extras")
+        .setting("path.repo", () -> repoDirectory.getRoot().getPath())
+        // The first node does not have the ingest role so we're sure ingest requests are forwarded:
+        .node(0, n -> n.setting("node.roles", "[master,data,ml,remote_cluster_client,transform]"))
+        .feature(FeatureFlag.TIME_SERIES_MODE)
+        .build();
+
+    @ClassRule
+    // Ensure the shared repo dir is created before cluster start
+    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
 
     public SmokeTestMultiNodeClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);
@@ -26,5 +47,10 @@ public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTe
     @ParametersFactory
     public static Iterable<Object[]> parameters() throws Exception {
         return ESClientYamlSuiteTestCase.createParameters();
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return cluster.getHttpAddresses();
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultEnvironmentProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultEnvironmentProvider.java
@@ -15,6 +15,7 @@ import org.elasticsearch.test.cluster.util.Version;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 public class DefaultEnvironmentProvider implements EnvironmentProvider {
     private static final String HOSTNAME_OVERRIDE = "LinuxDarwinHostname";
@@ -33,6 +34,9 @@ public class DefaultEnvironmentProvider implements EnvironmentProvider {
         // Override the system hostname variables for testing
         environment.put("HOSTNAME", HOSTNAME_OVERRIDE);
         environment.put("COMPUTERNAME", COMPUTERNAME_OVERRIDE);
+
+        // Use the same timezone as the test executor
+        environment.put("TZ", TimeZone.getDefault().getID());
 
         return environment;
     }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -226,14 +226,16 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
 
             try {
                 // Write settings to elasticsearch.yml
-                Map<String, String> pathSettings = new HashMap<>();
-                pathSettings.put("path.repo", workingDir.resolve("repo").toString());
-                pathSettings.put("path.data", workingDir.resolve("data").toString());
-                pathSettings.put("path.logs", workingDir.resolve("logs").toString());
+                Map<String, String> finalSettings = new HashMap<>();
+                finalSettings.put("path.repo", workingDir.resolve("repo").toString());
+                finalSettings.put("path.data", workingDir.resolve("data").toString());
+                finalSettings.put("path.logs", workingDir.resolve("logs").toString());
+                finalSettings.putAll(spec.resolveSettings());
 
                 Files.writeString(
                     configFile,
-                    Stream.concat(spec.resolveSettings().entrySet().stream(), pathSettings.entrySet().stream())
+                    finalSettings.entrySet()
+                        .stream()
                         .map(entry -> entry.getKey() + ": " + entry.getValue())
                         .collect(Collectors.joining("\n")),
                     StandardOpenOption.TRUNCATE_EXISTING,


### PR DESCRIPTION
Converts the `qa:smoke-test-multinode` project to use new junit testing framework.