### PR TITLE
[8.6] [TEST] FileSettingsRoleMappingsRestartIT - wait for green status (#92772)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -108,7 +108,6 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
         return new Tuple<>(savedClusterState, metadataVersion);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/pull/92454")
     public void testReservedStatePersistsOnRestart() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
 
@@ -126,6 +125,8 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
 
         logger.info("--> restart master");
         internalCluster().restartNode(masterNode);
+
+        ensureGreen();
 
         var clusterStateResponse = client().admin().cluster().state(new ClusterStateRequest()).actionGet();
         assertThat(


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [TEST] FileSettingsRoleMappingsRestartIT - wait for green status (#92772)