### PR TITLE
[8.6] [DOCS] Remove coming tag from 8.6.0 release notes (#92760)

### DIFF
--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.6.0]]
 == {es} version 8.6.0
 
-coming[8.6.0]
-
 Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 [[bug-8.6.0]]


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Remove coming tag from 8.6.0 release notes (#92760)