### PR TITLE
Enable profiling plugin by default

### DIFF
--- a/docs/changelog/92787.yaml
+++ b/docs/changelog/92787.yaml
@@ -1,0 +1,5 @@
+pr: 92787
+summary: Enable profiling plugin by default
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/ProfilingTestCase.java
+++ b/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/ProfilingTestCase.java
@@ -33,7 +33,6 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
-            .put(ProfilingPlugin.PROFILING_ENABLED.getKey(), true)
             .put(NetworkModule.TRANSPORT_TYPE_KEY, Netty4Plugin.NETTY_TRANSPORT_NAME)
             .put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME)
             .build();

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
@@ -30,7 +30,6 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
-import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -39,7 +38,6 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-import java.util.Locale;
 import java.util.function.Supplier;
 
 import static java.util.Collections.singletonList;
@@ -48,15 +46,12 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     private static final Logger logger = LogManager.getLogger(ProfilingPlugin.class);
     public static final Setting<Boolean> PROFILING_ENABLED = Setting.boolSetting(
         "xpack.profiling.enabled",
-        false,
+        true,
         Setting.Property.NodeScope
     );
-    private static final int REQUIRED_MAX_BUCKETS = 150_000;
-    private final Settings settings;
     private final boolean enabled;
 
     public ProfilingPlugin(Settings settings) {
-        this.settings = settings;
         this.enabled = PROFILING_ENABLED.get(settings);
     }
 
@@ -114,31 +109,6 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
     @Override
     public List<Setting<?>> getSettings() {
         return List.of(PROFILING_ENABLED);
-    }
-
-    @Override
-    public Settings additionalSettings() {
-        // workaround until https://github.com/elastic/elasticsearch/issues/91776 is implemented
-        final Settings.Builder builder = Settings.builder();
-        if (enabled) {
-            if (MultiBucketConsumerService.MAX_BUCKET_SETTING.exists(settings) == false) {
-                logger.debug("Overriding [{}] to [{}].", MultiBucketConsumerService.MAX_BUCKET_SETTING, REQUIRED_MAX_BUCKETS);
-                builder.put(MultiBucketConsumerService.MAX_BUCKET_SETTING.getKey(), REQUIRED_MAX_BUCKETS);
-            } else {
-                Integer configuredMaxBuckets = MultiBucketConsumerService.MAX_BUCKET_SETTING.get(settings);
-                if (configuredMaxBuckets != null && configuredMaxBuckets < REQUIRED_MAX_BUCKETS) {
-                    final String message = String.format(
-                        Locale.ROOT,
-                        "Profiling requires [%s] to be set at least to [%d] but was configured to [%d].",
-                        MultiBucketConsumerService.MAX_BUCKET_SETTING.getKey(),
-                        REQUIRED_MAX_BUCKETS,
-                        configuredMaxBuckets
-                    );
-                    throw new IllegalArgumentException(message);
-                }
-            }
-        }
-        return builder.build();
     }
 
     @Override


### PR DESCRIPTION
Originally the profiling plugin required to set `search.max_buckets` to a higher value than the current default. Had we enabled the profiling plugin by default, we would have changed the default value of that setting for all clusters implicitly. Due to a different bootstrapping process of the profiling solution, we do not require to change any settings anymore in the plugin. With this commit we therefore enable the plugin by default.

Relates #91640