### PR TITLE
[8.6][DOCS] Adds ML-CPP release notes

### DIFF
--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -62,9 +62,9 @@ Ingest Node::
 Machine Learning::
 * Copy more settings when creating DF analytics destination index {es-pull}91546[#91546] (issue: {es-issue}89795[#89795])
 * Fix for 'No statistics' error message {ml-pull}2410[#2410]
-* Fix for 'No counts available' error message. {ml-pull}2414[#2414]
+* Fix for 'No counts available' error message {ml-pull}2414[#2414]
 * Guard against input sequences that are too long for Question Answering models {es-pull}91924[#91924]
-* Improve performance of closing files before spawning. {ml-pull}2424[#2424]
+* Improve performance of closing files before spawning {ml-pull}2424[#2424]
 * Skip remote clusters when performing up front privileges validation for datafeeds {es-pull}91895[#91895] (issue: {es-issue}87832[#87832])
 * Support fields with commas in data frame analytics `analyzed_fields` {es-pull}91710[#91710] (issue: {es-issue}72541[#72541])
 * Validate rule filters are present on open anomaly detection api {es-pull}92207[#92207]

--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -61,10 +61,14 @@ Ingest Node::
 
 Machine Learning::
 * Copy more settings when creating DF analytics destination index {es-pull}91546[#91546] (issue: {es-issue}89795[#89795])
+* Fix for 'No statistics' error message {ml-pull}2410[#2410]
+* Fix for 'No counts available' error message. {ml-pull}2414[#2414]
 * Guard against input sequences that are too long for Question Answering models {es-pull}91924[#91924]
+* Improve performance of closing files before spawning. {ml-pull}2424[#2424]
 * Skip remote clusters when performing up front privileges validation for datafeeds {es-pull}91895[#91895] (issue: {es-issue}87832[#87832])
 * Support fields with commas in data frame analytics `analyzed_fields` {es-pull}91710[#91710] (issue: {es-issue}72541[#72541])
 * Validate rule filters are present on open anomaly detection api {es-pull}92207[#92207]
+
 
 Mapping::
 * Consolidate field name validation when parsing mappings and documents {es-pull}91328[#91328]


### PR DESCRIPTION
## Overview

This PR adds the ML-related release notes from the ML-CPP repo to the 8.6 release notes.
Changelog: https://github.com/elastic/ml-cpp/blob/8.6/docs/CHANGELOG.asciidoc

### Preview

[8.6 release notes](https://elasticsearch_92790.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.6/release-notes-8.6.0.html)