### PR TITLE
[8.6] Fix typo in expected header warning in update-by-query test (#92791)

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/110_update_by_query.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/110_update_by_query.yml
@@ -114,7 +114,7 @@
 
   - do:
       allowed_warnings:
-        - "index template [my-template2] has index patterns [simple-stream*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+        - "index template [my-template2] has index patterns [simple-stream*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template2] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template2
         body:


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix typo in expected header warning in update-by-query test (#92791)