### PR TITLE
Improve efficiency of nested Gradle builds

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -44,3 +44,9 @@ fi
 ## therefore we run main _AFTER_ we run 6.8 which uses an earlier gradle version
 export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
 ./gradlew --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none
+
+## Copy all dependencies into a "read-only" location to be used by nested Gradle builds
+mkdir -p ${HOME}/gradle_ro_cache
+cp -R ${HOME}/.gradle/caches/modules-2 ${HOME}/gradle_ro_cache
+rm ${HOME}/gradle_ro_cache/modules-2/gc.properties
+rm ${HOME}/gradle_ro_cache/modules-2/*.lock

--- a/build-tools-internal/build.gradle
+++ b/build-tools-internal/build.gradle
@@ -336,6 +336,10 @@ tasks.register("bootstrapPerformanceTests", Copy) {
           branchWrapper:"${-> gradle.gradleVersion}".toString()])
 }
 
+tasks.named("jar") {
+  exclude("classpath.index")
+}
+
 def resolveMainWrapperVersion() {
   new URL("https://raw.githubusercontent.com/elastic/elasticsearch/main/build-tools-internal/src/main/resources/minimumGradleVersion").text.trim()
 }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -237,11 +237,7 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
             } else {
                 c.getOutputs().files(expectedOutputFile);
             }
-            c.getOutputs().cacheIf("BWC distribution caching is disabled on 'main' branch", task -> {
-                String gitBranch = System.getenv("GIT_BRANCH");
-                return BuildParams.isCi()
-                    && (gitBranch == null || gitBranch.endsWith("master") == false || gitBranch.endsWith("main") == false);
-            });
+            c.getOutputs().doNotCacheIf("BWC distribution caching is disabled for local builds", task -> BuildParams.isCi() == false);
             c.getArgs().add(projectPath.replace('/', ':') + ":" + assembleTaskName);
             if (project.getGradle().getStartParameter().isBuildCacheEnabled()) {
                 c.getArgs().add("--build-cache");

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionBwcSetupPlugin.java
@@ -18,6 +18,7 @@ import org.gradle.api.Project;
 import org.gradle.api.Task;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.provider.ProviderFactory;
+import org.gradle.api.tasks.Copy;
 import org.gradle.api.tasks.TaskProvider;
 import org.gradle.language.base.plugins.LifecycleBasePlugin;
 
@@ -76,6 +77,15 @@ public class InternalDistributionBwcSetupPlugin implements Plugin<Project> {
 
         TaskProvider<Task> buildBwcTaskProvider = project.getTasks().register("buildBwc");
         List<DistributionProject> distributionProjects = resolveArchiveProjects(checkoutDir.get(), bwcVersion.get());
+
+        // Setup gradle user home directory
+        project.getTasks().register("setupGradleUserHome", Copy.class, copy -> {
+            copy.into(project.getGradle().getGradleUserHomeDir().getAbsolutePath() + "-" + project.getName());
+            copy.from(project.getGradle().getGradleUserHomeDir().getAbsolutePath(), copySpec -> {
+                copySpec.include("gradle.properties");
+                copySpec.include("init.d/*");
+            });
+        });
 
         for (DistributionProject distributionProject : distributionProjects) {
             createBuildBwcTask(


### PR DESCRIPTION
This is a follow up to #92159 to sort out some issues with using unique Gradle users homes for nested builds. First, we weren't using global init scripts located in the parent Gradle user home `init.d` folder. Second, since we're using a new Gradle user home, that means we're also using empty caches directories, meaning the nested jobs need to redownload a bunch of artifact dependencies. This commit updates our packer-cache.sh script to create a read only copy of the Gradle artifact cache which can then be used by concurrent nested build safely without running into lock contention.