### PR TITLE
Deserialized timeZone with DateUtils in RangeQueryBuilder -- ISSUE # 38449

### DIFF
--- a/docs/changelog/92805.yaml
+++ b/docs/changelog/92805.yaml
@@ -2,5 +2,4 @@ pr: 92805
 summary: added import for DateUtils and changed 'readOptionalZoneId() to dateTimeZoneToZoneId()'
 area: Core/Infra
 type: bug
-issues:
- - 92805
+issues: []

--- a/docs/changelog/92805.yaml 
+++ b/docs/changelog/92805.yaml 
@@ -1,0 +1,6 @@
+pr: 92805
+summary: added import for DateUtils and changed 'readOptionalZoneId() to dateTimeZoneToZoneId()'
+area: Core/Infra
+type: bug
+issues:
+ - 92805

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateMathParser;
+import org.elasticsearch.common.time.DateUtils;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -83,7 +84,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
         to = in.readGenericValue();
         includeLower = in.readBoolean();
         includeUpper = in.readBoolean();
-        timeZone = in.readOptionalZoneId();
+        timeZone = in.dateTimeZoneToZoneId();
         format = in.readOptionalString();
         String relationString = in.readOptionalString();
         if (relationString != null) {


### PR DESCRIPTION
Addressing issue #38449
- added import for DateUtils
- changed 'readOptionalZoneId() to dateTimeZoneToZoneId()'

