### PR TITLE
[8.5] [Doc] Fix typo in the JWT realm doc (#92779)

### DIFF
--- a/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
@@ -79,8 +79,8 @@ ascending order, where the realm with the lowest order value is consulted first.
 Specifies the client authentication type as `shared_secret`, which means that
 the client is authenticated using an HTTP request header that must match a
 pre-configured secret value. The client must provide this shared secret with
-every request in the `ES-Client-Authentication` header. The value must be a
-case-insensitive match to the realm's `client_authentication.shared_secret`.
+every request in the `ES-Client-Authentication` header. The header value must be a
+case-sensitive match to the realm's `client_authentication.shared_secret`.
 
 `allowed_issuer`::
 Sets a verifiable identifier for your JWT issuer. This value is typically a


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [Doc] Fix typo in the JWT realm doc (#92779)