### PR TITLE
Adjust doc about dangling indices after node is detached from cluster

### DIFF
--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -285,11 +285,13 @@ Unsafe cluster bootstrapping is only possible if there is at least one
 surviving master-eligible node. If there are no remaining master-eligible nodes
 then the cluster metadata is completely lost. However, the individual data
 nodes also contain a copy of the index metadata corresponding with their
-shards. This sometimes allows a new cluster to import these shards as
-<<modules-gateway-dangling-indices,dangling indices>>. You can sometimes
-recover some indices after the loss of all master-eligible nodes in a cluster
-by creating a new cluster and then using the `elasticsearch-node
-detach-cluster` command to move any surviving nodes into this new cluster.
+shards. It is therefore sometimes possible to manually import these shards as
+<<dangling-indices,dangling indices>>. For example you can sometimes recover some
+indices after the loss of all master-eligible nodes in a cluster by creating a new
+cluster and then using the `elasticsearch-node detach-cluster` command to move any
+surviving nodes into this new cluster. Once the new cluster is fully formed then
+the <<dangling-indices-api,Dangling indices API>> can be used to list the dangling
+indices that can be imported.
 
 There is a risk of data loss when importing a dangling index because data nodes
 may not have the most recent copy of the index metadata and do not have any
@@ -318,7 +320,9 @@ cluster`.
 <<modules-discovery-hosts-providers,discover the new cluster>>.
 6. Start each data node and verify that it has joined the new cluster.
 7. Wait for all recoveries to have completed, and investigate the data in the
-cluster to discover if any was lost during this process.
+cluster to discover if any was lost during this process. Use the
+<<dangling-indices-api,Dangling indices API>> to list, import or delete any
+dangling indices.
 
 The message `Node was successfully detached from the cluster` does not mean
 that there has been no data loss, it just means that tool was able to complete

--- a/docs/reference/commands/node-tool.asciidoc
+++ b/docs/reference/commands/node-tool.asciidoc
@@ -289,9 +289,9 @@ shards. It is therefore sometimes possible to manually import these shards as
 <<dangling-indices,dangling indices>>. For example you can sometimes recover some
 indices after the loss of all master-eligible nodes in a cluster by creating a new
 cluster and then using the `elasticsearch-node detach-cluster` command to move any
-surviving nodes into this new cluster. Once the new cluster is fully formed then
-the <<dangling-indices-api,Dangling indices API>> can be used to list the dangling
-indices that can be imported.
+surviving nodes into this new cluster. Once the new cluster is fully formed,
+use the <<dangling-indices-api,Dangling indices API>> to list, import or delete
+any dangling indices.
 
 There is a risk of data loss when importing a dangling index because data nodes
 may not have the most recent copy of the index metadata and do not have any


### PR DESCRIPTION
Dangling indices are not imported automatically  since 8.0 but the `elasticsearch-node detach-cluster` documentation still suggests it is. It tried to make it more explicit by listing the Dangling API to use and by using the work "manually".