### PR TITLE
[ML] Adapt for backport and reenable BWC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -137,9 +137,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = false
+boolean bwc_tests_enabled = true
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/92359"
+String bwc_tests_disabled_issue = ""
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -329,8 +329,8 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public Response(StreamInput in) throws IOException {
             super(in);
 
-            // Multiple results added in 8.7.0
-            if (in.getVersion().onOrAfter(Version.V_8_7_0)) {
+            // Multiple results added in 8.6.1
+            if (in.getVersion().onOrAfter(Version.V_8_6_1)) {
                 results = in.readNamedWriteableList(InferenceResults.class);
             } else {
                 results = List.of(in.readNamedWriteable(InferenceResults.class));
@@ -341,7 +341,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
 
-            if (out.getVersion().onOrAfter(Version.V_8_7_0)) {
+            if (out.getVersion().onOrAfter(Version.V_8_6_1)) {
                 out.writeNamedWriteableList(results);
             } else {
                 out.writeNamedWriteable(results.get(0));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentResponseTests.java
@@ -62,7 +62,7 @@ public class InferTrainedModelDeploymentResponseTests extends AbstractBWCWireSer
         InferTrainedModelDeploymentAction.Response instance,
         Version version
     ) {
-        if (version.before(Version.V_8_7_0)) {
+        if (version.before(Version.V_8_6_1)) {
             return new InferTrainedModelDeploymentAction.Response(instance.getResults().subList(0, 1));
         }
 


### PR DESCRIPTION
Reenable BWC tests after merging #92359 and its backport #92819