### PR TITLE
[DOCS] Remove coming tag from the 8.5 migration guide

### DIFF
--- a/docs/reference/migration/migrate_8_5.asciidoc
+++ b/docs/reference/migration/migrate_8_5.asciidoc
@@ -9,9 +9,6 @@ your application to {es} 8.5.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.5.0]
-
-
 [discrete]
 [[breaking-changes-8.5]]
 === Breaking changes


### PR DESCRIPTION
This PR removes the "Coming in 8.5.0" text from the 8.5 migration guide.