### PR TITLE
[8.6] [DOCS] Remove coming tag from 8.6 migration guide (#92827)

### DIFF
--- a/docs/reference/migration/migrate_8_6.asciidoc
+++ b/docs/reference/migration/migrate_8_6.asciidoc
@@ -9,9 +9,6 @@ your application to {es} 8.6.
 
 See also <<release-highlights>> and <<es-release-notes>>.
 
-coming::[8.6.0]
-
-
 [discrete]
 [[breaking-changes-8.6]]
 === Breaking changes


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Remove coming tag from 8.6 migration guide (#92827)