### PR TITLE
[Docs] Update remove processor with 'keep' option

### DIFF
--- a/docs/reference/ingest/processors/remove.asciidoc
+++ b/docs/reference/ingest/processors/remove.asciidoc
@@ -13,6 +13,7 @@ Removes existing fields. If one field doesn't exist, an exception will be thrown
 | Name             | Required  | Default  | Description
 | `field`          | yes       | -        | Fields to be removed. Supports <<template-snippets,template snippets>>.
 | `ignore_missing` | no        | `false`  | If `true` and `field` does not exist or is `null`, the processor quietly exits without modifying the document
+| `keep`           | no        | -        | Fields to be kept. When set, all fields other than those specified are removed.
 include::common-options.asciidoc[]
 |======
 
@@ -35,6 +36,18 @@ To remove multiple fields, you can use the following query:
 {
   "remove": {
     "field": ["user_agent", "url"]
+  }
+}
+--------------------------------------------------
+// NOTCONSOLE
+
+You can also choose to remove all fields other than a specified list:
+
+[source,js]
+--------------------------------------------------
+{
+  "remove": {
+    "keep": ["url"]
   }
 }
 --------------------------------------------------


### PR DESCRIPTION
Docs for the [remove processor](https://www.elastic.co/guide/en/elasticsearch/reference/current/remove-processor.html) were missing the nice, new `keep` option added in v8.2 via #83665.

Closes #92826