### PR TITLE
Fix reference to location of read-only Gradle dependency cache

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -43,7 +43,7 @@ fi
 ## Gradle is able to resolve dependencies resolved with earlier gradle versions
 ## therefore we run main _AFTER_ we run 6.8 which uses an earlier gradle version
 export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
-./gradlew --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none
+./gradlew --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none -Drecurse.bwc=true
 
 ## Copy all dependencies into a "read-only" location to be used by nested Gradle builds
 mkdir -p ${HOME}/gradle_ro_cache

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -52,12 +52,21 @@ public class BwcSetupExtension {
     }
 
     TaskProvider<LoggedExec> bwcTask(String name, Action<LoggedExec> configuration) {
-        return createRunBwcGradleTask(project, name, configuration);
+        return bwcTask(name, configuration, true);
     }
 
-    private TaskProvider<LoggedExec> createRunBwcGradleTask(Project project, String name, Action<LoggedExec> configAction) {
+    TaskProvider<LoggedExec> bwcTask(String name, Action<LoggedExec> configuration, boolean useUniqueUserHome) {
+        return createRunBwcGradleTask(project, name, configuration, useUniqueUserHome);
+    }
+
+    private TaskProvider<LoggedExec> createRunBwcGradleTask(
+        Project project,
+        String name,
+        Action<LoggedExec> configAction,
+        boolean useUniqueUserHome
+    ) {
         return project.getTasks().register(name, LoggedExec.class, loggedExec -> {
-            loggedExec.dependsOn("checkoutBwcBranch", "setupGradleUserHome");
+            loggedExec.dependsOn("checkoutBwcBranch");
             loggedExec.getWorkingDir().set(checkoutDir.get());
 
             loggedExec.getEnvironment().put("JAVA_HOME", unreleasedVersionInfo.zip(checkoutDir, (version, checkoutDir) -> {
@@ -76,7 +85,11 @@ public class BwcSetupExtension {
                 loggedExec.getExecutable().set(new File(checkoutDir.get(), "gradlew").toString());
             }
 
-            loggedExec.args("-g", project.getGradle().getGradleUserHomeDir().getAbsolutePath() + "-" + project.getName());
+            if (useUniqueUserHome) {
+                loggedExec.dependsOn("setupGradleUserHome");
+                loggedExec.args("-g", project.getGradle().getGradleUserHomeDir().getAbsolutePath() + "-" + project.getName());
+            }
+
             if (project.getGradle().getStartParameter().isOffline()) {
                 loggedExec.args("--offline");
             }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/BwcSetupExtension.java
@@ -66,7 +66,7 @@ public class BwcSetupExtension {
             }));
 
             if (BuildParams.isCi() && Os.isFamily(Os.FAMILY_WINDOWS) == false) {
-                loggedExec.getEnvironment().put("GRADLE_RO_DEP_CACHE", "$HOME/gradle_ro_cache");
+                loggedExec.getEnvironment().put("GRADLE_RO_DEP_CACHE", System.getProperty("user.home") + "/gradle_ro_cache");
             }
 
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -15,10 +15,10 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 BuildParams.getBwcVersions().forPreviousUnreleased { unreleasedVersion ->
     project(unreleasedVersion.gradleProjectPath) {
         Version currentVersion = Version.fromString(version)
-        TaskProvider<Task> resolveAllBwcDepsTaskProvider = bwcSetup.bwcTask("resolveAllBwcDependencies") {
+        TaskProvider<Task> resolveAllBwcDepsTaskProvider = bwcSetup.bwcTask("resolveAllBwcDependencies", {
             t -> t.args("resolveAllDependencies", "-Dorg.gradle.warning.mode=none")
-        }
-        if (currentVersion.getMinor() == 0 && currentVersion.getRevision() == 0) {
+        }, false)
+        if (Boolean.getBoolean("recurse.bwc")) {
             // We only want to resolve dependencies for live versions of main, without cascading this to older versions
             tasks.named("resolveAllDependencies").configure {
                 dependsOn(resolveAllBwcDepsTaskProvider)


### PR DESCRIPTION
Environment variable of course only works in the context of a shell. Instead of using `$HOME` just reference the `user.home` system property here.