### PR TITLE
Avoid eager creation of rest test tasks

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -107,7 +107,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
 
         });
 
-        project.getTasks().withType(StandaloneRestIntegTestTask.class, task -> {
+        project.getTasks().withType(StandaloneRestIntegTestTask.class).configureEach(task -> {
             SystemPropertyCommandLineArgumentProvider nonInputSystemProperties = task.getExtensions()
                 .getByType(SystemPropertyCommandLineArgumentProvider.class);
 


### PR DESCRIPTION
The standard Gradle `withType()` method that takes an action is the "legacy" API which realizes tasks eagerly. To avoid this, we need to explicitly use `configureEach()` to pass our configuration action.
