### PR TITLE
[7.17] Avoid eager creation of rest test tasks (#92855)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -105,7 +105,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
 
         });
 
-        project.getTasks().withType(StandaloneRestIntegTestTask.class, task -> {
+        project.getTasks().withType(StandaloneRestIntegTestTask.class).configureEach(task -> {
             SystemPropertyCommandLineArgumentProvider nonInputSystemProperties = task.getExtensions()
                 .getByType(SystemPropertyCommandLineArgumentProvider.class);
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Avoid eager creation of rest test tasks (#92855)