### PR TITLE
[Docs] Remove params['_source'] from runtime scripts

### DIFF
--- a/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
+++ b/docs/painless/painless-contexts/painless-runtime-fields-context.asciidoc
@@ -73,10 +73,6 @@ The signature for `emit` depends on the `type` of the field.
         Contains the fields of the specified document where each field is a
         `List` of values.
 
-{ref}/mapping-source-field.html[`params['_source']`] (`Map`, read-only)::
-        Contains extracted JSON in a `Map` and `List` structure for the fields
-        existing in a stored document.
-
 *Return*
 
 `void`::


### PR DESCRIPTION
The type `params['_source']` is not supported for runtime fields, so this removes it from the [Runtime fields context page](https://www.elastic.co/guide/en/elasticsearch/painless/8.6/painless-runtime-fields-context.html).

Closes #92850