### PR TITLE
Support retrieving inlined stack frames

### DIFF
--- a/docs/changelog/92863.yaml
+++ b/docs/changelog/92863.yaml
@@ -1,0 +1,5 @@
+pr: 92863
+summary: Support retrieving inlined stack frames
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
+++ b/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.profiler;
 
 import org.elasticsearch.rest.RestStatus;
 
+import java.util.List;
+
 public class GetProfilingActionIT extends ProfilingTestCase {
     @Override
     protected boolean useOnlyAllEvents() {
@@ -29,7 +31,7 @@ public class GetProfilingActionIT extends ProfilingTestCase {
 
         assertNotNull(response.getStackFrames());
         StackFrame stackFrame = response.getStackFrames().get("QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf");
-        assertEquals("_raw_spin_unlock_irqrestore", stackFrame.functionName);
+        assertEquals(List.of("_raw_spin_unlock_irqrestore", "inlined_frame_1", "inlined_frame_0"), stackFrame.functionName);
         assertNotNull(response.getStackTraceEvents());
         assertEquals(1, (int) response.getStackTraceEvents().get("QjoLteG7HX3VUUXr-J4kHQ"));
 

--- a/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/ProfilingTestCase.java
+++ b/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/ProfilingTestCase.java
@@ -101,7 +101,7 @@ public abstract class ProfilingTestCase extends ESIntegTestCase {
         indexDoc(
             "profiling-stackframes",
             "QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf",
-            Map.of("Stackframe.function.name", "_raw_spin_unlock_irqrestore")
+            Map.of("Stackframe.function.name", List.of("_raw_spin_unlock_irqrestore", "inlined_frame_1", "inlined_frame_0"))
         );
         indexDoc("profiling-executables", "QCCDqjSg3bMK1C4YRK6Tiw", Map.of("Executable.file.name", "libc.so.6"));
 

--- a/x-pack/plugin/profiler/src/internalClusterTest/resources/stackframes.json
+++ b/x-pack/plugin/profiler/src/internalClusterTest/resources/stackframes.json
@@ -8,32 +8,32 @@
   "mappings": {
     "_doc": {
       "_source": {
-        "mode": "synthetic"
+        "enabled": true
       },
       "properties": {
         "ecs.version": {
           "type": "keyword",
-          "index": true
+          "index": true,
+          "doc_values": false,
+          "store": false
         },
         "Stackframe.line.number": {
           "type": "integer",
-          "index": false
+          "index": false,
+          "doc_values": false,
+          "store": false
         },
         "Stackframe.file.name": {
           "type": "keyword",
-          "index": false
-        },
-        "Stackframe.source.type": {
-          "type": "short",
-          "index": false
+          "index": false,
+          "doc_values": false,
+          "store": false
         },
         "Stackframe.function.name": {
           "type": "keyword",
-          "index": false
-        },
-        "Stackframe.function.offset": {
-          "type": "integer",
-          "index": false
+          "index": false,
+          "doc_values": false,
+          "store": false
         }
       }
     }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -46,11 +46,11 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
             ? in.readMap(
                 StreamInput::readString,
                 i -> new StackFrame(
-                    i.readOptionalString(),
-                    i.readOptionalString(),
-                    i.readOptionalInt(),
-                    i.readOptionalInt(),
-                    i.readOptionalInt()
+                    i.readList(StreamInput::readString),
+                    i.readList(StreamInput::readString),
+                    i.readList(StreamInput::readInt),
+                    i.readList(StreamInput::readInt),
+                    i.readList(StreamInput::readInt)
                 )
             )
             : null;
@@ -106,11 +106,11 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         if (stackFrames != null) {
             out.writeBoolean(true);
             out.writeMap(stackFrames, StreamOutput::writeString, (o, v) -> {
-                o.writeOptionalString(v.fileName);
-                o.writeOptionalString(v.functionName);
-                o.writeOptionalInt(v.functionOffset);
-                o.writeOptionalInt(v.lineNumber);
-                o.writeOptionalInt(v.sourceType);
+                o.writeCollection(v.fileName, StreamOutput::writeString);
+                o.writeCollection(v.functionName, StreamOutput::writeString);
+                o.writeCollection(v.functionOffset, StreamOutput::writeInt);
+                o.writeCollection(v.lineNumber, StreamOutput::writeInt);
+                o.writeCollection(v.sourceType, StreamOutput::writeInt);
             });
         } else {
             out.writeBoolean(false);

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
@@ -12,32 +12,60 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 final class StackFrame implements ToXContentObject {
-    String fileName;
-    String functionName;
-    Integer functionOffset;
-    Integer lineNumber;
-    Integer sourceType;
+    List<String> fileName;
+    List<String> functionName;
+    List<Integer> functionOffset;
+    List<Integer> lineNumber;
+    List<Integer> sourceType;
 
-    StackFrame(String fileName, String functionName, Integer functionOffset, Integer lineNumber, Integer sourceType) {
-        this.fileName = fileName;
-        this.functionName = functionName;
-        this.functionOffset = functionOffset;
-        this.lineNumber = lineNumber;
-        this.sourceType = sourceType;
+    StackFrame(Object fileName, Object functionName, Object functionOffset, Object lineNumber, Object sourceType) {
+        this.fileName = listOf(fileName);
+        this.functionName = listOf(functionName);
+        this.functionOffset = listOf(functionOffset);
+        this.lineNumber = listOf(lineNumber);
+        this.sourceType = listOf(sourceType);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> List<T> listOf(Object o) {
+        if (o instanceof List) {
+            return (List<T>) o;
+        } else if (o != null) {
+            return List.of((T) o);
+        } else {
+            return Collections.emptyList();
+        }
     }
 
     public static StackFrame fromSource(Map<String, Object> source) {
-        return new StackFrame(
-            ObjectPath.eval("Stackframe.file.name", source),
-            ObjectPath.eval("Stackframe.function.name", source),
-            ObjectPath.eval("Stackframe.function.offset", source),
-            ObjectPath.eval("Stackframe.line.number", source),
-            ObjectPath.eval("Stackframe.source.type", source)
-        );
+        // stack frames may either be stored with synthetic source or regular one
+        // which results either in a nested or flat document structure.
+
+        if (source.containsKey("Stackframe")) {
+            // synthetic source
+            return new StackFrame(
+                ObjectPath.eval("Stackframe.file.name", source),
+                ObjectPath.eval("Stackframe.function.name", source),
+                ObjectPath.eval("Stackframe.function.offset", source),
+                ObjectPath.eval("Stackframe.line.number", source),
+                ObjectPath.eval("Stackframe.source.type", source)
+            );
+        } else {
+            // regular source
+            return new StackFrame(
+                source.get("Stackframe.file.name"),
+                source.get("Stackframe.function.name"),
+                source.get("Stackframe.function.offset"),
+                source.get("Stackframe.line.number"),
+                source.get("Stackframe.source.type")
+            );
+        }
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -37,15 +37,16 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
                 )
             )
         );
+        int maxInlined = randomInt(5);
         Map<String, StackFrame> stackFrames = randomNullable(
             Map.of(
                 "QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf",
                 new StackFrame(
-                    randomNullable(() -> randomAlphaOfLength(20)),
-                    randomNullable(() -> randomAlphaOfLength(20)),
-                    randomNullable(() -> randomIntBetween(1, Integer.MAX_VALUE)),
-                    randomNullable(() -> randomIntBetween(1, 30_000)),
-                    randomNullable(() -> randomIntBetween(1, 10))
+                    randomList(0, maxInlined, () -> randomAlphaOfLength(20)),
+                    randomList(0, maxInlined, () -> randomAlphaOfLength(20)),
+                    randomList(0, maxInlined, () -> randomIntBetween(1, Integer.MAX_VALUE)),
+                    randomList(0, maxInlined, () -> randomIntBetween(1, 30_000)),
+                    randomList(0, maxInlined, () -> randomIntBetween(1, 10))
                 )
             )
         );


### PR DESCRIPTION
With this commit we modify the response of the profiling plugin so that it can contain more than one entry per stack frame. This is useful to convey which frames have been inlined into an actually observed stack frame. The profiling plugin also adds a compatibility mode that allows to map stack frames both from synthetic source as well as regular source.
