### PR TITLE
Remove accidentaly added parameter to ListSetting

### DIFF
--- a/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/settings/ListSetting.java
+++ b/libs/plugin-api/src/main/java/org/elasticsearch/plugin/api/settings/ListSetting.java
@@ -23,6 +23,4 @@ public @interface ListSetting {
      * A name of a setting
      */
     String path();
-
-    String[] def() default {};
 }


### PR DESCRIPTION
I accidentally added a parameter to ListSetting https://github.com/elastic/elasticsearch/pull/92334#. 
this commit removes it
