### PR TITLE
Cache the creation of parsers within `DateProcessor` 

### DIFF
--- a/docs/changelog/92880.yaml
+++ b/docs/changelog/92880.yaml
@@ -1,0 +1,5 @@
+pr: 92880
+summary: Cache the creation of parsers within DateProcessor
+area: Ingest Node
+type: enhancement
+issues: []

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -36,11 +36,10 @@ enum DateFormat {
         @Override
         Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale) {
             return (date) -> {
-                TemporalAccessor accessor = DateFormatter.forPattern("iso8601").parse(date);
+                TemporalAccessor accessor = ISO_8601.parse(date);
                 // even though locale could be set to en-us, Locale.ROOT (following iso8601 calendar data rules) should be used
                 return DateFormatters.from(accessor, Locale.ROOT, timezone).withZoneSameInstant(timezone);
             };
-
         }
     },
     Unix {
@@ -114,6 +113,14 @@ enum DateFormat {
             };
         }
     };
+
+    /** It's important to keep this variable as a constant because {@link DateFormatter#forPattern(String)} is an expensive method and,
+     * in this case, it's a never changing value.
+     * <br>
+     * Also, we shouldn't inline it in the {@link DateFormat#Iso8601}'s enum because it'd make useless the cache used
+     * at {@link DateProcessor}).
+     */
+    private static final DateFormatter ISO_8601 = DateFormatter.forPattern("iso8601");
 
     abstract Function<String, ZonedDateTime> getFunction(String format, ZoneId timezone, Locale locale);
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -24,9 +24,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class DateProcessorTests extends ESTestCase {
 
@@ -334,5 +340,32 @@ public class DateProcessorTests extends ESTestCase {
         // output format is time only with nanosecond precision
         String expectedDate = "00:00:00." + Strings.format("%09d", nanosAfterEpoch);
         assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo(expectedDate));
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testCacheIsEvictedAfterReachMaxCapacity() {
+        Supplier<Function<String, ZonedDateTime>> supplier1 = mock(Supplier.class);
+        Supplier<Function<String, ZonedDateTime>> supplier2 = mock(Supplier.class);
+        Function<String, ZonedDateTime> zonedDateTimeFunction1 = str -> ZonedDateTime.now();
+        Function<String, ZonedDateTime> zonedDateTimeFunction2 = str -> ZonedDateTime.now();
+        var cache = new DateProcessor.Cache(1);
+        var key1 = new DateProcessor.Cache.Key("format-1", ZoneId.systemDefault(), Locale.ROOT);
+        var key2 = new DateProcessor.Cache.Key("format-2", ZoneId.systemDefault(), Locale.ROOT);
+
+        when(supplier1.get()).thenReturn(zonedDateTimeFunction1);
+        when(supplier2.get()).thenReturn(zonedDateTimeFunction2);
+
+        assertEquals(cache.getOrCompute(key1, supplier1), zonedDateTimeFunction1); // 1 call to supplier1
+        assertEquals(cache.getOrCompute(key2, supplier2), zonedDateTimeFunction2); // 1 call to supplier2
+        assertEquals(cache.getOrCompute(key1, supplier1), zonedDateTimeFunction1); // 1 more call to supplier1
+        assertEquals(cache.getOrCompute(key1, supplier1), zonedDateTimeFunction1); // should use cached value
+        assertEquals(cache.getOrCompute(key2, supplier2), zonedDateTimeFunction2); // 1 more call to supplier2
+        assertEquals(cache.getOrCompute(key2, supplier2), zonedDateTimeFunction2); // should use cached value
+        assertEquals(cache.getOrCompute(key2, supplier2), zonedDateTimeFunction2); // should use cached value
+        assertEquals(cache.getOrCompute(key2, supplier2), zonedDateTimeFunction2); // should use cached value
+        assertEquals(cache.getOrCompute(key1, supplier1), zonedDateTimeFunction1); // 1 more to call to supplier1
+
+        verify(supplier1, times(3)).get();
+        verify(supplier2, times(2)).get();
     }
 }


### PR DESCRIPTION
This PR introduces a cache mechanism within the `DateProcessor` class. This cache helps to memoize the creation of expensive objects, which are created through calls to `DateFormatter.forPattern(...)` method and other expensive methods.

We have benchmarked the change, obtaining an increase in performance between 10% and 80% for some of the `logging` benchmarks (`~80% for logs-postgresql.log-1.2.0`). 

# Benchmark

* Benchmarked using esbench (use-case=simple, track.name=`elastic/logs`)
* Beckhmarked 2 caches (size 16 & 64). There's a slight difference in processing time between them (200ns - 1ms), with the smaller cache as a winner. 
* Below results are summarised ([Full results](https://gist.github.com/HiDAl/f66ac8261499aaef944bc5c5595eca52))


## BASELINE
```
Ingest Summary:
===============
          count  time_in_millis  time_in_nanos
total  32367760         1532279          47340

Pipeline Summary:
=================
                                          count  time_in_millis  time_in_nanos  percent
logs-nginx.access-1.2.0                 1769000          188822         106740    24.0%
logs-postgresql.log-1.2.0                320000          185256         578924    23.6%
logs-system.syslog-1.6.4                2234000          109214          48888    13.9%
logs-system.auth-1.6.4                   195881           72172         368447     9.2%
logs-redis.log-1.1.0                    1600000           50652          31658     6.4%
.fleet_final_pipeline-1                 9398881           47060           5007     6.0%
logs-kafka.log-0.5.0                     640000           28595          44680     3.6%
logs-apache.access-1.3.0                 320000           27248          85150     3.5%
logs-mysql.error-1.1.0                   560000           24513          43774     3.1%
logs-apache.error-1.3.0                  320000           19929          62278     2.5%
logs-postgresql.log-1.2.0-pipeline-log   320000           14646          45769     1.9%
logs-nginx.error-1.2.0                   320000           12374          38669     1.6%
logs-mysql.slowlog-1.1.0                 160000            5424          33900     0.7%

```

## CACHE OF SIZE 16

```
Ingest Summary:
===============
          count  time_in_millis  time_in_nanos
total  33376000         1412871          42332

Pipeline Summary:
=================
                                          count  time_in_millis  time_in_nanos  percent
logs-nginx.access-1.2.0                 1920000          188206          98024    29.3%
logs-system.auth-1.6.4                   320000          116025         362577    18.0%
logs-system.syslog-1.6.4                2240000           91281          40751    14.2%
.fleet_final_pipeline-1                 9848000           44558           4525     6.9%
logs-postgresql.log-1.2.0                320000           44092         137788     6.9%
logs-redis.log-1.1.0                    1600000           37506          23442     5.8%
logs-kafka.log-0.5.0                     728000           26900          36951     4.2%
logs-apache.access-1.3.0                 320000           25326          79144     3.9%
logs-mysql.error-1.1.0                   640000           21607          33761     3.4%
logs-apache.error-1.3.0                  320000           18109          56591     2.8%
logs-postgresql.log-1.2.0-pipeline-log   320000           13532          42288     2.1%
logs-nginx.error-1.2.0                   320000           10569          33029     1.6%
logs-mysql.slowlog-1.1.0                 160000            5708          35675     0.9%
```

## CACHE OF SIZE 64

```
Ingest Summary:
===============
          count  time_in_millis  time_in_nanos
total  33376000         1445614          43313

Pipeline Summary:
=================
                                          count  time_in_millis  time_in_nanos  percent
logs-nginx.access-1.2.0                 1920000          195122         101626    29.3%
logs-system.auth-1.6.4                   320000          123478         385868    18.5%
logs-system.syslog-1.6.4                2240000           94484          42181    14.2%
.fleet_final_pipeline-1                 9848000           46163           4688     6.9%
logs-postgresql.log-1.2.0                320000           43839         136997     6.6%
logs-redis.log-1.1.0                    1600000           37604          23503     5.6%
logs-kafka.log-0.5.0                     728000           27726          38086     4.2%
logs-apache.access-1.3.0                 320000           25662          80194     3.8%
logs-mysql.error-1.1.0                   640000           23132          36144     3.5%
logs-apache.error-1.3.0                  320000           18514          57857     2.8%
logs-postgresql.log-1.2.0-pipeline-log   320000           13572          42413     2.0%
logs-nginx.error-1.2.0                   320000           11415          35672     1.7%
logs-mysql.slowlog-1.1.0                 160000            6134          38338     0.9%
```
