### PR TITLE
Add util method to build a Geometry from an H3 cell

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/util/ArrayUtils.java
@@ -84,4 +84,19 @@ public class ArrayUtils {
         updated[array.length] = added;
         return updated;
     }
+
+    /**
+     * Reverse the {@code length} values on the array starting from {@code offset}.
+     */
+    public static void reverseSubArray(double[] array, int offset, int length) {
+        int start = offset;
+        int end = offset + length;
+        while (end > start) {
+            final double scratch = array[start];
+            array[start] = array[end - 1];
+            array[end - 1] = scratch;
+            start++;
+            end--;
+        }
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/ArrayUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/ArrayUtilsTests.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.BitSet;
 
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class ArrayUtilsTests extends ESTestCase {
@@ -78,5 +79,30 @@ public class ArrayUtilsTests extends ESTestCase {
             sourceOfTruth.add(second[i]);
         }
         assertArrayEquals(sourceOfTruth.toArray(new String[0]), ArrayUtils.concat(first, second));
+    }
+
+    public void testReverseSubArray() {
+        final int length = randomIntBetween(10, 50);
+        final double[] array = new double[length];
+        for (int i = 0; i < array.length; i++) {
+            array[i] = randomDoubleBetween(Double.NEGATIVE_INFINITY, Double.MAX_VALUE, true);
+        }
+        assertReverseSubArray(array, 0, array.length);
+        for (int i = 0; i < 10; i++) {
+            final int start = randomInt(length);
+            final int end = randomIntBetween(start, length);
+            assertReverseSubArray(array, start, end - start);
+        }
+    }
+
+    private void assertReverseSubArray(double[] array, int from, int length) {
+        final double[] copy = array.clone();
+        ArrayUtils.reverseSubArray(copy, from, length);
+        final int endOffset = from + length - 1;
+        for (int i = 0; i < length; i++) {
+            assertThat(copy[endOffset - i], equalTo(array[from + i]));
+        }
+        ArrayUtils.reverseSubArray(copy, from, length);
+        assertThat(copy, equalTo(array));
     }
 }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtilTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/common/H3CartesianUtilTests.java
@@ -10,14 +10,9 @@ package org.elasticsearch.xpack.spatial.common;
 import org.apache.lucene.geo.Component2D;
 import org.apache.lucene.geo.LatLonGeometry;
 import org.apache.lucene.tests.geo.GeoTestUtil;
-import org.apache.lucene.util.ArrayUtil;
-import org.elasticsearch.common.geo.GeometryNormalizer;
-import org.elasticsearch.common.geo.Orientation;
 import org.elasticsearch.geo.GeometryTestUtils;
-import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.LinearRing;
 import org.elasticsearch.geometry.Point;
-import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.WellKnownText;
 import org.elasticsearch.h3.H3;
@@ -178,7 +173,7 @@ public class H3CartesianUtilTests extends ESTestCase {
     public void testRandomBasic() throws IOException {
         for (int res = 0; res < H3.MAX_H3_RES; res++) {
             final long h3 = H3.geoToH3(0, 0, res);
-            final GeoShapeValues.GeoShapeValue geoValue = GeoTestUtils.geoShapeValue(getGeometry(h3));
+            final GeoShapeValues.GeoShapeValue geoValue = GeoTestUtils.geoShapeValue(H3CartesianUtil.getNormalizeGeometry(h3));
             final long[] children = H3.h3ToChildren(h3);
             assertThat(geoValue.relate(getComponent(children[0])), Matchers.equalTo(GeoRelation.QUERY_INSIDE));
             for (int i = 1; i < children.length; i++) {
@@ -193,7 +188,7 @@ public class H3CartesianUtilTests extends ESTestCase {
     public void testRandomDateline() throws IOException {
         for (int res = 0; res < H3.MAX_H3_RES; res++) {
             final long h3 = H3.geoToH3(0, 180, res);
-            final GeoShapeValues.GeoShapeValue geoValue = GeoTestUtils.geoShapeValue(getGeometry(h3));
+            final GeoShapeValues.GeoShapeValue geoValue = GeoTestUtils.geoShapeValue(H3CartesianUtil.getNormalizeGeometry(h3));
             final long[] children = H3.h3ToChildren(h3);
             final Component2D component2D = getComponent(children[0]);
             // this is a current limitation because we break polygons around the dateline.
@@ -214,32 +209,6 @@ public class H3CartesianUtilTests extends ESTestCase {
         return LatLonGeometry.create(H3CartesianUtil.getLatLonGeometry(h3));
     }
 
-    private static Geometry getGeometry(long h3) {
-        final double[] xs = new double[H3CartesianUtil.MAX_ARRAY_SIZE];
-        final double[] ys = new double[H3CartesianUtil.MAX_ARRAY_SIZE];
-        final int numPoints = H3CartesianUtil.computePoints(h3, xs, ys);
-        final Polygon polygon = new Polygon(
-            new LinearRing(ArrayUtil.copyOfSubArray(xs, 0, numPoints), ArrayUtil.copyOfSubArray(ys, 0, numPoints))
-        );
-        double minX = Double.POSITIVE_INFINITY;
-        double maxX = Double.NEGATIVE_INFINITY;
-        for (int i = 0; i < numPoints; i++) {
-            minX = Math.min(minX, xs[i]);
-            maxX = Math.max(maxX, xs[i]);
-        }
-        if (maxX - minX > 180d && H3CartesianUtil.isPolar(h3) == false) {
-            final Geometry geometry = GeometryNormalizer.apply(Orientation.CCW, polygon);
-            if (geometry instanceof Polygon) {
-                // there is a bug on the code that breaks polygons across the dateline
-                // when polygon is close to the pole (I think) so we need to try again
-                return GeometryNormalizer.apply(Orientation.CW, polygon);
-            }
-            return geometry;
-        } else {
-            return polygon;
-        }
-    }
-
     public void testBoundingBox() {
         final double[] xs = new double[H3CartesianUtil.MAX_ARRAY_SIZE];
         final double[] ys = new double[H3CartesianUtil.MAX_ARRAY_SIZE];
@@ -257,6 +226,20 @@ public class H3CartesianUtilTests extends ESTestCase {
                     assertTrue(rectangle.getMaxX() >= lon && rectangle.getMinX() <= lon);
                 }
             }
+        }
+    }
+
+    public void testWronglyNormaliseGeometry() throws IOException {
+        // this he bin fails normalising in CCW, so we added hack to normalise it CW. If this test fails
+        // it might mean we fixed the bug in the GeometryNormaliser.
+        assertNotNull(GeoTestUtils.geoShapeValue(H3CartesianUtil.getNormalizeGeometry(576531121047601151L)));
+    }
+
+    public void testNormaliseGeometry() throws IOException {
+        Point point = GeometryTestUtils.randomPoint();
+        for (int res = 0; res <= H3.MAX_H3_RES; res++) {
+            long h3 = H3.geoToH3(point.getLat(), point.getLon(), res);
+            assertNotNull(GeoTestUtils.geoShapeValue(H3CartesianUtil.getNormalizeGeometry(h3)));
         }
     }
 }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/GridAggregation.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/GridAggregation.java
@@ -8,14 +8,8 @@
 package org.elasticsearch.xpack.vectortile.rest;
 
 import org.elasticsearch.common.geo.GeoUtils;
-import org.elasticsearch.common.geo.GeometryNormalizer;
-import org.elasticsearch.common.geo.Orientation;
-import org.elasticsearch.geometry.LinearRing;
-import org.elasticsearch.geometry.Polygon;
 import org.elasticsearch.geometry.Rectangle;
-import org.elasticsearch.h3.CellBoundary;
 import org.elasticsearch.h3.H3;
-import org.elasticsearch.h3.LatLng;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileGridAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
@@ -172,18 +166,7 @@ enum GridAggregation {
 
         @Override
         public byte[] toGrid(String bucketKey, FeatureFactory featureFactory) {
-            final CellBoundary boundary = H3.h3ToGeoBoundary(bucketKey);
-            final double[] lats = new double[boundary.numPoints() + 1];
-            final double[] lons = new double[boundary.numPoints() + 1];
-            for (int i = 0; i < boundary.numPoints(); i++) {
-                final LatLng latLng = boundary.getLatLon(i);
-                lats[i] = latLng.getLatDeg();
-                lons[i] = latLng.getLonDeg();
-            }
-            lats[boundary.numPoints()] = lats[0];
-            lons[boundary.numPoints()] = lons[0];
-            final Polygon polygon = new Polygon(new LinearRing(lons, lats));
-            final List<byte[]> x = featureFactory.getFeatures(GeometryNormalizer.apply(Orientation.CCW, polygon));
+            final List<byte[]> x = featureFactory.getFeatures(H3CartesianUtil.getNormalizeGeometry(H3.stringToH3(bucketKey)));
             return x.size() > 0 ? x.get(0) : null;
         }
 


### PR DESCRIPTION
There are a few places where we need to build a Geometry from an H3 cell, therefore lets add a method on  H3cartesianUtil that does that. This allows to make sure we build valid geometries that can be indexed. Therefore in this Pr we are 

- Reversing the points for the south pole as we are creating the points with the wrong orientation. 
- we are making sure we are splitting properly polygons across the dateline (bug in the GeometryNormalizer).