### PR TITLE
[7.17] Convert ServiceAccountIT to new test clusters framework (#92604)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -154,11 +154,32 @@ public class LocalClusterHandle implements ClusterHandle {
             wait.setUsername(credentials.getUsername());
             wait.setPassword(credentials.getPassword());
         }
-        if (securityAutoConfigured) {
+        if (sslEnabled) {
+            configureWaitSecurity(wait, node);
+        } else if (securityAutoConfigured) {
             wait.setCertificateAuthorities(node.getWorkingDir().resolve("config/certs/http_ca.crt").toFile());
         }
 
         return wait;
+    }
+
+    private void configureWaitSecurity(WaitForHttpResource wait, Node node) {
+        String caFile = node.getSpec().getSetting("xpack.security.http.ssl.certificate_authorities", null);
+        if (caFile != null) {
+            wait.setCertificateAuthorities(node.getWorkingDir().resolve("config").resolve(caFile).toFile());
+        }
+        String sslCertFile = node.getSpec().getSetting("xpack.security.http.ssl.certificate", null);
+        if (sslCertFile != null) {
+            wait.setCertificateAuthorities(node.getWorkingDir().resolve("config").resolve(sslCertFile).toFile());
+        }
+        String sslKeystoreFile = node.getSpec().getSetting("xpack.security.http.ssl.keystore.path", null);
+        if (sslKeystoreFile != null && caFile == null) { // Can not set both trust stores and CA
+            wait.setTrustStoreFile(node.getWorkingDir().resolve("config").resolve(sslKeystoreFile).toFile());
+        }
+        String keystorePassword = node.getSpec().getSetting("xpack.security.http.ssl.keystore.secure_password", null);
+        if (keystorePassword != null) {
+            wait.setTrustStorePassword(keystorePassword);
+        }
     }
 
     private boolean isSecurityAutoConfigured(Node node) {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -161,8 +161,20 @@ public class LocalClusterSpec implements ClusterSpec {
             );
         }
 
+        /**
+         * Return node configured setting or the provided default if no explicit value has been configured. This method returns all
+         * settings, to include security settings provided to the keystore
+         *
+         * @param setting the setting name
+         * @param defaultValue a default value
+         * @return the configured setting value or provided default
+         */
         public String getSetting(String setting, String defaultValue) {
-            return resolveSettings().getOrDefault(setting, defaultValue);
+            Map<String, String> allSettings = new HashMap<>();
+            allSettings.putAll(resolveSettings());
+            allSettings.putAll(keystoreSettings);
+
+            return allSettings.getOrDefault(setting, defaultValue);
         }
 
         /**

--- a/x-pack/plugin/security/qa/service-account/build.gradle
+++ b/x-pack/plugin/security/qa/service-account/build.gradle
@@ -1,44 +1,8 @@
-apply plugin: 'elasticsearch.legacy-java-rest-test'
+apply plugin: 'elasticsearch.internal-java-rest-test'
 
 dependencies {
   javaRestTestImplementation project(':x-pack:plugin:core')
   javaRestTestImplementation project(':client:rest-high-level')
   javaRestTestImplementation project(':x-pack:plugin:security')
-}
-
-testClusters.matching { it.name == 'javaRestTest' }.configureEach {
-  testDistribution = 'DEFAULT'
-  numberOfNodes = 2
-
-  extraConfigFile 'roles.yml', file('src/javaRestTest/resources/roles.yml')
-  extraConfigFile 'node.key', file('src/javaRestTest/resources/ssl/node.key')
-  extraConfigFile 'node.crt', file('src/javaRestTest/resources/ssl/node.crt')
-  extraConfigFile 'ca.crt', file('src/javaRestTest/resources/ssl/ca.crt')
-  extraConfigFile 'service_tokens', file('src/javaRestTest/resources/service_tokens')
-
-  setting 'xpack.ml.enabled', 'false'
-  setting 'xpack.license.self_generated.type', 'trial'
-
-  setting 'xpack.security.enabled', 'true'
-  setting 'xpack.security.authc.token.enabled', 'true'
-  setting 'xpack.security.authc.api_key.enabled', 'true'
-
-  setting 'xpack.security.http.ssl.enabled', 'true'
-  setting 'xpack.security.http.ssl.certificate', 'node.crt'
-  setting 'xpack.security.http.ssl.key', 'node.key'
-  setting 'xpack.security.http.ssl.certificate_authorities', 'ca.crt'
-
-  setting 'xpack.security.transport.ssl.enabled', 'true'
-  setting 'xpack.security.transport.ssl.certificate', 'node.crt'
-  setting 'xpack.security.transport.ssl.key', 'node.key'
-  setting 'xpack.security.transport.ssl.certificate_authorities', 'ca.crt'
-  setting 'xpack.security.transport.ssl.verification_mode', 'certificate'
-
-  keystore 'bootstrap.password', 'x-pack-test-password'
-  keystore 'xpack.security.transport.ssl.secure_key_passphrase', 'node-password'
-  keystore 'xpack.security.http.ssl.secure_key_passphrase', 'node-password'
-
-  user username: "test_admin", password: 'x-pack-test-password', role: "superuser"
-  user username: "elastic/fleet-server", password: 'x-pack-test-password', role: "superuser"
-  user username: "service_account_manager", password: 'x-pack-test-password', role: "service_account_manager"
+  clusterModules(project(":modules:analysis-common"))
 }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Convert ServiceAccountIT to new test clusters framework (#92604)