### PR TITLE
Fix unclosed directory stream in ClassReaders

### DIFF
--- a/docs/changelog/92890.yaml
+++ b/docs/changelog/92890.yaml
@@ -1,0 +1,6 @@
+pr: 92890
+summary: Fix unclosed directory stream in `ClassReaders`
+area: Infra/Plugins
+type: bug
+issues:
+ - 92866

--- a/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
+++ b/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
@@ -88,9 +88,8 @@ public class ClassReaders {
     }
 
     private static List<ClassReader> classesInPath(Path root) {
-        try (var stream = Files.walk(root)){
-            return stream
-                .filter(p -> p.toString().endsWith(".class"))
+        try (var stream = Files.walk(root)) {
+            return stream.filter(p -> p.toString().endsWith(".class"))
                 .filter(p -> p.toString().endsWith(MODULE_INFO) == false)
                 .filter(p -> p.toString().startsWith("/META-INF") == false)// skip multi-release files
                 .map(p -> {

--- a/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
+++ b/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
@@ -88,8 +88,8 @@ public class ClassReaders {
     }
 
     private static List<ClassReader> classesInPath(Path root) {
-        try {
-            return Files.walk(root)
+        try (var stream = Files.walk(root)){
+            return stream
                 .filter(p -> p.toString().endsWith(".class"))
                 .filter(p -> p.toString().endsWith(MODULE_INFO) == false)
                 .filter(p -> p.toString().startsWith("/META-INF") == false)// skip multi-release files


### PR DESCRIPTION
Using Files.walk requires closing the returned stream. This commit fixes a helper method in ClassReaders to use try-with-resources with the returned stream.

closes #92866