### PR TITLE
Fix wildcard expansion for delete-by-query on data streams

### DIFF
--- a/docs/changelog/92891.yaml
+++ b/docs/changelog/92891.yaml
@@ -1,0 +1,5 @@
+pr: 92891
+summary: Fix wildcard expansion for delete-by-query on data streams
+area: Data streams
+type: bug
+issues: []

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/100_delete_by_query.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/100_delete_by_query.yml
@@ -112,7 +112,7 @@
       indices.refresh:
         index: simple-stream1,simple-stream2
 
-  # increment by one any docs with number <= 4
+  # delete any docs with number <= 4
   - do:
       delete_by_query:
         index: simple-stream*
@@ -134,7 +134,7 @@
       indices.refresh:
         index: simple-stream1,simple-stream2
 
-  # verify that both numbers originally <= 4 have been incremented by one
+  # verify that both documents with number originally <= 4 have been deleted
   - do:
       search:
         index: simple-stream*

--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/100_delete_by_query.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/100_delete_by_query.yml
@@ -65,3 +65,88 @@
       indices.delete_data_stream:
         name: simple-data-stream1
   - is_true: acknowledged
+
+---
+"Delete by query for multiple data streams":
+  - skip:
+      features: allowed_warnings
+      version: " - 7.8.99"
+      reason: "data streams available in 7.9+"
+
+  - do:
+      allowed_warnings:
+        - "index template [my-template2] has index patterns [simple-stream*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+      indices.put_index_template:
+        name: my-template2
+        body:
+          index_patterns: [simple-stream*]
+          data_stream: {}
+
+  - do:
+      indices.create_data_stream:
+        name: simple-stream1
+  - is_true: acknowledged
+
+  - do:
+      index:
+        index:   simple-stream1
+        id:      "1"
+        op_type: create
+        body:    { "number": 4, '@timestamp': '2020-12-12' }
+
+  - do:
+      index:
+        index:   simple-stream2
+        id:      "2"
+        op_type: create
+        body:    { "number": 4, '@timestamp': '2020-12-12' }
+
+  - do:
+      index:
+        index:   simple-stream2
+        id:      "3"
+        op_type: create
+        body:    { "number": 6, '@timestamp': '2020-12-12' }
+
+  - do:
+      indices.refresh:
+        index: simple-stream1,simple-stream2
+
+  # increment by one any docs with number <= 4
+  - do:
+      delete_by_query:
+        index: simple-stream*
+        body:
+          query:
+            range:
+              number:
+                lte: 4
+
+  - match: {deleted: 2}
+  - match: {version_conflicts: 0}
+  - match: {batches: 1}
+  - match: {noops: 0}
+  - match: {failures: []}
+  - match: {throttled_millis: 0}
+  - gte: { took: 0 }
+
+  - do:
+      indices.refresh:
+        index: simple-stream1,simple-stream2
+
+  # verify that both numbers originally <= 4 have been incremented by one
+  - do:
+      search:
+        index: simple-stream*
+        body: { query: { range: { number: { lte: 5 } } } }
+  - length:   { hits.hits: 0 }
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-stream1
+  - is_true: acknowledged
+
+  - do:
+      indices.delete_data_stream:
+        name: simple-stream2
+  - is_true: acknowledged

--- a/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
+++ b/server/src/main/java/org/elasticsearch/index/reindex/DeleteByQueryRequest.java
@@ -124,6 +124,11 @@ public class DeleteByQueryRequest extends AbstractBulkByScrollRequest<DeleteByQu
     }
 
     @Override
+    public boolean includeDataStreams() {
+        return true;
+    }
+
+    @Override
     public ActionRequestValidationException validate() {
         ActionRequestValidationException e = super.validate();
         if (getSearchRequest().indices() == null || getSearchRequest().indices().length == 0) {


### PR DESCRIPTION
This commit allows wildcards for data streams to be used for delete-by-query. We always allowed multiple data streams (comma-separated), but the expansion did not include wildcards.

Relates to #90272 and #92717
