### PR TITLE
[8.6] Mute Lucene MMap warning (#92857)

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -260,8 +260,22 @@ public class LogConfigurator {
         // Redirect stdout/stderr to log4j. While we ensure Elasticsearch code does not write to those streams,
         // third party libraries may do that. Note that we do NOT close the streams because other code may have
         // grabbed a handle to the streams and intend to write to it, eg log4j for writing to the console
-        System.setOut(new PrintStream(new LoggingOutputStream(LogManager.getLogger("stdout"), Level.INFO), false, StandardCharsets.UTF_8));
-        System.setErr(new PrintStream(new LoggingOutputStream(LogManager.getLogger("stderr"), Level.WARN), false, StandardCharsets.UTF_8));
+        System.setOut(
+            new PrintStream(new LoggingOutputStream(LogManager.getLogger("stdout"), Level.INFO, List.of()), false, StandardCharsets.UTF_8)
+        );
+        System.setErr(
+            new PrintStream(
+                new LoggingOutputStream(
+                    LogManager.getLogger("stderr"),
+                    Level.WARN,
+                    // MMapDirectory messages come from Lucene, suggesting to users as a warning that they should enable preview features in
+                    // the JDK
+                    List.of("MMapDirectory")
+                ),
+                false,
+                StandardCharsets.UTF_8
+            )
+        );
 
         final Logger rootLogger = LogManager.getRootLogger();
         Appender appender = Loggers.findAppender(rootLogger, ConsoleAppender.class);

--- a/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LoggingOutputStream.java
@@ -15,6 +15,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
 
 /**
  * A stream whose output is sent to the configured logger, line by line.
@@ -42,9 +43,12 @@ class LoggingOutputStream extends OutputStream {
 
     private final Level level;
 
-    LoggingOutputStream(Logger logger, Level level) {
+    private final List<String> messageFilters;
+
+    LoggingOutputStream(Logger logger, Level level, List<String> messageFilters) {
         this.logger = logger;
         this.level = level;
+        this.messageFilters = messageFilters;
     }
 
     @Override
@@ -103,8 +107,17 @@ class LoggingOutputStream extends OutputStream {
         threadLocal = null;
     }
 
+    private void log(String msg) {
+        for (String filter : messageFilters) {
+            if (msg.contains(filter)) {
+                return;
+            }
+        }
+        this.log0(msg);
+    }
+
     // pkg private for testing
-    void log(String msg) {
+    protected void log0(String msg) {
         logger.log(level, msg);
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/LoggingOutputStreamTests.java
@@ -29,20 +29,22 @@ public class LoggingOutputStreamTests extends ESTestCase {
         List<String> lines = new ArrayList<>();
 
         TestLoggingOutputStream() {
-            super(null, null);
+            super(null, null, messageFilters);
         }
 
         @Override
-        void log(String msg) {
+        protected void log0(String msg) {
             lines.add(msg);
         }
     }
 
+    List<String> messageFilters = new ArrayList<>();
     TestLoggingOutputStream loggingStream;
     PrintStream printStream;
 
     @Before
     public void createStream() {
+        messageFilters.clear();
         loggingStream = new TestLoggingOutputStream();
         printStream = new PrintStream(loggingStream, false, StandardCharsets.UTF_8);
     }
@@ -114,5 +116,13 @@ public class LoggingOutputStreamTests extends ESTestCase {
         thread2.join();
         printStream.flush();
         assertThat(loggingStream.lines, contains("from thread 2", "from thread 1"));
+    }
+
+    public void testMessageFilters() throws Exception {
+        messageFilters.add("foo bar");
+        printStream.println("prefix foo bar suffix");
+        printStream.println("non-filtered message");
+        printStream.flush();
+        assertThat(loggingStream.lines, contains("non-filtered message"));
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Mute Lucene MMap warning (#92857)