### PR TITLE
[8.6] Fix unclosed directory stream in ClassReaders #92890

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/plugin/scanner/ClassReaders.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/plugin/scanner/ClassReaders.java
@@ -79,8 +79,7 @@ public class ClassReaders {
     }
 
     private static Stream<ClassReader> classesInPath(Path root) {
-        try {
-            Stream<Path> stream = Files.walk(root);
+        try (Stream<Path> stream = Files.walk(root)) {
             return stream.filter(p -> p.toString().endsWith(".class"))
                 .filter(p -> p.toString().endsWith("module-info.class") == false)
                 .map(p -> {


### PR DESCRIPTION
Using Files.walk requires closing the returned stream. This commit fixes a helper method in ClassReaders to use try-with-resources with the returned stream.
backports #92890
closes https://github.com/elastic/elasticsearch/issues/92866