### PR TITLE
Do not look up parent registration events using description

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -264,7 +264,7 @@ public class TasksIT extends ESIntegTestCase {
         // we will have as many [s][p] and [s][r] tasks as we have primary and replica shards
         assertEquals(numberOfShards.totalNumShards, numberOfEvents(RefreshAction.NAME + "[s][*]", Tuple::v1));
 
-        // we the [s][p] and [s][r] tasks should have a corresponding [s] task on the same node as a parent
+        // the [s][p] and [s][r] tasks should have a corresponding [s] task on the same node as a parent
         List<TaskInfo> spEvents = findEvents(RefreshAction.NAME + "[s][*]", Tuple::v1);
         for (TaskInfo taskInfo : spEvents) {
             List<TaskInfo> sTask;
@@ -272,17 +272,17 @@ public class TasksIT extends ESIntegTestCase {
                 // A [s][p] level task should have a corresponding [s] level task on the same node
                 sTask = findEvents(
                     RefreshAction.NAME + "[s]",
-                    event -> event.v1()
-                        && taskInfo.taskId().getNodeId().equals(event.v2().taskId().getNodeId())
-                        && taskInfo.description().equals(event.v2().description())
+                    event -> event.v1() // task registration event
+                        && event.v2().taskId().equals(taskInfo.parentTaskId())
+                        && event.v2().taskId().getNodeId().equals(taskInfo.taskId().getNodeId())
                 );
             } else {
-                // A [s][r] level task should have a corresponding [s] level task on the a different node (where primary is located)
+                // A [s][r] level task should have a corresponding [s] level task on a different node (where primary is located)
                 sTask = findEvents(
                     RefreshAction.NAME + "[s]",
-                    event -> event.v1()
-                        && taskInfo.parentTaskId().getNodeId().equals(event.v2().taskId().getNodeId())
-                        && taskInfo.description().equals(event.v2().description())
+                    event -> event.v1() // task registration event
+                        && event.v2().taskId().equals(taskInfo.parentTaskId())
+                        && event.v2().taskId().getNodeId().equals(taskInfo.taskId().getNodeId()) == false
                 );
             }
             // There should be only one parent task


### PR DESCRIPTION
In `testTransportBroadcastReplicationTasks`, when looking up parent task
registration events for [s][p] and [s][r] tasks, we could instead use
the parent task ID rather than the description of the task, since the
description would imply the task and its parent have the exact same
`toString()` which is not always the case.