### PR TITLE
[Docs] Remove tech preview notice from downsampling docs

### DIFF
--- a/docs/reference/data-streams/downsampling-ilm.asciidoc
+++ b/docs/reference/data-streams/downsampling-ilm.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Run downsampling with ILM</titleabbrev>
 ++++
 
-preview::[]
-
 This is a simplified example that allows you to see quickly how
 <<downsampling,downsampling>> works as part of an ILM policy to reduce the
 storage size of a sampled set of metrics. The example uses typical Kubernetes

--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -4,8 +4,6 @@
 <titleabbrev>Run downsampling manually</titleabbrev>
 ++++
 
-preview::[]
-
 This is a simplified example that allows you to see quickly how
 <<downsampling,downsampling>> works to reduce the storage size of a time series
 index. The example uses typical Kubernetes cluster monitoring data. To test out

--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -1,8 +1,6 @@
 [[downsampling]]
 === Downsampling a time series data stream
 
-preview::[]
-
 Downsampling provides a method to reduce the footprint of your <<tsds,time
 series data>> by storing it at reduced granularity.
 

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -4,7 +4,6 @@
 A time series data stream (TSDS) models timestamped metrics data as one or
 more time series.
 
-// TODO: Replace XX% with actual percentage
 You can use a TSDS to store metrics data more efficiently. In our benchmarks,
 metrics data stored in a TSDS used 44% less disk space than a regular data
 stream.

--- a/docs/reference/ilm/actions/ilm-downsample.asciidoc
+++ b/docs/reference/ilm/actions/ilm-downsample.asciidoc
@@ -2,8 +2,6 @@
 [[ilm-downsample]]
 === Downsample
 
-preview::[]
-
 Phases allowed: hot, warm, cold.
 
 Aggregates a time series (TSDS) index and stores

--- a/docs/reference/indices/downsample-data-stream.asciidoc
+++ b/docs/reference/indices/downsample-data-stream.asciidoc
@@ -5,8 +5,6 @@
 <titleabbrev>Downsample</titleabbrev>
 ++++
 
-preview::[]
-
 Aggregates a time series (TSDS) index and stores
 pre-computed statistical summaries (`min`, `max`, `sum`, `value_count` and
 `avg`) for each metric field grouped by a configured time interval. For example,


### PR DESCRIPTION
This removes the `tech preview` notice from the [downsampling documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/downsampling.html) as it will be generally available beginning with the 8.7 release.

The [TSDS ingest docs](https://www.elastic.co/guide/en/elasticsearch/reference/current/tsds.html) will also be GA for 8.7, and that change has already been handled via #91519.

