### PR TITLE
Ensure one-shot wrappers release their delegates

### DIFF
--- a/docs/changelog/92928.yaml
+++ b/docs/changelog/92928.yaml
@@ -1,0 +1,5 @@
+pr: 92928
+summary: Ensure one-shot wrappers release their delegates
+area: Infra/Core
+type: bug
+issues: []

--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -102,10 +102,18 @@ public enum Releasables {
      */
     public static Releasable releaseOnce(final Releasable releasable) {
         final var ref = new AtomicReference<>(releasable);
-        return () -> {
-            final var acquired = ref.getAndSet(null);
-            if (acquired != null) {
-                acquired.close();
+        return new Releasable() {
+            @Override
+            public void close() {
+                final var acquired = ref.getAndSet(null);
+                if (acquired != null) {
+                    acquired.close();
+                }
+            }
+
+            @Override
+            public String toString() {
+                return "releaseOnce[" + ref.get() + "]";
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -483,7 +483,7 @@ public interface ActionListener<Response> {
 
             @Override
             public String toString() {
-                return "notifyOnce[" + delegate + "]";
+                return "notifyOnce[" + delegateRef.get() + "]";
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/RunOnce.java
@@ -35,4 +35,9 @@ public class RunOnce implements Runnable {
     public boolean hasRun() {
         return delegateRef.get() == null;
     }
+
+    @Override
+    public String toString() {
+        return "RunOnce[" + delegateRef.get() + "]";
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ReachabilityChecker;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -305,6 +306,15 @@ public class ActionListenerTests extends ESTestCase {
             assertThat(onResponseTimes.get(), equalTo(0));
             assertThat(onFailureTimes.get(), equalTo(1));
         }
+    }
+
+    public void testNotifyOnceReleasesDelegate() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        final var listener = ActionListener.notifyOnce(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        reachabilityChecker.checkReachable();
+        listener.onResponse(null);
+        reachabilityChecker.ensureUnreachable();
+        assertEquals("notifyOnce[null]", listener.toString());
     }
 
     public void testConcurrentNotifyOnce() throws InterruptedException {

--- a/server/src/test/java/org/elasticsearch/common/ReleasablesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/ReleasablesTests.java
@@ -28,10 +28,13 @@ public class ReleasablesTests extends ESTestCase {
 
     public void testReleaseOnceReleasesDelegate() {
         final var reachabilityChecker = new ReachabilityChecker();
-        final var releaseOnce = Releasables.releaseOnce(reachabilityChecker.register(() -> logger.info("test")));
+        final var releaseOnce = Releasables.releaseOnce(reachabilityChecker.register(this::noop));
         reachabilityChecker.checkReachable();
         releaseOnce.close();
         reachabilityChecker.ensureUnreachable();
         assertEquals("releaseOnce[null]", releaseOnce.toString());
+    }
+
+    private void noop() {
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/ReleasablesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/ReleasablesTests.java
@@ -35,6 +35,5 @@ public class ReleasablesTests extends ESTestCase {
         assertEquals("releaseOnce[null]", releaseOnce.toString());
     }
 
-    private void noop() {
-    }
+    private void noop() {}
 }

--- a/server/src/test/java/org/elasticsearch/common/ReleasablesTests.java
+++ b/server/src/test/java/org/elasticsearch/common/ReleasablesTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.common;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ReachabilityChecker;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -23,5 +24,14 @@ public class ReleasablesTests extends ESTestCase {
         assertEquals(1, count.get());
         releasable.close();
         assertEquals(1, count.get());
+    }
+
+    public void testReleaseOnceReleasesDelegate() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        final var releaseOnce = Releasables.releaseOnce(reachabilityChecker.register(() -> logger.info("test")));
+        reachabilityChecker.checkReachable();
+        releaseOnce.close();
+        reachabilityChecker.ensureUnreachable();
+        assertEquals("releaseOnce[null]", releaseOnce.toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
@@ -8,9 +8,11 @@
 
 package org.elasticsearch.common.util.concurrent;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ReachabilityChecker;
 import org.junit.After;
 
 import java.util.concurrent.BrokenBarrierException;
@@ -123,5 +125,24 @@ public class ListenableFutureTests extends ESTestCase {
 
         assertEquals(numberOfThreads - 1, numResponses.get());
         assertEquals(0, numExceptions.get());
+    }
+
+    public void testAddedListenersReleasedOnCompletion() {
+        final ListenableFuture<Void> future = new ListenableFuture<>();
+        final ReachabilityChecker reachabilityChecker = new ReachabilityChecker();
+
+        for (int i = between(1, 3); i > 0; i--) {
+            future.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        }
+        reachabilityChecker.checkReachable();
+        if (randomBoolean()) {
+            future.onResponse(null);
+        } else {
+            future.onFailure(new ElasticsearchException("simulated"));
+        }
+        reachabilityChecker.ensureUnreachable();
+
+        future.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        reachabilityChecker.ensureUnreachable();
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
@@ -92,10 +92,13 @@ public class RunOnceTests extends ESTestCase {
 
     public void testReleasesDelegate() {
         final var reachabilityChecker = new ReachabilityChecker();
-        final var runOnce = new RunOnce(reachabilityChecker.register(() -> logger.info("test")));
+        final var runOnce = new RunOnce(reachabilityChecker.register(this::noop));
         reachabilityChecker.checkReachable();
         runOnce.run();
         reachabilityChecker.ensureUnreachable();
         assertEquals("RunOnce[null]", runOnce.toString());
+    }
+
+    private void noop() {
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
@@ -99,6 +99,5 @@ public class RunOnceTests extends ESTestCase {
         assertEquals("RunOnce[null]", runOnce.toString());
     }
 
-    private void noop() {
-    }
+    private void noop() {}
 }

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/RunOnceTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.ReachabilityChecker;
 
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -87,5 +88,14 @@ public class RunOnceTests extends ESTestCase {
             assertEquals(1, onAfter.get());
             assertTrue(runOnce.hasRun());
         }
+    }
+
+    public void testReleasesDelegate() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        final var runOnce = new RunOnce(reachabilityChecker.register(() -> logger.info("test")));
+        reachabilityChecker.checkReachable();
+        runOnce.run();
+        reachabilityChecker.ensureUnreachable();
+        assertEquals("RunOnce[null]", runOnce.toString());
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
@@ -31,6 +31,10 @@ public class ReachabilityChecker {
     private final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
     private final Queue<Registered> references = ConcurrentCollections.newQueue();
 
+    public ReachabilityChecker() {
+        memoryMXBean.gc();
+    }
+
     /**
      * Register the given target object for reachability checks.
      *

--- a/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.ref.PhantomReference;
+import java.lang.ref.ReferenceQueue;
+import java.util.Objects;
+import java.util.Queue;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Utility class for checking that objects become unreachable when expected.
+ */
+public class ReachabilityChecker {
+
+    private final MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+    private final Queue<Registered> references = ConcurrentCollections.newQueue();
+
+    /**
+     * Register the given target object for reachability checks.
+     *
+     * @return the given target object.
+     */
+    public <T> T register(T target) {
+        var referenceQueue = new ReferenceQueue<>();
+        references.add(
+            new Registered(target.toString(), new PhantomReference<>(Objects.requireNonNull(target), referenceQueue), referenceQueue)
+        );
+        return target;
+    }
+
+    /**
+     * Ensure that all registered objects have become unreachable.
+     */
+    public void ensureUnreachable() {
+        ensureUnreachable(TimeUnit.SECONDS.toMillis(10));
+    }
+
+    void ensureUnreachable(long timeoutMillis) {
+        Registered registered;
+        while ((registered = references.poll()) != null) {
+            registered.assertReferenceEnqueuedForCollection(memoryMXBean, timeoutMillis);
+        }
+    }
+
+    /**
+     * From the objects registered since the most recent call to {@link #ensureUnreachable()} (or since the construction of this {@link
+     * ReachabilityChecker} if {@link #ensureUnreachable()} has not been called) this method chooses one at random and verifies that it has
+     * not yet become unreachable.
+     */
+    public void checkReachable() {
+        if (references.peek() == null) {
+            throw new AssertionError("no references registered");
+        }
+
+        var target = Randomness.get().nextInt(references.size());
+        var iterator = references.iterator();
+        for (int i = 0; i < target; i++) {
+            assertTrue(iterator.hasNext());
+            assertNotNull(iterator.next());
+        }
+
+        assertTrue(iterator.hasNext());
+        iterator.next().assertReferenceNotEnqueuedForCollection(memoryMXBean);
+    }
+
+    private static final class Registered {
+        private final String description;
+        private final PhantomReference<?> phantomReference;
+        private final ReferenceQueue<?> referenceQueue;
+
+        Registered(String description, PhantomReference<?> phantomReference, ReferenceQueue<?> referenceQueue) {
+            this.description = description;
+            this.phantomReference = phantomReference;
+            this.referenceQueue = referenceQueue;
+        }
+
+        /**
+         * Attempts to trigger the GC repeatedly until the {@link ReferenceQueue} yields a reference.
+         */
+        public void assertReferenceEnqueuedForCollection(MemoryMXBean memoryMXBean, long timeoutMillis) {
+            try {
+                final var timeoutAt = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(timeoutMillis);
+                while (true) {
+                    memoryMXBean.gc();
+                    final var ref = referenceQueue.remove(500);
+                    if (ref != null) {
+                        ref.clear();
+                        return;
+                    }
+                    assertTrue("still reachable: " + description, System.nanoTime() < timeoutAt);
+                    assertNull(phantomReference.get()); // always succeeds, we're just doing this to use the phantomReference for something
+                }
+            } catch (Exception e) {
+                throw new AssertionError("unexpected", e);
+            }
+        }
+
+        /**
+         * Attempts to trigger the GC and verifies that the {@link ReferenceQueue} does not yield a reference.
+         */
+        public void assertReferenceNotEnqueuedForCollection(MemoryMXBean memoryMXBean) {
+            try {
+                memoryMXBean.gc();
+                assertNull("became unreachable: " + description, referenceQueue.remove(100));
+            } catch (Exception e) {
+                throw new AssertionError("unexpected", e);
+            }
+        }
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ReachabilityChecker.java
@@ -25,6 +25,11 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * Utility class for checking that objects become unreachable when expected.
+ *
+ * Registered objects become unreachable only when the GC notices them. This class attempts to trigger the GC at various points but does not
+ * guarantee a full GC. If we're unlucky, some of these objects may move to old enough heap generations that they are not subject to our GC
+ * attempts, resulting in test flakiness. Time will tell whether this is a problem in practice or not; if it is then we'll have to introduce
+ * some extra measures here.
  */
 public class ReachabilityChecker {
 

--- a/test/framework/src/test/java/org/elasticsearch/test/ReachabilityCheckerTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/ReachabilityCheckerTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test;
+
+import org.hamcrest.Matchers;
+
+public class ReachabilityCheckerTests extends ESTestCase {
+
+    public void testSuccess() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        var target = reachabilityChecker.register(createTarget());
+        reachabilityChecker.checkReachable();
+        target = null;
+        reachabilityChecker.ensureUnreachable();
+        assertNull(target);
+    }
+
+    public void testBecomesUnreachable() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        var target = reachabilityChecker.register(createTarget());
+        reachabilityChecker.checkReachable();
+        target = null;
+        assertThat(
+            expectThrows(AssertionError.class, reachabilityChecker::checkReachable).getMessage(),
+            Matchers.startsWith("became unreachable: test object")
+        );
+        assertNull(target);
+    }
+
+    public void testStaysReachable() {
+        final var reachabilityChecker = new ReachabilityChecker();
+        var target = reachabilityChecker.register(createTarget());
+        reachabilityChecker.checkReachable();
+        assertThat(
+            expectThrows(AssertionError.class, () -> reachabilityChecker.ensureUnreachable(500)).getMessage(),
+            Matchers.startsWith("still reachable: test object")
+        );
+        assertNotNull(target);
+    }
+
+    private static Object createTarget() {
+        return new Object() {
+            @Override
+            public String toString() {
+                return "test object";
+            }
+        };
+    }
+}


### PR DESCRIPTION
We recently adjusted `RunOnce`, `Releasables#releaseOnce` and `ActionListener#notifyOnce` so that once they have fired they drop the now-unnecessary reference to the delegate. This commit introduces tests to verify that this reference does genuinely become unreachable (i.e. available for garbage collection) as expected.

It also fixes a bug in `ActionListener#notifyOnce` which caused us to unexpectedly retain a reference to the delegate 🤦

Relates #92452
Relates #92507
Relates #92537