### PR TITLE
Reduce DEBUG log noise from FileSettingsService

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -342,8 +342,8 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
     }
 
     synchronized void stopWatcher() {
-        logger.debug("stopping watcher ...");
         if (watching()) {
+            logger.debug("stopping watcher ...");
             // make sure watch service is closed whatever
             // this will also close any outstanding keys
             try (var ws = watchService) {
@@ -369,7 +369,7 @@ public class FileSettingsService extends AbstractLifecycleComponent implements C
                 logger.info("watcher service stopped");
             }
         } else {
-            logger.debug("file settings service already stopped");
+            logger.trace("file settings service already stopped");
         }
     }
 


### PR DESCRIPTION
There's no need to log `DEBUG` messages on every cluster state update here. Dropping one that happens every time to `TRACE` and moving the other one under the `if`.