### PR TITLE
Reduce DEBUG log noise from LicenseService

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/LicenseService.java
@@ -520,17 +520,21 @@ public class LicenseService extends AbstractLifecycleComponent implements Cluste
 
             final LicensesMetadata prevLicensesMetadata = previousClusterState.getMetadata().custom(LicensesMetadata.TYPE);
             final LicensesMetadata currentLicensesMetadata = currentClusterState.getMetadata().custom(LicensesMetadata.TYPE);
-            if (logger.isDebugEnabled()) {
-                logger.debug("previous [{}]", prevLicensesMetadata);
-                logger.debug("current [{}]", currentLicensesMetadata);
-            }
             // notify all interested plugins
             if (previousClusterState.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK) || prevLicensesMetadata == null) {
                 if (currentLicensesMetadata != null) {
+                    logger.debug("state recovered: previous license [{}]", prevLicensesMetadata);
+                    logger.debug("state recovered: current license [{}]", currentLicensesMetadata);
                     onUpdate(currentLicensesMetadata);
+                } else {
+                    logger.trace("state recovered: no current license");
                 }
             } else if (prevLicensesMetadata.equals(currentLicensesMetadata) == false) {
+                logger.debug("previous [{}]", prevLicensesMetadata);
+                logger.debug("current [{}]", currentLicensesMetadata);
                 onUpdate(currentLicensesMetadata);
+            } else {
+                logger.trace("license unchanged [{}]", currentLicensesMetadata);
             }
 
             License currentLicense = null;


### PR DESCRIPTION
There's no need to log `DEBUG` messages on every cluster state update here. Dropping ones that happen every time to `TRACE` and moving the other ones under the `if`.