### PR TITLE
[8.6] [DOCS] Add API example for setting SQL permissions (#92491)

### DIFF
--- a/docs/reference/sql/security.asciidoc
+++ b/docs/reference/sql/security.asciidoc
@@ -24,13 +24,34 @@ PKI/X.509:: Use X.509 certificates to authenticate {es-sql} to {es}. For this, o
 [discrete]
 [[sql-security-permissions]]
 ==== Permissions (server-side)
-Lastly, one the server one need to add a few permissions to
-users so they can run SQL. To run SQL a user needs `read` and
+On the server, one needs to add a few permissions to
+users so they can run SQL. To run SQL, a user needs `read` and
 `indices:admin/get` permissions at minimum while some parts of 
-the API require `cluster:monitor/main`. 
+the API require `cluster:monitor/main`.
 
-The following example configures a role that can run SQL in JDBC querying the `test` and `bort`
-indices:
+You can add permissions by <<defining-roles,creating a role>>, and assigning
+that role to the user. Roles can be created using {kib}, an
+<<sql-role-api-example,API call>> or the <<sql-role-file-example,`roles.yml`
+configuration file>>. Using {kib} or the role management APIs is the preferred
+method for defining roles. File-based role management is useful if you want to
+define a role that doesn't need to change. You cannot use the role management
+APIs to view or edit a role defined in `roles.yml`. 
+
+[discrete]
+[[sql-role-api-example]]
+===== Add permissions with the role management APIs
+
+This example configures a role that can run SQL in JDBC querying the `test`
+index:
+
+include::{xes-repo-dir}/rest-api/security/create-roles.asciidoc[tag=sql-queries-permission]
+
+[discrete]
+[[sql-role-file-example]]
+===== Add permissions to `roles.yml`
+
+This example configures a role that can run SQL in JDBC querying the `test` and `bort`
+indices. Add the following to `roles.yml`:
 
 [source, yaml]
 --------------------------------------------------

--- a/x-pack/docs/en/rest-api/security/create-roles.asciidoc
+++ b/x-pack/docs/en/rest-api/security/create-roles.asciidoc
@@ -123,3 +123,21 @@ created or updated.
 --------------------------------------------------
 
 <1> When an existing role is updated, `created` is set to false.
+
+The following example configures a role that can run SQL in JDBC:
+
+// tag::sql-queries-permission[]
+[source,console]
+--------------------------------------------------
+POST /_security/role/cli_or_drivers_minimal
+{
+  "cluster": ["cluster:monitor/main"],
+  "indices": [
+    {
+      "names": ["test"],
+      "privileges": ["read", "indices:admin/get"]
+    }
+  ]
+}
+--------------------------------------------------
+// end::sql-queries-permission[]


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Add API example for setting SQL permissions (#92491)