### PR TITLE
Update ASM version for pluginscanner, 8.6 edition

### DIFF
--- a/docs/changelog/92784.yaml
+++ b/docs/changelog/92784.yaml
@@ -1,0 +1,6 @@
+pr: 92784
+summary: Update the version of asm used by plugin scanner
+area: Infra/Plugins
+type: bug
+issues:
+ - 92782

--- a/libs/plugin-scanner/build.gradle
+++ b/libs/plugin-scanner/build.gradle
@@ -19,8 +19,8 @@ dependencies {
   api project(':libs:elasticsearch-plugin-api')
   api project(":libs:elasticsearch-x-content")
 
-  implementation 'org.ow2.asm:asm:9.2'
-  implementation 'org.ow2.asm:asm-tree:9.2'
+  implementation 'org.ow2.asm:asm:9.3'
+  implementation 'org.ow2.asm:asm-tree:9.3'
 
   testImplementation "junit:junit:${versions.junit}"
   testImplementation(project(":test:framework")) {


### PR DESCRIPTION
Backport #92784 to 8.6

This fixes #92936