### PR TITLE
Update guide on re-registration of repository

### DIFF
--- a/docs/reference/troubleshooting/snapshot/add-repository.asciidoc
+++ b/docs/reference/troubleshooting/snapshot/add-repository.asciidoc
@@ -3,7 +3,9 @@
 
 Multiple {es} deployments are writing to the same snapshot repository. {es} doesn't 
 support this configuration and only one cluster is allowed to write to the same 
-repository.
+repository. See <<snapshot-repository-contents>> for potential side-effects of
+corruption of the repository contents, which may not be resolved by the following
+guide.
 To remedy the situation mark the repository as read-only or remove it from all the
 other deployments, and re-add (recreate) the repository in the current deployment:
 


### PR DESCRIPTION
Our guide on re-registering a corrupt repository should link to the warnings about the potential side-effects of corruption.