### PR TITLE
Additional Simplifications to Frozen Index Input

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -815,12 +815,12 @@ public class SharedBlobCacheService implements Releasable {
         }
     }
 
-    public class FrozenCacheFile {
+    public class CacheFile {
 
         private final CacheKey cacheKey;
         private final long length;
 
-        private FrozenCacheFile(CacheKey cacheKey, long length) {
+        private CacheFile(CacheKey cacheKey, long length) {
             this.cacheKey = cacheKey;
             this.length = length;
         }
@@ -833,13 +833,13 @@ public class SharedBlobCacheService implements Releasable {
             return cacheKey;
         }
 
-        public StepListener<Integer> populateAndRead(
+        public int populateAndRead(
             final ByteRange rangeToWrite,
             final ByteRange rangeToRead,
             final RangeAvailableHandler reader,
             final RangeMissingHandler writer,
             final Executor executor
-        ) {
+        ) throws Exception {
             StepListener<Integer> stepListener = null;
             final long writeStart = rangeToWrite.start();
             final long readStart = rangeToRead.start();
@@ -881,7 +881,7 @@ public class SharedBlobCacheService implements Releasable {
                 }
 
             }
-            return stepListener;
+            return stepListener.asFuture().get();
         }
 
         @Override
@@ -890,8 +890,8 @@ public class SharedBlobCacheService implements Releasable {
         }
     }
 
-    public FrozenCacheFile getFrozenCacheFile(CacheKey cacheKey, long length) {
-        return new FrozenCacheFile(cacheKey, length);
+    public CacheFile getFrozenCacheFile(CacheKey cacheKey, long length) {
+        return new CacheFile(cacheKey, length);
     }
 
     @FunctionalInterface
@@ -907,69 +907,16 @@ public class SharedBlobCacheService implements Releasable {
             throws IOException;
     }
 
-    public static class Stats {
-
+    public record Stats(
+        int numberOfRegions,
+        long size,
+        long regionSize,
+        long evictCount,
+        long writeCount,
+        long writeBytes,
+        long readCount,
+        long readBytes
+    ) {
         public static final Stats EMPTY = new Stats(0, 0L, 0L, 0L, 0L, 0L, 0L, 0L);
-
-        private final int numberOfRegions;
-        private final long size;
-        private final long regionSize;
-        private final long evictCount;
-        private final long writeCount;
-        private final long writeBytes;
-        private final long readCount;
-        private final long readBytes;
-
-        private Stats(
-            int numberOfRegions,
-            long size,
-            long regionSize,
-            long evictCount,
-            long writeCount,
-            long writeBytes,
-            long readCount,
-            long readBytes
-        ) {
-            this.numberOfRegions = numberOfRegions;
-            this.size = size;
-            this.regionSize = regionSize;
-            this.evictCount = evictCount;
-            this.writeCount = writeCount;
-            this.writeBytes = writeBytes;
-            this.readCount = readCount;
-            this.readBytes = readBytes;
-        }
-
-        public int getNumberOfRegions() {
-            return numberOfRegions;
-        }
-
-        public long getSize() {
-            return size;
-        }
-
-        public long getRegionSize() {
-            return regionSize;
-        }
-
-        public long getEvictCount() {
-            return evictCount;
-        }
-
-        public long getWriteCount() {
-            return writeCount;
-        }
-
-        public long getWriteBytes() {
-            return writeBytes;
-        }
-
-        public long getReadCount() {
-            return readCount;
-        }
-
-        public long getReadBytes() {
-            return readBytes;
-        }
     }
 }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBlobCacheServiceTests.java
@@ -364,7 +364,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
             SharedBlobCacheService cacheService = new SharedBlobCacheService(environment, settings, taskQueue.getThreadPool())
         ) {
-            assertEquals(val1.getBytes(), cacheService.getStats().getSize());
+            assertEquals(val1.getBytes(), cacheService.getStats().size());
         }
 
         ByteSizeValue val2 = new ByteSizeValue(randomIntBetween(1, 5), ByteSizeUnit.MB);
@@ -376,7 +376,7 @@ public class SharedBlobCacheServiceTests extends ESTestCase {
             NodeEnvironment environment = new NodeEnvironment(settings, TestEnvironment.newEnvironment(settings));
             SharedBlobCacheService cacheService = new SharedBlobCacheService(environment, settings, taskQueue.getThreadPool())
         ) {
-            assertEquals(val2.getBytes(), cacheService.getStats().getSize());
+            assertEquals(val2.getBytes(), cacheService.getStats().size());
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -127,14 +127,14 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
         }
         return new NodeCachesStatsResponse(
             clusterService.localNode(),
-            frozenCacheStats.getNumberOfRegions(),
-            frozenCacheStats.getSize(),
-            frozenCacheStats.getRegionSize(),
-            frozenCacheStats.getWriteCount(),
-            frozenCacheStats.getWriteBytes(),
-            frozenCacheStats.getReadCount(),
-            frozenCacheStats.getReadBytes(),
-            frozenCacheStats.getEvictCount()
+            frozenCacheStats.numberOfRegions(),
+            frozenCacheStats.size(),
+            frozenCacheStats.regionSize(),
+            frozenCacheStats.writeCount(),
+            frozenCacheStats.writeBytes(),
+            frozenCacheStats.readCount(),
+            frozenCacheStats.readBytes(),
+            frozenCacheStats.evictCount()
         );
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -22,10 +22,9 @@ import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.support.CountDownActionListener;
 import org.elasticsearch.blobcache.common.ByteRange;
-import org.elasticsearch.blobcache.common.CacheFile;
 import org.elasticsearch.blobcache.common.CacheKey;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
-import org.elasticsearch.blobcache.shared.SharedBlobCacheService.FrozenCacheFile;
+import org.elasticsearch.blobcache.shared.SharedBlobCacheService.CacheFile;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -365,7 +364,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         return new CacheKey(snapshotId.getUUID(), indexId.getName(), shardId, fileName);
     }
 
-    public CacheFile getCacheFile(CacheKey cacheKey, long fileLength) throws Exception {
+    public org.elasticsearch.blobcache.common.CacheFile getCacheFile(CacheKey cacheKey, long fileLength) throws Exception {
         return cacheService.get(cacheKey, fileLength, cacheDir);
     }
 
@@ -423,7 +422,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                 );
             }
         } else {
-            return new DirectBlobContainerIndexInput(name, this, fileInfo, context, inputStats, getUncachedChunkSize());
+            return new DirectBlobContainerIndexInput(name, blobContainer(), fileInfo, context, inputStats, getUncachedChunkSize());
         }
     }
 
@@ -712,7 +711,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         );
     }
 
-    public FrozenCacheFile getFrozenCacheFile(String fileName, long length) {
+    public CacheFile getFrozenCacheFile(String fileName, long length) {
         return sharedBlobCacheService.getFrozenCacheFile(createCacheKey(fileName), length);
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/BaseSearchableSnapshotIndexInput.java
@@ -10,14 +10,12 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.store.IOContext;
-import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.snapshots.blobstore.SlicedInputStream;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots;
 import org.elasticsearch.xpack.searchablesnapshots.store.IndexInputStats;
-import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -33,7 +31,6 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
 
     protected final Logger logger;
     protected final String name;
-    protected final SearchableSnapshotDirectory directory;
     protected final BlobContainer blobContainer;
     protected final FileInfo fileInfo;
     protected final IOContext context;
@@ -41,45 +38,28 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
     protected final long offset;
     protected final long length;
 
-    /**
-     * Range of bytes that should be cached in the blob cache for the current index input's header.
-     */
-    protected final ByteRange headerBlobCacheByteRange;
-
-    /**
-     * Range of bytes that should be cached in the blob cache for the current index input's footer. This footer byte range should only be
-     * required for slices of CFS files; regular files already have their footers extracted from the {@link FileInfo} (see method
-     * {@link BaseSearchableSnapshotIndexInput#maybeReadChecksumFromFileInfo}).
-     */
-    protected final ByteRange footerBlobCacheByteRange;
-
     // the following are only mutable so they can be adjusted after cloning/slicing
     protected volatile boolean isClone;
-    private AtomicBoolean closed;
+    protected AtomicBoolean closed;
 
     public BaseSearchableSnapshotIndexInput(
         Logger logger,
         String name,
-        SearchableSnapshotDirectory directory,
+        BlobContainer blobContainer,
         FileInfo fileInfo,
         IOContext context,
         IndexInputStats stats,
         long offset,
-        long length,
-        ByteRange headerBlobCacheByteRange,
-        ByteRange footerBlobCacheByteRange
+        long length
     ) {
         super(name, context);
         this.name = Objects.requireNonNull(name);
         this.logger = Objects.requireNonNull(logger);
-        this.directory = Objects.requireNonNull(directory);
-        this.blobContainer = Objects.requireNonNull(directory.blobContainer());
+        this.blobContainer = Objects.requireNonNull(blobContainer);
         this.fileInfo = Objects.requireNonNull(fileInfo);
         this.context = Objects.requireNonNull(context);
         assert fileInfo.metadata().hashEqualsContents() == false
             : "this method should only be used with blobs that are NOT stored in metadata's hash field " + "(fileInfo: " + fileInfo + ')';
-        this.headerBlobCacheByteRange = Objects.requireNonNull(headerBlobCacheByteRange);
-        this.footerBlobCacheByteRange = Objects.requireNonNull(footerBlobCacheByteRange);
         this.stats = Objects.requireNonNull(stats);
         this.offset = offset;
         this.length = length;
@@ -155,16 +135,6 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
         return success;
     }
 
-    protected ByteRange rangeToReadFromBlobCache(long position, int readLength) {
-        final long end = position + readLength;
-        if (headerBlobCacheByteRange.contains(position, end)) {
-            return headerBlobCacheByteRange;
-        } else if (footerBlobCacheByteRange.contains(position, end)) {
-            return footerBlobCacheByteRange;
-        }
-        return ByteRange.EMPTY;
-    }
-
     /**
      * Opens an {@link InputStream} for the given range of bytes which reads the data directly from the blob store. If the requested range
      * spans multiple blobs then this stream will request them in turn.
@@ -175,10 +145,10 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
     protected InputStream openInputStreamFromBlobStore(final long position, final long readLength) throws IOException {
         assert assertCurrentThreadMayAccessBlobStore();
         if (fileInfo.numberOfParts() == 1L) {
-            assert position + readLength <= fileInfo.partBytes(0)
+            assert position + readLength <= fileInfo.length()
                 : "cannot read [" + position + "-" + (position + readLength) + "] from [" + fileInfo + "]";
             stats.addBlobStoreBytesRequested(readLength);
-            return blobContainer.readBlob(fileInfo.partName(0), position, readLength);
+            return blobContainer.readBlob(fileInfo.name(), position, readLength);
         } else {
             final int startPart = getPartNumberForPosition(position);
             final int endPart = getPartNumberForPosition(position + readLength - 1);
@@ -260,12 +230,6 @@ public abstract class BaseSearchableSnapshotIndexInput extends BufferedIndexInpu
             return "slice(" + sliceDescription + ") of " + resourceDesc;
         }
         return resourceDesc;
-    }
-
-    protected void ensureOpen() throws IOException {
-        if (closed.get()) {
-            throw new IOException(toString() + " is closed");
-        }
     }
 
     @Override

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/DirectBlobContainerIndexInputTests.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.searchablesnapshots.store.input;
 
 import org.apache.lucene.store.BufferedIndexInput;
 import org.apache.lucene.util.Version;
-import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.common.blobstore.BlobContainer;
 import org.elasticsearch.common.lucene.store.ESIndexInputTestCase;
 import org.elasticsearch.common.unit.ByteSizeUnit;
@@ -16,9 +15,7 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot.FileInfo;
 import org.elasticsearch.index.store.StoreFileMetadata;
-import org.elasticsearch.xpack.searchablesnapshots.cache.blob.CachedBlob;
 import org.elasticsearch.xpack.searchablesnapshots.store.IndexInputStats;
-import org.elasticsearch.xpack.searchablesnapshots.store.SearchableSnapshotDirectory;
 
 import java.io.ByteArrayInputStream;
 import java.io.EOFException;
@@ -37,7 +34,6 @@ import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.lessThan;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.startsWith;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -122,13 +118,9 @@ public class DirectBlobContainerIndexInputTests extends ESIndexInputTestCase {
             }
         });
 
-        final SearchableSnapshotDirectory directory = mock(SearchableSnapshotDirectory.class);
-        when(directory.getCachedBlob(anyString(), any(ByteRange.class))).thenReturn(CachedBlob.CACHE_NOT_READY);
-        when(directory.blobContainer()).thenReturn(blobContainer);
-
         final DirectBlobContainerIndexInput indexInput = new DirectBlobContainerIndexInput(
             fileName,
-            directory,
+            blobContainer,
             fileInfo,
             randomIOContext(),
             new IndexInputStats(1L, fileInfo.length(), fileInfo.length(), fileInfo.length(), () -> 0L),


### PR DESCRIPTION
Moving methods as far down the inheritance as possible to make this code a little easier to reuse + remove unused future and make method blocking right away + some other minor cleanups.
