### PR TITLE
Fix instructions in max retry decider explanations

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/MaxRetryAllocationDecider.java
@@ -34,6 +34,8 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
         Setting.Property.NotCopyableOnResize
     );
 
+    private static final String RETRY_FAILED_API = "POST /_cluster/reroute?retry_failed&metric=none";
+
     public static final String NAME = "max_retry";
 
     private static final Decision YES_NO_FAILURES = Decision.single(Decision.Type.YES, NAME, "shard has no previous failures");
@@ -69,9 +71,9 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
             return Decision.single(
                 Decision.Type.NO,
                 NAME,
-                "shard has exceeded the maximum number of retries [%d] on failed allocation attempts - "
-                    + "manually call [/_cluster/reroute?retry_failed=true] to retry, [%s]",
+                "shard has exceeded the maximum number of retries [%d] on failed allocation attempts - manually call [%s] to retry, [%s]",
                 maxRetries,
+                RETRY_FAILED_API,
                 info.toString()
             );
         } else {
@@ -90,9 +92,9 @@ public class MaxRetryAllocationDecider extends AllocationDecider {
             return Decision.single(
                 Decision.Type.NO,
                 NAME,
-                "shard has exceeded the maximum number of retries [%d] on failed relocation attempts - "
-                    + "manually call [/_cluster/reroute?retry_failed=true] to retry, [%s]",
+                "shard has exceeded the maximum number of retries [%d] on failed relocation attempts - manually call [%s] to retry, [%s]",
                 maxRetries,
+                RETRY_FAILED_API,
                 info.toString()
             );
         } else {


### PR DESCRIPTION
Today we say `manually call [/_cluster/reroute?retry_failed=true]` if a shard exceeds the max number of retries. We should give a verb here, and also since #90399 we should recommend saying `metric=none` too.