### PR TITLE
Handle all exceptions in SearchableSnapshotDirectory.prewarmCache

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -547,7 +547,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                         );
                     }));
                 }
-            } catch (IOException e) {
+            } catch (Exception e) {
                 logger.warn(() -> format("%s unable to prewarm file [%s]", shardId, file.physicalName()), e);
                 if (submitted == false) {
                     completionListener.onFailure(e);


### PR DESCRIPTION
Only catching `IOException` here seems broken. Any unexpceted runtime exception when opening the input seems like it would cause a leak. Also as a side note, the `submitted == false` check in the exception handler would always be true if we only cared about `IOException` here.
=> since we can't rule out any other exceptions here we should stay on the safe side and handle all of them.
