### PR TITLE
Report recovered files as recovered from snapshot for fully mounted searchable snapshots

### DIFF
--- a/docs/changelog/92976.yaml
+++ b/docs/changelog/92976.yaml
@@ -1,0 +1,6 @@
+pr: 92976
+summary: Report recovered files as recovered from snapshot for fully mounted searchable
+  snapshots
+area: Recovery
+type: bug
+issues: []

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
@@ -105,6 +105,8 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
 
         assertThat("Physical cache size doesn't match with recovery state data", physicalCacheSize, equalTo(recoveredBytes));
         assertThat("Expected to recover 100% of files", recoveryState.getIndex().recoveredBytesPercent(), equalTo(100.0f));
+        assertThat(recoveryState.getIndex().recoveredFromSnapshotBytes(), equalTo(recoveredBytes));
+        assertThat(recoveryState.getIndex().recoveredBytes(), equalTo(recoveredBytes));
     }
 
     public void testFilesStoredInThePersistentCacheAreMarkedAsReusedInRecoveryState() throws Exception {
@@ -198,6 +200,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
         assertThat(physicalCacheSize, equalTo(expectedPhysicalCacheSize));
         assertThat(physicalCacheSize + inMemoryCacheSize, equalTo(recoveryState.getIndex().reusedBytes()));
         assertThat("Expected to recover 100% of files", recoveryState.getIndex().recoveredBytesPercent(), equalTo(100.0f));
+        assertThat(recoveryState.getIndex().recoveredFromSnapshotBytes(), equalTo(0L));
 
         for (RecoveryState.FileDetail fileDetail : recoveryState.getIndex().fileDetails()) {
             assertThat(fileDetail.name() + " wasn't mark as reused", fileDetail.reused(), equalTo(true));

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -532,7 +532,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
                         if (persistentCacheLength == file.length()) {
                             recoveryState.markIndexFileAsReused(file.physicalName());
                         } else {
-                            recoveryState.getIndex().addRecoveredBytesToFile(file.physicalName(), file.partBytes(part));
+                            recoveryState.getIndex().addRecoveredFromSnapshotBytesToFile(file.physicalName(), file.partBytes(part));
                         }
 
                         logger.trace(


### PR DESCRIPTION
Files recovered for fully mounted searchable snapshots indices are reported in the same manner as files recover from disk for regular indices. This can be confusing for users because we later introduced a `recovered_from_snapshot_in_bytes` (for snapshot based peer recoveries, that is not applicable to searchable snapshots indices) and this field is always `0` for  searchable snapshots indices.

This pull request changes the Recovery file details so that `recovered_from_snapshot_in_bytes` is now populated for files recovered for fully mounted searchable snapshots indices, which I think makes more sense now we have this  `recovered_from_snapshot_in_bytes` field. I also think it qualifies as a bug.