### PR TITLE
Asyncify IndexEventListener#beforeIndexShardRecovery

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/CompositeIndexEventListener.java
@@ -9,17 +9,22 @@
 package org.elasticsearch.index;
 
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.shard.IndexEventListener;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.cluster.IndicesClusterStateService.AllocatedIndices.IndexRemovalReason;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
 
 import static org.elasticsearch.core.Strings.format;
@@ -238,16 +243,53 @@ final class CompositeIndexEventListener implements IndexEventListener {
         }
     }
 
-    @Override
-    public void beforeIndexShardRecovery(final IndexShard indexShard, final IndexSettings indexSettings) {
-        for (IndexEventListener listener : listeners) {
+    private void iterateBeforeIndexShardRecovery(
+        final IndexShard indexShard,
+        final IndexSettings indexSettings,
+        final Iterator<IndexEventListener> iterator,
+        final ActionListener<Void> outerListener
+    ) {
+        while (iterator.hasNext()) {
+            final var nextListener = iterator.next();
+            final var future = new ListenableFuture<Void>();
             try {
-                listener.beforeIndexShardRecovery(indexShard, indexSettings);
+                nextListener.beforeIndexShardRecovery(indexShard, indexSettings, future);
+                if (future.isDone()) {
+                    // common case, not actually async, so just check for an exception and continue on the same thread
+                    future.get();
+                    continue;
+                }
             } catch (Exception e) {
-                logger.warn(() -> format("failed to invoke the listener before the shard recovery starts for %s", indexShard.shardId()), e);
-                throw e;
+                outerListener.onFailure(e);
+                return;
             }
+
+            // future was not completed straight away, but might be done by now, so continue on a fresh thread to avoid stack overflow
+            future.addListener(
+                outerListener.delegateFailure(
+                    (delegate, v) -> indexShard.getThreadPool()
+                        .executor(ThreadPool.Names.GENERIC)
+                        .execute(
+                            ActionRunnable.wrap(delegate, l -> iterateBeforeIndexShardRecovery(indexShard, indexSettings, iterator, l))
+                        )
+                )
+            );
+            return;
         }
+
+        outerListener.onResponse(null);
+    }
+
+    @Override
+    public void beforeIndexShardRecovery(
+        final IndexShard indexShard,
+        final IndexSettings indexSettings,
+        final ActionListener<Void> outerListener
+    ) {
+        iterateBeforeIndexShardRecovery(indexShard, indexSettings, listeners.iterator(), outerListener.delegateResponse((l, e) -> {
+            logger.warn(() -> format("failed to invoke the listener before the shard recovery starts for %s", indexShard.shardId()), e);
+            l.onFailure(e);
+        }));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexEventListener.java
@@ -7,6 +7,7 @@
  */
 package org.elasticsearch.index.shard;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
@@ -166,8 +167,11 @@ public interface IndexEventListener {
      *
      * @param indexShard    the shard that is about to recover
      * @param indexSettings the shard's index settings
+     * @param listener      listener notified when this step completes
      */
-    default void beforeIndexShardRecovery(IndexShard indexShard, IndexSettings indexSettings) {}
+    default void beforeIndexShardRecovery(IndexShard indexShard, IndexSettings indexSettings, ActionListener<Void> listener) {
+        listener.onResponse(null);
+    }
 
     /**
      * Called after the raw files have been restored from the repository but any other recovery processing has happened

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -1637,13 +1637,13 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         }
     }
 
-    public void preRecovery() {
+    public void preRecovery(ActionListener<Void> listener) {
         final IndexShardState currentState = this.state; // single volatile read
         if (currentState == IndexShardState.CLOSED) {
             throw new IndexShardNotRecoveringException(shardId, currentState);
         }
         assert currentState == IndexShardState.RECOVERING : "expected a recovering shard " + shardId + " but got " + currentState;
-        indexEventListener.beforeIndexShardRecovery(this, indexSettings);
+        indexEventListener.beforeIndexShardRecovery(this, indexSettings, listener);
     }
 
     public void postRecovery(String reason) throws IndexShardStartedException, IndexShardRelocatedException, IndexShardClosedException {

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -21,6 +21,7 @@ import org.apache.lucene.store.IndexInput;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -399,7 +400,7 @@ public final class StoreRecovery {
      * Recovers the state of the shard from the store.
      */
     private void internalRecoverFromStore(IndexShard indexShard, ActionListener<Void> outerListener) {
-        indexShard.preRecovery(outerListener.delegateFailure((listener, ignored) -> {
+        indexShard.preRecovery(outerListener.delegateFailure((listener, ignored) -> ActionRunnable.run(listener, () -> {
             final RecoveryState recoveryState = indexShard.recoveryState();
             final boolean indexShouldExists = recoveryState.getRecoverySource().getType() != RecoverySource.Type.EMPTY_STORE;
             indexShard.prepareForIndexRecovery();
@@ -476,7 +477,7 @@ public final class StoreRecovery {
             } finally {
                 store.decRef();
             }
-        }));
+        }).run()));
     }
 
     private static void writeEmptyRetentionLeasesFile(IndexShard indexShard) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/StoreRecovery.java
@@ -85,11 +85,13 @@ public final class StoreRecovery {
             RecoverySource.Type recoveryType = indexShard.recoveryState().getRecoverySource().getType();
             assert recoveryType == RecoverySource.Type.EMPTY_STORE || recoveryType == RecoverySource.Type.EXISTING_STORE
                 : "expected store recovery type but was: " + recoveryType;
-            ActionListener.completeWith(recoveryListener(indexShard, listener), () -> {
-                logger.debug("starting recovery from store ...");
-                internalRecoverFromStore(indexShard);
-                return true;
-            });
+            logger.debug("starting recovery from store ...");
+            final var recoveryListener = recoveryListener(indexShard, listener);
+            try {
+                internalRecoverFromStore(indexShard, recoveryListener.map(ignored -> true));
+            } catch (Exception e) {
+                recoveryListener.onFailure(e);
+            }
         } else {
             listener.onResponse(false);
         }
@@ -120,37 +122,42 @@ public final class StoreRecovery {
             Sort indexSort = indexShard.getIndexSort();
             final boolean hasNested = indexShard.mapperService().hasNested();
             final boolean isSplit = sourceMetadata.getNumberOfShards() < indexShard.indexSettings().getNumberOfShards();
-            ActionListener.completeWith(recoveryListener(indexShard, listener), () -> {
-                logger.debug("starting recovery from local shards {}", shards);
-                try {
-                    final Directory directory = indexShard.store().directory(); // don't close this directory!!
-                    final Directory[] sources = shards.stream().map(LocalShardSnapshot::getSnapshotDirectory).toArray(Directory[]::new);
-                    final long maxSeqNo = shards.stream().mapToLong(LocalShardSnapshot::maxSeqNo).max().getAsLong();
-                    final long maxUnsafeAutoIdTimestamp = shards.stream()
-                        .mapToLong(LocalShardSnapshot::maxUnsafeAutoIdTimestamp)
-                        .max()
-                        .getAsLong();
-                    addIndices(
-                        indexShard.recoveryState().getIndex(),
-                        directory,
-                        indexSort,
-                        sources,
-                        maxSeqNo,
-                        maxUnsafeAutoIdTimestamp,
-                        indexShard.indexSettings().getIndexMetadata(),
-                        indexShard.shardId().id(),
-                        isSplit,
-                        hasNested
-                    );
-                    internalRecoverFromStore(indexShard);
-                    // just trigger a merge to do housekeeping on the
-                    // copied segments - we will also see them in stats etc.
-                    indexShard.getEngine().forceMerge(false, -1, false, UUIDs.randomBase64UUID());
-                    return true;
-                } catch (IOException ex) {
-                    throw new IndexShardRecoveryException(indexShard.shardId(), "failed to recover from local shards", ex);
-                }
-            });
+
+            final var recoveryListener = recoveryListener(indexShard, listener);
+            logger.debug("starting recovery from local shards {}", shards);
+            try {
+                final Directory directory = indexShard.store().directory(); // don't close this directory!!
+                final Directory[] sources = shards.stream().map(LocalShardSnapshot::getSnapshotDirectory).toArray(Directory[]::new);
+                final long maxSeqNo = shards.stream().mapToLong(LocalShardSnapshot::maxSeqNo).max().getAsLong();
+                final long maxUnsafeAutoIdTimestamp = shards.stream()
+                    .mapToLong(LocalShardSnapshot::maxUnsafeAutoIdTimestamp)
+                    .max()
+                    .getAsLong();
+                addIndices(
+                    indexShard.recoveryState().getIndex(),
+                    directory,
+                    indexSort,
+                    sources,
+                    maxSeqNo,
+                    maxUnsafeAutoIdTimestamp,
+                    indexShard.indexSettings().getIndexMetadata(),
+                    indexShard.shardId().id(),
+                    isSplit,
+                    hasNested
+                );
+                internalRecoverFromStore(indexShard, recoveryListener.delegateFailure((delegate, v) -> {
+                    ActionListener.completeWith(delegate, () -> {
+                        // just trigger a merge to do housekeeping on the
+                        // copied segments - we will also see them in stats etc.
+                        indexShard.getEngine().forceMerge(false, -1, false, UUIDs.randomBase64UUID());
+                        return true;
+                    });
+                }));
+            } catch (IOException e) {
+                recoveryListener.onFailure(new IndexShardRecoveryException(indexShard.shardId(), "failed to recover from local shards", e));
+            } catch (Exception e) {
+                recoveryListener.onFailure(e);
+            }
         } else {
             listener.onResponse(false);
         }
@@ -391,84 +398,85 @@ public final class StoreRecovery {
     /**
      * Recovers the state of the shard from the store.
      */
-    private void internalRecoverFromStore(IndexShard indexShard) throws IndexShardRecoveryException {
-        indexShard.preRecovery();
-        final RecoveryState recoveryState = indexShard.recoveryState();
-        final boolean indexShouldExists = recoveryState.getRecoverySource().getType() != RecoverySource.Type.EMPTY_STORE;
-        indexShard.prepareForIndexRecovery();
-        SegmentInfos si = null;
-        final Store store = indexShard.store();
-        store.incRef();
-        try {
+    private void internalRecoverFromStore(IndexShard indexShard, ActionListener<Void> outerListener) {
+        indexShard.preRecovery(outerListener.delegateFailure((listener, ignored) -> {
+            final RecoveryState recoveryState = indexShard.recoveryState();
+            final boolean indexShouldExists = recoveryState.getRecoverySource().getType() != RecoverySource.Type.EMPTY_STORE;
+            indexShard.prepareForIndexRecovery();
+            SegmentInfos si = null;
+            final Store store = indexShard.store();
+            store.incRef();
             try {
-                store.failIfCorrupted();
                 try {
-                    si = store.readLastCommittedSegmentsInfo();
-                } catch (Exception e) {
-                    String files = "_unknown_";
+                    store.failIfCorrupted();
                     try {
-                        files = Arrays.toString(store.directory().listAll());
-                    } catch (Exception inner) {
-                        files += " (failure=" + ExceptionsHelper.stackTrace(inner) + ")";
+                        si = store.readLastCommittedSegmentsInfo();
+                    } catch (Exception e) {
+                        String files = "_unknown_";
+                        try {
+                            files = Arrays.toString(store.directory().listAll());
+                        } catch (Exception inner) {
+                            files += " (failure=" + ExceptionsHelper.stackTrace(inner) + ")";
+                        }
+                        if (indexShouldExists) {
+                            throw new IndexShardRecoveryException(
+                                shardId,
+                                "shard allocated for local recovery (post api), should exist, but doesn't, current files: " + files,
+                                e
+                            );
+                        }
                     }
-                    if (indexShouldExists) {
-                        throw new IndexShardRecoveryException(
-                            shardId,
-                            "shard allocated for local recovery (post api), should exist, but doesn't, current files: " + files,
-                            e
-                        );
+                    if (si != null && indexShouldExists == false) {
+                        // it exists on the directory, but shouldn't exist on the FS, its a leftover (possibly dangling)
+                        // its a "new index create" API, we have to do something, so better to clean it than use same data
+                        logger.trace("cleaning existing shard, shouldn't exists");
+                        Lucene.cleanLuceneIndex(store.directory());
+                        si = null;
                     }
+                } catch (Exception e) {
+                    throw new IndexShardRecoveryException(shardId, "failed to fetch index version after copying it over", e);
                 }
-                if (si != null && indexShouldExists == false) {
-                    // it exists on the directory, but shouldn't exist on the FS, its a leftover (possibly dangling)
-                    // its a "new index create" API, we have to do something, so better to clean it than use same data
-                    logger.trace("cleaning existing shard, shouldn't exists");
-                    Lucene.cleanLuceneIndex(store.directory());
-                    si = null;
-                }
-            } catch (Exception e) {
-                throw new IndexShardRecoveryException(shardId, "failed to fetch index version after copying it over", e);
-            }
-            if (recoveryState.getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS) {
-                assert indexShouldExists;
-                bootstrap(indexShard, store);
-                writeEmptyRetentionLeasesFile(indexShard);
-            } else if (indexShouldExists) {
-                if (recoveryState.getRecoverySource().shouldBootstrapNewHistoryUUID()) {
-                    store.bootstrapNewHistory();
+                if (recoveryState.getRecoverySource().getType() == RecoverySource.Type.LOCAL_SHARDS) {
+                    assert indexShouldExists;
+                    bootstrap(indexShard, store);
                     writeEmptyRetentionLeasesFile(indexShard);
-                }
-                // since we recover from local, just fill the files and size
-                final RecoveryState.Index index = recoveryState.getIndex();
-                try {
-                    if (si != null) {
-                        addRecoveredFileDetails(si, store, index);
+                } else if (indexShouldExists) {
+                    if (recoveryState.getRecoverySource().shouldBootstrapNewHistoryUUID()) {
+                        store.bootstrapNewHistory();
+                        writeEmptyRetentionLeasesFile(indexShard);
                     }
-                } catch (IOException e) {
-                    logger.debug("failed to list file details", e);
+                    // since we recover from local, just fill the files and size
+                    final RecoveryState.Index index = recoveryState.getIndex();
+                    try {
+                        if (si != null) {
+                            addRecoveredFileDetails(si, store, index);
+                        }
+                    } catch (IOException e) {
+                        logger.debug("failed to list file details", e);
+                    }
+                    index.setFileDetailsComplete();
+                } else {
+                    store.createEmpty();
+                    final String translogUUID = Translog.createEmptyTranslog(
+                        indexShard.shardPath().resolveTranslog(),
+                        SequenceNumbers.NO_OPS_PERFORMED,
+                        shardId,
+                        indexShard.getPendingPrimaryTerm()
+                    );
+                    store.associateIndexWithNewTranslog(translogUUID);
+                    writeEmptyRetentionLeasesFile(indexShard);
+                    indexShard.recoveryState().getIndex().setFileDetailsComplete();
                 }
-                index.setFileDetailsComplete();
-            } else {
-                store.createEmpty();
-                final String translogUUID = Translog.createEmptyTranslog(
-                    indexShard.shardPath().resolveTranslog(),
-                    SequenceNumbers.NO_OPS_PERFORMED,
-                    shardId,
-                    indexShard.getPendingPrimaryTerm()
-                );
-                store.associateIndexWithNewTranslog(translogUUID);
-                writeEmptyRetentionLeasesFile(indexShard);
-                indexShard.recoveryState().getIndex().setFileDetailsComplete();
+                indexShard.openEngineAndRecoverFromTranslog();
+                indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
+                indexShard.finalizeRecovery();
+                indexShard.postRecovery("post recovery from shard_store");
+            } catch (EngineException | IOException e) {
+                throw new IndexShardRecoveryException(shardId, "failed to recover from gateway", e);
+            } finally {
+                store.decRef();
             }
-            indexShard.openEngineAndRecoverFromTranslog();
-            indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
-            indexShard.finalizeRecovery();
-            indexShard.postRecovery("post recovery from shard_store");
-        } catch (EngineException | IOException e) {
-            throw new IndexShardRecoveryException(shardId, "failed to recover from gateway", e);
-        } finally {
-            store.decRef();
-        }
+        }));
     }
 
     private static void writeEmptyRetentionLeasesFile(IndexShard indexShard) throws IOException {
@@ -492,72 +500,74 @@ public final class StoreRecovery {
         IndexShard indexShard,
         Repository repository,
         SnapshotRecoverySource restoreSource,
-        ActionListener<Boolean> listener
+        ActionListener<Boolean> outerListener
     ) {
         logger.debug("restoring from {} ...", indexShard.recoveryState().getRecoverySource());
-        indexShard.preRecovery();
-        final RecoveryState.Translog translogState = indexShard.recoveryState().getTranslog();
-        if (restoreSource == null) {
-            listener.onFailure(new IndexShardRestoreFailedException(shardId, "empty restore source"));
-            return;
-        }
-        if (logger.isTraceEnabled()) {
-            logger.trace("[{}] restoring shard [{}]", restoreSource.snapshot(), shardId);
-        }
-        final ActionListener<Void> restoreListener = ActionListener.wrap(v -> {
-            indexShard.getIndexEventListener().afterFilesRestoredFromRepository(indexShard);
-            final Store store = indexShard.store();
-            bootstrap(indexShard, store);
-            assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
-            writeEmptyRetentionLeasesFile(indexShard);
-            indexShard.openEngineAndRecoverFromTranslog();
-            indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
-            indexShard.finalizeRecovery();
-            indexShard.postRecovery("restore done");
-            listener.onResponse(true);
-        }, e -> listener.onFailure(new IndexShardRestoreFailedException(shardId, "restore failed", e)));
-        try {
-            translogState.totalOperations(0);
-            translogState.totalOperationsOnStart(0);
-            indexShard.prepareForIndexRecovery();
-            final ShardId snapshotShardId;
-            final IndexId indexId = restoreSource.index();
-            if (shardId.getIndexName().equals(indexId.getName())) {
-                snapshotShardId = shardId;
-            } else {
-                snapshotShardId = new ShardId(indexId.getName(), IndexMetadata.INDEX_UUID_NA_VALUE, shardId.id());
+        indexShard.preRecovery(outerListener.delegateFailure((listener, ignored) -> {
+
+            final RecoveryState.Translog translogState = indexShard.recoveryState().getTranslog();
+            if (restoreSource == null) {
+                listener.onFailure(new IndexShardRestoreFailedException(shardId, "empty restore source"));
+                return;
             }
-            final StepListener<IndexId> indexIdListener = new StepListener<>();
-            // If the index UUID was not found in the recovery source we will have to load RepositoryData and resolve it by index name
-            if (indexId.getId().equals(IndexMetadata.INDEX_UUID_NA_VALUE)) {
-                // BwC path, running against an old version master that did not add the IndexId to the recovery source
-                repository.getRepositoryData(
-                    new ThreadedActionListener<>(
-                        logger,
-                        indexShard.getThreadPool(),
-                        ThreadPool.Names.GENERIC,
-                        indexIdListener.map(repositoryData -> repositoryData.resolveIndexId(indexId.getName())),
-                        false
-                    )
-                );
-            } else {
-                indexIdListener.onResponse(indexId);
+            if (logger.isTraceEnabled()) {
+                logger.trace("[{}] restoring shard [{}]", restoreSource.snapshot(), shardId);
             }
-            assert indexShard.getEngineOrNull() == null;
-            indexIdListener.whenComplete(idx -> {
-                assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC, ThreadPool.Names.SNAPSHOT);
-                repository.restoreShard(
-                    indexShard.store(),
-                    restoreSource.snapshot().getSnapshotId(),
-                    idx,
-                    snapshotShardId,
-                    indexShard.recoveryState(),
-                    restoreListener
-                );
-            }, restoreListener::onFailure);
-        } catch (Exception e) {
-            restoreListener.onFailure(e);
-        }
+            final ActionListener<Void> restoreListener = ActionListener.wrap(v -> {
+                indexShard.getIndexEventListener().afterFilesRestoredFromRepository(indexShard);
+                final Store store = indexShard.store();
+                bootstrap(indexShard, store);
+                assert indexShard.shardRouting.primary() : "only primary shards can recover from store";
+                writeEmptyRetentionLeasesFile(indexShard);
+                indexShard.openEngineAndRecoverFromTranslog();
+                indexShard.getEngine().fillSeqNoGaps(indexShard.getPendingPrimaryTerm());
+                indexShard.finalizeRecovery();
+                indexShard.postRecovery("restore done");
+                listener.onResponse(true);
+            }, e -> listener.onFailure(new IndexShardRestoreFailedException(shardId, "restore failed", e)));
+            try {
+                translogState.totalOperations(0);
+                translogState.totalOperationsOnStart(0);
+                indexShard.prepareForIndexRecovery();
+                final ShardId snapshotShardId;
+                final IndexId indexId = restoreSource.index();
+                if (shardId.getIndexName().equals(indexId.getName())) {
+                    snapshotShardId = shardId;
+                } else {
+                    snapshotShardId = new ShardId(indexId.getName(), IndexMetadata.INDEX_UUID_NA_VALUE, shardId.id());
+                }
+                final StepListener<IndexId> indexIdListener = new StepListener<>();
+                // If the index UUID was not found in the recovery source we will have to load RepositoryData and resolve it by index name
+                if (indexId.getId().equals(IndexMetadata.INDEX_UUID_NA_VALUE)) {
+                    // BwC path, running against an old version master that did not add the IndexId to the recovery source
+                    repository.getRepositoryData(
+                        new ThreadedActionListener<>(
+                            logger,
+                            indexShard.getThreadPool(),
+                            ThreadPool.Names.GENERIC,
+                            indexIdListener.map(repositoryData -> repositoryData.resolveIndexId(indexId.getName())),
+                            false
+                        )
+                    );
+                } else {
+                    indexIdListener.onResponse(indexId);
+                }
+                assert indexShard.getEngineOrNull() == null;
+                indexIdListener.whenComplete(idx -> {
+                    assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC, ThreadPool.Names.SNAPSHOT);
+                    repository.restoreShard(
+                        indexShard.store(),
+                        restoreSource.snapshot().getSnapshotId(),
+                        idx,
+                        snapshotShardId,
+                        indexShard.recoveryState(),
+                        restoreListener
+                    );
+                }, restoreListener::onFailure);
+            } catch (Exception e) {
+                restoreListener.onFailure(e);
+            }
+        }));
     }
 
     public static void bootstrap(final IndexShard indexShard, final Store store) throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/CompositeIndexEventListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/index/CompositeIndexEventListenerTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.index.shard.IndexEventListener;
+import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.IndexShardTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.hamcrest.Matchers;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class CompositeIndexEventListenerTests extends IndexShardTestCase {
+
+    private Exception getRootCause(Exception e) {
+        while (e.getCause()instanceof Exception ee) {
+            e = ee;
+        }
+        if (e.getCause() != null) {
+            throw new AssertionError(e.getCause());
+        }
+        return e;
+    }
+
+    public void testBeforeIndexShardRecoveryInOrder() throws Exception {
+        var shard = newShard(randomBoolean());
+        var appender = new MockLogAppender();
+        try (var ignored = appender.capturing(CompositeIndexEventListener.class)) {
+            final var stepNumber = new AtomicInteger();
+            final var stepCount = between(0, 20);
+            final var failAtStep = new AtomicInteger(-1);
+            final var indexEventListener = new CompositeIndexEventListener(
+                shard.indexSettings(),
+                IntStream.range(0, stepCount).mapToObj(step -> new IndexEventListener() {
+                    @Override
+                    public void beforeIndexShardRecovery(
+                        IndexShard indexShard,
+                        IndexSettings indexSettings,
+                        ActionListener<Void> listener
+                    ) {
+                        shard.getThreadPool()
+                            .executor(randomFrom(ThreadPool.Names.GENERIC, ThreadPool.Names.SAME))
+                            .execute(ActionRunnable.run(listener, () -> {
+                                assertThat(step, Matchers.lessThanOrEqualTo(failAtStep.get()));
+                                assertTrue(stepNumber.compareAndSet(step, step + 1));
+                                if (step == failAtStep.get()) {
+                                    throw new ElasticsearchException("simulated failure at step " + step);
+                                }
+                            }));
+                    }
+                }).collect(Collectors.toList())
+            );
+
+            final CheckedRunnable<Exception> beforeIndexShardRecoveryRunner = () -> assertNull(
+                PlainActionFuture.<Void, Exception>get(
+                    fut -> indexEventListener.beforeIndexShardRecovery(shard, shard.indexSettings(), fut),
+                    10,
+                    TimeUnit.SECONDS
+                )
+            );
+
+            failAtStep.set(stepCount);
+            beforeIndexShardRecoveryRunner.run();
+            assertEquals(stepCount, stepNumber.getAndSet(0));
+
+            if (stepCount > 0) {
+                appender.addExpectation(
+                    new MockLogAppender.SeenEventExpectation(
+                        "warning",
+                        CompositeIndexEventListener.class.getCanonicalName(),
+                        Level.WARN,
+                        "*failed to invoke the listener before the shard recovery starts for [index][0]"
+                    )
+                );
+
+                failAtStep.set(between(0, stepCount - 1));
+                final var rootCause = getRootCause(expectThrows(ElasticsearchException.class, beforeIndexShardRecoveryRunner::run));
+                assertEquals("simulated failure at step " + failAtStep.get(), rootCause.getMessage());
+                assertEquals(failAtStep.get() + 1, stepNumber.getAndSet(0));
+                appender.assertAllExpectationsMatched();
+            }
+
+        } finally {
+            closeShards(shard);
+        }
+    }
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexEventListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexEventListener.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.searchablesnapshots.allocation;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -55,9 +56,10 @@ public class SearchableSnapshotIndexEventListener implements IndexEventListener 
      * @param indexSettings the shard's index settings
      */
     @Override
-    public void beforeIndexShardRecovery(IndexShard indexShard, IndexSettings indexSettings) {
+    public void beforeIndexShardRecovery(IndexShard indexShard, IndexSettings indexSettings, ActionListener<Void> listener) {
         assert ThreadPool.assertCurrentThreadPool(ThreadPool.Names.GENERIC);
         ensureSnapshotIsLoaded(indexShard);
+        listener.onResponse(null);
     }
 
     private static void ensureSnapshotIsLoaded(IndexShard indexShard) {


### PR DESCRIPTION
We want to add a listener which may do some background work before letting the index shard recovery proceed, so this commit refactors `beforeIndexShardRecovery` to accept a listener and adjusts all its callers to match.