### PR TITLE
Make type in MappingMetadata private

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/MapperServiceFactory.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/index/mapper/MapperServiceFactory.java
@@ -12,6 +12,7 @@ import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
@@ -72,7 +73,7 @@ public class MapperServiceFactory {
         );
 
         try {
-            mapperService.merge("_doc", new CompressedXContent(mappings), MapperService.MergeReason.MAPPING_UPDATE);
+            mapperService.merge(new MappingMetadata(new CompressedXContent(mappings)), MapperService.MergeReason.MAPPING_UPDATE);
             return mapperService;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/QueryParserHelperBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/QueryParserHelperBenchmark.java
@@ -20,6 +20,7 @@ import org.apache.lucene.store.Directory;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -193,7 +194,7 @@ public class QueryParserHelperBenchmark {
         );
 
         try {
-            mapperService.merge("_doc", new CompressedXContent(mappings), MapperService.MergeReason.MAPPING_UPDATE);
+            mapperService.merge(new MappingMetadata(new CompressedXContent(mappings)), MapperService.MergeReason.MAPPING_UPDATE);
             return mapperService;
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/DataStreamIndexSettingsProvider.java
@@ -10,6 +10,7 @@ package org.elasticsearch.datastreams;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -159,7 +160,7 @@ public class DataStreamIndexSettingsProvider implements IndexSettingProvider {
         // Create MapperService just to extract keyword dimension fields:
         try (var mapperService = mapperServiceFactory.apply(tmpIndexMetadata.build())) {
             for (var mapping : combinedTemplateMappings) {
-                mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
+                mapperService.merge(new MappingMetadata(mapping), MapperService.MergeReason.INDEX_TEMPLATE);
             }
 
             List<String> routingPaths = new ArrayList<>();

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureMetaFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureMetaFieldMapperTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.index.mapper.extras;
 
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -18,6 +19,7 @@ import org.elasticsearch.index.mapper.MapperServiceTestCase;
 import org.elasticsearch.index.mapper.Mapping;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.hamcrest.CoreMatchers;
@@ -33,20 +35,18 @@ public class RankFeatureMetaFieldMapperTests extends MapperServiceTestCase {
     }
 
     public void testBasics() throws Exception {
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("type")
-                .startObject("properties")
-                .startObject("field")
-                .field("type", "rank_feature")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("type")
+            .startObject("properties")
+            .startObject("field")
+            .field("type", "rank_feature")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
-        Mapping parsedMapping = createMapperService(mapping).parseMapping("type", new CompressedXContent(mapping));
+        Mapping parsedMapping = createMapperService(mapping).parseMapping(toMappingMetadata(mapping));
         assertEquals(mapping, parsedMapping.toCompressedXContent().toString());
         assertNotNull(parsedMapping.getMetadataMapperByClass(RankFeatureMetaFieldMapper.class));
     }
@@ -58,8 +58,7 @@ public class RankFeatureMetaFieldMapperTests extends MapperServiceTestCase {
     public void testDocumentParsingFailsOnMetaField() throws Exception {
         String mapping = Strings.toString(XContentFactory.jsonBuilder().startObject().startObject("_doc").endObject().endObject());
         DocumentMapper mapper = createMapperService(mapping).merge(
-            "_doc",
-            new CompressedXContent(mapping),
+            new MappingMetadata(new CompressedXContent(mapping)),
             MapperService.MergeReason.MAPPING_UPDATE
         );
         String rfMetaField = RankFeatureMetaFieldMapper.CONTENT_TYPE;

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilderTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilderTests.java
@@ -12,6 +12,7 @@ import org.apache.lucene.document.FeatureField;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MapperService;
@@ -34,16 +35,17 @@ public class RankFeatureQueryBuilderTests extends AbstractQueryTestCase<RankFeat
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge(
-            "_doc",
-            new CompressedXContent(
-                Strings.toString(
-                    PutMappingRequest.simpleMapping(
-                        "my_feature_field",
-                        "type=rank_feature",
-                        "my_negative_feature_field",
-                        "type=rank_feature,positive_score_impact=false",
-                        "my_feature_vector_field",
-                        "type=rank_features"
+            new MappingMetadata(
+                new CompressedXContent(
+                    Strings.toString(
+                        PutMappingRequest.simpleMapping(
+                            "my_feature_field",
+                            "type=rank_feature",
+                            "my_negative_feature_field",
+                            "type=rank_feature,positive_score_impact=false",
+                            "my_feature_vector_field",
+                            "type=rank_features"
+                        )
                     )
                 )
             ),

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasChildQueryBuilderTests.java
@@ -23,8 +23,6 @@ import org.apache.lucene.search.similarities.PerFieldSimilarityWrapper;
 import org.apache.lucene.search.similarities.Similarity;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.IdFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
@@ -66,7 +64,6 @@ import static org.mockito.Mockito.when;
 
 public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQueryBuilder> {
 
-    private static final String TYPE = "_doc";
     private static final String PARENT_DOC = "parent";
     private static final String CHILD_DOC = "child";
 
@@ -120,7 +117,7 @@ public class HasChildQueryBuilderTests extends AbstractQueryTestCase<HasChildQue
             .endObject()
             .endObject();
 
-        mapperService.merge(TYPE, new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/HasParentQueryBuilderTests.java
@@ -13,8 +13,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.IdsQueryBuilder;
 import org.elasticsearch.index.query.InnerHitBuilder;
@@ -51,7 +49,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQueryBuilder> {
-    private static final String TYPE = "_doc";
+
     private static final String PARENT_DOC = "parent";
     private static final String CHILD_DOC = "child";
 
@@ -98,7 +96,7 @@ public class HasParentQueryBuilderTests extends AbstractQueryTestCase<HasParentQ
             .endObject()
             .endObject();
 
-        mapperService.merge(TYPE, new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     /**

--- a/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
+++ b/modules/parent-join/src/test/java/org/elasticsearch/join/query/ParentIdQueryBuilderTests.java
@@ -15,8 +15,6 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryShardException;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -40,7 +38,6 @@ import static org.mockito.Mockito.when;
 
 public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQueryBuilder> {
 
-    private static final String TYPE = "_doc";
     private static final String JOIN_FIELD_NAME = "join_field";
     private static final String PARENT_NAME = "parent";
     private static final String CHILD_NAME = "child";
@@ -86,7 +83,7 @@ public class ParentIdQueryBuilderTests extends AbstractQueryTestCase<ParentIdQue
             .endObject()
             .endObject();
 
-        mapperService.merge(TYPE, new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/CandidateQueryTests.java
@@ -66,10 +66,8 @@ import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.lucene.search.function.FunctionScoreQuery;
 import org.elasticsearch.common.settings.Settings;
@@ -86,6 +84,7 @@ import org.elasticsearch.lucene.queries.BlendedTermQuery;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.junit.After;
 import org.junit.Before;
@@ -136,52 +135,48 @@ public class CandidateQueryTests extends ESSingleNodeTestCase {
         indexService = createIndex(indexName, Settings.EMPTY);
         mapperService = indexService.mapperService();
 
-        String mapper = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("type")
-                .startObject("properties")
-                .startObject("int_field")
-                .field("type", "integer")
-                .endObject()
-                .startObject("long_field")
-                .field("type", "long")
-                .endObject()
-                .startObject("half_float_field")
-                .field("type", "half_float")
-                .endObject()
-                .startObject("float_field")
-                .field("type", "float")
-                .endObject()
-                .startObject("double_field")
-                .field("type", "double")
-                .endObject()
-                .startObject("ip_field")
-                .field("type", "ip")
-                .endObject()
-                .startObject("field")
-                .field("type", "keyword")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
-        mapperService.merge("type", new CompressedXContent(mapper), MapperService.MergeReason.MAPPING_UPDATE);
+        XContentBuilder mappings = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("type")
+            .startObject("properties")
+            .startObject("int_field")
+            .field("type", "integer")
+            .endObject()
+            .startObject("long_field")
+            .field("type", "long")
+            .endObject()
+            .startObject("half_float_field")
+            .field("type", "half_float")
+            .endObject()
+            .startObject("float_field")
+            .field("type", "float")
+            .endObject()
+            .startObject("double_field")
+            .field("type", "double")
+            .endObject()
+            .startObject("ip_field")
+            .field("type", "ip")
+            .endObject()
+            .startObject("field")
+            .field("type", "keyword")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        mapperService.merge(toMappingMetadata(mappings), MapperService.MergeReason.MAPPING_UPDATE);
 
         String queryField = "query_field";
-        String percolatorMapper = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("type")
-                .startObject("properties")
-                .startObject(queryField)
-                .field("type", "percolator")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
-        mapperService.merge("type", new CompressedXContent(percolatorMapper), MapperService.MergeReason.MAPPING_UPDATE);
+        mappings = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("type")
+            .startObject("properties")
+            .startObject(queryField)
+            .field("type", "percolator")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        mapperService.merge(toMappingMetadata(mappings), MapperService.MergeReason.MAPPING_UPDATE);
         fieldMapper = (PercolatorFieldMapper) mapperService.documentMapper().mappers().getMapper(queryField);
         fieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
 

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateQueryBuilderTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.core.RestApiVersion;
@@ -86,17 +85,11 @@ public class PercolateQueryBuilderTests extends AbstractQueryTestCase<PercolateQ
 
         docType = "_doc";
         mapperService.merge(
-            docType,
-            new CompressedXContent(
-                Strings.toString(
-                    PutMappingRequest.simpleMapping(queryField, "type=percolator", aliasField, "type=alias,path=" + queryField)
-                )
-            ),
+            toMappingMetadata(PutMappingRequest.simpleMapping(queryField, "type=percolator", aliasField, "type=alias,path=" + queryField)),
             MapperService.MergeReason.MAPPING_UPDATE
         );
         mapperService.merge(
-            docType,
-            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping(TEXT_FIELD_NAME, "type=text"))),
+            toMappingMetadata(PutMappingRequest.simpleMapping(TEXT_FIELD_NAME, "type=text")),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateWithNestedQueryBuilderTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolateWithNestedQueryBuilderTests.java
@@ -9,9 +9,7 @@
 package org.elasticsearch.percolator;
 
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -25,8 +23,7 @@ public class PercolateWithNestedQueryBuilderTests extends PercolateQueryBuilderT
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         super.initializeAdditionalMappings(mapperService);
         mapperService.merge(
-            "_doc",
-            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping("some_nested_object", "type=nested"))),
+            toMappingMetadata(PutMappingRequest.simpleMapping("some_nested_object", "type=nested")),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateSystemIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateSystemIndicesIT.java
@@ -29,6 +29,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.indices.TestSystemIndexDescriptor;
 import org.elasticsearch.indices.TestSystemIndexDescriptorAllowsTemplates;
 import org.elasticsearch.indices.TestSystemIndexPlugin;
@@ -371,7 +372,7 @@ public class CreateSystemIndicesIT extends ESIntegTestCase {
             mappings.containsKey(concreteIndex),
             equalTo(true)
         );
-        final Map<String, Object> sourceAsMap = mappings.get(concreteIndex).getSourceAsMap();
+        final Map<String, Object> sourceAsMap = Map.of(MapperService.SINGLE_MAPPING_NAME, mappings.get(concreteIndex).getSourceAsMap());
 
         try {
             assertThat(convertToXContent(sourceAsMap, XContentType.JSON).utf8ToString(), equalTo(expectedMappings));

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/NetNewSystemIndexAliasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/NetNewSystemIndexAliasIT.java
@@ -65,6 +65,7 @@ public class NetNewSystemIndexAliasIT extends ESIntegTestCase {
         public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
             try (XContentBuilder builder = jsonBuilder()) {
                 builder.startObject();
+                builder.startObject("_doc");
                 {
                     builder.startObject("_meta");
                     builder.field("version", Version.CURRENT.toString());
@@ -79,6 +80,7 @@ public class NetNewSystemIndexAliasIT extends ESIntegTestCase {
                     }
                     builder.endObject();
                 }
+                builder.endObject();
                 builder.endObject();
 
                 return Collections.singletonList(

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexManagerIT.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentType;
@@ -144,7 +145,10 @@ public class SystemIndexManagerIT extends ESIntegTestCase {
             mappings.containsKey(PRIMARY_INDEX_NAME),
             equalTo(true)
         );
-        final Map<String, Object> sourceAsMap = mappings.get(PRIMARY_INDEX_NAME).getSourceAsMap();
+        final Map<String, Object> sourceAsMap = Map.of(
+            MapperService.SINGLE_MAPPING_NAME,
+            mappings.get(PRIMARY_INDEX_NAME).getSourceAsMap()
+        );
 
         try {
             assertThat(convertToXContent(sourceAsMap, XContentType.JSON).utf8ToString(), equalTo(expectedMappings));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/TestSystemIndexDescriptor.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/TestSystemIndexDescriptor.java
@@ -95,6 +95,7 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
             final XContentBuilder builder = jsonBuilder();
 
             builder.startObject();
+            builder.startObject("_doc");
             {
                 builder.startObject("_meta");
                 builder.field("version", Version.CURRENT.previousMajor().toString());
@@ -108,7 +109,7 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
                 }
                 builder.endObject();
             }
-
+            builder.endObject();
             builder.endObject();
             return Strings.toString(builder);
         } catch (IOException e) {
@@ -121,6 +122,7 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
             final XContentBuilder builder = jsonBuilder();
 
             builder.startObject();
+            builder.startObject("_doc");
             {
                 builder.startObject("_meta");
                 builder.field("version", Version.CURRENT.toString());
@@ -137,7 +139,7 @@ public class TestSystemIndexDescriptor extends SystemIndexDescriptor {
                 }
                 builder.endObject();
             }
-
+            builder.endObject();
             builder.endObject();
             return Strings.toString(builder);
         } catch (IOException e) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/create/CreateIndexRequest.java
@@ -230,8 +230,7 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
      * </pre>
      */
     public CreateIndexRequest mapping(String mapping) {
-        this.mappings = mapping;
-        return this;
+        return mapping(new BytesArray(mapping), null);
     }
 
     /**
@@ -262,7 +261,6 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
     }
 
     private CreateIndexRequest mapping(BytesReference source, XContentType xContentType) {
-        Objects.requireNonNull(xContentType);
         Map<String, Object> mappingAsMap = XContentHelper.convertToMap(source, false, xContentType).v2();
         return mapping(MapperService.SINGLE_MAPPING_NAME, mappingAsMap);
     }
@@ -278,10 +276,11 @@ public class CreateIndexRequest extends AcknowledgedRequest<CreateIndexRequest> 
         try {
             XContentBuilder builder = XContentFactory.jsonBuilder();
             builder.map(source);
-            return mapping(Strings.toString(builder));
+            this.mappings = Strings.toString(builder);
         } catch (IOException e) {
             throw new ElasticsearchGenerationException("Failed to generate [" + source + "]", e);
         }
+        return this;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/post/TransportSimulateIndexTemplateAction.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.AliasMetadata;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.MetadataCreateIndexService;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService;
@@ -280,7 +281,7 @@ public class TransportSimulateIndexTemplateAction extends TransportMasterNodeRea
             tempIndexService -> {
                 MapperService mapperService = tempIndexService.mapperService();
                 for (CompressedXContent mapping : mappings) {
-                    mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
+                    mapperService.merge(new MappingMetadata(mapping), MapperService.MergeReason.INDEX_TEMPLATE);
                 }
 
                 DocumentMapper documentMapper = mapperService.documentMapper();

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportShardBulkAction.java
@@ -31,6 +31,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
 import org.elasticsearch.cluster.action.index.MappingUpdatedAction;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -363,8 +364,7 @@ public class TransportShardBulkAction extends TransportWriteAction<BulkShardRequ
             try {
                 primary.mapperService()
                     .merge(
-                        MapperService.SINGLE_MAPPING_NAME,
-                        new CompressedXContent(result.getRequiredMappingUpdate()),
+                        new MappingMetadata(new CompressedXContent(result.getRequiredMappingUpdate())),
                         MapperService.MergeReason.MAPPING_UPDATE_PREFLIGHT
                     );
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -2259,13 +2259,7 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
                 builder.startObject(KEY_MAPPINGS);
                 MappingMetadata mmd = indexMetadata.mapping();
                 if (mmd != null) {
-                    Map<String, Object> mapping = XContentHelper.convertToMap(mmd.source().uncompressed(), false).v2();
-                    if (mapping.size() == 1 && mapping.containsKey(mmd.type())) {
-                        // the type name is the root value, reduce it
-                        mapping = (Map<String, Object>) mapping.get(mmd.type());
-                    }
-                    builder.field(mmd.type());
-                    builder.map(mapping);
+                    mmd.toXContent(builder, params);
                 }
                 builder.endObject();
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -18,6 +18,8 @@ import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
@@ -29,18 +31,22 @@ import static org.elasticsearch.common.xcontent.support.XContentMapValues.nodeBo
 /**
  * Mapping configuration for a type.
  */
-public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
+public class MappingMetadata implements SimpleDiffable<MappingMetadata>, ToXContentFragment {
 
     public static final MappingMetadata EMPTY_MAPPINGS = new MappingMetadata(
         MapperService.SINGLE_MAPPING_NAME,
         Map.of(MapperService.SINGLE_MAPPING_NAME, Map.of())
     );
 
+    // TODO split this into CompressedXContent and Map-backed impls, similar to Source
+    // we end up serializing and deserializing stuff for no reason in far too many places
+
     private final String type;
 
+    // always includes the type at top-level
     private final CompressedXContent source;
 
-    private final boolean routingRequired;
+    private Boolean routingRequired = null;
 
     public MappingMetadata(DocumentMapper docMapper) {
         this.type = docMapper.type();
@@ -48,30 +54,36 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
         this.routingRequired = docMapper.routingFieldMapper().required();
     }
 
-    @SuppressWarnings("unchecked")
     public MappingMetadata(CompressedXContent mapping) {
         this.source = mapping;
+        // TODO do this via pull parsing - we don't need to reify the whole map!
         Map<String, Object> mappingMap = XContentHelper.convertToMap(mapping.compressedReference(), true).v2();
-        if (mappingMap.size() != 1) {
+        if (mappingMap.isEmpty()) {
+            this.type = MapperService.SINGLE_MAPPING_NAME;
+        } else if (mappingMap.size() != 1) {
             throw new IllegalStateException("Can't derive type from mapping, no root type: " + mapping.string());
+        } else {
+            this.type = mappingMap.keySet().iterator().next();
         }
-        this.type = mappingMap.keySet().iterator().next();
-        this.routingRequired = routingRequired((Map<String, Object>) mappingMap.get(this.type));
     }
 
-    @SuppressWarnings("unchecked")
     public MappingMetadata(String type, Map<String, Object> mapping) {
         this.type = type;
         try {
+            if (mapping.size() != 1 || mapping.containsKey(this.type) == false) {
+                mapping = Map.of(this.type, mapping);
+            }
             this.source = new CompressedXContent(mapping);
         } catch (IOException e) {
             throw new UncheckedIOException(e);  // XContent exception, should never happen
         }
-        Map<String, Object> withoutType = mapping;
-        if (mapping.size() == 1 && mapping.containsKey(type)) {
-            withoutType = (Map<String, Object>) mapping.get(type);
-        }
-        this.routingRequired = routingRequired(withoutType);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.field(type);
+        builder.map(sourceAsMap());
+        return builder;
     }
 
     public static void writeMappingMetadata(StreamOutput out, Map<String, MappingMetadata> mappings) throws IOException {
@@ -90,7 +102,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
     }
 
     @SuppressWarnings("unchecked")
-    private boolean routingRequired(Map<String, Object> withoutType) {
+    private static boolean routingRequired(Map<String, Object> withoutType) {
         boolean required = false;
         if (withoutType.containsKey("_routing")) {
             Map<String, Object> routingNode = (Map<String, Object>) withoutType.get("_routing");
@@ -101,19 +113,12 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
                     try {
                         required = nodeBooleanValue(fieldNode);
                     } catch (IllegalArgumentException ex) {
-                        throw new IllegalArgumentException(
-                            "Failed to create mapping for type [" + this.type() + "]. " + "Illegal value in field [_routing.required].",
-                            ex
-                        );
+                        throw new IllegalArgumentException("Failed to create mapping: illegal value in field [_routing.required].", ex);
                     }
                 }
             }
         }
         return required;
-    }
-
-    public String type() {
-        return this.type;
     }
 
     public CompressedXContent source() {
@@ -126,9 +131,9 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
     @SuppressWarnings("unchecked")
     public Map<String, Object> sourceAsMap() throws ElasticsearchParseException {
         Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true).v2();
-        if (mapping.size() == 1 && mapping.containsKey(type())) {
+        if (mapping.size() == 1 && mapping.containsKey(type)) {
             // the type name is the root value, reduce it
-            mapping = (Map<String, Object>) mapping.get(type());
+            mapping = (Map<String, Object>) mapping.get(type);
         }
         return mapping;
     }
@@ -144,13 +149,14 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
      * Converts the serialized compressed form of the mappings into a parsed map.
      * In contrast to {@link #sourceAsMap()}, this does not remove the type
      */
-    @SuppressWarnings("unchecked")
     public Map<String, Object> rawSourceAsMap() throws ElasticsearchParseException {
-        Map<String, Object> mapping = XContentHelper.convertToMap(source.compressedReference(), true).v2();
-        return mapping;
+        return XContentHelper.convertToMap(source.compressedReference(), true).v2();
     }
 
     public boolean routingRequired() {
+        if (this.routingRequired == null) {
+            this.routingRequired = routingRequired(sourceAsMap());
+        }
         return this.routingRequired;
     }
 
@@ -160,10 +166,10 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeString(type());
+        out.writeString(type);
         source().writeTo(out);
         // routing
-        out.writeBoolean(routingRequired);
+        out.writeBoolean(routingRequired());
     }
 
     @Override
@@ -173,7 +179,7 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata> {
 
         MappingMetadata that = (MappingMetadata) o;
 
-        if (Objects.equals(this.routingRequired, that.routingRequired) == false) return false;
+        if (Objects.equals(this.routingRequired(), that.routingRequired()) == false) return false;
         if (source.equals(that.source) == false) return false;
         if (type.equals(that.type) == false) return false;
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MappingMetadata.java
@@ -54,6 +54,12 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata>, ToXCont
         this.routingRequired = docMapper.routingFieldMapper().required();
     }
 
+    /**
+     * Create MappingMetadata from compressed XContent
+     *
+     * The xcontent should have a containing map whose key is a type - typically '_doc'. This
+     * will be discarded when the mapping is returned via {@link #sourceAsMap()}
+     */
     public MappingMetadata(CompressedXContent mapping) {
         this.source = mapping;
         // TODO do this via pull parsing - we don't need to reify the whole map!
@@ -67,6 +73,11 @@ public class MappingMetadata implements SimpleDiffable<MappingMetadata>, ToXCont
         }
     }
 
+    /**
+     * Create MappingMetadata from a java map
+     * @param type      the type, typically _doc
+     * @param mapping   the mappings, which may or not be wrapped with the type
+     */
     public MappingMetadata(String type, Map<String, Object> mapping) {
         this.type = type;
         try {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataCreateIndexService.java
@@ -1325,10 +1325,10 @@ public class MetadataCreateIndexService {
         IndexMode indexMode = indexService.getIndexSettings() != null ? indexService.getIndexSettings().getMode() : IndexMode.STANDARD;
         final CompressedXContent defaultMapping = indexMode.getDefaultMapping();
         if (defaultMapping != null) {
-            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, defaultMapping, MergeReason.INDEX_TEMPLATE);
+            mapperService.merge(new MappingMetadata(defaultMapping), MergeReason.INDEX_TEMPLATE);
         }
         for (CompressedXContent mapping : mappings) {
-            mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MergeReason.INDEX_TEMPLATE);
+            mapperService.merge(new MappingMetadata(mapping), MergeReason.INDEX_TEMPLATE);
         }
         indexMode.validateTimestampFieldMapping(request.dataStreamName() != null, mapperService.mappingLookup());
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateService.java
@@ -1429,7 +1429,7 @@ public class MetadataIndexTemplateService {
             try {
                 MapperService mapperService = tempIndexService.mapperService();
                 for (CompressedXContent mapping : mappings) {
-                    mapperService.merge(MapperService.SINGLE_MAPPING_NAME, mapping, MapperService.MergeReason.INDEX_TEMPLATE);
+                    mapperService.merge(new MappingMetadata(mapping), MapperService.MergeReason.INDEX_TEMPLATE);
                 }
 
                 if (template.getDataStreamTemplate() != null) {
@@ -1475,7 +1475,7 @@ public class MetadataIndexTemplateService {
             createdIndex = dummyIndexService.index();
 
             if (mappings != null) {
-                dummyIndexService.mapperService().merge(MapperService.SINGLE_MAPPING_NAME, mappings, MergeReason.MAPPING_UPDATE);
+                dummyIndexService.mapperService().merge(new MappingMetadata(mappings), MergeReason.MAPPING_UPDATE);
             }
 
         } finally {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMappingService.java
@@ -146,7 +146,7 @@ public class MetadataMappingService {
                 updateList.add(indexMetadata);
                 // try and parse it (no need to add it here) so we can bail early in case of parsing exception
                 // first, simulate: just call merge and ignore the result
-                Mapping mapping = mapperService.parseMapping(MapperService.SINGLE_MAPPING_NAME, mappingUpdateSource);
+                Mapping mapping = mapperService.parseMapping(new MappingMetadata(mappingUpdateSource));
                 MapperService.mergeMappings(mapperService.documentMapper(), mapping, MergeReason.MAPPING_UPDATE);
             }
             Metadata.Builder builder = Metadata.builder(metadata);
@@ -163,11 +163,7 @@ public class MetadataMappingService {
                 if (existingMapper != null) {
                     existingSource = existingMapper.mappingSource();
                 }
-                DocumentMapper mergedMapper = mapperService.merge(
-                    MapperService.SINGLE_MAPPING_NAME,
-                    mappingUpdateSource,
-                    MergeReason.MAPPING_UPDATE
-                );
+                DocumentMapper mergedMapper = mapperService.merge(new MappingMetadata(mappingUpdateSource), MergeReason.MAPPING_UPDATE);
                 CompressedXContent updatedSource = mergedMapper.mappingSource();
 
                 if (existingSource != null) {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamService.java
@@ -47,12 +47,18 @@ public class MetadataMigrateToDataStreamService {
 
     private static final Logger logger = LogManager.getLogger(MetadataMigrateToDataStreamService.class);
 
-    private static final CompressedXContent TIMESTAMP_MAPPING;
+    private static final MappingMetadata TIMESTAMP_MAPPING;
 
     static {
         try {
-            TIMESTAMP_MAPPING = new CompressedXContent(
-                ((builder, params) -> builder.startObject(DataStreamTimestampFieldMapper.NAME).field("enabled", true).endObject())
+            TIMESTAMP_MAPPING = new MappingMetadata(
+                new CompressedXContent(
+                    ((builder, params) -> builder.startObject(MapperService.SINGLE_MAPPING_NAME)
+                        .startObject(DataStreamTimestampFieldMapper.NAME)
+                        .field("enabled", true)
+                        .endObject()
+                        .endObject())
+                )
             );
         } catch (IOException e) {
             throw new AssertionError(e);
@@ -195,7 +201,7 @@ public class MetadataMigrateToDataStreamService {
 
         MapperService mapperService = mapperSupplier.apply(im);
         mapperService.merge(im, MapperService.MergeReason.MAPPING_RECOVERY);
-        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, TIMESTAMP_MAPPING, MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(TIMESTAMP_MAPPING, MapperService.MergeReason.MAPPING_UPDATE);
         DocumentMapper mapper = mapperService.documentMapper();
 
         var imb = IndexMetadata.builder(im);

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -288,11 +288,7 @@ public class SystemIndexManager implements ClusterStateListener {
             @SuppressWarnings("unchecked")
             Map<String, Object> meta = (Map<String, Object>) mappingMetadata.sourceAsMap().get("_meta");
             if (meta == null) {
-                logger.warn(
-                    "Missing _meta field in mapping [{}] of index [{}], assuming mappings update required",
-                    mappingMetadata.type(),
-                    indexName
-                );
+                logger.warn("Missing _meta field in mapping of index [{}], assuming mappings update required", indexName);
                 // This can happen with old system indices, such as .watches, which were created before we had the convention of
                 // storing a version under `_meta.` We should just replace the template to be sure.
                 return Version.V_EMPTY;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestPutMappingAction.java
@@ -79,12 +79,12 @@ public class RestPutMappingAction extends BaseRestHandler {
             }
 
             Map<String, Object> mappingSource = prepareV7Mappings(includeTypeName, sourceAsMap);
-            putMappingRequest.source(mappingSource);
+            putMappingRequest.source(Map.of(MapperService.SINGLE_MAPPING_NAME, mappingSource));
         } else {
             if (MapperService.isMappingSourceTyped(MapperService.SINGLE_MAPPING_NAME, sourceAsMap)) {
                 throw new IllegalArgumentException("Types cannot be provided in put mapping requests");
             }
-            putMappingRequest.source(sourceAsMap);
+            putMappingRequest.source(Map.of(MapperService.SINGLE_MAPPING_NAME, sourceAsMap));
         }
 
         putMappingRequest.timeout(request.paramAsTime("timeout", putMappingRequest.timeout()));

--- a/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/RestoreService.java
@@ -1660,10 +1660,7 @@ public class RestoreService implements ClusterStateApplier {
                 // TODO: automatically add runtime field definitions for source-only snapshots
             }
 
-            Map<String, Object> newMapping = new LinkedHashMap<>();
-            newMapping.put(mappingMetadata.type(), newMappingSource);
-
-            MappingMetadata updatedMappingMetadata = new MappingMetadata(mappingMetadata.type(), newMapping);
+            MappingMetadata updatedMappingMetadata = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, newMappingSource);
             convertedIndexMetadataBuilder.putMapping(updatedMappingMetadata);
             IndexMetadata convertedIndexMetadata = convertedIndexMetadataBuilder.build();
 
@@ -1689,10 +1686,7 @@ public class RestoreService implements ClusterStateApplier {
                 newMappingSource.clear();
                 newMappingSource.put("_meta", legacyMapping);
 
-                newMapping = new LinkedHashMap<>();
-                newMapping.put(mappingMetadata.type(), newMappingSource);
-
-                updatedMappingMetadata = new MappingMetadata(mappingMetadata.type(), newMapping);
+                updatedMappingMetadata = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, newMappingSource);
                 convertedIndexMetadataBuilder.putMapping(updatedMappingMetadata);
                 throw new IllegalArgumentException(e);
             }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskResultsService.java
@@ -121,6 +121,7 @@ public class TaskResultsService {
             final XContentBuilder builder = jsonBuilder();
 
             builder.startObject();
+            builder.startObject("_doc");
             {
                 builder.startObject("_meta");
                 builder.field(TASK_RESULT_MAPPING_VERSION_META_FIELD, Version.CURRENT.toString());
@@ -199,7 +200,7 @@ public class TaskResultsService {
                 }
                 builder.endObject();
             }
-
+            builder.endObject();
             builder.endObject();
             return builder;
         } catch (IOException e) {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/MappingStatsTests.java
@@ -107,8 +107,8 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
               "mappings" : {
                 "total_field_count" : 12,
                 "total_deduplicated_field_count" : 6,
-                "total_deduplicated_mapping_size" : "260b",
-                "total_deduplicated_mapping_size_in_bytes" : 260,
+                "total_deduplicated_mapping_size" : "266b",
+                "total_deduplicated_mapping_size_in_bytes" : 266,
                 "field_types" : [
                   {
                     "name" : "dense_vector",
@@ -227,8 +227,8 @@ public class MappingStatsTests extends AbstractWireSerializingTestCase<MappingSt
               "mappings" : {
                 "total_field_count" : 18,
                 "total_deduplicated_field_count" : 12,
-                "total_deduplicated_mapping_size" : "519b",
-                "total_deduplicated_mapping_size_in_bytes" : 519,
+                "total_deduplicated_mapping_size" : "530b",
+                "total_deduplicated_mapping_size_in_bytes" : 530,
                 "field_types" : [
                   {
                     "name" : "dense_vector",

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -41,7 +41,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         // TODO - it will be nice to get a random mapping generator
         final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "text" }}}""");
+            { "_doc": { "properties": { "field": { "type": "text" }}}}""");
         request.indices(new Index[] { indexService.index() });
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
@@ -63,7 +63,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "text" }}}""").indices(new Index[] { indexService.index() });
+            { "_doc": { "properties": { "field": { "type": "text" }}}}""").indices(new Index[] { indexService.index() });
         final var resultingState1 = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
             mappingService.putMappingExecutor,
@@ -83,7 +83,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("""
-            { "properties": { "field": { "type": "text" }}}""");
+            { "_doc": { "properties": { "field": { "type": "text" }}}}""");
         request.indices(new Index[] { indexService.index() });
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),
@@ -98,7 +98,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         final long previousVersion = indexService.getMetadata().getMappingVersion();
         final MetadataMappingService mappingService = getInstanceFromNode(MetadataMappingService.class);
         final ClusterService clusterService = getInstanceFromNode(ClusterService.class);
-        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("{ \"properties\": {}}");
+        final PutMappingClusterStateUpdateRequest request = new PutMappingClusterStateUpdateRequest("{ \"_doc\": { \"properties\": {}} }");
         request.indices(new Index[] { indexService.index() });
         final var resultingState = ClusterStateTaskExecutorUtils.executeAndAssertSuccessful(
             clusterService.state(),

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMigrateToDataStreamServiceTests.java
@@ -435,7 +435,7 @@ public class MetadataMigrateToDataStreamServiceTests extends MapperServiceTestCa
 
     private MapperService getMapperService(IndexMetadata im) {
         try {
-            return createMapperService("{\"_doc\": " + im.mapping().source().toString() + "}");
+            return createMapperService(im.mapping().source().toString());
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.codec;
 
 import org.apache.lucene.codecs.lucene94.Lucene94Codec;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -61,7 +62,7 @@ public class PerFieldMapperCodecTests extends ESTestCase {
         MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), settings.build(), "test");
         if (timestampField) {
             String mapping = """
-                {
+                { "_doc" : {
                     "_data_stream_timestamp": {
                         "enabled": true
                     },
@@ -70,9 +71,9 @@ public class PerFieldMapperCodecTests extends ESTestCase {
                             "type": "date"
                         }
                     }
-                }
+                } }
                 """;
-            mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
         }
         return new PerFieldMapperCodec(Lucene94Codec.Mode.BEST_SPEED, mapperService, BigArrays.NON_RECYCLING_INSTANCE);
     }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/BinaryDVFieldDataTests.java
@@ -10,9 +10,7 @@ package org.elasticsearch.index.fielddata;
 
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.DocumentMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.ParsedDocument;
@@ -34,21 +32,19 @@ public class BinaryDVFieldDataTests extends AbstractFieldDataTestCase {
     }
 
     public void testDocValue() throws Exception {
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("test")
-                .startObject("properties")
-                .startObject("field")
-                .field("type", "binary")
-                .field("doc_values", true)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("test")
+            .startObject("properties")
+            .startObject("field")
+            .field("type", "binary")
+            .field("doc_values", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
-        DocumentMapper mapper = mapperService.merge("test", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        DocumentMapper mapper = mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
 
         List<BytesRef> bytesList1 = new ArrayList<>(2);
         bytesList1.add(randomBytes());

--- a/server/src/test/java/org/elasticsearch/index/mapper/CamelCaseFieldNameTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CamelCaseFieldNameTests.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.index.mapper;
 
+import org.elasticsearch.cluster.metadata.MappingMetadata;
+
 public class CamelCaseFieldNameTests extends MapperServiceTestCase {
 
     public void testCamelCaseFieldNameStaysAsIs() throws Exception {
@@ -24,7 +26,7 @@ public class CamelCaseFieldNameTests extends MapperServiceTestCase {
         assertNotNull(documentMapper.mappers().getMapper("thisIsCamelCase"));
         assertNull(documentMapper.mappers().getMapper("this_is_camel_case"));
 
-        documentMapper = mapperService.merge("_doc", documentMapper.mappingSource(), MapperService.MergeReason.MAPPING_UPDATE);
+        documentMapper = mapperService.merge(new MappingMetadata(documentMapper), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertNotNull(documentMapper.mappers().getMapper("thisIsCamelCase"));
         assertNull(documentMapper.mappers().getMapper("this_is_camel_case"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocumentMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.analysis.core.KeywordAnalyzer;
 import org.apache.lucene.analysis.core.WhitespaceAnalyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -176,7 +177,7 @@ public class DocumentMapperTests extends MapperServiceTestCase {
                     Mapping update = doc.dynamicMappingsUpdate();
                     assert update != null;
                     lastIntroducedFieldName.set(fieldName);
-                    mapperService.merge("_doc", new CompressedXContent(update.toString()), MergeReason.MAPPING_UPDATE);
+                    mapperService.merge(new MappingMetadata(new CompressedXContent(update.toString())), MergeReason.MAPPING_UPDATE);
                 }
             } catch (Exception e) {
                 error.set(e);

--- a/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/JavaMultiFieldMergeTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.xcontent.XContentFactory;
@@ -20,6 +21,7 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
+
     public void testMergeMultiField() throws Exception {
         String mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping1.json");
         MapperService mapperService = createMapperService(mapping);
@@ -35,7 +37,7 @@ public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
         assertThat(f, nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping2.json");
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertTrue(mapperService.fieldType("name").isSearchable());
 
@@ -51,7 +53,7 @@ public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
         assertThat(f, notNullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping3.json");
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertTrue(mapperService.fieldType("name").isSearchable());
 
@@ -61,7 +63,7 @@ public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
         assertThat(mapperService.fieldType("name.not_indexed3"), nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/test-mapping4.json");
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertTrue(mapperService.fieldType("name").isSearchable());
 
@@ -85,7 +87,7 @@ public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
         assertThat(f, nullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade1.json");
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertTrue(mapperService.fieldType("name").isSearchable());
 
@@ -101,7 +103,7 @@ public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
         assertThat(f, notNullValue());
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade2.json");
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
 
         assertTrue(mapperService.fieldType("name").isSearchable());
 
@@ -112,7 +114,7 @@ public class JavaMultiFieldMergeTests extends MapperServiceTestCase {
 
         mapping = copyToStringFromClasspath("/org/elasticsearch/index/mapper/multifield/merge/upgrade3.json");
         try {
-            mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
             fail();
         } catch (IllegalArgumentException e) {
             assertThat(e.getMessage(), containsString("Cannot update parameter [index] from [true] to [false]"));

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -257,7 +258,7 @@ public class MapperServiceTests extends MapperServiceTestCase {
             )
         );
 
-        DocumentMapper documentMapper = mapperService.merge("_doc", mapping, MergeReason.MAPPING_RECOVERY);
+        DocumentMapper documentMapper = mapperService.merge(new MappingMetadata(mapping), MergeReason.MAPPING_RECOVERY);
 
         assertEquals(testString, documentMapper.mappers().getMapper(testString).simpleName());
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.compress.CompressedXContent;
@@ -514,7 +515,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         );
         MergeReason mergeReason = randomFrom(MergeReason.MAPPING_UPDATE, MergeReason.INDEX_TEMPLATE);
 
-        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(mapping), mergeReason);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), mergeReason);
         DocumentMapper docMapper = mapperService.documentMapper();
 
         ParsedDocument doc = docMapper.parse(
@@ -620,7 +621,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         );
         MergeReason mergeReason = randomFrom(MergeReason.MAPPING_UPDATE, MergeReason.INDEX_TEMPLATE);
 
-        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(mapping), mergeReason);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), mergeReason);
         DocumentMapper docMapper = mapperService.documentMapper();
 
         ParsedDocument doc = docMapper.parse(
@@ -680,7 +681,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
                 .endObject()
                 .endObject()
         );
-        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(firstMapping), MergeReason.INDEX_TEMPLATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(firstMapping)), MergeReason.INDEX_TEMPLATE);
 
         String secondMapping = Strings.toString(
             XContentFactory.jsonBuilder()
@@ -703,7 +704,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
                 .endObject()
         );
 
-        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(secondMapping), MergeReason.INDEX_TEMPLATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(secondMapping)), MergeReason.INDEX_TEMPLATE);
         DocumentMapper docMapper = mapperService.documentMapper();
 
         ParsedDocument doc = docMapper.parse(

--- a/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ParametrizedMapperTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.mapper;
 
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.Lucene;
@@ -463,7 +464,7 @@ public class ParametrizedMapperTests extends MapperServiceTestCase {
         MapperService mapperService = createMapperService(mapping);
         assertEquals(mapping, Strings.toString(mapperService.documentMapper().mapping()));
 
-        mapperService.merge("_doc", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
         assertEquals(mapping, Strings.toString(mapperService.documentMapper().mapping()));
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldQueryStringQueryBuilderTests.java
@@ -19,8 +19,6 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.PointRangeQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.time.DateMathParser;
 import org.elasticsearch.index.query.QueryStringQueryBuilder;
@@ -46,28 +44,25 @@ public class RangeFieldQueryStringQueryBuilderTests extends AbstractQueryTestCas
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge(
-            "_doc",
-            new CompressedXContent(
-                Strings.toString(
-                    PutMappingRequest.simpleMapping(
-                        INTEGER_RANGE_FIELD_NAME,
-                        "type=integer_range",
-                        LONG_RANGE_FIELD_NAME,
-                        "type=long_range",
-                        FLOAT_RANGE_FIELD_NAME,
-                        "type=float_range",
-                        DOUBLE_RANGE_FIELD_NAME,
-                        "type=double_range",
-                        DATE_RANGE_FIELD_NAME,
-                        "type=date_range",
-                        IP_RANGE_FIELD_NAME,
-                        "type=ip_range"
-                    )
+            toMappingMetadata(
+                PutMappingRequest.simpleMapping(
+                    INTEGER_RANGE_FIELD_NAME,
+                    "type=integer_range",
+                    LONG_RANGE_FIELD_NAME,
+                    "type=long_range",
+                    FLOAT_RANGE_FIELD_NAME,
+                    "type=float_range",
+                    DOUBLE_RANGE_FIELD_NAME,
+                    "type=double_range",
+                    DATE_RANGE_FIELD_NAME,
+                    "type=date_range",
+                    IP_RANGE_FIELD_NAME,
+                    "type=ip_range"
                 )
+
             ),
             MapperService.MergeReason.MAPPING_UPDATE
         );
-
     }
 
     public void testIntegerRangeQuery() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RootObjectMapperTests.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class RootObjectMapperTests extends MapperServiceTestCase {
@@ -353,9 +352,9 @@ public class RootObjectMapperTests extends MapperServiceTestCase {
                 .endObject()
         );
 
-        // Empty name not allowed in index created after 5.0
-        Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(mapping));
-        assertThat(e.getMessage(), containsString("type cannot be an empty string"));
+        // Type names are now ignored completely
+        MapperService mapperService = createMapperService(mapping);
+        assertNotNull(mapperService.fieldType("name"));
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/SparseVectorFieldMapperTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.index.mapper.vectors;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -22,6 +21,7 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.SourceToParse;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.VersionUtils;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -49,23 +49,18 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("index", settings);
         MapperService mapperService = indexService.mapperService();
 
-        BytesReference mapping = BytesReference.bytes(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("_doc")
-                .startObject("properties")
-                .startObject("my-vector")
-                .field("type", "sparse_vector")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my-vector")
+            .field("type", "sparse_vector")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
-        MapperParsingException e = expectThrows(
-            MapperParsingException.class,
-            () -> mapperService.parseMapping(MapperService.SINGLE_MAPPING_NAME, new CompressedXContent(mapping))
-        );
+        MapperParsingException e = expectThrows(MapperParsingException.class, () -> mapperService.parseMapping(toMappingMetadata(mapping)));
         assertThat(e.getMessage(), containsString(SparseVectorFieldMapper.ERROR_MESSAGE));
     }
 
@@ -76,24 +71,18 @@ public class SparseVectorFieldMapperTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("index", settings);
         MapperService mapperService = indexService.mapperService();
 
-        BytesReference mapping = BytesReference.bytes(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("_doc")
-                .startObject("properties")
-                .startObject("my-vector")
-                .field("type", "sparse_vector")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("_doc")
+            .startObject("properties")
+            .startObject("my-vector")
+            .field("type", "sparse_vector")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
-        DocumentMapper mapper = mapperService.merge(
-            MapperService.SINGLE_MAPPING_NAME,
-            new CompressedXContent(mapping),
-            MapperService.MergeReason.MAPPING_UPDATE
-        );
+        DocumentMapper mapper = mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         assertWarnings(SparseVectorFieldMapper.ERROR_MESSAGE_7X);
 
         // Check that new vectors cannot be indexed.

--- a/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/IntervalQueryBuilderTests.java
@@ -19,7 +19,6 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.script.Script;
@@ -79,7 +78,7 @@ public class IntervalQueryBuilderTests extends AbstractQueryTestCase<IntervalQue
             .endObject()
             .endObject();
 
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     private static IntervalsSourceProvider createRandomSource(int depth, boolean useScripts) {

--- a/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/MatchQueryBuilderTests.java
@@ -30,7 +30,6 @@ import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.search.MultiPhrasePrefixQuery;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.unit.Fuzziness;
@@ -387,11 +386,8 @@ public class MatchQueryBuilderTests extends AbstractQueryTestCase<MatchQueryBuil
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge(
-            "_doc",
-            new CompressedXContent(
-                Strings.toString(
-                    PutMappingRequest.simpleMapping("string_boost", "type=text", "string_no_pos", "type=text,index_options=docs")
-                )
+            toMappingMetadata(
+                PutMappingRequest.simpleMapping("string_boost", "type=text", "string_no_pos", "type=text,index_options=docs")
             ),
             MapperService.MergeReason.MAPPING_UPDATE
         );

--- a/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/NestedQueryBuilderTests.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.join.ScoreMode;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -51,26 +52,27 @@ public class NestedQueryBuilderTests extends AbstractQueryTestCase<NestedQueryBu
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge(
-            "_doc",
-            new CompressedXContent(
-                Strings.toString(
-                    PutMappingRequest.simpleMapping(
-                        TEXT_FIELD_NAME,
-                        "type=text",
-                        INT_FIELD_NAME,
-                        "type=integer",
-                        DOUBLE_FIELD_NAME,
-                        "type=double",
-                        BOOLEAN_FIELD_NAME,
-                        "type=boolean",
-                        DATE_FIELD_NAME,
-                        "type=date",
-                        OBJECT_FIELD_NAME,
-                        "type=object",
-                        GEO_POINT_FIELD_NAME,
-                        "type=geo_point",
-                        "nested1",
-                        "type=nested"
+            new MappingMetadata(
+                new CompressedXContent(
+                    Strings.toString(
+                        PutMappingRequest.simpleMapping(
+                            TEXT_FIELD_NAME,
+                            "type=text",
+                            INT_FIELD_NAME,
+                            "type=integer",
+                            DOUBLE_FIELD_NAME,
+                            "type=double",
+                            BOOLEAN_FIELD_NAME,
+                            "type=boolean",
+                            DATE_FIELD_NAME,
+                            "type=date",
+                            OBJECT_FIELD_NAME,
+                            "type=object",
+                            GEO_POINT_FIELD_NAME,
+                            "type=geo_point",
+                            "nested1",
+                            "type=nested"
+                        )
                     )
                 )
             ),

--- a/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/QueryStringQueryBuilderTests.java
@@ -43,7 +43,6 @@ import org.apache.lucene.util.automaton.Operations;
 import org.apache.lucene.util.automaton.TooComplexToDeterminizeException;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.Fuzziness;
 import org.elasticsearch.index.mapper.MapperService;
@@ -94,7 +93,7 @@ public class QueryStringQueryBuilderTests extends AbstractQueryTestCase<QueryStr
             .endObject()
             .endObject();
 
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/RangeQueryRewriteTests.java
@@ -11,12 +11,11 @@ package org.elasticsearch.index.query;
 import org.apache.lucene.index.IndexReader;
 import org.apache.lucene.index.MultiReader;
 import org.apache.lucene.search.IndexSearcher;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.mapper.MappedFieldType.Relation;
 import org.elasticsearch.index.mapper.MapperService.MergeReason;
 import org.elasticsearch.test.ESSingleNodeTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 
 import static java.util.Collections.emptyMap;
@@ -56,19 +55,17 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
 
     public void testRewriteMissingReader() throws Exception {
         IndexService indexService = createIndex("test");
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("type")
-                .startObject("properties")
-                .startObject("foo")
-                .field("type", "date")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
-        indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("type")
+            .startObject("properties")
+            .startObject("foo")
+            .field("type", "date")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        indexService.mapperService().merge(toMappingMetadata(mapping), MergeReason.MAPPING_UPDATE);
         QueryRewriteContext context = new SearchExecutionContext(
             0,
             0,
@@ -97,19 +94,17 @@ public class RangeQueryRewriteTests extends ESSingleNodeTestCase {
 
     public void testRewriteEmptyReader() throws Exception {
         IndexService indexService = createIndex("test");
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("type")
-                .startObject("properties")
-                .startObject("foo")
-                .field("type", "date")
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
-        indexService.mapperService().merge("type", new CompressedXContent(mapping), MergeReason.MAPPING_UPDATE);
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("type")
+            .startObject("properties")
+            .startObject("foo")
+            .field("type", "date")
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        indexService.mapperService().merge(toMappingMetadata(mapping), MergeReason.MAPPING_UPDATE);
         IndexReader reader = new MultiReader();
         QueryRewriteContext context = new SearchExecutionContext(
             0,

--- a/server/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/SpanMultiTermQueryBuilderTests.java
@@ -28,8 +28,6 @@ import org.apache.lucene.search.TopTermsRewrite;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.lucene.search.SpanBooleanQueryRewriteWithMaxClause;
 import org.elasticsearch.index.mapper.MapperService;
@@ -75,7 +73,7 @@ public class SpanMultiTermQueryBuilderTests extends AbstractQueryTestCase<SpanMu
             .endObject()
             .endObject();
 
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/query/TermsSetQueryBuilderTests.java
@@ -28,8 +28,6 @@ import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.plugins.Plugin;
@@ -65,10 +63,8 @@ public class TermsSetQueryBuilderTests extends AbstractQueryTestCase<TermsSetQue
 
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
-        String docType = "_doc";
         mapperService.merge(
-            docType,
-            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping("m_s_m", "type=long"))),
+            toMappingMetadata(PutMappingRequest.simpleMapping("m_s_m", "type=long")),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryParserTests.java
+++ b/server/src/test/java/org/elasticsearch/index/search/MultiMatchQueryParserTests.java
@@ -20,7 +20,7 @@ import org.apache.lucene.search.SynonymQuery;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.tests.analysis.MockSynonymAnalyzer;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Strings;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.lucene.search.Queries;
 import org.elasticsearch.common.settings.Settings;
@@ -35,6 +35,7 @@ import org.elasticsearch.lucene.queries.BlendedTermQuery;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESSingleNodeTestCase;
 import org.elasticsearch.test.MockKeywordPlugin;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.junit.Before;
 
@@ -89,7 +90,7 @@ public class MultiMatchQueryParserTests extends ESSingleNodeTestCase {
                 }
             }
             """;
-        mapperService.merge("person", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(new MappingMetadata(new CompressedXContent(mapping)), MapperService.MergeReason.MAPPING_UPDATE);
         this.indexService = indexService;
     }
 
@@ -342,32 +343,30 @@ public class MultiMatchQueryParserTests extends ESSingleNodeTestCase {
                 .build()
         );
         MapperService mapperService = indexService.mapperService();
-        String mapping = Strings.toString(
-            XContentFactory.jsonBuilder()
-                .startObject()
-                .startObject("type")
-                .startObject("properties")
-                .startObject("field")
-                .field("type", "keyword")
-                .endObject()
-                .startObject("field_normalizer")
-                .field("type", "keyword")
-                .field("normalizer", "my_lowercase")
-                .endObject()
-                .startObject("field_split")
-                .field("type", "keyword")
-                .field("split_queries_on_whitespace", true)
-                .endObject()
-                .startObject("field_split_normalizer")
-                .field("type", "keyword")
-                .field("normalizer", "my_lowercase")
-                .field("split_queries_on_whitespace", true)
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
-        mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        XContentBuilder mapping = XContentFactory.jsonBuilder()
+            .startObject()
+            .startObject("type")
+            .startObject("properties")
+            .startObject("field")
+            .field("type", "keyword")
+            .endObject()
+            .startObject("field_normalizer")
+            .field("type", "keyword")
+            .field("normalizer", "my_lowercase")
+            .endObject()
+            .startObject("field_split")
+            .field("type", "keyword")
+            .field("split_queries_on_whitespace", true)
+            .endObject()
+            .startObject("field_split_normalizer")
+            .field("type", "keyword")
+            .field("normalizer", "my_lowercase")
+            .field("split_queries_on_whitespace", true)
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
+        mapperService.merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
             randomInt(20),
             0,

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3129,7 +3129,7 @@ public class IndexShardTests extends IndexShardTestCase {
 
         assertThat(requestedMappingUpdates, hasKey("_doc"));
         assertThat(requestedMappingUpdates.get("_doc").source().string(), equalTo("""
-            {"properties":{"foo":{"type":"text"}}}"""));
+            {"_doc":{"properties":{"foo":{"type":"text"}}}}"""));
 
         closeShards(sourceShard, targetShard);
     }

--- a/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
+++ b/server/src/test/java/org/elasticsearch/index/similarity/SimilarityTests.java
@@ -20,6 +20,7 @@ import org.apache.lucene.search.similarities.LMDirichletSimilarity;
 import org.apache.lucene.search.similarities.LMJelinekMercerSimilarity;
 import org.apache.lucene.search.similarities.LambdaTTF;
 import org.apache.lucene.search.similarities.NormalizationH2;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -254,7 +255,7 @@ public class SimilarityTests extends ESSingleNodeTestCase {
         IndexService indexService = createIndex("foo");
         MapperParsingException e = expectThrows(
             MapperParsingException.class,
-            () -> indexService.mapperService().parseMapping("type", new CompressedXContent(mapping))
+            () -> indexService.mapperService().parseMapping(new MappingMetadata(new CompressedXContent(mapping)))
         );
         assertThat(e.getMessage(), equalTo("Failed to parse mapping: Unknown Similarity type [unknown_similarity] for field [field1]"));
     }

--- a/server/src/test/java/org/elasticsearch/search/geo/GeoPointShapeQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/geo/GeoPointShapeQueryTests.java
@@ -67,6 +67,7 @@ public class GeoPointShapeQueryTests extends BasePointShapeQueryTestCase<GeoShap
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
+                .startObject("_doc")
                 .startObject("properties")
                 .startObject(defaultFieldName)
                 .field("type", "geo_point")
@@ -74,6 +75,7 @@ public class GeoPointShapeQueryTests extends BasePointShapeQueryTestCase<GeoShap
                 .startObject("alias")
                 .field("type", "alias")
                 .field("path", defaultFieldName)
+                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -17,9 +17,7 @@ import org.apache.lucene.document.StoredField;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.search.suggest.document.ContextSuggestField;
 import org.apache.lucene.util.BytesRef;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.mapper.CompletionFieldMapper.CompletionFieldType;
 import org.elasticsearch.index.mapper.DocumentMapper;
@@ -51,26 +49,24 @@ import static org.hamcrest.Matchers.equalTo;
 public class CategoryContextMappingTests extends ESSingleNodeTestCase {
 
     public void testIndexingWithNoContexts() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         ParsedDocument parsedDocument = defaultMapper.parse(
             new SourceToParse(
@@ -101,26 +97,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithSimpleContexts() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         ParsedDocument parsedDocument = defaultMapper.parse(
             new SourceToParse(
@@ -146,26 +140,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithSimpleNumberContexts() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         ParsedDocument parsedDocument = defaultMapper.parse(
             new SourceToParse(
@@ -191,26 +183,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithSimpleBooleanContexts() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         ParsedDocument parsedDocument = defaultMapper.parse(
             new SourceToParse(
@@ -236,26 +226,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithSimpleNULLContexts() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         XContentBuilder builder = jsonBuilder().startObject()
             .startArray("completion")
             .startObject()
@@ -279,26 +267,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithContextList() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         ParsedDocument parsedDocument = defaultMapper.parse(
             new SourceToParse(
@@ -322,26 +308,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithMixedTypeContextList() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         ParsedDocument parsedDocument = defaultMapper.parse(
             new SourceToParse(
@@ -365,26 +349,24 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithMixedTypeContextListHavingNULL() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         XContentBuilder builder = jsonBuilder().startObject()
             .startObject("completion")
             .array("input", "suggestion5", "suggestion6", "suggestion7")
@@ -403,30 +385,28 @@ public class CategoryContextMappingTests extends ESSingleNodeTestCase {
     }
 
     public void testIndexingWithMultipleContexts() throws Exception {
-        String mapping = Strings.toString(
-            jsonBuilder().startObject()
-                .startObject("type1")
-                .startObject("properties")
-                .startObject("completion")
-                .field("type", "completion")
-                .startArray("contexts")
-                .startObject()
-                .field("name", "ctx")
-                .field("type", "category")
-                .endObject()
-                .startObject()
-                .field("name", "type")
-                .field("type", "category")
-                .endObject()
-                .endArray()
-                .endObject()
-                .endObject()
-                .endObject()
-                .endObject()
-        );
+        XContentBuilder mapping = jsonBuilder().startObject()
+            .startObject("type1")
+            .startObject("properties")
+            .startObject("completion")
+            .field("type", "completion")
+            .startArray("contexts")
+            .startObject()
+            .field("name", "ctx")
+            .field("type", "category")
+            .endObject()
+            .startObject()
+            .field("name", "type")
+            .field("type", "category")
+            .endObject()
+            .endArray()
+            .endObject()
+            .endObject()
+            .endObject()
+            .endObject();
 
         DocumentMapper defaultMapper = createIndex("test").mapperService()
-            .merge("type1", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+            .merge(toMappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         Mapper fieldMapper = defaultMapper.mappers().getMapper("completion");
         XContentBuilder builder = jsonBuilder().startObject()
             .startArray("completion")

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnVectorQueryBuilderTests.java
@@ -13,8 +13,6 @@ import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.KnnVectorQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -46,6 +44,7 @@ public class KnnVectorQueryBuilderTests extends AbstractQueryTestCase<KnnVectorQ
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         XContentBuilder builder = XContentFactory.jsonBuilder()
             .startObject()
+            .startObject("_doc")
             .startObject("properties")
             .startObject(VECTOR_FIELD)
             .field("type", "dense_vector")
@@ -58,12 +57,9 @@ public class KnnVectorQueryBuilderTests extends AbstractQueryTestCase<KnnVectorQ
             .field("path", VECTOR_FIELD)
             .endObject()
             .endObject()
+            .endObject()
             .endObject();
-        mapperService.merge(
-            MapperService.SINGLE_MAPPING_NAME,
-            new CompressedXContent(Strings.toString(builder)),
-            MapperService.MergeReason.MAPPING_UPDATE
-        );
+        mapperService.merge(toMappingMetadata(builder), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -52,6 +52,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.routing.AllocationId;
 import org.elasticsearch.common.CheckedBiFunction;
 import org.elasticsearch.common.Randomness;
@@ -454,8 +455,7 @@ public abstract class EngineTestCase extends ESTestCase {
                 .endObject()
         );
         final DocumentMapper nestedMapper = mapperService.merge(
-            "type",
-            new CompressedXContent(nestedMapping),
+            new MappingMetadata(new CompressedXContent(nestedMapping)),
             MapperService.MergeReason.MAPPING_UPDATE
         );
         return (docId, nestedFieldValues) -> {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -21,6 +21,7 @@ import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.Accountable;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.breaker.CircuitBreaker;
@@ -299,18 +300,26 @@ public abstract class MapperServiceTestCase extends ESTestCase {
      * Merge a new mapping into the one in the provided {@link MapperService}.
      */
     protected final void merge(MapperService mapperService, String mapping) throws IOException {
-        mapperService.merge(null, new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(mappingMetadata(mapping), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     protected final void merge(MapperService mapperService, MapperService.MergeReason reason, String mapping) throws IOException {
-        mapperService.merge(null, new CompressedXContent(mapping), reason);
+        mapperService.merge(mappingMetadata(mapping), reason);
     }
 
     /**
      * Merge a new mapping into the one in the provided {@link MapperService} with a specific {@code MergeReason}
      */
     protected final void merge(MapperService mapperService, MapperService.MergeReason reason, XContentBuilder mapping) throws IOException {
-        mapperService.merge(null, new CompressedXContent(BytesReference.bytes(mapping)), reason);
+        mapperService.merge(mappingMetadata(mapping), reason);
+    }
+
+    private static MappingMetadata mappingMetadata(String mapping) throws IOException {
+        return new MappingMetadata(new CompressedXContent(mapping));
+    }
+
+    private static MappingMetadata mappingMetadata(XContentBuilder mapping) throws IOException {
+        return mappingMetadata(Strings.toString(mapping));
     }
 
     protected final XContentBuilder topMapping(CheckedConsumer<XContentBuilder, IOException> buildFields) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MetadataMapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MetadataMapperTestCase.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.test.VersionUtils;
@@ -119,7 +120,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
             + "}";
         MapperParsingException exception = expectThrows(
             MapperParsingException.class,
-            () -> mapperService.parseMapping("_doc", new CompressedXContent(mappingAsString))
+            () -> mapperService.parseMapping(new MappingMetadata(new CompressedXContent(mappingAsString)))
         );
         assertEquals(
             "Failed to parse mapping: unknown parameter [anything] on metadata field [" + fieldName() + "]",
@@ -135,7 +136,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
         String mappingAsString = "{\n" + "    \"_doc\" : {\n" + "      \"" + fieldName() + "\" : {\n" + "      }\n" + "    }\n" + "}";
         MapperParsingException exception = expectThrows(
             MapperParsingException.class,
-            () -> mapperService.parseMapping("_doc", new CompressedXContent(mappingAsString))
+            () -> mapperService.parseMapping(new MappingMetadata(new CompressedXContent(mappingAsString)))
         );
         assertEquals("Failed to parse mapping: " + fieldName() + " is not configurable", exception.getMessage());
     }
@@ -160,7 +161,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
                 + "      }\n"
                 + "    }\n"
                 + "}";
-            assertNotNull(mapperService.parseMapping("_doc", new CompressedXContent(mappingAsString)));
+            assertNotNull(mapperService.parseMapping(new MappingMetadata(new CompressedXContent(mappingAsString))));
         }
     }
 
@@ -183,7 +184,7 @@ public abstract class MetadataMapperTestCase extends MapperServiceTestCase {
                 + "      }\n"
                 + "    }\n"
                 + "}";
-            assertNotNull(mapperService.parseMapping("_doc", new CompressedXContent(mappingAsString)));
+            assertNotNull(mapperService.parseMapping(new MappingMetadata(new CompressedXContent(mappingAsString))));
             assertWarnings("Parameter [" + param + "] has no effect on metadata field [" + fieldName() + "] and will be removed in future");
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BasePointShapeQueryTestCase.java
@@ -310,9 +310,11 @@ public abstract class BasePointShapeQueryTestCase<T extends AbstractGeometryQuer
         String queryShapesMapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
+                .startObject("_doc")
                 .startObject("properties")
                 .startObject(indexedShapePath)
                 .field("type", fieldTypeName())
+                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeQueryTestCase.java
@@ -72,6 +72,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
         String mapping = Strings.toString(
             XContentFactory.jsonBuilder()
                 .startObject()
+                .startObject("_doc")
                 .startObject("properties")
                 .startObject(defaultFieldName)
                 .field("type", fieldTypeName())
@@ -79,6 +80,7 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
                 .startObject("alias")
                 .field("type", "alias")
                 .field("path", defaultFieldName)
+                .endObject()
                 .endObject()
                 .endObject()
                 .endObject()
@@ -299,9 +301,11 @@ public abstract class BaseShapeQueryTestCase<T extends AbstractGeometryQueryBuil
     public void testEdgeCases() throws Exception {
         XContentBuilder xcb = XContentFactory.jsonBuilder()
             .startObject()
+            .startObject("_doc")
             .startObject("properties")
             .startObject(defaultFieldName)
             .field("type", fieldTypeName())
+            .endObject()
             .endObject()
             .endObject()
             .endObject();

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.termvectors.MultiTermVectorsRequest;
 import org.elasticsearch.action.termvectors.MultiTermVectorsResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
@@ -423,50 +424,51 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
 
             if (registerType) {
                 mapperService.merge(
-                    "_doc",
-                    new CompressedXContent(
-                        Strings.toString(
-                            PutMappingRequest.simpleMapping(
-                                TEXT_FIELD_NAME,
-                                "type=text",
-                                KEYWORD_FIELD_NAME,
-                                "type=keyword",
-                                TEXT_ALIAS_FIELD_NAME,
-                                "type=alias,path=" + TEXT_FIELD_NAME,
-                                INT_FIELD_NAME,
-                                "type=integer",
-                                INT_ALIAS_FIELD_NAME,
-                                "type=alias,path=" + INT_FIELD_NAME,
-                                INT_RANGE_FIELD_NAME,
-                                "type=integer_range",
-                                DOUBLE_FIELD_NAME,
-                                "type=double",
-                                BOOLEAN_FIELD_NAME,
-                                "type=boolean",
-                                DATE_NANOS_FIELD_NAME,
-                                "type=date_nanos",
-                                DATE_FIELD_NAME,
-                                "type=date",
-                                DATE_ALIAS_FIELD_NAME,
-                                "type=alias,path=" + DATE_FIELD_NAME,
-                                DATE_RANGE_FIELD_NAME,
-                                "type=date_range",
-                                OBJECT_FIELD_NAME,
-                                "type=object",
-                                GEO_POINT_FIELD_NAME,
-                                "type=geo_point",
-                                GEO_POINT_ALIAS_FIELD_NAME,
-                                "type=alias,path=" + GEO_POINT_FIELD_NAME,
-                                BINARY_FIELD_NAME,
-                                "type=binary"
+                    new MappingMetadata(
+                        new CompressedXContent(
+                            Strings.toString(
+                                PutMappingRequest.simpleMapping(
+                                    TEXT_FIELD_NAME,
+                                    "type=text",
+                                    KEYWORD_FIELD_NAME,
+                                    "type=keyword",
+                                    TEXT_ALIAS_FIELD_NAME,
+                                    "type=alias,path=" + TEXT_FIELD_NAME,
+                                    INT_FIELD_NAME,
+                                    "type=integer",
+                                    INT_ALIAS_FIELD_NAME,
+                                    "type=alias,path=" + INT_FIELD_NAME,
+                                    INT_RANGE_FIELD_NAME,
+                                    "type=integer_range",
+                                    DOUBLE_FIELD_NAME,
+                                    "type=double",
+                                    BOOLEAN_FIELD_NAME,
+                                    "type=boolean",
+                                    DATE_NANOS_FIELD_NAME,
+                                    "type=date_nanos",
+                                    DATE_FIELD_NAME,
+                                    "type=date",
+                                    DATE_ALIAS_FIELD_NAME,
+                                    "type=alias,path=" + DATE_FIELD_NAME,
+                                    DATE_RANGE_FIELD_NAME,
+                                    "type=date_range",
+                                    OBJECT_FIELD_NAME,
+                                    "type=object",
+                                    GEO_POINT_FIELD_NAME,
+                                    "type=geo_point",
+                                    GEO_POINT_ALIAS_FIELD_NAME,
+                                    "type=alias,path=" + GEO_POINT_FIELD_NAME,
+                                    BINARY_FIELD_NAME,
+                                    "type=binary"
+                                )
                             )
                         )
                     ),
                     MapperService.MergeReason.MAPPING_UPDATE
                 );
                 // also add mappings for two inner field in the object field
-                mapperService.merge("_doc", new CompressedXContent(Strings.format("""
-                    {
+                mapperService.merge(new MappingMetadata(new CompressedXContent(Strings.format("""
+                    { "_doc" : {
                       "properties": {
                         "%s": {
                           "type": "object",
@@ -480,7 +482,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                           }
                         }
                       }
-                    }""", OBJECT_FIELD_NAME, DATE_FIELD_NAME, INT_FIELD_NAME)), MapperService.MergeReason.MAPPING_UPDATE);
+                    }}""", OBJECT_FIELD_NAME, DATE_FIELD_NAME, INT_FIELD_NAME))), MapperService.MergeReason.MAPPING_UPDATE);
                 testCase.initializeAdditionalMappings(mapperService);
             }
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -44,7 +44,9 @@ import org.elasticsearch.bootstrap.BootstrapForTesting;
 import org.elasticsearch.client.internal.Requests;
 import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -1900,5 +1902,9 @@ public abstract class ESTestCase extends LuceneTestCase {
         }
         secureRandomFips.setSeed(seed); // DEFAULT/BCFIPS setSeed() is non-deterministic
         return secureRandomFips;
+    }
+
+    protected static MappingMetadata toMappingMetadata(XContentBuilder b) throws IOException {
+        return new MappingMetadata(new CompressedXContent(BytesReference.bytes(b)));
     }
 }

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/ConstantKeywordFieldMapperTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.constantkeyword.mapper;
 
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.settings.Settings;
@@ -99,7 +100,7 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
         assertNotNull(doc.dynamicMappingsUpdate());
 
         CompressedXContent mappingUpdate = new CompressedXContent(Strings.toString(doc.dynamicMappingsUpdate()));
-        DocumentMapper updatedMapper = mapperService.merge("_doc", mappingUpdate, MergeReason.MAPPING_UPDATE);
+        DocumentMapper updatedMapper = mapperService.merge(new MappingMetadata(mappingUpdate), MergeReason.MAPPING_UPDATE);
         String expectedMapping = Strings.toString(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
         assertEquals(expectedMapping, updatedMapper.mappingSource().toString());
 
@@ -119,7 +120,7 @@ public class ConstantKeywordFieldMapperTests extends MapperTestCase {
         assertNotNull(doc.dynamicMappingsUpdate());
 
         CompressedXContent mappingUpdate = new CompressedXContent(Strings.toString(doc.dynamicMappingsUpdate()));
-        DocumentMapper updatedMapper = mapperService.merge("_doc", mappingUpdate, MergeReason.MAPPING_UPDATE);
+        DocumentMapper updatedMapper = mapperService.merge(new MappingMetadata(mappingUpdate), MergeReason.MAPPING_UPDATE);
         String expectedMapping = Strings.toString(fieldMapping(b -> b.field("type", "constant_keyword").field("value", "foo")));
         assertEquals(expectedMapping, updatedMapper.mappingSource().toString());
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Template;
 import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.document.DocumentField;
@@ -738,8 +739,8 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         final IndexMetadata indexMetadata = client().admin().cluster().prepareState().get().getState().getMetadata().index(sourceIndex);
         final IndicesService indicesService = getInstanceFromNode(IndicesService.class);
         final MapperService mapperService = indicesService.createIndexMapperServiceForValidation(indexMetadata);
-        final CompressedXContent sourceIndexCompressedXContent = new CompressedXContent(sourceIndexMappings);
-        mapperService.merge(MapperService.SINGLE_MAPPING_NAME, sourceIndexCompressedXContent, MapperService.MergeReason.INDEX_TEMPLATE);
+        final MappingMetadata mappingMetadata = new MappingMetadata(MapperService.SINGLE_MAPPING_NAME, sourceIndexMappings);
+        mapperService.merge(mappingMetadata, MapperService.MergeReason.INDEX_TEMPLATE);
         TimeseriesFieldTypeHelper helper = new TimeseriesFieldTypeHelper.Builder(mapperService).build(config.getTimestampField());
 
         Map<String, TimeSeriesParams.MetricType> metricFields = new HashMap<>();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityIndexManager.java
@@ -318,7 +318,7 @@ public class SecurityIndexManager implements ClusterStateListener {
             @SuppressWarnings("unchecked")
             Map<String, Object> meta = (Map<String, Object>) mappingMetadata.sourceAsMap().get("_meta");
             if (meta == null) {
-                logger.info("Missing _meta field in mapping [{}] of index [{}]", mappingMetadata.type(), indexName);
+                logger.info("Missing _meta field in mapping of index [{}]", indexName);
                 throw new IllegalStateException("Cannot read security-version string in index " + indexName);
             }
             return Version.fromString((String) meta.get(SECURITY_VERSION_STRING));

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoBoundingBoxQueryBuilderGeoShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoBoundingBoxQueryBuilderGeoShapeTests.java
@@ -11,8 +11,6 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.GeoBoundingBoxQueryBuilder;
@@ -40,7 +38,7 @@ public class GeoBoundingBoxQueryBuilderGeoShapeTests extends GeoBoundingBoxQuery
             GEO_SHAPE_ALIAS_FIELD_NAME,
             "type=alias,path=" + GEO_SHAPE_FIELD_NAME
         );
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(builder)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(builder), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoDistanceQueryBuilderGeoShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoDistanceQueryBuilderGeoShapeTests.java
@@ -11,8 +11,6 @@ import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.query.GeoDistanceQueryBuilder;
@@ -41,7 +39,7 @@ public class GeoDistanceQueryBuilderGeoShapeTests extends GeoDistanceQueryBuilde
             GEO_SHAPE_ALIAS_FIELD_NAME,
             "type=alias,path=" + GEO_SHAPE_FIELD_NAME
         );
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(builder)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(builder), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoGridQueryBuilderTests.java
@@ -15,7 +15,6 @@ import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.Geohash;
@@ -54,7 +53,7 @@ public class GeoGridQueryBuilderTests extends AbstractQueryTestCase<GeoGridQuery
             GEO_SHAPE_ALIAS_FIELD_NAME,
             "type=alias,path=" + GEO_SHAPE_FIELD_NAME
         );
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(builder)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(builder), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeQueryBuilderGeoShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeQueryBuilderGeoShapeTests.java
@@ -8,8 +8,6 @@ package org.elasticsearch.xpack.spatial.index.query;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
@@ -42,7 +40,7 @@ public class GeoShapeQueryBuilderGeoShapeTests extends GeoShapeQueryBuilderTestC
             GEO_SHAPE_ALIAS_FIELD_NAME,
             "type=alias,path=" + GEO_SHAPE_FIELD_NAME
         );
-        mapperService.merge("_doc", new CompressedXContent(Strings.toString(builder)), MapperService.MergeReason.MAPPING_UPDATE);
+        mapperService.merge(toMappingMetadata(builder), MapperService.MergeReason.MAPPING_UPDATE);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/GeoShapeWithDocValuesQueryBuilderTests.java
@@ -11,8 +11,6 @@ import org.apache.lucene.search.ConstantScoreQuery;
 import org.apache.lucene.search.IndexOrDocValuesQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.index.mapper.MappedFieldType;
@@ -42,14 +40,12 @@ public class GeoShapeWithDocValuesQueryBuilderTests extends AbstractQueryTestCas
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         if (randomBoolean()) {
             mapperService.merge(
-                "_doc",
-                new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping("test", "type=geo_shape"))),
+                toMappingMetadata(PutMappingRequest.simpleMapping("test", "type=geo_shape")),
                 MapperService.MergeReason.MAPPING_UPDATE
             );
         } else {
             mapperService.merge(
-                "_doc",
-                new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping("test", "type=geo_shape,doc_values=false"))),
+                toMappingMetadata(PutMappingRequest.simpleMapping("test", "type=geo_shape,doc_values=false")),
                 MapperService.MergeReason.MAPPING_UPDATE
             );
         }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverPointTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverPointTests.java
@@ -7,8 +7,6 @@
 package org.elasticsearch.xpack.spatial.index.query;
 
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.ShapeType;
@@ -22,8 +20,7 @@ public class ShapeQueryBuilderOverPointTests extends ShapeQueryBuilderTests {
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge(
-            docType,
-            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping(fieldName(), "type=point"))),
+            toMappingMetadata(PutMappingRequest.simpleMapping(fieldName(), "type=point")),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/ShapeQueryBuilderOverShapeTests.java
@@ -8,8 +8,6 @@ package org.elasticsearch.xpack.spatial.index.query;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
-import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.compress.CompressedXContent;
 import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.geometry.Geometry;
 import org.elasticsearch.geometry.ShapeType;
@@ -24,8 +22,7 @@ public class ShapeQueryBuilderOverShapeTests extends ShapeQueryBuilderTests {
     @Override
     protected void initializeAdditionalMappings(MapperService mapperService) throws IOException {
         mapperService.merge(
-            docType,
-            new CompressedXContent(Strings.toString(PutMappingRequest.simpleMapping(fieldName(), "type=shape"))),
+            toMappingMetadata(PutMappingRequest.simpleMapping(fieldName(), "type=shape")),
             MapperService.MergeReason.MAPPING_UPDATE
         );
     }


### PR DESCRIPTION
We still have types hanging around internally in mappings, and it can be
a bit confusing trying to work out when they are needed and when not.  This
commit moves type handling entirely within MappingMetadata, and removes
it from the public methods on MapperService.

This change means that system index descriptors need to explicitly wrap 
their mapping values in a `_doc` type.  Most of them already appear to do
this.