### PR TITLE
Allow searching unsearchable shards

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -356,6 +356,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
         return null;
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93010")
     public void testSearchRouting() throws InterruptedException {
 
         var routingTableWatcher = new RoutingTableWatcher();

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
@@ -50,14 +50,8 @@ public final class SearchShardIterator implements Comparable<SearchShardIterator
      * @param originalIndices the indices that the search request originally related to (before any rewriting happened)
      */
     public SearchShardIterator(@Nullable String clusterAlias, ShardId shardId, List<ShardRouting> shards, OriginalIndices originalIndices) {
-        this(
-            clusterAlias,
-            shardId,
-            shards.stream().filter(ShardRouting::isSearchable).map(ShardRouting::currentNodeId).toList(),
-            originalIndices,
-            null,
-            null
-        );
+        // TODO ensure all target nodes hold shards with a searchable ShardRoutingRole - at the moment, searches don't check this
+        this(clusterAlias, shardId, shards.stream().map(ShardRouting::currentNodeId).toList(), originalIndices, null, null);
     }
 
     public SearchShardIterator(


### PR DESCRIPTION
In #92668 we adjusted `SearchShardIterator` so that it only iterates over shards whose role indicates that they are searchable. We're not ready for this restriction yet, so this commit reverts it.