### PR TITLE
[ML] Persist data counts and datafeed timing stats asynchronously

### DIFF
--- a/docs/changelog/93000.yaml
+++ b/docs/changelog/93000.yaml
@@ -1,0 +1,5 @@
+pr: 93000
+summary: Persist data counts and datafeed timing stats asynchronously
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -491,7 +491,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         storedDataCounts.incrementInputBytes(1L);
         storedDataCounts.incrementMissingFieldCount(1L);
         JobDataCountsPersister jobDataCountsPersister = new JobDataCountsPersister(client(), resultsPersisterService, auditor);
-        jobDataCountsPersister.persistDataCounts(job.getId(), storedDataCounts);
+        jobDataCountsPersister.persistDataCounts(job.getId(), storedDataCounts, true);
         jobResultsPersister.commitWrites(job.getId(), JobResultsPersister.CommitType.RESULTS);
 
         setOrThrow.get();
@@ -1046,9 +1046,9 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         }
     }
 
-    private void indexDataCounts(DataCounts counts, String jobId) {
+    private void indexDataCounts(DataCounts counts, String jobId) throws InterruptedException {
         JobDataCountsPersister persister = new JobDataCountsPersister(client(), resultsPersisterService, auditor);
-        persister.persistDataCounts(jobId, counts);
+        persister.persistDataCounts(jobId, counts, true);
     }
 
     private void indexFilters(List<MlFilter> filters) throws IOException {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPreviewDatafeedAction.java
@@ -140,7 +140,7 @@ public class TransportPreviewDatafeedAction extends HandledTransportAction<Previ
                 job,
                 xContentRegistry,
                 // Fake DatafeedTimingStatsReporter that does not have access to results index
-                new DatafeedTimingStatsReporter(new DatafeedTimingStats(datafeedConfig.getJobId()), (ts, refreshPolicy) -> {}),
+                new DatafeedTimingStatsReporter(new DatafeedTimingStats(datafeedConfig.getJobId()), (ts, refreshPolicy, listener1) -> {}),
                 listener.delegateFailure(
                     (l, dataExtractorFactory) -> isDateNanos(
                         previewDatafeedConfig,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartDatafeedAction.java
@@ -355,7 +355,7 @@ public class TransportStartDatafeedAction extends TransportMasterNodeAction<Star
             job,
             xContentRegistry,
             // Fake DatafeedTimingStatsReporter that does not have access to results index
-            new DatafeedTimingStatsReporter(new DatafeedTimingStats(job.getId()), (ts, refreshPolicy) -> {}),
+            new DatafeedTimingStatsReporter(new DatafeedTimingStats(job.getId()), (ts, refreshPolicy, listener1) -> {}),
             ActionListener.wrap(
                 unused -> persistentTasksService.sendStartRequest(
                     MlTasks.datafeedTaskId(params.getDatafeedId()),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -8,38 +8,48 @@ package org.elasticsearch.xpack.ml.datafeed;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xpack.core.ml.datafeed.DatafeedTimingStats;
 import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 
 import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 /**
- * {@link DatafeedTimingStatsReporter} class handles the logic of persisting {@link DatafeedTimingStats} if they changed significantly
- * since the last time they were persisted.
- *
+ * {@link DatafeedTimingStatsReporter} class handles the logic of persisting {@link DatafeedTimingStats} for a single job
+ * if they changed significantly since the last time they were persisted.
+ * <p>
  * This class is not thread-safe.
  */
 public class DatafeedTimingStatsReporter {
 
-    private static final Logger LOGGER = LogManager.getLogger(DatafeedTimingStatsReporter.class);
+    private static final Logger logger = LogManager.getLogger(DatafeedTimingStatsReporter.class);
 
     /** Interface used for persisting current timing stats to the results index. */
     @FunctionalInterface
     public interface DatafeedTimingStatsPersister {
         /** Does nothing by default. This behavior is useful when creating fake {@link DatafeedTimingStatsReporter} objects. */
-        void persistDatafeedTimingStats(DatafeedTimingStats timingStats, WriteRequest.RefreshPolicy refreshPolicy);
+        void persistDatafeedTimingStats(
+            DatafeedTimingStats timingStats,
+            WriteRequest.RefreshPolicy refreshPolicy,
+            ActionListener<BulkResponse> listener
+        );
     }
 
     /** Persisted timing stats. May be stale. */
-    private DatafeedTimingStats persistedTimingStats;
+    private volatile DatafeedTimingStats persistedTimingStats;
     /** Current timing stats. */
-    private volatile DatafeedTimingStats currentTimingStats;
+    private final DatafeedTimingStats currentTimingStats;
     /** Object used to persist current timing stats. */
     private final DatafeedTimingStatsPersister persister;
     /** Whether or not timing stats will be persisted by the persister object. */
     private volatile boolean allowedPersisting;
+    /** Records whether a persist is currently in progress. */
+    private CountDownLatch persistInProgressLatch;
 
     public DatafeedTimingStatsReporter(DatafeedTimingStats timingStats, DatafeedTimingStatsPersister persister) {
         Objects.requireNonNull(timingStats);
@@ -81,9 +91,11 @@ public class DatafeedTimingStatsReporter {
 
     /** Finishes reporting of timing stats. Makes timing stats persisted immediately. */
     public void finishReporting() {
-        // Don't flush if current timing stats are identical to the persisted ones
-        if (currentTimingStats.equals(persistedTimingStats) == false) {
-            flush(WriteRequest.RefreshPolicy.IMMEDIATE);
+        try {
+            flush(WriteRequest.RefreshPolicy.IMMEDIATE, true);
+        } catch (InterruptedException e) {
+            logger.warn("[{}] interrupted while finishing reporting of datafeed timing stats", currentTimingStats.getJobId());
+            Thread.currentThread().interrupt();
         }
     }
 
@@ -94,19 +106,50 @@ public class DatafeedTimingStatsReporter {
 
     private void flushIfDifferSignificantly() {
         if (differSignificantly(currentTimingStats, persistedTimingStats)) {
-            flush(WriteRequest.RefreshPolicy.NONE);
+            try {
+                flush(WriteRequest.RefreshPolicy.NONE, false);
+            } catch (InterruptedException e) {
+                // This is extremely unlikely to happen, as we only wait 1 nanosecond in this case
+                Thread.currentThread().interrupt();
+            }
         }
     }
 
-    private void flush(WriteRequest.RefreshPolicy refreshPolicy) {
-        persistedTimingStats = new DatafeedTimingStats(currentTimingStats);
-        if (allowedPersisting) {
-            try {
-                persister.persistDatafeedTimingStats(persistedTimingStats, refreshPolicy);
-            } catch (Exception ex) {
-                // Since persisting datafeed timing stats is not critical, we just log a warning here.
-                LOGGER.warn(() -> "[" + currentTimingStats.getJobId() + "] failed to report datafeed timing stats", ex);
-            }
+    private synchronized void flush(WriteRequest.RefreshPolicy refreshPolicy, boolean mustWait) throws InterruptedException {
+        String jobId = currentTimingStats.getJobId();
+        if (allowedPersisting && mustWait && persistInProgressLatch != null) {
+            persistInProgressLatch.await();
+            persistInProgressLatch = null;
+        }
+        // Don't persist if:
+        // 1. Persistence is disallowed
+        // 2. There is already a persist in progress
+        // 3. Current timing stats are identical to the persisted ones
+        if (allowedPersisting == false) {
+            logger.trace("[{}] not persisting datafeed timing stats as persistence is disallowed", jobId);
+            return;
+        }
+        if (persistInProgressLatch != null && persistInProgressLatch.await(1, TimeUnit.NANOSECONDS) == false) {
+            logger.trace("[{}] not persisting datafeed timing stats as the previous persist is still in progress", jobId);
+            return;
+        }
+        if (currentTimingStats.equals(persistedTimingStats)) {
+            logger.trace("[{}] not persisting datafeed timing stats as they are identical to latest already persisted", jobId);
+            return;
+        }
+        final CountDownLatch thisPersistLatch = new CountDownLatch(1);
+        final DatafeedTimingStats thisPersistTimingStats = new DatafeedTimingStats(currentTimingStats);
+        persistInProgressLatch = thisPersistLatch;
+        persister.persistDatafeedTimingStats(thisPersistTimingStats, refreshPolicy, ActionListener.wrap(r -> {
+            persistedTimingStats = thisPersistTimingStats;
+            thisPersistLatch.countDown();
+        }, e -> {
+            thisPersistLatch.countDown();
+            // Since persisting datafeed timing stats is not critical, we just log a warning here.
+            logger.warn(() -> "[" + jobId + "] failed to report datafeed timing stats", e);
+        }));
+        if (mustWait) {
+            thisPersistLatch.await();
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/datafeed/DatafeedTimingStatsReporter.java
@@ -17,7 +17,6 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.DataCounts;
 
 import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 /**
  * {@link DatafeedTimingStatsReporter} class handles the logic of persisting {@link DatafeedTimingStats} for a single job
@@ -109,7 +108,7 @@ public class DatafeedTimingStatsReporter {
             try {
                 flush(WriteRequest.RefreshPolicy.NONE, false);
             } catch (InterruptedException e) {
-                // This is extremely unlikely to happen, as we only wait 1 nanosecond in this case
+                assert false : "This should never happen when flush is called with mustWait set to false";
                 Thread.currentThread().interrupt();
             }
         }
@@ -129,7 +128,7 @@ public class DatafeedTimingStatsReporter {
             logger.trace("[{}] not persisting datafeed timing stats as persistence is disallowed", jobId);
             return;
         }
-        if (persistInProgressLatch != null && persistInProgressLatch.await(1, TimeUnit.NANOSECONDS) == false) {
+        if (persistInProgressLatch != null && persistInProgressLatch.getCount() > 0) {
             logger.trace("[{}] not persisting datafeed timing stats as the previous persist is still in progress", jobId);
             return;
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/JobManager.java
@@ -688,7 +688,7 @@ public class JobManager {
         CheckedConsumer<Boolean, Exception> updateHandler = response -> {
             if (response) {
                 ModelSizeStats revertedModelSizeStats = new ModelSizeStats.Builder(modelSizeStats).setLogTime(new Date()).build();
-                jobResultsPersister.persistModelSizeStats(
+                jobResultsPersister.persistModelSizeStatsWithoutRetries(
                     revertedModelSizeStats,
                     WriteRequest.RefreshPolicy.IMMEDIATE,
                     ActionListener.wrap(modelSizeStatsResponseHandler, actionListener::onFailure)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporter.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporter.java
@@ -20,7 +20,7 @@ import java.util.function.Predicate;
 /**
  * Status reporter for tracking counts of the good/bad records written to the API.
  * Call one of the reportXXX() methods to update the records counts.
- *
+ * <p>
  * Stats are logged at specific stages
  * <ol>
  * <li>Every 10,000 records for the first 100,000 records</li>
@@ -42,6 +42,8 @@ public class DataCountsReporter {
 
     private final DataCounts totalRecordStats;
     private volatile DataCounts incrementalRecordStats;
+
+    private DataCounts unreportedStats;
 
     private long analyzedFieldsPerRecord = 1;
 
@@ -236,7 +238,32 @@ public class DataCountsReporter {
         totalRecordStats.setLastDataTimeStamp(now);
         diagnostics.flush();
         retrieveDiagnosticsIntermediateResults();
-        dataCountsPersister.persistDataCounts(job.getId(), runningTotalStats());
+        synchronized (this) {
+            unreportedStats = null;
+        }
+        DataCounts statsToReport = runningTotalStats();
+        try {
+            if (dataCountsPersister.persistDataCounts(job.getId(), statsToReport, false) == false) {
+                synchronized (this) {
+                    unreportedStats = statsToReport;
+                }
+            }
+        } catch (InterruptedException e) {
+            assert false : "This should never happen when persistDataCounts is called with mustWait set to false";
+            Thread.currentThread().interrupt();
+        }
+    }
+
+    /**
+     * Report the most recent counts, if any, that {@link #finishReporting} failed to
+     * report when the previous persistence was in progress.
+     */
+    public synchronized void writeUnreportedCounts() throws InterruptedException {
+        if (unreportedStats != null) {
+            boolean persisted = dataCountsPersister.persistDataCounts(job.getId(), unreportedStats, true);
+            assert persisted;
+            unreportedStats = null;
+        }
     }
 
     /**

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectCommunicator.java
@@ -180,6 +180,7 @@ public class AutodetectCommunicator implements Closeable {
         try {
             future.get();
             autodetectWorkerExecutor.shutdown();
+            dataCountsReporter.writeUnreportedCounts();
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
@@ -256,6 +257,11 @@ public class AutodetectCommunicator implements Closeable {
     public void flushJob(FlushJobParams params, BiConsumer<FlushAcknowledgement, Exception> handler) {
         submitOperation(() -> {
             String flushId = autodetectProcess.flushJob(params);
+            try {
+                dataCountsReporter.writeUnreportedCounts();
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
             return waitFlushToCompletion(flushId, params.isWaitForNormalization());
         }, handler);
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -289,7 +289,11 @@ public class JobResultsPersisterTests extends ESTestCase {
             666.0,
             new ExponentialAverageCalculationContext(600.0, Instant.ofEpochMilli(123456789), 60.0)
         );
-        persister.persistDatafeedTimingStats(timingStats, WriteRequest.RefreshPolicy.IMMEDIATE);
+        persister.persistDatafeedTimingStats(
+            timingStats,
+            WriteRequest.RefreshPolicy.IMMEDIATE,
+            ActionListener.wrap(r -> {}, e -> fail("unexpected exception " + e.getMessage()))
+        );
 
         InOrder inOrder = inOrder(client);
         inOrder.verify(client).settings();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/DataCountsReporterTests.java
@@ -18,8 +18,8 @@ import org.junit.Before;
 import org.mockito.Mockito;
 
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Date;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -37,10 +37,10 @@ public class DataCountsReporterTests extends ESTestCase {
 
     @Before
     public void setUpMocks() {
-        AnalysisConfig.Builder acBuilder = new AnalysisConfig.Builder(Arrays.asList(new Detector.Builder("metric", "field").build()));
+        AnalysisConfig.Builder acBuilder = new AnalysisConfig.Builder(List.of(new Detector.Builder("metric", "field").build()));
         acBuilder.setBucketSpan(bucketSpan);
         acBuilder.setLatency(TimeValue.ZERO);
-        acBuilder.setDetectors(Arrays.asList(new Detector.Builder("metric", "field").build()));
+        acBuilder.setDetectors(List.of(new Detector.Builder("metric", "field").build()));
 
         Job.Builder builder = new Job.Builder("sr");
         builder.setAnalysisConfig(acBuilder);
@@ -153,7 +153,7 @@ public class DataCountsReporterTests extends ESTestCase {
         assertEquals(5001L, dataCountsReporter.incrementalStats().getLatestRecordTimeStamp().getTime());
     }
 
-    public void testReportRecordsWritten() {
+    public void testReportRecordsWritten() throws InterruptedException {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(job, new DataCounts(job.getId()), jobDataCountsPersister);
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
 
@@ -174,7 +174,7 @@ public class DataCountsReporterTests extends ESTestCase {
 
         assertEquals(dataCountsReporter.incrementalStats(), dataCountsReporter.runningTotalStats());
 
-        verify(jobDataCountsPersister, never()).persistDataCounts(anyString(), any(DataCounts.class));
+        verify(jobDataCountsPersister, never()).persistDataCounts(anyString(), any(DataCounts.class), eq(false));
     }
 
     public void testReportRecordsWritten_Given9999Records() {
@@ -262,7 +262,7 @@ public class DataCountsReporterTests extends ESTestCase {
         assertEquals(20, dataCountsReporter.getLogStatusCallCount());
     }
 
-    public void testFinishReporting() {
+    public void testFinishReporting() throws InterruptedException {
         DataCountsReporter dataCountsReporter = new DataCountsReporter(job, new DataCounts(job.getId()), jobDataCountsPersister);
 
         dataCountsReporter.setAnalysedFieldsPerRecord(3);
@@ -300,7 +300,7 @@ public class DataCountsReporterTests extends ESTestCase {
         );
 
         dc.setLastDataTimeStamp(dataCountsReporter.incrementalStats().getLastDataTimeStamp());
-        verify(jobDataCountsPersister, times(1)).persistDataCounts(eq("sr"), eq(dc));
+        verify(jobDataCountsPersister, times(1)).persistDataCounts(eq("sr"), eq(dc), eq(false));
         assertEquals(dc, dataCountsReporter.incrementalStats());
     }
 


### PR DESCRIPTION
When an anomaly detection job runs, the majority of results originate from the C++ autodetect process, so can be persisted in bulk. However, there are two types of results, namely data counts and datafeed timing stats, that are generated wholly within the ML Java code and where there are serious downsides to batching them up with the output of the C++ process. (If we batched them and the C++ process stopped generating results then the input side stats would also stall, so it is better that the input side stats are written independently.)

The approach used in this PR is to write data counts and datafeed timing stats asynchronously _except_ at certain key points, like job flush and close, and datafeed stop. At these key points the latest stats _are_ persisted synchronously, like before. When large amounts of data are being processed the code will generate updated stats documents faster than they can be indexed. The approach taken here is to skip persistence of the newer document if persistence of the previous document is still in progress. This can lead to the stats being slightly out of date while a job is running. However, at key points like flush and close the data counts will be up-to-date, and the datafeed timing stats will get written at least once per datafeed `frequency`, so should not be more out-of-date than that.