### PR TITLE
Used a shared repo path for all nodes of a given cluster

### DIFF
--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -18,9 +18,6 @@ import org.elasticsearch.test.cluster.FeatureFlag;
 import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
 import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
 import org.junit.ClassRule;
-import org.junit.rules.RuleChain;
-import org.junit.rules.TemporaryFolder;
-import org.junit.rules.TestRule;
 
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
 public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {

--- a/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
+++ b/qa/smoke-test-multinode/src/yamlRestTest/java/org/elasticsearch/smoketest/SmokeTestMultiNodeClientYamlTestSuiteIT.java
@@ -25,21 +25,15 @@ import org.junit.rules.TestRule;
 @TimeoutSuite(millis = 40 * TimeUnits.MINUTE) // some of the windows test VMs are slow as hell
 public class SmokeTestMultiNodeClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
-    private static TemporaryFolder repoDirectory = new TemporaryFolder();
-
-    private static ElasticsearchCluster cluster = ElasticsearchCluster.local()
+    @ClassRule
+    public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .nodes(2)
         .module("mapper-extras")
         .module("ingest-common")
-        .setting("path.repo", () -> repoDirectory.getRoot().getPath())
         // The first node does not have the ingest role so we're sure ingest requests are forwarded:
         .node(0, n -> n.setting("node.roles", "[master,data,ml,remote_cluster_client,transform]"))
         .feature(FeatureFlag.TIME_SERIES_MODE)
         .build();
-
-    @ClassRule
-    // Ensure the shared repo dir is created before cluster start
-    public static TestRule ruleChain = RuleChain.outerRule(repoDirectory).around(cluster);
 
     public SmokeTestMultiNodeClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {
         super(testCandidate);

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -75,7 +75,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         private final LocalNodeSpec spec;
         private final Path workingDir;
         private final Path distributionDir;
-        private final Path snapshotsDir;
+        private final Path repoDir;
         private final Path dataDir;
         private final Path logsDir;
         private final Path configDir;
@@ -89,7 +89,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             this.spec = spec;
             this.workingDir = baseWorkingDir.resolve(spec.getCluster().getName()).resolve(spec.getName());
             this.distributionDir = workingDir.resolve("distro"); // location of es distribution files, typically hard-linked
-            this.snapshotsDir = workingDir.resolve("repo");
+            this.repoDir = baseWorkingDir.resolve("repo");
             this.dataDir = workingDir.resolve("data");
             this.logsDir = workingDir.resolve("logs");
             this.configDir = workingDir.resolve("config");
@@ -204,7 +204,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                     IOUtils.deleteWithRetry(distributionDir);
                     IOUtils.syncWithCopy(distributionDescriptor.getDistributionDir(), distributionDir);
                 }
-                Files.createDirectories(snapshotsDir);
+                Files.createDirectories(repoDir);
                 Files.createDirectories(dataDir);
                 Files.createDirectories(logsDir);
                 Files.createDirectories(tempDir);
@@ -227,9 +227,9 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             try {
                 // Write settings to elasticsearch.yml
                 Map<String, String> finalSettings = new HashMap<>();
-                finalSettings.put("path.repo", workingDir.resolve("repo").toString());
-                finalSettings.put("path.data", workingDir.resolve("data").toString());
-                finalSettings.put("path.logs", workingDir.resolve("logs").toString());
+                finalSettings.put("path.repo", repoDir.toString());
+                finalSettings.put("path.data", dataDir.toString());
+                finalSettings.put("path.logs", logsDir.toString());
                 finalSettings.putAll(spec.resolveSettings());
 
                 Files.writeString(


### PR DESCRIPTION
As mentioned in #92929 the repo path should be the same for all nodes in a cluster. For many use cases, using a per-node repo path makes no sense or simply won't work.