### PR TITLE
[8.6] Avoid using autogenerated project name with docker compose plugin (#93015)

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/testfixtures/TestFixturesPlugin.java
@@ -117,6 +117,7 @@ public class TestFixturesPlugin implements Plugin<Project> {
             maybeSkipTask(dockerSupport, buildFixture);
 
             ComposeExtension composeExtension = project.getExtensions().getByType(ComposeExtension.class);
+            composeExtension.setProjectName(project.getName());
             composeExtension.getUseComposeFiles().addAll(Collections.singletonList(DOCKER_COMPOSE_YML));
             composeExtension.getRemoveContainers().set(true);
             composeExtension.getCaptureContainersOutput()


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Avoid using autogenerated project name with docker compose plugin (#93015)