### PR TITLE
Delete temp jars in classfile tests sooner

### DIFF
--- a/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/ClassReadersTests.java
+++ b/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/ClassReadersTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.plugin.scanner;
 
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.compiler.InMemoryJavaCompiler;
 import org.elasticsearch.test.jar.JarUtils;
@@ -39,6 +40,9 @@ public class ClassReadersTests extends ESTestCase {
 
         List<ClassReader> classReaders = ClassReaders.ofPaths(Stream.of(jar));
         org.hamcrest.MatcherAssert.assertThat(classReaders, Matchers.empty());
+
+        // aggressively delete the jar dir, so that any leaked filed handles fail this specific test on windows
+        IOUtils.rm(tmp);
     }
 
     public void testTwoClassesInAStreamFromJar() throws IOException {
@@ -57,6 +61,9 @@ public class ClassReadersTests extends ESTestCase {
         List<ClassReader> classReaders = ClassReaders.ofPaths(Stream.of(jar));
         List<String> collect = classReaders.stream().map(cr -> cr.getClassName()).collect(Collectors.toList());
         org.hamcrest.MatcherAssert.assertThat(collect, Matchers.containsInAnyOrder("p/A", "p/B"));
+
+        // aggressively delete the jar dir, so that any leaked filed handles fail this specific test on windows
+        IOUtils.rm(tmp);
     }
 
     public void testStreamOfJarsAndIndividualClasses() throws IOException {

--- a/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/NamedComponentScannerTests.java
+++ b/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/NamedComponentScannerTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.plugin.scanner;
 
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.plugin.scanner.test_model.ExtensibleClass;
 import org.elasticsearch.plugin.scanner.test_model.ExtensibleInterface;
 import org.elasticsearch.plugin.scanner.test_model.TestNamedComponent;
@@ -100,6 +101,9 @@ public class NamedComponentScannerTests extends ESTestCase {
                 )
             )
         );
+
+        // aggressively delete the jar dir, so that any leaked filed handles fail this specific test on windows
+        IOUtils.rm(tmp);
     }
 
     public void testNamedComponentsCanExtednCommonSuperClass() throws IOException {
@@ -174,6 +178,9 @@ public class NamedComponentScannerTests extends ESTestCase {
                 )
             )
         );
+
+        // aggressively delete the jar dir, so that any leaked filed handles fail this specific test on windows
+        IOUtils.rm(tmp);
     }
 
     public void testWriteToFile() throws IOException {


### PR DESCRIPTION
This commit more aggressively deletes the temporary jar files produced to test jar scanning for plugins. By deleting right after use, any leaked file handles should cause the tests to fail on windows.

relates #93005