### PR TITLE
[7.17] [DOCS] Fix incorrect statement for slow log level removal

### DIFF
--- a/docs/changelog/93022.yaml
+++ b/docs/changelog/93022.yaml
@@ -1,0 +1,5 @@
+pr: 93022
+summary: 'Fix incorrect statement for slow log level removal'
+area: Core/Infra/Logging
+type: docs
+issues: []

--- a/docs/reference/migration/migrate_7_13.asciidoc
+++ b/docs/reference/migration/migrate_7_13.asciidoc
@@ -288,8 +288,10 @@ errors in 8.0.0.
 The `index.indexing.slowlog.level` and `index.search.slowlog.level` index
 settings are now deprecated. You use these setting to set the logging level for
 the search and indexing slow logs. To reproduce similar results, use the
-respective `index.*.slowlog.threshold.index.debug` and
-`index.*.slowlog.threshold.index.trace` index settings instead.
+respective `index.indexing.slowlog.threshold.index.debug` and
+`index.indexing.slowlog.threshold.index.trace` index settings instead.
+The same applies to `index.search.slowlog.level` which should be replaced with
+`index.search.slowlog.threshold.query.{level}`.
 
 For example, to reproduce a `index.indexing.slowlog.level` setting of `INFO`,
 set `index.indexing.slowlog.threshold.index.debug` and


### PR DESCRIPTION
This migration guide doesn't exist on 8.x so targeted the 7.17 branch.

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/migrating-7.13.html#slow-log-level-removal currently says:

> The index.indexing.slowlog.level and index.search.slowlog.level index settings are now deprecated. You use these setting to set the logging level for the search and indexing slow logs. To reproduce similar results, use the respective index.*.slowlog.threshold.index.debug and index.*.slowlog.threshold.index.trace index settings instead.

But `index.*.slowlog.threshold.index.${log_level}` isn't true, e.g. for `index.search.slowlog.threshold.query`, we have to modify `index.search.slowlog.threshold.query.{debug,trace}` in that case. So, it should say `index.*.slowlog.threshold.*.${log_level}` instead, I think.
