### PR TITLE
Ensure plugin class scanner always closes its directory stream

### DIFF
--- a/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
+++ b/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
@@ -45,7 +45,7 @@ public class ClassReaders {
             return Collections.emptyList();
         }
         Path dir = Paths.get(path);
-        try (var stream = Files.list(dir)){
+        try (var stream = Files.list(dir)) {
             return ofPaths(stream);
         } catch (IOException e) {
             throw new UncheckedIOException(e);

--- a/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
+++ b/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
@@ -45,8 +45,8 @@ public class ClassReaders {
             return Collections.emptyList();
         }
         Path dir = Paths.get(path);
-        try {
-            return ofPaths(Files.list(dir));
+        try (var stream = Files.list(dir)){
+            return ofPaths(stream);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/ClassReadersTests.java
+++ b/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/ClassReadersTests.java
@@ -25,12 +25,8 @@ import java.util.stream.Stream;
 
 public class ClassReadersTests extends ESTestCase {
 
-    private Path tmpDir() throws IOException {
-        return createTempDir();
-    }
-
     public void testModuleInfoIsNotReturnedAsAClassFromJar() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
         Path jar = dirWithJar.resolve("api.jar");
@@ -46,7 +42,7 @@ public class ClassReadersTests extends ESTestCase {
     }
 
     public void testTwoClassesInAStreamFromJar() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
         Path jar = dirWithJar.resolve("api.jar");
@@ -67,7 +63,7 @@ public class ClassReadersTests extends ESTestCase {
     }
 
     public void testStreamOfJarsAndIndividualClasses() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
 
@@ -104,7 +100,7 @@ public class ClassReadersTests extends ESTestCase {
     }
 
     public void testMultipleJarsInADir() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
 


### PR DESCRIPTION
Ensure directory stream is closed. (another instance of #92890)

Additionally, use the test name in the temporary directory, which helps with failure diagnosis.


closes #93005