### PR TITLE
[8.6] Pipeline setting missing in reindex.asciidoc (#89125)

### DIFF
--- a/docs/reference/docs/reindex.asciidoc
+++ b/docs/reference/docs/reindex.asciidoc
@@ -575,6 +575,9 @@ Valid values: `index`, `create`. Defaults to `index`.
 IMPORTANT: To reindex to a data stream destination, this argument must be
 `create`.
 
+`pipeline`:::
+(Optional, string) the name of the <<reindex-with-an-ingest-pipeline,pipeline>> to use.
+
 `script`::
 `source`:::
 (Optional, string) The script to run to update the document source or metadata when reindexing.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Pipeline setting missing in reindex.asciidoc (#89125)](https://github.com/elastic/elasticsearch/pull/89125)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)