### PR TITLE
[8.6] Ensure plugin class scanner always closes its directory stream (#93027)

### DIFF
--- a/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
+++ b/libs/plugin-scanner/src/main/java/org/elasticsearch/plugin/scanner/ClassReaders.java
@@ -45,8 +45,8 @@ public class ClassReaders {
             return Collections.emptyList();
         }
         Path dir = Paths.get(path);
-        try {
-            return ofPaths(Files.list(dir));
+        try (var stream = Files.list(dir)) {
+            return ofPaths(stream);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/ClassReadersTests.java
+++ b/libs/plugin-scanner/src/test/java/org/elasticsearch/plugin/scanner/ClassReadersTests.java
@@ -24,12 +24,8 @@ import java.util.stream.Stream;
 
 public class ClassReadersTests extends ESTestCase {
 
-    private Path tmpDir() throws IOException {
-        return createTempDir();
-    }
-
     public void testModuleInfoIsNotReturnedAsAClassFromJar() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
         Path jar = dirWithJar.resolve("api.jar");
@@ -42,7 +38,7 @@ public class ClassReadersTests extends ESTestCase {
     }
 
     public void testTwoClassesInAStreamFromJar() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
         Path jar = dirWithJar.resolve("api.jar");
@@ -60,7 +56,7 @@ public class ClassReadersTests extends ESTestCase {
     }
 
     public void testStreamOfJarsAndIndividualClasses() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
 
@@ -97,7 +93,7 @@ public class ClassReadersTests extends ESTestCase {
     }
 
     public void testMultipleJarsInADir() throws IOException {
-        final Path tmp = tmpDir();
+        final Path tmp = createTempDir(getTestName());
         final Path dirWithJar = tmp.resolve("jars-dir");
         Files.createDirectories(dirWithJar);
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Ensure plugin class scanner always closes its directory stream (#93027)