### PR TITLE
Fixing testClusterAllowPartialsWithRedState assertion for windows case

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
@@ -28,6 +28,7 @@ import java.util.List;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyArray;
 import static org.hamcrest.Matchers.equalTo;
@@ -70,7 +71,13 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
             assertThat(failure.getCause(), instanceOf(NoShardAvailableActionException.class));
             assertThat(failure.getCause().getStackTrace(), emptyArray());
             // We don't write out the entire, repetitive stacktrace in the reason
-            assertThat(failure.reason(), equalTo("org.elasticsearch.action.NoShardAvailableActionException\n"));
+            assertThat(
+                failure.reason(),
+                anyOf(
+                    equalTo("org.elasticsearch.action.NoShardAvailableActionException\n"),
+                    equalTo("org.elasticsearch.action.NoShardAvailableActionException\r\n")
+                )
+            );
         }
     }
 


### PR DESCRIPTION
Newline may actually be `\r\n`. 

closes: https://github.com/elastic/elasticsearch/issues/92938