### PR TITLE
Exclude the class from jackson jar

### DIFF
--- a/libs/x-content/impl/es-jackson-core/build.gradle
+++ b/libs/x-content/impl/es-jackson-core/build.gradle
@@ -26,6 +26,9 @@ tasks.named("dependencyLicenses").configure {
 }
 
 shadowJar {
+  exclude { element ->
+    element.file == null && element.path.endsWith("FilteringParserDelegate.class")
+  }
   manifest {
     attributes 'Multi-Release' : 'true'
   }


### PR DESCRIPTION
in #92984 we override a file in jackson jar, but we rely on gradle internals which might change at any point.
This fixes this by excluding a element from a jar and allowing a new class to be added

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
