### PR TITLE
Forbid searching unsearchable shards

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -356,7 +356,6 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
         return null;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93010")
     public void testSearchRouting() throws InterruptedException {
 
         var routingTableWatcher = new RoutingTableWatcher();

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardIterator.java
@@ -50,8 +50,14 @@ public final class SearchShardIterator implements Comparable<SearchShardIterator
      * @param originalIndices the indices that the search request originally related to (before any rewriting happened)
      */
     public SearchShardIterator(@Nullable String clusterAlias, ShardId shardId, List<ShardRouting> shards, OriginalIndices originalIndices) {
-        // TODO ensure all target nodes hold shards with a searchable ShardRoutingRole - at the moment, searches don't check this
-        this(clusterAlias, shardId, shards.stream().map(ShardRouting::currentNodeId).toList(), originalIndices, null, null);
+        this(
+            clusterAlias,
+            shardId,
+            shards.stream().filter(ShardRouting::isSearchable).map(ShardRouting::currentNodeId).toList(),
+            originalIndices,
+            null,
+            null
+        );
     }
 
     public SearchShardIterator(


### PR DESCRIPTION
This reverts commit 3fa78426ad2ac893a91bbee6e9335c0ff6c2bd69.