### PR TITLE
[TEST] Make testNotReadyOnBadFileSettings more reliable

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -242,7 +242,6 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
         logger.info("--> New file settings: [{}]", Strings.format(json, version));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93036")
     public void testNotReadyOnBadFileSettings() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -7,10 +7,11 @@
  */
 package org.elasticsearch.readiness;
 
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.ReservedStateErrorMetadata;
 import org.elasticsearch.cluster.metadata.ReservedStateHandlerMetadata;
 import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
@@ -32,7 +33,6 @@ import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -326,7 +326,7 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
         tcpReadinessProbeTrue(s);
     }
 
-    private void causeClusterStateUpdate() throws ExecutionException, InterruptedException {
+    private void causeClusterStateUpdate() {
         internalCluster().getCurrentMasterNodeInstance(ClusterService.class)
             .submitUnbatchedStateUpdateTask("poke", new ClusterStateUpdateTask() {
                 @Override

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -194,12 +194,6 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     // package private for testing
     synchronized void stopListener() {
         assert enabled(environment);
-
-        // don't spam the logs with repeated false, if we were never active
-        if (ready() == false) {
-            return;
-        }
-
         try {
             logger.info(
                 "stopping readiness service on channel {}",

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -194,6 +194,12 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     // package private for testing
     synchronized void stopListener() {
         assert enabled(environment);
+
+        // don't spam the logs with repeated false, if we were never active
+        if (ready() == false) {
+            return;
+        }
+
         try {
             logger.info(
                 "stopping readiness service on channel {}",


### PR DESCRIPTION
The ReadinessClusterIT.testNotReadyOnBadFileSettings test expects to receive a cluster state update event, showing that we have recorded an error during processing of the file settings.

However, since we process these file settings on node start, the node can launch the file settings watcher thread and process everything before the test ever sets up the cluster state listener. Therefore, the test may never receive a cluster state update to unlock the await.

The fix introduced a harmless write of some cluster settings, to ensure that at least one cluster state event will be sent after we setup the cluster state listener.

Closes https://github.com/elastic/elasticsearch/issues/93036