### PR TITLE
[8.6] Exclude jackson patched class from spotlessApply (#93059)

### DIFF
--- a/libs/x-content/impl/es-jackson-core/build.gradle
+++ b/libs/x-content/impl/es-jackson-core/build.gradle
@@ -21,6 +21,14 @@ dependencies {
   }
 }
 
+pluginManager.withPlugin('com.diffplug.spotless') {
+  spotless {
+    java {
+      targetExclude "src/main/java/com/fasterxml/jackson/core/filter/FilteringParserDelegate.java"
+    }
+  }
+}
+
 tasks.named("dependencyLicenses").configure {
   mapping from: /jackson-.*/, to: 'jackson'
 }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Exclude jackson patched class from spotlessApply (#93059)