### PR TITLE
[8.6] Fix line ending assertion for search index state test (#93063)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
@@ -70,7 +70,7 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
             assertThat(failure.getCause(), instanceOf(NoShardAvailableActionException.class));
             assertThat(failure.getCause().getStackTrace(), emptyArray());
             // We don't write out the entire, repetitive stacktrace in the reason
-            assertThat(failure.reason(), equalTo("org.elasticsearch.action.NoShardAvailableActionException\n"));
+            assertThat(failure.reason(), equalTo("org.elasticsearch.action.NoShardAvailableActionException" + System.lineSeparator()));
         }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix line ending assertion for search index state test (#93063)