### PR TITLE
Fix role filter in RecoveryTarget

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTarget.java
@@ -495,8 +495,7 @@ public class RecoveryTarget extends AbstractRefCounted implements RecoveryTarget
             final Store store = store();
             store.incRef();
             try {
-                if (DiscoveryNode.isStateless(indexShard.indexSettings().getNodeSettings()) == false
-                    || indexShard.routingEntry().primary()) {
+                if (indexShard.routingEntry().isPromotableToPrimary()) {
                     store.cleanupAndVerify("recovery CleanFilesRequestHandler", sourceMetadata);
                 }
                 final String translogUUID = Translog.createEmptyTranslog(


### PR DESCRIPTION
Shards now have the correct roles so we can fix the filter in `RecoveryTarget`.