### PR TITLE
Fixed the doc URL for rest API update trained model deployment

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/ml.update_trained_model_deployment.json
@@ -1,7 +1,7 @@
 {
   "ml.update_trained_model_deployment":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-update-trained-model-deployment.html",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/update-trained-model-deployment.html",
       "description":"Updates certain properties of trained model deployment."
     },
     "stability":"beta",


### PR DESCRIPTION
As titled, the previous URL was 404.