### PR TITLE
[8.6] Fix typo in delete-by-query yaml test (#93094)

### DIFF
--- a/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/100_delete_by_query.yml
+++ b/modules/data-streams/src/yamlRestTest/resources/rest-api-spec/test/data_stream/100_delete_by_query.yml
@@ -75,7 +75,7 @@
 
   - do:
       allowed_warnings:
-        - "index template [my-template2] has index patterns [simple-stream*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template1] will take precedence during new index creation"
+        - "index template [my-template2] has index patterns [simple-stream*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [my-template2] will take precedence during new index creation"
       indices.put_index_template:
         name: my-template2
         body:


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix typo in delete-by-query yaml test (#93094)