### PR TITLE
Introduce RefCountingListener#isFailing

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/RefCountingListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RefCountingListener.java
@@ -174,4 +174,12 @@ public final class RefCountingListener implements Releasable {
     public String toString() {
         return "refCounting[" + delegate + "]";
     }
+
+    /**
+     * @return {@code true} if at least one acquired listener has completed exceptionally, which means that the delegate listener will also
+     *         complete exceptionally once all acquired listeners are completed.
+     */
+    public boolean isFailing() {
+        return exceptionRef.get() != null;
+    }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/RefCountingListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/RefCountingListenerTests.java
@@ -93,12 +93,14 @@ public class RefCountingListenerTests extends ESTestCase {
                         } else {
                             exceptionCount.incrementAndGet();
                             ref.onFailure(new ElasticsearchException("simulated"));
+                            assertTrue(refs.isFailing());
                         }
                     });
                 }
             }
 
             assertFalse(executed.get());
+            assertFalse(refs.isFailing());
         }
 
         assertNotEquals(async, executed.get());


### PR DESCRIPTION
Sometimes it's useful to know whether any of the other acquired listeners have failed. For instance, it may be preferable to avoid doing certain async tasks if we already know that the overall operation will fail due to the failure of an an earlier task. This commit exposes this information on `RefCountingListener`.