### PR TITLE
[8.6] Get repository metadata from the cluster state doesn't throw an exception if a repo is missing (#92914)

### DIFF
--- a/docs/changelog/92914.yaml
+++ b/docs/changelog/92914.yaml
@@ -1,0 +1,6 @@
+pr: 92914
+summary: Get repository metadata from the cluster state doesn't throw an exception
+  if a repo is missing
+area: ILM+SLM
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/GetSnapshotsIT.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsRequestB
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsResponse;
 import org.elasticsearch.cluster.SnapshotsInProgress;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.repositories.RepositoryMissingException;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -29,8 +30,10 @@ import java.util.Set;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.in;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
 public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
@@ -576,6 +579,23 @@ public class GetSnapshotsIT extends AbstractSnapshotIntegTestCase {
             .get();
         assertThat(paginatedResponse2.getSnapshots(), is(List.of(snapshot1, snapshot2)));
         assertThat(paginatedResponse2.totalCount(), is(3));
+    }
+
+    public void testRetrievingSnapshotsWhenRepositoryIsMissing() throws Exception {
+        final String repoName = "test-repo";
+        final Path repoPath = randomRepoPath();
+        createRepository(repoName, "fs", repoPath);
+        final String missingRepoName = "missing";
+
+        final List<String> snapshotNames = createNSnapshots(repoName, randomIntBetween(1, 10));
+        snapshotNames.sort(String::compareTo);
+
+        final GetSnapshotsResponse response = clusterAdmin().prepareGetSnapshots(repoName, missingRepoName)
+            .setSort(GetSnapshotsRequest.SortBy.NAME)
+            .get();
+        assertThat(response.getSnapshots().stream().map(info -> info.snapshotId().getName()).toList(), equalTo(snapshotNames));
+        assertTrue(response.getFailures().containsKey(missingRepoName));
+        assertThat(response.getFailures().get(missingRepoName), instanceOf(RepositoryMissingException.class));
     }
 
     // Create a snapshot that is guaranteed to have a unique start time and duration for tests around ordering by either.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -132,7 +132,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     }
 
     /**
-     * Returns true if there is a least one failed response.
+     * Returns true if there is at least one failed response.
      */
     public boolean isFailed() {
         return failures.isEmpty() == false;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -58,7 +58,6 @@ import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import java.util.function.ToLongFunction;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -112,12 +111,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         getMultipleReposSnapshotInfo(
             request.isSingleRepositoryRequest() == false,
             state.custom(SnapshotsInProgress.TYPE, SnapshotsInProgress.EMPTY),
-            maybeFilterRepositories(
-                TransportGetRepositoriesAction.getRepositories(state, request.repositories()),
-                request.sort(),
-                request.order(),
-                request.fromSortValue()
-            ),
+            TransportGetRepositoriesAction.getRepositories(state, request.repositories()),
             request.snapshots(),
             request.ignoreUnavailable(),
             request.verbose(),
@@ -127,6 +121,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             request.offset(),
             request.size(),
             request.order(),
+            request.fromSortValue(),
             SnapshotPredicates.fromRequest(request),
             request.includeIndexNames(),
             listener
@@ -156,7 +151,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
     private void getMultipleReposSnapshotInfo(
         boolean isMultiRepoRequest,
         SnapshotsInProgress snapshotsInProgress,
-        List<RepositoryMetadata> repos,
+        TransportGetRepositoriesAction.RepositoriesResult repositoriesResult,
         String[] snapshots,
         boolean ignoreUnavailable,
         boolean verbose,
@@ -166,27 +161,33 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         int offset,
         int size,
         SortOrder order,
+        String fromSortValue,
         SnapshotPredicates predicates,
         boolean indices,
         ActionListener<GetSnapshotsResponse> listener
     ) {
+        // Process the missing repositories
+        final Map<String, ElasticsearchException> failures = new HashMap<>();
+        for (String missingRepo : repositoriesResult.missing()) {
+            failures.put(missingRepo, new RepositoryMissingException(missingRepo));
+        }
+
         // short-circuit if there are no repos, because we can not create GroupedActionListener of size 0
-        if (repos.isEmpty()) {
-            listener.onResponse(new GetSnapshotsResponse(Collections.emptyList(), Collections.emptyMap(), null, 0, 0));
+        if (repositoriesResult.metadata().isEmpty()) {
+            listener.onResponse(new GetSnapshotsResponse(List.of(), failures, null, 0, 0));
             return;
         }
+        List<RepositoryMetadata> repositories = maybeFilterRepositories(repositoriesResult.metadata(), sortBy, order, fromSortValue);
         final GroupedActionListener<Tuple<Tuple<String, ElasticsearchException>, SnapshotsInRepo>> groupedActionListener =
             new GroupedActionListener<>(listener.map(responses -> {
-                assert repos.size() == responses.size();
+                assert repositories.size() == responses.size();
                 final List<SnapshotInfo> allSnapshots = responses.stream()
                     .map(Tuple::v2)
                     .filter(Objects::nonNull)
                     .flatMap(snapshotsInRepo -> snapshotsInRepo.snapshotInfos.stream())
                     .toList();
-                final Map<String, ElasticsearchException> failures = responses.stream()
-                    .map(Tuple::v1)
-                    .filter(Objects::nonNull)
-                    .collect(Collectors.toMap(Tuple::v1, Tuple::v2));
+
+                responses.stream().map(Tuple::v1).filter(Objects::nonNull).forEach(tuple -> failures.put(tuple.v1(), tuple.v2()));
                 final SnapshotsInRepo snInfos = sortSnapshots(allSnapshots, sortBy, after, offset, size, order);
                 final List<SnapshotInfo> snapshotInfos = snInfos.snapshotInfos;
                 final int remaining = snInfos.remaining + responses.stream()
@@ -203,10 +204,10 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                     responses.stream().map(Tuple::v2).filter(Objects::nonNull).mapToInt(s -> s.totalCount).sum(),
                     remaining
                 );
-            }), repos.size());
+            }), repositories.size());
 
-        for (final RepositoryMetadata repo : repos) {
-            final String repoName = repo.name();
+        for (final RepositoryMetadata repository : repositories) {
+            final String repoName = repository.name();
             getSingleRepoSnapshotInfo(
                 snapshotsInProgress,
                 repoName,

--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/slm/SnapshotLifecycleRestIT.java
@@ -598,6 +598,74 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         assertNotNull(slm.get("policy_stats"));
     }
 
+    public void testSnapshotRetentionWithMissingRepo() throws Exception {
+        // Create two snapshot repositories
+        String repo = "test-repo";
+        initializeRepo(repo);
+        String missingRepo = "missing-repo";
+        initializeRepo(missingRepo);
+
+        // Create a policy per repository
+        final String indexName = "test";
+        final String policyName = "policy-1";
+        createSnapshotPolicy(
+            policyName,
+            "snap",
+            NEVER_EXECUTE_CRON_SCHEDULE,
+            repo,
+            indexName,
+            true,
+            new SnapshotRetentionConfiguration(TimeValue.timeValueMillis(1), null, null)
+        );
+        final String policyWithMissingRepo = "policy-2";
+        createSnapshotPolicy(
+            policyWithMissingRepo,
+            "snap",
+            NEVER_EXECUTE_CRON_SCHEDULE,
+            missingRepo,
+            indexName,
+            true,
+            new SnapshotRetentionConfiguration(TimeValue.timeValueMillis(1), null, null)
+        );
+
+        // Delete the repo of one of the policies
+        deleteRepository(missingRepo);
+
+        // Manually create a snapshot based on the "correct" policy
+        final String snapshotName = executePolicy(policyName);
+
+        // Check that the executed snapshot is created
+        assertBusy(() -> {
+            try {
+                Response response = client().performRequest(new Request("GET", "/_snapshot/" + repo + "/" + snapshotName));
+                Map<String, Object> snapshotResponseMap;
+                try (InputStream is = response.getEntity().getContent()) {
+                    snapshotResponseMap = XContentHelper.convertToMap(XContentType.JSON.xContent(), is, true);
+                }
+                assertThat(snapshotResponseMap.size(), greaterThan(0));
+                final Map<String, Object> metadata = extractMetadata(snapshotResponseMap, snapshotName);
+                assertNotNull(metadata);
+                assertThat(metadata.get("policy"), equalTo(policyName));
+                assertHistoryIsPresent(policyName, true, repo, CREATE_OPERATION);
+            } catch (ResponseException e) {
+                fail("expected snapshot to exist but it does not: " + EntityUtils.toString(e.getResponse().getEntity()));
+            }
+        }, 60, TimeUnit.SECONDS);
+
+        execute_retention(client());
+
+        // Check that the snapshot created by the policy has been removed by retention
+        assertBusy(() -> {
+            try {
+                Response response = client().performRequest(new Request("GET", "/_snapshot/" + repo + "/" + snapshotName));
+                assertThat(EntityUtils.toString(response.getEntity()), containsString("snapshot_missing_exception"));
+            } catch (ResponseException e) {
+                assertThat(EntityUtils.toString(e.getResponse().getEntity()), containsString("snapshot_missing_exception"));
+            }
+            assertHistoryIsPresent(policyName, true, repo, DELETE_OPERATION);
+        }, 60, TimeUnit.SECONDS);
+    }
+
     public Map<String, Object> getLocation(String path) {
         try {
             Response executeRepsonse = client().performRequest(new Request("GET", path));
@@ -831,6 +899,11 @@ public class SnapshotLifecycleRestIT extends ESRestTestCase {
         document.endObject();
         final Request request = new Request("POST", "/" + index + "/_doc/" + id);
         request.setJsonEntity(Strings.toString(document));
+        assertOK(client.performRequest(request));
+    }
+
+    private static void execute_retention(RestClient client) throws IOException {
+        final Request request = new Request("POST", "/_slm/_execute_retention");
         assertOK(client.performRequest(request));
     }
 

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -295,9 +295,14 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                         snapshots.computeIfAbsent(info.repository(), repo -> new ArrayList<>()).add(info);
                     }
                 }
+                if (resp.isFailed()) {
+                    for (String repo : resp.getFailures().keySet()) {
+                        logger.debug(() -> "unable to retrieve snapshots for [" + repo + "] repositories: ", resp.getFailures().get(repo));
+                    }
+                }
                 listener.onResponse(snapshots);
             }, e -> {
-                logger.debug(() -> "unable to retrieve snapshots for [" + repositories + "] repositories", e);
+                logger.debug(() -> "unable to retrieve snapshots for [" + repositories + "] repositories: ", e);
                 listener.onFailure(e);
             }));
     }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Get repository metadata from the cluster state doesn't throw an exception if a repo is missing (#92914)](https://github.com/elastic/elasticsearch/pull/92914)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)