### PR TITLE
Remove version constant for 8.5.4

### DIFF
--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -128,7 +128,6 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public static final Version V_8_5_1 = new Version(8_05_01_99, TransportVersion.V_8_5_1, org.apache.lucene.util.Version.LUCENE_9_4_1);
     public static final Version V_8_5_2 = new Version(8_05_02_99, TransportVersion.V_8_5_2, org.apache.lucene.util.Version.LUCENE_9_4_1);
     public static final Version V_8_5_3 = new Version(8_05_03_99, TransportVersion.V_8_5_3, org.apache.lucene.util.Version.LUCENE_9_4_2);
-    public static final Version V_8_5_4 = new Version(8_05_04_99, TransportVersion.V_8_5_4, org.apache.lucene.util.Version.LUCENE_9_4_2);
     public static final Version V_8_6_0 = new Version(8_06_00_99, TransportVersion.V_8_6_0, org.apache.lucene.util.Version.LUCENE_9_4_2);
     public static final Version V_8_6_1 = new Version(8_06_01_99, TransportVersion.V_8_6_1, org.apache.lucene.util.Version.LUCENE_9_4_2);
     public static final Version V_8_7_0 = new Version(8_07_00_99, TransportVersion.V_8_7_0, org.apache.lucene.util.Version.LUCENE_9_5_0);


### PR DESCRIPTION
This looks to have snuck back in as part of https://github.com/elastic/elasticsearch/pull/92869.