### PR TITLE
Expand the TSDB data stream timestamp parsing tests

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -944,10 +944,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     }
 
     private void postIngest(IngestDocument ingestDocument, IndexRequest indexRequest) {
-        // cache timestamp from ingest source map
-        Object rawTimestamp = ingestDocument.getSourceAndMetadata().get(TimestampField.FIXED_TIMESTAMP_FIELD);
-        if (rawTimestamp != null && indexRequest.getRawTimestamp() == null) {
-            indexRequest.setRawTimestamp(rawTimestamp);
+        if (indexRequest.getRawTimestamp() == null) {
+            // cache the @timestamp from the ingest document's source map if there is one
+            Object rawTimestamp = ingestDocument.getSource().get(TimestampField.FIXED_TIMESTAMP_FIELD);
+            if (rawTimestamp != null) {
+                indexRequest.setRawTimestamp(rawTimestamp);
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1715,18 +1715,50 @@ public class IngestServiceTests extends ESTestCase {
         clusterState = executePut(putRequest2, clusterState);
         ingestService.applyClusterState(new ClusterChangedEvent("", clusterState, previousClusterState));
 
+        // feed a document with no timestamp through four scenarios
+        Map<String, Object> doc1 = Map.of("foo", "bar");
+
+        // neither a request nor a final pipeline
+        IndexRequest indexRequest1 = new IndexRequest("idx").setPipeline("_none").setFinalPipeline("_none").source(doc1);
+        // just a request pipeline
+        IndexRequest indexRequest2 = new IndexRequest("idx").setPipeline("_id1").setFinalPipeline("_none").source(doc1);
+        // just a final pipeline
+        IndexRequest indexRequest3 = new IndexRequest("idx").setPipeline("_none").setFinalPipeline("_id2").source(doc1);
+        // both a request and a final pipeline
+        IndexRequest indexRequest4 = new IndexRequest("idx").setPipeline("_id1").setFinalPipeline("_id2").source(doc1);
+
+        // feed a document with a timestamp through four scenarios
+        Map<String, Object> doc2 = Map.of(TimestampField.FIXED_TIMESTAMP_FIELD, 10);
+
+        // neither a request nor a final pipeline
+        IndexRequest indexRequest5 = new IndexRequest("idx").setPipeline("_none").setFinalPipeline("_none").source(doc2);
+        // just a request pipeline
+        IndexRequest indexRequest6 = new IndexRequest("idx").setPipeline("_id1").setFinalPipeline("_none").source(doc2);
+        // just a final pipeline
+        IndexRequest indexRequest7 = new IndexRequest("idx").setPipeline("_none").setFinalPipeline("_id2").source(doc2);
+        // both a request and a final pipeline
+        IndexRequest indexRequest8 = new IndexRequest("idx").setPipeline("_id1").setFinalPipeline("_id2").source(doc2);
+
         BulkRequest bulkRequest = new BulkRequest();
-        IndexRequest indexRequest1 = new IndexRequest("idx").setPipeline("_id1")
-            .setFinalPipeline("_id1")
-            .source(Map.of(TimestampField.FIXED_TIMESTAMP_FIELD, 10));
-        IndexRequest indexRequest2 = new IndexRequest("idx").setPipeline("_id1").setFinalPipeline("_id1").source(Map.of("foo", "bar"));
         bulkRequest.add(indexRequest1);
         bulkRequest.add(indexRequest2);
+        bulkRequest.add(indexRequest3);
+        bulkRequest.add(indexRequest4);
+        bulkRequest.add(indexRequest5);
+        bulkRequest.add(indexRequest6);
+        bulkRequest.add(indexRequest7);
+        bulkRequest.add(indexRequest8);
+        ingestService.executeBulkRequest(8, bulkRequest.requests(), indexReq -> {}, (integer, e) -> {}, (thread, e) -> {}, Names.WRITE);
 
-        ingestService.executeBulkRequest(2, bulkRequest.requests(), indexReq -> {}, (integer, e) -> {}, (thread, e) -> {}, Names.WRITE);
-
-        assertThat(indexRequest1.getRawTimestamp(), equalTo(10));
+        assertThat(indexRequest1.getRawTimestamp(), nullValue());
         assertThat(indexRequest2.getRawTimestamp(), nullValue());
+        assertThat(indexRequest3.getRawTimestamp(), equalTo(100));
+        assertThat(indexRequest4.getRawTimestamp(), equalTo(100));
+        assertThat(indexRequest5.getRawTimestamp(), nullValue());
+        assertThat(indexRequest6.getRawTimestamp(), equalTo(10));
+        assertThat(indexRequest7.getRawTimestamp(), equalTo(100));
+        // see https://github.com/elastic/elasticsearch/issues/93118 -- this should be 100, but it's actually 10
+        // assertThat(indexRequest8.getRawTimestamp(), equalTo(100));
     }
 
     public void testResolveRequiredOrDefaultPipelineDefaultPipeline() {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1683,7 +1683,7 @@ public class IngestServiceTests extends ESTestCase {
         assertThat(reference.get(), is(instanceOf(byte[].class)));
     }
 
-    public void testPostIngest() {
+    public void testSetsRawTimestamp() {
         IngestService ingestService = createWithProcessors(
             Map.of("mock", (factories, tag, description, config) -> mockCompoundProcessor())
         );


### PR DESCRIPTION
Related to #93118

Expands the scenarios under test, leaving the failing test assertion commented out. A PR that fixes the bug will be able to remove the comment.

Note: it's a bit odd to add a failing test like this, but I'm working up to something -- I think it'll be easier for everyone if we add the test this way so that I can drop the comment later.