### PR TITLE
Document how to set ES_TMPDIR in the service file

### DIFF
--- a/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
+++ b/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
@@ -27,9 +27,20 @@ filesystem, or configure {es} to use a different location for its temporary
 directory by setting the <<es-tmpdir,`$ES_TMPDIR`>> environment variable. For
 instance:
 
+* If you are running {es} directly from a shell, set `$ES_TMPDIR` as follows:
++
 ["source","sh",subs="attributes"]
 --------------------------------------------
 export ES_TMPDIR=/usr/share/elasticsearch/tmp
+--------------------------------------------
+
+* If you are using `systemd` to run {es} as a service, using the `systemctl`
+command, add the following line to the `[Service]` section of your
+`elasticsearch.service` unit file:
++
+[source,text]
+--------------------------------------------
+Environment=ES_TMPDIR=/usr/share/elasticsearch/tmp
 --------------------------------------------
 
 If you need finer control over the location of these temporary files, you can


### PR DESCRIPTION
Today we suggest that users set `ES_TMPDIR` using `export`, which only works if you're running things directly from the shell. Yet most users encountering `ES_TMPDIR` problems seem to on RHEL and trying to run things via `systemd`, for whom the `export` suggestion doesn't work.

This commit adds to the docs a suggestion of how to adjust the `systemd` service file to set the appropriate environment variable.

Relates #80651