### PR TITLE
Omit master-ineligible nodes from initial_master_nodes

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -65,8 +65,15 @@ public class DefaultSettingsProvider implements SettingsProvider {
         settings.put("action.destructive_requires_name", "false");
 
         // Setup cluster discovery
-        String nodeNames = nodeSpec.getCluster().getNodes().stream().map(LocalNodeSpec::getName).collect(Collectors.joining(","));
-        settings.put("cluster.initial_master_nodes", "[" + nodeNames + "]");
+        settings.put(
+            "cluster.initial_master_nodes",
+            nodeSpec.getCluster()
+                .getNodes()
+                .stream()
+                .filter(LocalNodeSpec::isMasterEligible)
+                .map(LocalNodeSpec::getName)
+                .collect(Collectors.joining(",", "[", "]"))
+        );
         settings.put("discovery.seed_providers", "file");
         settings.put("discovery.seed_hosts", "[]");
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -209,6 +209,10 @@ public class LocalClusterSpec implements ClusterSpec {
             return resolvedSettings;
         }
 
+        public boolean isMasterEligible() {
+            return settings.getOrDefault("node.roles", "master").contains("master");
+        }
+
         /**
          * Resolve node environment variables. Order of precedence is as follows:
          * <ol>


### PR DESCRIPTION
Today the `test-clusters` framework sets `cluster.initial_master_nodes` to the names of all the nodes in the cluster, but this only makes sense if they're all master-eligible. This commit filters this setting down to just the master-eligible node names.