### PR TITLE
Fix DataTierDataStreamIT test

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataTierDataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataTierDataStreamIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.datastreams;
 
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
-import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
@@ -48,29 +47,27 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             PutComposableIndexTemplateAction.INSTANCE,
             new PutComposableIndexTemplateAction.Request("template").indexTemplate(template)
         ).actionGet();
-        client().prepareIndex(index).setCreate(true).setId("1").setSource("@timestamp", "2020-09-09").setWaitForActiveShards(0).get();
 
-        Settings idxSettings = client().admin()
-            .indices()
-            .prepareGetIndex()
-            .addIndices(index)
+        var dsIndexName = client().prepareIndex(index)
+            .setCreate(true)
+            .setId("1")
+            .setSource("@timestamp", "2020-09-09")
+            .setWaitForActiveShards(0)
             .get()
-            .getSettings()
-            .get(DataStream.getDefaultBackingIndexName(index, 1));
+            .getIndex();
+        var idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(dsIndexName);
         assertThat(DataTier.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         logger.info("--> waiting for {} to be yellow", index);
         ensureYellow(index);
 
         // Roll over index and ensure the second index also went to the "hot" tier
-        client().admin().indices().prepareRolloverIndex(index).get();
-        idxSettings = client().admin()
-            .indices()
-            .prepareGetIndex()
-            .addIndices(index)
-            .get()
-            .getSettings()
-            .get(DataStream.getDefaultBackingIndexName(index, 2));
+        var rolledOverIndexName = client().admin().indices().prepareRolloverIndex(index).get().getNewIndex();
+
+        // new index name should have the rolled over name
+        assertNotEquals(dsIndexName, rolledOverIndexName);
+
+        idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(rolledOverIndexName);
         assertThat(DataTier.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
     }
 


### PR DESCRIPTION
If this test runs right before midnight, it's possible when getting the settings for the index, it doesn't exist, due to a mismatch between the names (datastream names have the date in their name, "uuuu.MM.dd")

Closes #92368
