### PR TITLE
[7.17] Support custom PBKDF2 password hashes (#92871)

### DIFF
--- a/docs/changelog/92871.yaml
+++ b/docs/changelog/92871.yaml
@@ -1,0 +1,5 @@
+pr: 92871
+summary: Support custom PBKDF2 password hashes
+area: Authentication
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ChangePasswordRequestBuilder.java
@@ -70,9 +70,11 @@ public class ChangePasswordRequestBuilder extends ActionRequestBuilder<ChangePas
      */
     public ChangePasswordRequestBuilder passwordHash(char[] passwordHashChars, Hasher configuredHasher) {
         final Hasher resolvedHasher = Hasher.resolveFromHash(passwordHashChars);
-        if (resolvedHasher.equals(configuredHasher) == false) {
+        if (resolvedHasher.equals(configuredHasher) == false && resolvedHasher == Hasher.NOOP) {
             throw new IllegalArgumentException(
-                "Provided password hash uses [" + resolvedHasher + "] but the configured hashing algorithm is [" + configuredHasher + "]"
+                "The provided password hash could not be resolved to a known hash algorithm. "
+                    + "If attempting to use a plain text hash then 'clear_text' must be explicitly configured "
+                    + "as hashing algorithm to allow plain text hashes."
             );
         }
         if (request.passwordHash() != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/PutUserRequestBuilder.java
@@ -92,9 +92,11 @@ public class PutUserRequestBuilder extends ActionRequestBuilder<PutUserRequest, 
 
     public PutUserRequestBuilder passwordHash(char[] passwordHash, Hasher configuredHasher) {
         final Hasher resolvedHasher = Hasher.resolveFromHash(passwordHash);
-        if (resolvedHasher.equals(configuredHasher) == false) {
+        if (resolvedHasher.equals(configuredHasher) == false && resolvedHasher == Hasher.NOOP) {
             throw new IllegalArgumentException(
-                "Provided password hash uses [" + resolvedHasher + "] but the configured hashing algorithm is [" + configuredHasher + "]"
+                "The provided password hash could not be resolved to a known hash algorithm. "
+                    + "If attempting to use a plain text hash then 'clear_text' must be explicitly configured "
+                    + "as hashing algorithm to allow plain text hashes."
             );
         }
         if (request.passwordHash() != null) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/Hasher.java
@@ -192,7 +192,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, PBKDF2_DEFAULT_COST, PBKDF2_PREFIX);
         }
 
     },
@@ -205,7 +205,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, 1000, PBKDF2_PREFIX);
         }
 
     },
@@ -218,7 +218,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, 10000, PBKDF2_PREFIX);
         }
 
     },
@@ -231,7 +231,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, 50000, PBKDF2_PREFIX);
         }
 
     },
@@ -244,7 +244,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, 100000, PBKDF2_PREFIX);
         }
 
     },
@@ -257,7 +257,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, 500000, PBKDF2_PREFIX);
         }
 
     },
@@ -270,7 +270,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(data, hash, PBKDF2_PREFIX);
+            return verifyPbkdf2Hash(data, hash, 1000000, PBKDF2_PREFIX);
         }
 
     },
@@ -283,7 +283,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_DEFAULT_COST, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -296,7 +296,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, 1000, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -309,7 +309,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, 10000, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -322,7 +322,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, 50000, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -335,7 +335,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, 100000, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -348,7 +348,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, 500000, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -361,7 +361,7 @@ public enum Hasher {
 
         @Override
         public boolean verify(SecureString data, char[] hash) {
-            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, PBKDF2_STRETCH_PREFIX);
+            return verifyPbkdf2Hash(new SecureString(hashSha512(data)), hash, 1000000, PBKDF2_STRETCH_PREFIX);
         }
 
     },
@@ -486,11 +486,13 @@ public enum Hasher {
     private static final int PBKDF2_KEY_LENGTH = 256;
     private static final int BCRYPT_DEFAULT_COST = 10;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final int HMAC_SHA512_BLOCK_SIZE_IN_BITS = 128;
+    private static final int PBKDF2_MIN_SALT_LENGTH_IN_BYTES = 8;
 
     /**
      * Returns a {@link Hasher} instance of the appropriate algorithm and associated cost as
      * indicated by the {@code name}. Name identifiers for the default costs for
-     * BCRYPT and PBKDF2 return the he default BCRYPT and PBKDF2 Hasher instead of the specific
+     * BCRYPT and PBKDF2 return the default BCRYPT and PBKDF2 Hasher instead of the specific
      * instances for the associated cost.
      *
      * @param name The name of the algorithm and cost combination identifier
@@ -577,10 +579,10 @@ public enum Hasher {
             int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, BCRYPT_PREFIX_LENGTH, hash.length - 54)));
             return cost == BCRYPT_DEFAULT_COST ? Hasher.BCRYPT : resolve("bcrypt" + cost);
         } else if (CharArrays.charsBeginsWith(PBKDF2_STRETCH_PREFIX, hash)) {
-            int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, PBKDF2_STRETCH_PREFIX.length(), hash.length - 90)));
+            int cost = parsePbkdf2Iterations(hash, PBKDF2_STRETCH_PREFIX);
             return cost == PBKDF2_DEFAULT_COST ? Hasher.PBKDF2_STRETCH : resolve("pbkdf2_stretch_" + cost);
         } else if (CharArrays.charsBeginsWith(PBKDF2_PREFIX, hash)) {
-            int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, PBKDF2_PREFIX.length(), hash.length - 90)));
+            int cost = parsePbkdf2Iterations(hash, PBKDF2_PREFIX);
             return cost == PBKDF2_DEFAULT_COST ? Hasher.PBKDF2 : resolve("pbkdf2_" + cost);
         } else if (CharArrays.charsBeginsWith(SHA1_PREFIX, hash)) {
             return Hasher.SHA1;
@@ -642,27 +644,96 @@ public enum Hasher {
         }
     }
 
-    private static boolean verifyPbkdf2Hash(SecureString data, char[] hash, String prefix) {
-        // Base64 string length : (4*(n/3)) rounded up to the next multiple of 4 because of padding.
-        // n is 32 (PBKDF2_KEY_LENGTH in bytes), so tokenLength is 44
-        final int tokenLength = 44;
+    private static int parsePbkdf2Iterations(char[] hash, String prefix) {
+        int separator = -1;
+        for (int i = prefix.length(); i < hash.length; i++) {
+            if (hash[i] == '$') {
+                separator = i;
+                break;
+            }
+        }
+        if (separator == -1) {
+            throw new IllegalArgumentException("The number of iterations could not be determined from the provided PBKDF2 hash.");
+        }
+        try {
+            return Integer.parseInt(new String(hash, prefix.length(), separator - prefix.length()));
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("The number of iterations could not be determined from the provided PBKDF2 hash.", e);
+        }
+    }
+
+    /**
+     * Hashes the given clear text password {@code data} and compares it against the given {@code hash}.
+     *
+     * <p>
+     * <b>Note:</b> When verifying the password hashes we dynamically determine the key and salt lengths for user provided hashes,
+     * but for hashes we create we always use the get method to create hashes with fixed key {@link #PBKDF2_KEY_LENGTH}
+     * and fixed salt lengths.
+     *
+     * @param data the clear text password to hash and verify
+     * @param hash the stored hash against to verify password
+     * @param iterations the number of iterations for PBKDF2 function
+     * @param prefix the PBKDF2 hash prefix
+     * @return {@code true} if password data matches given hash after hashing it, otherwise {@code false}
+     */
+    private static boolean verifyPbkdf2Hash(final SecureString data, final char[] hash, final int iterations, final String prefix) {
+        if (CharArrays.charsBeginsWith(prefix, hash) == false) {
+            return false;
+        }
+
+        int separator1 = -1, separator2 = -1;
+        for (int i = prefix.length() + String.valueOf(iterations).length(); i < hash.length; i++) {
+            if (hash[i] == '$') {
+                separator1 = i;
+                break;
+            }
+        }
+        if (separator1 == -1) {
+            return false;
+        }
+        for (int i = separator1 + 1; i < hash.length; i++) {
+            if (hash[i] == '$') {
+                separator2 = i;
+                break;
+            }
+        }
+        if (separator2 == -1) {
+            return false;
+        }
+
         char[] hashChars = null;
         char[] saltChars = null;
+        try {
+            hashChars = Arrays.copyOfRange(hash, separator2 + 1, hash.length);
+            saltChars = Arrays.copyOfRange(hash, separator1 + 1, separator2);
+            // Convert from base64 (n * 3/4) to the nearest multiple of 16 bytes (/16 * 16) to bits (*8)
+            // (n * 3/4) / 16 * 16 * 8 ==> n * 3 / 64 * 128
+            final int keySize = (hashChars.length * 3) / 64 * 128;
+            return verifyPbkdf2Hash(data, iterations, keySize, saltChars, hashChars);
+        } finally {
+            if (null != hashChars) {
+                Arrays.fill(hashChars, '\u0000');
+            }
+            if (null != saltChars) {
+                Arrays.fill(saltChars, '\u0000');
+            }
+        }
+    }
+
+    private static boolean verifyPbkdf2Hash(SecureString data, int iterations, int keyLength, char[] saltChars, char[] hashChars) {
+        if (keyLength <= 0 || keyLength % HMAC_SHA512_BLOCK_SIZE_IN_BITS != 0) {
+            throw new ElasticsearchException(
+                "PBKDF2 key length must be positive and multiple of [" + HMAC_SHA512_BLOCK_SIZE_IN_BITS + " bits]"
+            );
+        }
+        final byte[] saltBytes = Base64.getDecoder().decode(CharArrays.toUtf8Bytes(saltChars));
+        if (saltBytes.length < PBKDF2_MIN_SALT_LENGTH_IN_BYTES) {
+            throw new ElasticsearchException("PBKDF2 salt must be at least [" + PBKDF2_MIN_SALT_LENGTH_IN_BYTES + " bytes] long");
+        }
         char[] computedPwdHash = null;
         try {
-            if (CharArrays.charsBeginsWith(prefix, hash) == false) {
-                return false;
-            }
-            hashChars = Arrays.copyOfRange(hash, hash.length - tokenLength, hash.length);
-            saltChars = Arrays.copyOfRange(hash, hash.length - (2 * tokenLength + 1), hash.length - (tokenLength + 1));
-            int cost = Integer.parseInt(new String(Arrays.copyOfRange(hash, prefix.length(), hash.length - (2 * tokenLength + 2))));
             SecretKeyFactory secretKeyFactory = SecretKeyFactory.getInstance("PBKDF2withHMACSHA512");
-            PBEKeySpec keySpec = new PBEKeySpec(
-                data.getChars(),
-                Base64.getDecoder().decode(CharArrays.toUtf8Bytes(saltChars)),
-                cost,
-                PBKDF2_KEY_LENGTH
-            );
+            PBEKeySpec keySpec = new PBEKeySpec(data.getChars(), saltBytes, iterations, keyLength);
             computedPwdHash = CharArrays.utf8BytesToChars(
                 Base64.getEncoder().encode(secretKeyFactory.generateSecret(keySpec).getEncoded())
             );
@@ -675,12 +746,6 @@ public enum Hasher {
             // salt, iv, or password length is not met. We catch this because we don't want the JVM to exit.
             throw new ElasticsearchException("Error using PBKDF2 implementation from the selected Security Provider", e);
         } finally {
-            if (null != hashChars) {
-                Arrays.fill(hashChars, '\u0000');
-            }
-            if (null != saltChars) {
-                Arrays.fill(saltChars, '\u0000');
-            }
             if (null != computedPwdHash) {
                 Arrays.fill(computedPwdHash, '\u0000');
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/ChangePasswordRequestBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/ChangePasswordRequestBuilderTests.java
@@ -49,7 +49,7 @@ public class ChangePasswordRequestBuilderTests extends ESTestCase {
         assertThat(request.passwordHash(), equalTo(hash));
     }
 
-    public void testWithHashedPasswordWithWrongAlgo() {
+    public void testWithHashedPasswordWithDifferentAlgo() throws IOException {
         final Hasher systemHasher = getFastStoredHashAlgoForTests();
         Hasher userHasher = getFastStoredHashAlgoForTests();
         while (userHasher.name().equals(systemHasher.name())) {
@@ -58,12 +58,43 @@ public class ChangePasswordRequestBuilderTests extends ESTestCase {
         final char[] hash = userHasher.hash(new SecureString("superlongpassword".toCharArray()));
         final String json = "{\n" + "    \"password_hash\": \"" + new String(hash) + "\"" + "}";
         ChangePasswordRequestBuilder builder = new ChangePasswordRequestBuilder(mock(Client.class));
-        final IllegalArgumentException e = expectThrows(
-            IllegalArgumentException.class,
-            () -> { builder.source(new BytesArray(json.getBytes(StandardCharsets.UTF_8)), XContentType.JSON, systemHasher).request(); }
-        );
-        assertThat(e.getMessage(), containsString(userHasher.name()));
-        assertThat(e.getMessage(), containsString(systemHasher.name()));
+        final ChangePasswordRequest request = builder.source(
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON,
+            systemHasher
+        ).request();
+        assertThat(request.passwordHash(), equalTo(hash));
+    }
+
+    public void testWithHashedPasswordAndNoopSystemHasher() throws IOException {
+        final Hasher systemHasher = Hasher.NOOP;
+        final Hasher userHasher = getFastStoredHashAlgoForTests();
+        final char[] hash = userHasher.hash(new SecureString("superlongpassword".toCharArray()));
+        final String json = Strings.format("""
+            {"password_hash": "%s"}
+            """, new String(hash));
+        ChangePasswordRequestBuilder builder = new ChangePasswordRequestBuilder(mock(Client.class));
+        final ChangePasswordRequest request = builder.source(
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON,
+            systemHasher
+        ).request();
+        assertThat(request.passwordHash(), equalTo(hash));
+    }
+
+    public void testWithClearTextPasswordAndNoopSystemHasher() throws IOException {
+        final Hasher systemHasher = Hasher.NOOP;
+        final char[] hash = randomAlphaOfLengthBetween(14, 20).toCharArray();
+        final String json = Strings.format("""
+            {"password_hash": "%s"}
+            """, new String(hash));
+        ChangePasswordRequestBuilder builder = new ChangePasswordRequestBuilder(mock(Client.class));
+        final ChangePasswordRequest request = builder.source(
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON,
+            systemHasher
+        ).request();
+        assertThat(request.passwordHash(), equalTo(hash));
     }
 
     public void testWithHashedPasswordNotHash() {
@@ -75,8 +106,7 @@ public class ChangePasswordRequestBuilderTests extends ESTestCase {
             IllegalArgumentException.class,
             () -> { builder.source(new BytesArray(json.getBytes(StandardCharsets.UTF_8)), XContentType.JSON, systemHasher).request(); }
         );
-        assertThat(e.getMessage(), containsString(Hasher.NOOP.name()));
-        assertThat(e.getMessage(), containsString(systemHasher.name()));
+        assertThat(e.getMessage(), containsString("The provided password hash could not be resolved to a known hash algorithm."));
     }
 
     public void testWithPasswordAndHash() throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/PutUserRequestBuilderTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/user/PutUserRequestBuilderTests.java
@@ -164,7 +164,7 @@ public class PutUserRequestBuilderTests extends ESTestCase {
         assertThat(request.username(), equalTo("hash_user"));
     }
 
-    public void testWithMismatchedPasswordHashingAlgorithm() throws IOException {
+    public void testWithDifferentPasswordHashingAlgorithm() throws IOException {
         final Hasher systemHasher = getFastStoredHashAlgoForTests();
         Hasher userHasher = getFastStoredHashAlgoForTests();
         while (userHasher.name().equals(systemHasher.name())) {
@@ -174,15 +174,52 @@ public class PutUserRequestBuilderTests extends ESTestCase {
         final String json = "{\n" + "    \"password_hash\": \"" + new String(hash) + "\"," + "    \"roles\": []\n" + "}";
 
         PutUserRequestBuilder builder = new PutUserRequestBuilder(mock(Client.class));
-        final IllegalArgumentException ex = expectThrows(
-            IllegalArgumentException.class,
-            () -> {
-                builder.source("hash_user", new BytesArray(json.getBytes(StandardCharsets.UTF_8)), XContentType.JSON, systemHasher)
-                    .request();
-            }
-        );
-        assertThat(ex.getMessage(), containsString(userHasher.name()));
-        assertThat(ex.getMessage(), containsString(systemHasher.name()));
+        PutUserRequest request = builder.source(
+            "hash_user",
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON,
+            systemHasher
+        ).request();
+        assertThat(request.passwordHash(), equalTo(hash));
+    }
+
+    public void testWithPasswordHashAndNoopSystemHasher() throws IOException {
+        final Hasher systemHasher = Hasher.NOOP;
+        final Hasher userHasher = getFastStoredHashAlgoForTests();
+        final char[] hash = userHasher.hash(new SecureString("secretpassword".toCharArray()));
+        final String json = Strings.format("""
+            {
+              "password_hash": "%s",
+              "roles": []
+            }""", new String(hash));
+
+        PutUserRequestBuilder builder = new PutUserRequestBuilder(mock(Client.class));
+        PutUserRequest request = builder.source(
+            "hash_user",
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON,
+            systemHasher
+        ).request();
+        assertThat(request.passwordHash(), equalTo(hash));
+    }
+
+    public void testWithClearTextPasswordHashAndNoopSystemHasher() throws IOException {
+        final Hasher systemHasher = Hasher.NOOP;
+        final char[] hash = randomAlphaOfLengthBetween(14, 20).toCharArray();
+        final String json = Strings.format("""
+            {
+              "password_hash": "%s",
+              "roles": []
+            }""", new String(hash));
+
+        PutUserRequestBuilder builder = new PutUserRequestBuilder(mock(Client.class));
+        PutUserRequest request = builder.source(
+            "hash_user",
+            new BytesArray(json.getBytes(StandardCharsets.UTF_8)),
+            XContentType.JSON,
+            systemHasher
+        ).request();
+        assertThat(request.passwordHash(), equalTo(hash));
     }
 
     public void testWithPasswordHashThatsNotReallyAHash() throws IOException {
@@ -197,8 +234,7 @@ public class PutUserRequestBuilderTests extends ESTestCase {
                     .request();
             }
         );
-        assertThat(ex.getMessage(), containsString(Hasher.NOOP.name()));
-        assertThat(ex.getMessage(), containsString(systemHasher.name()));
+        assertThat(ex.getMessage(), containsString("The provided password hash could not be resolved to a known hash algorithm."));
     }
 
     public void testWithBothPasswordAndHash() throws IOException {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/HasherTests.java
@@ -249,6 +249,71 @@ public class HasherTests extends ESTestCase {
         assertThat(Hasher.resolveFromHash("notavalidhashformat".toCharArray()), sameInstance(Hasher.NOOP));
     }
 
+    public void testPbkdf2ArbitrarySaltAndKeyLengths() {
+        // In FIPS 140 mode, passwords for PBKDF2 need to be at least 14 chars (112 bits)
+        assumeFalse("This should not run in FIPS mode", inFipsJvm());
+
+        // PBKDF2withHMACSHA512, 16 byte salt, 512 bits key
+        check(
+            "{PBKDF2}10000$"
+                + "NUG78+T6yahKzMHPgTbFmw==$"
+                + "Ohp+ZCG936Q+w1XTquEz5SmQmDUJVv5ZxilRaDPpHFRzHNDMjeFl8btefZd/0yNtfQPwpfhe5DSDFlPP9WMxEQ==",
+            "passw0rd",
+            true
+        );
+        check(
+            "{PBKDF2}10000$"
+                + "NUG78+T6yahKzMHPgTbFmw==$"
+                + "Ohp+ZCG936Q+w1XTquEz5SmQmDUJVv5ZxilRaDPpHFRzHNDMjeFl8btefZd/0yNtfQPwpfhe5DSDFlPP9WMxEQ==",
+            "admin",
+            false
+        );
+        check(
+            "{PBKDF2}100000$"
+                + "V+G8sM59pOTQ77ElFvIvbQ==$"
+                + "alomPA4LKmmu5d/y8BZI1fb5SnxxI6ClTFqe6vH3JJaz3cxrWfki5EO6Wy5eLuNr2BAdMVN0jnHGdsZzS+k+vw==",
+            "ginger",
+            true
+        );
+
+        // PBKDF2withHMACSHA512, 8 byte salt, 128 bits key
+        check("{PBKDF2}10000$vT/GxENkGSc=$4/b2cEHvSeAqzEoTM+RAYA==", "s3cr3t", true);
+
+        // PBKDF2withHMACSHA512, 64 byte salt, 512 bits key
+        check(
+            "{PBKDF2}1000$"
+                + "yJ1Mdnp6AEQfWKNdo6jw6BTy1KpxsthgaOHWQGhYWrzw826GZjX9vRN6h/4jRM750WWVhju2hxAZwP7yPzYdtA==$"
+                + "U1PnM55HWq6VKk/G0EpmTZJIRAfNMVpi78/cOc0I2qEGs68Ozg1Am4frXnSpb5lbundzkLxl+cg7MmAvM14JSQ==",
+            "somelongpasswordwith$peci@lch\u00E4rs!",
+            true
+        );
+
+        // PBKDF2withHMACSHA512, 32 byte salt, 256 bits key
+        check(
+            "{PBKDF2}50000$bjxn3/UGdT7zNtCVfgRp0REhPvLkIv4PZm9fullIQxc=$wuSFQZeOxifopubSzKbIE2xAGdxJlEcUVlqvjFU1TTI=",
+            "Tr0ub4dor&3",
+            true
+        );
+
+        // 12345 iterations are not supported
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> { check("{PBKDF2}12345$Rvr0LPiggps=$qBVD7TdDG3mgnLI5yZuR2g==", "s3cr3t", true); }
+        );
+        assertThat(e.getMessage(), containsString("unknown hash function [pbkdf2_12345]"));
+
+        // salt smaller than 8 bytes is not supported
+        ElasticsearchException ee = expectThrows(
+            ElasticsearchException.class,
+            () -> { check("{PBKDF2}10000$erwUfw==$Pv/wuOn49EH5nY88LOtY2g==", "s3cr3t", true); }
+        );
+        assertThat(ee.getMessage(), containsString("PBKDF2 salt must be at least [8 bytes] long"));
+
+        // derived key length is not multiple of 128 bits
+        ee = expectThrows(ElasticsearchException.class, () -> { check("{PBKDF2}10000$0jtIBOnhz7Q=$njOn++ANoMAXn0gi", "s3cr3t", true); });
+        assertThat(ee.getMessage(), containsString("PBKDF2 key length must be positive and multiple of [128 bits]"));
+    }
+
     public void testPbkdf2WithShortPasswordThrowsInFips() {
         assumeTrue("This should run only in FIPS mode", inFipsJvm());
         SecureString passwd = new SecureString(randomAlphaOfLength(between(6, 13)).toCharArray());


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Support custom PBKDF2 password hashes (#92871)](https://github.com/elastic/elasticsearch/pull/92871)

<!--- Backport version: 8.9.3 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)