### PR TITLE
Remove unused AdapterActionFuture#convert

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/AdapterActionFuture.java
@@ -18,7 +18,7 @@ import org.elasticsearch.core.TimeValue;
 
 import java.util.concurrent.TimeUnit;
 
-public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements ActionFuture<T>, ActionListener<L> {
+public abstract class AdapterActionFuture<T> extends BaseFuture<T> implements ActionFuture<T>, ActionListener<T> {
 
     @Override
     public T actionGet() {
@@ -54,16 +54,14 @@ public abstract class AdapterActionFuture<T, L> extends BaseFuture<T> implements
     }
 
     @Override
-    public void onResponse(L result) {
-        set(convert(result));
+    public void onResponse(T result) {
+        set(result);
     }
 
     @Override
     public void onFailure(Exception e) {
         setException(e);
     }
-
-    protected abstract T convert(L listenerResponse);
 
     private static RuntimeException unwrapEsException(ElasticsearchException esEx) {
         Throwable root = esEx.unwrapCause();

--- a/server/src/main/java/org/elasticsearch/action/support/ListenableActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ListenableActionFuture.java
@@ -17,7 +17,7 @@ import java.util.List;
  * A {@code Future} and {@link ActionListener} against which other {@link ActionListener}s can be registered later, to support
  * fanning-out a result to a dynamic collection of listeners.
  */
-public class ListenableActionFuture<T> extends AdapterActionFuture<T, T> {
+public class ListenableActionFuture<T> extends AdapterActionFuture<T> {
 
     private Object listeners;
     private boolean executedListeners = false;
@@ -75,11 +75,6 @@ public class ListenableActionFuture<T> extends AdapterActionFuture<T, T> {
                 executeListener((ActionListener<T>) listenersToExecute);
             }
         }
-    }
-
-    @Override
-    protected T convert(T listenerResponse) {
-        return listenerResponse;
     }
 
     private void executeListener(final ActionListener<T> listener) {

--- a/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
+++ b/server/src/main/java/org/elasticsearch/action/support/PlainActionFuture.java
@@ -12,7 +12,7 @@ import org.elasticsearch.core.CheckedConsumer;
 
 import java.util.concurrent.TimeUnit;
 
-public class PlainActionFuture<T> extends AdapterActionFuture<T, T> {
+public class PlainActionFuture<T> extends AdapterActionFuture<T> {
 
     public static <T> PlainActionFuture<T> newFuture() {
         return new PlainActionFuture<>();
@@ -28,10 +28,5 @@ public class PlainActionFuture<T> extends AdapterActionFuture<T, T> {
         PlainActionFuture<T> fut = newFuture();
         e.accept(fut);
         return fut.actionGet(timeout, unit);
-    }
-
-    @Override
-    protected T convert(T listenerResponse) {
-        return listenerResponse;
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/AdapterActionFutureTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.RemoteTransportException;
 
-import java.util.Objects;
 import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
@@ -24,10 +23,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 public class AdapterActionFutureTests extends ESTestCase {
 
     public void testInterruption() throws Exception {
-        final AdapterActionFuture<String, Integer> adapter = new AdapterActionFuture<String, Integer>() {
+        final AdapterActionFuture<Object> adapter = new AdapterActionFuture<>() {
             @Override
-            protected String convert(final Integer listenerResponse) {
-                return Objects.toString(listenerResponse);
+            protected boolean set(Object value) {
+                throw new AssertionError("should not be called");
             }
         };
 
@@ -83,11 +82,10 @@ public class AdapterActionFutureTests extends ESTestCase {
     }
 
     private void checkUnwrap(Exception exception, Class<? extends Exception> actionGetException, Class<? extends Exception> getException) {
-        final AdapterActionFuture<Void, Void> adapter = new AdapterActionFuture<Void, Void>() {
+        final AdapterActionFuture<Void> adapter = new AdapterActionFuture<>() {
             @Override
-            protected Void convert(Void listenerResponse) {
-                fail();
-                return null;
+            protected boolean set(Void value) {
+                throw new AssertionError("should not be called");
             }
         };
 

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/ProgressListenableActionFuture.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/ProgressListenableActionFuture.java
@@ -23,7 +23,7 @@ import java.util.function.Supplier;
  * Listeners are executed within the thread that triggers the completion, the failure or the progress update and
  * the progress value passed to the listeners on execution is the last updated value.
  */
-class ProgressListenableActionFuture extends AdapterActionFuture<Long, Long> {
+class ProgressListenableActionFuture extends AdapterActionFuture<Long> {
 
     protected final long start;
     protected final long end;
@@ -111,6 +111,10 @@ class ProgressListenableActionFuture extends AdapterActionFuture<Long, Long> {
 
     @Override
     public void onResponse(Long result) {
+        if (result == null || result < start || end < result) {
+            assert false : start + " < " + result + " < " + end;
+            throw new IllegalArgumentException("Invalid completion value [start=" + start + ",end=" + end + ",response=" + result + ']');
+        }
         ensureNotCompleted();
         super.onResponse(result);
     }
@@ -178,15 +182,6 @@ class ProgressListenableActionFuture extends AdapterActionFuture<Long, Long> {
         } catch (Exception e) {
             listener.onFailure(e);
         }
-    }
-
-    @Override
-    protected Long convert(Long response) {
-        if (response == null || response < start || end < response) {
-            assert false : start + " < " + response + " < " + end;
-            throw new IllegalArgumentException("Invalid completion value [start=" + start + ",end=" + end + ",response=" + response + ']');
-        }
-        return response;
     }
 
     @Override


### PR DESCRIPTION
`AdapterActionFuture` allows implementations to convert between the type received as a listener and the type emitted as a future. This ability is completely unused in practice, so this commit simplifies things by removing it.