### PR TITLE
Assert that ActionListener.runBefore/runAfter are executed once

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action;
 
-import org.elasticsearch.Assertions;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.CheckedConsumer;
@@ -411,10 +410,8 @@ public interface ActionListener<Response> {
         }
 
         private boolean assertNotExecuted() {
-            if (Assertions.ENABLED) {
-                assert executed == false : "listener already executed";
-                executed = true;
-            }
+            assert executed == false : "listener already executed";
+            executed = true;
             return true;
         }
 
@@ -468,10 +465,8 @@ public interface ActionListener<Response> {
         }
 
         private boolean assertNotExecuted() {
-            if (Assertions.ENABLED) {
-                assert executed == false : "listener already executed";
-                executed = true;
-            }
+            assert executed == false : "listener already executed";
+            executed = true;
             return true;
         }
 

--- a/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
@@ -7,7 +7,10 @@
  */
 package org.elasticsearch.action;
 
+import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.Assertions;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.test.ESTestCase;
@@ -452,6 +455,63 @@ public class ActionListenerTests extends ESTestCase {
         assertThat(exReference.get(), instanceOf(IllegalArgumentException.class));
         mapped.onFailure(new IllegalStateException());
         assertThat(exReference.get(), instanceOf(IllegalStateException.class));
+    }
+
+    public void testRunBeforeThrowsAssertionErrorIfExecutedMoreThanOnce() {
+        assumeTrue("test only works with assertions enabled", Assertions.ENABLED);
+        var count = new AtomicInteger();
+        final ActionListener<Void> runBefore = ActionListener.runBefore(ActionListener.noop(), count::incrementAndGet);
+
+        completeListener(randomBoolean(), runBefore);
+
+        var error = expectThrows(AssertionError.class, () -> completeListener(true, runBefore));
+        assertThat(error.getMessage(), equalTo("listener already executed"));
+    }
+
+    public void testRunAfterThrowsAssertionErrorIfExecutedMoreThanOnce() {
+        assumeTrue("test only works with assertions enabled", Assertions.ENABLED);
+        var count = new AtomicInteger();
+        final ActionListener<Void> runAfter = ActionListener.runAfter(ActionListener.noop(), count::incrementAndGet);
+
+        completeListener(randomBoolean(), runAfter);
+
+        var error = expectThrows(AssertionError.class, () -> completeListener(true, runAfter));
+        assertThat(error.getMessage(), equalTo("listener already executed"));
+    }
+
+    public void testWrappedRunBeforeOrAfterThrowsAssertionErrorIfExecutedMoreThanOnce() {
+        assumeTrue("test only works with assertions enabled", Assertions.ENABLED);
+        final ActionListener<Void> throwingListener = new ActionListener<>() {
+            @Override
+            public void onResponse(Void o) {
+                throw new AlreadyClosedException("throwing on purpose");
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError("should not be called");
+            }
+        };
+
+        var count = new AtomicInteger();
+        final ActionListener<Void> runBeforeOrAfterListener = randomBoolean()
+            ? ActionListener.runBefore(throwingListener, count::incrementAndGet)
+            : ActionListener.runAfter(throwingListener, count::incrementAndGet);
+
+        final ActionListener<Void> wrappedListener = ActionListener.wrap(new AbstractRunnable() {
+            @Override
+            public void onFailure(Exception e) {
+                runBeforeOrAfterListener.onFailure(e);
+            }
+
+            @Override
+            protected void doRun() {
+                runBeforeOrAfterListener.onResponse(null);
+            }
+        });
+
+        var error = expectThrows(AssertionError.class, () -> completeListener(true, wrappedListener));
+        assertThat(error.getMessage(), equalTo("listener already executed"));
     }
 
     public void testReleasing() {

--- a/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/AbstractSearchAsyncActionTests.java
@@ -243,8 +243,6 @@ public class AbstractSearchAsyncActionTests extends ESTestCase {
         SearchShardIterator skipIterator = new SearchShardIterator(null, null, Collections.emptyList(), null);
         skipIterator.resetAndSkip();
         action.skipShard(skipIterator);
-        // expect at least 2 shards, so onPhaseDone should report failure.
-        action.onPhaseDone();
         assertThat(exception.get(), instanceOf(SearchPhaseExecutionException.class));
         SearchPhaseExecutionException searchPhaseExecutionException = (SearchPhaseExecutionException) exception.get();
         assertEquals("Partial shards failure (" + (numShards - 1) + " shards unavailable)", searchPhaseExecutionException.getMessage());


### PR DESCRIPTION
I've recently encountered a bug (illustrated by a test in this pull request) where a `ActionListener.runAfter` listener got called multiple times because of an unexpected exception was thrown in a wrapped listener.

Asserting that the `runAfter` or `releaseAfter` is called only once would have helped a lot to catch the bug. We don't enforce listeners (or delegating listeners) to be called once and some of them are designed on purpose to be called multiple times, yet I think we can expect `runBefore/runAfter` to be used to release resources and as such they should be run once. 

I remain open to contrary opinions of course.