### PR TITLE
Avoid forking in ListenableFuture

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -45,7 +45,6 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Nullable;
@@ -1874,7 +1873,7 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     ackListener.onNodeAck(getLocalNode(), exception); // other nodes have acked, but not the master.
                     publishListener.onFailure(exception);
                 }
-            }, EsExecutors.DIRECT_EXECUTOR_SERVICE, transportService.getThreadPool().getThreadContext());
+            });
         }
 
         private void cancelTimeoutHandlers() {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ListenableFuture.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ListenableFuture.java
@@ -9,27 +9,23 @@
 package org.elasticsearch.common.util.concurrent;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.support.ContextPreservingActionListener;
-import org.elasticsearch.core.Tuple;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 
 /**
  * A future implementation that allows for the result to be passed to listeners waiting for
  * notification. This is useful for cases where a computation is requested many times
  * concurrently, but really only needs to be performed a single time. Once the computation
- * has been performed the registered listeners will be notified by submitting a runnable
- * for execution in the provided {@link ExecutorService}. If the computation has already
+ * has been performed the registered listeners will be notified. If the computation has already
  * been performed, a request to add a listener will simply result in execution of the listener
  * on the calling thread.
  */
 public final class ListenableFuture<V> extends BaseFuture<V> implements ActionListener<V> {
 
     private volatile boolean done = false;
-    private List<Tuple<ActionListener<V>, ExecutorService>> listeners;
+    private List<ActionListener<V>> listeners;
 
     /**
      * Adds a listener to this future. If the future has not yet completed, the listener will be
@@ -38,18 +34,6 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
      * a different thread.
      */
     public void addListener(ActionListener<V> listener) {
-        addListener(listener, EsExecutors.DIRECT_EXECUTOR_SERVICE, null);
-    }
-
-    /**
-     * Adds a listener to this future. If the future has not yet completed, the listener will be
-     * notified of a response or exception in a runnable submitted to the ExecutorService provided.
-     * If the future has completed, the listener will be notified immediately without forking to
-     * a different thread.
-     *
-     * It will apply the provided ThreadContext (if not null) when executing the listening.
-     */
-    public void addListener(ActionListener<V> listener, ExecutorService executor, ThreadContext threadContext) {
         if (done) {
             // run the callback directly, we don't hold the lock and don't need to fork!
             notifyListenerDirectly(listener);
@@ -61,16 +45,10 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
                 if (done) {
                     run = true;
                 } else {
-                    final ActionListener<V> wrappedListener;
-                    if (threadContext == null) {
-                        wrappedListener = listener;
-                    } else {
-                        wrappedListener = ContextPreservingActionListener.wrapPreservingContext(listener, threadContext);
-                    }
                     if (listeners == null) {
                         listeners = new ArrayList<>();
                     }
-                    listeners.add(new Tuple<>(wrappedListener, executor));
+                    listeners.add(listener);
                     run = false;
                 }
             }
@@ -84,7 +62,7 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
 
     @Override
     protected void done(boolean ignored) {
-        final List<Tuple<ActionListener<V>, ExecutorService>> existingListeners;
+        final List<ActionListener<V>> existingListeners;
         synchronized (this) {
             done = true;
             existingListeners = listeners;
@@ -93,14 +71,8 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
             }
             listeners = null;
         }
-        for (Tuple<ActionListener<V>, ExecutorService> t : existingListeners) {
-            final ExecutorService executorService = t.v2();
-            final ActionListener<V> listener = t.v1();
-            if (executorService == EsExecutors.DIRECT_EXECUTOR_SERVICE) {
-                notifyListenerDirectly(listener);
-            } else {
-                notifyListener(listener, executorService);
-            }
+        for (ActionListener<V> listener : existingListeners) {
+            notifyListenerDirectly(listener);
         }
     }
 
@@ -109,26 +81,7 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
             // call get in a non-blocking fashion as we could be on a network thread
             // or another thread like the scheduler, which we should never block!
             assert done;
-            V value = FutureUtils.get(ListenableFuture.this, 0L, TimeUnit.NANOSECONDS);
-            listener.onResponse(value);
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
-    }
-
-    private void notifyListener(ActionListener<V> listener, ExecutorService executorService) {
-        try {
-            executorService.execute(new Runnable() {
-                @Override
-                public void run() {
-                    notifyListenerDirectly(listener);
-                }
-
-                @Override
-                public String toString() {
-                    return "ListenableFuture notification";
-                }
-            });
+            listener.onResponse(FutureUtils.get(this, 0L, TimeUnit.NANOSECONDS));
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealm.java
@@ -7,6 +7,8 @@
 package org.elasticsearch.xpack.security.authc.support;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ContextPreservingActionListener;
+import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.common.cache.Cache;
 import org.elasticsearch.common.cache.CacheBuilder;
 import org.elasticsearch.common.settings.SecureString;
@@ -131,65 +133,73 @@ public abstract class CachingUsernamePasswordRealm extends UsernamePasswordRealm
             });
             if (authenticationInCache.get()) {
                 // there is a cached or an inflight authenticate request
-                listenableCacheEntry.addListener(ActionListener.wrap(cachedResult -> {
-                    final boolean credsMatch = cachedResult.verify(token.credentials());
-                    if (cachedResult.authenticationResult.isAuthenticated()) {
-                        if (credsMatch) {
-                            // cached credential hash matches the credential hash for this forestalled request
-                            handleCachedAuthentication(cachedResult.user, ActionListener.wrap(authResult -> {
-                                if (authResult.isAuthenticated()) {
-                                    logger.debug(
-                                        "realm [{}] authenticated user [{}], with roles [{}] (cached)",
-                                        name(),
-                                        token.principal(),
-                                        authResult.getValue().roles()
-                                    );
+                listenableCacheEntry.addListener(
+                    new ThreadedActionListener<>(
+                        logger,
+                        threadPool,
+                        ThreadPool.Names.GENERIC,
+                        ContextPreservingActionListener.wrapPreservingContext(ActionListener.wrap(cachedResult -> {
+                            final boolean credsMatch = cachedResult.verify(token.credentials());
+                            if (cachedResult.authenticationResult.isAuthenticated()) {
+                                if (credsMatch) {
+                                    // cached credential hash matches the credential hash for this forestalled request
+                                    handleCachedAuthentication(cachedResult.user, ActionListener.wrap(authResult -> {
+                                        if (authResult.isAuthenticated()) {
+                                            logger.debug(
+                                                "realm [{}] authenticated user [{}], with roles [{}] (cached)",
+                                                name(),
+                                                token.principal(),
+                                                authResult.getValue().roles()
+                                            );
+                                        } else {
+                                            logger.debug(
+                                                "realm [{}] authenticated user [{}] from cache, but then failed [{}]",
+                                                name(),
+                                                token.principal(),
+                                                authResult.getMessage()
+                                            );
+                                        }
+                                        listener.onResponse(authResult);
+                                    }, listener::onFailure));
                                 } else {
-                                    logger.debug(
-                                        "realm [{}] authenticated user [{}] from cache, but then failed [{}]",
+                                    logger.trace(
+                                        "realm [{}], provided credentials for user [{}] do not match (known good) cached credentials,"
+                                            + " invalidating cache and retrying",
                                         name(),
-                                        token.principal(),
-                                        authResult.getMessage()
+                                        token.principal()
                                     );
+                                    // its credential hash does not match the
+                                    // hash of the credential for this forestalled request.
+                                    // clear cache and try to reach the authentication source again because password
+                                    // might have changed there and the local cached hash got stale
+                                    cache.invalidate(token.principal(), listenableCacheEntry);
+                                    authenticateWithCache(token, listener);
                                 }
-                                listener.onResponse(authResult);
-                            }, listener::onFailure));
-                        } else {
-                            logger.trace(
-                                "realm [{}], provided credentials for user [{}] do not match (known good) cached credentials,"
-                                    + " invalidating cache and retrying",
-                                name(),
-                                token.principal()
-                            );
-                            // its credential hash does not match the
-                            // hash of the credential for this forestalled request.
-                            // clear cache and try to reach the authentication source again because password
-                            // might have changed there and the local cached hash got stale
-                            cache.invalidate(token.principal(), listenableCacheEntry);
-                            authenticateWithCache(token, listener);
-                        }
-                    } else if (credsMatch) {
-                        // not authenticated but instead of hammering reuse the result. a new
-                        // request will trigger a retried auth
-                        logger.trace(
-                            "realm [{}], provided credentials for user [{}] are invalid (cached result) status:[{}] message:[{}]",
-                            name(),
-                            token.principal(),
-                            cachedResult.authenticationResult.getStatus(),
-                            cachedResult.authenticationResult.getMessage()
-                        );
-                        listener.onResponse(cachedResult.authenticationResult);
-                    } else {
-                        logger.trace(
-                            "realm [{}], provided credentials for user [{}] do not match (possibly invalid) cached credentials,"
-                                + " invalidating cache and retrying",
-                            name(),
-                            token.principal()
-                        );
-                        cache.invalidate(token.principal(), listenableCacheEntry);
-                        authenticateWithCache(token, listener);
-                    }
-                }, listener::onFailure), threadPool.executor(ThreadPool.Names.GENERIC), threadPool.getThreadContext());
+                            } else if (credsMatch) {
+                                // not authenticated but instead of hammering reuse the result. a new
+                                // request will trigger a retried auth
+                                logger.trace(
+                                    "realm [{}], provided credentials for user [{}] are invalid (cached result) status:[{}] message:[{}]",
+                                    name(),
+                                    token.principal(),
+                                    cachedResult.authenticationResult.getStatus(),
+                                    cachedResult.authenticationResult.getMessage()
+                                );
+                                listener.onResponse(cachedResult.authenticationResult);
+                            } else {
+                                logger.trace(
+                                    "realm [{}], provided credentials for user [{}] do not match (possibly invalid) cached credentials,"
+                                        + " invalidating cache and retrying",
+                                    name(),
+                                    token.principal()
+                                );
+                                cache.invalidate(token.principal(), listenableCacheEntry);
+                                authenticateWithCache(token, listener);
+                            }
+                        }, listener::onFailure), threadPool.getThreadContext()),
+                        false
+                    )
+                );
             } else {
                 logger.trace(
                     "realm [{}] does not have a cached result for user [{}]; attempting fresh authentication",
@@ -297,13 +307,15 @@ public abstract class CachingUsernamePasswordRealm extends UsernamePasswordRealm
                     listenableCacheEntry.onFailure(e);
                 }));
             }
-            listenableCacheEntry.addListener(ActionListener.wrap(cachedResult -> {
-                if (cachedResult.user != null) {
-                    listener.onResponse(cachedResult.user);
-                } else {
-                    listener.onResponse(null);
-                }
-            }, listener::onFailure), threadPool.executor(ThreadPool.Names.GENERIC), threadPool.getThreadContext());
+            listenableCacheEntry.addListener(
+                new ThreadedActionListener<>(logger, threadPool, ThreadPool.Names.GENERIC, ActionListener.wrap(cachedResult -> {
+                    if (cachedResult.user != null) {
+                        listener.onResponse(cachedResult.user);
+                    } else {
+                        listener.onResponse(null);
+                    }
+                }, listener::onFailure), false)
+            );
         } catch (final ExecutionException e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/esnative/ReservedRealmTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.rest.RestStatus;
@@ -79,6 +80,7 @@ public class ReservedRealmTests extends ESTestCase {
         mockGetAllReservedUserInfo(usersStore, Collections.emptyMap());
         threadPool = mock(ThreadPool.class);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
+        when(threadPool.executor(any())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
     }
 
     public void testInvalidHashingAlgorithmFails() {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/file/FileRealmTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.security.authc.file;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.env.TestEnvironment;
 import org.elasticsearch.test.ESTestCase;
@@ -71,6 +72,7 @@ public class FileRealmTests extends ESTestCase {
         threadPool = mock(ThreadPool.class);
         threadContext = new ThreadContext(globalSettings);
         when(threadPool.getThreadContext()).thenReturn(threadContext);
+        when(threadPool.executor(any())).thenReturn(EsExecutors.DIRECT_EXECUTOR_SERVICE);
     }
 
     public void testAuthenticate() throws Exception {


### PR DESCRIPTION
Today `ListenableFuture` allows callers to submit listeners whose eventual completion may be forked onto a separate thread. This is kind of trappy because it doesn't fork if the listener is already complete, and also kind of buggy because it submits a bare `Runnable` to the executor which might throw on rejection, leaking the listener.

None of the callers seem to need to avoid forking, so this commit moves all callers over to using a `ThreadedActionListener` which has more predictable forking behaviour and handles rejection properly, and then removes the now-unused forking behaviour in `ListenableFuture`.