### PR TITLE
[doc] (minor) _ingest/geoip/stats returns stats.databases_count

### DIFF
--- a/docs/reference/ingest/apis/geoip-stats-api.asciidoc
+++ b/docs/reference/ingest/apis/geoip-stats-api.asciidoc
@@ -49,7 +49,7 @@ Total number of failed database downloads.
 (integer)
 Total milliseconds spent downloading databases.
 
-`database_count`::
+`databases_count`::
 (integer)
 Current number of databases available for use.
 


### PR DESCRIPTION
minor ingest geoip stats documentation update

- updated documentation to reflect current field name returned : _ingest/geoip/stats returns stats.databases_count (databases in plural form) not stats.database_count

