### PR TITLE
Introduce EngineConfig#isPromotableToPrimary

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -27,6 +27,7 @@ import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineFactory;
+import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.NoOpEngine;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.plugins.ClusterPlugin;
@@ -92,8 +93,11 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
         @Override
         public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
-            // TODO revert this once replication/recovery ignores unpromotable shards
-            return Optional.of(config -> new NoOpEngine(config, new TranslogStats(0, 0, 0, 0, 0)));
+            return Optional.of(
+                config -> config.isPromotableToPrimary()
+                    ? new InternalEngine(config)
+                    : new NoOpEngine(config, new TranslogStats(0, 0, 0, 0, 0))
+            );
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndexingMemoryControllerIT.java
@@ -80,7 +80,7 @@ public class IndexingMemoryControllerIT extends ESSingleNodeTestCase {
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
                 config.getIndexCommitListener(),
-                config.isRecoveringAsPrimary()
+                config.isPromotableToPrimary()
             );
         }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/EngineConfig.java
@@ -128,7 +128,7 @@ public final class EngineConfig {
     @Nullable
     private final Engine.IndexCommitListener indexCommitListener;
 
-    private final boolean recoveringAsPrimary;
+    private final boolean promotableToPrimary;
 
     /**
      * Creates a new {@link org.elasticsearch.index.engine.EngineConfig}
@@ -159,7 +159,7 @@ public final class EngineConfig {
         Comparator<LeafReader> leafSorter,
         LongSupplier relativeTimeInNanosSupplier,
         Engine.IndexCommitListener indexCommitListener,
-        boolean recoveringAsPrimary
+        boolean promotableToPrimary
     ) {
         this.shardId = shardId;
         this.indexSettings = indexSettings;
@@ -201,7 +201,7 @@ public final class EngineConfig {
         this.leafSorter = leafSorter;
         this.relativeTimeInNanosSupplier = relativeTimeInNanosSupplier;
         this.indexCommitListener = indexCommitListener;
-        this.recoveringAsPrimary = recoveringAsPrimary;
+        this.promotableToPrimary = promotableToPrimary;
     }
 
     /**
@@ -418,10 +418,9 @@ public final class EngineConfig {
     }
 
     /**
-     * Represents the primary state only in case when a recovery starts.
-     * IMPORTANT: The flag is a temporary solution and should NOT be used outside of Stateless.
+     * @return whether the engine should be configured so that it can be promoted to primary in future
      */
-    public boolean isRecoveringAsPrimary() {
-        return recoveringAsPrimary;
+    public boolean isPromotableToPrimary() {
+        return promotableToPrimary;
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3288,7 +3288,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             isTimeseriesIndex ? TIMESERIES_LEAF_READERS_SORTER : null,
             relativeTimeInNanosSupplier,
             indexCommitListener,
-            recoveryState != null && recoveryState.getPrimary()
+            routingEntry().isPromotableToPrimary()
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -3591,7 +3591,7 @@ public class InternalEngineTests extends EngineTestCase {
             null,
             config.getRelativeTimeInNanosSupplier(),
             null,
-            false
+            true
         );
         expectThrows(EngineCreationFailureException.class, () -> new InternalEngine(brokenConfig));
 
@@ -7264,7 +7264,7 @@ public class InternalEngineTests extends EngineTestCase {
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
                 config.getIndexCommitListener(),
-                config.isRecoveringAsPrimary()
+                config.isPromotableToPrimary()
             );
             try (InternalEngine engine = createEngine(configWithWarmer)) {
                 assertThat(warmedUpReaders, empty());

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -2925,7 +2925,7 @@ public class IndexShardTests extends IndexShardTestCase {
         // Shard should now be active since we did recover:
         assertTrue(shard.isActive());
         // Recovery state should be propagated to the engine
-        assertEquals(isPrimary, shard.getEngine().config().isRecoveringAsPrimary());
+        assertEquals(isPrimary, shard.getEngine().config().isPromotableToPrimary());
         closeShards(shard);
     }
 
@@ -4533,7 +4533,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 config.getLeafSorter(),
                 config.getRelativeTimeInNanosSupplier(),
                 config.getIndexCommitListener(),
-                config.isRecoveringAsPrimary()
+                config.isPromotableToPrimary()
             );
             return new InternalEngine(configWithWarmer);
         });

--- a/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/RefreshListenersTests.java
@@ -154,7 +154,7 @@ public class RefreshListenersTests extends ESTestCase {
             null,
             System::nanoTime,
             null,
-            false
+            true
         );
         engine = new InternalEngine(config);
         engine.recoverFromTranslog((e, s) -> 0, Long.MAX_VALUE);

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -403,7 +403,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.isRecoveringAsPrimary()
+            config.isPromotableToPrimary()
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/engine/EngineTestCase.java
@@ -276,7 +276,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.isRecoveringAsPrimary()
+            config.isPromotableToPrimary()
         );
     }
 
@@ -307,7 +307,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.isRecoveringAsPrimary()
+            config.isPromotableToPrimary()
         );
     }
 
@@ -338,7 +338,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.isRecoveringAsPrimary()
+            config.isPromotableToPrimary()
         );
     }
 
@@ -862,7 +862,7 @@ public abstract class EngineTestCase extends ESTestCase {
             null,
             System::nanoTime,
             indexCommitListener,
-            false
+            true
         );
     }
 
@@ -901,7 +901,7 @@ public abstract class EngineTestCase extends ESTestCase {
             config.getLeafSorter(),
             config.getRelativeTimeInNanosSupplier(),
             config.getIndexCommitListener(),
-            config.isRecoveringAsPrimary()
+            config.isPromotableToPrimary()
         );
     }
 

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowingEngineTests.java
@@ -289,7 +289,7 @@ public class FollowingEngineTests extends ESTestCase {
             null,
             System::nanoTime,
             null,
-            false
+            true
         );
     }
 


### PR DESCRIPTION
Rather than recording whether the engine is recovering as a primary or replica, we must track whether the corresponding shard is promotable or not. This commit renames `recoveringAsPrimary` to `promotableToPrimary`.