### PR TITLE
Add extra logging to PrioritizedThrottledTaskRunnerTests#assertNoRunningTasks

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
@@ -231,9 +231,14 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
     }
 
     private void assertNoRunningTasks(PrioritizedThrottledTaskRunner<TestTask> taskRunner) {
+        logger.info("--> ensure that there are no running tasks in the executor");
         final var barrier = new CyclicBarrier(maxThreads + 1);
         for (int i = 0; i < maxThreads; i++) {
-            executor.execute(() -> awaitBarrier(barrier));
+            executor.execute(() -> {
+                logger.info("--> await until barrier is released");
+                awaitBarrier(barrier);
+                logger.info("--> the barrier is released");
+            });
         }
         awaitBarrier(barrier);
         assertThat(taskRunner.runningTasks(), equalTo(0));

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/PrioritizedThrottledTaskRunnerTests.java
@@ -231,7 +231,7 @@ public class PrioritizedThrottledTaskRunnerTests extends ESTestCase {
     }
 
     private void assertNoRunningTasks(PrioritizedThrottledTaskRunner<TestTask> taskRunner) {
-        logger.info("--> ensure that there are no running tasks in the executor");
+        logger.info("--> ensure that there are no running tasks in the executor. Max number of threads [{}]", maxThreads);
         final var barrier = new CyclicBarrier(maxThreads + 1);
         for (int i = 0; i < maxThreads; i++) {
             executor.execute(() -> {


### PR DESCRIPTION
This should help debugging #92910 and rule out possible environmental issues, such us slowness creating threads due to an overloaded CI worker.