### PR TITLE
Reduce logging on readiness service stop

### DIFF
--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -194,6 +194,13 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     // package private for testing
     synchronized void stopListener() {
         assert enabled(environment);
+
+        // Avoid unnecessary logging if stop is repeatedly called.
+        // This can happen because we call stop listener on cluster state updates.
+        if (ready() == false) {
+            return;
+        }
+
         try {
             logger.info(
                 "stopping readiness service on channel {}",


### PR DESCRIPTION
Readiness service start and stop are driven by changes to cluster state. Until a master is elected the service is not running for most nodes. During this initial period, multiple cluster state changes might arrive, all signalling that a master isn't elected yet. This causes the service stop method to log multiple times that the readiness service is turned off.

With this change, we reduce the amount of this logging, essentially we don't double stop the service if it's not running at all.