### PR TITLE
Restore printing bootstrap checks as errors

### DIFF
--- a/docs/changelog/93178.yaml
+++ b/docs/changelog/93178.yaml
@@ -1,0 +1,6 @@
+pr: 93178
+summary: Restore printing bootstrap checks as errors
+area: Infra/CLI
+type: bug
+issues:
+ - 93074

--- a/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Bootstrap.java
@@ -11,13 +11,13 @@ package org.elasticsearch.bootstrap;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.node.NodeValidationException;
 
 import java.io.PrintStream;
-
-import static org.elasticsearch.bootstrap.BootstrapInfo.USER_EXCEPTION_MARKER;
 
 /**
  * A container for transient state during bootstrap of the Elasticsearch process.
@@ -71,10 +71,10 @@ class Bootstrap {
         return nodeEnv.get();
     }
 
-    void exitWithUserException(int exitCode, Exception e) {
-        err.print(USER_EXCEPTION_MARKER);
-        err.println(e.getMessage());
-        gracefullyExit(exitCode);
+    void exitWithNodeValidationException(NodeValidationException e) {
+        Logger logger = LogManager.getLogger(Elasticsearch.class);
+        logger.error("node validation exception\n{}", e.getMessage());
+        gracefullyExit(ExitCodes.CONFIG);
     }
 
     void exitWithUnknownException(Throwable e) {

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -16,7 +16,6 @@ import org.apache.lucene.util.Constants;
 import org.apache.lucene.util.StringHelper;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.Version;
-import org.elasticsearch.cli.ExitCodes;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.filesystem.FileSystemNatives;
 import org.elasticsearch.common.io.stream.InputStreamStreamInput;

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -68,7 +68,7 @@ class Elasticsearch {
             initPhase2(bootstrap);
             initPhase3(bootstrap);
         } catch (NodeValidationException e) {
-            bootstrap.exitWithUserException(ExitCodes.CONFIG, e);
+            bootstrap.exitWithNodeValidationException(e);
         } catch (Throwable t) {
             bootstrap.exitWithUnknownException(t);
         }


### PR DESCRIPTION
Bootstrap check failures were unintentionally moved to the info level in the log output. This commit restores logging them as errors.

closes #93074