### PR TITLE
Avoid double-completion of ListenableFuture

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ListenableFuture.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ListenableFuture.java
@@ -138,6 +138,7 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
     public void onResponse(V v) {
         final boolean set = set(v);
         if (set == false) {
+            assert false;
             throw new IllegalStateException("did not set value, value or exception already set?");
         }
     }
@@ -146,6 +147,7 @@ public final class ListenableFuture<V> extends BaseFuture<V> implements ActionLi
     public void onFailure(Exception e) {
         final boolean set = setException(e);
         if (set == false) {
+            assert false;
             throw new IllegalStateException("did not set exception, value already set or exception already set?");
         }
     }


### PR DESCRIPTION
`ListenableFuture` throws an `IllegalStateException` if completed more than once, which (at best) is just silently swallowed and (at worst) may prevent other cleanup from happening. In particular, we do not expect `onFailure()` to throw an exception as happens here. This commit elevates this check to an assertion, and fixes the places that violate it today.