### PR TITLE
Adjust range of allowed percentages of deletes in an index.

### DIFF
--- a/docs/changelog/93188.yaml
+++ b/docs/changelog/93188.yaml
@@ -1,0 +1,5 @@
+pr: 93188
+summary: Adjust range of allowed percentages of deletes in an index
+area: Engine
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -71,8 +71,8 @@ import org.elasticsearch.core.SuppressForbidden;
  *
  *     Controls the maximum percentage of deleted documents that is tolerated in
  *     the index. Lower values make the index more space efficient at the
- *     expense of increased CPU and I/O activity. Values must be between <code>20</code> and
- *     <code>50</code>. Default value is <code>33</code>.
+ *     expense of increased CPU and I/O activity. Values must be between <code>5</code> and
+ *     <code>50</code>. Default value is <code>20</code>.
  * </ul>
  *
  * <p>
@@ -110,7 +110,7 @@ public final class MergePolicyConfig {
     public static final int DEFAULT_MAX_MERGE_AT_ONCE = 10;
     public static final ByteSizeValue DEFAULT_MAX_MERGED_SEGMENT = new ByteSizeValue(5, ByteSizeUnit.GB);
     public static final double DEFAULT_SEGMENTS_PER_TIER = 10.0d;
-    public static final double DEFAULT_DELETES_PCT_ALLOWED = 33.0d;
+    public static final double DEFAULT_DELETES_PCT_ALLOWED = 20.0d;
     private static final String INDEX_COMPOUND_FORMAT_SETTING_KEY = "index.compound_format";
     public static final Setting<CompoundFileThreshold> INDEX_COMPOUND_FORMAT_SETTING = new Setting<>(
         INDEX_COMPOUND_FORMAT_SETTING_KEY,
@@ -164,7 +164,7 @@ public final class MergePolicyConfig {
     public static final Setting<Double> INDEX_MERGE_POLICY_DELETES_PCT_ALLOWED_SETTING = Setting.doubleSetting(
         "index.merge.policy.deletes_pct_allowed",
         DEFAULT_DELETES_PCT_ALLOWED,
-        20.0d,
+        5.0d,
         50.0d,
         Property.Dynamic,
         Property.IndexScope


### PR DESCRIPTION
Lucene 9.5 changed the allowed range and the default value for the allowed percentage of deletes in an index. It used to allow values in [20, 50] with a default of 33. It now allows values in [5, 50] with a default of 20.

See apache/lucene#11831.
