### PR TITLE
Update tsdb docs to include warning and additional limitations

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -111,7 +111,8 @@ always a short encoded hash. To prevent the `_tsid` value from being overly
 large, {es} limits the number of dimensions for an index using the
 <<index-mapping-dimension-fields-limit,`index.mapping.dimension_fields.limit`>>
 index setting. While you can increase this limit, the resulting document `_tsid`
-value can't exceed 32KB.
+value can't exceed 32KB. Additionally the field name of a dimension cannot be
+longer than 512 bytes and the each dimension value can't exceed 1kb.
 ****
 
 [discrete]
@@ -185,6 +186,9 @@ The `_tsid` field is not queryable or updatable. You also can't retrieve a
 document's `_tsid` using a <<docs-get,get document>> request. However, you can
 use the `_tsid` field in aggregations and retrieve the `_tsid` value in searches
 using the <<search-fields-param,`fields` parameter>>.
+
+WARNING: The format is the `_tsid` field shouldn't be relied upon. It may change
+from version to version.
 
 [discrete]
 [[time-bound-indices]]

--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -187,7 +187,7 @@ document's `_tsid` using a <<docs-get,get document>> request. However, you can
 use the `_tsid` field in aggregations and retrieve the `_tsid` value in searches
 using the <<search-fields-param,`fields` parameter>>.
 
-WARNING: The format is the `_tsid` field shouldn't be relied upon. It may change
+WARNING: The format of the `_tsid` field shouldn't be relied upon. It may change
 from version to version.
 
 [discrete]


### PR DESCRIPTION
Update tsdb docs to include a warning that the format of the `_tsid` field shouldn't be relied upon and 
added additional limitations about dimension fields.