### PR TITLE
Don't bound low precision geohex aggregations on vector tiles

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -241,7 +241,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         mvtRequest.setJsonEntity("{\"size\" : 100}");
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
-        // 33 points, 1 polygon and two from geometry collection
+        // 33 points, 1 big polygon, 1 polygon and two from geometry collection
         assertLayer(tile, HITS_LAYER, 4096, 37, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);

--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -46,6 +46,7 @@ public class VectorTileRestIT extends ESRestTestCase {
     private static final String INDEX_POINTS = "index-points";
     private static final String INDEX_POLYGON = "index-polygon";
     private static final String INDEX_COLLECTION = "index-collection";
+    private static final String INDEX_BIG_POLYGON = "index-big-polygon";
     private static final String INDEX_POINTS_SHAPES = INDEX_POINTS + "," + INDEX_POLYGON;
     private static final String INDEX_ALL = "index*";
     private static final String META_LAYER = "meta";
@@ -62,7 +63,8 @@ public class VectorTileRestIT extends ESRestTestCase {
             x = randomIntBetween(0, (1 << z) - 1);
             y = randomIntBetween(0, (1 << z) - 1);
             indexPoints();
-            indexShapes();
+            indexPolygon();
+            indexBigPolygon();
             indexCollection();
             oneTimeSetup = true;
         }
@@ -106,9 +108,14 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_OK));
     }
 
-    private void indexShapes() throws IOException {
+    private void indexPolygon() throws IOException {
         final Rectangle r = GeoTileUtils.toBoundingBox(x, y, z);
         createIndexAndPutGeometry(INDEX_POLYGON, toPolygon(r), "polygon");
+    }
+
+    private void indexBigPolygon() throws IOException {
+        final Rectangle r = new Rectangle(-180, 180, 90, -90);
+        createIndexAndPutGeometry(INDEX_BIG_POLYGON, toPolygon(r), "polygon");
     }
 
     private void createIndexAndPutGeometry(String indexName, Geometry geometry, String id) throws IOException {
@@ -235,7 +242,7 @@ public class VectorTileRestIT extends ESRestTestCase {
         final VectorTile.Tile tile = execute(mvtRequest);
         assertThat(tile.getLayersCount(), Matchers.equalTo(3));
         // 33 points, 1 polygon and two from geometry collection
-        assertLayer(tile, HITS_LAYER, 4096, 36, 2);
+        assertLayer(tile, HITS_LAYER, 4096, 37, 2);
         assertLayer(tile, AGGS_LAYER, 4096, 256 * 256, 2);
         assertLayer(tile, META_LAYER, 4096, 1, 13);
     }
@@ -322,6 +329,51 @@ public class VectorTileRestIT extends ESRestTestCase {
             mvtRequest.setJsonEntity("{\"grid_precision\": 9 }");
             final ResponseException ex = expectThrows(ResponseException.class, () -> execute(mvtRequest));
             assertThat(ex.getResponse().getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_BAD_REQUEST));
+        }
+    }
+
+    public void testGridPrecisionGeoTile() throws Exception {
+        final int z = randomIntBetween(0, GeoTileUtils.MAX_ZOOM - 10);
+        final int x = randomIntBetween(0, (1 << z) - 1);
+        final int y = randomIntBetween(0, (1 << z) - 1);
+        for (int i = 1; i <= 8; i++) {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_BIG_POLYGON + "/_mvt/location/" + z + "/" + x + "/" + y);
+            mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_agg\" : \"geotile\", \"grid_precision\" : " + i + " }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(2));
+            assertLayer(tile, AGGS_LAYER, 4096, (1 << i) * (1 << i), 2);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+        }
+    }
+
+    public void testGridPrecisionGeoHex() throws Exception {
+        // the number of hex depends on the position of the tile, therefore we just check some of them.
+        final int[] expected_zoom_0 = new int[] { 122, 122, 842, 842, 5872, 5872, 41058, 41058 };
+        for (int i = 1; i <= 8; i++) {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_BIG_POLYGON + "/_mvt/location/0/0/0");
+            mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_agg\" : \"geohex\", \"grid_precision\" : " + i + " }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(2));
+            assertLayer(tile, AGGS_LAYER, 4096, expected_zoom_0[i - 1], 2);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+        }
+        final int[] expected_zoom_1 = new int[] { 45, 241, 241, 1559, 1559, 10531, 10531, 10531 };
+        for (int i = 1; i <= 8; i++) {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_BIG_POLYGON + "/_mvt/location/1/0/0");
+            mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_agg\" : \"geohex\", \"grid_precision\" : " + i + " }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(2));
+            assertLayer(tile, AGGS_LAYER, 4096, expected_zoom_1[i - 1], 2);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
+        }
+        final int[] expected_zoom_5 = new int[] { 12, 55, 55, 55, 292, 292, 1873, 12673 };
+        for (int i = 1; i <= 8; i++) {
+            final Request mvtRequest = new Request(getHttpMethod(), INDEX_BIG_POLYGON + "/_mvt/location/5/16/8");
+            mvtRequest.setJsonEntity("{\"size\" : 0, \"grid_agg\" : \"geohex\", \"grid_precision\" : " + i + " }");
+            final VectorTile.Tile tile = execute(mvtRequest);
+            assertThat(tile.getLayersCount(), Matchers.equalTo(2));
+            assertLayer(tile, AGGS_LAYER, 4096, expected_zoom_5[i - 1], 2);
+            assertLayer(tile, META_LAYER, 4096, 1, 13);
         }
     }
 

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -215,11 +215,17 @@ public class RestVectorTileAction extends BaseRestHandler {
         }
         searchRequestBuilder.setQuery(qBuilder);
         if (request.getGridPrecision() > 0) {
-            final Rectangle rectangle = request.getBoundingBox();
-            final GeoBoundingBox boundingBox = new GeoBoundingBox(
-                new GeoPoint(rectangle.getMaxLat(), rectangle.getMinLon()),
-                new GeoPoint(rectangle.getMinLat(), rectangle.getMaxLon())
-            );
+            final GeoBoundingBox boundingBox;
+            if (request.getGridAgg().needsBounding(request.getZ(), request.getGridPrecision())) {
+                final Rectangle rectangle = request.getBoundingBox();
+                boundingBox = new GeoBoundingBox(
+                    new GeoPoint(rectangle.getMaxLat(), rectangle.getMinLon()),
+                    new GeoPoint(rectangle.getMinLat(), rectangle.getMaxLon())
+                );
+            } else {
+                // unbounded
+                boundingBox = new GeoBoundingBox(new GeoPoint(Double.NaN, Double.NaN), new GeoPoint(Double.NaN, Double.NaN));
+            }
             final GeoGridAggregationBuilder tileAggBuilder = request.getGridAgg()
                 .newAgg(GRID_FIELD)
                 .field(request.getField())


### PR DESCRIPTION
One of the tricky parts of integrating geohex aggregations with vector tiles is that hexagons might be intersecting more than one tile. Still when requesting a tile together we want those hexagons to report the total number of documents they contain. In order to achieve that, we are buffering our queries in order to collect all documents that might be inside the hexagons.

The side effect is that for low precision aggregations, we are adding a big buffer, so we are potentially collecting a lot of documents. This can make geohex aggregations on geo_points very expensive as there might be many docs outside of the aggregation bounds that will need to be check against the hexagon boundary. This is unnecessary for aggregations that generate less than the default max buckets, so let's not bound those aggregations.  

This PR adds a mechanism so geohex aggregations with precision <= 3 are created with unbounded bounds.  This speeds up considerable the generation of those tiles at zoom levels 0 and 1.