### PR TITLE
Add null check for G1 related options and origin field

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmErgonomics.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmErgonomics.java
@@ -66,13 +66,17 @@ final class JvmErgonomics {
     static boolean tuneG1GCHeapRegion(final Map<String, JvmOption> finalJvmOptions, final boolean tuneG1GCForSmallHeap) {
         JvmOption g1GCHeapRegion = finalJvmOptions.get("G1HeapRegionSize");
         JvmOption g1GC = finalJvmOptions.get("UseG1GC");
-        return (tuneG1GCForSmallHeap && g1GC.getMandatoryValue().equals("true") && g1GCHeapRegion.isCommandLineOrigin() == false);
+        return (tuneG1GCForSmallHeap
+            && g1GC != null
+            && g1GC.getMandatoryValue().equals("true")
+            && g1GCHeapRegion != null
+            && g1GCHeapRegion.isCommandLineOrigin() == false);
     }
 
     static int tuneG1GCReservePercent(final Map<String, JvmOption> finalJvmOptions, final boolean tuneG1GCForSmallHeap) {
         JvmOption g1GC = finalJvmOptions.get("UseG1GC");
         JvmOption g1GCReservePercent = finalJvmOptions.get("G1ReservePercent");
-        if (g1GC.getMandatoryValue().equals("true")) {
+        if (g1GC != null && g1GC.getMandatoryValue().equals("true") && g1GCReservePercent != null) {
             if (g1GCReservePercent.isCommandLineOrigin() == false && tuneG1GCForSmallHeap) {
                 return 15;
             } else if (g1GCReservePercent.isCommandLineOrigin() == false && tuneG1GCForSmallHeap == false) {
@@ -85,7 +89,10 @@ final class JvmErgonomics {
     static boolean tuneG1GCInitiatingHeapOccupancyPercent(final Map<String, JvmOption> finalJvmOptions) {
         JvmOption g1GC = finalJvmOptions.get("UseG1GC");
         JvmOption g1GCInitiatingHeapOccupancyPercent = finalJvmOptions.get("InitiatingHeapOccupancyPercent");
-        return g1GCInitiatingHeapOccupancyPercent.isCommandLineOrigin() == false && g1GC.getMandatoryValue().equals("true");
+        return g1GCInitiatingHeapOccupancyPercent != null
+            && g1GCInitiatingHeapOccupancyPercent.isCommandLineOrigin() == false
+            && g1GC != null
+            && g1GC.getMandatoryValue().equals("true");
     }
 
     private static final Pattern SYSTEM_PROPERTY = Pattern.compile("^-D(?<key>[\\w+].*?)=(?<value>.*)$");

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOption.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/JvmOption.java
@@ -42,7 +42,7 @@ class JvmOption {
     }
 
     public boolean isCommandLineOrigin() {
-        return this.origin.contains("command line");
+        return this.origin != null && this.origin.contains("command line");
     }
 
     private static final Pattern OPTION = Pattern.compile(

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmErgonomicsTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmErgonomicsTests.java
@@ -179,4 +179,19 @@ public class JvmErgonomicsTests extends ESTestCase {
         );
     }
 
+    public void testTuneG1GCHeapRegionWithEmptyFinalJvmOptionsReturnsFalse() {
+        Map<String, JvmOption> finalJvmOptions = new HashMap<>();
+        assertFalse(JvmErgonomics.tuneG1GCHeapRegion(finalJvmOptions, true));
+    }
+
+    public void testTuneG1GCReservePercentWithEmptyFinalJvmOptionsReturnsZero() {
+        Map<String, JvmOption> finalJvmOptions = new HashMap<>();
+        assertEquals(JvmErgonomics.tuneG1GCReservePercent(finalJvmOptions, true), 0);
+    }
+
+    public void testTuneG1GCInitiatingHeapOccupancyPercentWithEmptyFinalJvmOptionsReturnsFalse() {
+        Map<String, JvmOption> finalJvmOptions = new HashMap<>();
+        assertFalse(JvmErgonomics.tuneG1GCInitiatingHeapOccupancyPercent(finalJvmOptions));
+    }
+
 }

--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/JvmOptionsParserTests.java
@@ -344,4 +344,9 @@ public class JvmOptionsParserTests extends ESTestCase {
         assertThat(seenInvalidLines, equalTo(invalidLines));
     }
 
+    public void testIsCommandLineOriginWithNullOriginReturnsFalse() {
+        JvmOption jvmOption = new JvmOption("value", null);
+        assertFalse(jvmOption.isCommandLineOrigin());
+    }
+
 }

--- a/docs/changelog/93197.yaml
+++ b/docs/changelog/93197.yaml
@@ -1,0 +1,6 @@
+pr: 93197
+summary: Add null check for G1 related options and origin field. This change avoids NPE when starting Elasticsearch on the Azul Platform Prime JDK.
+area: Infra/Settings
+type: bug
+issues:
+ - 91577


### PR DESCRIPTION
This patch fixes some issues when starting Elasticsearch on the Azul Platform Prime JDK.
The first of them is related to the fact that the Azul Platform Prime JDK does not have a G1 garbage collector, and, as a result, there are no options for configuring it. One fix checks that these options exist and are not null.
The second fix is related to the following. When parsing the message output, which is obtained using the `-XX:+PrintFlagsFinal` option, we are tied to the fact that there is an `origin` field in the PrintFlagsFinal message string. This is valid for jdk11+ versions, however jdk8 does not have this field. Older versions of the Azul Platform Prime JDK use the PrintFlagsFinal message format that jdk8 uses, but for later versions. The second fix adds a null check for the `origin` field in the JvmOption class.
Relates #91577.