### PR TITLE
[ML] Add new sparse scored terms mapped field

### DIFF
--- a/docs/changelog/93198.yaml
+++ b/docs/changelog/93198.yaml
@@ -1,0 +1,5 @@
+pr: 93198
+summary: Add new sparse scored terms mapped field
+area: "Search, Machine Learning"
+type: feature
+issues: []

--- a/docs/reference/mapping/types.asciidoc
+++ b/docs/reference/mapping/types.asciidoc
@@ -104,6 +104,7 @@ as-you-type completion.
 ==== Other types
 
 <<percolator,`percolator`>>::   Indexes queries written in <<query-dsl,Query DSL>>.
+<<sparse-scored-terms,`sparse_scored_terms`>>:: Indexes terms with associated scores for search.
 
 
 [discrete]
@@ -176,6 +177,8 @@ include::types/rank-feature.asciidoc[]
 include::types/rank-features.asciidoc[]
 
 include::types/search-as-you-type.asciidoc[]
+
+include::types/sparse-scored-terms.asciidoc[]
 
 include::types/shape.asciidoc[]
 

--- a/docs/reference/mapping/types/sparse-scored-terms.asciidoc
+++ b/docs/reference/mapping/types/sparse-scored-terms.asciidoc
@@ -1,0 +1,68 @@
+[role="xpack"]
+[[sparse-scored-terms]]
+=== Sparse Scored Terms field type
+++++
+<titleabbrev>Sparse Scored Terms</titleabbrev>
+++++
+
+A field to store terms along with their associated scores.
+This data is defined using two paired arrays:
+
+* A `terms` array of string values indicating which terms to be indexed.
+* A corresponding `scores` array of positive <<number, `integer`>> numbers indicating
+the individual term score. Consider this value similar to term frequency.
+
+Because the elements in the `terms` array correspond to the elements in the
+same position of the `scores` array, these two arrays must have the same length.
+
+[IMPORTANT]
+========
+* `sparse_scored_terms` fields do not support sorting.
+========
+
+[role="child_attributes"]
+[[sparse-scored-terms-uses]]
+==== Uses
+
+`sparse_scored_terms` are useful when a collection of terms are known and should be
+weighted or scored in a specific way to improve relevance and recall.
+
+Currently, no aggregations are allowed to be executed against the values in this field type and
+only basic terms queries are allowed.
+
+[[sparse-scored-terms-ex]]
+==== Examples
+
+The following <<indices-create-index, create index>> API request creates a new index with two field mappings:
+
+* `my_terms`, a `sparse-scored-terms` field
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001
+{
+  "mappings" : {
+    "properties" : {
+      "my_terms" : {
+        "type" : "sparse_scored_terms"
+      }
+    }
+  }
+}
+--------------------------------------------------
+
+The following <<docs-index_,index>> API requests stores some scored terms
+
+[source,console]
+--------------------------------------------------
+PUT my-index-000001/_doc/1
+{
+  "my_terms" : {
+      "terms" : ["state", "mind", "carolina"], <1>
+      "scores" : [3, 12, 156] <2>
+   }
+}
+
+--------------------------------------------------
+<1> The sparse terms for indexing.
+<2> Their respective scores.

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/mapper/SparseScoredTermsMapper.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/mapper/SparseScoredTermsMapper.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.mapper;
+
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.analysis.tokenattributes.OffsetAttribute;
+import org.apache.lucene.analysis.tokenattributes.TermFrequencyAttribute;
+import org.apache.lucene.document.Field;
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.index.IndexOptions;
+import org.elasticsearch.common.Explicit;
+import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
+import org.elasticsearch.index.mapper.DocumentParserContext;
+import org.elasticsearch.index.mapper.FieldMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperBuilderContext;
+import org.elasticsearch.index.mapper.MapperParsingException;
+import org.elasticsearch.index.mapper.SourceValueFetcher;
+import org.elasticsearch.index.mapper.TermBasedFieldType;
+import org.elasticsearch.index.mapper.TextSearchInfo;
+import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentSubParser;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+public class SparseScoredTermsMapper extends FieldMapper {
+    public static final String CONTENT_TYPE = "sparse_scored_terms";
+    private final Explicit<Boolean> ignoreMalformed;
+    private final boolean ignoreMalformedByDefault;
+
+    public static final TypeParser PARSER = new TypeParser(
+        (n, c) -> new SparseScoredTermsMapper.Builder(n, IGNORE_MALFORMED_SETTING.get(c.getSettings()))
+    );
+
+    public static class Defaults {
+        public static final FieldType FIELD_TYPE = new FieldType();
+
+        static {
+            FIELD_TYPE.setTokenized(true);
+            FIELD_TYPE.setOmitNorms(true);
+            FIELD_TYPE.setIndexOptions(IndexOptions.DOCS_AND_FREQS);
+            FIELD_TYPE.freeze();
+        }
+        public static TextSearchInfo TEXT_SEARCH_INFO = new TextSearchInfo(
+            FIELD_TYPE,
+            null,
+            Lucene.KEYWORD_ANALYZER,
+            Lucene.KEYWORD_ANALYZER
+        );
+    }
+
+    public SparseScoredTermsMapper(
+        String simpleName,
+        MappedFieldType mappedFieldType,
+        MultiFields multiFields,
+        CopyTo copyTo,
+        Builder builder
+    ) {
+        super(simpleName, mappedFieldType, multiFields, copyTo);
+        this.ignoreMalformed = builder.ignoreMalformed.getValue();
+        this.ignoreMalformedByDefault = builder.ignoreMalformed.getDefaultValue().value();
+    }
+
+    private record SparseTermsAndScores(List<String> terms, List<Integer> scores) {
+
+    }
+
+    @SuppressWarnings("unchecked")
+    private static final ConstructingObjectParser<SparseTermsAndScores, Void> SPARSE_TERMS_MAPPED_FIELD_PARSER =
+        new ConstructingObjectParser<>(
+            "sparse_terms_mapped_field",
+            false,
+            a -> new SparseTermsAndScores((List<String>) a[0], (List<Integer>) a[1])
+        );
+    static {
+        SPARSE_TERMS_MAPPED_FIELD_PARSER.declareStringArray(ConstructingObjectParser.constructorArg(), new ParseField("terms"));
+        SPARSE_TERMS_MAPPED_FIELD_PARSER.declareIntArray(ConstructingObjectParser.constructorArg(), new ParseField("scores"));
+    }
+
+    @Override
+    protected void parseCreateField(DocumentParserContext context) throws IOException {
+        context.path().add(simpleName());
+        XContentParser.Token token;
+        XContentSubParser subParser = null;
+        try {
+            token = context.parser().currentToken();
+            if (token == XContentParser.Token.VALUE_NULL) {
+                context.path().remove();
+                return;
+            }
+            // should be an object
+            ensureExpectedToken(XContentParser.Token.START_OBJECT, token, context.parser());
+            subParser = new XContentSubParser(context.parser());
+            SparseTermsAndScores doc = SPARSE_TERMS_MAPPED_FIELD_PARSER.apply(subParser, null);
+            if (doc.terms.size() != doc.scores.size()) {
+                throw new MapperParsingException(
+                    Strings.format(
+                        "failed to parse field [%s] of type [%s], [terms] and [scores] must have equal length; found [%d] and [%d]",
+                        fieldType().name(),
+                        CONTENT_TYPE,
+                        doc.terms.size(),
+                        doc.scores.size()
+                    )
+                );
+            }
+            int i = 0;
+            for (Integer score : doc.scores) {
+                if (score < 0) {
+                    throw new MapperParsingException(
+                        Strings.format(
+                            "failed to parse field [%s] of type [%s], [scores] must be non-negative; found [%d] at position [%d]",
+                            fieldType().name(),
+                            CONTENT_TYPE,
+                            score,
+                            i
+                        )
+                    );
+                }
+                ++i;
+            }
+            if (doc.terms.size() > Sets.newHashSet(doc.terms).size()) {
+                throw new MapperParsingException(
+                    Strings.format(
+                        "failed to parse field [%s] of type [%s]; requires unique items in [terms]",
+                        fieldType().name(),
+                        CONTENT_TYPE
+                    )
+                );
+            }
+            context.doc()
+                .addWithKey(fieldType().name(), new Field(name(), new TermCountStream(doc.terms, doc.scores), Defaults.FIELD_TYPE));
+            context.addToFieldNames(fieldType().name());
+        } catch (Exception ex) {
+            if (ignoreMalformed.value() == false) {
+                if (ex instanceof MapperParsingException) {
+                    throw ex;
+                }
+                throw new MapperParsingException("failed to parse field [{}] of type [{}]", ex, fieldType().name(), fieldType().typeName());
+            }
+
+            if (subParser != null) {
+                // close the subParser so we advance to the end of the object
+                subParser.close();
+            }
+            context.addIgnoredField(fieldType().name());
+        }
+        context.path().remove();
+    }
+
+    @Override
+    public Map<String, NamedAnalyzer> indexAnalyzers() {
+        return Map.of(mappedFieldType.name(), Lucene.KEYWORD_ANALYZER);
+    }
+
+    @Override
+    public FieldMapper.Builder getMergeBuilder() {
+        return new Builder(simpleName(), ignoreMalformedByDefault).init(this);
+    }
+
+    @Override
+    protected String contentType() {
+        return CONTENT_TYPE;
+    }
+
+    @Override
+    public boolean ignoreMalformed() {
+        return ignoreMalformed.value();
+    }
+
+    private static class TermCountStream extends TokenStream {
+
+        private final CharTermAttribute termAtt = addAttribute(CharTermAttribute.class);
+        private final OffsetAttribute offsetAtt = addAttribute(OffsetAttribute.class);
+        private final TermFrequencyAttribute termFreq = addAttribute(TermFrequencyAttribute.class);
+
+        int pos = 0;
+        private final List<String> term;
+        private final List<Integer> count;
+
+        private TermCountStream(List<String> term, List<Integer> count) {
+            this.term = term;
+            this.count = count;
+        }
+
+        @Override
+        public void end() throws IOException {
+            super.end();
+            pos = term.size();
+        }
+
+        @Override
+        public void reset() throws IOException {
+            super.reset();
+            pos = 0;
+        }
+
+        @Override
+        public boolean incrementToken() {
+            if (pos < term.size()) {
+                while (pos < term.size() && count.get(pos) <= 0) {
+                    pos++;
+                }
+                if (pos >= term.size()) {
+                    return false;
+                }
+                termAtt.setEmpty().append(term.get(pos));
+                offsetAtt.setOffset(pos, pos + 1);
+                termFreq.setTermFrequency(count.get(pos));
+                pos++;
+                return true;
+            }
+            return false;
+        }
+    }
+
+    public static class Builder extends FieldMapper.Builder {
+
+        private final Parameter<Map<String, String>> meta = Parameter.metaParam();
+        private final Parameter<Explicit<Boolean>> ignoreMalformed;
+
+        /**
+         * Creates a new Builder with a field name
+         *
+         * @param name the field name
+         */
+        public Builder(String name, boolean ignoreMalformedByDefault) {
+            super(name);
+            this.ignoreMalformed = Parameter.explicitBoolParam(
+                "ignore_malformed",
+                true,
+                m -> ((SparseScoredTermsMapper) m).ignoreMalformed,
+                ignoreMalformedByDefault
+            );
+        }
+
+        @Override
+        protected Parameter<?>[] getParameters() {
+            return new Parameter<?>[] { ignoreMalformed, meta };
+        }
+
+        @Override
+        public FieldMapper build(MapperBuilderContext context) {
+            return new SparseScoredTermsMapper(
+                name,
+                new SparseScoredTermsFieldType(context.buildFullName(name), meta.getValue()),
+                multiFieldsBuilder.build(this, context),
+                copyTo.build(),
+                this
+            );
+        }
+    }
+
+    public static final class SparseScoredTermsFieldType extends TermBasedFieldType {
+
+        // TODO we may want regular term searches against this field as well. Treating the terms as keywords
+        public SparseScoredTermsFieldType(String name, Map<String, String> meta) {
+            super(name, true, false, false, Defaults.TEXT_SEARCH_INFO, meta);
+        }
+
+        @Override
+        public ValueFetcher valueFetcher(SearchExecutionContext context, String format) {
+            return SourceValueFetcher.identity(name(), context, format);
+        }
+
+        @Override
+        public String typeName() {
+            return CONTENT_TYPE;
+        }
+    }
+
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/mapper/SparseScoredTermsMapperTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/mapper/SparseScoredTermsMapperTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml.mapper;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.MappedFieldType;
+import org.elasticsearch.index.mapper.MapperTestCase;
+import org.elasticsearch.index.mapper.ParsedDocument;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.ml.MachineLearning;
+import org.junit.AssumptionViolatedException;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.notNullValue;
+
+public class SparseScoredTermsMapperTests extends MapperTestCase {
+
+    @Override
+    protected Object getSampleValueForDocument() {
+        return Map.of("terms", List.of("1", "123"), "scores", List.of(1, 3));
+    }
+
+    @Override
+    protected Collection<? extends Plugin> getPlugins() {
+        return List.of(new MachineLearning(Settings.EMPTY));
+    }
+
+    @Override
+    protected void minimalMapping(XContentBuilder b) throws IOException {
+        b.field("type", SparseScoredTermsMapper.CONTENT_TYPE);
+    }
+
+    @Override
+    protected void registerParameters(ParameterChecker checker) throws IOException {
+        checker.registerUpdateCheck(b -> b.field("ignore_malformed", true), m -> assertTrue(m.ignoreMalformed()));
+    }
+
+    @Override
+    protected boolean supportsSearchLookup() {
+        return true;
+    }
+
+    @Override
+    protected boolean supportsStoredFields() {
+        return false;
+    }
+
+    public void testParseValue() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc = mapper.parse(source(b -> b.field("field", Map.of("terms", List.of("1", "2"), "scores", List.of(54, 100)))));
+        assertThat(doc.rootDoc().getField("field"), notNullValue());
+    }
+
+    @Override
+    protected List<ExampleMalformedValue> exampleMalformedValues() {
+        return List.of(
+            exampleMalformedValue(b -> b.startObject().startArray("scores").value(2).value(2).endArray().endObject()).errorMatches(
+                "failed to parse field [field] of type [sparse_scored_terms]"
+            ),
+            exampleMalformedValue(b -> b.startObject().field("terms", List.of("foo", "bar")).endObject()).errorMatches(
+                "failed to parse field [field] of type [sparse_scored_terms]"
+            ),
+            exampleMalformedValue(b -> b.startObject().field("scores", List.of(-1, 1)).field("terms", List.of("foo", "bar")).endObject())
+                .errorMatches("[scores] must be non-negative"),
+            exampleMalformedValue(b -> b.startObject().field("scores", List.of(1)).field("terms", List.of("foo", "bar")).endObject())
+                .errorMatches("[terms] and [scores] must have equal length"),
+            exampleMalformedValue(b -> b.startObject().field("scores", List.of(1, 2)).field("terms", List.of("bar")).endObject())
+                .errorMatches("[terms] and [scores] must have equal length"),
+            exampleMalformedValue(b -> b.startObject().field("scores", List.of(1, 2)).field("terms", List.of("bar", "bar")).endObject())
+                .errorMatches("requires unique items in [terms]"),
+            exampleMalformedValue(
+                b -> b.startObject()
+                    .field("unknown", "foo")
+                    .field("scores", List.of(1, 2))
+                    .field("terms", List.of("foo", "bar"))
+                    .endObject()
+            ).errorMatches("failed to parse field [field] of type [sparse_scored_terms]")
+        );
+    }
+
+    @Override
+    protected boolean supportsIgnoreMalformed() {
+        return true;
+    }
+
+    @Override
+    protected Object generateRandomInputValue(MappedFieldType ft) {
+        assumeFalse("We don't have a way to assert things here", true);
+        return null;
+    }
+
+    @Override
+    protected IngestScriptSupport ingestScriptSupport() {
+        throw new AssumptionViolatedException("not supported");
+    }
+
+    @Override
+    protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
+        throw new AssumptionViolatedException("not supported");
+    }
+}


### PR DESCRIPTION
Adds a new indexed field type called `sparse_scored_terms`. This field allows for terms to be indexed with associated scores (internally represented by term frequency). 

Regular term queries are supported against this field and those queries see the scores as the term frequency for that given document.

 - Terms and scores are the same length
 - Scores must be positive integers
 - This is a "text" type field, so aggregations are not allowed (for now)
 - Term values must be unique.