### PR TITLE
[Transform] Support "offset" parameter in DateHistogramGroupSource

### DIFF
--- a/docs/changelog/93203.yaml
+++ b/docs/changelog/93203.yaml
@@ -1,0 +1,5 @@
+pr: 93203
+summary: Support "offset" parameter in `DateHistogramGroupSource`
+area: Transform
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSource.java
@@ -207,7 +207,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
     private final Interval interval;
     private final ZoneId timeZone;
     private final Rounding.Prepared rounding;
-    private final Long offset;
+    private final long offset;
 
     public DateHistogramGroupSource(
         String field,
@@ -220,7 +220,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         super(field, scriptConfig, missingBucket);
         this.interval = interval;
         this.timeZone = timeZone;
-        this.offset = offset;
+        this.offset = offset != null ? offset : 0;
         this.rounding = buildRounding();
     }
 
@@ -229,9 +229,9 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         this.interval = readInterval(in);
         this.timeZone = in.readOptionalZoneId();
         if (in.getVersion().onOrAfter(Version.V_8_7_0)) {
-            this.offset = in.readOptionalLong();
+            this.offset = in.readLong();
         } else {
-            this.offset = null;
+            this.offset = 0;
         }
         this.rounding = buildRounding();
     }
@@ -248,7 +248,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         if (timeZone != null) {
             roundingBuilder.timeZone(timeZone);
         }
-        if (offset != null) {
+        if (offset != 0) {
             roundingBuilder.offset(offset);
         }
         return roundingBuilder.build().prepareForUnknown();
@@ -324,7 +324,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         return rounding;
     }
 
-    public Long getOffset() {
+    public long getOffset() {
         return offset;
     }
 
@@ -334,7 +334,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         writeInterval(interval, out);
         out.writeOptionalZoneId(timeZone);
         if (out.getVersion().onOrAfter(Version.V_8_7_0)) {
-            out.writeOptionalLong(offset);
+            out.writeLong(offset);
         }
     }
 
@@ -346,7 +346,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         if (timeZone != null) {
             builder.field(TIME_ZONE.getPreferredName(), timeZone.toString());
         }
-        if (offset != null) {
+        if (offset != 0) {
             builder.field(OFFSET.getPreferredName(), offset);
         }
         builder.endObject();
@@ -370,7 +370,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
             && Objects.equals(this.scriptConfig, that.scriptConfig)
             && Objects.equals(this.interval, that.interval)
             && Objects.equals(this.timeZone, that.timeZone)
-            && Objects.equals(this.offset, that.offset);
+            && this.offset == that.offset;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSource.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.transform.transforms.pivot;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.common.Rounding;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -13,6 +14,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.bucket.histogram.DateHistogramInterval;
+import org.elasticsearch.search.aggregations.bucket.histogram.Histogram;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -197,6 +199,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
 
     private static final String NAME = "data_frame_date_histogram_group";
     private static final ParseField TIME_ZONE = new ParseField("time_zone");
+    private static final ParseField OFFSET = Histogram.OFFSET_FIELD;
 
     private static final ConstructingObjectParser<DateHistogramGroupSource, Void> STRICT_PARSER = createParser(false);
     private static final ConstructingObjectParser<DateHistogramGroupSource, Void> LENIENT_PARSER = createParser(true);
@@ -204,19 +207,33 @@ public class DateHistogramGroupSource extends SingleGroupSource {
     private final Interval interval;
     private final ZoneId timeZone;
     private final Rounding.Prepared rounding;
+    private final Long offset;
 
-    public DateHistogramGroupSource(String field, ScriptConfig scriptConfig, boolean missingBucket, Interval interval, ZoneId timeZone) {
+    public DateHistogramGroupSource(
+        String field,
+        ScriptConfig scriptConfig,
+        boolean missingBucket,
+        Interval interval,
+        ZoneId timeZone,
+        Long offset
+    ) {
         super(field, scriptConfig, missingBucket);
         this.interval = interval;
         this.timeZone = timeZone;
-        rounding = buildRounding();
+        this.offset = offset;
+        this.rounding = buildRounding();
     }
 
     public DateHistogramGroupSource(StreamInput in) throws IOException {
         super(in);
         this.interval = readInterval(in);
         this.timeZone = in.readOptionalZoneId();
-        rounding = buildRounding();
+        if (in.getVersion().onOrAfter(Version.V_8_7_0)) {
+            this.offset = in.readOptionalLong();
+        } else {
+            this.offset = null;
+        }
+        this.rounding = buildRounding();
     }
 
     private Rounding.Prepared buildRounding() {
@@ -231,6 +248,9 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         if (timeZone != null) {
             roundingBuilder.timeZone(timeZone);
         }
+        if (offset != null) {
+            roundingBuilder.offset(offset);
+        }
         return roundingBuilder.build().prepareForUnknown();
     }
 
@@ -242,6 +262,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
             String fixedInterval = (String) args[3];
             String calendarInterval = (String) args[4];
             ZoneId zoneId = (ZoneId) args[5];
+            Long offset = (Long) args[6];
 
             Interval interval = null;
 
@@ -255,7 +276,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
                 throw new IllegalArgumentException("You must specify either fixed_interval or calendar_interval, found none");
             }
 
-            return new DateHistogramGroupSource(field, scriptConfig, missingBucket, interval, zoneId);
+            return new DateHistogramGroupSource(field, scriptConfig, missingBucket, interval, zoneId, offset);
         });
 
         declareValuesSourceFields(parser, lenient);
@@ -270,6 +291,14 @@ public class DateHistogramGroupSource extends SingleGroupSource {
                 return ZoneOffset.ofHours(p.intValue());
             }
         }, TIME_ZONE, ObjectParser.ValueType.LONG);
+
+        parser.declareField(optionalConstructorArg(), p -> {
+            if (p.currentToken() == XContentParser.Token.VALUE_NUMBER) {
+                return p.longValue();
+            } else {
+                return DateHistogramAggregationBuilder.parseStringOffset(p.text());
+            }
+        }, OFFSET, ObjectParser.ValueType.LONG);
 
         return parser;
     }
@@ -295,11 +324,18 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         return rounding;
     }
 
+    public Long getOffset() {
+        return offset;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         writeInterval(interval, out);
         out.writeOptionalZoneId(timeZone);
+        if (out.getVersion().onOrAfter(Version.V_8_7_0)) {
+            out.writeOptionalLong(offset);
+        }
     }
 
     @Override
@@ -309,6 +345,9 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         interval.toXContent(builder, params);
         if (timeZone != null) {
             builder.field(TIME_ZONE.getPreferredName(), timeZone.toString());
+        }
+        if (offset != null) {
+            builder.field(OFFSET.getPreferredName(), offset);
         }
         builder.endObject();
         return builder;
@@ -330,11 +369,12 @@ public class DateHistogramGroupSource extends SingleGroupSource {
             && Objects.equals(this.field, that.field)
             && Objects.equals(this.scriptConfig, that.scriptConfig)
             && Objects.equals(this.interval, that.interval)
-            && Objects.equals(this.timeZone, that.timeZone);
+            && Objects.equals(this.timeZone, that.timeZone)
+            && Objects.equals(this.offset, that.offset);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(field, scriptConfig, missingBucket, interval, timeZone);
+        return Objects.hash(field, scriptConfig, missingBucket, interval, timeZone, offset);
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSource.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSource.java
@@ -248,9 +248,7 @@ public class DateHistogramGroupSource extends SingleGroupSource {
         if (timeZone != null) {
             roundingBuilder.timeZone(timeZone);
         }
-        if (offset != 0) {
-            roundingBuilder.offset(offset);
-        }
+        roundingBuilder.offset(offset);
         return roundingBuilder.build().prepareForUnknown();
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
@@ -58,6 +58,7 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
             field = fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         }
         boolean missingBucket = version.onOrAfter(Version.V_7_10_0) ? randomBoolean() : false;
+        Long offset = version.onOrAfter(Version.V_8_7_0) ? randomOffset() : null;
 
         DateHistogramGroupSource dateHistogramGroupSource;
         if (randomBoolean()) {
@@ -66,7 +67,8 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
                 scriptConfig,
                 missingBucket,
                 new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval(randomTimeValue(1, 100, "d", "h", "ms", "s", "m"))),
-                randomBoolean() ? randomZone() : null
+                randomBoolean() ? randomZone() : null,
+                randomBoolean() ? offset : null
             );
         } else {
             dateHistogramGroupSource = new DateHistogramGroupSource(
@@ -76,7 +78,8 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
                 new DateHistogramGroupSource.CalendarInterval(
                     new DateHistogramInterval(randomTimeValue(1, 1, "m", "h", "d", "w", "M", "q", "y"))
                 ),
-                randomBoolean() ? randomZone() : null
+                randomBoolean() ? randomZone() : null,
+                randomBoolean() ? offset : null
             );
         }
 
@@ -122,7 +125,8 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
             null,
             randomBoolean(),
             new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval("1d")),
-            null
+            null,
+            randomBoolean() ? randomOffset() : null
         );
 
         // not meant to be complete rounding tests, see {@link RoundingTests} for more
@@ -145,7 +149,8 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
             null,
             randomBoolean(),
             new DateHistogramGroupSource.CalendarInterval(new DateHistogramInterval("1w")),
-            null
+            null,
+            randomBoolean() ? randomOffset() : null
         );
 
         // not meant to be complete rounding tests, see {@link RoundingTests} for more
@@ -168,5 +173,9 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
     private static long time(String time) {
         TemporalAccessor accessor = DateFormatter.forPattern("date_optional_time").withZone(ZoneOffset.UTC).parse(time);
         return DateFormatters.from(accessor).toInstant().toEpochMilli();
+    }
+
+    private static long randomOffset() {
+        return randomLongBetween(-1_000_000, 1_000_000);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
@@ -121,10 +121,56 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
         return DateHistogramGroupSource::new;
     }
 
+    public void testOffset() {
+        {
+            DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
+                null,
+                null,
+                false,
+                new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval("1d")),
+                null,
+                null
+            );
+            assertThat(dateHistogramGroupSource.getOffset(), equalTo(0L));
+        }
+        {
+            DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
+                null,
+                null,
+                false,
+                new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval("1d")),
+                null,
+                0L
+            );
+            assertThat(dateHistogramGroupSource.getOffset(), equalTo(0L));
+        }
+        {
+            DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
+                null,
+                null,
+                false,
+                new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval("1d")),
+                null,
+                DateHistogramAggregationBuilder.parseStringOffset("-1h")
+            );
+            assertThat(dateHistogramGroupSource.getOffset(), equalTo(-3_600_000L));
+        }
+        {
+            DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
+                null,
+                null,
+                false,
+                new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval("1d")),
+                null,
+                DateHistogramAggregationBuilder.parseStringOffset("+1h")
+            );
+            assertThat(dateHistogramGroupSource.getOffset(), equalTo(3_600_000L));
+        }
+    }
+
     public void testRoundingDateHistogramFixedInterval() {
-        String field = randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20);
         DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
-            field,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20),
             null,
             randomBoolean(),
             new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval("1d")),
@@ -144,9 +190,8 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
     }
 
     public void testRoundingDateHistogramCalendarInterval() {
-        String field = randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20);
         DateHistogramGroupSource dateHistogramGroupSource = new DateHistogramGroupSource(
-            field,
+            randomBoolean() ? null : randomAlphaOfLengthBetween(1, 20),
             null,
             randomBoolean(),
             new DateHistogramGroupSource.CalendarInterval(new DateHistogramInterval("1w")),

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/preview_transforms.yml
@@ -161,6 +161,45 @@ setup:
   - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
 
 ---
+"Test preview transform with offset":
+  - do:
+      transform.preview_transform:
+        body: >
+          {
+            "source": { "index": "airline-data" },
+            "pivot": {
+              "group_by": {
+                "airline": {"terms": {"field": "airline"}},
+                "by-hour": {"date_histogram": {"fixed_interval": "1h", "field": "time", "offset": "-15m"}}},
+              "aggs": {
+                "avg_response": {"avg": {"field": "responsetime"}},
+                "time.max": {"max": {"field": "time"}},
+                "time.min": {"min": {"field": "time"}}
+              }
+            }
+          }
+  - match: { preview.0.airline: foo }
+  - match: { preview.0.by-hour: "2017-02-17T23:45:00.000Z" }
+  - match: { preview.0.avg_response: 1.0 }
+  - match: { preview.0.time.max: "2017-02-18T00:30:00.000Z" }
+  - match: { preview.0.time.min: "2017-02-18T00:00:00.000Z" }
+  - match: { preview.1.airline: bar }
+  - match: { preview.1.by-hour: "2017-02-18T00:45:00.000Z" }
+  - match: { preview.1.avg_response: 42.0 }
+  - match: { preview.1.time.max: "2017-02-18T01:00:00.000Z" }
+  - match: { preview.1.time.min: "2017-02-18T01:00:00.000Z" }
+  - match: { preview.2.airline: foo }
+  - match: { preview.2.by-hour: "2017-02-18T00:45:00.000Z" }
+  - match: { preview.2.avg_response: 42.0 }
+  - match: { preview.2.time.max: "2017-02-18T01:01:00.000Z" }
+  - match: { preview.2.time.min: "2017-02-18T01:01:00.000Z" }
+  - match: { generated_dest_index.mappings.properties.airline.type: "keyword" }
+  - match: { generated_dest_index.mappings.properties.by-hour.type: "date" }
+  - match: { generated_dest_index.mappings.properties.avg_response.type: "double" }
+  - match: { generated_dest_index.mappings.properties.time\.max.type: "date" }
+  - match: { generated_dest_index.mappings.properties.time\.min.type: "date" }
+
+---
 "Test preview transform with timeout":
   - do:
       transform.preview_transform:

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -290,7 +290,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         DateHistogramInterval interval,
         ZoneId zone
     ) {
-        return new DateHistogramGroupSource(field, null, false, new DateHistogramGroupSource.FixedInterval(interval), zone);
+        return new DateHistogramGroupSource(field, null, false, new DateHistogramGroupSource.FixedInterval(interval), zone, null);
     }
 
     protected DateHistogramGroupSource createDateHistogramGroupSourceWithCalendarInterval(
@@ -298,7 +298,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
         DateHistogramInterval interval,
         ZoneId zone
     ) {
-        return new DateHistogramGroupSource(field, null, false, new DateHistogramGroupSource.CalendarInterval(interval), zone);
+        return new DateHistogramGroupSource(field, null, false, new DateHistogramGroupSource.CalendarInterval(interval), zone, null);
     }
 
     /**

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByIT.java
@@ -67,6 +67,7 @@ public class DateHistogramGroupByIT extends ContinuousTestCase {
                     null,
                     missing,
                     new DateHistogramGroupSource.FixedInterval(DateHistogramInterval.SECOND),
+                    null,
                     null
                 )
             ),

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/DateHistogramGroupByOtherTimeFieldIT.java
@@ -73,6 +73,7 @@ public class DateHistogramGroupByOtherTimeFieldIT extends ContinuousTestCase {
                 null,
                 false,
                 new DateHistogramGroupSource.FixedInterval(DateHistogramInterval.SECOND),
+                null,
                 null
             )
         );

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TimeBasedCheckpointProviderTests.java
@@ -298,6 +298,7 @@ public class TimeBasedCheckpointProviderTests extends ESTestCase {
             null,
             false,
             new DateHistogramGroupSource.FixedInterval(new DateHistogramInterval(dateHistogramInterval.getStringRep())),
+            null,
             null
         );
         Supplier<SingleGroupSource> singleGroupSourceSupplier = new Supplier<>() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/CompositeBucketsChangeCollectorTests.java
@@ -140,6 +140,7 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
             null,
             false,
             new DateHistogramGroupSource.FixedInterval(DateHistogramInterval.MINUTE),
+            null,
             null
         );
         groups.put("output_timestamp", groupBy);
@@ -224,6 +225,7 @@ public class CompositeBucketsChangeCollectorTests extends ESTestCase {
             null,
             true,
             new DateHistogramGroupSource.FixedInterval(DateHistogramInterval.MINUTE),
+            null,
             null
         );
         groups.put("output_timestamp", groupBy);


### PR DESCRIPTION
This PR adds support for the `offset` parameter in `DateHistogramGroupSource`.
`DateHistogramGroupSource.offset` gets translated directly to `date_histogram` aggregations's `offset` parameter which is described in the [Date Histogram Aggregation documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-datehistogram-aggregation.html#search-aggregations-bucket-datehistogram-offset).

Relates https://github.com/elastic/elasticsearch/issues/86452