### PR TITLE
Remove user exception marker from server cli

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
@@ -19,19 +19,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.concurrent.CountDownLatch;
 
 import static org.elasticsearch.bootstrap.BootstrapInfo.SERVER_READY_MARKER;
-import static org.elasticsearch.bootstrap.BootstrapInfo.USER_EXCEPTION_MARKER;
 import static org.elasticsearch.server.cli.ProcessUtil.nonInterruptibleVoid;
 
 /**
  * A thread which reads stderr of the jvm process and writes it to this process' stderr.
  *
- * <p> Two special state markers are watched for. These are ascii control characters which signal
- * to the cli process something has changed in the server process. The two possible special messages are:
- * <ul>
- *     <li>{@link BootstrapInfo#USER_EXCEPTION_MARKER} - signals a bootstrap error has occurred, and is followed
- *     by the error message</li>
- *     <li>{@link BootstrapInfo#SERVER_READY_MARKER} - signals the server is ready so the cli may detach if daemonizing</li>
- * </ul>
+ * <p> The thread watches for a special state marker from the process. The ascii character
+ * {@link BootstrapInfo#SERVER_READY_MARKER} signals the server is ready and the cli may
+ * detach if daemonizing. All other messages are passed through to stderr.
  */
 class ErrorPumpThread extends Thread {
     private final BufferedReader reader;
@@ -42,9 +37,6 @@ class ErrorPumpThread extends Thread {
 
     // a flag denoting whether the ready marker has been received by the server process
     private volatile boolean ready;
-
-    // an exception message received alongside the user exception marker, if a bootstrap error has occurred
-    private volatile String userExceptionMsg;
 
     // an unexpected io failure that occurred while pumping stderr
     private volatile IOException ioFailure;
@@ -66,10 +58,6 @@ class ErrorPumpThread extends Thread {
         if (ioFailure != null) {
             throw ioFailure;
         }
-        if (ready == false) {
-            return userExceptionMsg;
-        }
-        assert userExceptionMsg == null;
         return null;
     }
 
@@ -85,10 +73,7 @@ class ErrorPumpThread extends Thread {
         try {
             String line;
             while ((line = reader.readLine()) != null) {
-                if (line.isEmpty() == false && line.charAt(0) == USER_EXCEPTION_MARKER) {
-                    userExceptionMsg = line.substring(1);
-                    readyOrDead.countDown();
-                } else if (line.isEmpty() == false && line.charAt(0) == SERVER_READY_MARKER) {
+                if (line.isEmpty() == false && line.charAt(0) == SERVER_READY_MARKER) {
                     ready = true;
                     readyOrDead.countDown();
                 } else {

--- a/server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/BootstrapInfo.java
@@ -67,13 +67,6 @@ public final class BootstrapInfo {
     public static final String UNTRUSTED_CODEBASE = "/untrusted";
 
     /**
-     * A non-printable character denoting a UserException has occurred.
-     *
-     * This is sent over stderr to the controlling CLI process.
-     */
-    public static final char USER_EXCEPTION_MARKER = '\u0015';
-
-    /**
      * A non-printable character denoting the server is ready to process requests.
      *
      * This is sent over stderr to the controlling CLI process.


### PR DESCRIPTION
Previously UserExceptions could be thrown from the main Elasticsearch process during startup. With recent refactorings all remaining validation of arguments was moved to the server cli. Since there are no longer any uses of the user exception in server, the marker code is no longer needed. This commit removes that marker and the associated code in the server cli error pump.