### PR TITLE
Suggest systemd override file instead of unit file for tmpdir

### DIFF
--- a/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
+++ b/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
@@ -34,9 +34,8 @@ instance:
 export ES_TMPDIR=/usr/share/elasticsearch/tmp
 --------------------------------------------
 
-* If you are using `systemd` to run {es} as a service, using the `systemctl`
-command, add the following line to the `[Service]` section of your
-`elasticsearch.service` unit file:
+* If you are using `systemd` to run {es} as a service, add the following
+line to the `[Service]` section in a <<systemd,service override file>>:
 +
 [source,text]
 --------------------------------------------


### PR DESCRIPTION
The systemd unit file is part of the Elasticsearch package and should not be edited. Instead, we recommend creating a service override file. This commit tweaks the docs for setting tmp dir with systemd to use the override file instead of editing the unit file.

relates #93121