### PR TITLE
Extract some methods from IngestService's innerExecute method

### DIFF
--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -885,8 +885,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             } else {
                 updateIndexRequestMetadata(indexRequest, ingestDocument.getMetadata());
                 try {
-                    boolean ensureNoSelfReferences = ingestDocument.doNoSelfReferencesCheck();
-                    indexRequest.source(ingestDocument.getSource(), indexRequest.getContentType(), ensureNoSelfReferences);
+                    updateIndexRequestSource(indexRequest, ingestDocument);
                 } catch (IllegalArgumentException ex) {
                     // An IllegalArgumentException can be thrown when an ingest processor creates a source map that is self-referencing.
                     // In that case, we catch and wrap the exception, so we can include which pipeline failed.
@@ -948,6 +947,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             mergedDynamicTemplates.putAll(map);
             request.setDynamicTemplates(mergedDynamicTemplates);
         }
+    }
+
+    private static void updateIndexRequestSource(final IndexRequest request, final IngestDocument document) {
+        boolean ensureNoSelfReferences = document.doNoSelfReferencesCheck();
+        request.source(document.getSource(), request.getContentType(), ensureNoSelfReferences);
     }
 
     private static void cacheRawTimestamp(final IndexRequest request, final IngestDocument document) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -913,6 +913,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         });
     }
 
+    /**
+     * Builds a new ingest document from the passed-in index request.
+     */
     private static IngestDocument newIngestDocument(final IndexRequest request) {
         return new IngestDocument(
             request.index(),
@@ -924,6 +927,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         );
     }
 
+    /**
+     * Updates an index request based on the metadata of an ingest document.
+     */
     private static void updateIndexRequestMetadata(final IndexRequest request, final org.elasticsearch.script.Metadata metadata) {
         // it's fine to set all metadata fields all the time, as ingest document holds their starting values
         // before ingestion, which might also get modified during ingestion.
@@ -949,11 +955,18 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
     }
 
+    /**
+     * Updates an index request based on the source of an ingest document, guarding against self-references if necessary.
+     */
     private static void updateIndexRequestSource(final IndexRequest request, final IngestDocument document) {
         boolean ensureNoSelfReferences = document.doNoSelfReferencesCheck();
         request.source(document.getSource(), request.getContentType(), ensureNoSelfReferences);
     }
 
+    /**
+     * Grab the @timestamp and store it on the index request so that TSDB can use it without needing to parse
+     * the source for this document.
+     */
     private static void cacheRawTimestamp(final IndexRequest request, final IngestDocument document) {
         if (request.getRawTimestamp() == null) {
             // cache the @timestamp from the ingest document's source map if there is one

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -930,7 +930,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                     mergedDynamicTemplates.putAll(map);
                     indexRequest.setDynamicTemplates(mergedDynamicTemplates);
                 }
-                postIngest(ingestDocument, indexRequest);
+                cacheRawTimestamp(indexRequest, ingestDocument);
 
                 handler.accept(null);
             }
@@ -948,12 +948,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         );
     }
 
-    private void postIngest(IngestDocument ingestDocument, IndexRequest indexRequest) {
-        if (indexRequest.getRawTimestamp() == null) {
+    private static void cacheRawTimestamp(final IndexRequest request, final IngestDocument document) {
+        if (request.getRawTimestamp() == null) {
             // cache the @timestamp from the ingest document's source map if there is one
-            Object rawTimestamp = ingestDocument.getSource().get(TimestampField.FIXED_TIMESTAMP_FIELD);
+            Object rawTimestamp = document.getSource().get(TimestampField.FIXED_TIMESTAMP_FIELD);
             if (rawTimestamp != null) {
-                indexRequest.setRawTimestamp(rawTimestamp);
+                request.setRawTimestamp(rawTimestamp);
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -875,13 +875,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
             return;
         }
 
-        String index = indexRequest.index();
-        String id = indexRequest.id();
-        String routing = indexRequest.routing();
-        long version = indexRequest.version();
-        VersionType versionType = indexRequest.versionType();
-        Map<String, Object> sourceAsMap = indexRequest.sourceAsMap();
-        IngestDocument ingestDocument = new IngestDocument(index, id, version, routing, versionType, sourceAsMap);
+        IngestDocument ingestDocument = newIngestDocument(indexRequest);
         ingestDocument.executePipeline(pipeline, (result, e) -> {
             if (e != null) {
                 handler.accept(e);
@@ -941,6 +935,17 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 handler.accept(null);
             }
         });
+    }
+
+    private static IngestDocument newIngestDocument(final IndexRequest request) {
+        return new IngestDocument(
+            request.index(),
+            request.id(),
+            request.version(),
+            request.routing(),
+            request.versionType(),
+            request.sourceAsMap()
+        );
     }
 
     private void postIngest(IngestDocument ingestDocument, IndexRequest indexRequest) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -901,6 +901,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 if ((number = metadata.getIfPrimaryTerm()) != null) {
                     indexRequest.setIfPrimaryTerm(number.longValue());
                 }
+                Map<String, String> map;
+                if ((map = metadata.getDynamicTemplates()) != null) {
+                    Map<String, String> mergedDynamicTemplates = new HashMap<>(indexRequest.getDynamicTemplates());
+                    mergedDynamicTemplates.putAll(map);
+                    indexRequest.setDynamicTemplates(mergedDynamicTemplates);
+                }
                 try {
                     boolean ensureNoSelfReferences = ingestDocument.doNoSelfReferencesCheck();
                     indexRequest.source(ingestDocument.getSource(), indexRequest.getContentType(), ensureNoSelfReferences);
@@ -923,12 +929,6 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                         new RuntimeException("Failed to generate the source document for ingest pipeline [" + pipeline.getId() + "]", ex)
                     );
                     return;
-                }
-                Map<String, String> map;
-                if ((map = metadata.getDynamicTemplates()) != null) {
-                    Map<String, String> mergedDynamicTemplates = new HashMap<>(indexRequest.getDynamicTemplates());
-                    mergedDynamicTemplates.putAll(map);
-                    indexRequest.setDynamicTemplates(mergedDynamicTemplates);
                 }
                 cacheRawTimestamp(indexRequest, ingestDocument);
 


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/81244

This PR hollows out the body of `innerExecute` by extracting some methods from it (and updating it to call those methods).

There's no real change in behavior here, I tried to keep this a 1-to-1 in terms of the before and after. The closest thing there is to a change is that the `getDynamicTemplates` / `setDynamicTemplates` block is executed slightly earlier than before, since it moves into the body of `updateIndexRequestMetadata`, but I don't think that affects anything else.

This PR is a prelude to a follow up PR which will rework these new functions to be called outside of `innerExecute`, but I'm hoping to keep the overall effort more reviewable by keeping this PR to just the "pull out some new methods" part of the work.