### PR TITLE
[7.17] Suggest systemd override file instead of unit file for tmpdir (#93211)

### DIFF
--- a/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
+++ b/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
@@ -34,9 +34,8 @@ instance:
 export ES_TMPDIR=/usr/share/elasticsearch/tmp
 --------------------------------------------
 
-* If you are using `systemd` to run {es} as a service, using the `systemctl`
-command, add the following line to the `[Service]` section of your
-`elasticsearch.service` unit file:
+* If you are using `systemd` to run {es} as a service, add the following
+line to the `[Service]` section in a <<systemd,service override file>>:
 +
 [source,text]
 --------------------------------------------


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Suggest systemd override file instead of unit file for tmpdir (#93211)