### PR TITLE
[8.6] Ensure initial_master_nodes includes only master-eligible nodes (#93212)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -65,8 +65,20 @@ public class DefaultSettingsProvider implements SettingsProvider {
         settings.put("action.destructive_requires_name", "false");
 
         // Setup cluster discovery
-        String nodeNames = nodeSpec.getCluster().getNodes().stream().map(LocalNodeSpec::getName).collect(Collectors.joining(","));
-        settings.put("cluster.initial_master_nodes", "[" + nodeNames + "]");
+        String masterEligibleNodes = nodeSpec.getCluster()
+            .getNodes()
+            .stream()
+            .filter(LocalNodeSpec::isMasterEligible)
+            .map(LocalNodeSpec::getName)
+            .collect(Collectors.joining(","));
+
+        if (masterEligibleNodes.isEmpty()) {
+            throw new IllegalStateException(
+                "Cannot start cluster '" + nodeSpec.getCluster().getName() + "' as it configured with no master-eligible nodes."
+            );
+        }
+
+        settings.put("cluster.initial_master_nodes", "[" + masterEligibleNodes + "]");
         settings.put("discovery.seed_providers", "file");
         settings.put("discovery.seed_hosts", "[]");
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Ensure initial_master_nodes includes only master-eligible nodes (#93212)