### PR TITLE
Fix ESIndexInputTestCase#randomReadAndSlice

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/lucene/store/ESIndexInputTestCase.java
@@ -62,7 +62,7 @@ public class ESIndexInputTestCase extends ESTestCase {
         int readPos = (int) indexInput.getFilePointer();
         byte[] output = new byte[length];
         while (readPos < length) {
-            final var readStrategy = randomFrom(2, 6);
+            final var readStrategy = between(0, 8);
             switch (readStrategy) {
                 case 0, 1, 2, 3:
                     if (length - readPos >= Long.BYTES && readStrategy <= 0) {


### PR DESCRIPTION
In #93205 we fixed a bug in `ByteArrayIndexInput` but accidentally reduced the coverage of the test suite with a supposedly-temporary change for debugging purposes. This commit brings the test suite back up to full strength again.

This was fixed in `main` by #93208, but most of that change is not for backporting.