### PR TITLE
Enable Panama-based mmap directory by default

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -73,6 +73,3 @@
 
 ## GC logging
 -Xlog:gc*,gc+age=trace,safepoint:file=@loggc@:utctime,level,pid,tags:filecount=32,filesize=64m
-
-# temporarily disable the Panama-based MMapDirectory
--Dorg.apache.lucene.store.MMapDirectory.enableMemorySegments=false


### PR DESCRIPTION
When we upgraded to lucene 9.5 (snapshot) with #92957 we initially disabled panama-based mmap directory through a system property. With this commit we remove the system property and enable java 19 memory segments by default (based on https://github.com/apache/lucene/pull/12033).