### PR TITLE
Add support for closed unpromotable shards

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -30,6 +30,8 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.NoOpEngine;
+import org.elasticsearch.index.seqno.SeqNoStats;
+import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.indices.IndicesService;
@@ -100,7 +102,11 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
             return Optional.of(
                 config -> config.isPromotableToPrimary()
                     ? new InternalEngine(config)
-                    : new NoOpEngine(config, new TranslogStats(0, 0, 0, 0, 0))
+                    : new NoOpEngine(
+                        config,
+                        new TranslogStats(0, 0, 0, 0, 0),
+                        new SeqNoStats(SequenceNumbers.NO_OPS_PERFORMED, SequenceNumbers.NO_OPS_PERFORMED, SequenceNumbers.NO_OPS_PERFORMED)
+                    )
             );
         }
     }
@@ -300,7 +306,8 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
                 for (IndexShard indexShard : indexService) {
                     final var engine = indexShard.getEngineOrNull();
                     assertNotNull(engine);
-                    if (indexShard.routingEntry().isPromotableToPrimary()) {
+                    if (indexShard.routingEntry().isPromotableToPrimary()
+                        && indexShard.indexSettings().getIndexMetadata().getState() == IndexMetadata.State.OPEN) {
                         assertThat(engine, instanceOf(InternalEngine.class));
                     } else {
                         assertThat(engine, instanceOf(NoOpEngine.class));
@@ -453,4 +460,27 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
         }
     }
 
+    public void testClosedIndex() {
+        var routingTableWatcher = new RoutingTableWatcher();
+
+        var numDataNodes = routingTableWatcher.numReplicas + 2;
+        internalCluster().ensureAtLeastNumDataNodes(numDataNodes);
+        getMasterNodePlugin().numIndexingCopies = routingTableWatcher.numIndexingCopies;
+
+        final var masterClusterService = internalCluster().getCurrentMasterNodeInstance(ClusterService.class);
+        try {
+            // verify the correct number of shard copies of each role as the routing table evolves
+            masterClusterService.addListener(routingTableWatcher);
+
+            createIndex(INDEX_NAME, routingTableWatcher.getIndexSettings());
+            ensureGreen(INDEX_NAME);
+            assertEngineTypes();
+
+            assertAcked(client().admin().indices().prepareClose(INDEX_NAME));
+            ensureGreen(INDEX_NAME);
+            assertEngineTypes();
+        } finally {
+            masterClusterService.removeListener(routingTableWatcher);
+        }
+    }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -30,10 +30,7 @@ import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineFactory;
 import org.elasticsearch.index.engine.InternalEngine;
 import org.elasticsearch.index.engine.NoOpEngine;
-import org.elasticsearch.index.seqno.SeqNoStats;
-import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.IndexShard;
-import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.EnginePlugin;
@@ -99,15 +96,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
         @Override
         public Optional<EngineFactory> getEngineFactory(IndexSettings indexSettings) {
-            return Optional.of(
-                config -> config.isPromotableToPrimary()
-                    ? new InternalEngine(config)
-                    : new NoOpEngine(
-                        config,
-                        new TranslogStats(0, 0, 0, 0, 0),
-                        new SeqNoStats(SequenceNumbers.NO_OPS_PERFORMED, SequenceNumbers.NO_OPS_PERFORMED, SequenceNumbers.NO_OPS_PERFORMED)
-                    )
-            );
+            return Optional.of(config -> config.isPromotableToPrimary() ? new InternalEngine(config) : new NoOpEngine(config));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/NoOpEngine.java
@@ -18,6 +18,7 @@ import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.seqno.SeqNoStats;
 import org.elasticsearch.index.seqno.SequenceNumbers;
 import org.elasticsearch.index.shard.DocsStats;
 import org.elasticsearch.index.store.Store;
@@ -45,11 +46,21 @@ public final class NoOpEngine extends ReadOnlyEngine {
     private final DocsStats docsStats;
 
     public NoOpEngine(EngineConfig config) {
-        this(config, null);
+        this(
+            config,
+            config.isPromotableToPrimary() ? null : new TranslogStats(0, 0, 0, 0, 0),
+            config.isPromotableToPrimary()
+                ? null
+                : new SeqNoStats(
+                    config.getGlobalCheckpointSupplier().getAsLong(),
+                    config.getGlobalCheckpointSupplier().getAsLong(),
+                    config.getGlobalCheckpointSupplier().getAsLong()
+                )
+        );
     }
 
-    public NoOpEngine(EngineConfig config, @Nullable TranslogStats translogStats) {
-        super(config, null, translogStats, true, Function.identity(), true, true);
+    public NoOpEngine(EngineConfig config, @Nullable TranslogStats translogStats, SeqNoStats seqNoStats) {
+        super(config, seqNoStats, translogStats, true, Function.identity(), true, true);
         this.segmentsStats = new SegmentsStats();
         Directory directory = store.directory();
         try (DirectoryReader reader = openDirectory(directory)) {


### PR DESCRIPTION
Today it doesn't work to close an index which holds unpromotable shards. This commit fixes that.