### PR TITLE
 [DOCS] Remove coming tag from 8.6.1 release notes

### DIFF
--- a/docs/reference/release-notes/8.6.1.asciidoc
+++ b/docs/reference/release-notes/8.6.1.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.6.1]]
 == {es} version 8.6.1
 
-coming[8.6.1]
-
 Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 [[bug-8.6.1]]


### PR DESCRIPTION
This updates the Elasticsearch [8.6.1 release notes page](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-8.1.1.html) to remove the `coming` tag.

I will open a separate PR for `main` once the 8.6.1 release notes file appears in that branch (just wanted to have this all ready to go for when 8.6.1 goes live).

