### PR TITLE
[Docs] Replace outdated ingest-guide attribute

### DIFF
--- a/docs/reference/data-streams/set-up-a-data-stream.asciidoc
+++ b/docs/reference/data-streams/set-up-a-data-stream.asciidoc
@@ -73,7 +73,7 @@ template is used for data streams.
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
 patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{fleet-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams.
 
 If you use {agent}, assign your index templates a priority lower than `100` to

--- a/docs/reference/docs/index_.asciidoc
+++ b/docs/reference/docs/index_.asciidoc
@@ -171,7 +171,7 @@ the operation automatically creates the index and applies any matching
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
 patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{fleet-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. If you use {agent}, assign your index templates a priority
 lower than `100` to avoid overriding the built-in templates.
 

--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -30,7 +30,7 @@ following index patterns:
 - `metrics-*-*`
 // end::built-in-index-template-patterns[]
 
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{fleet-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. If you use {agent}, assign your index templates a priority
 lower than `100` to avoid an overriding the built-in templates. Otherwise, to avoid
 accidentally applying the built-in templates, do one or more of the following:

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -88,7 +88,7 @@ used to match the names of data streams and indices during creation.
 ====
 {es} has built-in index templates for the `metrics-*-*` and `logs-*-*` index
 patterns, each with a priority of `100`.
-{ingest-guide}/ingest-management-overview.html[{agent}] uses these templates to
+{fleet-guide}/ingest-management-overview.html[{agent}] uses these templates to
 create data streams. If you use {agent}, assign your index templates a priority
 lower than `100` to avoid an overriding the built-in templates.
 


### PR DESCRIPTION
This pre-emptively fixes broken links that will occur when the docs shared `ingest-guide` attribute is repurposed.

```
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.9/docs-index_.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.9/index-templates.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.9/indices-put-template.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
15:24:17 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/7.9/set-up-a-data-stream.html contains broken links to:
15:24:17 INFO:build_docs:   - en/ingest/7.9/ingest-management-overview.html
```