### PR TITLE
[DOCS] Clarify capabilities of built-in `editor` role

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -59,6 +59,8 @@ Grants full access to all features in {kib} (including Solutions) and read-only 
 ===============================
 * This role provides read access to any index that is not prefixed with a dot.
 * This role automatically grants full access to new {kib} features as soon as they are released.
+* Some {kib} features may also require creation or write access to data indices. {ml-cap} {dfanalytics-jobs}
+  is an example. For such features those privileges must be defined in a separate role.
 ===============================
 
 --


### PR DESCRIPTION
The built-in `editor` role allows "all" access to all Kibana features, but only read access to data indices. This doesn't work well for functionality that spans Kibana and Elasticsearch and allows the user to choose their own results index, like ML data frame analytics.

This change adjusts the notes on the `editor` role to make clear that in this case an additional role must be granted to give the necessary access on the data index that the results will be written to.