### PR TITLE
Fix compilation issue in TransportListTasksAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -128,11 +128,9 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
             } else {
                 future.addListener(
                     new ThreadedActionListener<>(
-                        logger,
-                        clusterService.threadPool(),
-                        ThreadPool.Names.MANAGEMENT,
-                        allMatchedTasksRemovedListener,
-                        false
+                        clusterService.threadPool().executor(ThreadPool.Names.MANAGEMENT),
+                        false,
+                        allMatchedTasksRemovedListener
                     )
                 );
                 var cancellable = clusterService.threadPool()


### PR DESCRIPTION
Use the new constructor signature for `ThreadedActionListener` from #93184

See #90977