### PR TITLE
Improve heuristic in geotile aggregation for using recursive vs brute  force strategy

### DIFF
--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoTileGridTiler.java
@@ -77,7 +77,7 @@ public abstract class GeoTileGridTiler extends GeoGridTiler {
         final long count = (long) (maxXTile - minXTile + 1) * (maxYTile - minYTile + 1);
         if (count == 1) {
             return setValue(values, minXTile, minYTile);
-        } else if (count <= precision) {
+        } else if (count <= 8L * precision) {
             return setValuesByBruteForceScan(values, geoValue, minXTile, minYTile, maxXTile, maxYTile);
         } else {
             return setValuesByRasterization(0, 0, 0, values, 0, geoValue);


### PR DESCRIPTION
Brute force approach is only executed if the bounding box of the geo_shape value intersects with the same number of tiles as the aggregation precision. This seems too conservative, more over as in each level we are visiting at least 4 tiles. Performance test suggest an improvement in the brute approach until we are visiting 8 tiles per level, other wise it is better the recursive approach.

This PR updates the heuristics to reflect those findings.