### PR TITLE
[8.6] [DOCS] Clarify capabilities of built-in `editor` role (#93260)

### DIFF
--- a/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
+++ b/x-pack/docs/en/security/authorization/built-in-roles.asciidoc
@@ -59,6 +59,8 @@ Grants full access to all features in {kib} (including Solutions) and read-only 
 ===============================
 * This role provides read access to any index that is not prefixed with a dot.
 * This role automatically grants full access to new {kib} features as soon as they are released.
+* Some {kib} features may also require creation or write access to data indices. {ml-cap} {dfanalytics-jobs}
+  is an example. For such features those privileges must be defined in a separate role.
 ===============================
 
 --


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Clarify capabilities of built-in `editor` role (#93260)