### PR TITLE
Additional debug logging

### DIFF
--- a/qa/rolling-upgrade/build.gradle
+++ b/qa/rolling-upgrade/build.gradle
@@ -40,6 +40,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
     setting 'xpack.security.enabled', 'false'
     setting 'logger.org.elasticsearch.cluster.routing.allocation.allocator.DesiredBalanceShardsAllocator', 'TRACE'
+    setting 'logger.org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders', 'TRACE'
     requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
   }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDeciders.java
@@ -142,6 +142,14 @@ public class AllocationDeciders {
             Decision decision = allocationDecider.canAllocate(indexMetadata, node, allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                        "Can not allocate [{}] on node [{}] due to [{}]",
+                        indexMetadata.getIndex().getName(),
+                        node.node(),
+                        allocationDecider.getClass().getSimpleName()
+                    );
+                }
                 if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {
@@ -178,6 +186,13 @@ public class AllocationDeciders {
             Decision decision = allocationDecider.canAllocate(shardRouting, allocation);
             // short track if a NO is returned.
             if (decision.type() == Decision.Type.NO) {
+                if (logger.isTraceEnabled()) {
+                    logger.trace(
+                        "Can not allocate [{}] on any node due to [{}]",
+                        shardRouting,
+                        allocationDecider.getClass().getSimpleName()
+                    );
+                }
                 if (allocation.debugDecision() == false) {
                     return Decision.NO;
                 } else {


### PR DESCRIPTION
According to the trace logs for the test failure https://github.com/elastic/elasticsearch/issues/93271, the shard is not allocated as there is no second node id for it in the desired balance produced by computer. This change could help identify a decider that is not allowing allocation during computation.

Related to: #93271 