### PR TITLE
IngestCtxMap hashmap optimization

### DIFF
--- a/docs/changelog/93278.yaml
+++ b/docs/changelog/93278.yaml
@@ -1,0 +1,5 @@
+pr: 93278
+summary: '`IngestCtxMap` hashmap optimization'
+area: Ingest Node
+type: enhancement
+issues: []

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/JsonProcessorTests.java
@@ -169,10 +169,7 @@ public class JsonProcessorTests extends ESTestCase {
         String processorTag = randomAlphaOfLength(3);
         JsonProcessor lenientJsonProcessor = new JsonProcessor(processorTag, null, "a", null, true, REPLACE, true);
 
-        Map<String, Object> document = new HashMap<>();
-        String json = "{\"a\": 1, \"a\": 2}";
-        document.put("a", json);
-        document.put("c", "see");
+        Map<String, Object> document = Map.of("a", "{\"a\": 1, \"a\": 2}", "c", "see");
 
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
         lenientJsonProcessor.execute(ingestDocument);

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/GeoIpProcessorFactoryTests.java
@@ -418,8 +418,7 @@ public class GeoIpProcessorFactoryTests extends ESTestCase {
         Map<String, Object> config = new HashMap<>();
         config.put("field", "source_field");
         GeoIpProcessor processor = (GeoIpProcessor) factory.create(null, null, null, config);
-        Map<String, Object> document = new HashMap<>();
-        document.put("source_field", "89.160.20.128");
+        Map<String, Object> document = Map.of("source_field", "89.160.20.128");
         {
             IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
             processor.execute(ingestDocument);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestCtxMap.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestCtxMap.java
@@ -42,7 +42,12 @@ class IngestCtxMap extends CtxMap<IngestDocMetadata> {
         ZonedDateTime timestamp,
         Map<String, Object> source
     ) {
-        super(new HashMap<>(source), new IngestDocMetadata(index, id, version, routing, versionType, timestamp));
+        // if source is already a HashMap, then just use it as is, otherwise we'll need to copy into a new HashMap so that
+        // we have something mutable
+        super(
+            (source instanceof HashMap) ? source : new HashMap<>(source),
+            new IngestDocMetadata(index, id, version, routing, versionType, timestamp)
+        );
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/ConditionalProcessorTests.java
@@ -62,7 +62,6 @@ public class ConditionalProcessorTests extends ESTestCase {
             new HashMap<>(ScriptModule.CORE_CONTEXTS),
             () -> 1L
         );
-        Map<String, Object> document = new HashMap<>();
         LongSupplier relativeTimeProvider = mock(LongSupplier.class);
         when(relativeTimeProvider.getAsLong()).thenReturn(0L, TimeUnit.MILLISECONDS.toNanos(1), 0L, TimeUnit.MILLISECONDS.toNanos(2));
         ConditionalProcessor processor = new ConditionalProcessor(
@@ -105,7 +104,7 @@ public class ConditionalProcessorTests extends ESTestCase {
 
         // false, never call processor never increments metrics
         String falseValue = "falsy";
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Map.of());
         ingestDocument.setFieldValue(conditionalField, falseValue);
         execProcessor(processor, ingestDocument, (result, e) -> {});
         assertThat(ingestDocument.getSourceAndMetadata().get(conditionalField), is(falseValue));
@@ -113,21 +112,21 @@ public class ConditionalProcessorTests extends ESTestCase {
         assertStats(processor, 0, 0, 0);
         assertEquals(scriptName, processor.getCondition());
 
-        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Map.of());
         ingestDocument.setFieldValue(conditionalField, falseValue);
         ingestDocument.setFieldValue("error", true);
         execProcessor(processor, ingestDocument, (result, e) -> {});
         assertStats(processor, 0, 0, 0);
 
         // true, always call processor and increments metrics
-        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Map.of());
         ingestDocument.setFieldValue(conditionalField, trueValue);
         execProcessor(processor, ingestDocument, (result, e) -> {});
         assertThat(ingestDocument.getSourceAndMetadata().get(conditionalField), is(trueValue));
         assertThat(ingestDocument.getSourceAndMetadata().get("foo"), is("bar"));
         assertStats(processor, 1, 0, 1);
 
-        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Map.of());
         ingestDocument.setFieldValue(conditionalField, trueValue);
         ingestDocument.setFieldValue("error", true);
         IngestDocument finalIngestDocument = ingestDocument;


### PR DESCRIPTION
A small optimization in terms of lines of code, but we're running this for every single document that goes through ingest, so it adds up. In one of my benchmarks we're spending 1% of the time spent inside `IngestService` and its callees just doing these re-hashes.