### PR TITLE
Refactor GeoIp tests to use database service directly

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeIT.java
@@ -112,9 +112,8 @@ public class GeoIpProcessorNonIngestNodeIT extends AbstractGeoIpIT {
     }
 
     private void assertDatabaseLoadStatus(final String node, final boolean loaded) {
-        final IngestService ingestService = internalCluster().getInstance(IngestService.class, node);
-        final GeoIpProcessor.Factory factory = (GeoIpProcessor.Factory) ingestService.getProcessorFactories().get("geoip");
-        for (final DatabaseReaderLazyLoader loader : factory.getAllDatabases()) {
+        final DatabaseNodeService databaseNodeService = internalCluster().getInstance(DatabaseNodeService.class, node);
+        for (final DatabaseReaderLazyLoader loader : databaseNodeService.getAllDatabases()) {
             if (loaded) {
                 assertNotNull(loader.databaseReader.get());
             } else {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -380,10 +380,6 @@ public final class GeoIpProcessor extends AbstractProcessor {
         private final DatabaseNodeService databaseNodeService;
         private final ClusterService clusterService;
 
-        List<DatabaseReaderLazyLoader> getAllDatabases() {
-            return databaseNodeService.getAllDatabases();
-        }
-
         public Factory(DatabaseNodeService databaseNodeService, ClusterService clusterService) {
             this.databaseNodeService = databaseNodeService;
             this.clusterService = clusterService;


### PR DESCRIPTION
This is just a really small refactoring to remove some interface bloat from the GeoIp processor that is stuck around for testing purposes. Nothing of note should have changed with this PR.

One test uses a method on the GeoIp processor factory to retrieve all current databases. The processor delegates the call to the DatabaseNodeService that it's holding. The test case gets an instance of the processor factory by getting an instance of a node's IngestService and looking up the processor. It's much simpler if the test simply gets the DatabaseNodeService from the node to cut out the middleman, since that service is surfaced as an injection component in the plugin.