### PR TITLE
[8.6] Refactor GeoIp tests to use database service directly (#93281)

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpProcessorNonIngestNodeIT.java
@@ -112,9 +112,8 @@ public class GeoIpProcessorNonIngestNodeIT extends AbstractGeoIpIT {
     }
 
     private void assertDatabaseLoadStatus(final String node, final boolean loaded) {
-        final IngestService ingestService = internalCluster().getInstance(IngestService.class, node);
-        final GeoIpProcessor.Factory factory = (GeoIpProcessor.Factory) ingestService.getProcessorFactories().get("geoip");
-        for (final DatabaseReaderLazyLoader loader : factory.getAllDatabases()) {
+        final DatabaseNodeService databaseNodeService = internalCluster().getInstance(DatabaseNodeService.class, node);
+        for (final DatabaseReaderLazyLoader loader : databaseNodeService.getAllDatabases()) {
             if (loaded) {
                 assertNotNull(loader.databaseReader.get());
             } else {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpProcessor.java
@@ -380,10 +380,6 @@ public final class GeoIpProcessor extends AbstractProcessor {
         private final DatabaseNodeService databaseNodeService;
         private final ClusterService clusterService;
 
-        List<DatabaseReaderLazyLoader> getAllDatabases() {
-            return databaseNodeService.getAllDatabases();
-        }
-
         public Factory(DatabaseNodeService databaseNodeService, ClusterService clusterService) {
             this.databaseNodeService = databaseNodeService;
             this.clusterService = clusterService;


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Refactor GeoIp tests to use database service directly (#93281)