### PR TITLE
Faster set intersection

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -159,6 +159,14 @@ public final class Sets {
         return union;
     }
 
+    /**
+     * The intersection of two sets. Namely, the resulting set contains all the elements that are in both sets.
+     * Neither input is mutated by this operation, an entirely new set is returned.
+     *
+     * @param set1 the first set
+     * @param set2 the second set
+     * @return the unmodifiable intersection of the two sets
+     */
     public static <T> Set<T> intersection(Set<T> set1, Set<T> set2) {
         Objects.requireNonNull(set1);
         Objects.requireNonNull(set2);
@@ -171,7 +179,21 @@ public final class Sets {
             left = set2;
             right = set1;
         }
-        return left.stream().filter(right::contains).collect(Collectors.toSet());
+
+        final Set<T> empty = Set.of();
+        Set<T> result = empty;
+        for (T t : left) {
+            if (right.contains(t)) {
+                if (result == empty) {
+                    // delay allocation of a non-empty result set
+                    result = new HashSet<>();
+                }
+                result.add(t);
+            }
+        }
+
+        // the empty set is already unmodifiable
+        return result == empty ? result : Collections.unmodifiableSet(result);
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
@@ -25,7 +25,9 @@ import static org.elasticsearch.common.util.set.Sets.addToCopy;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.sameInstance;
 
 public class SetsTests extends ESTestCase {
 
@@ -77,6 +79,14 @@ public class SetsTests extends ESTestCase {
             .filter(i -> (sets.v1().contains(i) && sets.v2().contains(i)))
             .collect(Collectors.toSet());
         assertThat(intersection, containsInAnyOrder(expectedIntersection.toArray(new Integer[0])));
+
+        final Set<Integer> emptyIntersection = Sets.intersection(
+            Sets.difference(sets.v1(), intersection),
+            Sets.difference(sets.v2(), intersection)
+        );
+        assertThat(emptyIntersection.isEmpty(), is(true));
+        // as an implementation detail, it's not just *some* empty set, but precisely *this* empty set
+        assertThat(emptyIntersection, sameInstance(Set.of()));
     }
 
     public void testNewHashSetWithExpectedSize() {


### PR DESCRIPTION
Replaces #93279

Unroll stream code, plain collections are faster for this.

Before:

<img width="1378" alt="Screen Shot 2023-01-26 at 5 36 15 PM" src="https://user-images.githubusercontent.com/187034/214966498-096cd2e2-53bb-473c-ac6c-95fbb7ec520d.png">

After:

<img width="1378" alt="Screen Shot 2023-01-26 at 5 38 30 PM" src="https://user-images.githubusercontent.com/187034/214966856-b3a8b96f-8e93-4259-bfb6-2ba198794c5c.png">


