### PR TITLE
Assert one-shot completion in IndexShardOperationPermits

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -540,7 +540,7 @@ public interface ActionListener<Response> {
                 private final AtomicReference<ElasticsearchException> firstCompletion = new AtomicReference<>();
 
                 private void assertFirstRun() {
-                    var previousRun = firstCompletion.compareAndExchange(null, new ElasticsearchException("first run"));
+                    var previousRun = firstCompletion.compareAndExchange(null, new ElasticsearchException(delegate.toString()));
                     assert previousRun == null : previousRun; // reports the stack traces of both completions
                 }
 

--- a/server/src/main/java/org/elasticsearch/action/ActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionListener.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action;
 
 import org.elasticsearch.Assertions;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.common.CheckedSupplier;
 import org.elasticsearch.core.CheckedConsumer;
@@ -19,7 +20,6 @@ import org.elasticsearch.core.Releasables;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
@@ -532,20 +532,27 @@ public interface ActionListener<Response> {
         };
     }
 
-    private static <Response> ActionListener<Response> assertOnce(ActionListener<Response> delegate) {
+    static <Response> ActionListener<Response> assertOnce(ActionListener<Response> delegate) {
         if (Assertions.ENABLED) {
             return new ActionListener<>() {
-                private final AtomicBoolean alreadyRan = new AtomicBoolean();
+
+                // if complete, records the stack trace which first completed it
+                private final AtomicReference<ElasticsearchException> firstCompletion = new AtomicReference<>();
+
+                private void assertFirstRun() {
+                    var previousRun = firstCompletion.compareAndExchange(null, new ElasticsearchException("first run"));
+                    assert previousRun == null : previousRun; // reports the stack traces of both completions
+                }
 
                 @Override
                 public void onResponse(Response response) {
-                    assert alreadyRan.compareAndSet(false, true) : "already executed: " + this;
+                    assertFirstRun();
                     delegate.onResponse(response);
                 }
 
                 @Override
                 public void onFailure(Exception e) {
-                    assert alreadyRan.compareAndSet(false, true) : "already executed: " + this;
+                    assertFirstRun();
                     delegate.onFailure(e);
                 }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
@@ -8,7 +8,10 @@
 
 package org.elasticsearch.index.shard;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.Assertions;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
@@ -18,6 +21,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext.StoredContext;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -29,7 +33,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
@@ -40,6 +43,8 @@ import java.util.function.Supplier;
  * completed.
  */
 final class IndexShardOperationPermits implements Closeable {
+
+    private static final Logger logger = LogManager.getLogger(IndexShardOperationPermits.class);
 
     private final ShardId shardId;
     private final ThreadPool threadPool;
@@ -81,7 +86,7 @@ final class IndexShardOperationPermits implements Closeable {
      * started. Delayed operations are run once the {@link Releasable} is released or if a failure occurs while acquiring all permits; in
      * this case the {@code onFailure} handler will be invoked after delayed operations are released.
      *
-     * @param onAcquired {@link ActionListener} that is invoked once acquisition is successful or failed
+     * @param onAcquired {@link ActionListener} that is invoked once acquisition is successful or failed. This listener should not throw.
      * @param timeout    the maximum time to wait for the in-flight operations block
      * @param timeUnit   the time unit of the {@code timeout} argument
      * @param executor   executor on which to wait for in-flight operations to finish and acquire all permits
@@ -106,9 +111,23 @@ final class IndexShardOperationPermits implements Closeable {
             }
 
             @Override
-            protected void doRun() throws Exception {
-                final Releasable releasable = acquireAll(timeout, timeUnit);
-                onAcquired.onResponse(() -> Releasables.close(releasable, released));
+            protected void doRun() {
+                final Releasable releasable;
+                try {
+                    releasable = acquireAll(timeout, timeUnit);
+                } catch (Exception e) {
+                    onFailure(e);
+                    return;
+                }
+
+                final Releasable combined = Releasables.wrap(releasable, released);
+                try {
+                    onAcquired.onResponse(combined);
+                } catch (Exception e) {
+                    logger.error("onAcquired#onResponse should not throw", e);
+                    assert false : e; // should not throw, we cannot do anything with this exception
+                    combined.close();
+                }
             }
         });
     }
@@ -123,7 +142,7 @@ final class IndexShardOperationPermits implements Closeable {
         }
     }
 
-    private Releasable acquireAll(final long timeout, final TimeUnit timeUnit) throws InterruptedException, TimeoutException {
+    private Releasable acquireAll(final long timeout, final TimeUnit timeUnit) throws InterruptedException {
         if (Assertions.ENABLED) {
             // since delayed is not volatile, we have to synchronize even here for visibility
             synchronized (this) {
@@ -137,7 +156,7 @@ final class IndexShardOperationPermits implements Closeable {
             });
             return release;
         } else {
-            throw new TimeoutException("timeout while blocking operations");
+            throw new ElasticsearchTimeoutException("timeout while blocking operations after [" + new TimeValue(timeout, timeUnit) + "]");
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShardOperationPermits.java
@@ -88,6 +88,10 @@ final class IndexShardOperationPermits implements Closeable {
      */
     public void blockOperations(final ActionListener<Releasable> onAcquired, final long timeout, final TimeUnit timeUnit, String executor) {
         delayOperations();
+        waitUntilBlocked(ActionListener.assertOnce(onAcquired), timeout, timeUnit, executor);
+    }
+
+    private void waitUntilBlocked(ActionListener<Releasable> onAcquired, long timeout, TimeUnit timeUnit, String executor) {
         threadPool.executor(executor).execute(new AbstractRunnable() {
 
             final Releasable released = Releasables.releaseOnce(() -> releaseDelayedOperations());
@@ -195,7 +199,7 @@ final class IndexShardOperationPermits implements Closeable {
         } else {
             stackTrace = null;
         }
-        acquire(onAcquired, executorOnDelay, forceExecution, debugInfo, stackTrace);
+        acquire(ActionListener.assertOnce(onAcquired), executorOnDelay, forceExecution, debugInfo, stackTrace);
     }
 
     private void acquire(

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -410,6 +410,8 @@ public class RecoverySourceHandler {
     ) {
         cancellableThreads.execute(() -> {
             CompletableFuture<Releasable> permit = new CompletableFuture<>();
+
+            // this wrapping looks unnecessary necessary, see #93290; TODO remove it
             final ActionListener<Releasable> onAcquired = new ActionListener<Releasable>() {
                 @Override
                 public void onResponse(Releasable releasable) {


### PR DESCRIPTION
It's vital that listeners passed to the `IndexShardOperationPermits` are not completed more than once, because otherwise the caller might not release the returned `Releasable` which would leak a permit. It looks like this is the case today, but one of its callers has some explicit protection against such a leak. This commit adds some assertions to demonstrate that this protection is not required.