### PR TITLE
Fix DataStreamIT#testWriteLoadAndAvgShardSizeIsStoredInABestEffort

### DIFF
--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -2099,6 +2099,7 @@ public class DataStreamIT extends ESIntegTestCase {
         DataStreamIT.putComposableIndexTemplate("my-template", null, List.of("logs-*"), indexSettings, null);
         final var createDataStreamRequest = new CreateDataStreamAction.Request(dataStreamName);
         assertAcked(client().execute(CreateDataStreamAction.INSTANCE, createDataStreamRequest).actionGet());
+        ensureGreen(dataStreamName);
 
         indexDocsAndEnsureThereIsCapturedWriteLoad(dataStreamName);
 


### PR DESCRIPTION
Ensure that all shards are started before making progress, this avoids issues when we expect one of the shards to be active but it isn't.

Closes #91967
