### PR TITLE
Remove length check for source-only keyword fields

### DIFF
--- a/docs/changelog/93299.yaml
+++ b/docs/changelog/93299.yaml
@@ -1,0 +1,6 @@
+pr: 93299
+summary: No length check for source-only keyword fields
+area: Mapping
+type: bug
+issues:
+ - 9304

--- a/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/KeywordFieldMapper.java
@@ -1003,37 +1003,39 @@ public final class KeywordFieldMapper extends FieldMapper {
             context.getDimensions().addString(fieldType().name(), binaryValue);
         }
 
-        // If the UTF8 encoding of the field value is bigger than the max length 32766, Lucene fill fail the indexing request and, to roll
-        // back the changes, will mark the (possibly partially indexed) document as deleted. This results in deletes, even in an append-only
-        // workload, which in turn leads to slower merges, as these will potentially have to fall back to MergeStrategy.DOC instead of
-        // MergeStrategy.BULK. To avoid this, we do a preflight check here before indexing the document into Lucene.
-        if (binaryValue.length > MAX_TERM_LENGTH) {
-            byte[] prefix = new byte[30];
-            System.arraycopy(binaryValue.bytes, binaryValue.offset, prefix, 0, 30);
-            String msg = "Document contains at least one immense term in field=\""
-                + fieldType().name()
-                + "\" (whose "
-                + "UTF8 encoding is longer than the max length "
-                + MAX_TERM_LENGTH
-                + "), all of which were "
-                + "skipped. Please correct the analyzer to not produce such terms. The prefix of the first immense "
-                + "term is: '"
-                + Arrays.toString(prefix)
-                + "...'";
-            throw new IllegalArgumentException(msg);
-        }
-
-        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
-            Field field = new KeywordField(fieldType().name(), binaryValue, fieldType);
-            context.doc().add(field);
-
-            if (fieldType().hasDocValues() == false && fieldType.omitNorms()) {
-                context.addToFieldNames(fieldType().name());
+        if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored() || fieldType().hasDocValues()) {
+            // If the UTF8 encoding of the field value is bigger than the max length 32766, Lucene fill fail the indexing request and, to
+            // roll back the changes, will mark the (possibly partially indexed) document as deleted. This results in deletes, even in an
+            // append-only workload, which in turn leads to slower merges, as these will potentially have to fall back to MergeStrategy.DOC
+            // instead of MergeStrategy.BULK. To avoid this, we do a preflight check here before indexing the document into Lucene.
+            if (binaryValue.length > MAX_TERM_LENGTH) {
+                byte[] prefix = new byte[30];
+                System.arraycopy(binaryValue.bytes, binaryValue.offset, prefix, 0, 30);
+                String msg = "Document contains at least one immense term in field=\""
+                    + fieldType().name()
+                    + "\" (whose "
+                    + "UTF8 encoding is longer than the max length "
+                    + MAX_TERM_LENGTH
+                    + "), all of which were "
+                    + "skipped. Please correct the analyzer to not produce such terms. The prefix of the first immense "
+                    + "term is: '"
+                    + Arrays.toString(prefix)
+                    + "...'";
+                throw new IllegalArgumentException(msg);
             }
-        }
 
-        if (fieldType().hasDocValues()) {
-            context.doc().add(new SortedSetDocValuesField(fieldType().name(), binaryValue));
+            if (fieldType.indexOptions() != IndexOptions.NONE || fieldType.stored()) {
+                Field field = new KeywordField(fieldType().name(), binaryValue, fieldType);
+                context.doc().add(field);
+
+                if (fieldType().hasDocValues() == false && fieldType.omitNorms()) {
+                    context.addToFieldNames(fieldType().name());
+                }
+            }
+
+            if (fieldType().hasDocValues()) {
+                context.doc().add(new SortedSetDocValuesField(fieldType().name(), binaryValue));
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -631,6 +631,23 @@ public class KeywordFieldMapperTests extends MapperTestCase {
         assertThat(e.getCause().getMessage(), containsString("UTF8 encoding is longer than the max length"));
     }
 
+    /**
+     * Test that we don't error on exceeding field size if field is neither indexed nor has doc values
+     */
+    public void testKeywordFieldUtf8LongerThan32766SourceOnly() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
+            b.field("type", "keyword");
+            b.field("index", false);
+            b.field("doc_values", false);
+            b.field("store", false);
+        }));
+        StringBuilder stringBuilder = new StringBuilder(32768);
+        for (int i = 0; i < 32768; i++) {
+            stringBuilder.append("a");
+        }
+        mapper.parse(source(b -> b.field("field", stringBuilder.toString())));
+    }
+
     @Override
     protected boolean supportsIgnoreMalformed() {
         return false;


### PR DESCRIPTION
Since 8.2 we check keyword fields length against Lucenes MAX_TERM_LENGTH size before indexing to prevent later errors and potential need for rollbacks (see #83738). This, however, currently also triggers even if the field is defined as not-indexed, not stored and without doc-values (effectively a source-only field). In this case, we don't need to apply the length check, making storing larger source-only keyword fields possible as before.

Closes #93046