### PR TITLE
Add America/Pangnirtung to the tz ignore list

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/DateUtilsTests.java
@@ -50,7 +50,7 @@ public class DateUtilsTests extends ESTestCase {
 
     // A temporary list of zones and JDKs, where Joda and the JDK timezone data are out of sync, until either Joda or the JDK
     // are updated, see https://github.com/elastic/elasticsearch/issues/82356
-    private static final Set<String> IGNORE_IDS = new HashSet<>(Arrays.asList("Pacific/Niue"));
+    private static final Set<String> IGNORE_IDS = new HashSet<>(Arrays.asList("Pacific/Niue", "America/Pangnirtung"));
 
     private static boolean maybeIgnore(String jodaId) {
         if (IGNORE_IDS.contains(jodaId)) {
@@ -59,7 +59,6 @@ public class DateUtilsTests extends ESTestCase {
         return false;
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93291")
     public void testTimezoneIds() {
         assertNull(DateUtils.dateTimeZoneToZoneId(null));
         assertNull(DateUtils.zoneIdToDateTimeZone(null));


### PR DESCRIPTION
This fixes #93291 and unmutes #93295.

The latest release of jdk11 updated the tzdata to 2022f, which includes changes to America/Pangnirtung. This is not reflected in joda time, so ignore this timezone when testing for differences