### PR TITLE
[8.6] Mute ComponentTemplatesFileSettingsIT.testSettingsApplied (#93300)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
@@ -531,6 +531,7 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         return new Tuple<>(savedClusterState, metadataVersion);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93202")
     public void testSettingsApplied() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Mute ComponentTemplatesFileSettingsIT.testSettingsApplied (#93300)