### PR TITLE
[ML] improve frequent_items performance by using global ordinals

### DIFF
--- a/docs/changelog/93304.yaml
+++ b/docs/changelog/93304.yaml
@@ -1,0 +1,5 @@
+pr: 93304
+summary: Improve `frequent_items` performance using global ordinals
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducer.java
@@ -9,10 +9,14 @@ package org.elasticsearch.xpack.ml.aggs.frequentitemsets;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.common.io.stream.ByteArrayStreamInput;
+import org.elasticsearch.common.io.stream.BytesRefStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.BytesRefArray;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Tuple;
@@ -132,6 +136,11 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
     private final Map<String, Object> profilingInfoReduce;
     private final Map<String, Object> profilingInfoMap;
 
+    @Override
+    protected OrdinalOptimization getDefaultOrdinalOptimization() {
+        return OrdinalOptimization.GLOBAL_ORDINALS;
+    }
+
     public EclatMapReducer(String aggregationName, double minimumSupport, int minimumSetSize, int size, boolean profiling) {
         super(aggregationName, NAME);
 
@@ -199,8 +208,10 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
     }
 
     @Override
-    protected ImmutableTransactionStore mapFinalize(HashBasedTransactionStore transactionStore) {
+    protected ImmutableTransactionStore mapFinalize(HashBasedTransactionStore transactionStore, List<OrdinalLookupFunction> ordinalLookup)
+        throws IOException {
 
+        final long relativeStartNanos = System.nanoTime();
         // reported by shard in collectDebugInfo
         if (profiling) {
             // note: collect this before creating the immutable transaction store as memory gets freed
@@ -212,13 +223,70 @@ public final class EclatMapReducer extends AbstractItemSetMapReducer<
             profilingInfoMap.put("unique_transactions_after_map", transactionStore.getUniqueTransactionCount());
         }
 
-        ImmutableTransactionStore transactionStoreMapFinalize = transactionStore.createImmutableTransactionStore();
+        ImmutableTransactionStore transactionStoreMapFinalize = rewriteOrdinalItems(
+            transactionStore.createImmutableTransactionStore(),
+            ordinalLookup
+        );
 
         if (profiling) {
             profilingInfoMap.put("ram_bytes_transactionstore_map_finalize", transactionStoreMapFinalize.ramBytesUsed());
+            profilingInfoMap.put("runtime_ms_finalize_map", TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - relativeStartNanos));
         }
 
         return transactionStoreMapFinalize;
+    }
+
+    /**
+     * rewrites items that use ordinals to their real values
+     */
+    private ImmutableTransactionStore rewriteOrdinalItems(
+        ImmutableTransactionStore transactionStore,
+        List<OrdinalLookupFunction> ordinalLookups
+    ) throws IOException {
+        if (ordinalLookups == null || ordinalLookups.isEmpty()) {
+            return transactionStore;
+        }
+
+        logger.trace("rewrite items based on ordinals");
+
+        BytesRef scratchBytesRef = new BytesRef();
+        ByteArrayStreamInput scratchByteArrayStreamInput = new ByteArrayStreamInput();
+        BytesRefStreamOutput scratchItemBytesStreamOutput = new BytesRefStreamOutput();
+        BytesRefArray items = transactionStore.getItems();
+
+        BytesRefArray rewrittenItems = null;
+        try {
+            rewrittenItems = new BytesRefArray(items.size(), transactionStore.getBigArrays());
+
+            for (long i = 0; i < items.size(); ++i) {
+                items.get(i, scratchBytesRef);
+                scratchByteArrayStreamInput.reset(scratchBytesRef.bytes, scratchBytesRef.offset, scratchBytesRef.length);
+                int fieldId = scratchByteArrayStreamInput.readVInt();
+                Object ordinal = scratchByteArrayStreamInput.readGenericValue();
+                scratchItemBytesStreamOutput.reset();
+                scratchItemBytesStreamOutput.writeVInt(fieldId);
+                scratchItemBytesStreamOutput.writeGenericValue(ordinalLookups.get(fieldId).apply(ordinal));
+
+                rewrittenItems.append(scratchItemBytesStreamOutput.get());
+            }
+
+            // swap items
+            ImmutableTransactionStore rewrittenStore = new ImmutableTransactionStore(
+                transactionStore.getBigArrays(),
+                rewrittenItems,
+                transactionStore.getItemCounts(),
+                transactionStore.getTotalItemCount(),
+                transactionStore.getTransactions(),
+                transactionStore.getTransactionCounts(),
+                transactionStore.getTotalTransactionCount(),
+                transactionStore.getFilteredTransactionCount()
+            );
+
+            rewrittenItems = items;
+            return rewrittenStore;
+        } finally {
+            Releasables.close(rewrittenItems);
+        }
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilder.java
@@ -32,8 +32,6 @@ import org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr.ItemSetMapReduceValue
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.TreeSet;
 
 import static org.elasticsearch.common.Strings.format;
 
@@ -44,7 +42,7 @@ public final class FrequentItemSetsAggregationBuilder extends AbstractAggregatio
     public static final double DEFAULT_MINIMUM_SUPPORT = 0.01;
     public static final int DEFAULT_MINIMUM_SET_SIZE = 1;
     public static final int DEFAULT_SIZE = 10;
-    public static final Set<String> EXECUTION_HINT_ALLOWED_MODES = new TreeSet<>(Set.of("global_ordinals", "map"));
+    public static final List<String> EXECUTION_HINT_ALLOWED_MODES = List.of("global_ordinals", "map");
 
     public static final ParseField MINIMUM_SUPPORT = new ParseField("minimum_support");
     public static final ParseField MINIMUM_SET_SIZE = new ParseField("minimum_set_size");

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionStore.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/TransactionStore.java
@@ -194,6 +194,10 @@ abstract class TransactionStore implements Writeable, Releasable, Accountable {
         this.bigArrays = bigArrays;
     }
 
+    BigArrays getBigArrays() {
+        return bigArrays;
+    }
+
     /**
      * Get the total number of items
      *

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/AbstractItemSetMapReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/AbstractItemSetMapReducer.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.core.CheckedFunction;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.InternalAggregation;
@@ -69,11 +70,8 @@ public abstract class AbstractItemSetMapReducer<
 
     /**
      * Interface to lookup the real object from an ordinal
-     * Note: not using Function due to the possible IOException
      */
-    public interface OrdinalLookupFunction {
-        Object apply(Object ord) throws IOException;
-    }
+    public interface OrdinalLookupFunction extends CheckedFunction<Object, Object, IOException> {}
 
     private final String aggregationName;
     private final String mapReducerName;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregation.java
@@ -17,7 +17,6 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.SamplingContext;
 import org.elasticsearch.search.profile.SearchProfileResults;
 import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.ToXContent.DelegatingMapParams;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr.ItemSetMapReduceValueSource.Field;
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
@@ -217,7 +217,6 @@ public abstract class ItemSetMapReduceAggregator<
             return buildEmptyAggregation();
         }
 
-        //
         return new InternalItemSetMapReduceAggregation<>(name, metadata(), mapReducer, context, null, fields, profiling);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceAggregator.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr;
 
+import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.Weight;
@@ -55,6 +57,7 @@ public abstract class ItemSetMapReduceAggregator<
     private final BigArrays bigArraysForMapReduce;
     private final LongObjectPagedHashMap<Object> mapReduceContextByBucketOrdinal;
     private final boolean profiling;
+    private final boolean rewriteBasedOnOrdinals;
     private final DelegatingCircuitBreakerService breakerService;
 
     protected ItemSetMapReduceAggregator(
@@ -65,29 +68,35 @@ public abstract class ItemSetMapReduceAggregator<
         Map<String, Object> metadata,
         AbstractItemSetMapReducer<MapContext, MapFinalContext, ReduceContext, Result> mapReducer,
         List<Tuple<ValuesSourceConfig, IncludeExclude>> configsAndValueFilters,
-        QueryBuilder documentFilter
+        QueryBuilder documentFilter,
+        AbstractItemSetMapReducer.OrdinalOptimization ordinalOptimization
     ) throws IOException {
         super(name, AggregatorFactories.EMPTY, context, parent, CardinalityUpperBound.NONE, metadata);
 
         List<ItemSetMapReduceValueSource> valueSources = new ArrayList<>();
         List<Field> fields = new ArrayList<>();
         IndexSearcher contextSearcher = context.searcher();
+        LeafReaderContext ctx = getLeafReaderForOrdinals(context);
 
         int id = 0;
         this.weightDocumentFilter = documentFilter != null
             ? contextSearcher.createWeight(contextSearcher.rewrite(context.buildQuery(documentFilter)), ScoreMode.COMPLETE_NO_SCORES, 1f)
             : null;
 
+        boolean rewriteBasedOnOrdinals = false;
+
         for (var c : configsAndValueFilters) {
             ItemSetMapReduceValueSource e = context.getValuesSourceRegistry()
                 .getAggregator(registryKey, c.v1())
-                .build(c.v1(), id++, c.v2());
+                .build(c.v1(), id++, c.v2(), ordinalOptimization, ctx);
             if (e.getField().getName() != null) {
                 fields.add(e.getField());
                 valueSources.add(e);
             }
+            rewriteBasedOnOrdinals |= e.usesOrdinals();
         }
 
+        this.rewriteBasedOnOrdinals = rewriteBasedOnOrdinals;
         this.valueSources = Collections.unmodifiableList(valueSources);
         this.fields = Collections.unmodifiableList(fields);
         this.mapReducer = mapReducer;
@@ -157,10 +166,20 @@ public abstract class ItemSetMapReduceAggregator<
     }
 
     @Override
-    public void doPostCollection() {
+    public void doPostCollection() throws IOException {
+        List<AbstractItemSetMapReducer.OrdinalLookupFunction> ordinalLookupFunctions = null;
+
+        // only rewrite ordinals back to real values when required
+        if (rewriteBasedOnOrdinals) {
+            ordinalLookupFunctions = new ArrayList<>(valueSources.size());
+            for (ItemSetMapReduceValueSource valueSource : valueSources) {
+                ordinalLookupFunctions.add(valueSource::mapOrdinal);
+            }
+        }
+
         for (long ordIdx = 0; ordIdx < mapReduceContextByBucketOrdinal.size(); ordIdx++) {
             MapContext context = getMapReduceContext(ordIdx);
-            mapReduceContextByBucketOrdinal.put(ordIdx, mapReducer.mapFinalize(context));
+            mapReduceContextByBucketOrdinal.put(ordIdx, mapReducer.mapFinalize(context, ordinalLookupFunctions));
         }
     }
 
@@ -198,7 +217,12 @@ public abstract class ItemSetMapReduceAggregator<
             return buildEmptyAggregation();
         }
 
+        //
         return new InternalItemSetMapReduceAggregation<>(name, metadata(), mapReducer, context, null, fields, profiling);
     }
 
+    private static LeafReaderContext getLeafReaderForOrdinals(AggregationContext context) {
+        IndexReader reader = context.searcher().getIndexReader();
+        return reader.leaves().get(0);
+    }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java
@@ -319,7 +319,9 @@ public abstract class ItemSetMapReduceValueSource {
         ) throws IOException {
             super(config, id, ValueFormatter.BYTES_REF);
 
-            if (AbstractItemSetMapReducer.OrdinalOptimization.GLOBAL_ORDINALS.equals(ordinalOptimization) && config.hasOrdinals()) {
+            if (AbstractItemSetMapReducer.OrdinalOptimization.GLOBAL_ORDINALS.equals(ordinalOptimization)
+                && config.getValuesSource() instanceof Bytes.WithOrdinals
+                && ((Bytes.WithOrdinals) config.getValuesSource()).supportsGlobalOrdinalsMapping()) {
                 logger.debug("Use ordinals for field [{}]", config.fieldContext().field());
 
                 this.executionStrategy = new GlobalOrdinals(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java
@@ -179,14 +179,14 @@ public abstract class ItemSetMapReduceValueSource {
             boolean usesOrdinals();
         }
 
-        static class GlobalOrdinals implements ExecutionStrategy {
+        static class GlobalOrdinalsStrategy implements ExecutionStrategy {
 
             private final Field field;
             private final Bytes.WithOrdinals source;
             private final SortedSetDocValues docValues;
             private final LongBitSet bitSetFilter;
 
-            GlobalOrdinals(
+            GlobalOrdinalsStrategy(
                 Field field,
                 Bytes.WithOrdinals source,
                 IncludeExclude.OrdinalsFilter globalOrdinalsFilter,
@@ -250,13 +250,13 @@ public abstract class ItemSetMapReduceValueSource {
             }
         }
 
-        static class Map implements ExecutionStrategy {
+        static class MapStrategy implements ExecutionStrategy {
 
             private final Field field;
             private final Bytes source;
             private final IncludeExclude.StringFilter stringFilter;
 
-            Map(Field field, Bytes source, IncludeExclude.StringFilter stringFilter) {
+            MapStrategy(Field field, Bytes source, IncludeExclude.StringFilter stringFilter) {
                 this.field = field;
                 this.source = source;
                 this.stringFilter = stringFilter;
@@ -324,14 +324,14 @@ public abstract class ItemSetMapReduceValueSource {
                 && ((Bytes.WithOrdinals) config.getValuesSource()).supportsGlobalOrdinalsMapping()) {
                 logger.debug("Use ordinals for field [{}]", config.fieldContext().field());
 
-                this.executionStrategy = new GlobalOrdinals(
+                this.executionStrategy = new GlobalOrdinalsStrategy(
                     getField(),
                     (Bytes.WithOrdinals) config.getValuesSource(),
                     includeExclude == null ? null : includeExclude.convertToOrdinalsFilter(config.format()),
                     ctx
                 );
             } else {
-                this.executionStrategy = new Map(
+                this.executionStrategy = new MapStrategy(
                     getField(),
                     (Bytes) config.getValuesSource(),
                     includeExclude == null ? null : includeExclude.convertToStringFilter(config.format())

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/ItemSetMapReduceValueSource.java
@@ -7,9 +7,13 @@
 
 package org.elasticsearch.xpack.ml.aggs.frequentitemsets.mr;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.SortedNumericDocValues;
+import org.apache.lucene.index.SortedSetDocValues;
 import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.LongBitSet;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -39,7 +43,13 @@ public abstract class ItemSetMapReduceValueSource {
      */
     @FunctionalInterface
     public interface ValueSourceSupplier {
-        ItemSetMapReduceValueSource build(ValuesSourceConfig config, int id, IncludeExclude includeExclude);
+        ItemSetMapReduceValueSource build(
+            ValuesSourceConfig config,
+            int id,
+            IncludeExclude includeExclude,
+            AbstractItemSetMapReducer.OrdinalOptimization ordinalOptimization,
+            LeafReaderContext ctx
+        ) throws IOException;
     }
 
     /**
@@ -134,6 +144,7 @@ public abstract class ItemSetMapReduceValueSource {
     }
 
     private final Field field;
+    private static final Logger logger = LogManager.getLogger(ItemSetMapReduceValueSource.class);
 
     abstract ValueCollector getValueCollector(LeafReaderContext ctx) throws IOException;
 
@@ -150,51 +161,206 @@ public abstract class ItemSetMapReduceValueSource {
         return field;
     }
 
-    public static class KeywordValueSource extends ItemSetMapReduceValueSource {
-        private final ValuesSource.Bytes source;
-        private final IncludeExclude.StringFilter stringFilter;
+    boolean usesOrdinals() {
+        return false;
+    }
 
-        public KeywordValueSource(ValuesSourceConfig config, int id, IncludeExclude includeExclude) {
+    Object mapOrdinal(Object ord) throws IOException {
+        return ord;
+    }
+
+    public static class KeywordValueSource extends ItemSetMapReduceValueSource {
+
+        interface ExecutionStrategy {
+            ValueCollector getValueCollector(LeafReaderContext ctx) throws IOException;
+
+            Object mapOrdinal(Object ord) throws IOException;
+
+            boolean usesOrdinals();
+        }
+
+        static class GlobalOrdinals implements ExecutionStrategy {
+
+            private final Field field;
+            private final Bytes.WithOrdinals source;
+            private final LeafReaderContext ctx;
+            private final LongBitSet bitSetFilter;
+
+            GlobalOrdinals(
+                Field field,
+                Bytes.WithOrdinals source,
+                IncludeExclude.OrdinalsFilter globalOrdinalsFilter,
+                LeafReaderContext ctx
+            ) throws IOException {
+                this.field = field;
+                this.source = source;
+                this.ctx = ctx;
+
+                bitSetFilter = globalOrdinalsFilter != null
+                    ? globalOrdinalsFilter.acceptedGlobalOrdinals(source.globalOrdinalsValues(ctx))
+                    : null;
+            }
+
+            @Override
+            public ValueCollector getValueCollector(LeafReaderContext ctx) throws IOException {
+                final SortedSetDocValues values = source.globalOrdinalsValues(ctx);
+                final Tuple<Field, List<Object>> empty = new Tuple<>(field, Collections.emptyList());
+
+                return doc -> {
+                    if (values.advanceExact(doc)) {
+                        int valuesCount = values.docValueCount();
+
+                        if (valuesCount == 1) {
+                            long v = values.nextOrd();
+                            if (bitSetFilter == null || bitSetFilter.get(v)) {
+                                return new Tuple<>(field, Collections.singletonList(v));
+                            }
+                            return empty;
+                        }
+
+                        if (valuesCount == 0) {
+                            return empty;
+                        }
+
+                        List<Object> objects = new ArrayList<>(valuesCount);
+
+                        for (int i = 0; i < valuesCount; ++i) {
+                            long v = values.nextOrd();
+                            if (bitSetFilter == null || bitSetFilter.get(v)) {
+                                objects.add(v);
+                            }
+                        }
+                        return new Tuple<>(field, objects);
+                    }
+                    return empty;
+                };
+            }
+
+            @Override
+            public boolean usesOrdinals() {
+                return true;
+            }
+
+            @Override
+            public Object mapOrdinal(Object ord) throws IOException {
+                return source.globalOrdinalsValues(ctx).lookupOrd((Long) ord);
+            }
+        }
+
+        static class Map implements ExecutionStrategy {
+
+            private final Field field;
+            private final Bytes source;
+            private final IncludeExclude.StringFilter stringFilter;
+
+            Map(Field field, Bytes source, IncludeExclude.StringFilter stringFilter) {
+                this.field = field;
+                this.source = source;
+                this.stringFilter = stringFilter;
+            }
+
+            @Override
+            public ValueCollector getValueCollector(LeafReaderContext ctx) throws IOException {
+                final SortedBinaryDocValues values = source.bytesValues(ctx);
+                final Tuple<Field, List<Object>> empty = new Tuple<>(field, Collections.emptyList());
+
+                return doc -> {
+                    if (values.advanceExact(doc)) {
+                        int valuesCount = values.docValueCount();
+
+                        if (valuesCount == 1) {
+                            BytesRef v = values.nextValue();
+                            if (stringFilter == null || stringFilter.accept(v)) {
+                                return new Tuple<>(field, Collections.singletonList(BytesRef.deepCopyOf(v)));
+                            }
+                            return empty;
+                        }
+
+                        if (valuesCount == 0) {
+                            return empty;
+                        }
+
+                        List<Object> objects = new ArrayList<>(valuesCount);
+
+                        for (int i = 0; i < valuesCount; ++i) {
+                            BytesRef v = values.nextValue();
+                            if (stringFilter == null || stringFilter.accept(v)) {
+                                objects.add(BytesRef.deepCopyOf(v));
+                            }
+                        }
+                        return new Tuple<>(field, objects);
+                    }
+                    return empty;
+                };
+            }
+
+            @Override
+            public boolean usesOrdinals() {
+                return false;
+            }
+
+            @Override
+            public Object mapOrdinal(Object ord) {
+                return ord;
+            }
+        }
+
+        private final ExecutionStrategy executionStrategy;
+
+        public KeywordValueSource(
+            ValuesSourceConfig config,
+            int id,
+            IncludeExclude includeExclude,
+            AbstractItemSetMapReducer.OrdinalOptimization ordinalOptimization,
+            LeafReaderContext ctx
+        ) throws IOException {
             super(config, id, ValueFormatter.BYTES_REF);
-            this.source = (Bytes) config.getValuesSource();
-            this.stringFilter = includeExclude == null ? null : includeExclude.convertToStringFilter(config.format());
+
+            if (AbstractItemSetMapReducer.OrdinalOptimization.GLOBAL_ORDINALS.equals(ordinalOptimization) && config.hasOrdinals()) {
+                logger.debug("Use ordinals for field [{}]", config.fieldContext().field());
+
+                this.executionStrategy = new GlobalOrdinals(
+                    getField(),
+                    (Bytes.WithOrdinals) config.getValuesSource(),
+                    includeExclude == null ? null : includeExclude.convertToOrdinalsFilter(config.format()),
+                    ctx
+                );
+            } else {
+                this.executionStrategy = new Map(
+                    getField(),
+                    (Bytes) config.getValuesSource(),
+                    includeExclude == null ? null : includeExclude.convertToStringFilter(config.format())
+                );
+            }
         }
 
         @Override
         ValueCollector getValueCollector(LeafReaderContext ctx) throws IOException {
-            final SortedBinaryDocValues values = source.bytesValues(ctx);
-            final Field field = getField();
-            final Tuple<Field, List<Object>> empty = new Tuple<>(field, Collections.emptyList());
-
-            return doc -> {
-                if (values.advanceExact(doc)) {
-                    int valuesCount = values.docValueCount();
-
-                    if (valuesCount == 0) {
-                        return empty;
-                    }
-
-                    List<Object> objects = new ArrayList<>(valuesCount);
-
-                    for (int i = 0; i < valuesCount; ++i) {
-                        BytesRef v = values.nextValue();
-                        if (stringFilter == null || stringFilter.accept(v)) {
-                            objects.add(BytesRef.deepCopyOf(v));
-                        }
-                    }
-                    return new Tuple<>(field, objects);
-                }
-                return empty;
-            };
+            return executionStrategy.getValueCollector(ctx);
         }
 
+        @Override
+        public boolean usesOrdinals() {
+            return executionStrategy.usesOrdinals();
+        }
+
+        @Override
+        Object mapOrdinal(Object ord) throws IOException {
+            return executionStrategy.mapOrdinal(ord);
+        }
     }
 
     public static class NumericValueSource extends ItemSetMapReduceValueSource {
         private final ValuesSource.Numeric source;
         private final IncludeExclude.LongFilter longFilter;
 
-        public NumericValueSource(ValuesSourceConfig config, int id, IncludeExclude includeExclude) {
+        public NumericValueSource(
+            ValuesSourceConfig config,
+            int id,
+            IncludeExclude includeExclude,
+            AbstractItemSetMapReducer.OrdinalOptimization unusedOrdinalOptimization,
+            LeafReaderContext unusedCtx
+        ) {
             super(config, id, ValueFormatter.LONG);
             this.source = (Numeric) config.getValuesSource();
             this.longFilter = includeExclude == null ? null : includeExclude.convertToLongFilter(config.format());
@@ -209,6 +375,14 @@ public abstract class ItemSetMapReduceValueSource {
             return doc -> {
                 if (values.advanceExact(doc)) {
                     int valuesCount = values.docValueCount();
+
+                    if (valuesCount == 1) {
+                        long v = values.nextValue();
+                        if (longFilter == null || longFilter.accept(v)) {
+                            return new Tuple<>(getField(), Collections.singletonList(v));
+                        }
+                        return empty;
+                    }
 
                     if (valuesCount == 0) {
                         return empty;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/EclatMapReducerTests.java
@@ -485,7 +485,7 @@ public class EclatMapReducerTests extends ESTestCase {
         HashBasedTransactionStore transactionStoreForReduce = eclat.reduceInit(mockBigArrays());
 
         for (HashBasedTransactionStore transactionStore : transactionStores) {
-            ImmutableTransactionStore transactionStoreAfterFinalizing = eclat.mapFinalize(transactionStore);
+            ImmutableTransactionStore transactionStoreAfterFinalizing = eclat.mapFinalize(transactionStore, null);
             List<ImmutableTransactionStore> allPartitions = List.of(transactionStoreAfterFinalizing);
             eclat.reduce(allPartitions.stream(), transactionStoreForReduce, doNotCancelSupplier);
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregationBuilderTests.java
@@ -31,6 +31,7 @@ import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.ml.aggs.frequentitemsets.FrequentItemSetsAggregationBuilder.EXECUTION_HINT_ALLOWED_MODES;
 import static org.hamcrest.Matchers.hasSize;
 
 public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSerializingTestCase<FrequentItemSetsAggregationBuilder> {
@@ -62,7 +63,8 @@ public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSer
             randomDoubleBetween(0.0, 1.0, false),
             randomIntBetween(1, 20),
             randomIntBetween(1, 20),
-            randomBoolean() ? QueryBuilders.termQuery(randomAlphaOfLength(10), randomAlphaOfLength(10)) : null
+            randomBoolean() ? QueryBuilders.termQuery(randomAlphaOfLength(10), randomAlphaOfLength(10)) : null,
+            randomFrom(EXECUTION_HINT_ALLOWED_MODES)
         );
     }
 
@@ -125,7 +127,8 @@ public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSer
                 1.2,
                 randomIntBetween(1, 20),
                 randomIntBetween(1, 20),
-                null
+                null,
+                randomFrom(EXECUTION_HINT_ALLOWED_MODES)
             )
         );
         assertEquals("[minimum_support] must be greater than 0 and less or equal to 1. Found [1.2] in [fi]", e.getMessage());
@@ -141,7 +144,8 @@ public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSer
                 randomDoubleBetween(0.0, 1.0, false),
                 -4,
                 randomIntBetween(1, 20),
-                null
+                null,
+                randomFrom(EXECUTION_HINT_ALLOWED_MODES)
             )
         );
 
@@ -158,7 +162,8 @@ public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSer
                 randomDoubleBetween(0.0, 1.0, false),
                 randomIntBetween(1, 20),
                 -2,
-                null
+                null,
+                randomFrom(EXECUTION_HINT_ALLOWED_MODES)
             )
         );
 
@@ -175,26 +180,47 @@ public class FrequentItemSetsAggregationBuilderTests extends AbstractXContentSer
             randomDoubleBetween(0.0, 1.0, false),
             randomIntBetween(1, 20),
             randomIntBetween(1, 20),
-            null
+            null,
+            randomFrom(EXECUTION_HINT_ALLOWED_MODES)
         ).subAggregation(AggregationBuilders.avg("fieldA")));
 
         assertEquals("Aggregator [fi] of type [frequent_items] cannot accept sub-aggregations", e.getMessage());
 
-        e = expectThrows(IllegalArgumentException.class, () ->
-
-        new FrequentItemSetsAggregationBuilder(
-            "fi",
-            List.of(
-                new MultiValuesSourceFieldConfig.Builder().setFieldName("fieldA").build(),
-                new MultiValuesSourceFieldConfig.Builder().setFieldName("fieldB").build()
-            ),
-            randomDoubleBetween(0.0, 1.0, false),
-            randomIntBetween(1, 20),
-            randomIntBetween(1, 20),
-            null
-        ).subAggregations(new AggregatorFactories.Builder().addAggregator(AggregationBuilders.avg("fieldA"))));
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new FrequentItemSetsAggregationBuilder(
+                "fi",
+                List.of(
+                    new MultiValuesSourceFieldConfig.Builder().setFieldName("fieldA").build(),
+                    new MultiValuesSourceFieldConfig.Builder().setFieldName("fieldB").build()
+                ),
+                randomDoubleBetween(0.0, 1.0, false),
+                randomIntBetween(1, 20),
+                randomIntBetween(1, 20),
+                null,
+                randomFrom(EXECUTION_HINT_ALLOWED_MODES)
+            ).subAggregations(new AggregatorFactories.Builder().addAggregator(AggregationBuilders.avg("fieldA")))
+        );
 
         assertEquals("Aggregator [fi] of type [frequent_items] cannot accept sub-aggregations", e.getMessage());
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> new FrequentItemSetsAggregationBuilder(
+                "fi",
+                List.of(
+                    new MultiValuesSourceFieldConfig.Builder().setFieldName("fieldA").build(),
+                    new MultiValuesSourceFieldConfig.Builder().setFieldName("fieldB").build()
+                ),
+                randomDoubleBetween(0.0, 1.0, false),
+                randomIntBetween(1, 20),
+                randomIntBetween(1, 20),
+                null,
+                "wrong-execution-mode"
+            )
+        );
+
+        assertEquals("[execution_hint] must be one of [global_ordinals,map]. Found [wrong-execution-mode]", e.getMessage());
     }
 
     private static IncludeExclude randomIncludeExclude() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetsAggregatorTests.java
@@ -51,6 +51,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Tuple.tuple;
+import static org.elasticsearch.xpack.ml.aggs.frequentitemsets.FrequentItemSetsAggregationBuilder.EXECUTION_HINT_ALLOWED_MODES;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
 public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
@@ -87,7 +88,8 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             FrequentItemSetsAggregationBuilder.DEFAULT_MINIMUM_SUPPORT,
             FrequentItemSetsAggregationBuilder.DEFAULT_MINIMUM_SET_SIZE,
             FrequentItemSetsAggregationBuilder.DEFAULT_SIZE,
-            null
+            null,
+            randomFrom(EXECUTION_HINT_ALLOWED_MODES)
         );
     }
 
@@ -134,7 +136,8 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             minimumSupport,
             minimumSetSize,
             size,
-            null
+            null,
+            randomFrom(EXECUTION_HINT_ALLOWED_MODES)
         );
 
         testCase(iw -> {
@@ -337,7 +340,8 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             minimumSupport,
             minimumSetSize,
             size,
-            null
+            null,
+            randomFrom(EXECUTION_HINT_ALLOWED_MODES)
         );
 
         testCase(iw -> {
@@ -552,7 +556,8 @@ public class FrequentItemSetsAggregatorTests extends AggregatorTestCase {
             minimumSupport,
             minimumSetSize,
             size,
-            null
+            null,
+            randomFrom(EXECUTION_HINT_ALLOWED_MODES)
         );
 
         testCase(iw -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
@@ -149,7 +149,7 @@ public class InternalItemSetMapReduceAggregationTests extends InternalAggregatio
         }
 
         @Override
-        protected WordCounts mapFinalize(WordCounts mapReduceContext) {
+        protected WordCounts mapFinalize(WordCounts mapReduceContext, List<OrdinalLookupFunction> ordinalLookup) {
             return mapReduceContext;
         }
 


### PR DESCRIPTION
implement global ordinals for frequent items and add execution_hint to switch between the old (map) based lookup and global ordinals

Ordinals in a nutshell: Instead of reading a value directly when collecting, we only read the ordinal ("value number 5"). This makes collection faster and speeds up de-duplication. At the end of mapping (because global ordinals are per shard) we need an extra step to resolve "value number 5" to its real value.