### PR TITLE
Add missing counter field support to some aggregations.

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -221,3 +221,45 @@ setup:
 
   - match: { aggregations.date_field_max.value: 1619827200000 }
   - match: { aggregations.date_field_max.value_as_string: "2021-05-01T00:00:00.000Z" }
+
+---
+"Counter field":
+  - skip:
+      version: " - 8.6.99"
+      reason: "counter field support added in 8.7"
+
+  - do:
+      indices.create:
+        index: myindex
+        body:
+          mappings:
+            properties:
+              counter_field:
+                type : long
+                time_series_metric: counter
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: myindex
+              _id:    "1"
+          - counter_field: 2
+          - index:
+              _index: myindex
+              _id:    "2"
+          - counter_field: 4
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: myindex
+        body:
+          aggs:
+            the_counter_max:
+              max:
+                field: counter_field
+
+  - match: { hits.total: 2 }
+  - length: { hits.hits: 2 }
+  - match: { aggregations.the_counter_max.value: 2 }

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -262,4 +262,4 @@ setup:
 
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
-  - match: { aggregations.the_counter_max.value: 2 }
+  - match: { aggregations.the_counter_max.value: 4 }

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/min_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/min_metric.yml
@@ -175,3 +175,45 @@ setup:
             the_string_min:
               min:
                 field: string_field
+
+---
+"Counter field":
+  - skip:
+      version: " - 8.6.99"
+      reason: "counter field support added in 8.7"
+
+  - do:
+      indices.create:
+        index: myindex
+        body:
+          mappings:
+            properties:
+              counter_field:
+                type : long
+                time_series_metric: counter
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: myindex
+              _id:    "1"
+          - counter_field: 2
+          - index:
+              _index: myindex
+              _id:    "2"
+          - counter_field: 4
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: myindex
+        body:
+          aggs:
+            the_counter_min:
+              min:
+                field: counter_field
+
+  - match: { hits.total: 2 }
+  - length: { hits.hits: 2 }
+  - match: { aggregations.the_counter_min.value: 2 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -29,7 +30,12 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory {
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
         builder.register(
             MaxAggregationBuilder.REGISTRY_KEY,
-            List.of(CoreValuesSourceType.NUMERIC, CoreValuesSourceType.DATE, CoreValuesSourceType.BOOLEAN),
+            List.of(
+                CoreValuesSourceType.NUMERIC,
+                CoreValuesSourceType.DATE,
+                CoreValuesSourceType.BOOLEAN,
+                TimeSeriesValuesSourceType.COUNTER
+            ),
             MaxAggregator::new,
             true
         );

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
+import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
@@ -29,7 +30,12 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory {
     static void registerAggregators(ValuesSourceRegistry.Builder builder) {
         builder.register(
             MinAggregationBuilder.REGISTRY_KEY,
-            List.of(CoreValuesSourceType.NUMERIC, CoreValuesSourceType.DATE, CoreValuesSourceType.BOOLEAN),
+            List.of(
+                CoreValuesSourceType.NUMERIC,
+                CoreValuesSourceType.DATE,
+                CoreValuesSourceType.BOOLEAN,
+                TimeSeriesValuesSourceType.COUNTER
+            ),
             MinAggregator::new,
             true
         );

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/topmetrics/TopMetricsAggregationBuilder.java
@@ -17,6 +17,7 @@ import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.MultiValuesSourceFieldConfig;
+import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry.RegistryKey;
 import org.elasticsearch.search.sort.SortBuilder;
@@ -49,7 +50,12 @@ public class TopMetricsAggregationBuilder extends AbstractAggregationBuilder<Top
 
     public static void registerAggregators(ValuesSourceRegistry.Builder registry) {
         registry.registerUsage(NAME);
-        registry.register(REGISTRY_KEY, List.of(CoreValuesSourceType.NUMERIC), TopMetricsAggregator::buildNumericMetricValues, false);
+        registry.register(
+            REGISTRY_KEY,
+            List.of(CoreValuesSourceType.NUMERIC, TimeSeriesValuesSourceType.COUNTER),
+            TopMetricsAggregator::buildNumericMetricValues,
+            false
+        );
         registry.register(
             REGISTRY_KEY,
             List.of(CoreValuesSourceType.BOOLEAN, CoreValuesSourceType.DATE),

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -721,8 +721,10 @@
           mappings:
             properties:
               counter_field:
-                type : long
+                type: long
                 time_series_metric: counter
+              number_field:
+                type: long
 
   - do:
       bulk:
@@ -731,13 +733,13 @@
           - index:
               _index: myindex
               _id:    "1"
-          - host_field: "hosta"
-          - counter_field: 2
+          - number_field: 1
+            counter_field: 2
           - index:
               _index: myindex
               _id:    "2"
-          - host_field: "hostb"
-          - counter_field: 4
+          - number_field: 2
+            counter_field: 4
   - do:
       search:
         rest_total_hits_as_int: true
@@ -749,9 +751,9 @@
                 metrics:
                   field: counter_field
                 sort:
-                  host: asc
+                  number_field: asc
 
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
-  - match: { aggregations.the_counter_top_metrics.0.sort: ["hosta"] }
-  - match: { aggregations.the_counter_top_metrics.0.metrics.counter_field: 2 }
+  - match: { aggregations.the_counter_top_metrics.top.0.sort: [1] }
+  - match: { aggregations.the_counter_top_metrics.top.0.metrics.counter_field: 2 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -707,3 +707,51 @@
                 size: 3
   - match: { aggregations.tm.top.0.sort: [1] }
   - match: { aggregations.tm.top.0.metrics.host\.hostname: abc }
+
+---
+"Counter field":
+  - skip:
+      version: " - 8.6.99"
+      reason: "counter field support added in 8.7"
+
+  - do:
+      indices.create:
+        index: myindex
+        body:
+          mappings:
+            properties:
+              counter_field:
+                type : long
+                time_series_metric: counter
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: myindex
+              _id:    "1"
+          - host_field: "hosta"
+          - counter_field: 2
+          - index:
+              _index: myindex
+              _id:    "2"
+          - host_field: "hostb"
+          - counter_field: 4
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: myindex
+        body:
+          aggs:
+            the_counter_top_metrics:
+              top_metrics:
+                metrics:
+                  field: counter_field
+                sort:
+                  host: asc
+
+  - match: { hits.total: 2 }
+  - length: { hits.hits: 2 }
+  - match: { aggregations.the_counter_top_metrics.0.sort: ["hosta"] }
+  - match: { aggregations.the_counter_top_metrics.0.metrics.counter_field: 2 }


### PR DESCRIPTION
This adds missing counter field support to min, max and top_metrics aggregations.

Not all aggregations support field with `time_series_metric` set to `counter`.
This is because computing certain aggregations on these counter fields don't make much sense.
For example, computing a `sum` or `avg` on a counter field doesn't make sense, because
counter fields are monodically increasing number fields (with sometimes a reset). 

However supporting counter field support to min, max and top_metrics aggregations makes sense 
and can be useful.