### PR TITLE
[6.8] Mute MapperSizeClientYamlTestSuiteIT test {yaml=mapper_size/10_basic/Mapper Size} (#93305)

### DIFF
--- a/plugins/mapper-size/src/test/resources/rest-api-spec/test/mapper_size/10_basic.yml
+++ b/plugins/mapper-size/src/test/resources/rest-api-spec/test/mapper_size/10_basic.yml
@@ -3,6 +3,9 @@
 
 ---
 "Mapper Size":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/93303"
 
     - do:
         indices.create:


### PR DESCRIPTION
Backports the following commits to 6.8:
 - Mute MapperSizeClientYamlTestSuiteIT test {yaml=mapper_size/10_basic/Mapper Size} (#93305)