### PR TITLE
[ML] Prevent modification of immutable set in trained model rebalancer

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -809,15 +809,15 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         final PersistentTasksCustomMetadata currentPersistentTasks = event.state().getMetadata().custom(PersistentTasksCustomMetadata.TYPE);
         Set<String> previousMlTaskIds = findMlProcessTaskIds(previousPersistentTasks);
         Set<String> currentMlTaskIds = findMlProcessTaskIds(currentPersistentTasks);
-        previousMlTaskIds.removeAll(currentMlTaskIds);
         Set<String> stoppedTaskTypes = previousMlTaskIds.stream()
+            .filter(id -> currentMlTaskIds.contains(id) == false) // remove the tasks that are still present. Stopped Ids only.
             .map(previousPersistentTasks::getTask)
             .map(PersistentTasksCustomMetadata.PersistentTask::getTaskName)
             .map(MlTasks::prettyPrintTaskName)
             .collect(Collectors.toSet());
-        if (previousMlTaskIds.size() == 1) {
+        if (stoppedTaskTypes.size() == 1) {
             return Optional.of("ML [" + stoppedTaskTypes.iterator().next() + "] job stopped");
-        } else if (previousMlTaskIds.size() > 1) {
+        } else if (stoppedTaskTypes.size() > 1) {
             return Optional.of("ML " + stoppedTaskTypes + " jobs stopped");
         }
         return Optional.empty();


### PR DESCRIPTION
The set returned by `TrainedModelAssignmentClusterService::findMlProcessTaskIds(PersistentTasksCustomMetadata)` is an immutable empty set if the argument is null. The code then attempts to modify this set causing an `UnsupportedOperationException` to be thrown. 

https://github.com/elastic/elasticsearch/blob/7b71c94884c1e418a840373e890f3d2c19db126b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java#L827

Non issue as the only side effect was to spam the logs with the UOE. In the rare cases it failed the operation is tried again on the next cluster change event.

For #93062