### PR TITLE
[7.17] Correctly mute MapperSizeClientYamlTestSuiteIT test {yaml=mapper_size/10_basic/Mapper Size} (#93315)

### DIFF
--- a/plugins/mapper-size/src/yamlRestTest/resources/rest-api-spec/test/mapper_size/10_basic.yml
+++ b/plugins/mapper-size/src/yamlRestTest/resources/rest-api-spec/test/mapper_size/10_basic.yml
@@ -4,6 +4,10 @@
 ---
 "Mapper Size":
 
+    - skip:
+        version: "all"
+        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/93303"
+
     - do:
         indices.create:
             index: test


### PR DESCRIPTION
Relates #93303
