### PR TITLE
[TEST] Fix staleness in fetching component templates

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
@@ -399,15 +399,17 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         boolean awaitSuccessful = savedClusterState.await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
-        final var response = client().execute(
-            GetComposableIndexTemplateAction.INSTANCE,
-            new GetComposableIndexTemplateAction.Request("template*")
-        ).get();
+        assertBusy(() -> {
+            final var response = client().execute(
+                GetComposableIndexTemplateAction.INSTANCE,
+                new GetComposableIndexTemplateAction.Request("template*")
+            ).get();
 
-        assertThat(
-            response.indexTemplates().keySet().stream().collect(Collectors.toSet()),
-            containsInAnyOrder("template_1", "template_2", "template_other")
-        );
+            assertThat(
+                response.indexTemplates().keySet().stream().collect(Collectors.toSet()),
+                containsInAnyOrder("template_1", "template_2", "template_other")
+            );
+        }, 60L, TimeUnit.SECONDS);
 
         assertTrue(
             expectThrows(
@@ -531,7 +533,6 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
         return new Tuple<>(savedClusterState, metadataVersion);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93202")
     public void testSettingsApplied() throws Exception {
         internalCluster().setBootstrapMasterNodeIndex(0);
         logger.info("--> start data node / non master node");


### PR DESCRIPTION
Result from the API call seems behind the most recent state. This change changes how we fetch the templates to ensure we use the most recent metadata version.

Based on the server logs we did write the index and component templates as we should've, but the API call made doesn't find them occasionally. I believe this is because the state hasn't propagated fully so we should retry the API call for a bit.

From the logs:

```
1> [2023-01-27T05:25:15,717][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t1] adding component template [runtime_component_template] |  
-- | --
  | 1> [2023-01-27T05:25:15,718][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t1] adding component template [component_template1] |  
  | 1> [2023-01-27T05:25:15,720][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t1] adding component template [other_component_template] |  
  | 1> [2023-01-27T05:25:15,722][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t1] adding index template [template_other] for index patterns [foo*, mar*] |  
  | 1> [2023-01-27T05:25:15,725][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t1] adding index template [template_2] for index patterns [foo*, mar*] |  
  | 1> [2023-01-27T05:25:15,727][INFO ][o.e.c.m.MetadataIndexTemplateService] [node_t1] adding index template [template_1] for index patterns [te*, bar*]
```

Closes https://github.com/elastic/elasticsearch/issues/93202