### PR TITLE
[ML] Fix data counts race condition when starting a datafeed

### DIFF
--- a/docs/changelog/93324.yaml
+++ b/docs/changelog/93324.yaml
@@ -1,0 +1,6 @@
+pr: 93324
+summary: Fix data counts race condition when starting a datafeed
+area: Machine Learning
+type: bug
+issues:
+ - 93298

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -334,7 +334,6 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
         ModelSnapshot modelSnapshot,
         String jobId
     ) {
-
         return ActionListener.wrap(response -> jobResultsProvider.dataCounts(jobId, counts -> {
             counts.setLatestRecordTimeStamp(modelSnapshot.getLatestRecordTimeStamp());
             jobDataCountsPersister.persistDataCountsAsync(jobId, counts, listener.delegateFailure((l, r) -> l.onResponse(response)));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -95,6 +95,7 @@ import org.elasticsearch.xpack.core.ml.MlMetaIndex;
 import org.elasticsearch.xpack.core.ml.action.GetBucketsAction;
 import org.elasticsearch.xpack.core.ml.action.GetCategoriesAction;
 import org.elasticsearch.xpack.core.ml.action.GetInfluencersAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetRecordsAction;
 import org.elasticsearch.xpack.core.ml.calendars.Calendar;
 import org.elasticsearch.xpack.core.ml.calendars.ScheduledEvent;
@@ -2010,17 +2011,36 @@ public class JobResultsProvider {
     public void getRestartTimeInfo(String jobId, ActionListener<RestartTimeInfo> listener) {
         AtomicReference<Bucket> latestFinalBucketHolder = new AtomicReference<>();
 
-        Consumer<DataCounts> dataCountsHandler = dataCounts -> listener.onResponse(
-            new RestartTimeInfo(
-                latestFinalBucketHolder.get() == null ? null : latestFinalBucketHolder.get().getTimestamp().getTime(),
-                dataCounts.getLatestRecordTimeStamp() == null ? null : dataCounts.getLatestRecordTimeStamp().getTime(),
-                dataCounts.getInputRecordCount() > 0
-            )
-        );
+        ActionListener<GetJobsStatsAction.Response> jobStatsHandler = ActionListener.wrap(r -> {
+            QueryPage<GetJobsStatsAction.Response.JobStats> page = r.getResponse();
+            if (page.count() == 1) {
+                DataCounts dataCounts = page.results().get(0).getDataCounts();
+                listener.onResponse(
+                    new RestartTimeInfo(
+                        latestFinalBucketHolder.get() == null ? null : latestFinalBucketHolder.get().getTimestamp().getTime(),
+                        dataCounts.getLatestRecordTimeStamp() == null ? null : dataCounts.getLatestRecordTimeStamp().getTime(),
+                        dataCounts.getInputRecordCount() > 0
+                    )
+                );
+            } else {
+                listener.onFailure(
+                    new IllegalStateException(
+                        "[" + jobId + "] Incorrect response for job stats for single job: got [" + page.count() + "] stats."
+                    )
+                );
+            }
+        }, listener::onFailure);
 
         ActionListener<Bucket> latestFinalBucketListener = ActionListener.wrap(latestFinalBucket -> {
             latestFinalBucketHolder.set(latestFinalBucket);
-            dataCounts(jobId, dataCountsHandler, listener::onFailure);
+            // If the job is open we must get the data counts from the running job instead of from the index,
+            // as the data counts in the running job might be more recent than those that have been indexed. If
+            // we go to the index it would be more efficient to just get the data counts rather than all stats.
+            // However, we _shouldn't_ ever do this when starting a datafeed, because a precondition for starting
+            // the datafeed is that its job is open. Therefore, it's reasonable to always go via the get job stats
+            // endpoint, on the assumption it will almost always get the stats from memory. (The only edge case
+            // where this won't happen is when the job fails during datafeed startup, and that should be very rare.)
+            client.execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request(jobId), jobStatsHandler);
         }, listener::onFailure);
 
         getLatestFinalBucket(jobId, latestFinalBucketListener);


### PR DESCRIPTION
When a datafeed starts up it looks at the job's data counts to decide where to pick up from where a previous invocation finished. Previously the datafeed was always getting the data counts from the index. In the case where a datafeed has been stopped and restarted while its corresponding job was continually opened this is incorrect. In this case the data counts need to be obtained from the running job. (In the case where the job was closed and reopened while the datafeed was stopped this does not matter, as closing the job will have persisted the up-to-date data counts.)

This bug has always existed, yet is made much more likely to cause a noticeable discrepancy by the changes made in #93000.

Fixes #93298