### PR TITLE
[ML] Wait for _infer to work after restart in full cluster restart tests.

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/test/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -99,8 +99,10 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractFullClusterRe
                 request.addParameter("timeout", "70s");
             }));
             waitForDeploymentStarted(modelId);
-            assertInfer(modelId);
-            assertNewInfer(modelId);
+            assertBusy(() -> {
+                assertInfer(modelId);
+                assertNewInfer(modelId);
+            }, 90, TimeUnit.SECONDS);
             stopDeployment(modelId);
         }
     }


### PR DESCRIPTION
After a full cluster restart a model's deployment status is reported as _started_ if it was started before the restart. This can cause a temporary inconsistency while the model is starting up again. Eventually the model either starts and the _started_ status is now correct or the model deployment fails the status is updated with a failure reason. 

Rolling upgrades do not suffer the same problem as the trained model allocator notices nodes disappearing/reappearing updates the model's status at that point.

Closes #93325