### PR TITLE
Handle a default/request pipeline and a final pipeline with minimal additional overhead

### DIFF
--- a/docs/changelog/93329.yaml
+++ b/docs/changelog/93329.yaml
@@ -2,7 +2,7 @@ pr: 93329
 summary: Handle a default/request pipeline and a final pipeline with minimal additional
   overhead
 area: Ingest Node
-type: refactoring
+type: "bug, refactoring"
 issues:
  - 92843
  - 81244

--- a/docs/changelog/93329.yaml
+++ b/docs/changelog/93329.yaml
@@ -1,0 +1,57 @@
+pr: 93329
+summary: Handle a default/request pipeline and a final pipeline with minimal additional
+  overhead
+area: Ingest Node
+type: refactoring
+issues:
+ - 92843
+ - 81244
+ - 93118
+highlight:
+  title: Handle a default/request pipeline and a final pipeline with minimal additional
+    overhead
+  body: |-
+    Closes #81244 Closes #92843 Closes #93118
+
+    Tightens up the document handling aspects of `executePipelines` and its
+    callees. `innerExecute` becomes trivial, and nearly drops out (renamed
+    to `executePipeline` where it remains just to adapt handler shapes).
+
+    At a high level, the execution goes from:
+
+    ```
+    - pipeline 1 (default/request pipeline):
+      - parse json
+      - execute processors
+      - generate json
+    - pipeline 2 (final pipeline):
+      - parse json
+      - execute processors
+      - generate json
+    ```
+
+    to
+
+    ```
+    - parse json
+    - pipeline 1 (default/request pipeline):
+      - execute processors
+    - pipeline 2 (final pipeline):
+      - execute processors
+    - generate json
+    ```
+
+    The difference in the flame graph is pretty clear. Before:
+
+    <img width="1792" alt="Screen Shot 2023-01-25 at 3 29 39 PM"
+    src="https://user-images.githubusercontent.com/187034/214683083-9537b47a-971a-4a2a-afec-1e351ab6c003.png">
+
+    After:
+
+    <img width="1738" alt="Screen Shot 2023-01-27 at 12 59 31 PM"
+    src="https://user-images.githubusercontent.com/187034/215160676-61133594-04b9-4570-b2cc-3e9025436797.png">
+
+    And the performance is much better, as one would expect, with the total
+    time spent in any ingest code for the nightly security benchmark
+    dropping from 4994128 to 3568490 millis -- a decrease of 29%.
+  notable: true

--- a/docs/changelog/93329.yaml
+++ b/docs/changelog/93329.yaml
@@ -8,50 +8,13 @@ issues:
  - 81244
  - 93118
 highlight:
-  title: Handle a default/request pipeline and a final pipeline with minimal additional
-    overhead
+  title: Speed up ingest processing with multiple pipelines
   body: |-
-    Closes #81244 Closes #92843 Closes #93118
+    Processing documents with both a request/default and a final
+    pipeline is significantly faster.
 
-    Tightens up the document handling aspects of `executePipelines` and its
-    callees. `innerExecute` becomes trivial, and nearly drops out (renamed
-    to `executePipeline` where it remains just to adapt handler shapes).
-
-    At a high level, the execution goes from:
-
-    ```
-    - pipeline 1 (default/request pipeline):
-      - parse json
-      - execute processors
-      - generate json
-    - pipeline 2 (final pipeline):
-      - parse json
-      - execute processors
-      - generate json
-    ```
-
-    to
-
-    ```
-    - parse json
-    - pipeline 1 (default/request pipeline):
-      - execute processors
-    - pipeline 2 (final pipeline):
-      - execute processors
-    - generate json
-    ```
-
-    The difference in the flame graph is pretty clear. Before:
-
-    <img width="1792" alt="Screen Shot 2023-01-25 at 3 29 39 PM"
-    src="https://user-images.githubusercontent.com/187034/214683083-9537b47a-971a-4a2a-afec-1e351ab6c003.png">
-
-    After:
-
-    <img width="1738" alt="Screen Shot 2023-01-27 at 12 59 31 PM"
-    src="https://user-images.githubusercontent.com/187034/215160676-61133594-04b9-4570-b2cc-3e9025436797.png">
-
-    And the performance is much better, as one would expect, with the total
-    time spent in any ingest code for the nightly security benchmark
-    dropping from 4994128 to 3568490 millis -- a decrease of 29%.
+    Rather than marshalling a document from and to json once per
+    pipeline, a document is now marshalled from json before any
+    pipelines execute and then back to json after all pipelines have
+    executed.
   notable: true

--- a/docs/changelog/93329.yaml
+++ b/docs/changelog/93329.yaml
@@ -2,7 +2,7 @@ pr: 93329
 summary: Handle a default/request pipeline and a final pipeline with minimal additional
   overhead
 area: Ingest Node
-type: "bug, refactoring"
+type: bug
 issues:
  - 92843
  - 81244

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/190_script_processor.yml
@@ -313,7 +313,7 @@ teardown:
               "foo": "bar"
             }
           }
-  - match: { error.root_cause.0.reason: "Failed to generate the source document for ingest pipeline [my_pipeline]" }
+  - match: { error.root_cause.0.reason: "Failed to generate the source document for ingest pipeline [my_pipeline] for document [test/1]" }
 
 ---
 "Test metadata":

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
@@ -53,6 +53,7 @@ import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasToString;
@@ -89,7 +90,12 @@ public class FinalPipelineIT extends ESIntegTestCase {
             IllegalStateException.class,
             () -> client().prepareIndex("index").setId("1").setSource(Map.of("field", "value")).get()
         );
-        assertThat(e, hasToString(containsString("final pipeline [final_pipeline] can't change the target index")));
+        assertThat(
+            e,
+            hasToString(
+                endsWith("final pipeline [final_pipeline] can't change the target index (from [index] to [target]) for document [1]")
+            )
+        );
     }
 
     public void testFinalPipelineOfOldDestinationIsNotInvoked() {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocument.java
@@ -829,6 +829,12 @@ public final class IngestDocument {
      * @param handler handles the result or failure
      */
     public void executePipeline(Pipeline pipeline, BiConsumer<IngestDocument, Exception> handler) {
+        // shortcut if the pipeline is empty
+        if (pipeline.getProcessors().isEmpty()) {
+            handler.accept(this, null);
+            return;
+        }
+
         if (executedPipelines.add(pipeline.getId())) {
             Object previousPipeline = ingestMetadata.put("pipeline", pipeline.getId());
             pipeline.execute(this, (result, e) -> {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -742,12 +742,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         assert it.hasNext();
         final String pipelineId = it.next();
         try {
-            PipelineHolder holder = pipelines.get(pipelineId);
+            final PipelineHolder holder = pipelines.get(pipelineId);
             if (holder == null) {
                 throw new IllegalArgumentException("pipeline with id [" + pipelineId + "] does not exist");
             }
-            Pipeline pipeline = holder.pipeline;
-            String originalIndex = indexRequest.indices()[0];
+            final Pipeline pipeline = holder.pipeline;
+            final String originalIndex = indexRequest.indices()[0];
             long startTimeInNanos = System.nanoTime();
             totalMetrics.preIngest();
             innerExecute(slot, indexRequest, pipeline, onDropped, e -> {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -819,7 +819,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
                 Iterator<String> newIt = it;
                 boolean newHasFinalPipeline = hasFinalPipeline;
-                String newIndex = indexRequest.indices()[0];
+                final String newIndex = indexRequest.indices()[0];
 
                 if (Objects.equals(originalIndex, newIndex) == false) {
                     if (hasFinalPipeline && it.hasNext() == false) {

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -907,11 +907,6 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
     }
 
     private void innerExecute(final IngestDocument ingestDocument, final Pipeline pipeline, final BiConsumer<Boolean, Exception> handler) {
-        if (pipeline.getProcessors().isEmpty()) {
-            handler.accept(true, null);
-            return;
-        }
-
         ingestDocument.executePipeline(pipeline, (result, e) -> {
             if (e != null) {
                 handler.accept(true, e);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -823,7 +823,17 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
                 if (Objects.equals(originalIndex, newIndex) == false) {
                     if (hasFinalPipeline && pipelineIds.hasNext() == false) {
-                        listener.onFailure(new IllegalStateException("final pipeline [" + pipelineId + "] can't change the target index"));
+                        listener.onFailure(
+                            new IllegalStateException(
+                                format(
+                                    "final pipeline [%s] can't change the target index (from [%s] to [%s]) for document [%s]",
+                                    pipelineId,
+                                    originalIndex,
+                                    newIndex,
+                                    indexRequest.id()
+                                )
+                            )
+                        );
                         return; // document failed!
                     } else {
                         indexRequest.isPipelineResolved(false);

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -805,7 +805,12 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                     // In that case, we catch and wrap the exception, so we can include more details
                     listener.onFailure(
                         new IllegalArgumentException(
-                            format("Failed to generate the source document for ingest pipeline [%s]", pipelineId),
+                            format(
+                                "Failed to generate the source document for ingest pipeline [%s] for document [%s/%s]",
+                                pipelineId,
+                                indexRequest.index(),
+                                indexRequest.id()
+                            ),
                             ex
                         )
                     );

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1864,8 +1864,7 @@ public class IngestServiceTests extends ESTestCase {
         assertThat(indexRequest5.getRawTimestamp(), nullValue());
         assertThat(indexRequest6.getRawTimestamp(), equalTo(10));
         assertThat(indexRequest7.getRawTimestamp(), equalTo(100));
-        // see https://github.com/elastic/elasticsearch/issues/93118 -- this should be 100, but it's actually 10
-        // assertThat(indexRequest8.getRawTimestamp(), equalTo(100));
+        assertThat(indexRequest8.getRawTimestamp(), equalTo(100));
     }
 
     public void testResolveRequiredOrDefaultPipelineDefaultPipeline() {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1484,8 +1484,7 @@ public class IngestServiceTests extends ESTestCase {
             assertThat(ingestStats.getPipelineStats().size(), equalTo(3));
 
             // total
-            // see https://github.com/elastic/elasticsearch/issues/92843 -- this should be 1, but it's actually 2
-            // assertStats(ingestStats.getTotalStats(), 1, 0, 0);
+            assertStats(ingestStats.getTotalStats(), 1, 0, 0);
             // pipeline
             assertPipelineStats(ingestStats.getPipelineStats(), "_id1", 1, 0, 0);
             assertPipelineStats(ingestStats.getPipelineStats(), "_id2", 1, 0, 0);


### PR DESCRIPTION
Closes #81244
Closes #92843
Closes #93118

Tightens up the document handling aspects of `executePipelines` and its callees. `innerExecute` becomes trivial, and nearly drops out (renamed to `executePipeline` where it remains just to adapt handler shapes).

At a high level, the execution goes from:
```
- pipeline 1 (default/request pipeline):
  - parse json
  - execute processors
  - generate json
- pipeline 2 (final pipeline):
  - parse json
  - execute processors
  - generate json
```
to 
```
- parse json
- pipeline 1 (default/request pipeline):
  - execute processors
- pipeline 2 (final pipeline):
  - execute processors
- generate json
```

The difference in the flame graph is pretty clear. Before:

<img width="1792" alt="Screen Shot 2023-01-25 at 3 29 39 PM" src="https://user-images.githubusercontent.com/187034/214683083-9537b47a-971a-4a2a-afec-1e351ab6c003.png">

After:

<img width="1738" alt="Screen Shot 2023-01-27 at 12 59 31 PM" src="https://user-images.githubusercontent.com/187034/215160676-61133594-04b9-4570-b2cc-3e9025436797.png">

And the performance is much better, as one would expect, with the total time spent in any ingest code for the nightly security benchmark dropping from 4994128 to 3568490 millis -- a decrease of 29%.

This is the direct follow up to #93213, but I've been working up to over a while -- #93119 and #93120 added the tests that are now made passing by this PR, while #92203, #92308, #92455 laid some of the groundwork for the eventual document listener cleanup.