### PR TITLE
Test approach for splitting out single search data from global search data in

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QuerySearchResult.java
@@ -389,7 +389,7 @@ public final class QuerySearchResult extends SearchPhaseResult {
     }
 
     public QuerySearchResult from(int from) {
-        primarySearchResult.size();
+        primarySearchResult.from(from);
         return this;
     }
 


### PR DESCRIPTION
Add secondary search results to QuerySearchResult so we can support multiple queries through the query and fetch phases.