### PR TITLE
Script: Metadata validateMetadata optimization

### DIFF
--- a/docs/changelog/93333.yaml
+++ b/docs/changelog/93333.yaml
@@ -1,0 +1,5 @@
+pr: 93333
+summary: "Script: Metadata `validateMetadata` optimization"
+area: Infra/Scripting
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -72,7 +72,7 @@ public class Metadata {
      * @param map the backing map for this metadata instance
      * @param properties the map of defined properties for the type of metadata represented by this instance
      */
-    public Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
+    protected Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
         this.map = map;
         this.properties = Map.copyOf(properties);
         validateMetadata();

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -239,7 +239,7 @@ public class Metadata {
 
     @Override
     public Metadata clone() {
-        // properties is an UnmodifiableMap, no need to create a copy
+        // properties is an unmodifiable map, no need to create a copy here
         return new Metadata(new HashMap<>(map), properties);
     }
 

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -58,6 +58,20 @@ public class Metadata {
     private final Map<String, FieldProperty<?>> properties;
     protected static final FieldProperty<?> BAD_KEY = new FieldProperty<>(null, false, false, null);
 
+    /**
+     * Constructs a new Metadata object represented by the given map and properties.
+     * <p>
+     * The passed-in map is used directly -- subsequent modifications to it outside the methods of this class may result in
+     * undefined behavior. By contrast, the properties map is copied via {@link Map#copyOf(Map)}) in order to ensure that it cannot be
+     * changed.
+     * <p>
+     * As an implementation detail, since {@link Map#copyOf(Map)} is a no-op if the passed-in instance is an "unmodifiable map"
+     * (as defined by {@link Map#copyOf(Map)}), callers of this constructor should construct their passed-in properties map via
+     * {@link Map#of(Object, Object)}} in order to ensure optimal performance.
+     *
+     * @param map the backing map for this metadata instance
+     * @param properties the map of defined properties for the type of metadata represented by this instance
+     */
     public Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
         this.map = map;
         this.properties = Map.copyOf(properties);

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -78,6 +78,9 @@ public class Metadata {
         validateMetadata();
     }
 
+    // a 'not found' sentinel value for use in validateMetadata below
+    private static final Object NOT_FOUND = new Object();
+
     /**
      * Check that all metadata map contains only valid metadata and no extraneous keys
      */
@@ -85,10 +88,15 @@ public class Metadata {
         int numMetadata = 0;
         for (Map.Entry<String, FieldProperty<?>> entry : properties.entrySet()) {
             String key = entry.getKey();
-            if (map.containsKey(key)) {
+            Object value = map.getOrDefault(key, NOT_FOUND);
+            if (value != NOT_FOUND) {
                 numMetadata++;
+                // check whether it's permissible to have the value for the property
+                entry.getValue().check(MapOperation.INIT, key, value);
+            } else {
+                // check whether it's permissible to *not* have a value for the property
+                entry.getValue().check(MapOperation.INIT, key, null);
             }
-            entry.getValue().check(MapOperation.INIT, key, map.get(key));
         }
         if (numMetadata < map.size()) {
             Set<String> keys = new HashSet<>(map.keySet());

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -90,14 +90,13 @@ public class Metadata {
         int numMetadata = 0;
         for (Map.Entry<String, FieldProperty<?>> entry : properties.entrySet()) {
             String key = entry.getKey();
-            Object value = map.getOrDefault(key, NOT_FOUND);
-            if (value != NOT_FOUND) {
-                numMetadata++;
-                // check whether it's permissible to have the value for the property
-                entry.getValue().check(MapOperation.INIT, key, value);
-            } else {
+            Object value = map.getOrDefault(key, NOT_FOUND); // getOrDefault is faster than containsKey + get
+            if (value == NOT_FOUND) {
                 // check whether it's permissible to *not* have a value for the property
                 entry.getValue().check(MapOperation.INIT, key, null);
+            } else {
+                numMetadata++;
+                entry.getValue().check(MapOperation.INIT, key, value);
             }
         }
         if (numMetadata < map.size()) {

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -62,7 +62,8 @@ public class Metadata {
      * Constructs a new Metadata object represented by the given map and properties.
      * <p>
      * The passed-in map is used directly -- subsequent modifications to it outside the methods of this class may result in
-     * undefined behavior.
+     * undefined behavior. Note also that mutation-like methods (e.g. setters, etc) on this class rely on the map being mutable,
+     * which is the expected use for this class.
      * <p>
      * The properties map is used directly as well, but we verify at runtime that it <b>must</b> be an immutable map (i.e. constructed
      * via a call to {@link Map#of()} (or similar) in production, or via {@link Map#copyOf(Map)}} in tests). Since it must be an

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -60,7 +60,7 @@ public class Metadata {
 
     public Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
         this.map = map;
-        this.properties = Collections.unmodifiableMap(properties);
+        this.properties = Map.copyOf(properties);
         validateMetadata();
     }
 

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -62,19 +62,21 @@ public class Metadata {
      * Constructs a new Metadata object represented by the given map and properties.
      * <p>
      * The passed-in map is used directly -- subsequent modifications to it outside the methods of this class may result in
-     * undefined behavior. By contrast, the properties map is copied via {@link Map#copyOf(Map)}) in order to ensure that it cannot be
-     * changed.
+     * undefined behavior.
      * <p>
-     * As an implementation detail, since {@link Map#copyOf(Map)} is a no-op if the passed-in instance is an "unmodifiable map"
-     * (as defined by {@link Map#copyOf(Map)}), callers of this constructor should construct their passed-in properties map via
-     * {@link Map#of(Object, Object)}} in order to ensure optimal performance.
+     * The properties map is used directly as well, but we verify at runtime that it <b>must</b> be an immutable map (i.e. constructed
+     * via a call to {@link Map#of()} (or similar) in production, or via {@link Map#copyOf(Map)}} in tests). Since it must be an
+     * immutable map, subsequent modifications are not possible.
      *
      * @param map the backing map for this metadata instance
-     * @param properties the map of defined properties for the type of metadata represented by this instance
+     * @param properties the immutable map of defined properties for the type of metadata represented by this instance
      */
     protected Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
         this.map = map;
+        // we can't tell the compiler that properties must be a java.util.ImmutableCollections.AbstractImmutableMap, but
+        // we can use this copyOf + assert to verify that at runtime.
         this.properties = Map.copyOf(properties);
+        assert this.properties == properties : "properties map must be constructed via Map.of(...) or Map.copyOf(...)";
         validateMetadata();
     }
 

--- a/server/src/main/java/org/elasticsearch/script/Metadata.java
+++ b/server/src/main/java/org/elasticsearch/script/Metadata.java
@@ -55,7 +55,7 @@ public class Metadata {
     public static FieldProperty<Number> LongField = new FieldProperty<>(Number.class).withValidation(FieldProperty.LONGABLE_NUMBER);
 
     protected final Map<String, Object> map;
-    protected final Map<String, FieldProperty<?>> properties;
+    private final Map<String, FieldProperty<?>> properties;
     protected static final FieldProperty<?> BAD_KEY = new FieldProperty<>(null, false, false, null);
 
     public Metadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {

--- a/server/src/test/java/org/elasticsearch/script/CtxMapTests.java
+++ b/server/src/test/java/org/elasticsearch/script/CtxMapTests.java
@@ -25,7 +25,7 @@ public class CtxMapTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        map = new CtxMap<>(new HashMap<>(), new Metadata(new HashMap<>(), new HashMap<>()));
+        map = new CtxMap<>(new HashMap<>(), new Metadata(Map.of(), Map.of()));
     }
 
     public void testAddingJunkToCtx() {

--- a/server/src/test/java/org/elasticsearch/script/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/MetadataTests.java
@@ -264,4 +264,18 @@ public class MetadataTests extends ESTestCase {
             odd.check(op, key, value);
         }
     }
+
+    public void testImmutablePropertiesMap() {
+        // a mutable metadata properties map is not permitted
+        AssertionError e1 = expectThrows(AssertionError.class, () -> new Metadata(Map.of(), new HashMap<>()));
+        assertEquals("properties map must be constructed via Map.of(...) or Map.copyOf(...)", e1.getMessage());
+
+        // furthermore, for optimization reasons, just calling Collections.unmodifiableMap() is not sufficient
+        AssertionError e2 = expectThrows(AssertionError.class, () -> new Metadata(Map.of(), Collections.unmodifiableMap(new HashMap<>())));
+        assertEquals("properties map must be constructed via Map.of(...) or Map.copyOf(...)", e1.getMessage());
+
+        // Map.of and Map.copyOf are permissible (the former for code that should be fast, and the latter for e.g. tests)
+        new Metadata(Map.of(), Map.of());
+        new Metadata(Map.of(), Map.copyOf(new HashMap<>()));
+    }
 }

--- a/server/src/test/java/org/elasticsearch/script/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/script/MetadataTests.java
@@ -58,7 +58,7 @@ public class MetadataTests extends ESTestCase {
         for (String key : keys) {
             validators.put(key, Metadata.FieldProperty.ALLOW_ALL);
         }
-        return validators;
+        return Map.copyOf(validators);
     }
 
     public void testValidateMetadata() {

--- a/test/framework/src/main/java/org/elasticsearch/ingest/TestIngestCtxMetadata.java
+++ b/test/framework/src/main/java/org/elasticsearch/ingest/TestIngestCtxMetadata.java
@@ -15,7 +15,7 @@ import java.util.Map;
 
 public class TestIngestCtxMetadata extends IngestDocMetadata {
     public TestIngestCtxMetadata(Map<String, Object> map, Map<String, FieldProperty<?>> properties) {
-        super(map, properties, null);
+        super(map, Map.copyOf(properties), null);
     }
 
     public static TestIngestCtxMetadata withNullableVersion(Map<String, Object> map) {


### PR DESCRIPTION
### Map.copyOf

The first load-bearing bit here is the change from `this.properties = Collections.unmodifiableMap(properties);` to `this.properties = Map.copyOf(properties);`. Since all non-test callers pass in a `properties` map that was constructed via a call to `Map.of`, it's already an "immutable map" and `Map.copyOf` ends up being a no-op. 

The precise details of this are very annoying, but if you trace `Map.copyOf` and `Collections.unmodifiableMap` through, both do have shortcutting behavior for multiple calls to themselves, but they are **not** _mutually_ shortcutting -- so even though all our non-test properties maps are constructed as immutable via a call to `Map.of`, they were still wrapped in another layer on unmodifiability via the call to `Collections.unmodifiableMap`. On its own that's not so bad, it's just an allocation, but the wrapping also extends to another immutable wrapper being generated around each individual `Entry` when you loop over one of these maps via `entrySet`, which we do on construction for all of these maps in the form of `validateMetadata()`.

That is, prior to this PR, we were at O(N*M) allocations here -- N on the number of Metadata being constructed, and M on the number of entries in their associated properties. After this PR there are no additional allocations, just N no-oping method calls.

### getOrDefault

The second important change is that rather than calling `.containsKey(key)` and then immediately calling `.get(key)` after that, we can call `getOrDefault(key, NOT_FOUND)` just once and avoid an extra hashmap lookup. It's only a factor of 2 (so not actually speedup in terms of big O, right?), but it is still a small speedup in reality.

-----

Overall, this changes the picture from this flamegraph before:

![Screen Shot 2023-01-29 at 4 11 24 PM](https://user-images.githubusercontent.com/187034/215356099-6a1d76ee-c028-4d33-8fae-71ede5778746.png)

To this flamegraph after:

![Screen Shot 2023-01-29 at 4 11 47 PM](https://user-images.githubusercontent.com/187034/215356103-270d4a59-1b35-4bbb-a7ca-56cdd3e6dd8a.png)

I've normalized the `Matched: x.xx%` to be as compared to all of the time spent in the IngestService, so these changes together are shaving 0.5% off our overall ingest time. Not an enormous win, but the changes themselves are pretty tidy and self-contained, so I think this is a nice small speedup as low-hanging fruit.