### PR TITLE
Prefer Strings#format over String#format(Locale, ...

### DIFF
--- a/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
+++ b/build-tools-internal/src/main/resources/forbidden/es-server-signatures.txt
@@ -139,7 +139,9 @@ org.apache.logging.log4j.LogManager#getLogger()
 
 # This is permitted in test code, where we have a Checkstyle rule to guard
 # against unsafe uses. This leniency does not extend to server code.
-java.lang.String#formatted(java.lang.Object[]) @ Uses default locale - use String#format(Locale, String, Object...) instead
+@defaultMessage Uses default locale - use org.elasticsearch.common.Strings#format(String, Object...) instead
+java.lang.String#formatted(java.lang.Object[])
+java.lang.String#format(java.lang.String,java.lang.Object[])
 
 @defaultMessage Unbatched cluster state tasks are a source of performance and stability bugs. Implement the update logic in a executor which is reused across tasks instead.
 org.elasticsearch.cluster.service.MasterService#submitUnbatchedStateUpdateTask(java.lang.String, org.elasticsearch.cluster.ClusterStateUpdateTask)


### PR DESCRIPTION
Today we forbid the trappy locale-free `String#format` and `String#formatted` and suggest to use the `String#format` override which accepts an explicit `Locale`. These days a better alternative is `Strings#format`, so this commit adjusts the message that `forbidddenApis` returns to reflect that.