### PR TITLE
Note in CONTRIBUTING.md re. unsupported platforms

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -870,7 +870,7 @@ benefits of this kind of change are very small, and in our experience it is not
 worth investing the substantial effort needed to review them. This especially
 includes changes suggested by tools.
 
-We also normally immediately reject PRs which target platforms or system
+We normally immediately reject PRs which target platforms or system
 configurations that are not in the [official support
 matrix](https://www.elastic.co/support/matrix). We choose to support particular
 platforms with care because we must work to ensure that every Elasticsearch

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -870,6 +870,18 @@ benefits of this kind of change are very small, and in our experience it is not
 worth investing the substantial effort needed to review them. This especially
 includes changes suggested by tools.
 
+We also normally immediately reject PRs which target platforms or system
+configurations that are not in the [official support
+matrix](https://www.elastic.co/support/matrix). We choose to support particular
+platforms with care because we must work to ensure that every Elasticsearch
+release works completely on every platform, and we must spend time
+investigating test failures and performance regressions there too. We cannot
+determine whether PRs which target unsupported platforms or configurations meet
+our quality standards, nor can we guarantee that the change they introduce will
+continue to work in future releases. It would be a very bad experience for our
+users if Elasticsearch suddenly stopped working on a particular platform after
+an upgrade.
+
 We sometimes reject contributions due to the low quality of the submission
 since low-quality submissions tend to take unreasonable effort to review
 properly. Quality is rather subjective so it is hard to describe exactly how to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -878,10 +878,8 @@ release works completely on every platform, and we must spend time
 investigating test failures and performance regressions there too. We cannot
 determine whether PRs which target unsupported platforms or configurations meet
 our quality standards, nor can we guarantee that the change they introduce will
-continue to work in future releases. We do not want Elasticsearch to suddenly 
+continue to work in future releases. We do not want Elasticsearch to suddenly
 stop working on a particular platform after an upgrade.
-users if Elasticsearch suddenly stopped working on a particular platform after
-an upgrade.
 
 We sometimes reject contributions due to the low quality of the submission
 since low-quality submissions tend to take unreasonable effort to review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -878,7 +878,8 @@ release works completely on every platform, and we must spend time
 investigating test failures and performance regressions there too. We cannot
 determine whether PRs which target unsupported platforms or configurations meet
 our quality standards, nor can we guarantee that the change they introduce will
-continue to work in future releases. It would be a very bad experience for our
+continue to work in future releases. We do not want Elasticsearch to suddenly 
+stop working on a particular platform after an upgrade.
 users if Elasticsearch suddenly stopped working on a particular platform after
 an upgrade.
 


### PR DESCRIPTION
We have an internal policy about contributions which target unsupported platforms but this is not spelled out in the contributing guide. This commit adds the missing info.

Relates #93341