### PR TITLE
Add a section about token-based authentication

### DIFF
--- a/x-pack/docs/en/watcher/input/http.asciidoc
+++ b/x-pack/docs/en/watcher/input/http.asciidoc
@@ -139,6 +139,28 @@ http://openweathermap.org/appid[OpenWeatherMap] service:
 --------------------------------------------------
 // NOTCONSOLE
 
+===== Using Token-Based Authentication
+
+You can also call an API using a `Bearer token` instead of the basic authentication. The `request.headers` object contains the HTTP headers:
+
+[source,js]
+--------------------------------------------------
+"input" : {
+  "http" : {
+    "request" : {
+      "url": "https://api.example.com/v1/something",
+      "headers": {
+        "authorization" : "Bearer ABCD1234...",
+        "content-type": "application/json"
+        # other headers params..
+        },
+      "connection_timeout": "30s"
+    }
+  }
+}
+--------------------------------------------------
+// NOTCONSOLE
+
 ==== Using templates
 
 The `http` input supports templating. You can use <<templates,templates>> when

--- a/x-pack/docs/en/watcher/input/http.asciidoc
+++ b/x-pack/docs/en/watcher/input/http.asciidoc
@@ -139,7 +139,7 @@ http://openweathermap.org/appid[OpenWeatherMap] service:
 --------------------------------------------------
 // NOTCONSOLE
 
-===== Using Token-Based Authentication
+===== Using token-based authentication
 
 You can also call an API using a `Bearer token` instead of the basic authentication. The `request.headers` object contains the HTTP headers:
 

--- a/x-pack/docs/en/watcher/input/http.asciidoc
+++ b/x-pack/docs/en/watcher/input/http.asciidoc
@@ -141,7 +141,7 @@ http://openweathermap.org/appid[OpenWeatherMap] service:
 
 ===== Using token-based authentication
 
-You can also call an API using a `Bearer token` instead of the basic authentication. The `request.headers` object contains the HTTP headers:
+You can also call an API using a `Bearer token` instead of basic authentication. The `request.headers` object contains the HTTP headers:
 
 [source,js]
 --------------------------------------------------


### PR DESCRIPTION
It took me a considerable time to figure out the code for a token-based authentication, and I said why not add it to the documentation.
