### PR TITLE
Check if shard could be allocated before initializing it

### DIFF
--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
@@ -42,7 +42,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class SnapshotBasedRecoveryIT extends AbstractRollingTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93271")
     public void testSnapshotBasedRecovery() throws Exception {
         final String indexName = "snapshot_based_recovery";
         final String repositoryName = "snapshot_based_recovery_repo";
@@ -111,31 +110,12 @@ public class SnapshotBasedRecoveryIT extends AbstractRollingTestCase {
                     indexName,
                     Settings.builder().put(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.getKey(), 1)
                 );
-                try {
-                    ensureGreen(indexName);
-                } catch (AssertionError e) {
-                    logAllocationExplain();
-                    throw e;
-                }
+                ensureGreen(indexName);
                 assertMatchAllReturnsAllDocuments(indexName, numDocs);
                 assertMatchQueryReturnsAllDocuments(indexName, numDocs);
             }
             default -> throw new IllegalStateException("unknown type " + CLUSTER_TYPE);
         }
-    }
-
-    private void logAllocationExplain() throws Exception {
-        // Used to debug #91383
-        var request = new Request(HttpGet.METHOD_NAME, "_cluster/allocation/explain?include_disk_info=true&include_yes_decisions=true");
-        request.setJsonEntity("""
-                    {
-                      "index": "snapshot_based_recovery",
-                      "shard": 0,
-                      "primary": false
-                    }
-            """);
-        var response = client().performRequest(request);
-        logger.info("--> allocation explain {}", EntityUtils.toString(response.getEntity()));
     }
 
     private List<String> getUpgradedNodeIds() throws IOException {


### PR DESCRIPTION
DesiredBalanceComputer might blindly start unassigned shard in-place even if it could no longer be allocated on the node.
The way to reproduce this is described here: https://github.com/elastic/elasticsearch/issues/93271#issuecomment-1406330919

This was discovered while trying to fix flaky `SnapshotBasedRecoveryIT#testSnapshotBasedRecovery`.

Close: #93271 