### PR TITLE
improve code documentation of ValueSource regarding (global, segment) ordinals

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -121,8 +121,7 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
             ValuesSource dataSource;
-            if (indexFieldData instanceof IndexOrdinalsFieldData
-                && ((IndexOrdinalsFieldData) indexFieldData).supportsGlobalOrdinalsMapping()) {
+            if (indexFieldData instanceof IndexOrdinalsFieldData) {
                 dataSource = new ValuesSource.Bytes.WithOrdinals.FieldData((IndexOrdinalsFieldData) indexFieldData);
             } else {
                 dataSource = new ValuesSource.Bytes.FieldData(indexFieldData);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/CoreValuesSourceType.java
@@ -121,7 +121,8 @@ public enum CoreValuesSourceType implements ValuesSourceType {
         public ValuesSource getField(FieldContext fieldContext, AggregationScript.LeafFactory script) {
             final IndexFieldData<?> indexFieldData = fieldContext.indexFieldData();
             ValuesSource dataSource;
-            if (indexFieldData instanceof IndexOrdinalsFieldData) {
+            if (indexFieldData instanceof IndexOrdinalsFieldData
+                && ((IndexOrdinalsFieldData) indexFieldData).supportsGlobalOrdinalsMapping()) {
                 dataSource = new ValuesSource.Bytes.WithOrdinals.FieldData((IndexOrdinalsFieldData) indexFieldData);
             } else {
                 dataSource = new ValuesSource.Bytes.FieldData(indexFieldData);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfig.java
@@ -408,7 +408,11 @@ public class ValuesSourceConfig {
     }
 
     /**
-     * Check if this values source supports using global and segment ordinals.
+     * Check if this values source supports segment ordinals. Global ordinals might or might not be supported.
+     * <p>
+     * If this returns {@code true} then it is safe to cast it to {@link ValuesSource.Bytes.WithOrdinals}.
+     * Call {@link ValuesSource.Bytes.WithOrdinals#supportsGlobalOrdinalsMapping} to find out if global ordinals are supported.
+     *
      */
     public boolean hasOrdinals() {
         return valuesSource.hasOrdinals();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
@@ -405,4 +405,21 @@ public class ValuesSourceConfigTests extends MapperServiceTestCase {
             assertTrue(config.alignesWithSearchIndex());
         });
     }
+
+    public void testFlattened() throws Exception {
+        MapperService mapperService = createMapperService(fieldMapping(b -> b.field("type", "flattened")));
+        withAggregationContext(mapperService, List.of(source(b -> b.startObject("field").field("key", "abc").endObject())), context -> {
+            ValuesSourceConfig config;
+            config = ValuesSourceConfig.resolve(context, null, "field.key", null, null, null, null, CoreValuesSourceType.KEYWORD);
+
+            ValuesSource.Bytes valuesSource = (ValuesSource.Bytes) config.getValuesSource();
+            LeafReaderContext ctx = context.searcher().getIndexReader().leaves().get(0);
+            SortedBinaryDocValues values = valuesSource.bytesValues(ctx);
+            assertTrue(values.advanceExact(0));
+            assertEquals(1, values.docValueCount());
+            assertEquals(new BytesRef("abc"), values.nextValue());
+            assertFalse(config.hasOrdinals());
+            assertFalse(valuesSource.hasOrdinals());
+        });
+    }
 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/support/ValuesSourceConfigTests.java
@@ -418,8 +418,11 @@ public class ValuesSourceConfigTests extends MapperServiceTestCase {
             assertTrue(values.advanceExact(0));
             assertEquals(1, values.docValueCount());
             assertEquals(new BytesRef("abc"), values.nextValue());
-            assertFalse(config.hasOrdinals());
-            assertFalse(valuesSource.hasOrdinals());
+
+            // flattened supports ordinals, but _not_ global ordinals
+            assertTrue(config.hasOrdinals());
+            ValuesSource.Bytes.WithOrdinals valuesSourceWithOrdinals = (ValuesSource.Bytes.WithOrdinals) valuesSource;
+            assertFalse(valuesSourceWithOrdinals.supportsGlobalOrdinalsMapping());
         });
     }
 }


### PR DESCRIPTION
Lookups on sub-objects in flattened fields don't support global ordinals, but only segment ordinals. Currently code documentation claims support for segment and global ordinals. This change fixes the documentation and adds further
details how to check for global ordinal support. This also adds testcase for `flattened` as example for this special case.

relates #93304
