### PR TITLE
[7.17] Make `--debug-server-jvm` work with new test framework (#93355)

### DIFF
--- a/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
+++ b/build-tools/src/main/java/org/elasticsearch/gradle/testclusters/StandaloneRestIntegTestTask.java
@@ -67,6 +67,7 @@ public class StandaloneRestIntegTestTask extends Test implements TestClustersAwa
     @Option(option = "debug-server-jvm", description = "Enable debugging configuration, to allow attaching a debugger to elasticsearch.")
     public void setDebugServer(boolean enabled) {
         this.debugServer = enabled;
+        systemProperty("tests.cluster.debug.enabled", Boolean.toString(enabled));
     }
 
     @Nested

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -60,6 +60,9 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
     private static final String TESTS_CLUSTER_PLUGINS_PATH_SYSPROP = "tests.cluster.plugins.path";
     private static final String TESTS_CLUSTER_FIPS_JAR_PATH_SYSPROP = "tests.cluster.fips.jars.path";
     public static final Pattern BUNDLE_ARTIFACT_PATTERN = Pattern.compile("(.+)(?:-\\d\\.\\d\\.\\d-SNAPSHOT\\.zip)?");
+    private static final String TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP = "tests.cluster.debug.enabled";
+    private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
+    private static final int DEFAULT_DEBUG_PORT = 5007;
 
     private final Path baseWorkingDir;
     private final DistributionResolver distributionResolver;
@@ -549,13 +552,20 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                     .collect(Collectors.joining(" "));
             }
 
+            String debugArgs = "";
+            if (Boolean.getBoolean(TESTS_CLUSTER_DEBUG_ENABLED_SYSPROP)) {
+                int port = DEFAULT_DEBUG_PORT + spec.getCluster().getNodes().indexOf(spec);
+                debugArgs = ENABLE_DEBUG_JVM_ARGS + port;
+            }
+
             String heapSize = System.getProperty("tests.heap.size", "512m");
             environment.put("ES_JAVA_OPTS", "-Xms" + heapSize + " -Xmx" + heapSize + " -ea -esa "
             // Support passing in additional JVM arguments
                 + System.getProperty("tests.jvm.argline", "")
                 + " "
                 + featureFlagProperties
-                + systemProperties);
+                + systemProperties
+                + debugArgs);
 
             return environment;
         }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Make `--debug-server-jvm` work with new test framework (#93355)