### PR TITLE
Use passed-in configuration for SslChannelInitializer

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/core/security/transport/netty4/SecurityNetty4Transport.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/core/security/transport/netty4/SecurityNetty4Transport.java
@@ -144,7 +144,7 @@ public class SecurityNetty4Transport extends Netty4Transport {
     }
 
     protected ServerChannelInitializer getSslChannelInitializer(final String name, final SslConfiguration configuration) {
-        return new SslChannelInitializer(name, sslConfiguration);
+        return new SslChannelInitializer(name, configuration);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a trivial bug in getSslChannelInitializer where the passed-in configuration is ignored and the initializer is always instantiated with the default configuration.

This is a trivial bug because the method is overridden by its subclass and hence is *not* used at all.
