### PR TITLE
[8.6] Fix MapperSizeClientYamlTestSuiteIT when FIPS is enabled (#93357)

### DIFF
--- a/plugins/mapper-size/src/yamlRestTest/resources/rest-api-spec/test/mapper_size/10_basic.yml
+++ b/plugins/mapper-size/src/yamlRestTest/resources/rest-api-spec/test/mapper_size/10_basic.yml
@@ -4,10 +4,6 @@
 ---
 "Mapper Size":
 
-    - skip:
-        version: "all"
-        reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/93303"
-
     - do:
         indices.create:
             index: test

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -106,22 +106,20 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 distributionDescriptor = resolveDistribution();
                 LOGGER.info("Distribution for node '{}': {}", spec.getName(), distributionDescriptor);
                 initializeWorkingDirectory();
+                createConfigDirectory();
+                copyExtraConfigFiles(); // extra config files might be needed for running cli tools like plugin install
                 copyExtraJarFiles();
                 installPlugins();
                 if (spec.getDistributionType() == DistributionType.INTEG_TEST) {
                     installModules();
                 }
                 initialized = true;
+            } else {
+                createConfigDirectory();
+                copyExtraConfigFiles();
             }
 
-            try {
-                IOUtils.deleteWithRetry(configDir);
-                Files.createDirectories(configDir);
-            } catch (IOException e) {
-                throw new UncheckedIOException("An error occurred creating config directory", e);
-            }
             writeConfiguration();
-            copyExtraConfigFiles();
             createKeystore();
             addKeystoreSettings();
             configureSecurity();
@@ -184,6 +182,15 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 throw new RuntimeException("Timed out after " + NODE_UP_TIMEOUT + " waiting for ports files for: " + this);
             } catch (ExecutionException e) {
                 throw new RuntimeException("An error occurred while waiting for ports file for: " + this, e);
+            }
+        }
+
+        private void createConfigDirectory() {
+            try {
+                IOUtils.deleteWithRetry(configDir);
+                Files.createDirectories(configDir);
+            } catch (IOException e) {
+                throw new UncheckedIOException("An error occurred creating config directory", e);
             }
         }
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix MapperSizeClientYamlTestSuiteIT when FIPS is enabled (#93357)