### PR TITLE
Support geo-grid ingest processor

### DIFF
--- a/docs/changelog/93370.yaml
+++ b/docs/changelog/93370.yaml
@@ -1,0 +1,22 @@
+pr: 93370
+summary: Support geo_grid ingest processor
+area: Geo
+type: feature
+issues:
+ - 92473
+highlight:
+  title: Support geo_grid ingest processor
+  body: |-
+    The `geo_grid` ingest processor supports creating indexable geometries from geohash, geotile and H3 cells.
+
+    There already exists a `circle` ingest processor that creates a polygon from a point and radius definition.
+    This concept is useful when there is need to use spatial operations that work with indexable geometries on
+    geometric objects that are not defined spatially (or at least not indexable by lucene).
+    In this case, the string `4/8/5` does not have spatial meaning, until we interpret it as the address
+    of a rectangular `geotile`, and save the bounding box defining its border for further use.
+    Likewise we can interpret `geohash` strings like `u0` as a tile, and H3 strings like `811fbffffffffff`
+    as an hexagonal cell, saving the cell border as a polygon.
+
+    [role="screenshot"]
+    image::../images/spatial/geogrid_h3_children.png[Kibana map with three H3 layers: cell, children and intersecting non-children]
+  notable: true

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/SpatialPlugin.java
@@ -50,6 +50,7 @@ import org.elasticsearch.xpack.spatial.index.mapper.ShapeFieldMapper;
 import org.elasticsearch.xpack.spatial.index.query.GeoGridQueryBuilder;
 import org.elasticsearch.xpack.spatial.index.query.ShapeQueryBuilder;
 import org.elasticsearch.xpack.spatial.ingest.CircleProcessor;
+import org.elasticsearch.xpack.spatial.ingest.GeoGridProcessor;
 import org.elasticsearch.xpack.spatial.search.aggregations.GeoLineAggregationBuilder;
 import org.elasticsearch.xpack.spatial.search.aggregations.InternalGeoLine;
 import org.elasticsearch.xpack.spatial.search.aggregations.bucket.geogrid.GeoGridTiler;
@@ -188,7 +189,7 @@ public class SpatialPlugin extends Plugin implements ActionPlugin, MapperPlugin,
 
     @Override
     public Map<String, Processor.Factory> getProcessors(Processor.Parameters parameters) {
-        return Map.of(CircleProcessor.TYPE, new CircleProcessor.Factory());
+        return Map.of(CircleProcessor.TYPE, new CircleProcessor.Factory(), GeoGridProcessor.TYPE, new GeoGridProcessor.Factory());
     }
 
     private static void registerGeoShapeBoundsAggregator(ValuesSourceRegistry.Builder builder) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/ingest/GeoGridProcessor.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/ingest/GeoGridProcessor.java
@@ -1,0 +1,374 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.spatial.ingest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.geo.GeometryParserFormat;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.utils.Geohash;
+import org.elasticsearch.h3.H3;
+import org.elasticsearch.ingest.AbstractProcessor;
+import org.elasticsearch.ingest.ConfigurationUtils;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.Processor;
+import org.elasticsearch.search.aggregations.bucket.geogrid.GeoTileUtils;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.spatial.common.H3CartesianUtil;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static org.elasticsearch.common.geo.GeometryParserFormat.GEOJSON;
+import static org.elasticsearch.common.geo.GeometryParserFormat.WKT;
+
+/**
+ *  The geo-grid-processor converts a geohash, geotile or geohex tile cell definition into an indexable geometry describing the tile shape.
+ */
+public final class GeoGridProcessor extends AbstractProcessor {
+    public static final String TYPE = "geo_grid";
+
+    private final FieldConfig config;
+    private final boolean ignoreMissing;
+    private final GeometryParserFormat targetFormat;
+    private final TileFieldType tileFieldType;
+
+    GeoGridProcessor(
+        String tag,
+        String description,
+        FieldConfig config,
+        boolean ignoreMissing,
+        GeometryParserFormat targetFormat,
+        TileFieldType tileFieldType
+    ) {
+        super(tag, description);
+        this.config = config;
+        this.ignoreMissing = ignoreMissing;
+        this.targetFormat = targetFormat;
+        this.tileFieldType = tileFieldType;
+    }
+
+    public static class FieldConfig {
+        private final String field;
+        private final String targetField;
+        private final String parentField;
+        private final String childrenField;
+        private final String nonChildrenField;
+        private final String precisionField;
+
+        FieldConfig(
+            String field,
+            String targetField,
+            String parentField,
+            String childrenField,
+            String nonChildrenField,
+            String precisionField
+        ) {
+            this.field = field;
+            this.targetField = targetField;
+            this.parentField = parentField;
+            this.childrenField = childrenField;
+            this.nonChildrenField = nonChildrenField;
+            this.precisionField = precisionField;
+        }
+
+        public String field(String key) {
+            return switch (key) {
+                case "field" -> field;
+                case "target_field" -> targetField;
+                case "parent_field" -> parentField;
+                case "children_field" -> childrenField;
+                case "non_children_field" -> nonChildrenField;
+                case "precision_field" -> precisionField;
+                default -> throw new IllegalArgumentException("Invalid geo_grid processor field type [" + key + "]");
+            };
+        }
+    }
+
+    @Override
+    public IngestDocument execute(IngestDocument ingestDocument) {
+        Object obj = ingestDocument.getFieldValue(config.field, Object.class, ignoreMissing);
+
+        if (obj == null && ignoreMissing) {
+            return ingestDocument;
+        } else if (obj == null) {
+            throw new IllegalArgumentException("field [" + config.field + "] is null, cannot process it.");
+        }
+        if (obj instanceof String == false) {
+            throw new IllegalArgumentException("field [" + config.field + "] must be a String tile address");
+        }
+
+        try {
+            final TileHandler handler = switch (tileFieldType) {
+                case GEOTILE -> new GeotileHandler(obj.toString());
+                case GEOHASH -> new GeohashHandler(obj.toString());
+                case GEOHEX -> new GeohexHandler(obj.toString());
+            };
+            final Geometry geometry = handler.makeGeometry();
+            XContentBuilder newValueBuilder = XContentFactory.jsonBuilder().startObject().field("val");
+            targetFormat.toXContent(geometry, newValueBuilder, ToXContent.EMPTY_PARAMS);
+            newValueBuilder.endObject();
+            Map<String, Object> newObj = XContentHelper.convertToMap(BytesReference.bytes(newValueBuilder), true, XContentType.JSON).v2();
+            ingestDocument.setFieldValue(config.targetField, newObj.get("val"));
+            if (config.parentField != null && config.parentField.length() > 0) {
+                final String parent = handler.getParent();
+                if (parent != null && parent.length() > 0) {
+                    ingestDocument.setFieldValue(config.parentField, parent);
+                }
+            }
+            if (config.childrenField != null && config.childrenField.length() > 0) {
+                final List<String> children = handler.makeChildren();
+                if (children.size() > 0) {
+                    ingestDocument.setFieldValue(config.childrenField, children);
+                }
+            }
+            if (config.nonChildrenField != null && config.nonChildrenField.length() > 0) {
+                final List<String> nonChildren = handler.makeNonChildren();
+                if (nonChildren.size() > 0) {
+                    ingestDocument.setFieldValue(config.nonChildrenField, nonChildren);
+                }
+            }
+            if (config.precisionField != null && config.precisionField.length() > 0) {
+                final int precision = handler.getPrecision();
+                if (precision >= 0) {
+                    ingestDocument.setFieldValue(config.precisionField, precision);
+                }
+            }
+        } catch (Exception e) {
+            throw new IllegalArgumentException("invalid tile definition", e);
+        }
+
+        return ingestDocument;
+    }
+
+    /**
+     * This class handles the different tile types, rectangular or hexagonal.
+     * Each of geohash, geotile and geohex have different ways of describing geometries, and other attributes.
+     */
+    abstract static class TileHandler {
+        abstract Geometry makeGeometry();
+
+        abstract List<String> makeChildren();
+
+        // Most tilers have no intersecting non-children
+        List<String> makeNonChildren() {
+            return Collections.emptyList();
+        }
+
+        abstract int getPrecision();
+
+        abstract String getParent();
+    }
+
+    static class GeotileHandler extends TileHandler {
+        private final String address;
+        private final int zoom;
+        private final int x;
+        private final int y;
+
+        GeotileHandler(String address) {
+            this.address = address;
+            final int[] hashAsInts = GeoTileUtils.parseHash(address);
+            this.zoom = hashAsInts[0];
+            this.x = hashAsInts[1];
+            this.y = hashAsInts[2];
+        }
+
+        @Override
+        Geometry makeGeometry() {
+            return GeoTileUtils.toBoundingBox(address);
+        }
+
+        @Override
+        List<String> makeChildren() {
+            int z = zoom + 1;
+            if (z > GeoTileUtils.MAX_ZOOM) {
+                return Collections.emptyList();
+            }
+            int xo = x * 2;
+            int yo = y * 2;
+            return Arrays.asList(hash(z, xo, yo), hash(z, xo + 1, yo), hash(z, xo, yo + 1), hash(z, xo + 1, yo + 1));
+        }
+
+        private static String hash(int zoom, int x, int y) {
+            return zoom + "/" + x + "/" + y;
+        }
+
+        @Override
+        String getParent() {
+            return zoom == 0 ? "" : hash(zoom - 1, x / 2, y / 2);
+        }
+
+        @Override
+        int getPrecision() {
+            return zoom;
+        }
+    }
+
+    static class GeohashHandler extends TileHandler {
+        private final String hash;
+
+        GeohashHandler(String hash) {
+            this.hash = hash;
+        }
+
+        @Override
+        Geometry makeGeometry() {
+            return Geohash.toBoundingBox(hash);
+        }
+
+        @Override
+        String getParent() {
+            return hash.length() == 0 ? "" : hash.substring(0, hash.length() - 1);
+        }
+
+        @Override
+        List<String> makeChildren() {
+            return Arrays.asList(Geohash.getSubGeohashes(hash));
+        }
+
+        @Override
+        int getPrecision() {
+            return hash.length();
+        }
+    }
+
+    static class GeohexHandler extends TileHandler {
+        private final long h3;
+
+        GeohexHandler(String spec) {
+            this.h3 = H3.stringToH3(spec);
+        }
+
+        @Override
+        Geometry makeGeometry() {
+            return makePolygonFromH3(h3);
+        }
+
+        @Override
+        String getParent() {
+            int res = H3.getResolution(h3);
+            if (res == 0) {
+                return "";
+            }
+            long parent = H3.h3ToParent(h3);
+            return H3.h3ToString(parent);
+        }
+
+        @Override
+        List<String> makeChildren() {
+            return asStringList(H3.h3ToChildren(h3));
+        }
+
+        @Override
+        List<String> makeNonChildren() {
+            return asStringList(H3.h3ToNoChildrenIntersecting(h3));
+        }
+
+        @Override
+        int getPrecision() {
+            return H3.getResolution(h3);
+        }
+
+        private static Geometry makePolygonFromH3(long h3) {
+            return H3CartesianUtil.getNormalizeGeometry(h3);
+        }
+
+        private static List<String> asStringList(long[] cells) {
+            ArrayList<String> addresses = new ArrayList<>(cells.length);
+            for (long cell : cells) {
+                addresses.add(H3.h3ToString(cell));
+            }
+            return addresses;
+        }
+    }
+
+    @Override
+    public String getType() {
+        return TYPE;
+    }
+
+    String field(String key) {
+        return config.field(key);
+    }
+
+    GeometryParserFormat targetFormat() {
+        return targetFormat;
+    }
+
+    TileFieldType tileType() {
+        return tileFieldType;
+    }
+
+    public static final class Factory implements Processor.Factory {
+
+        public GeoGridProcessor create(
+            Map<String, Processor.Factory> registry,
+            String processorTag,
+            String description,
+            Map<String, Object> config
+        ) {
+            String field = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
+            String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", field);
+            String parentField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "parent_field", "");
+            String childrenField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "children_field", "");
+            String nonChildrenField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "non_children_field", "");
+            String precisionField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "precision_field", "");
+            boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
+            TileFieldType tileFieldType = TileFieldType.parse(
+                ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "tile_type"),
+                processorTag
+            );
+            GeometryParserFormat targetFormat = getTargetFormat(processorTag, config);
+            FieldConfig fields = new FieldConfig(field, targetField, parentField, childrenField, nonChildrenField, precisionField);
+            return new GeoGridProcessor(processorTag, description, fields, ignoreMissing, targetFormat, tileFieldType);
+        }
+
+        private GeometryParserFormat getTargetFormat(String processorTag, Map<String, Object> config) {
+            String propertyName = "target_format";
+            String targetFormat = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, propertyName, GEOJSON.name());
+            return switch (targetFormat.toLowerCase(Locale.ROOT).trim()) {
+                case "geojson" -> GEOJSON;
+                case "wkt" -> WKT;
+                default -> throw ConfigurationUtils.newConfigurationException(
+                    TYPE,
+                    processorTag,
+                    propertyName,
+                    "illegal value [" + targetFormat + "], valid values are [WKT, GEOJSON]"
+                );
+            };
+        }
+    }
+
+    enum TileFieldType {
+        GEOHASH,
+        GEOTILE,
+        GEOHEX;
+
+        public static TileFieldType parse(String value, String tag) {
+            EnumSet<TileFieldType> validValues = EnumSet.allOf(TileFieldType.class);
+            try {
+                return valueOf(value.toUpperCase(Locale.ROOT));
+            } catch (IllegalArgumentException e) {
+                throw ConfigurationUtils.newConfigurationException(
+                    TYPE,
+                    tag,
+                    "tile_type",
+                    "illegal value [" + value + "], valid values are " + Arrays.toString(validValues.toArray())
+                );
+            }
+        }
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/GeoGridProcessorFactoryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/GeoGridProcessorFactoryTests.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.spatial.ingest;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.geo.GeometryParserFormat;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class GeoGridProcessorFactoryTests extends ESTestCase {
+
+    private GeoGridProcessor.Factory factory;
+
+    @Before
+    public void init() {
+        factory = new GeoGridProcessor.Factory();
+    }
+
+    public void testCreateGeohash() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOHASH.name());
+        String processorTag = randomAlphaOfLength(10);
+        GeoGridProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertFields(processor, "field1", "field1");
+        assertThat(processor.tileType(), equalTo(GeoGridProcessor.TileFieldType.GEOHASH));
+        assertThat(processor.targetFormat(), equalTo(GeometryParserFormat.GEOJSON));
+    }
+
+    public void testCreateGeoTile() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOTILE.name());
+        String processorTag = randomAlphaOfLength(10);
+        GeoGridProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertFields(processor, "field1", "field1");
+        assertThat(processor.tileType(), equalTo(GeoGridProcessor.TileFieldType.GEOTILE));
+        assertThat(processor.targetFormat(), equalTo(GeometryParserFormat.GEOJSON));
+    }
+
+    public void testCreateGeohex() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOHEX.name());
+        String processorTag = randomAlphaOfLength(10);
+        GeoGridProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertFields(processor, "field1", "field1");
+        assertThat(processor.tileType(), equalTo(GeoGridProcessor.TileFieldType.GEOHEX));
+        assertThat(processor.targetFormat(), equalTo(GeometryParserFormat.GEOJSON));
+    }
+
+    public void testCreateInvalidTargetFormat() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOTILE.name());
+        config.put("target_format", "invalid");
+        String processorTag = randomAlphaOfLength(10);
+        ElasticsearchParseException e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> factory.create(null, processorTag, null, config)
+        );
+        assertThat(e.getMessage(), equalTo("[target_format] illegal value [invalid], valid values are [WKT, GEOJSON]"));
+    }
+
+    public void testCreateMissingField() {
+        Map<String, Object> config = new HashMap<>();
+        String processorTag = randomAlphaOfLength(10);
+        ElasticsearchParseException e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> factory.create(null, processorTag, null, config)
+        );
+        assertThat(e.getMessage(), equalTo("[field] required property is missing"));
+    }
+
+    public void testCreateWithTargetField() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("target_field", "other");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOTILE.name());
+        config.put("target_format", "wkt");
+        String processorTag = randomAlphaOfLength(10);
+        GeoGridProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertFields(processor, "field1", "other");
+        assertThat(processor.tileType(), equalTo(GeoGridProcessor.TileFieldType.GEOTILE));
+        assertThat(processor.targetFormat(), equalTo(GeometryParserFormat.WKT));
+    }
+
+    public void testCreateWithChildrenField() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOHEX.name());
+        config.put("children_field", "children");
+        String processorTag = randomAlphaOfLength(10);
+        GeoGridProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertFields(processor, "field1", "field1", "", "children", "", "");
+        assertThat(processor.tileType(), equalTo(GeoGridProcessor.TileFieldType.GEOHEX));
+        assertThat(processor.targetFormat(), equalTo(GeometryParserFormat.GEOJSON));
+    }
+
+    public void testCreateWithExtraFields() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", GeoGridProcessor.TileFieldType.GEOHEX.name());
+        config.put("parent_field", "parent");
+        config.put("children_field", "children");
+        config.put("non_children_field", "nonChildren");
+        config.put("precision_field", "precision");
+        config.put("target_format", "wkt");
+        String processorTag = randomAlphaOfLength(10);
+        GeoGridProcessor processor = factory.create(null, processorTag, null, config);
+        assertThat(processor.getTag(), equalTo(processorTag));
+        assertFields(processor, "field1", "field1", "parent", "children", "nonChildren", "precision");
+        assertThat(processor.tileType(), equalTo(GeoGridProcessor.TileFieldType.GEOHEX));
+        assertThat(processor.targetFormat(), equalTo(GeometryParserFormat.WKT));
+    }
+
+    public void testCreateWithNoTileTypeDefined() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        String processorTag = randomAlphaOfLength(10);
+        ElasticsearchParseException e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> factory.create(null, processorTag, null, config)
+        );
+        assertThat(e.getMessage(), equalTo("[tile_type] required property is missing"));
+    }
+
+    public void testCreateWithInvalidTileTypeDefined() {
+        Map<String, Object> config = new HashMap<>();
+        config.put("field", "field1");
+        config.put("tile_type", "super_tiles");
+        String processorTag = randomAlphaOfLength(10);
+        ElasticsearchParseException e = expectThrows(
+            ElasticsearchParseException.class,
+            () -> factory.create(null, processorTag, null, config)
+        );
+        assertThat(e.getMessage(), equalTo("[tile_type] illegal value [super_tiles], valid values are [GEOHASH, GEOTILE, GEOHEX]"));
+    }
+
+    private void assertFields(GeoGridProcessor processor, String field, String targetField) {
+        assertFields(processor, field, targetField, "", "", "", "");
+    }
+
+    private void assertFields(
+        GeoGridProcessor processor,
+        String field,
+        String targetField,
+        String parentField,
+        String childrenField,
+        String nonChildrenField,
+        String precisionField
+    ) {
+        assertThat(processor.field("field"), equalTo(field));
+        assertThat(processor.field("target_field"), equalTo(targetField));
+        assertThat(processor.field("parent_field"), equalTo(parentField));
+        assertThat(processor.field("children_field"), equalTo(childrenField));
+        assertThat(processor.field("non_children_field"), equalTo(nonChildrenField));
+        assertThat(processor.field("precision_field"), equalTo(precisionField));
+    }
+}

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/GeoGridProcessorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/ingest/GeoGridProcessorTests.java
@@ -1,0 +1,314 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.spatial.ingest;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.geo.GeoJson;
+import org.elasticsearch.common.geo.GeometryParserFormat;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.geometry.Geometry;
+import org.elasticsearch.geometry.Polygon;
+import org.elasticsearch.geometry.Rectangle;
+import org.elasticsearch.geometry.utils.WellKnownText;
+import org.elasticsearch.ingest.IngestDocument;
+import org.elasticsearch.ingest.RandomDocumentPicks;
+import org.elasticsearch.ingest.TestIngestDocument;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.ingest.IngestDocumentMatcher.assertIngestDocument;
+import static org.elasticsearch.xpack.spatial.ingest.GeoGridProcessor.TileFieldType.GEOHASH;
+import static org.elasticsearch.xpack.spatial.ingest.GeoGridProcessor.TileFieldType.GEOHEX;
+import static org.elasticsearch.xpack.spatial.ingest.GeoGridProcessor.TileFieldType.GEOTILE;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+
+public class GeoGridProcessorTests extends ESTestCase {
+
+    public void testFieldNotFound() {
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, GEOTILE);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        Exception e = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
+        assertThat(e.getMessage(), containsString("not present as part of path [field]"));
+    }
+
+    public void testFieldNotFoundWithIgnoreMissing() {
+        GeoGridProcessor processor = makeGridProcessor(true, GeometryParserFormat.WKT, GEOTILE);
+        IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), new HashMap<>());
+        IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
+        processor.execute(ingestDocument);
+        assertIngestDocument(originalIngestDocument, ingestDocument);
+    }
+
+    public void testNullValue() {
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, GEOTILE);
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
+        Exception e = expectThrows(Exception.class, () -> processor.execute(ingestDocument));
+        assertThat(e.getMessage(), equalTo("field [field] is null, cannot process it."));
+    }
+
+    public void testNullValueWithIgnoreMissing() {
+        GeoGridProcessor processor = makeGridProcessor(true, GeometryParserFormat.WKT, GEOTILE);
+        IngestDocument originalIngestDocument = RandomDocumentPicks.randomIngestDocument(random(), Collections.singletonMap("field", null));
+        IngestDocument ingestDocument = new IngestDocument(originalIngestDocument);
+        processor.execute(ingestDocument);
+        assertIngestDocument(originalIngestDocument, ingestDocument);
+    }
+
+    public void testGeohash2GeoJson() throws IOException {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "u0");
+        Geometry expectedPoly = new GeoGridProcessor.GeohashHandler("u0").makeGeometry();
+        assertThat(expectedPoly, instanceOf(Rectangle.class));
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.GEOJSON, GEOHASH);
+        processor.execute(ingestDocument);
+        assertFieldAsGeoJSON(ingestDocument, "field", expectedPoly);
+    }
+
+    public void testGeotile2GeoJson() throws IOException {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "6/32/22");
+        Geometry expectedPoly = new GeoGridProcessor.GeotileHandler("6/32/22").makeGeometry();
+        assertThat(expectedPoly, instanceOf(Rectangle.class));
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.GEOJSON, GEOTILE);
+        processor.execute(ingestDocument);
+        assertFieldAsGeoJSON(ingestDocument, "field", expectedPoly);
+    }
+
+    public void testGeohex2GeoJson() throws IOException {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "811fbffffffffff");
+        Geometry expectedPoly = new GeoGridProcessor.GeohexHandler("811fbffffffffff").makeGeometry();
+        assertThat(expectedPoly, instanceOf(Polygon.class));
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.GEOJSON, GEOHEX);
+        processor.execute(ingestDocument);
+        assertFieldAsGeoJSON(ingestDocument, "field", expectedPoly);
+    }
+
+    public void testGeohash2WKT() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "u0");
+        Geometry expectedPoly = new GeoGridProcessor.GeohashHandler("u0").makeGeometry();
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, GEOHASH);
+        processor.execute(ingestDocument);
+        String polyString = ingestDocument.getFieldValue("field", String.class);
+        assertThat(polyString, equalTo(WellKnownText.toWKT(expectedPoly)));
+    }
+
+    public void testGeotile2WKT() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "6/32/22");
+        Geometry expectedPoly = new GeoGridProcessor.GeotileHandler("6/32/22").makeGeometry();
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, GEOTILE);
+        processor.execute(ingestDocument);
+        String polyString = ingestDocument.getFieldValue("field", String.class);
+        assertThat(polyString, equalTo(WellKnownText.toWKT(expectedPoly)));
+    }
+
+    public void testGeohex2WKT() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "811fbffffffffff");
+        Geometry expectedPoly = new GeoGridProcessor.GeohexHandler("811fbffffffffff").makeGeometry();
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, GEOHEX);
+        processor.execute(ingestDocument);
+        String polyString = ingestDocument.getFieldValue("field", String.class);
+        assertThat(polyString, equalTo(WellKnownText.toWKT(expectedPoly)));
+    }
+
+    public void testGeohex_WithChildrenAndPrecision() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("geohex", "811fbffffffffff");
+        Geometry expectedGeometry = new GeoGridProcessor.GeohexHandler("811fbffffffffff").makeGeometry();
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(
+            "geohex",
+            "polygon",
+            "parent",
+            "children",
+            "non_children",
+            "depth",
+            GeometryParserFormat.WKT,
+            GEOHEX
+        );
+        processor.execute(ingestDocument);
+        String polyString = ingestDocument.getFieldValue("polygon", String.class);
+        assertThat(polyString, equalTo(WellKnownText.toWKT(expectedGeometry)));
+        assertTrue("should have parent field", ingestDocument.hasField("parent"));
+        String parent = ingestDocument.getFieldValue("parent", String.class);
+        assertThat(parent, equalTo("801ffffffffffff"));
+        assertTrue("should have children field", ingestDocument.hasField("children"));
+        List<?> children = ingestDocument.getFieldValue("children", List.class);
+        assertThat(children.size(), equalTo(7));
+        assertThat(
+            children,
+            containsInAnyOrder(
+                equalTo("821f87fffffffff"),
+                equalTo("821f8ffffffffff"),
+                equalTo("821f97fffffffff"),
+                equalTo("821f9ffffffffff"),
+                equalTo("821fa7fffffffff"),
+                equalTo("821faffffffffff"),
+                equalTo("821fb7fffffffff")
+            )
+        );
+        assertTrue("should have non_children field", ingestDocument.hasField("non_children"));
+        List<?> nonChildren = ingestDocument.getFieldValue("non_children", List.class);
+        assertThat(nonChildren.size(), equalTo(6));
+        int depth = ingestDocument.getFieldValue("depth", Integer.class);
+        assertThat(depth, equalTo(1));
+    }
+
+    public void testGeotile_WithChildrenAndPrecision() {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", "4/8/5");
+        Geometry expectedGeometry = new GeoGridProcessor.GeotileHandler("4/8/5").makeGeometry();
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(
+            "field",
+            "shape",
+            "encompassing",
+            "inner_tiles",
+            "intersecting",
+            "zoom",
+            GeometryParserFormat.WKT,
+            GEOTILE
+        );
+        processor.execute(ingestDocument);
+        String polyString = ingestDocument.getFieldValue("shape", String.class);
+        assertThat(polyString, equalTo(WellKnownText.toWKT(expectedGeometry)));
+        String encompassing = ingestDocument.getFieldValue("encompassing", String.class);
+        assertThat(encompassing, equalTo("3/4/2"));
+        assertTrue("should have children field", ingestDocument.hasField("inner_tiles"));
+        List<?> innerTiles = ingestDocument.getFieldValue("inner_tiles", List.class);
+        assertThat(innerTiles.size(), equalTo(4));
+        assertThat(innerTiles, containsInAnyOrder(equalTo("5/16/10"), equalTo("5/17/10"), equalTo("5/16/11"), equalTo("5/17/11")));
+        assertFalse("should have no intersecting field", ingestDocument.hasField("intersecting"));
+        int zoom = ingestDocument.getFieldValue("zoom", Integer.class);
+        assertThat(zoom, equalTo(4));
+    }
+
+    public void testGeohash_WithChildrenAndPrecision() throws IOException {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("geohash", "u0");
+        Geometry expectedGeometry = new GeoGridProcessor.GeohashHandler("u0").makeGeometry();
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(
+            "geohash",
+            "shape",
+            "higher_level",
+            "next_level",
+            "intersecting",
+            "precision",
+            GeometryParserFormat.GEOJSON,
+            GEOHASH
+        );
+        processor.execute(ingestDocument);
+        assertFieldAsGeoJSON(ingestDocument, "shape", expectedGeometry);
+        String higher_level = ingestDocument.getFieldValue("higher_level", String.class);
+        assertThat(higher_level, equalTo("u"));
+        assertTrue("should have next_level field", ingestDocument.hasField("next_level"));
+        List<?> next_level = ingestDocument.getFieldValue("next_level", List.class);
+        assertThat(next_level.size(), equalTo(32));
+        assertFalse("should have no intersecting field", ingestDocument.hasField("intersecting"));
+        int precision = ingestDocument.getFieldValue("precision", Integer.class);
+        assertThat(precision, equalTo(2));
+    }
+
+    public void testInvalidGeohash() {
+        assertInvalidTile(GEOHASH, "unsupported symbol", "invalid geohash");
+    }
+
+    public void testInvalidGeotile() {
+        assertInvalidTile(GEOTILE, "Must be three integers in a form \"zoom/x/y\"", "invalid tile");
+    }
+
+    public void testInvalidGeohex() {
+        assertInvalidTile(GEOHEX, "NumberFormatException", "not a hex");
+    }
+
+    public void testMissingField() {
+        IngestDocument ingestDocument = TestIngestDocument.emptyIngestDocument();
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, GEOTILE);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
+        assertThat(e.getMessage(), equalTo("field [field] not present as part of path [field]"));
+    }
+
+    @SuppressWarnings("unchecked")
+    private void assertFieldAsGeoJSON(IngestDocument ingestDocument, String field, Geometry expectedGeometry) throws IOException {
+        Map<String, Object> polyMap = ingestDocument.getFieldValue(field, Map.class);
+        XContentBuilder builder = XContentFactory.jsonBuilder();
+        GeoJson.toXContent(expectedGeometry, builder, ToXContent.EMPTY_PARAMS);
+        Tuple<XContentType, Map<String, Object>> expected = XContentHelper.convertToMap(
+            BytesReference.bytes(builder),
+            true,
+            XContentType.JSON
+        );
+        assertThat(polyMap, equalTo(expected.v2()));
+    }
+
+    private void assertInvalidTile(GeoGridProcessor.TileFieldType type, String innerError, String content) {
+        HashMap<String, Object> map = new HashMap<>();
+        map.put("field", content);
+        IngestDocument ingestDocument = TestIngestDocument.withDefaultVersion(map);
+        GeoGridProcessor processor = makeGridProcessor(false, GeometryParserFormat.WKT, type);
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
+        assertThat(type + " field '" + map.get("field") + "'", e.getMessage(), equalTo("invalid tile definition"));
+        assertThat(type + " field '" + map.get("field") + "'", e.getCause().toString(), containsString(innerError));
+        map.put("field", "POINT (30 10)");
+        e = expectThrows(IllegalArgumentException.class, () -> processor.execute(ingestDocument));
+        assertThat(type + " field '" + map.get("field") + "'", e.getMessage(), equalTo("invalid tile definition"));
+        assertThat(type + " field '" + map.get("field") + "'", e.getCause().toString(), containsString(innerError));
+    }
+
+    private GeoGridProcessor makeGridProcessor(
+        boolean ignoreMissing,
+        GeometryParserFormat format,
+        GeoGridProcessor.TileFieldType tileFieldType
+    ) {
+        GeoGridProcessor.FieldConfig config = new GeoGridProcessor.FieldConfig("field", "field", null, null, null, null);
+        return new GeoGridProcessor("tag", null, config, ignoreMissing, format, tileFieldType);
+    }
+
+    private GeoGridProcessor makeGridProcessor(
+        String field,
+        String targetField,
+        String parentField,
+        String childrenField,
+        String nonChildrenField,
+        String precisionField,
+        GeometryParserFormat format,
+        GeoGridProcessor.TileFieldType tileFieldType
+    ) {
+        GeoGridProcessor.FieldConfig config = new GeoGridProcessor.FieldConfig(
+            field,
+            targetField,
+            parentField,
+            childrenField,
+            nonChildrenField,
+            precisionField
+        );
+        return new GeoGridProcessor("tag", null, config, false, format, tileFieldType);
+    }
+}

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/100_geo_grid_ingest.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/100_geo_grid_ingest.yml
@@ -1,0 +1,465 @@
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "my_pipeline"
+        ignore: 404
+
+---
+"Test geo_grid on geotile using default target format":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field" : "geocell",
+                  "tile_type": "geotile"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "4/8/5"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match:
+      _source:
+        geocell:
+          type: "Envelope"
+          coordinates:
+            - [ 0.0, 55.77657301866769 ]
+            - [ 22.5, 40.979898069620134 ]
+
+---
+"Test geo_grid on geotile using WKT":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field" : "geocell",
+                  "tile_type": "geotile",
+                  "target_format": "wkt"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "4/8/5"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.geocell: "BBOX (0.0, 22.5, 55.77657301866769, 40.979898069620134)" }
+
+---
+"Test geo_grid on geohash using WKT":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field" : "geocell",
+                  "tile_type": "geohash",
+                  "target_format": "wkt"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "u0"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.geocell: "BBOX (0.0, 11.25, 50.625, 45.0)" }
+
+---
+"Test geo_grid on geohex using WKT":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field" : "geocell",
+                  "tile_type": "geohex",
+                  "target_format": "wkt"
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "811fbffffffffff"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match: { _source.geocell: "POLYGON ((1.1885095294564962 49.470279179513454, 2.0265689212828875 45.18424864858389, 7.509948452934623 43.786609335802495, 12.6773177459836 46.40695743262768, 12.345747342333198 50.55427505169064, 6.259687012061477 51.964770150370896, 3.6300085578113794 50.610463307239115, 1.1885095294564962 49.470279179513454))" }
+
+---
+"Test geo_grid on geotile with advanced pipeline and cell hierarchy using WKT":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field": "geocell",
+                  "tile_type": "geotile",
+                  "target_format": "wkt",
+                  "target_field": "shape",
+                  "parent_field": "parent",
+                  "children_field": "children",
+                  "depth_field": "depth"
+                }
+              },
+              {
+                "set": {
+                  "field": "childrenShapes",
+                  "copy_from": "children"
+                }
+              },
+              {
+                "foreach" : {
+                  "field" : "childrenShapes",
+                  "processor" : {
+                    "geo_grid": {
+                      "field": "_ingest._value",
+                      "tile_type": "geotile",
+                      "target_format": "wkt"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "4/8/5"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match:
+      _source:
+        geocell: "4/8/5"
+        shape: "BBOX (0.0, 22.5, 55.77657301866769, 40.979898069620134)"
+        parent: "3/4/2"
+        depth: 4
+        children: [ "5/16/10", "5/17/10", "5/16/11", "5/17/11" ]
+        childrenShapes:
+          - "BBOX (0.0, 11.25, 55.77657301866769, 48.922499263758255)"
+          - "BBOX (11.25, 22.5, 55.77657301866769, 48.922499263758255)"
+          - "BBOX (0.0, 11.25, 48.922499263758255, 40.979898069620134)"
+          - "BBOX (11.25, 22.5, 48.922499263758255, 40.979898069620134)"
+
+---
+"Test geo_grid on geohash with advanced pipeline and cell hierarchy using WKT":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field": "geocell",
+                  "tile_type": "geohash",
+                  "target_format": "wkt",
+                  "target_field": "shape",
+                  "parent_field": "parent",
+                  "children_field": "children",
+                  "depth_field": "depth"
+                }
+              },
+              {
+                "set": {
+                  "field": "childrenShapes",
+                  "copy_from": "children"
+                }
+              },
+              {
+                "foreach" : {
+                  "field" : "childrenShapes",
+                  "processor" : {
+                    "geo_grid": {
+                      "field": "_ingest._value",
+                      "tile_type": "geohash",
+                      "target_format": "wkt"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "u0"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match:
+      _source:
+        geocell: "u0"
+        shape: "BBOX (0.0, 11.25, 50.625, 45.0)"
+        parent: "u"
+        depth: 2
+        children:
+          - "u00"
+          - "u01"
+          - "u02"
+          - "u03"
+          - "u04"
+          - "u05"
+          - "u06"
+          - "u07"
+          - "u08"
+          - "u09"
+          - "u0b"
+          - "u0c"
+          - "u0d"
+          - "u0e"
+          - "u0f"
+          - "u0g"
+          - "u0h"
+          - "u0j"
+          - "u0k"
+          - "u0m"
+          - "u0n"
+          - "u0p"
+          - "u0q"
+          - "u0r"
+          - "u0s"
+          - "u0t"
+          - "u0u"
+          - "u0v"
+          - "u0w"
+          - "u0x"
+          - "u0y"
+          - "u0z"
+        childrenShapes:
+          - "BBOX (0.0, 1.40625, 46.40625, 45.0)"
+          - "BBOX (1.40625, 2.8125, 46.40625, 45.0)"
+          - "BBOX (0.0, 1.40625, 47.8125, 46.40625)"
+          - "BBOX (1.40625, 2.8125, 47.8125, 46.40625)"
+          - "BBOX (2.8125, 4.21875, 46.40625, 45.0)"
+          - "BBOX (4.21875, 5.625, 46.40625, 45.0)"
+          - "BBOX (2.8125, 4.21875, 47.8125, 46.40625)"
+          - "BBOX (4.21875, 5.625, 47.8125, 46.40625)"
+          - "BBOX (0.0, 1.40625, 49.21875, 47.8125)"
+          - "BBOX (1.40625, 2.8125, 49.21875, 47.8125)"
+          - "BBOX (0.0, 1.40625, 50.625, 49.21875)"
+          - "BBOX (1.40625, 2.8125, 50.625, 49.21875)"
+          - "BBOX (2.8125, 4.21875, 49.21875, 47.8125)"
+          - "BBOX (4.21875, 5.625, 49.21875, 47.8125)"
+          - "BBOX (2.8125, 4.21875, 50.625, 49.21875)"
+          - "BBOX (4.21875, 5.625, 50.625, 49.21875)"
+          - "BBOX (5.625, 7.03125, 46.40625, 45.0)"
+          - "BBOX (7.03125, 8.4375, 46.40625, 45.0)"
+          - "BBOX (5.625, 7.03125, 47.8125, 46.40625)"
+          - "BBOX (7.03125, 8.4375, 47.8125, 46.40625)"
+          - "BBOX (8.4375, 9.84375, 46.40625, 45.0)"
+          - "BBOX (9.84375, 11.25, 46.40625, 45.0)"
+          - "BBOX (8.4375, 9.84375, 47.8125, 46.40625)"
+          - "BBOX (9.84375, 11.25, 47.8125, 46.40625)"
+          - "BBOX (5.625, 7.03125, 49.21875, 47.8125)"
+          - "BBOX (7.03125, 8.4375, 49.21875, 47.8125)"
+          - "BBOX (5.625, 7.03125, 50.625, 49.21875)"
+          - "BBOX (7.03125, 8.4375, 50.625, 49.21875)"
+          - "BBOX (8.4375, 9.84375, 49.21875, 47.8125)"
+          - "BBOX (9.84375, 11.25, 49.21875, 47.8125)"
+          - "BBOX (8.4375, 9.84375, 50.625, 49.21875)"
+          - "BBOX (9.84375, 11.25, 50.625, 49.21875)"
+
+---
+"Test geo_grid on geohex with advanced pipeline and cell hierarchy using WKT":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body: >
+          {
+            "description": "_description",
+            "processors": [
+              {
+                "geo_grid": {
+                  "field": "geocell",
+                  "tile_type": "geohex",
+                  "target_format": "wkt",
+                  "target_field": "shape",
+                  "parent_field": "parent",
+                  "children_field": "children",
+                  "non_children_field": "nonChildren",
+                  "depth_field": "depth"
+                }
+              },
+              {
+                "set": {
+                  "field": "childrenShapes",
+                  "copy_from": "children"
+                }
+              },
+              {
+                "set": {
+                  "field": "nonChildrenShapes",
+                  "copy_from": "nonChildren"
+                }
+              },
+              {
+                "foreach" : {
+                  "field" : "childrenShapes",
+                  "processor" : {
+                    "geo_grid": {
+                      "field": "_ingest._value",
+                      "tile_type": "geohex",
+                      "target_format": "wkt"
+                    }
+                  }
+                }
+              },
+              {
+                "foreach" : {
+                  "field" : "nonChildrenShapes",
+                  "processor" : {
+                    "geo_grid": {
+                      "field": "_ingest._value",
+                      "tile_type": "geohex",
+                      "target_format": "wkt"
+                    }
+                  }
+                }
+              }
+            ]
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      index:
+        index: test
+        id: "1"
+        pipeline: "my_pipeline"
+        body: >
+          {
+            "geocell": "811fbffffffffff"
+          }
+
+  - do:
+      get:
+        index: test
+        id: "1"
+  - match:
+      _source:
+        geocell: "811fbffffffffff"
+        shape: "POLYGON ((1.1885095294564962 49.470279179513454, 2.0265689212828875 45.18424864858389, 7.509948452934623 43.786609335802495, 12.6773177459836 46.40695743262768, 12.345747342333198 50.55427505169064, 6.259687012061477 51.964770150370896, 3.6300085578113794 50.610463307239115, 1.1885095294564962 49.470279179513454))"
+        parent: "801ffffffffffff"
+        depth: 1
+        children:
+          - "821f87fffffffff"
+          - "821f8ffffffffff"
+          - "821f97fffffffff"
+          - "821f9ffffffffff"
+          - "821fa7fffffffff"
+          - "821faffffffffff"
+          - "821fb7fffffffff"
+        nonChildren:
+          - "821ea7fffffffff"
+          - "82186ffffffffff"
+          - "82396ffffffffff"
+          - "821f17fffffffff"
+          - "821e37fffffffff"
+          - "82194ffffffffff"
+        nonChildrenShapes:
+          - "POLYGON ((10.343212774023414 45.92192775104195, 9.731941111385822 44.323804839514196, 11.369192842394114 43.20897659752518, 13.642238667234778 43.67433743085712, 14.337206231430173 45.273432224057615, 12.6773177459836 46.40695743262768, 10.343212774023414 45.92192775104195))"
+          - "POLYGON ((0.7640258967876434 47.907450324855745, -1.3966082129627466 47.44351194240153, -1.7527981102466583 45.828917124308646, -0.028004944324493408 44.71297777723521, 2.0265689212828875 45.18424864858389, 2.4589017033576965 46.76373050082475, 0.7640258967876434 47.907450324855745))"
+          - "POLYGON ((3.696701768785715 44.22123494558036, 3.2493495382368565 42.60479216929525, 4.868332073092461 41.58031489234418, 6.977840261533856 42.158615668304265, 7.509948452934623 43.786609335802495, 5.848476877436042 44.82546979095787, 3.696701768785715 44.22123494558036))"
+          - "POLYGON ((6.848228881135583 53.43156033195555, 6.259687012061477 51.964770150370896, 8.08863085694611 51.039695707149804, 10.549622755497694 51.56398999504745, 11.24517043121159 53.03203972522169, 9.374530809000134 53.975513661280274, 6.848228881135583 53.43156033195555))"
+          - "POLYGON ((12.345747342333198 50.55427505169064, 11.648396300151944 49.039345127530396, 13.37434759363532 47.96593840699643, 15.817383527755737 48.38812246453017, 16.606046771630645 49.899182128719985, 14.863026738166809 50.99274770356715, 12.345747342333198 50.55427505169064))"
+          - "POLYGON ((2.101313956081867 52.51713396515697, -0.21913748234510422 52.14168077800423, -0.6310947798192501 50.60191108379513, 1.1885095294564962 49.470279179513454, 3.384771505370736 49.85377031844109, 3.8811334781348705 51.36037617456168, 2.101313956081867 52.51713396515697))"
+        childrenShapes:
+          - "POLYGON ((5.163510935381055 48.943763938732445, 4.6524353697896 47.393027362413704, 6.371338488534093 46.417016638442874, 8.645314201712608 46.97706841863692, 9.251571390777826 48.53467794600874, 7.489805733785033 49.52621237374842, 5.163510935381055 48.943763938732445))"
+          - "POLYGON ((9.251571390777826 48.53467794600874, 8.645314201712608 46.97706841863692, 10.343212774023414 45.92192775104195, 12.6773177459836 46.40695743262768, 13.37434759363532 47.96593840699643, 11.648396300151944 49.039345127530396, 9.251571390777826 48.53467794600874))"
+          - "POLYGON ((2.4589017033576965 46.76373050082475, 2.0265689212828875 45.18424864858389, 3.696701768785715 44.22123494558036, 5.848476877436042 44.82546979095787, 6.371338488534093 46.417016638442874, 4.6524353697896 47.393027362413704, 2.4589017033576965 46.76373050082475))"
+          - "POLYGON ((6.371338488534093 46.417016638442874, 5.848476877436042 44.82546979095787, 7.509948452934623 43.786609335802495, 9.731941111385822 44.323804839514196, 10.343212774023414 45.92192775104195, 8.645314201712608 46.97706841863692, 6.371338488534093 46.417016638442874))"
+          - "POLYGON ((3.8811334781348705 51.36037617456168, 3.384771505370736 49.85377031844109, 5.163510935381055 48.943763938732445, 7.489805733785033 49.52621237374842, 8.08863085694611 51.039695707149804, 6.259687012061477 51.964770150370896, 3.8811334781348705 51.36037617456168))"
+          - "POLYGON ((8.08863085694611 51.039695707149804, 7.489805733785033 49.52621237374842, 9.251571390777826 48.53467794600874, 11.648396300151944 49.039345127530396, 12.345747342333198 50.55427505169064, 10.549622755497694 51.56398999504745, 8.08863085694611 51.039695707149804))"
+          - "POLYGON ((1.1885095294564962 49.470279179513454, 0.7640258967876434 47.907450324855745, 2.4589017033576965 46.76373050082475, 4.6524353697896 47.393027362413704, 5.163510935381055 48.943763938732445, 3.384771505370736 49.85377031844109, 1.1885095294564962 49.470279179513454))"

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/100_geo_grid_ingest.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/100_geo_grid_ingest.yml
@@ -171,7 +171,7 @@ teardown:
                   "target_field": "shape",
                   "parent_field": "parent",
                   "children_field": "children",
-                  "depth_field": "depth"
+                  "precision_field": "precision"
                 }
               },
               {
@@ -215,7 +215,7 @@ teardown:
         geocell: "4/8/5"
         shape: "BBOX (0.0, 22.5, 55.77657301866769, 40.979898069620134)"
         parent: "3/4/2"
-        depth: 4
+        precision: 4
         children: [ "5/16/10", "5/17/10", "5/16/11", "5/17/11" ]
         childrenShapes:
           - "BBOX (0.0, 11.25, 55.77657301866769, 48.922499263758255)"
@@ -240,7 +240,7 @@ teardown:
                   "target_field": "shape",
                   "parent_field": "parent",
                   "children_field": "children",
-                  "depth_field": "depth"
+                  "precision_field": "precision"
                 }
               },
               {
@@ -284,7 +284,7 @@ teardown:
         geocell: "u0"
         shape: "BBOX (0.0, 11.25, 50.625, 45.0)"
         parent: "u"
-        depth: 2
+        precision: 2
         children:
           - "u00"
           - "u01"
@@ -370,7 +370,7 @@ teardown:
                   "parent_field": "parent",
                   "children_field": "children",
                   "non_children_field": "nonChildren",
-                  "depth_field": "depth"
+                  "precision_field": "precision"
                 }
               },
               {
@@ -432,7 +432,7 @@ teardown:
         geocell: "811fbffffffffff"
         shape: "POLYGON ((1.1885095294564962 49.470279179513454, 2.0265689212828875 45.18424864858389, 7.509948452934623 43.786609335802495, 12.6773177459836 46.40695743262768, 12.345747342333198 50.55427505169064, 6.259687012061477 51.964770150370896, 3.6300085578113794 50.610463307239115, 1.1885095294564962 49.470279179513454))"
         parent: "801ffffffffffff"
-        depth: 1
+        precision: 1
         children:
           - "821f87fffffffff"
           - "821f8ffffffffff"


### PR DESCRIPTION
This processor can read geohash, geotile or geohex tile specifications and generate a polygon describing the outside of those tiles.

Examples are:

* geohash: `u0`
* geotile: `6/32/22`
* geohex: `811fbffffffffff`

Fixes https://github.com/elastic/elasticsearch/issues/92473

* [x] Create `geo_grid` ingest processor
* [x] Support `geohash`
* [x] Support `geotile`
* [x] Support `geohex`
* [x] Unit tests
* [x] Support cell hierarchies (parent, children, depth, etc.)
* [x] Documentation
* [x] yamlRestTests
* [x] Verify works with re-indexing
* [x] Verify works in ingest pipelines that modify input/output (use-case child cell processing)
* [x] Using `BBOX` instead of `POLYGON` for rectangular tiles
* [x] Remove experimental feature for `H3.geoToH3(lat,lng,res)`
* [x] Change default format to GeoJSON and test that more
* [x] Change `depth` to `precision`