### PR TITLE
[7.17] Adds ML CPP items to 7.17.9 release notes

### DIFF
--- a/docs/reference/release-notes/7.17.9.asciidoc
+++ b/docs/reference/release-notes/7.17.9.asciidoc
@@ -28,7 +28,7 @@ Infra/Core::
 * Remove unnecessary `thirdPartyAudit` exclusions {es-pull}92352[#92352] (issue: {es-issue}92346[#92346])
 
 Machine Learning::
-* Improve performance of closing files before spawning. {ml-pull}2424[#2424].
+* Improve performance of closing files before spawning {ml-pull}2424[#2424].
 
 Mapping::
 * Fix `_bulk` api `dynamic_templates` and explicit `op_type` {es-pull}92687[#92687]

--- a/docs/reference/release-notes/7.17.9.asciidoc
+++ b/docs/reference/release-notes/7.17.9.asciidoc
@@ -27,6 +27,9 @@ ILM+SLM::
 Infra/Core::
 * Remove unnecessary `thirdPartyAudit` exclusions {es-pull}92352[#92352] (issue: {es-issue}92346[#92346])
 
+Machine Learning::
+* Improve performance of closing files before spawning. {ml-pull}2424[#2424].
+
 Mapping::
 * Fix `_bulk` api `dynamic_templates` and explicit `op_type` {es-pull}92687[#92687]
 


### PR DESCRIPTION
## Overview

This PR adds the ML-related items from the ML CPP repo to the release notes.
Source: https://github.com/elastic/ml-cpp/blob/7.17/docs/CHANGELOG.asciidoc

### Preview

[7.17.9 RN in ES](https://elasticsearch_93381.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/7.17/release-notes-7.17.9.html)