### PR TITLE
Allow `null` to be provided for dense_vector field values

### DIFF
--- a/docs/changelog/93388.yaml
+++ b/docs/changelog/93388.yaml
@@ -1,0 +1,5 @@
+pr: 93388
+summary: Allow `null` to be provided for `dense_vector` field values
+area: Vector Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -837,7 +837,9 @@ public class DenseVectorFieldMapper extends FieldMapper {
                     + "] doesn't not support indexing multiple values for the same field in the same document"
             );
         }
-
+        if (Token.VALUE_NULL == context.parser().currentToken()) {
+            return;
+        }
         Field field = fieldType().indexed ? parseKnnVector(context) : parseBinaryDocValuesVector(context);
         context.doc().addWithKey(fieldType().name(), field);
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -491,7 +491,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
     @Override
     protected boolean allowsNullValues() {
-        return false;       // TODO should this allow null values?
+        return true;
     }
 
     public void testCannotBeUsedInMultifields() {


### PR DESCRIPTION
If a document has `null` specified as the vector value, the vector field will not be parsed or indexed.

This is useful for when deleting vector values from an indexed document.

closes: https://github.com/elastic/elasticsearch/issues/70470