### PR TITLE
Fix potential ESLoggingHandlerIT stack overflow

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
@@ -28,7 +28,8 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
 
     public void setUp() throws Exception {
         super.setUp();
-        appender = new MockLogAppender();
+        // Only watch for single line logs to avoid Netty .
+        appender = new MockLogAppender("^[^\\n]+$");
         Loggers.addAppender(LogManager.getLogger(ESLoggingHandler.class), appender);
         Loggers.addAppender(LogManager.getLogger(TransportLogger.class), appender);
         Loggers.addAppender(LogManager.getLogger(TcpTransport.class), appender);


### PR DESCRIPTION
The mock logging appender framework occasionally throws stackoverflow errors when analyzing hexdump logs. This commit resolves the issue, but only including logs that are a single line. Fixes #70847.