### PR TITLE
[ML] Increase timeout in MlTrainedModelsUpgradeIT

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
@@ -62,7 +62,7 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
             case OLD -> {
                 createIndexWithName(INDEX_NAME);
                 indexData(INDEX_NAME, 1000);
-                createAndRunClassificationJob();
+                createAndRunClassificationJob("classification-upgrade-job");
                 createAndRunRegressionJob();
                 List<String> oldModels = getTrainedModels();
                 createPipelines(oldModels);
@@ -172,7 +172,7 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
         putAndStartDFAAndWaitForFinish(config, "regression");
     }
 
-    void createAndRunClassificationJob() throws Exception {
+    void createAndRunClassificationJob(String jobName) throws Exception {
         String config = Strings.format("""
             {
               "source": {
@@ -188,7 +188,7 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
               },
               "model_memory_limit": "18mb"
             }""", INDEX_NAME, KEYWORD_FIELD);
-        putAndStartDFAAndWaitForFinish(config, "classification");
+        putAndStartDFAAndWaitForFinish(config, jobName);
     }
 
     @SuppressWarnings("unchecked")
@@ -202,7 +202,7 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
                 client().performRequest(new Request("GET", "_ml/data_frame/analytics/" + id + "/_stats"))
             ).get("data_frame_analytics")).get(0);
             assertThat(state.get("state"), equalTo("stopped"));
-        }, 1, TimeUnit.MINUTES);
+        }, 2, TimeUnit.MINUTES);
     }
 
     void createPipeline(String id, String modelType, String modelId) throws Exception {


### PR DESCRIPTION
The failure in #93393 is due to timing out waiting for a data frame analytics jobs to finish. The timeout period is set to 1 minute but we can see in the logs from the failure that the job took more than 1 minute 21seconds to complete.

Timeout is bumped to 2 minutes. 

```
[2023-01-31T20:39:11,098][INFO ][o.e.x.m.a.TransportStartDataFrameAnalyticsAction] [v8.7.0-0] [classification] Starting data frame analytics from state [stopped]
...
[2023-01-31T20:40:32,210][INFO ][o.e.x.m.d.DataFrameAnalyticsManager] [v8.7.0-0] [classification] Marking task completed
```


Closes #93393