### PR TITLE
Do not refresh all indices in TransportBulkAction

### DIFF
--- a/docs/changelog/93417.yaml
+++ b/docs/changelog/93417.yaml
@@ -1,0 +1,5 @@
+pr: 93417
+summary: Do not refresh all indices in `TransportBulkAction`
+area: CRUD
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -30,6 +30,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.ingest.IngestActionForwarder;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.WriteResponse;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -209,7 +210,12 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
                         docWriteResponse.setForcedRefresh(true);
                     }
                 }
-                client.admin().indices().prepareRefresh().setIndices(indices.toArray(Strings.EMPTY_ARRAY)).execute(l.map(ignored -> r));
+                client.admin()
+                    .indices()
+                    .prepareRefresh()
+                    .setIndices(indices.toArray(Strings.EMPTY_ARRAY))
+                    .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_HIDDEN)
+                    .execute(l.map(ignored -> r));
             });
             bulkRequest.setRefreshPolicy(WriteRequest.RefreshPolicy.NONE);
         }


### PR DESCRIPTION
Since we know which indices were involved in the Bulk request we can refresh only those instead of all indices.

Relates #93160