### PR TITLE
[8.6] Fix thirdPartyAudit tasks when running with Java 20 (#93394)

### DIFF
--- a/libs/plugin-analysis-api/build.gradle
+++ b/libs/plugin-analysis-api/build.gradle
@@ -1,3 +1,5 @@
+import org.elasticsearch.gradle.internal.info.BuildParams
+
 /*
  * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
  * or more contributor license agreements. Licensed under the Elastic License
@@ -25,4 +27,14 @@ tasks.named('forbiddenApisMain').configure {
 
 tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
+}
+
+tasks.named("thirdPartyAudit").configure {
+  if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20) {
+    ignoreMissingClasses(
+      // This class was removed in Java 20 but is only referenced by a class that requires preview features anyhow
+      // See: https://github.com/apache/lucene/pull/12042
+      'java.lang.foreign.MemorySession',
+    )
+  }
 }

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -229,6 +229,14 @@ tasks.named("thirdPartyAudit").configure {
             'org.zeromq.ZMQ',
     )
     ignoreMissingClasses 'javax.xml.bind.DatatypeConverter'
+
+    if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20) {
+      ignoreMissingClasses(
+        // This class was removed in Java 20 but is only referenced by a class that requires preview features anyhow
+        // See: https://github.com/apache/lucene/pull/12042
+        'java.lang.foreign.MemorySession',
+      )
+    }
 }
 
 tasks.named("dependencyLicenses").configure {


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix thirdPartyAudit tasks when running with Java 20 (#93394)