### PR TITLE
Block storing invalid pipeline configs caused by nested processors

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -154,6 +154,32 @@
           }
 
 ---
+"Test valid config with sequential processors":
+  - do:
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [{}, {}, {}]
+          }
+  - match: { acknowledged: true }
+
+---
+"Test invalid config with nested processors":
+  - do:
+      catch: /illegal_argument_exception/
+      ingest.put_pipeline:
+        id: "my_pipeline"
+        body:  >
+          {
+            "description": "_description",
+            "processors": [{"grok": {}}, {"grok": {}, "date": {}}]
+          }
+  - match: { error.reason: "[processors] contains nested objects but should be a list of single-entry objects" }
+
+
+---
 "Test Get Summarized Pipelines":
   - skip:
       version: " - 7.12.99"

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/ingest/10_basic.yml
@@ -167,11 +167,14 @@
 
 ---
 "Test invalid config with nested processors":
+  - skip:
+      version: " - 8.6.99"
+      reason: "bug fixed in 8.7.0"
   - do:
       catch: /illegal_argument_exception/
       ingest.put_pipeline:
         id: "my_pipeline"
-        body:  >
+        body: >
           {
             "description": "_description",
             "processors": [{"grok": {}}, {"grok": {}, "date": {}}]

--- a/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/SimulatePipelineRequest.java
@@ -151,11 +151,9 @@ public class SimulatePipelineRequest extends ActionRequest implements ToXContent
         Map<String, Object> pipelineConfig = ConfigurationUtils.readMap(null, null, config, Fields.PIPELINE);
 
         // check for nested objects in processor configs
-        List<Map<String, Object>> processorConfigs = ConfigurationUtils.readList(null, null, pipelineConfig, PROCESSORS_KEY);
-        if (processorConfigs.stream().anyMatch(processor -> processor.keySet().size() > 1)) {
+        if (Pipeline.containsNestedProcessors(pipelineConfig)) {
             throw new IllegalArgumentException("[processors] contains nested objects but should be a list of single-entry objects");
         }
-        pipelineConfig.put(PROCESSORS_KEY, processorConfigs);
 
         Pipeline pipeline = Pipeline.create(
             SIMULATED_PIPELINE_ID,

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -68,6 +68,14 @@ public final class Pipeline {
         this.relativeTimeProvider = relativeTimeProvider;
     }
 
+    public static boolean containsNestedProcessors(Map<String, Object> config) {
+        boolean result;
+        List<Map<String, Object>> processorConfigs = ConfigurationUtils.readList(null, null, config, PROCESSORS_KEY);
+        result = processorConfigs.stream().anyMatch(processor -> processor.keySet().size() > 1);
+        config.put(PROCESSORS_KEY, processorConfigs);
+        return result;
+    }
+
     public static Pipeline create(
         String id,
         Map<String, Object> config,

--- a/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
+++ b/server/src/main/java/org/elasticsearch/ingest/Pipeline.java
@@ -70,6 +70,7 @@ public final class Pipeline {
 
     public static boolean containsNestedProcessors(Map<String, Object> config) {
         boolean result;
+
         List<Map<String, Object>> processorConfigs = ConfigurationUtils.readList(null, null, config, PROCESSORS_KEY);
         result = processorConfigs.stream().anyMatch(processor -> processor.keySet().size() > 1);
         config.put(PROCESSORS_KEY, processorConfigs);

--- a/server/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/ingest/RestPutPipelineAction.java
@@ -11,7 +11,9 @@ package org.elasticsearch.rest.action.ingest;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.ingest.Pipeline;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
@@ -20,10 +22,12 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestPutPipelineAction extends BaseRestHandler {
+    public static final String PROCESSORS_KEY = "processors";
 
     @Override
     public List<Route> routes() {
@@ -51,6 +55,13 @@ public class RestPutPipelineAction extends BaseRestHandler {
 
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
         PutPipelineRequest request = new PutPipelineRequest(restRequest.param("id"), sourceTuple.v2(), sourceTuple.v1(), ifVersion);
+
+        // check for nested processors in the config
+        Map<String, Object> config = XContentHelper.convertToMap(request.getSource(), false, request.getXContentType()).v2();
+        if (Pipeline.containsNestedProcessors(config)) {
+            throw new IllegalArgumentException("[processors] contains nested objects but should be a list of single-entry objects");
+        }
+
         request.masterNodeTimeout(restRequest.paramAsTime("master_timeout", request.masterNodeTimeout()));
         request.timeout(restRequest.paramAsTime("timeout", request.timeout()));
         return channel -> client.admin().cluster().putPipeline(request, new RestToXContentListener<>(channel));

--- a/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/SimulatePipelineRequestParsingTests.java
@@ -210,6 +210,7 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         assertThat(actualRequest.pipeline().getDescription(), nullValue());
         assertThat(actualRequest.pipeline().getProcessors().size(), equalTo(numProcessors));
     }
+
     public void testParseWithNestedProcessors() throws Exception {
         Map<String, Object> requestContent = new HashMap<>();
         Map<String, Object> pipelineConfig = new HashMap<>();
@@ -237,12 +238,8 @@ public class SimulatePipelineRequestParsingTests extends ESTestCase {
         // parse and expect failure
         Exception e = expectThrows(
             IllegalArgumentException.class,
-            () -> SimulatePipelineRequest.parse(
-                requestContent,
-                false,
-                ingestService,
-                RestApiVersion.current()
-            ));
+            () -> SimulatePipelineRequest.parse(requestContent, false, ingestService, RestApiVersion.current())
+        );
         assertThat(e.getMessage(), equalTo("[processors] contains nested objects but should be a list of single-entry objects"));
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
@@ -53,7 +53,7 @@ public class PipelineFactoryTests extends ESTestCase {
         assertThat(pipeline.getProcessors().get(1).getTag(), nullValue());
     }
 
-    public void testContainsNestedProcessors() throws  Exception {
+    public void testContainsNestedProcessors() throws Exception {
         // create a pipeline with non-nested processors
         Map<String, Object> processorConfig0 = new HashMap<>();
         Map<String, Object> processorConfig1 = new HashMap<>();
@@ -64,8 +64,7 @@ public class PipelineFactoryTests extends ESTestCase {
         if (metadata != null) {
             pipelineConfig.put(Pipeline.META_KEY, metadata);
         }
-        pipelineConfig.put(Pipeline.PROCESSORS_KEY,
-            List.of(Map.of("test", processorConfig0), Map.of("test", processorConfig1)));
+        pipelineConfig.put(Pipeline.PROCESSORS_KEY, List.of(Map.of("test", processorConfig0), Map.of("test", processorConfig1)));
 
         assertFalse(Pipeline.containsNestedProcessors(pipelineConfig));
 
@@ -73,11 +72,10 @@ public class PipelineFactoryTests extends ESTestCase {
         Map<String, Object> processorConfigNested = new HashMap<>();
         processorConfigNested.put("mock_grok", new HashMap<>());
         processorConfigNested.put("mock_date", new HashMap<>());
-        pipelineConfig.put(Pipeline.PROCESSORS_KEY,
-            List.of(
-                Map.of("test", processorConfig0),
-                Map.of("test", processorConfig1),
-                processorConfigNested));
+        pipelineConfig.put(
+            Pipeline.PROCESSORS_KEY,
+            List.of(Map.of("test", processorConfig0), Map.of("test", processorConfig1), processorConfigNested)
+        );
         assertTrue(Pipeline.containsNestedProcessors(pipelineConfig));
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/PipelineFactoryTests.java
@@ -53,6 +53,34 @@ public class PipelineFactoryTests extends ESTestCase {
         assertThat(pipeline.getProcessors().get(1).getTag(), nullValue());
     }
 
+    public void testContainsNestedProcessors() throws  Exception {
+        // create a pipeline with non-nested processors
+        Map<String, Object> processorConfig0 = new HashMap<>();
+        Map<String, Object> processorConfig1 = new HashMap<>();
+        processorConfig0.put(ConfigurationUtils.TAG_KEY, "first-processor");
+        Map<String, Object> pipelineConfig = new HashMap<>();
+        pipelineConfig.put(Pipeline.DESCRIPTION_KEY, "_description");
+        pipelineConfig.put(Pipeline.VERSION_KEY, versionString);
+        if (metadata != null) {
+            pipelineConfig.put(Pipeline.META_KEY, metadata);
+        }
+        pipelineConfig.put(Pipeline.PROCESSORS_KEY,
+            List.of(Map.of("test", processorConfig0), Map.of("test", processorConfig1)));
+
+        assertFalse(Pipeline.containsNestedProcessors(pipelineConfig));
+
+        // now add one with nested processors
+        Map<String, Object> processorConfigNested = new HashMap<>();
+        processorConfigNested.put("mock_grok", new HashMap<>());
+        processorConfigNested.put("mock_date", new HashMap<>());
+        pipelineConfig.put(Pipeline.PROCESSORS_KEY,
+            List.of(
+                Map.of("test", processorConfig0),
+                Map.of("test", processorConfig1),
+                processorConfigNested));
+        assertTrue(Pipeline.containsNestedProcessors(pipelineConfig));
+    }
+
     public void testCreateWithNoProcessorsField() throws Exception {
         Map<String, Object> pipelineConfig = new HashMap<>();
         pipelineConfig.put(Pipeline.DESCRIPTION_KEY, "_description");

--- a/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/ingest/RestPutPipelineActionTests.java
@@ -46,7 +46,7 @@ public class RestPutPipelineActionTests extends RestActionTestCase {
 
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
             .withPath("/_ingest/pipeline/my_pipeline")
-            .withContent(new BytesArray("{\"processors\":{}}"), XContentType.JSON)
+            .withContent(new BytesArray("{\"processors\":[]}"), XContentType.JSON)
             .withParams(params)
             .build();
 
@@ -60,7 +60,7 @@ public class RestPutPipelineActionTests extends RestActionTestCase {
 
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
             .withPath("/_ingest/pipeline/my_pipeline")
-            .withContent(new BytesArray("{\"processors\":{}}"), XContentType.JSON)
+            .withContent(new BytesArray("{\"processors\":[]}"), XContentType.JSON)
             .withParams(params)
             .build();
 
@@ -94,7 +94,7 @@ public class RestPutPipelineActionTests extends RestActionTestCase {
 
         RestRequest request = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.PUT)
             .withPath("/_ingest/pipeline/my_pipeline")
-            .withContent(new BytesArray("{\"processors\":{}}"), XContentType.JSON)
+            .withContent(new BytesArray("{\"processors\":[]}"), XContentType.JSON)
             .withParams(params)
             .build();
 


### PR DESCRIPTION
This fixes #41837 by blocking `PUT _ingest/pipeline` or `POST _ingest/pipeline/_simulate` calls if there is are nested processors in any of the processor configs.

It will not do anything to pipelines with nested processors which have already been stored in the server. The behavior of those pipelines will remain as they are before this change (which is to say, non-deterministic in their processing order based on the use of `HashMap` for their storage).