### PR TITLE
Fix context leak in list tasks API

### DIFF
--- a/docs/changelog/93431.yaml
+++ b/docs/changelog/93431.yaml
@@ -1,0 +1,6 @@
+pr: 93431
+summary: Fix context leak in list tasks API
+area: Task Management
+type: bug
+issues:
+ - 93428

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/ListTasksIT.java
@@ -128,7 +128,7 @@ public class ListTasksIT extends ESSingleNodeTestCase {
             }));
 
         // briefly fill up the generic pool so that (a) we know the wait has started and (b) we know it's not blocking
-        // flushThreadPool(threadPool, ThreadPool.Names.GENERIC); // TODO it _is_ blocking right now!!
+        // flushThreadPool(threadPool, ThreadPool.Names.GENERIC); // TODO it _is_ blocking right now!!, unmute this in #93375
 
         assertFalse(listWaitFuture.isDone());
         assertFalse(testActionFuture.isDone());


### PR DESCRIPTION
In #90977 we made the list tasks API fully async, but failed to notice that if we waited for a task to complete then we would respond in the thread context of the last-completing task. This commit fixes the problem by restoring the context of the list-tasks task before responding.

Closes #93428