### PR TITLE
Speed up retrieval of data for flamegraphs

### DIFF
--- a/docs/changelog/93448.yaml
+++ b/docs/changelog/93448.yaml
@@ -1,0 +1,5 @@
+pr: 93448
+summary: Speed up retrieval of data for flamegraphs
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
@@ -108,7 +108,12 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<Setting<?>> getSettings() {
-        return List.of(PROFILING_ENABLED);
+        return List.of(
+            PROFILING_ENABLED,
+            TransportGetProfilingAction.PROFILING_MAX_STACKTRACE_QUERY_SLICES,
+            TransportGetProfilingAction.PROFILING_MAX_DETAIL_QUERY_SLICES,
+            TransportGetProfilingAction.PROFILING_QUERY_REALTIME
+        );
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/TransportGetProfilingActionTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/TransportGetProfilingActionTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.profiler;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+public class TransportGetProfilingActionTests extends ESTestCase {
+    public void testSliceEmptyList() {
+        assertEquals(List.of(List.of()), TransportGetProfilingAction.sliced(Collections.emptyList(), 4));
+    }
+
+    public void testSliceListSmallerOrEqualToSliceCount() {
+        int slices = 7;
+        List<String> input = randomList(0, slices, () -> randomAlphaOfLength(3));
+        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        assertEquals(1, sliced.size());
+        assertEquals(input, sliced.get(0));
+    }
+
+    public void testSliceListMultipleOfSliceCount() {
+        int slices = 2;
+        List<String> input = List.of("a", "b", "c", "d");
+        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        assertEquals(slices, sliced.size());
+        assertEquals(List.of("a", "b"), sliced.get(0));
+        assertEquals(List.of("c", "d"), sliced.get(1));
+    }
+
+    public void testSliceListGreaterThanSliceCount() {
+        int slices = 3;
+        List<String> input = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
+        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        assertEquals(slices, sliced.size());
+        assertEquals(List.of("a", "b", "c", "d"), sliced.get(0));
+        assertEquals(List.of("e", "f", "g", "h"), sliced.get(1));
+        assertEquals(List.of("i", "j"), sliced.get(2));
+    }
+}


### PR DESCRIPTION
With this commit we parallelize the retrieval of stacktraces via the `mget` API in the profiling plugin as experiments have shown that we can better utilize the available resources and thus decrease latency. Furthermore, we prepare the parallel retrieval of stackframes and executables using the same approach. Our experiments have not shown a clear indication of the optimal value for this setting, therefore we set the default value to `1` to effectively keep the prior behavior. Finally, we also introduce a setting that can be used to toggle the `realtime` (default kept as `true`) to allow for further experimentation with that flag.