### PR TITLE
Make password long enough for FIPS mode

### DIFF
--- a/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
+++ b/distribution/tools/server-cli/src/test/java/org/elasticsearch/server/cli/ServerCliTests.java
@@ -331,11 +331,11 @@ public class ServerCliTests extends CommandTestCase {
 
     public void testSecureSettingsLoaderWithPassword() throws Exception {
         var loader = setupMockKeystoreLoader();
-        assertKeystorePassword("aaa");
+        assertKeystorePassword("aaaaaaaaaaaaaaaaaa");
         assertTrue(loader.loaded);
         assertTrue(loader.bootstrapped);
         // the password we read should match what we passed in
-        assertEquals("aaa", loader.password);
+        assertEquals("aaaaaaaaaaaaaaaaaa", loader.password);
         // after the command the secrets password is closed
         assertEquals(
             "SecureString has already been closed",


### PR DESCRIPTION
In FIPS mode, passwords require a minimal length. This PR adjusts a test to adhere to this.

Fixes: #93449 