### PR TITLE
[7.17] Requiring the presence of the geoip fixture to run GeoIpDownloaderStats.testStats() (#91662)

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderStatsIT.java
@@ -66,6 +66,11 @@ public class GeoIpDownloaderStatsIT extends AbstractGeoIpIT {
     }
 
     public void testStats() throws Exception {
+        /*
+         * Testing without the geoip endpoint fixture falls back to https://storage.googleapis.com/, which can cause this test to run too
+         * slowly to pass.
+         */
+        assumeTrue("only test with fixture to have stable results", ENDPOINT != null);
         GeoIpDownloaderStatsAction.Request req = new GeoIpDownloaderStatsAction.Request();
         GeoIpDownloaderStatsAction.Response response = client().execute(GeoIpDownloaderStatsAction.INSTANCE, req).actionGet();
         XContentTestUtils.JsonMapView jsonMapView = new XContentTestUtils.JsonMapView(convertToMap(response));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Requiring the presence of the geoip fixture to run GeoIpDownloaderStats.testStats() (#91662)](https://github.com/elastic/elasticsearch/pull/91662)

This backport should fix the test failure reported in https://github.com/elastic/elasticsearch/issues/87035#issuecomment-1412286510.

Closes https://github.com/elastic/elasticsearch/issues/87035
<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)