### PR TITLE
[ML] Change result format to suit rank feature mapping

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/SlimResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/SlimResults.java
@@ -26,9 +26,6 @@ public class SlimResults extends NlpInferenceResults {
 
     public record WeightedToken(int token, float weight) implements Writeable, ToXContentObject {
 
-        public static final String TOKEN = "token";
-        public static final String WEIGHT = "weight";
-
         public WeightedToken(StreamInput in) throws IOException {
             this(in.readVInt(), in.readFloat());
         }
@@ -42,14 +39,13 @@ public class SlimResults extends NlpInferenceResults {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(TOKEN, token);
-            builder.field(WEIGHT, weight);
+            builder.field(Integer.toString(token), weight);
             builder.endObject();
             return builder;
         }
 
         public Map<String, Object> asMap() {
-            return Map.of(TOKEN, token, WEIGHT, weight);
+            return Map.of(Integer.toString(token), weight);
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/SlimResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/SlimResultsTests.java
@@ -32,7 +32,7 @@ public class SlimResultsTests extends InferenceResultsTestCase<SlimResults> {
 
     @Override
     protected SlimResults mutateInstance(SlimResults instance) {
-        return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+        return new SlimResults(instance.getResultsField() + "-FOO", instance.getWeightedTokens(), instance.isTruncated() == false);
     }
 
     @Override
@@ -45,8 +45,11 @@ public class SlimResultsTests extends InferenceResultsTestCase<SlimResults> {
         var originalTokens = createdInstance.getWeightedTokens();
         assertEquals(originalTokens.size(), ingestedTokens.size());
         for (int i = 0; i < createdInstance.getWeightedTokens().size(); i++) {
-            assertEquals(originalTokens.get(i).token(), (int) ingestedTokens.get(i).get("token"));
-            assertEquals(originalTokens.get(i).weight(), (float) ingestedTokens.get(i).get("weight"), 0.0001);
+            assertEquals(
+                originalTokens.get(i).weight(),
+                (float) ingestedTokens.get(i).get(Integer.toString(originalTokens.get(i).token())),
+                0.0001
+            );
         }
     }
 }


### PR DESCRIPTION
The result format becomes `{"token": weight}` which is compatible with the rank features mapping type. 
Using this format means the results of the inference processor can be ingested directly without any modification

Given the ingest pipeline:
```
PUT _ingest/pipeline/my-pipeline
{
  "processors": [
    {
      "inference": {
        "model_id": "slim",
        "target_field": "ml",
        "inference_config": {
          "slim": {
            "results_field": "tokens"
          }
        }
      }
    }
  ]
}
```

Produces a document such as
```
{
  "docs": [
    {
      "doc": {
       ...
        "_source": {
          "text_field": "You could be laughing 60% more of the time",
          "ml": {
            "tokens": [
              {
                "100": 2.0369442
              },
              {
                "1012": 0.026091535
              },
               ....
}
```

Which can be indexed directly into an index with `ml.tokens` as a `rank_features` mapping:
```
PUT my-index
{
  "mappings": {
    "properties": {
      "ml.tokens": {
        "type": "rank_features" 
      }
    }
  }
}
```

Note `ml.tokens` field can be an array of objects (as in the example above) or individual fields.
Either format is valid, the example below works just as well.
```
PUT my-index/_doc/1
{
  "ml.tokens": {
    "token-91": 8.2,
    "token-54": 1.5,
    "token-45": 0.8
  }
}
```



