### PR TITLE
[DOCS] Remove coming tag from 7.17.9 release notes

### DIFF
--- a/docs/reference/release-notes/7.17.9.asciidoc
+++ b/docs/reference/release-notes/7.17.9.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-7.17.9]]
 == {es} version 7.17.9
 
-coming[7.17.9]
-
 Also see <<breaking-changes-7.17,Breaking changes in 7.17>>.
 
 [[bug-7.17.9]]


### PR DESCRIPTION
Removes the `coming` tag from the Elasticsearch [7.17.9 release notes](https://www.elastic.co/guide/en/elasticsearch/reference/current/release-notes-7.17.9.html).