### PR TITLE
Describe delete-snapshot tasks

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/delete/DeleteSnapshotRequest.java
@@ -10,10 +10,12 @@ package org.elasticsearch.action.admin.cluster.snapshots.delete;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 
 import java.io.IOException;
+import java.util.Arrays;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
@@ -110,5 +112,10 @@ public class DeleteSnapshotRequest extends MasterNodeRequest<DeleteSnapshotReque
     public DeleteSnapshotRequest snapshots(String... snapshots) {
         this.snapshots = snapshots;
         return this;
+    }
+
+    @Override
+    public String getDescription() {
+        return Strings.format("[%s]%s", repository, Arrays.toString(snapshots));
     }
 }


### PR DESCRIPTION
Delete-snapshot tasks can sometimes be very long-running, but they're hard to monitor because the tasks API does not include a description of the snapshot(s) which are being deleted. This commit adds such a description.