### PR TITLE
Introduce ability to override default directory factory

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexModuleTests.java
@@ -607,6 +607,21 @@ public class IndexModuleTests extends ESTestCase {
         assertThat(e, hasToString(containsString("store type [" + storeType + "] is not allowed")));
     }
 
+    public void testRegisterCustomDefaultDirectoryFactory() throws IOException {
+        final IndexSettings indexSettings = IndexSettingsModule.newIndexSettings(new Index("foo", "_na_"), Settings.EMPTY, Settings.EMPTY);
+        final IndexModule module = createIndexModule(indexSettings, emptyAnalysisRegistry, indexNameExpressionResolver);
+        final IndexStorePlugin.DirectoryFactory factory = new IndexStorePlugin.DirectoryFactory() {
+            @Override
+            public Directory newDirectory(IndexSettings idxSettings, ShardPath shardPath) throws IOException {
+                throw new AssertionError("should never be called");
+            }
+        };
+        module.setDefaultDirectoryFactory(factory);
+        IndexService service = newIndexService(module);
+        assertSame(factory, service.getDirectoryFactory());
+        service.close("closing ...", true);
+    }
+
     public void testRegisterCustomRecoveryStateFactory() throws IOException {
         final Settings settings = Settings.builder()
             .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)


### PR DESCRIPTION
This is really all we need to enable a plugin to always use a certain store type by default I think.
