### PR TITLE
Avoiding a NullPointerException in GeoIpDownloaderIT

### DIFF
--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -311,8 +311,9 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
             .get();
         assertTrue(settingsResponse.isAcknowledged());
         assertBusy(() -> {
-            assertNotNull(getTask());
-            assertNull(getTask().getState());
+            PersistentTasksCustomMetadata.PersistentTask<PersistentTaskParams> task = getTask();
+            assertNotNull(task);
+            assertNull(task.getState());
             putGeoIpPipeline(); // This is to work around the race condition described in #92888
         });
         putNonGeoipPipeline(pipelineId);


### PR DESCRIPTION
This fixes a possible NPE when the geoip downloader task goes from not-null to null due to race conditions in the GeoIpDownloader. I have not been able to reproduce this, but you can see it at https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+pull-request+part-1/28051/consoleFull. This relates to #92888 and #92335.
Closes #93405