### PR TITLE
[DOCS] Remove excessive white space from the landing page

### DIFF
--- a/docs/reference/index-custom-title-page.html
+++ b/docs/reference/index-custom-title-page.html
@@ -41,6 +41,14 @@
       -moz-columns: 2;
     }
   }
+
+  #guide h3.gtk {
+    margin-top: 0;
+  }
+
+  .mb-4, .my-4 {
+    margin-bottom: 0!important;
+  }
 </style>
 
 <div class="legalnotice"></div>
@@ -68,7 +76,7 @@
   </div>
 </div>
 
-<h3>Get to know Elasticsearch</h3>
+<h3 class="gtk">Get to know Elasticsearch</h3>
 
 <div class="my-5">
   <div class="d-flex align-items-center mb-3">
@@ -191,7 +199,7 @@
   </ul>
 </div>
 
-<h3>Explore by use case</h3>
+<h3 class="explore">Explore by use case</h3>
 
 <div class="row my-4">
   <div class="col-md-4 col-12 mb-2">


### PR DESCRIPTION
This PR removes excessive white space from the Elasticsearch documentation landing page.

Before:

![image](https://user-images.githubusercontent.com/9715543/216382636-21ca9748-93cb-415d-8edf-71436a8104a1.png)

After:

<img width="962" alt="image" src="https://user-images.githubusercontent.com/9715543/216382703-ee4c8cc6-6adb-43b3-b698-97ea87c57762.png">
