### PR TITLE
[8.5] [DOCS] Adds size parameter details to aggregating data for faster performance page (#93475)

### DIFF
--- a/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
+++ b/docs/reference/ml/anomaly-detection/ml-configuring-aggregations.asciidoc
@@ -34,6 +34,10 @@ to match. For example, if you use a `max` aggregation on a time field called
 descending order. Additional `composite` aggregation value sources are allowed, 
 such as `terms`.
 
+* The `size` parameter of the non-composite aggregations must match the 
+cardinality of your data. A greater value of the `size` parameter increases the 
+memory requirement of the aggregation.
+
 * If you set the `summary_count_field_name` property to a non-null value, the 
 {anomaly-job} expects to receive aggregated input. The property must be set to 
 the name of the field that contains the count of raw data points that have been 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.5`:
 - [[DOCS] Adds size parameter details to aggregating data for faster performance page (#93475)](https://github.com/elastic/elasticsearch/pull/93475)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)