### PR TITLE
Adding another section to the SAML troubleshooting docs

### DIFF
--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -727,7 +727,7 @@ This error indicates that {es} received a SAML response tied to a particular SAM
 didn't explicitly specify ID of that request. This usually means that {kib} cannot find the user session where
 it previously stored the SAML request ID.
 
-To resolve this issue, ensure that in your {kib} configuration that `xpack.security.sameSiteCookies` is not set to `Strict`.
+To resolve this issue, ensure that in your {kib} configuration `xpack.security.sameSiteCookies` is not set to `Strict`.
 Depending on your configuration, you may be able to rely on the default value or explicitly set the value to `None`.
 
 For further information,

--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -716,7 +716,7 @@ the `basic` `authProvider` in {kib}. The process is documented in the
 . *Symptoms:*
 +
 --
-No response ID values are being passed from {kib} to {es}
+No SAML request ID values are being passed from {kib} to {es}:
 
 ....
 Caused by org.elasticsearch.ElasticsearchSecurityException: SAML content is in-response-to [_A1B2C3D4E5F6G8H9I0] but expected one of []

--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -723,12 +723,19 @@ Caused by org.elasticsearch.ElasticsearchSecurityException: SAML content is in-r
 ....
 
 *Resolution:*
+This error indicates that {es} received a SAML response tied to a particular SAML request, but {kib}
+didn't explicitly specify ID of that request. This usually means that {kib} cannot find the user session where
+it previously stored the SAML request ID.
 
-Verify in your {kib} configuration that `xpack.security.sameSiteCookies` is not set to `Strict`.
+To resolve this issue, ensure that in your {kib} configuration that `xpack.security.sameSiteCookies` is not set to `Strict`.
 Depending on your configuration, you may be able to rely on the default value or explicitly set the value to `None`.
 
 For further information,
 please read https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[MDN SameSite cookies]
+
+If you serve multiple {kib} installations behind a load balancer make sure to use the
+https://www.elastic.co/guide/en/kibana/current/production.html#load-balancing-kibana[same security configuration]
+for all installations.
 --
 
 *Logging:*

--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -107,7 +107,7 @@ The role definition might be missing or invalid.
 
 |======================
 
-To help track down these possibilities, enable additional logging to troubleshoot further. 
+To help track down these possibilities, enable additional logging to troubleshoot further.
 You can enable debug logging by configuring the following persistent setting:
 
 [source, console]
@@ -120,7 +120,7 @@ PUT /_cluster/settings
 }
 ----
 
-Alternatively, you can add the following lines to the end of 
+Alternatively, you can add the following lines to the end of
 the `log4j2.properties` configuration file in the `ES_PATH_CONF`:
 
 [source,properties]
@@ -710,6 +710,25 @@ If you want your users to be able to use local credentials to authenticate to
 {kib} in addition to using the SAML realm for Single Sign-On, you must enable
 the `basic` `authProvider` in {kib}. The process is documented in the
 <<saml-kibana-basic, SAML Guide>>
+
+--
+
+. *Symptoms:*
++
+--
+No response ID values are being passed from {kib} to {es}
+
+....
+Caused by org.elasticsearch.ElasticsearchSecurityException: SAML content is in-response-to [_A1B2C3D4E5F6G8H9I0] but expected one of []
+....
+
+*Resolution:*
+
+Verify in your {kib} configuration that `xpack.security.sameSiteCookies` is not set to `Strict`.
+Depending on your configuration, you may be able to rely on the default value or explicitly set the value to `None`.
+
+For further information,
+please read https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[MDN SameSite cookies]
 --
 
 *Logging:*


### PR DESCRIPTION
This issue has come up in multiple SDH and is not currently listed in the docs.

While it is technically a KB config, it manifests as an error in ES when the response IDs are not sent (and that is where this Troubleshooting guide lives)
