### PR TITLE
Improve the clipping logic in vector tiles for geometries inside the tile

### DIFF
--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -283,28 +283,36 @@ public class FeatureFactory {
         }
 
         private org.locationtech.jts.geom.Geometry clipGeometry(
-            org.locationtech.jts.geom.Geometry envelope,
+            org.locationtech.jts.geom.Geometry tile,
             org.locationtech.jts.geom.Geometry geometry
         ) {
-            try {
-                final IntersectionMatrix matrix = envelope.relate(geometry);
-                if (matrix.isContains()) {
-                    // no need to clip
-                    return geometry;
-                } else if (matrix.isWithin()) {
-                    // the clipped geometry is the envelope
-                    return envelope.copy();
-                } else if (matrix.isIntersects()) {
-                    // clip it (clone envelope as coordinates are copied by reference)
-                    return envelope.copy().intersection(geometry);
-                } else {
-                    // disjoint
-                    assert envelope.copy().intersection(geometry).isEmpty();
-                    return null;
+            final Envelope tileEnvelope = tile.getEnvelopeInternal();
+            final Envelope geometryEnvelope = geometry.getEnvelopeInternal();
+            if (tileEnvelope.intersects(geometryEnvelope) == false) {
+                return null; // disjoint
+            } else if (tileEnvelope.contains(geometryEnvelope)) {
+                return geometry; // geometry within the tile
+            } else {
+                try {
+                    final IntersectionMatrix matrix = tile.relate(geometry);
+                    if (matrix.isContains()) {
+                        // no need to clip
+                        return geometry;
+                    } else if (matrix.isWithin()) {
+                        // the clipped geometry is the envelope
+                        return tile.copy();
+                    } else if (matrix.isIntersects()) {
+                        // clip it (clone envelope as coordinates are copied by reference)
+                        return tile.copy().intersection(geometry);
+                    } else {
+                        // disjoint
+                        assert tile.copy().intersection(geometry).isEmpty();
+                        return null;
+                    }
+                } catch (TopologyException ex) {
+                    // we should never get here but just to be super safe because a TopologyException will kill the node
+                    throw new IllegalArgumentException(ex);
                 }
-            } catch (TopologyException ex) {
-                // we should never get here but just to be super safe because a TopologyException will kill the node
-                throw new IllegalArgumentException(ex);
             }
         }
     }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -295,10 +295,7 @@ public class FeatureFactory {
             } else {
                 try {
                     final IntersectionMatrix matrix = tile.relate(geometry);
-                    if (matrix.isContains()) {
-                        // no need to clip
-                        return geometry;
-                    } else if (matrix.isWithin()) {
+                    if (matrix.isWithin()) {
                         // the clipped geometry is the envelope
                         return tile.copy();
                     } else if (matrix.isIntersects()) {


### PR DESCRIPTION
Looking at the generated flame graph of the vector tile 0/0/0 for some test data I noticed that we spend quite a lot of time on the clipping algorithm, in particular checking the relationship between the geometry and the tile:

![image](https://user-images.githubusercontent.com/29038686/216902810-85d9927f-d8b9-4144-aec8-0e36d33e11c1.png)


For this tile, all data should be inside the tile and that check can e done very fast using the bounding box of the geometry. This PR adds the fast check before computing the intersection matrix which result in a n improvement in performance:

![image](https://user-images.githubusercontent.com/29038686/216902583-88936496-c99e-4781-9ba9-fbfdf794c9af.png)


