### PR TITLE
Add size parameter to time_series aggregation

### DIFF
--- a/docs/changelog/93496.yaml
+++ b/docs/changelog/93496.yaml
@@ -1,5 +1,0 @@
-pr: 93496
-summary: Size for time series
-area: Geo
-type: enhancement
-issues: []

--- a/docs/changelog/93496.yaml
+++ b/docs/changelog/93496.yaml
@@ -1,0 +1,5 @@
+pr: 93496
+summary: Size for time series
+area: Geo
+type: feature
+issues: []

--- a/docs/changelog/93496.yaml
+++ b/docs/changelog/93496.yaml
@@ -1,5 +1,5 @@
 pr: 93496
 summary: Size for time series
 area: Geo
-type: feature
+type: enhancement
 issues: []

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -220,7 +220,6 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
         Integer size = reduceContext.builder() instanceof TimeSeriesAggregationBuilder
             ? ((TimeSeriesAggregationBuilder) reduceContext.builder()).getSize()
             : null; // tests may use a fake builder
-        int count = 0;
         List<InternalBucket> bucketsWithSameKey = new ArrayList<>(aggregations.size());
         BytesRef prevTsid = null;
         while (pq.size() > 0) {
@@ -251,7 +250,7 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
             BytesRef tsid = reducedBucket.key;
             assert prevTsid == null || tsid.compareTo(prevTsid) > 0;
             reduced.buckets.add(reducedBucket);
-            if (size != null && ++count >= size) {
+            if (size != null && reduced.buckets.size() >= size) {
                 break;
             }
             prevTsid = tsid;

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/InternalTimeSeries.java
@@ -217,6 +217,10 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
         }
 
         InternalTimeSeries reduced = new InternalTimeSeries(name, new ArrayList<>(initialCapacity), keyed, getMetadata());
+        Integer size = reduceContext.builder() instanceof TimeSeriesAggregationBuilder
+            ? ((TimeSeriesAggregationBuilder) reduceContext.builder()).getSize()
+            : null; // tests may use a fake builder
+        int count = 0;
         List<InternalBucket> bucketsWithSameKey = new ArrayList<>(aggregations.size());
         BytesRef prevTsid = null;
         while (pq.size() > 0) {
@@ -247,6 +251,9 @@ public class InternalTimeSeries extends InternalMultiBucketAggregation<InternalT
             BytesRef tsid = reducedBucket.key;
             assert prevTsid == null || tsid.compareTo(prevTsid) > 0;
             reduced.buckets.add(reducedBucket);
+            if (size != null && ++count >= size) {
+                break;
+            }
             prevTsid = tsid;
         }
         return reduced;

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
@@ -15,6 +15,7 @@ import org.elasticsearch.search.aggregations.AbstractAggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
+import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.xcontent.InstantiatingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -36,7 +37,7 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
     private boolean keyed;
     private int size;
 
-    private static final int DEFAULT_SIZE = 10000;
+    private static final int DEFAULT_SIZE = MultiBucketConsumerService.DEFAULT_MAX_BUCKETS;
 
     static {
         InstantiatingObjectParser.Builder<TimeSeriesAggregationBuilder, String> parser = InstantiatingObjectParser.builder(

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
@@ -30,9 +30,13 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<TimeSeriesAggregationBuilder> {
     public static final String NAME = "time_series";
     public static final ParseField KEYED_FIELD = new ParseField("keyed");
+    public static final ParseField SIZE_FIELD = new ParseField("size");
     public static final InstantiatingObjectParser<TimeSeriesAggregationBuilder, String> PARSER;
 
     private boolean keyed;
+    private int size;
+
+    private static final int DEFAULT_SIZE = 10000;
 
     static {
         InstantiatingObjectParser.Builder<TimeSeriesAggregationBuilder, String> parser = InstantiatingObjectParser.builder(
@@ -41,17 +45,23 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
             TimeSeriesAggregationBuilder.class
         );
         parser.declareBoolean(optionalConstructorArg(), KEYED_FIELD);
+        parser.declareInt(optionalConstructorArg(), SIZE_FIELD);
         PARSER = parser.build();
     }
 
     public TimeSeriesAggregationBuilder(String name) {
-        this(name, true);
+        this(name, true, DEFAULT_SIZE);
+    }
+
+    public TimeSeriesAggregationBuilder(String name, Boolean keyed) {
+        this(name, keyed, DEFAULT_SIZE);
     }
 
     @ParserConstructor
-    public TimeSeriesAggregationBuilder(String name, Boolean keyed) {
+    public TimeSeriesAggregationBuilder(String name, Boolean keyed, Integer size) {
         super(name);
         this.keyed = keyed != null ? keyed : true;
+        this.size = size != null ? size : DEFAULT_SIZE;
     }
 
     protected TimeSeriesAggregationBuilder(
@@ -61,16 +71,19 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
     ) {
         super(clone, factoriesBuilder, metadata);
         this.keyed = clone.keyed;
+        this.size = clone.size;
     }
 
     public TimeSeriesAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         keyed = in.readBoolean();
+        size = in.readVInt();
     }
 
     @Override
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeBoolean(keyed);
+        out.writeVInt(size);
     }
 
     @Override
@@ -79,13 +92,14 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder
     ) throws IOException {
-        return new TimeSeriesAggregationFactory(name, keyed, context, parent, subFactoriesBuilder, metadata);
+        return new TimeSeriesAggregationFactory(name, keyed, size, context, parent, subFactoriesBuilder, metadata);
     }
 
     @Override
     protected XContentBuilder internalXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(KEYED_FIELD.getPreferredName(), keyed);
+        builder.field(SIZE_FIELD.getPreferredName(), size);
         builder.endObject();
         return builder;
     }
@@ -116,6 +130,18 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
 
     public void setKeyed(boolean keyed) {
         this.keyed = keyed;
+    }
+
+    public TimeSeriesAggregationBuilder setSize(int size) {
+        if (size <= 0) {
+            throw new IllegalArgumentException("[size] must be greater than 0. Found [" + size + "] in [" + name + "]");
+        }
+        this.size = size;
+        return this;
+    }
+
+    public int getSize() {
+        return size;
     }
 
     @Override

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationFactory.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationFactory.java
@@ -21,9 +21,12 @@ public class TimeSeriesAggregationFactory extends AggregatorFactory {
 
     private final boolean keyed;
 
+    private final int size;
+
     public TimeSeriesAggregationFactory(
         String name,
         boolean keyed,
+        int size,
         AggregationContext context,
         AggregatorFactory parent,
         AggregatorFactories.Builder subFactoriesBuilder,
@@ -31,11 +34,12 @@ public class TimeSeriesAggregationFactory extends AggregatorFactory {
     ) throws IOException {
         super(name, context, parent, subFactoriesBuilder, metadata);
         this.keyed = keyed;
+        this.size = size;
     }
 
     @Override
     protected Aggregator createInternal(Aggregator parent, CardinalityUpperBound cardinality, Map<String, Object> metadata)
         throws IOException {
-        return new TimeSeriesAggregator(name, factories, keyed, context, parent, cardinality, metadata);
+        return new TimeSeriesAggregator(name, factories, keyed, context, parent, cardinality, metadata, size);
     }
 }

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregator.java
@@ -56,7 +56,6 @@ public class TimeSeriesAggregator extends BucketsAggregator {
             BytesKeyedBucketOrds.BucketOrdsEnum ordsEnum = bucketOrds.ordsEnum(owningBucketOrds[ordIdx]);
             List<InternalTimeSeries.InternalBucket> buckets = new ArrayList<>();
             BytesRef prev = null;
-            int count = 0;
             while (ordsEnum.next()) {
                 long docCount = bucketDocCount(ordsEnum.ord());
                 ordsEnum.readValue(spare);
@@ -70,7 +69,7 @@ public class TimeSeriesAggregator extends BucketsAggregator {
                 );
                 bucket.bucketOrd = ordsEnum.ord();
                 buckets.add(bucket);
-                if (++count >= size) {
+                if (buckets.size() >= size) {
                     break;
                 }
             }

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilderTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilderTests.java
@@ -14,7 +14,7 @@ public class TimeSeriesAggregationBuilderTests extends AggregationBuilderTestCas
 
     @Override
     protected TimeSeriesAggregationBuilder createTestAggregatorBuilder() {
-        return new TimeSeriesAggregationBuilder(randomAlphaOfLength(10), randomBoolean());
+        return new TimeSeriesAggregationBuilder(randomAlphaOfLength(10), randomBoolean(), 10000);
     }
 
 }

--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilderTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilderTests.java
@@ -14,7 +14,8 @@ public class TimeSeriesAggregationBuilderTests extends AggregationBuilderTestCas
 
     @Override
     protected TimeSeriesAggregationBuilder createTestAggregatorBuilder() {
-        return new TimeSeriesAggregationBuilder(randomAlphaOfLength(10), randomBoolean(), 10000);
+        // Size set large enough tests not intending to hit the size limit shouldn't see it.
+        return new TimeSeriesAggregationBuilder(randomAlphaOfLength(10), randomBoolean(), randomIntBetween(1000, 100_000));
     }
 
 }

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -54,7 +54,7 @@ setup:
 ---
 "Basic test":
   - skip:
-      version: " - 8.5.99"
+      version: " - 8.6.99"
       reason: Time series result serialization changed in 8.6.0
 
   - do:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -74,10 +74,50 @@ setup:
 
 
   - match: { hits.total.value: 1 }
-  - length: { aggregations.ts.buckets: 1 }
+  - length: { aggregations: 1 }
 
   - match: { aggregations.ts.buckets.0.key: { "key": "foo" } }
   - match: { aggregations.ts.buckets.0.doc_count: 1 }
+
+---
+"Size test":
+  - skip:
+      version: " - 8.6.99"
+      reason: Size added in 8.7.0
+
+  - do:
+      search:
+        index: tsdb
+        body:
+          query:
+            range:
+              "@timestamp":
+                gte: "2019-01-01T00:10:00Z"
+          size: 0
+          aggs:
+            ts:
+              time_series:
+                keyed: false
+                size: 1
+
+  - length: { aggregations.ts.buckets: 1 }
+
+  - do:
+      search:
+        index: tsdb
+        body:
+          query:
+            range:
+              "@timestamp":
+                gte: "2019-01-01T00:10:00Z"
+          size: 0
+          aggs:
+            ts:
+              time_series:
+                keyed: false
+                size: 3
+
+  - length: { aggregations.ts.buckets: 3 }
 
 ---
 "Sampler aggregation with nested time series aggregation failure":

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -101,6 +101,7 @@ setup:
                 size: 1
 
   - length: { aggregations.ts.buckets: 1 }
+  - match: { aggregations.ts.buckets.0.key: { "key": "bar" } }
 
   - do:
       search:
@@ -118,6 +119,9 @@ setup:
                 size: 3
 
   - length: { aggregations.ts.buckets: 3 }
+  - match: { aggregations.ts.buckets.0.key: { "key": "bar" } }
+  - match: { aggregations.ts.buckets.1.key: { "key": "baz" } }
+  - match: { aggregations.ts.buckets.2.key: { "key": "foo" } }
 
 ---
 "Sampler aggregation with nested time series aggregation failure":


### PR DESCRIPTION
Adds an optional size parameter which caps the number of buckets in responses.

After aggregation, caps the number of buckets we send back in responses and in reduction.