### PR TITLE
[8.6] [DOCS] Remove excessive white space from the landing page (#93472)

### DIFF
--- a/docs/reference/index-custom-title-page.html
+++ b/docs/reference/index-custom-title-page.html
@@ -41,6 +41,14 @@
       -moz-columns: 2;
     }
   }
+
+  #guide h3.gtk {
+    margin-top: 0;
+  }
+
+  .mb-4, .my-4 {
+    margin-bottom: 0!important;
+  }
 </style>
 
 <div class="legalnotice"></div>
@@ -68,7 +76,7 @@
   </div>
 </div>
 
-<h3>Get to know Elasticsearch</h3>
+<h3 class="gtk">Get to know Elasticsearch</h3>
 
 <div class="my-5">
   <div class="d-flex align-items-center mb-3">
@@ -191,7 +199,7 @@
   </ul>
 </div>
 
-<h3>Explore by use case</h3>
+<h3 class="explore">Explore by use case</h3>
 
 <div class="row my-4">
   <div class="col-md-4 col-12 mb-2">


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Remove excessive white space from the landing page (#93472)