### PR TITLE
AbstractThrottledTaskRunnerTests needs all-core threads

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractThrottledTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractThrottledTaskRunnerTests.java
@@ -36,7 +36,7 @@ public class AbstractThrottledTaskRunnerTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         maxThreads = between(1, 10);
-        executor = EsExecutors.newScaling("test", 1, maxThreads, 0, TimeUnit.MILLISECONDS, false, threadFactory, threadContext);
+        executor = EsExecutors.newScaling("test", maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS, false, threadFactory, threadContext);
     }
 
     @Override
@@ -144,7 +144,7 @@ public class AbstractThrottledTaskRunnerTests extends ESTestCase {
 
     public void testFailsTasksOnRejectionOrShutdown() throws Exception {
         final var executor = randomBoolean()
-            ? EsExecutors.newScaling("test", 1, maxThreads, 0, TimeUnit.MILLISECONDS, true, threadFactory, threadContext)
+            ? EsExecutors.newScaling("test", maxThreads, maxThreads, 0, TimeUnit.MILLISECONDS, true, threadFactory, threadContext)
             : EsExecutors.newFixed("test", maxThreads, between(1, 5), threadFactory, threadContext, false);
 
         final var totalPermits = between(1, maxThreads * 2);


### PR DESCRIPTION
The same fix as in #93446, which was missed in #93436