### PR TITLE
Decrease queue capacity in EnrichResiliencyTests for resiliency

### DIFF
--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichResiliencyTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichResiliencyTests.java
@@ -52,7 +52,7 @@ public class EnrichResiliencyTests extends ESSingleNodeTestCase {
             .put(EnrichPlugin.CACHE_SIZE.getKey(), 0)
             .put(EnrichPlugin.COORDINATOR_PROXY_MAX_CONCURRENT_REQUESTS.getKey(), 1)
             .put(EnrichPlugin.COORDINATOR_PROXY_MAX_LOOKUPS_PER_REQUEST.getKey(), 1)
-            .put(EnrichPlugin.COORDINATOR_PROXY_QUEUE_CAPACITY.getKey(), 10)
+            .put(EnrichPlugin.COORDINATOR_PROXY_QUEUE_CAPACITY.getKey(), 2)
             // TODO Fix the test so that it runs with security enabled
             // https://github.com/elastic/elasticsearch/issues/75940
             .put(XPackSettings.SECURITY_ENABLED.getKey(), false)


### PR DESCRIPTION
Fixes [#82719](https://github.com/elastic/elasticsearch/issues/82719) according to the recommendation in https://github.com/elastic/elasticsearch/issues/82719#issuecomment-1022313035.

> I think this failed in CI, because of slowness. The executes a bulk request with a number of index requests (50) and then assumes that some of these index requests failed, because enrich queue was at capacity. The queue capacity is set to 10. I think we should to set the queue size to an even smaller value, like 2. To make it likely to reach queue capacity when test execution is slow.
> 
> In the mentioned build failure, it took 12 seconds to run this test, while locally here it takes 707 ms.


