### PR TITLE
Experimental H3 function support in geo_tile ingest processor

### DIFF
--- a/docs/changelog/93508.yaml
+++ b/docs/changelog/93508.yaml
@@ -1,0 +1,5 @@
+pr: 93508
+summary: Experimental H3 function support in `geo_tile` ingest processor
+area: Geo
+type: enhancement
+issues: []


### PR DESCRIPTION
Adds an experimental feature to https://github.com/elastic/elasticsearch/pull/93370

When processing geo_grid of type `geohex`, the h3 address is checked for the prefix `H3.` and if so is interpreted as a function call to the H3 library. Initially only two functions are understood and both are expected to return an H3 address:

* `H3.geoToH3(lat,lng,res)`
* `H3.h3ToParent(h3)`

This feature could be satisfied instead with a script ingest processor in the pipeline before the geo_grid processor, but that requires that painless be giving access to the H3 library, which is not yet the case.