### PR TITLE
Unmute testThatLoadingWithNonExistingIndexWorks

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -40,7 +40,6 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
     // this is the standard setup when starting watcher in a regular cluster
     // the index does not exist, a watch gets added
     // the watch should be executed properly, despite the index being created and the cluster state listener being reloaded
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/54096")
     public void testThatLoadingWithNonExistingIndexWorks() throws Exception {
         stopWatcher();
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();


### PR DESCRIPTION
Closes #54096.

We are reevaluating old failures to see if they still happen. With this PR we close the test failure issue and we will re-open it if the same failure happens.