### PR TITLE
Add a pattern bank cache to Grok Processors

### DIFF
--- a/docs/changelog/93510.yaml
+++ b/docs/changelog/93510.yaml
@@ -1,0 +1,5 @@
+pr: 93510
+summary: Add a pattern bank cache to Grok Processors
+area: Ingest Node
+type: enhancement
+issues: []


### PR DESCRIPTION
Pattern banks are identical between different processors, making them highly cacheable and allowing us to save some memory bytes. Also, uses immutable maps, just to clearly indicate that the banks won't be changed later on.

To validate the change I've created a ingest pipeline with 100 processors in total, but only 4 different versions (the different combinations of `ecs_compatibility` values plus having and not having custom `pattern_definitions`):

```json
PUT _ingest/pipeline/grok-size
{
  "processors": [
    {
      "grok": {
        "field": "message",
        "patterns": [
          "%{WORD:grok.client}"
        ],
        "ecs_compatibility": "v1",
        "pattern_definitions": {
          "FAVORITE_DOG": "beagle",
          "RGB": "RED|GREEN|BLUE"
        }
      }
    },
    {
      "grok": {
        "field": "message",
        "patterns": [
          "%{WORD:grok.client}"
        ],
        "pattern_definitions": {
          "FAVORITE_DOG": "beagle",
          "RGB": "RED|GREEN|BLUE"
        }
      }
    },
    {
      "grok": {
        "field": "message",
        "patterns": [
          "%{WORD:grok.client}"
        ]
      }
    },
    {
      "grok": {
        "field": "message",
        "ecs_compatibility": "v1",
        "patterns": [
          "%{WORD:grok.client}"
        ]
      }
    },
    ...
  ]
}
```

taking a heap dump, we can see the amount of saved memory:

> before
> <img width="1049" alt="Screenshot 2023-02-06 at 12 16 11" src="https://user-images.githubusercontent.com/284537/216958335-6e073a37-e869-42c8-bd5c-c8ab6a3bfc6f.png">


> after
> <img width="1049" alt="Screenshot 2023-02-06 at 12 16 07" src="https://user-images.githubusercontent.com/284537/216958326-300c1057-c5ec-408a-9382-b417aa5fcc61.png">


The same pipeline went from `~1.33MB` to `91KB` of total resident memory used. 