### PR TITLE
Add ShardRouting to DirectoryFactory interface

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexModule.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexModule.java
@@ -589,10 +589,9 @@ public final class IndexModule {
         assert frozen.get() : "IndexModule configuration not frozen";
         if (directoryWrapper != null) {
             return new IndexStorePlugin.DirectoryFactory() {
-
                 @Override
                 public Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath) throws IOException {
-                    return directoryWrapper.wrap(factory.newDirectory(indexSettings, shardPath), null);
+                    return newDirectory(indexSettings, shardPath, null);
                 }
 
                 @Override

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -494,7 +494,12 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     warmer.warm(reader, shard, IndexService.this.indexSettings);
                 }
             };
-            Directory directory = directoryFactory.newDirectory(this.indexSettings, path);
+            final Directory directory = directoryFactory.newDirectory(
+                this.indexSettings,
+                path,
+                routing.isSearchable(),
+                routing.isPromotableToPrimary()
+            );
             store = new Store(
                 shardId,
                 this.indexSettings,

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -494,12 +494,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                     warmer.warm(reader, shard, IndexService.this.indexSettings);
                 }
             };
-            final Directory directory = directoryFactory.newDirectory(
-                this.indexSettings,
-                path,
-                routing.isSearchable(),
-                routing.isPromotableToPrimary()
-            );
+            final Directory directory = directoryFactory.newDirectory(this.indexSettings, path, routing);
             store = new Store(
                 shardId,
                 this.indexSettings,

--- a/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
@@ -44,6 +44,20 @@ public interface IndexStorePlugin {
          * @throws IOException if an IOException occurs while opening the directory
          */
         Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath) throws IOException;
+
+        /**
+         * Creates a new directory per shard. This method is called once per shard on shard creation.
+         * @param indexSettings the shards index settings
+         * @param shardPath the path the shard is using
+         * @param isSearchable true if the shard for which the directory is created is a searchable shard copy
+         * @param isPromotable true if the shard for which the directory is created is a shard copy that can be promoted as a primary shard
+         * @return a new lucene directory instance
+         * @throws IOException if an IOException occurs while opening the directory
+         */
+        default Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath, boolean isSearchable, boolean isPromotable)
+            throws IOException {
+            return newDirectory(indexSettings, shardPath);
+        }
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/IndexStorePlugin.java
@@ -49,13 +49,11 @@ public interface IndexStorePlugin {
          * Creates a new directory per shard. This method is called once per shard on shard creation.
          * @param indexSettings the shards index settings
          * @param shardPath the path the shard is using
-         * @param isSearchable true if the shard for which the directory is created is a searchable shard copy
-         * @param isPromotable true if the shard for which the directory is created is a shard copy that can be promoted as a primary shard
+         * @param shardRouting the {@link ShardRouting}
          * @return a new lucene directory instance
          * @throws IOException if an IOException occurs while opening the directory
          */
-        default Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath, boolean isSearchable, boolean isPromotable)
-            throws IOException {
+        default Directory newDirectory(IndexSettings indexSettings, ShardPath shardPath, ShardRouting shardRouting) throws IOException {
             return newDirectory(indexSettings, shardPath);
         }
     }


### PR DESCRIPTION
Some `Directory` factories would benefit from knowing if a `Directory` is created for a promotable and/or searchable shard, as well as knowing the shard id. This change adds the `ShardRouting` to the `DirectoryFactory` interface and adjusts the `DirectoryWrapper` accordingly (until we have a better way to override the default directory factory).