### PR TITLE
Extract and dry more IO logic out of searchable snapshots module

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
@@ -50,8 +50,8 @@ public class BlobCacheUtils {
         return ByteRange.of(start, end);
     }
 
-    public static void ensureSlice(String sliceName, long sliceOffset, long sliceLength, IndexInput indexInput) {
-        if (sliceOffset < 0 || sliceLength < 0 || sliceOffset + sliceLength > indexInput.length()) {
+    public static void ensureSlice(String sliceName, long sliceOffset, long sliceLength, IndexInput input) {
+        if (sliceOffset < 0 || sliceLength < 0 || sliceOffset + sliceLength > input.length()) {
             throw new IllegalArgumentException(
                 "slice() "
                     + sliceName
@@ -60,9 +60,9 @@ public class BlobCacheUtils {
                     + ",length="
                     + sliceLength
                     + ",fileLength="
-                    + indexInput.length()
+                    + input.length()
                     + ": "
-                    + indexInput
+                    + input
             );
         }
     }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/BlobCacheUtils.java
@@ -7,7 +7,17 @@
 
 package org.elasticsearch.blobcache;
 
+import org.apache.lucene.store.IndexInput;
+import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.common.unit.ByteSizeUnit;
+import org.elasticsearch.core.Streams;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+import static org.elasticsearch.core.Strings.format;
 
 public class BlobCacheUtils {
 
@@ -19,5 +29,57 @@ public class BlobCacheUtils {
      */
     public static int toIntBytes(long l) {
         return ByteSizeUnit.BYTES.toIntBytes(l);
+    }
+
+    public static void throwEOF(long channelPos, long len, Object file) throws EOFException {
+        throw new EOFException(format("unexpected EOF reading [%d-%d] from %s", channelPos, channelPos + len, file));
+    }
+
+    public static void ensureSeek(long pos, IndexInput input) throws IOException {
+        final long length = input.length();
+        if (pos > length) {
+            throw new EOFException("Reading past end of file [position=" + pos + ", length=" + input.length() + "] for " + input);
+        } else if (pos < 0L) {
+            throw new IOException("Seeking to negative position [" + pos + "] for " + input);
+        }
+    }
+
+    public static ByteRange computeRange(long rangeSize, long position, long length) {
+        long start = (position / rangeSize) * rangeSize;
+        long end = Math.min(start + rangeSize, length);
+        return ByteRange.of(start, end);
+    }
+
+    public static void ensureSlice(String sliceName, long sliceOffset, long sliceLength, IndexInput indexInput) {
+        if (sliceOffset < 0 || sliceLength < 0 || sliceOffset + sliceLength > indexInput.length()) {
+            throw new IllegalArgumentException(
+                "slice() "
+                    + sliceName
+                    + " out of bounds: offset="
+                    + sliceOffset
+                    + ",length="
+                    + sliceLength
+                    + ",fileLength="
+                    + indexInput.length()
+                    + ": "
+                    + indexInput
+            );
+        }
+    }
+
+    /**
+     * Perform a single {@code read()} from {@code inputStream} into {@code copyBuffer}, handling an EOF by throwing an {@link EOFException}
+     * rather than returning {@code -1}. Returns the number of bytes read, which is always positive.
+     *
+     * Most of its arguments are there simply to make the message of the {@link EOFException} more informative.
+     */
+    public static int readSafe(InputStream inputStream, ByteBuffer copyBuffer, long rangeStart, long remaining, Object cacheFileReference)
+        throws IOException {
+        final int len = (remaining < copyBuffer.remaining()) ? toIntBytes(remaining) : copyBuffer.remaining();
+        final int bytesRead = Streams.read(inputStream, copyBuffer, len);
+        if (bytesRead <= 0) {
+            throwEOF(rangeStart, remaining, cacheFileReference);
+        }
+        return bytesRead;
     }
 }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/store/InMemoryNoOpCommitDirectory.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/store/InMemoryNoOpCommitDirectory.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.xpack.searchablesnapshots.store;
+package org.elasticsearch.blobcache.store;
 
 import org.apache.lucene.store.ByteBuffersDirectory;
 import org.apache.lucene.store.Directory;
@@ -33,7 +33,7 @@ public class InMemoryNoOpCommitDirectory extends FilterDirectory {
     private final Directory realDirectory;
     private final Set<String> deletedFiles = new CopyOnWriteArraySet<>();
 
-    InMemoryNoOpCommitDirectory(Directory realDirectory) {
+    public InMemoryNoOpCommitDirectory(Directory realDirectory) {
         super(new ByteBuffersDirectory(NoLockFactory.INSTANCE));
         this.realDirectory = realDirectory;
     }

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/BlobCacheUtilsTests.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.blobcache;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.EOFException;
+import java.nio.ByteBuffer;
+
+public class BlobCacheUtilsTests extends ESTestCase {
+
+    public void testReadSafeThrows() {
+        final ByteBuffer buffer = ByteBuffer.allocate(randomIntBetween(1, 1025));
+        final int remaining = randomIntBetween(1, 1025);
+        expectThrows(EOFException.class, () -> BlobCacheUtils.readSafe(BytesArray.EMPTY.streamInput(), buffer, 0, remaining, null));
+    }
+}

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/store/InMemoryNoOpCommitDirectoryTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/store/InMemoryNoOpCommitDirectoryTests.java
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-package org.elasticsearch.xpack.searchablesnapshots.store;
+package org.elasticsearch.blobcache.store;
 
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -23,6 +23,7 @@ import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.support.CountDownActionListener;
 import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
+import org.elasticsearch.blobcache.store.InMemoryNoOpCommitDirectory;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.common.blobstore.BlobContainer;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInput.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.IntStream;
 
+import static org.elasticsearch.blobcache.BlobCacheUtils.readSafe;
 import static org.elasticsearch.blobcache.BlobCacheUtils.toIntBytes;
 
 public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
@@ -171,7 +172,7 @@ public class CachedBlobContainerIndexInput extends MetadataCachingIndexInput {
                 while (remainingBytes > 0L) {
                     assert totalBytesRead + remainingBytes == range.length();
                     copyBuffer.clear();
-                    final int bytesRead = readSafe(input, copyBuffer, range.start(), range.end(), remainingBytes, cacheFileReference);
+                    final int bytesRead = readSafe(input, copyBuffer, range.start(), remainingBytes, cacheFileReference);
 
                     // The range to prewarm in cache
                     final long readStart = range.start() + totalBytesRead;


### PR DESCRIPTION
Extracting more of the IO logic to the blob cache to make it reusable as well as dry it up a little. Small changes to the EOF exception message format in 2 cases in here that only remove redundant information.
