### PR TITLE
More useful toString on UpdateSettingsTask

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/UpdateSettingsClusterStateUpdateRequest.java
@@ -11,6 +11,8 @@ package org.elasticsearch.action.admin.indices.settings.put;
 import org.elasticsearch.cluster.ack.IndicesClusterStateUpdateRequest;
 import org.elasticsearch.common.settings.Settings;
 
+import java.util.Arrays;
+
 /**
  * Cluster state update request that allows to update settings for some indices
  */
@@ -50,5 +52,10 @@ public class UpdateSettingsClusterStateUpdateRequest extends IndicesClusterState
     public UpdateSettingsClusterStateUpdateRequest settings(Settings settings) {
         this.settings = settings;
         return this;
+    }
+
+    @Override
+    public String toString() {
+        return Arrays.toString(indices()) + settings;
     }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/MetadataUpdateSettingsService.java
@@ -305,6 +305,11 @@ public class MetadataUpdateSettingsService {
 
             return updatedState;
         }
+
+        @Override
+        public String toString() {
+            return request.toString();
+        }
     }
 
     public void updateSettings(final UpdateSettingsClusterStateUpdateRequest request, final ActionListener<AcknowledgedResponse> listener) {


### PR DESCRIPTION
Today `UpdateSettingsTask#toString` is just the default which is not helpful when it appears in logs. This commit makes it include the affected indices and settings.