### PR TITLE
WIP Add query rules management endpoints

### DIFF
--- a/docs/reference/migration/apis/feature-migration.asciidoc
+++ b/docs/reference/migration/apis/feature-migration.asciidoc
@@ -97,6 +97,12 @@ Example response:
       "indices" : [ ]
     },
     {
+      "feature_name" : "query_rules_management",
+      "minimum_index_version" : "8.0.0",
+      "migration_status" : "NO_MIGRATION_NEEDED",
+      "indices" : [ ]
+    },
+    {
       "feature_name" : "searchable_snapshots",
       "minimum_index_version" : "8.0.0",
       "migration_status" : "NO_MIGRATION_NEEDED",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.delete.json
@@ -1,0 +1,30 @@
+{
+  "query_rules.delete":{
+    "documentation":{
+      "url":"TODO",
+      "description":"Allows to delete a query rules set from the cluster"
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_query_rules/{rulesetId}",
+          "methods":[
+            "DELETE"
+          ],
+          "parts":{
+            "rulesetId":{
+              "type":"string",
+              "description":"A unique rule set id"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.delete.json
@@ -1,7 +1,7 @@
 {
   "query_rules.delete":{
     "documentation":{
-      "url":"TODO",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/todo.html",
       "description":"Allows to delete a query rules set from the cluster"
     },
     "stability":"experimental",
@@ -13,12 +13,12 @@
     "url":{
       "paths":[
         {
-          "path":"/_query_rules/{rulesetId}",
+          "path":"/_query_rules/{ruleset_id}",
           "methods":[
             "DELETE"
           ],
           "parts":{
-            "rulesetId":{
+            "ruleset_id":{
               "type":"string",
               "description":"A unique rule set id"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.get.json
@@ -1,7 +1,7 @@
 {
   "query_rules.get":{
     "documentation":{
-      "url":"TODO",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/todo.html",
       "description":"Allows to get a query rules set to the cluster"
     },
     "stability":"experimental",
@@ -13,12 +13,12 @@
     "url":{
       "paths":[
         {
-          "path":"/_query_rules/{rulesetId}",
+          "path":"/_query_rules/{ruleset_id}",
           "methods":[
             "GET"
           ],
           "parts":{
-            "rulesetId":{
+            "ruleset_id":{
               "type":"string",
               "description":"A unique rule set id"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.get.json
@@ -1,0 +1,30 @@
+{
+  "query_rules.get":{
+    "documentation":{
+      "url":"TODO",
+      "description":"Allows to get a query rules set to the cluster"
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_query_rules/{rulesetId}",
+          "methods":[
+            "GET"
+          ],
+          "parts":{
+            "rulesetId":{
+              "type":"string",
+              "description":"A unique rule set id"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
@@ -1,7 +1,7 @@
 {
   "query_rules.list":{
     "documentation":{
-      "url":"TODO",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/todo.html",
       "description":"List all available rule set ids"
     },
     "stability":"experimental",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
@@ -1,0 +1,24 @@
+{
+  "query_rules.list":{
+    "documentation":{
+      "url":"TODO",
+      "description":"List all available rule set ids"
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_query_rules/_list",
+          "methods":[
+            "GET"
+          ]
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
@@ -13,7 +13,7 @@
     "url":{
       "paths":[
         {
-          "path":"/_query_rules/_list",
+          "path":"/_query_rules/list",
           "methods":[
             "POST"
           ]

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.list.json
@@ -15,10 +15,14 @@
         {
           "path":"/_query_rules/_list",
           "methods":[
-            "GET"
+            "POST"
           ]
         }
       ]
+    },
+    "body":{
+      "description":"The list ids optional parameters",
+      "required":false
     }
   }
 }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.put.json
@@ -1,7 +1,7 @@
 {
   "query_rules.put":{
     "documentation":{
-      "url":"TODO",
+      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/current/todo.html",
       "description":"Allows to add a query rules set to the cluster"
     },
     "stability":"experimental",
@@ -13,12 +13,12 @@
     "url":{
       "paths":[
         {
-          "path":"/_query_rules/{rulesetId}",
+          "path":"/_query_rules/{ruleset_id}",
           "methods":[
             "PUT"
           ],
           "parts":{
-            "rulesetId":{
+            "ruleset_id":{
               "type":"string",
               "description":"A unique rule set id"
             }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_rules.put.json
@@ -1,0 +1,34 @@
+{
+  "query_rules.put":{
+    "documentation":{
+      "url":"TODO",
+      "description":"Allows to add a query rules set to the cluster"
+    },
+    "stability":"experimental",
+    "visibility":"public",
+    "headers":{
+      "accept": [ "application/json"],
+      "content_type": ["application/json"]
+    },
+    "url":{
+      "paths":[
+        {
+          "path":"/_query_rules/{rulesetId}",
+          "methods":[
+            "PUT"
+          ],
+          "parts":{
+            "rulesetId":{
+              "type":"string",
+              "description":"A unique rule set id"
+            }
+          }
+        }
+      ]
+    },
+    "body":{
+      "description":"The rule set itself",
+      "required":true
+    }
+  }
+}

--- a/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-builtin-privileges.asciidoc
@@ -99,6 +99,7 @@ A successful call returns an object with "cluster" and "index" fields.
     "monitor_transform",
     "monitor_watcher",
     "none",
+    "query_rules",
     "read_ccr",
     "read_ilm",
     "read_pipeline",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -189,7 +189,6 @@ public final class ClientHelper {
     public static final String SEARCHABLE_SNAPSHOTS_ORIGIN = "searchable_snapshots";
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
-
     public static final String QUERY_RULES_MANAGEMENT_ORIGIN = "query_rules_management";
 
     private ClientHelper() {}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -190,6 +190,8 @@ public final class ClientHelper {
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
 
+    public static final String QUERY_RULES_MANAGEMENT_ORIGIN = "query_rules_management";
+
     private ClientHelper() {}
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -158,6 +158,7 @@ import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
 import org.elasticsearch.xpack.core.rollup.job.RollupJobStatus;
 import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
 import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
 import org.elasticsearch.xpack.core.searchablesnapshots.SearchableSnapshotFeatureSetUsage;
 import org.elasticsearch.xpack.core.security.SecurityFeatureSetUsage;
@@ -411,7 +412,9 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
             TermsEnumAction.INSTANCE,
             // TSDB Downsampling
             RollupIndexerAction.INSTANCE,
-            org.elasticsearch.xpack.core.downsample.DownsampleAction.INSTANCE
+            org.elasticsearch.xpack.core.downsample.DownsampleAction.INSTANCE,
+            // Quey Rules
+            QueryRulesPutAction.INSTANCE
         );
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesDeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesDeleteAction.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.search.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class QueryRulesDeleteAction extends ActionType<AcknowledgedResponse> {
+
+    public static final QueryRulesDeleteAction INSTANCE = new QueryRulesDeleteAction();
+    public static final String NAME = "cluster:admin/read/query_rules/delete";
+
+    private QueryRulesDeleteAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String rulesetId;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.rulesetId = in.readString();
+        }
+
+        public Request(String rulesetId) {
+            this.rulesetId = rulesetId;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(rulesetId);
+        }
+
+        public String getRuleSetId() {
+            return this.rulesetId;
+        }
+
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesDeleteAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesDeleteAction.java
@@ -19,7 +19,7 @@ import java.io.IOException;
 public class QueryRulesDeleteAction extends ActionType<AcknowledgedResponse> {
 
     public static final QueryRulesDeleteAction INSTANCE = new QueryRulesDeleteAction();
-    public static final String NAME = "cluster:admin/read/query_rules/delete";
+    public static final String NAME = "cluster:admin/query_rules/delete";
 
     private QueryRulesDeleteAction() {
         super(NAME, AcknowledgedResponse::readFrom);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesGetAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesGetAction.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 public class QueryRulesGetAction extends ActionType<QueryRulesGetAction.Response> {
 
     public static final QueryRulesGetAction INSTANCE = new QueryRulesGetAction();
-    public static final String NAME = "cluster:admin/read/query_rules/get";
+    public static final String NAME = "cluster:admin/query_rules/get";
 
     private QueryRulesGetAction() {
         super(NAME, QueryRulesGetAction.Response::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesGetAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesGetAction.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.search.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class QueryRulesGetAction extends ActionType<QueryRulesGetAction.Response> {
+
+    public static final QueryRulesGetAction INSTANCE = new QueryRulesGetAction();
+    public static final String NAME = "cluster:admin/read/query_rules/get";
+
+    private QueryRulesGetAction() {
+        super(NAME, QueryRulesGetAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String rulesetId;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.rulesetId = in.readString();
+        }
+
+        public Request(String rulesetId) {
+            this.rulesetId = rulesetId;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            // TODO check id and body non null, body has required fields etc...
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(rulesetId);
+        }
+
+        public String getRuleSetId() {
+            return this.rulesetId;
+        }
+
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private final BytesReference source;
+        private final boolean found;
+        private final String rulesetId;
+
+        public Response(String rulesetId, boolean found, BytesReference sourceAsBytes) {
+            this.source = sourceAsBytes;
+            this.found = found;
+            this.rulesetId = rulesetId;
+        }
+
+        Response(StreamInput in) throws IOException {
+            super(in);
+            this.source = in.readBytesReference();
+            this.rulesetId = in.readString();
+            this.found = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBytesReference(this.source);
+            out.writeString(rulesetId);
+            out.writeBoolean(found);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("ruleset_id", this.rulesetId);
+            builder.field("found", this.found);
+            if (found) {
+                XContentHelper.writeRawField(SourceFieldMapper.NAME, source, builder, params);
+            }
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesListAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesListAction.java
@@ -13,8 +13,11 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
@@ -29,16 +32,57 @@ public class QueryRulesListAction extends ActionType<QueryRulesListAction.Respon
 
     public static class Request extends ActionRequest {
 
+        private final int size;
+        private final int from;
+
         public Request(StreamInput in) throws IOException {
             super(in);
+            this.size = in.readVInt();
+            this.from = in.readVInt();
         }
 
-        public Request() {}
+        public Request(int size, int offset) {
+            this.size = size;
+            this.from = offset;
+        }
+
+        private static final ParseField SIZE_FIELD = new ParseField("size");
+        private static final ParseField FROM_FIELD = new ParseField("from");
+
+        private static final ConstructingObjectParser<Request, Void> PARSER = new ConstructingObjectParser<>("query_rules_list", a -> {
+            int size = (a[0] == null ? 10 : (Integer) a[0]);
+            int offset = (a[1] == null ? 0 : (Integer) a[1]);
+            return new Request(size, offset);
+        });
+
+        static {
+            PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), SIZE_FIELD);
+            PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), FROM_FIELD);
+        }
+
+        public static Request parse(XContentParser parser) {
+            return PARSER.apply(parser, null);
+        }
+
+        public int getSize() {
+            return size;
+        }
+
+        public int getFrom() {
+            return from;
+        }
+
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeVInt(size);
+            out.writeVInt(from);
+        }
 
         @Override
         public ActionRequestValidationException validate() {
             return null;
         }
+
     }
 
     public static class Response extends ActionResponse implements ToXContentObject {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesListAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesListAction.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 public class QueryRulesListAction extends ActionType<QueryRulesListAction.Response> {
 
     public static final QueryRulesListAction INSTANCE = new QueryRulesListAction();
-    public static final String NAME = "cluster:admin/read/query_rules/list";
+    public static final String NAME = "cluster:admin/query_rules/list";
 
     private QueryRulesListAction() {
         super(NAME, QueryRulesListAction.Response::new);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesListAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesListAction.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.search.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+public class QueryRulesListAction extends ActionType<QueryRulesListAction.Response> {
+
+    public static final QueryRulesListAction INSTANCE = new QueryRulesListAction();
+    public static final String NAME = "cluster:admin/read/query_rules/list";
+
+    private QueryRulesListAction() {
+        super(NAME, QueryRulesListAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+        }
+
+        public Request() {}
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        private final String[] ids;
+
+        public Response(String[] ids) {
+            this.ids = ids;
+        }
+
+        Response(StreamInput in) throws IOException {
+            super(in);
+            this.ids = in.readStringArray();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeStringArray(this.ids);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.array("ruleset_ids", ids);
+            builder.endObject();
+            return builder;
+        }
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesPutAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesPutAction.java
@@ -26,7 +26,7 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class QueryRulesPutAction extends ActionType<AcknowledgedResponse> {
 
     public static final QueryRulesPutAction INSTANCE = new QueryRulesPutAction();
-    public static final String NAME = "cluster:admin/read/query_rules/put";
+    public static final String NAME = "cluster:admin/query_rules/put";
 
     private QueryRulesPutAction() {
         super(NAME, AcknowledgedResponse::readFrom);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesPutAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesPutAction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.search.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class QueryRulesPutAction extends ActionType<AcknowledgedResponse> {
+
+    public static final QueryRulesPutAction INSTANCE = new QueryRulesPutAction();
+    public static final String NAME = "cluster:admin/read/query_rules/put";
+
+    private QueryRulesPutAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String rulesetIds;
+        public final BytesReference content;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.rulesetIds = in.readString();
+            this.content = in.readBytesReference();
+        }
+
+        public Request(String rulesetId, BytesReference content) {
+            this.rulesetIds = rulesetId;
+            this.content = content;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            // TODO check id and body non null, body has required fields etc...
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(rulesetIds);
+            out.writeBytesReference(content);
+        }
+
+        public String getRuleSetId() {
+            return this.rulesetIds;
+        }
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesPutAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/QueryRulesPutAction.java
@@ -9,12 +9,15 @@ package org.elasticsearch.xpack.core.search.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
@@ -23,13 +26,13 @@ import java.util.Map;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public class QueryRulesPutAction extends ActionType<AcknowledgedResponse> {
+public class QueryRulesPutAction extends ActionType<QueryRulesPutAction.Response> {
 
     public static final QueryRulesPutAction INSTANCE = new QueryRulesPutAction();
     public static final String NAME = "cluster:admin/query_rules/put";
 
     private QueryRulesPutAction() {
-        super(NAME, AcknowledgedResponse::readFrom);
+        super(NAME, QueryRulesPutAction.Response::new);
     }
 
     public static class Request extends ActionRequest {
@@ -92,6 +95,33 @@ public class QueryRulesPutAction extends ActionType<AcknowledgedResponse> {
 
         public XContentType getContentType() {
             return contentType;
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        final DocWriteResponse.Result result;
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            result = DocWriteResponse.Result.readFrom(in);
+        }
+
+        public Response(DocWriteResponse.Result result) {
+            this.result = result;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            this.result.writeTo(out);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("result", this.result.getLowercase());
+            builder.endObject();
+            return builder;
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -113,6 +113,8 @@ public class ClusterPrivilegeResolver {
     );
     private static final Set<String> MANAGE_INGEST_PIPELINE_PATTERN = Set.of("cluster:admin/ingest/pipeline/*");
     private static final Set<String> READ_PIPELINE_PATTERN = Set.of(GetPipelineAction.NAME, SimulatePipelineAction.NAME);
+
+    private static final Set<String> QUERY_RULES_PATTERN = Set.of("cluster:admin/query_rules/*");
     private static final Set<String> MANAGE_ROLLUP_PATTERN = Set.of("cluster:admin/xpack/rollup/*", "cluster:monitor/xpack/rollup/*");
     private static final Set<String> MANAGE_CCR_PATTERN = Set.of(
         "cluster:admin/xpack/ccr/*",
@@ -181,6 +183,8 @@ public class ClusterPrivilegeResolver {
         MANAGE_INGEST_PIPELINE_PATTERN
     );
     public static final NamedClusterPrivilege READ_PIPELINE = new ActionClusterPrivilege("read_pipeline", READ_PIPELINE_PATTERN);
+
+    public static final NamedClusterPrivilege QUERY_RULES = new ActionClusterPrivilege("query_rules", QUERY_RULES_PATTERN);
     public static final NamedClusterPrivilege TRANSPORT_CLIENT = new ActionClusterPrivilege("transport_client", TRANSPORT_CLIENT_PATTERN);
     public static final NamedClusterPrivilege MANAGE_SECURITY = new ActionClusterPrivilege(
         "manage_security",
@@ -293,7 +297,8 @@ public class ClusterPrivilegeResolver {
             MANAGE_OWN_API_KEY,
             MANAGE_ENRICH,
             MANAGE_LOGSTASH_PIPELINES,
-            CANCEL_TASK
+            CANCEL_TASK,
+            QUERY_RULES
         )
     );
 

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesDeleteAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesDeleteAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.search.action.QueryRulesDeleteAction;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+public class RestQueryRulesDeleteAction extends BaseRestHandler {
+
+    public static final String ENDPOINT = "_query_rules";
+
+    @Override
+    public String getName() {
+        return "query_rules_delete_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, "/" + ENDPOINT + "/{rulesetId}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        QueryRulesDeleteAction.Request request = new QueryRulesDeleteAction.Request(restRequest.param("rulesetId"));
+        return channel -> client.execute(
+            QueryRulesDeleteAction.INSTANCE,
+            request,
+            new RestToXContentListener<AcknowledgedResponse>(channel)
+        );
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesDeleteAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesDeleteAction.java
@@ -30,12 +30,12 @@ public class RestQueryRulesDeleteAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(DELETE, "/" + ENDPOINT + "/{rulesetId}"));
+        return List.of(new Route(DELETE, "/" + ENDPOINT + "/{ruleset_id}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        QueryRulesDeleteAction.Request request = new QueryRulesDeleteAction.Request(restRequest.param("rulesetId"));
+        QueryRulesDeleteAction.Request request = new QueryRulesDeleteAction.Request(restRequest.param("ruleset_id"));
         return channel -> client.execute(
             QueryRulesDeleteAction.INSTANCE,
             request,

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesGetAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesGetAction.java
@@ -11,34 +11,34 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
-import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
+import org.elasticsearch.xpack.core.search.action.QueryRulesGetAction;
 
 import java.io.IOException;
 import java.util.List;
 
-import static org.elasticsearch.rest.RestRequest.Method.PUT;
+import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-public class RestQueryRulesPutAction extends BaseRestHandler {
+public class RestQueryRulesGetAction extends BaseRestHandler {
 
     public static final String ENDPOINT = "_query_rules";
 
     @Override
     public String getName() {
-        return "query_rules_put_action";
+        return "query_rules_get_action";
     }
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(PUT, "/" + ENDPOINT + "/{rulesetId}"));
+        return List.of(new Route(GET, "/" + ENDPOINT + "/{rulesetId}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        QueryRulesPutAction.Request request = new QueryRulesPutAction.Request(
-            restRequest.param("rulesetId"),
-            restRequest.content(),
-            restRequest.getXContentType()
+        QueryRulesGetAction.Request request = new QueryRulesGetAction.Request(restRequest.param("rulesetId"));
+        return channel -> client.execute(
+            QueryRulesGetAction.INSTANCE,
+            request,
+            new RestToXContentListener<QueryRulesGetAction.Response>(channel)
         );
-        return channel -> client.execute(QueryRulesPutAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesGetAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesGetAction.java
@@ -29,12 +29,12 @@ public class RestQueryRulesGetAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/" + ENDPOINT + "/{rulesetId}"));
+        return List.of(new Route(GET, "/" + ENDPOINT + "/{ruleset_id}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        QueryRulesGetAction.Request request = new QueryRulesGetAction.Request(restRequest.param("rulesetId"));
+        QueryRulesGetAction.Request request = new QueryRulesGetAction.Request(restRequest.param("ruleset_id"));
         return channel -> client.execute(
             QueryRulesGetAction.INSTANCE,
             request,

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesListAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesListAction.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.search.action.QueryRulesListAction;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.GET;
+
+public class RestQueryRulesListAction extends BaseRestHandler {
+
+    public static final String ENDPOINT = "_query_rules/_list";
+
+    @Override
+    public String getName() {
+        return "query_rules_list_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(GET, "/" + ENDPOINT));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        QueryRulesListAction.Request request = new QueryRulesListAction.Request();
+        return channel -> client.execute(
+            QueryRulesListAction.INSTANCE,
+            request,
+            new RestToXContentListener<QueryRulesListAction.Response>(channel)
+        );
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesListAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesListAction.java
@@ -16,7 +16,7 @@ import org.elasticsearch.xpack.core.search.action.QueryRulesListAction;
 import java.io.IOException;
 import java.util.List;
 
-import static org.elasticsearch.rest.RestRequest.Method.GET;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestQueryRulesListAction extends BaseRestHandler {
 
@@ -29,12 +29,17 @@ public class RestQueryRulesListAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/" + ENDPOINT));
+        return List.of(new Route(POST, "/" + ENDPOINT));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
-        QueryRulesListAction.Request request = new QueryRulesListAction.Request();
+        QueryRulesListAction.Request request;
+        if (restRequest.hasContent()) {
+            request = QueryRulesListAction.Request.parse(restRequest.contentParser());
+        } else {
+            request = new QueryRulesListAction.Request(10, 0);
+        }
         return channel -> client.execute(
             QueryRulesListAction.INSTANCE,
             request,

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesListAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesListAction.java
@@ -20,7 +20,7 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestQueryRulesListAction extends BaseRestHandler {
 
-    public static final String ENDPOINT = "_query_rules/_list";
+    public static final String ENDPOINT = "_query_rules/list";
 
     @Override
     public String getName() {

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesPutAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesPutAction.java
@@ -29,13 +29,13 @@ public class RestQueryRulesPutAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(PUT, "/" + ENDPOINT + "/{rulesetId}"));
+        return List.of(new Route(PUT, "/" + ENDPOINT + "/{ruleset_id}"));
     }
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         QueryRulesPutAction.Request request = new QueryRulesPutAction.Request(
-            restRequest.param("rulesetId"),
+            restRequest.param("ruleset_id"),
             restRequest.content(),
             restRequest.getXContentType()
         );

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesPutAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/RestQueryRulesPutAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+
+public class RestQueryRulesPutAction extends BaseRestHandler {
+
+    public static final String ENDPOINT = "_query_rules";
+
+    @Override
+    public String getName() {
+        return "query_rules_put_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(PUT, "/" + ENDPOINT + "/{rulesetId}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        BytesReference content = restRequest.content();
+        QueryRulesPutAction.Request request = new QueryRulesPutAction.Request(restRequest.param("rulesetId"), content);
+        return channel -> client.execute(QueryRulesPutAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
@@ -25,6 +25,7 @@ import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.search.action.QueryRulesDeleteAction;
 import org.elasticsearch.xpack.core.search.action.QueryRulesGetAction;
 import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
 
@@ -48,7 +49,8 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
         return Arrays.asList(
             new ActionHandler<>(QueryRulesPutAction.INSTANCE, TransportQueryRulesPutAction.class),
-            new ActionHandler<>(QueryRulesGetAction.INSTANCE, TransportQueryRulesGetAction.class)
+            new ActionHandler<>(QueryRulesGetAction.INSTANCE, TransportQueryRulesGetAction.class),
+            new ActionHandler<>(QueryRulesDeleteAction.INSTANCE, TransportQueryRulesDeleteAction.class)
         );
     }
 
@@ -62,7 +64,7 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return Arrays.asList(new RestQueryRulesPutAction(), new RestQueryRulesGetAction());
+        return Arrays.asList(new RestQueryRulesPutAction(), new RestQueryRulesGetAction(), new RestQueryRulesDeleteAction());
     }
 
     @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
@@ -97,7 +97,6 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
     private Settings getIndexSettings() {
         return Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
-            // TODO check replication requirements
             .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-1")
             .build();
     }

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
@@ -25,12 +25,13 @@ import org.elasticsearch.plugins.SystemIndexPlugin;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.search.action.QueryRulesGetAction;
 import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
@@ -45,7 +46,10 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
 
     @Override
     public List<ActionHandler<? extends ActionRequest, ? extends ActionResponse>> getActions() {
-        return Collections.singletonList(new ActionHandler<>(QueryRulesPutAction.INSTANCE, TransportQueryRulesPutAction.class));
+        return Arrays.asList(
+            new ActionHandler<>(QueryRulesPutAction.INSTANCE, TransportQueryRulesPutAction.class),
+            new ActionHandler<>(QueryRulesGetAction.INSTANCE, TransportQueryRulesGetAction.class)
+        );
     }
 
     @Override
@@ -58,7 +62,7 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return Collections.singletonList(new RestQueryRulesPutAction());
+        return Arrays.asList(new RestQueryRulesPutAction(), new RestQueryRulesGetAction());
     }
 
     @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/SearchBusinessRules.java
@@ -27,6 +27,7 @@ import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.search.action.QueryRulesDeleteAction;
 import org.elasticsearch.xpack.core.search.action.QueryRulesGetAction;
+import org.elasticsearch.xpack.core.search.action.QueryRulesListAction;
 import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
 
 import java.io.IOException;
@@ -50,7 +51,8 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
         return Arrays.asList(
             new ActionHandler<>(QueryRulesPutAction.INSTANCE, TransportQueryRulesPutAction.class),
             new ActionHandler<>(QueryRulesGetAction.INSTANCE, TransportQueryRulesGetAction.class),
-            new ActionHandler<>(QueryRulesDeleteAction.INSTANCE, TransportQueryRulesDeleteAction.class)
+            new ActionHandler<>(QueryRulesDeleteAction.INSTANCE, TransportQueryRulesDeleteAction.class),
+            new ActionHandler<>(QueryRulesListAction.INSTANCE, TransportQueryRulesListAction.class)
         );
     }
 
@@ -64,7 +66,12 @@ public class SearchBusinessRules extends Plugin implements SearchPlugin, ActionP
         IndexNameExpressionResolver indexNameExpressionResolver,
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
-        return Arrays.asList(new RestQueryRulesPutAction(), new RestQueryRulesGetAction(), new RestQueryRulesDeleteAction());
+        return Arrays.asList(
+            new RestQueryRulesPutAction(),
+            new RestQueryRulesGetAction(),
+            new RestQueryRulesDeleteAction(),
+            new RestQueryRulesListAction()
+        );
     }
 
     @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesDeleteAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesDeleteAction.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.delete.DeleteAction;
+import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.delete.DeleteResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.search.action.QueryRulesDeleteAction;
+
+import static org.elasticsearch.xpack.core.ClientHelper.QUERY_RULES_MANAGEMENT_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.searchbusinessrules.SearchBusinessRules.QUERY_RULES_CONCRETE_INDEX_NAME;
+
+public class TransportQueryRulesDeleteAction extends HandledTransportAction<QueryRulesDeleteAction.Request, AcknowledgedResponse> {
+
+    private final Client client;
+
+    @Inject
+    public TransportQueryRulesDeleteAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+        super(QueryRulesDeleteAction.NAME, transportService, actionFilters, QueryRulesDeleteAction.Request::new);
+        this.client = new OriginSettingClient(client, QUERY_RULES_MANAGEMENT_ORIGIN);
+    }
+
+    @Override
+    protected void doExecute(Task task, QueryRulesDeleteAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        DeleteRequest deleteRequest = new DeleteRequest(QUERY_RULES_CONCRETE_INDEX_NAME).id(request.getRuleSetId());
+
+        executeAsyncWithOrigin(client, QUERY_RULES_MANAGEMENT_ORIGIN, DeleteAction.INSTANCE, deleteRequest, new ActionListener<>() {
+
+            @Override
+            public void onResponse(DeleteResponse indexResponse) {
+                listener.onResponse(
+                    indexResponse.getResult().equals(DocWriteResponse.Result.DELETED)
+                        ? AcknowledgedResponse.TRUE
+                        : AcknowledgedResponse.FALSE
+                );
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesGetAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesGetAction.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.get.GetAction;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.search.action.QueryRulesGetAction;
+
+import static org.elasticsearch.xpack.core.ClientHelper.QUERY_RULES_MANAGEMENT_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.searchbusinessrules.SearchBusinessRules.QUERY_RULES_CONCRETE_INDEX_NAME;
+
+public class TransportQueryRulesGetAction extends HandledTransportAction<QueryRulesGetAction.Request, QueryRulesGetAction.Response> {
+
+    private final Client client;
+
+    @Inject
+    public TransportQueryRulesGetAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+        super(QueryRulesGetAction.NAME, transportService, actionFilters, QueryRulesGetAction.Request::new);
+        this.client = new OriginSettingClient(client, QUERY_RULES_MANAGEMENT_ORIGIN);
+    }
+
+    @Override
+    protected void doExecute(Task task, QueryRulesGetAction.Request request, ActionListener<QueryRulesGetAction.Response> listener) {
+        GetRequest getRequest = new GetRequest(QUERY_RULES_CONCRETE_INDEX_NAME).id(request.getRuleSetId());
+
+        executeAsyncWithOrigin(client, QUERY_RULES_MANAGEMENT_ORIGIN, GetAction.INSTANCE, getRequest, new ActionListener<>() {
+            @Override
+            public void onResponse(GetResponse getResponse) {
+                BytesReference source = null;
+                if (getResponse.isExists()) {
+                    source = getResponse.getSourceAsBytesRef();
+                }
+                listener.onResponse(new QueryRulesGetAction.Response(request.getRuleSetId(), getResponse.isExists(), source));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesListAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesListAction.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.index.query.QueryBuilders;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.search.action.QueryRulesListAction;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.xpack.core.ClientHelper.QUERY_RULES_MANAGEMENT_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.searchbusinessrules.SearchBusinessRules.QUERY_RULES_CONCRETE_INDEX_NAME;
+
+public class TransportQueryRulesListAction extends HandledTransportAction<QueryRulesListAction.Request, QueryRulesListAction.Response> {
+
+    private final Client client;
+
+    @Inject
+    public TransportQueryRulesListAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+        super(QueryRulesListAction.NAME, transportService, actionFilters, QueryRulesListAction.Request::new);
+        this.client = new OriginSettingClient(client, QUERY_RULES_MANAGEMENT_ORIGIN);
+    }
+
+    @Override
+    protected void doExecute(Task task, QueryRulesListAction.Request request, ActionListener<QueryRulesListAction.Response> listener) {
+        SearchRequest searchRequest = new SearchRequest(QUERY_RULES_CONCRETE_INDEX_NAME).source(
+            new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).fetchSource(false)
+        );
+        logger.info("0 >>> " + searchRequest);
+
+        executeAsyncWithOrigin(
+            client,
+            QUERY_RULES_MANAGEMENT_ORIGIN,
+            SearchAction.INSTANCE,
+            searchRequest,
+            new ActionListener<SearchResponse>() {
+                @Override
+                public void onResponse(SearchResponse response) {
+                    logger.info("1 >>> " + Strings.toString(response));
+                    List<String> ids = Arrays.stream(response.getHits().getHits()).map(hit -> hit.getId()).toList();
+
+                    listener.onResponse(new QueryRulesListAction.Response(ids.toArray(new String[ids.size()])));
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            }
+        );
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesListAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesListAction.java
@@ -43,9 +43,11 @@ public class TransportQueryRulesListAction extends HandledTransportAction<QueryR
     @Override
     protected void doExecute(Task task, QueryRulesListAction.Request request, ActionListener<QueryRulesListAction.Response> listener) {
         SearchRequest searchRequest = new SearchRequest(QUERY_RULES_CONCRETE_INDEX_NAME).source(
-            new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).fetchSource(false)
+            new SearchSourceBuilder().query(QueryBuilders.matchAllQuery())
+                .fetchSource(false)
+                .size(request.getSize())
+                .from(request.getFrom())
         );
-        logger.info("0 >>> " + searchRequest);
 
         executeAsyncWithOrigin(
             client,

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
@@ -7,14 +7,13 @@
 
 package org.elasticsearch.xpack.searchbusinessrules;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexAction;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
@@ -29,8 +28,6 @@ import static org.elasticsearch.xpack.searchbusinessrules.SearchBusinessRules.QU
 
 public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRulesPutAction.Request, AcknowledgedResponse> {
 
-    private static final Logger logger = LogManager.getLogger(TransportQueryRulesPutAction.class);
-
     private final Client client;
 
     @Inject
@@ -42,7 +39,8 @@ public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRu
     @Override
     protected void doExecute(Task task, QueryRulesPutAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         IndexRequest indexRequest = new IndexRequest(QUERY_RULES_CONCRETE_INDEX_NAME).id(request.getRuleSetId())
-            .source(request.getContent(), request.getContentType());
+            .source(request.getContent(), request.getContentType())
+            .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 
         executeAsyncWithOrigin(client, QUERY_RULES_MANAGEMENT_ORIGIN, IndexAction.INSTANCE, indexRequest, new ActionListener<>() {
             @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.searchbusinessrules;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
+
+import java.io.IOException;
+
+public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRulesPutAction.Request, AcknowledgedResponse> {
+
+    @Inject
+    public TransportQueryRulesPutAction(TransportService transportService, ActionFilters actionFilters) {
+        super(QueryRulesPutAction.NAME, transportService, actionFilters, QueryRulesPutAction.Request::new);
+    }
+
+    @Override
+    protected void doExecute(Task task, QueryRulesPutAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        listener.onResponse(new AcknowledgedResponse(true) {
+            @Override
+            protected void addCustomFields(XContentBuilder builder, Params params) throws IOException {
+                builder.field("rules_id", request.getRuleSetId());
+            }
+        });
+    }
+}

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
@@ -14,7 +14,6 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.WriteRequest;
-import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.inject.Inject;
@@ -26,7 +25,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.QUERY_RULES_MANAGEMENT_O
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 import static org.elasticsearch.xpack.searchbusinessrules.SearchBusinessRules.QUERY_RULES_CONCRETE_INDEX_NAME;
 
-public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRulesPutAction.Request, AcknowledgedResponse> {
+public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRulesPutAction.Request, QueryRulesPutAction.Response> {
 
     private final Client client;
 
@@ -37,7 +36,7 @@ public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRu
     }
 
     @Override
-    protected void doExecute(Task task, QueryRulesPutAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+    protected void doExecute(Task task, QueryRulesPutAction.Request request, ActionListener<QueryRulesPutAction.Response> listener) {
         IndexRequest indexRequest = new IndexRequest(QUERY_RULES_CONCRETE_INDEX_NAME).id(request.getRuleSetId())
             .source(request.getContent(), request.getContentType())
             .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
@@ -45,7 +44,7 @@ public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRu
         executeAsyncWithOrigin(client, QUERY_RULES_MANAGEMENT_ORIGIN, IndexAction.INSTANCE, indexRequest, new ActionListener<>() {
             @Override
             public void onResponse(IndexResponse indexResponse) {
-                listener.onResponse(AcknowledgedResponse.TRUE);
+                listener.onResponse(new QueryRulesPutAction.Response(indexResponse.getResult()));
             }
 
             @Override

--- a/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
+++ b/x-pack/plugin/search-business-rules/src/main/java/org/elasticsearch/xpack/searchbusinessrules/TransportQueryRulesPutAction.java
@@ -7,31 +7,52 @@
 
 package org.elasticsearch.xpack.searchbusinessrules;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.index.IndexAction;
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.search.action.QueryRulesPutAction;
 
-import java.io.IOException;
+import static org.elasticsearch.xpack.core.ClientHelper.QUERY_RULES_MANAGEMENT_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+import static org.elasticsearch.xpack.searchbusinessrules.SearchBusinessRules.QUERY_RULES_CONCRETE_INDEX_NAME;
 
 public class TransportQueryRulesPutAction extends HandledTransportAction<QueryRulesPutAction.Request, AcknowledgedResponse> {
 
+    private static final Logger logger = LogManager.getLogger(TransportQueryRulesPutAction.class);
+
+    private final Client client;
+
     @Inject
-    public TransportQueryRulesPutAction(TransportService transportService, ActionFilters actionFilters) {
+    public TransportQueryRulesPutAction(TransportService transportService, ActionFilters actionFilters, Client client) {
         super(QueryRulesPutAction.NAME, transportService, actionFilters, QueryRulesPutAction.Request::new);
+        this.client = new OriginSettingClient(client, QUERY_RULES_MANAGEMENT_ORIGIN);
     }
 
     @Override
     protected void doExecute(Task task, QueryRulesPutAction.Request request, ActionListener<AcknowledgedResponse> listener) {
-        listener.onResponse(new AcknowledgedResponse(true) {
+        IndexRequest indexRequest = new IndexRequest(QUERY_RULES_CONCRETE_INDEX_NAME).id(request.getRuleSetId())
+            .source(request.getContent(), request.getContentType());
+
+        executeAsyncWithOrigin(client, QUERY_RULES_MANAGEMENT_ORIGIN, IndexAction.INSTANCE, indexRequest, new ActionListener<>() {
             @Override
-            protected void addCustomFields(XContentBuilder builder, Params params) throws IOException {
-                builder.field("rules_id", request.getRuleSetId());
+            public void onResponse(IndexResponse indexResponse) {
+                listener.onResponse(AcknowledgedResponse.TRUE);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
             }
         });
     }

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -12,7 +12,6 @@ import java.util.Set;
 public class Constants {
 
     public static final Set<String> NON_OPERATOR_ACTIONS = Set.of(
-        // TODO not sure if we need to add new actions here too
         // "cluster:admin/autoscaling/delete_autoscaling_policy",
         "cluster:admin/autoscaling/get_autoscaling_capacity",
         "cluster:admin/autoscaling/get_autoscaling_policy",
@@ -48,6 +47,10 @@ public class Constants {
         "cluster:admin/persistent/remove",
         "cluster:admin/persistent/start",
         "cluster:admin/persistent/update_status",
+        "cluster:admin/query_rules/put",
+        "cluster:admin/query_rules/get",
+        "cluster:admin/query_rules/list",
+        "cluster:admin/query_rules/delete",
         "cluster:admin/reindex/rethrottle",
         "cluster:admin/repository/_cleanup",
         "cluster:admin/repository/delete",

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -12,6 +12,7 @@ import java.util.Set;
 public class Constants {
 
     public static final Set<String> NON_OPERATOR_ACTIONS = Set.of(
+        // TODO not sure if we need to add new actions here too
         // "cluster:admin/autoscaling/delete_autoscaling_policy",
         "cluster:admin/autoscaling/get_autoscaling_capacity",
         "cluster:admin/autoscaling/get_autoscaling_policy",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -34,6 +34,7 @@ import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.LOGSTASH_MANAGEMENT_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.MONITORING_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.QUERY_RULES_MANAGEMENT_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ROLLUP_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SEARCHABLE_SNAPSHOTS_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.SECURITY_ORIGIN;
@@ -138,6 +139,7 @@ public final class AuthorizationUtils {
             case SEARCHABLE_SNAPSHOTS_ORIGIN:
             case LOGSTASH_MANAGEMENT_ORIGIN:
             case FLEET_ORIGIN:
+            case QUERY_RULES_MANAGEMENT_ORIGIN:
             case TASKS_ORIGIN:   // TODO use a more limited user for tasks
                 securityContext.executeAsInternalUser(XPackUser.INSTANCE, version, consumer);
                 break;

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
@@ -15,5 +15,5 @@ setup:
   # This is fragile - it needs to be updated every time we add a new cluster/index privilege
   # I would much prefer we could just check that specific entries are in the array, but we don't have
   # an assertion for that
-  - length: { "cluster" : 43 }
+  - length: { "cluster" : 44 }
   - length: { "index" : 19 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -6,10 +6,20 @@
         ruleset_id: my-rules-id
         body:
           mappings:
+            user: integer
+          rules: [{ "condition" : {}, "action" : {}}]
+
+  - match: { result: created }
+
+  - do:
+      query_rules.put:
+        ruleset_id: my-rules-id
+        body:
+          mappings:
             user: string
           rules: [{ "condition" : {}, "action" : {}}]
 
-  - match: { acknowledged: true }
+  - match: { result: updated }
 
   - do:
       query_rules.get:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -27,3 +27,14 @@
 
   - match: { ruleset_id : some-other-id }
   - match: { found : false }
+
+  - do:
+      query_rules.delete:
+        rulesetId: my-rules-id
+
+  - do:
+      query_rules.get:
+        rulesetId: my-rules-id
+
+  - match: { ruleset_id: my-rules-id }
+  - match: { found: false }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -63,6 +63,20 @@
 
   - match : { ruleset_ids : [ my-rules-id, my-other-rules-id] }
 
+  - do:
+      query_rules.list:
+        body:
+          size: 1
+
+  - match : { ruleset_ids : [ my-rules-id ] }
+
+  - do:
+      query_rules.list:
+        body:
+          size: 1
+          from: 1
+
+  - match : { ruleset_ids : [ my-other-rules-id ] }
 ---
 "Test put query rules validation":
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -1,0 +1,12 @@
+---
+"Test put query rules":
+
+  - do:
+      query_rules.put:
+        rulesetId: my-rules-id
+        body:
+          mapping:
+            user: "string"
+
+  - match: { acknowledged: true }
+  - match: { rules_id: my-rules-id }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -6,8 +6,8 @@
         rulesetId: my-rules-id
         body:
           mappings:
-            user: kimchy
-          rules: [{ "condition" : { "foo"}, "action" : {}}]
+            user: string
+          rules: [{ "condition" : {}, "action" : {}}]
 
   - match: { acknowledged: true }
 
@@ -17,7 +17,7 @@
 
   - match: { ruleset_id: my-rules-id }
   - match: { found: true }
-  - match: { _source.mappings.user: kimchy }
+  - match: { _source.mappings.user: string }
   - is_true: _source.rules.0.condition
   - is_true: _source.rules.0.action
 
@@ -38,3 +38,27 @@
 
   - match: { ruleset_id: my-rules-id }
   - match: { found: false }
+
+---
+"Test query rules list ids":
+
+  - do:
+      query_rules.put:
+        rulesetId: my-rules-id
+        body:
+          mappings:
+            user: string
+          rules: [{ "condition" : {}, "action" : {}}]
+
+  - do:
+      query_rules.put:
+        rulesetId: my-other-rules-id
+        body:
+          mappings:
+            user: string
+          rules: [{ "condition" : {}, "action" : {}}]
+
+  - do:
+      query_rules.list: {}
+
+  - match : { ruleset_ids : [ my-rules-id, my-other-rules-id] }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -62,3 +62,39 @@
       query_rules.list: {}
 
   - match : { ruleset_ids : [ my-rules-id, my-other-rules-id] }
+
+---
+"Test put query rules validation":
+
+  - do:
+      catch: "/rules are missing/"
+      query_rules.put:
+        rulesetId: my-rules-id
+        body:
+          mappings:
+            user: string
+
+  - do:
+      catch: "/rules definition should be an array/"
+      query_rules.put:
+        rulesetId: my-rules-id
+        body:
+          mappings:
+            user: string
+          rules: my-rules
+
+  - do:
+      catch: "/mappings are missing/"
+      query_rules.put:
+        rulesetId: my-rules-id
+        body:
+          rules: [{ "condition" : {}, "action" : {}}]
+
+  - do:
+      catch: "/mappings definition should be an object/"
+      query_rules.put:
+        rulesetId: my-rules-id
+        body:
+          mappings:
+            [ { user: "string" } ]
+          rules: [{ "condition" : {}, "action" : {}}]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -3,7 +3,7 @@
 
   - do:
       query_rules.put:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
         body:
           mappings:
             user: string
@@ -13,7 +13,7 @@
 
   - do:
       query_rules.get:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
 
   - match: { ruleset_id: my-rules-id }
   - match: { found: true }
@@ -23,18 +23,18 @@
 
   - do:
       query_rules.get:
-        rulesetId: some-other-id
+        ruleset_id: some-other-id
 
   - match: { ruleset_id : some-other-id }
   - match: { found : false }
 
   - do:
       query_rules.delete:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
 
   - do:
       query_rules.get:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
 
   - match: { ruleset_id: my-rules-id }
   - match: { found: false }
@@ -44,7 +44,7 @@
 
   - do:
       query_rules.put:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
         body:
           mappings:
             user: string
@@ -52,7 +52,7 @@
 
   - do:
       query_rules.put:
-        rulesetId: my-other-rules-id
+        ruleset_id: my-other-rules-id
         body:
           mappings:
             user: string
@@ -69,7 +69,7 @@
   - do:
       catch: "/rules are missing/"
       query_rules.put:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
         body:
           mappings:
             user: string
@@ -77,7 +77,7 @@
   - do:
       catch: "/rules definition should be an array/"
       query_rules.put:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
         body:
           mappings:
             user: string
@@ -86,14 +86,14 @@
   - do:
       catch: "/mappings are missing/"
       query_rules.put:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
         body:
           rules: [{ "condition" : {}, "action" : {}}]
 
   - do:
       catch: "/mappings definition should be an object/"
       query_rules.put:
-        rulesetId: my-rules-id
+        ruleset_id: my-rules-id
         body:
           mappings:
             [ { user: "string" } ]

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/search-business-rules/20_query_rules.yml
@@ -1,12 +1,29 @@
 ---
-"Test put query rules":
+"Test basic query rule lifecycle":
 
   - do:
       query_rules.put:
         rulesetId: my-rules-id
         body:
-          mapping:
-            user: "string"
+          mappings:
+            user: kimchy
+          rules: [{ "condition" : { "foo"}, "action" : {}}]
 
   - match: { acknowledged: true }
-  - match: { rules_id: my-rules-id }
+
+  - do:
+      query_rules.get:
+        rulesetId: my-rules-id
+
+  - match: { ruleset_id: my-rules-id }
+  - match: { found: true }
+  - match: { _source.mappings.user: kimchy }
+  - is_true: _source.rules.0.condition
+  - is_true: _source.rules.0.action
+
+  - do:
+      query_rules.get:
+        rulesetId: some-other-id
+
+  - match: { ruleset_id : some-other-id }
+  - match: { found : false }


### PR DESCRIPTION
This change adds new endpoints that allow management of sets of query rules that
in conjunction with a new dedicated query will allow for query expansion rules.
The new endpoints allow storing retrieving and deleting rules sets by a unique
id. In addition there is an endpoint for listing all available rule set ids
managed by the cluster.

Relates to https://github.com/elastic/elasticsearch/issues/92273