### PR TITLE
[Transform] POC expose refresh parameter for state persistence

### DIFF
--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -474,7 +474,17 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         TransformStoredDoc storedDocs = TransformStoredDocTests.randomTransformStoredDoc(transformId);
         SeqNoPrimaryTermAndIndex firstIndex = new SeqNoPrimaryTermAndIndex(0, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
 
-        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(storedDocs, null, listener), firstIndex, null, null);
+        assertAsync(
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
+                storedDocs,
+                null,
+                WriteRequest.RefreshPolicy.IMMEDIATE,
+                listener
+            ),
+            firstIndex,
+            null,
+            null
+        );
         assertAsync(
             listener -> transformConfigManager.getTransformStoredDoc(transformId, false, listener),
             tuple(storedDocs, firstIndex),
@@ -485,7 +495,12 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         SeqNoPrimaryTermAndIndex secondIndex = new SeqNoPrimaryTermAndIndex(1, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
         TransformStoredDoc updated = TransformStoredDocTests.randomTransformStoredDoc(transformId);
         assertAsync(
-            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(updated, firstIndex, listener),
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
+                updated,
+                firstIndex,
+                WriteRequest.RefreshPolicy.IMMEDIATE,
+                listener
+            ),
             secondIndex,
             null,
             null
@@ -498,7 +513,12 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         );
 
         assertAsync(
-            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(updated, firstIndex, listener),
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
+                updated,
+                firstIndex,
+                WriteRequest.RefreshPolicy.IMMEDIATE,
+                listener
+            ),
             (SeqNoPrimaryTermAndIndex) null,
             r -> fail("did not fail with version conflict."),
             e -> assertThat(
@@ -515,7 +535,17 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             SeqNoPrimaryTermAndIndex initialSeqNo = new SeqNoPrimaryTermAndIndex(i, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
             TransformStoredDoc stat = TransformStoredDocTests.randomTransformStoredDoc(randomAlphaOfLength(6) + i);
             expectedDocs.add(stat);
-            assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(stat, null, listener), initialSeqNo, null, null);
+            assertAsync(
+                listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
+                    stat,
+                    null,
+                    WriteRequest.RefreshPolicy.IMMEDIATE,
+                    listener
+                ),
+                initialSeqNo,
+                null,
+                null
+            );
         }
 
         // remove one of the put docs so we don't retrieve all
@@ -586,6 +616,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
                 transformStoredDoc,
                 new SeqNoPrimaryTermAndIndex(3, 1, oldIndex),
+                WriteRequest.RefreshPolicy.IMMEDIATE,
                 listener
             ),
             new SeqNoPrimaryTermAndIndex(0, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME),
@@ -618,7 +649,17 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         // create some other docs to check they are not getting accidentally deleted
         TransformStoredDoc storedDocs = TransformStoredDocTests.randomTransformStoredDoc(transformId);
         SeqNoPrimaryTermAndIndex firstIndex = new SeqNoPrimaryTermAndIndex(0, 1, TransformInternalIndexConstants.LATEST_INDEX_NAME);
-        assertAsync(listener -> transformConfigManager.putOrUpdateTransformStoredDoc(storedDocs, null, listener), firstIndex, null, null);
+        assertAsync(
+            listener -> transformConfigManager.putOrUpdateTransformStoredDoc(
+                storedDocs,
+                null,
+                WriteRequest.RefreshPolicy.IMMEDIATE,
+                listener
+            ),
+            firstIndex,
+            null,
+            null
+        );
 
         TransformConfig transformConfig = TransformConfigTests.randomTransformConfig(transformId);
         assertAsync(listener -> transformConfigManager.putTransformConfiguration(transformConfig, listener), true, null, null);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformUpdater.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformUpdater.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -237,7 +238,8 @@ public class TransformUpdater {
             // else: the state is on an old index, update by persisting it to the latest index
             transformConfigManager.putOrUpdateTransformStoredDoc(
                 currentState.v1(),
-                null, // set seqNoPrimaryTermAndIndex to `null` to force optype `create`, gh#80073
+                null,
+                WriteRequest.RefreshPolicy.IMMEDIATE, // set seqNoPrimaryTermAndIndex to `null` to force optype `create`, gh#80073
                 ActionListener.wrap(r -> listener.onResponse(lastCheckpoint), e -> {
                     if (org.elasticsearch.ExceptionsHelper.unwrapCause(e) instanceof VersionConflictEngineException) {
                         // if a version conflict occurs a new state has been written between us reading and writing.

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/IndexBasedTransformConfigManager.java
@@ -682,14 +682,15 @@ public class IndexBasedTransformConfigManager implements TransformConfigManager 
     public void putOrUpdateTransformStoredDoc(
         TransformStoredDoc storedDoc,
         SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        WriteRequest.RefreshPolicy refreshPolicy,
         ActionListener<SeqNoPrimaryTermAndIndex> listener
     ) {
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = storedDoc.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
 
-            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).setRefreshPolicy(
-                WriteRequest.RefreshPolicy.IMMEDIATE
-            ).id(TransformStoredDoc.documentId(storedDoc.getId())).source(source);
+            IndexRequest indexRequest = new IndexRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).setRefreshPolicy(refreshPolicy)
+                .id(TransformStoredDoc.documentId(storedDoc.getId()))
+                .source(source);
             if (seqNoPrimaryTermAndIndex != null) {
                 // if seqNoPrimaryTermAndIndex is set, use optype index even if not on the latest index, because the upgrader
                 // could have been called, see gh#80073

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManager.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.transform.persistence;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.xpack.core.action.util.PageParams;
@@ -194,6 +195,7 @@ public interface TransformConfigManager {
     void putOrUpdateTransformStoredDoc(
         TransformStoredDoc storedDoc,
         SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        WriteRequest.RefreshPolicy refreshPolicy,
         ActionListener<SeqNoPrimaryTermAndIndex> listener
     );
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -26,6 +26,7 @@ import org.elasticsearch.action.search.OpenPointInTimeRequest;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.logging.LoggerMessageFormat;
@@ -289,7 +290,7 @@ class ClientTransformIndexer extends TransformIndexer {
      * Runs the persistence part of state storage
      */
     @Override
-    protected void persistState(TransformState state, ActionListener<Void> listener) {
+    protected void persistState(TransformState state, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<Void> listener) {
         // This could be `null` but the putOrUpdateTransformStoredDoc handles that case just fine
         SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex = getSeqNoPrimaryTermAndIndex();
 
@@ -299,6 +300,7 @@ class ClientTransformIndexer extends TransformIndexer {
         transformsConfigManager.putOrUpdateTransformStoredDoc(
             new TransformStoredDoc(getJobId(), state, getStats()),
             seqNoPrimaryTermAndIndex,
+            refreshPolicy,
             ActionListener.wrap(r -> {
                 updateSeqNoPrimaryTermAndIndex(seqNoPrimaryTermAndIndex, r);
                 context.resetStatePersistenceFailureCount();

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/InMemoryTransformConfigManager.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.transform.persistence;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
@@ -325,6 +326,7 @@ public class InMemoryTransformConfigManager implements TransformConfigManager {
     public void putOrUpdateTransformStoredDoc(
         TransformStoredDoc storedDoc,
         SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+        WriteRequest.RefreshPolicy refreshPolicy,
         ActionListener<SeqNoPrimaryTermAndIndex> listener
     ) {
         // for now we ignore seqNoPrimaryTermAndIndex

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureHandlingTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.breaker.CircuitBreaker.Durability;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -272,7 +273,7 @@ public class TransformIndexerFailureHandlingTests extends ESTestCase {
         }
 
         @Override
-        protected void persistState(TransformState state, ActionListener<Void> listener) {
+        protected void persistState(TransformState state, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<Void> listener) {
             listener.onResponse(null);
         }
     }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerFailureOnStatePersistenceTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.transforms;
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
@@ -116,12 +117,13 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
         public void putOrUpdateTransformStoredDoc(
             TransformStoredDoc storedDoc,
             SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+            WriteRequest.RefreshPolicy refreshPolicy,
             ActionListener<SeqNoPrimaryTermAndIndex> listener
         ) {
             if (failAt.contains(persistenceCallCount++)) {
                 listener.onFailure(exception);
             } else {
-                super.putOrUpdateTransformStoredDoc(storedDoc, seqNoPrimaryTermAndIndex, listener);
+                super.putOrUpdateTransformStoredDoc(storedDoc, seqNoPrimaryTermAndIndex, refreshPolicy, listener);
             }
         }
     }
@@ -137,6 +139,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
         public void putOrUpdateTransformStoredDoc(
             TransformStoredDoc storedDoc,
             SeqNoPrimaryTermAndIndex seqNoPrimaryTermAndIndex,
+            WriteRequest.RefreshPolicy refreshPolicy,
             ActionListener<SeqNoPrimaryTermAndIndex> listener
         ) {
             if (seqNo != -1) {
@@ -148,7 +151,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 }
             }
 
-            super.putOrUpdateTransformStoredDoc(storedDoc, seqNoPrimaryTermAndIndex, ActionListener.wrap(r -> {
+            super.putOrUpdateTransformStoredDoc(storedDoc, seqNoPrimaryTermAndIndex, refreshPolicy, ActionListener.wrap(r -> {
                 // always inc seqNo, primaryTerm at random
                 if (randomBoolean()) {
                     primaryTerm++;
@@ -246,6 +249,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -258,6 +262,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -270,6 +275,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -328,6 +334,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -341,6 +348,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsync(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     r -> {
@@ -353,6 +361,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -365,6 +374,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -377,6 +387,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                 this.<Void>assertAsyncFailure(
                     listener -> indexer.persistState(
                         new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                        WriteRequest.RefreshPolicy.IMMEDIATE,
                         listener
                     ),
                     e -> {
@@ -459,6 +470,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
             this.<Void>assertAsync(
                 listener -> indexer.persistState(
                     new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                    WriteRequest.RefreshPolicy.IMMEDIATE,
                     listener
                 ),
                 r -> {
@@ -476,6 +488,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
                         indexer.getStats()
                     ),
                     indexer.getSeqNoPrimaryTermAndIndex(),
+                    WriteRequest.RefreshPolicy.IMMEDIATE,
                     listener
                 ),
                 seqNoPrimaryTermAndIndex -> assertThat(
@@ -488,6 +501,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
             this.<Void>assertAsyncFailure(
                 listener -> indexer.persistState(
                     new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                    WriteRequest.RefreshPolicy.IMMEDIATE,
                     listener
                 ),
                 e -> {
@@ -501,6 +515,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
             this.<Void>assertAsync(
                 listener -> indexer.persistState(
                     new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                    WriteRequest.RefreshPolicy.IMMEDIATE,
                     listener
                 ),
                 r -> {
@@ -514,6 +529,7 @@ public class TransformIndexerFailureOnStatePersistenceTests extends ESTestCase {
             this.<Void>assertAsync(
                 listener -> indexer.persistState(
                     new TransformState(TransformTaskState.STARTED, IndexerState.INDEXING, null, 42, null, null, null, false),
+                    WriteRequest.RefreshPolicy.IMMEDIATE,
                     listener
                 ),
                 r -> {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -244,7 +245,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        void persistState(TransformState state, ActionListener<Void> listener) {
+        void persistState(TransformState state, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<Void> listener) {
             persistedState = state;
             listener.onResponse(null);
         }
@@ -332,7 +333,7 @@ public class TransformIndexerStateTests extends ESTestCase {
         }
 
         @Override
-        void persistState(TransformState state, ActionListener<Void> listener) {
+        void persistState(TransformState state, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<Void> listener) {
             listener.onResponse(null);
         }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -266,7 +267,7 @@ public class TransformIndexerTests extends ESTestCase {
         }
 
         @Override
-        void persistState(TransformState state, ActionListener<Void> listener) {
+        void persistState(TransformState state, WriteRequest.RefreshPolicy refreshPolicy, ActionListener<Void> listener) {
             listener.onResponse(null);
         }
 


### PR DESCRIPTION
**Discuss**

This experimental change demonstrates how state persistence can be optimized for lower refresh rates
by exposing and handling the refresh parameter differently based on the client.


**Opinion**: This is just a POC, demonstrating it for 1 method. Going this way all methods need to be changed like this and callers have to be changed to do less refreshes. The code changes and added bloat isn't the biggest problem. Clients are designed around the consistency the current implementation offers. If we relax refresh, API's need to be redesigned and failure scenarios need re-consideration. This will lead to more complexity.