### PR TITLE
[8.6] [CI] Mute MlHiddenIndicesFullClusterRestartIT.testMlIndicesBecomeHidden (#93523)

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MlHiddenIndicesFullClusterRestartIT.java
@@ -72,6 +72,7 @@ public class MlHiddenIndicesFullClusterRestartIT extends AbstractXpackFullCluste
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93521")
     public void testMlIndicesBecomeHidden() throws Exception {
         if (isRunningAgainstOldCluster()) {
             // trigger ML indices creation


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [CI] Mute MlHiddenIndicesFullClusterRestartIT.testMlIndicesBecomeHidden (#93523)