### PR TITLE
[8.6] Avoid copying test cluster distributions when possible (#93486)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -10,6 +10,8 @@ import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.internal.test.rest.RestTestBasePlugin
+import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
 // gradle has an open issue of failing applying plugins in
 // precompiled script plugins (see https://github.com/gradle/gradle/issues/17004)
@@ -41,5 +43,14 @@ configure(allprojects) {
                 testClustersPlugin.setRuntimeJava(providers.provider(() -> file("${project.jdks.provisioned_runtime.javaHomePath}")))
             }
         }
+    }
+
+    project.plugins.withType(RestTestBasePlugin) {
+      tasks.withType(StandaloneRestIntegTestTask).configureEach {
+        if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
+          dependsOn(project.jdks.provisioned_runtime)
+          nonInputProperties.systemProperty("tests.runtime.java", "${-> project.jdks.provisioned_runtime.javaHomePath}")
+        }
+      }
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/DefaultDistributionDescriptor.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/distribution/DefaultDistributionDescriptor.java
@@ -18,10 +18,10 @@ public class DefaultDistributionDescriptor implements DistributionDescriptor {
     private final Path distributionDir;
     private final DistributionType type;
 
-    public DefaultDistributionDescriptor(Version version, boolean snapshot, Path distributionDir, DistributionType type) {
+    public DefaultDistributionDescriptor(Version version, boolean snapshot, Path extractedDir, DistributionType type) {
         this.version = version;
         this.snapshot = snapshot;
-        this.distributionDir = distributionDir;
+        this.distributionDir = extractedDir;
         this.type = type;
     }
 
@@ -34,7 +34,7 @@ public class DefaultDistributionDescriptor implements DistributionDescriptor {
     }
 
     public Path getDistributionDir() {
-        return distributionDir;
+        return distributionDir.resolve("elasticsearch-" + version + (snapshot ? "-SNAPSHOT" : ""));
     }
 
     public DistributionType getType() {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/IOUtils.java
@@ -92,11 +92,6 @@ public final class IOUtils {
         try (Stream<Path> stream = Files.walk(sourceRoot)) {
             stream.forEach(source -> {
                 Path relativeDestination = sourceRoot.relativize(source);
-                if (relativeDestination.getNameCount() <= 1) {
-                    return;
-                }
-                // Throw away the first name as the archives have everything in a single top level folder we are not interested in
-                relativeDestination = relativeDestination.subpath(1, relativeDestination.getNameCount());
 
                 Path destination = destinationRoot.resolve(relativeDestination);
                 if (Files.isDirectory(source)) {


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Avoid copying test cluster distributions when possible (#93486)