### PR TITLE
Document correct get thread pool size

### DIFF
--- a/docs/changelog/93541.yaml
+++ b/docs/changelog/93541.yaml
@@ -1,0 +1,5 @@
+pr: 93541
+summary: Document correct get thread pool size
+area: "Search, CRUD"
+type: bug
+issues: []

--- a/docs/changelog/93541.yaml
+++ b/docs/changelog/93541.yaml
@@ -1,5 +1,0 @@
-pr: 93541
-summary: Document correct get thread pool size
-area: "Search, CRUD"
-type: bug
-issues: []

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -27,9 +27,9 @@ There are several thread pools, but the important ones include:
 `# of allocated processors`>>`) / 2)`, and queue_size of `1000`.
 
 `get`::
-    For get operations. Thread pool type is `fixed`
-    with a size of <<node.processors, `# of allocated processors`>>,
-    queue_size of `1000`.
+    For get operations. Thread pool type is
+    `fixed` with a size of `int((`<<node.processors,
+    `# of allocated processors`>>`pass:[ * ]3) / 2) + 1`, and queue_size of `1000`.
 
 `analyze`::
     For analyze requests. Thread pool type is `fixed` with a size of `1`, queue
@@ -180,7 +180,7 @@ the number of detected processors. This can be done by explicitly setting the
 `node.processors` setting. This setting is bounded by the number of available
 processors and accepts floating point numbers, which can be useful in environments
 where the {es} nodes are configured to run with CPU limits, such as cpu
-shares or quota under `Cgroups`. 
+shares or quota under `Cgroups`.
 
 [source,yaml]
 --------------------------------------------------


### PR DESCRIPTION
In #92309 we have aligned the size of the `search` and the `get` thread pool but the docs still contain the prior `get` thread pool size. With this commit we also align the docs.

Relates #92309