### PR TITLE
[8.6][DOCS] Adds admonition to frequent items agg docs about the renaming

### DIFF
--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -6,6 +6,8 @@
 
 experimental::[]
 
+IMPORTANT: This aggregation is renamed to `frequent item sets` in 8.7.
+
 A bucket aggregation which finds frequent item sets. It is a form of association 
 rules mining that identifies items that often occur together. Items that are 
 frequently purchased together or log events that tend to co-occur are examples 


### PR DESCRIPTION
## Overview

This PR adds an `important` admonition block to the top of the frequent items aggregation docs in 8.6 that informs users about the renaming of the aggregation that happens in 8.7. It gives more warning to users who are reading the 8.6 docs.

### Preview

[Frequent items](https://elasticsearch_93547.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-frequent-items-aggregation.html)