### PR TITLE
Handle closed shards

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.open/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.open/10_basic.yml
@@ -8,7 +8,7 @@
         index: test_index
         body:
           settings:
-            number_of_replicas: 0
+            auto_expand_replicas: 0-1
 
   - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.open/20_multiple_indices.yml
@@ -4,19 +4,19 @@ setup:
         index: test_index1
         body:
           settings:
-            number_of_replicas: 0
+            auto_expand_replicas: 0-1
   - do:
       indices.create:
         index: test_index2
         body:
           settings:
-            number_of_replicas: 0
+            auto_expand_replicas: 0-1
   - do:
       indices.create:
         index: test_index3
         body:
           settings:
-            number_of_replicas: 0
+            auto_expand_replicas: 0-1
   - do:
       cluster.health:
         wait_for_status: green

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/30_snapshot.yml
@@ -33,8 +33,8 @@ teardown:
                 time_series:
                   start_time: 2021-04-28T00:00:00Z
                   end_time: 2021-04-29T00:00:00Z
-                number_of_replicas: 0
                 number_of_shards: 2
+                auto_expand_replicas: 0-1
             mappings:
               properties:
                 "@timestamp":


### PR DESCRIPTION
This tests were failing due to missing replica that could not be used as a search shards

Related to: es-5311