### PR TITLE
Utility to broadcast to unpromotable shards

### DIFF
--- a/docs/changelog/93552.yaml
+++ b/docs/changelog/93552.yaml
@@ -1,0 +1,5 @@
+pr: 93552
+summary: Utility to broadcast to unpromotable shards
+area: CRUD
+type: feature
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -351,7 +351,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final ClusterState state = client().admin().cluster().prepareState().get().getState();
 
         assertEquals(
-            Collections.singleton(state.routingTable().index(idxName).shard(0).primary.allocationId().getId()),
+            Collections.singleton(state.routingTable().index(idxName).shard(0).primary().allocationId().getId()),
             state.metadata().index(idxName).inSyncAllocationIds(0)
         );
 
@@ -676,7 +676,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         assertBusy(() -> {
             ClusterState state = client(master).admin().cluster().prepareState().get().getState();
             final IndexShardRoutingTable shardRoutingTable = state.routingTable().shardRoutingTable(shardId);
-            final String newPrimaryNode = state.getRoutingNodes().node(shardRoutingTable.primary.currentNodeId()).node().getName();
+            final String newPrimaryNode = state.getRoutingNodes().node(shardRoutingTable.primary().currentNodeId()).node().getName();
             assertThat(newPrimaryNode, not(equalTo(oldPrimary)));
             Set<String> selectedPartition = replicasSide1.contains(newPrimaryNode) ? replicasSide1 : replicasSide2;
             assertThat(shardRoutingTable.activeShards(), hasSize(selectedPartition.size()));

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -9,34 +9,30 @@
 package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
-import org.elasticsearch.action.support.RefCountingListener;
 import org.elasticsearch.action.support.replication.BasicReplicationRequest;
+import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.action.support.replication.TransportReplicationAction;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
-import org.elasticsearch.cluster.node.DiscoveryNode;
-import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.TransportRequestOptions;
-import org.elasticsearch.transport.TransportResponse;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
-import java.util.function.Predicate;
-import java.util.stream.Collectors;
+
+import static org.elasticsearch.action.support.TransportActions.broadcastToUnpromotableShards;
 
 public class TransportShardRefreshAction extends TransportReplicationAction<
     BasicReplicationRequest,
@@ -48,6 +44,8 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
     public static final String NAME = RefreshAction.NAME + "[s]";
     public static final ActionType<ReplicationResponse> TYPE = new ActionType<>(NAME, ReplicationResponse::new);
     public static final String SOURCE_API = "api";
+
+    protected Engine.RefreshResult primaryRefreshResult = Engine.RefreshResult.NO_REFRESH;
 
     @Inject
     public TransportShardRefreshAction(
@@ -86,43 +84,11 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
         IndexShard primary,
         ActionListener<PrimaryResult<BasicReplicationRequest, ReplicationResponse>> listener
     ) {
-        try (var listeners = new RefCountingListener(listener.map(v -> new PrimaryResult<>(shardRequest, new ReplicationResponse())))) {
-            var refreshResult = primary.refresh(SOURCE_API);
+        ActionListener.completeWith(listener, () -> {
+            primaryRefreshResult = primary.refresh(SOURCE_API);
             logger.trace("{} refresh request executed on primary", primary.shardId());
-
-            // Forward the request to all nodes that hold unpromotable replica shards
-            final ClusterState clusterState = clusterService.state();
-            final Task parentTaskId = taskManager.getTask(shardRequest.getParentTask().getId());
-            clusterState.routingTable()
-                .shardRoutingTable(shardRequest.shardId())
-                .assignedShards()
-                .stream()
-                .filter(Predicate.not(ShardRouting::isPromotableToPrimary))
-                .map(ShardRouting::currentNodeId)
-                .collect(Collectors.toUnmodifiableSet())
-                .forEach(nodeId -> {
-                    final DiscoveryNode node = clusterState.nodes().get(nodeId);
-                    UnpromotableShardRefreshRequest request = new UnpromotableShardRefreshRequest(
-                        primary.shardId(),
-                        refreshResult.generation()
-                    );
-                    logger.trace("forwarding refresh request [{}] to node [{}]", request, node);
-                    transportService.sendChildRequest(
-                        node,
-                        TransportUnpromotableShardRefreshAction.NAME,
-                        request,
-                        parentTaskId,
-                        TransportRequestOptions.EMPTY,
-                        new ActionListenerResponseHandler<>(
-                            listeners.acquire(ignored -> {}),
-                            (in) -> TransportResponse.Empty.INSTANCE,
-                            ThreadPool.Names.REFRESH
-                        )
-                    );
-                });
-        } catch (Exception e) {
-            listener.onFailure(e);
-        }
+            return new PrimaryResult<>(shardRequest, new ReplicationResponse());
+        });
     }
 
     @Override
@@ -132,5 +98,34 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
             logger.trace("{} refresh request executed on replica", replica.shardId());
             return new ReplicaResult();
         });
+    }
+
+    @Override
+    protected ReplicationOperation.Replicas<BasicReplicationRequest> newReplicasProxy() {
+        return new UnpromotableReplicasRefreshProxy();
+    }
+
+    protected class UnpromotableReplicasRefreshProxy extends ReplicasProxy {
+
+        @Override
+        public void onPrimaryOperationComplete(BasicReplicationRequest request, ActionListener<Void> listener) {
+            assert primaryRefreshResult.refreshed() : "primary has not refreshed";
+            ShardId primary = request.shardId();
+            UnpromotableShardRefreshRequest replicaRequest = new UnpromotableShardRefreshRequest(
+                primary,
+                primaryRefreshResult.generation()
+            );
+            final Task parentTask = taskManager.getTask(request.getParentTask().getId());
+            broadcastToUnpromotableShards(
+                primary,
+                replicaRequest,
+                TransportUnpromotableShardRefreshAction.NAME,
+                parentTask,
+                clusterService,
+                transportService,
+                ThreadPool.Names.REFRESH,
+                listener
+            );
+        }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -108,17 +108,17 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
     protected class UnpromotableReplicasRefreshProxy extends ReplicasProxy {
 
         @Override
-        public void onPrimaryOperationComplete(BasicReplicationRequest request, ActionListener<Void> listener) {
+        public void onPrimaryOperationComplete(BasicReplicationRequest replicaRequest, ActionListener<Void> listener) {
             assert primaryRefreshResult.refreshed() : "primary has not refreshed";
-            ShardId primary = request.shardId();
-            UnpromotableShardRefreshRequest replicaRequest = new UnpromotableShardRefreshRequest(
+            ShardId primary = replicaRequest.shardId();
+            UnpromotableShardRefreshRequest unpromotableReplicaRequest = new UnpromotableShardRefreshRequest(
                 primary,
                 primaryRefreshResult.generation()
             );
-            final Task parentTask = taskManager.getTask(request.getParentTask().getId());
+            final Task parentTask = taskManager.getTask(replicaRequest.getParentTask().getId());
             broadcastToUnpromotableShards(
                 primary,
-                replicaRequest,
+                unpromotableReplicaRequest,
                 TransportUnpromotableShardRefreshAction.NAME,
                 parentTask,
                 clusterService,

--- a/server/src/main/java/org/elasticsearch/action/support/TransportActions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/TransportActions.java
@@ -47,14 +47,26 @@ public class TransportActions {
         return isShardNotAvailableException(e) == false;
     }
 
+    /**
+     * Broadcasts a given action request to all unpromotable assigned shards of a provided {@link ShardId}.
+     *
+     * @param shardId                        the routing table of this given shard will be used to get all unpromotable assigned shards
+     * @param request                        the request to broadcast
+     * @param action                         the action to broadcast
+     * @param parentTask                     the task that will be parent of the children broadcast requests
+     * @param clusterService                 the cluster service
+     * @param transportService               the transport service
+     * @param responseHandlerExecutor        the executor to be used in the {@link ActionListenerResponseHandler}
+     * @param listener                       the listener to notify when all children requests are done
+     */
     public static void broadcastToUnpromotableShards(
         ShardId shardId,
         ActionRequest request,
         String action,
-        Task parentTaskId,
+        Task parentTask,
         ClusterService clusterService,
         TransportService transportService,
-        String executor,
+        String responseHandlerExecutor,
         ActionListener<Void> listener
     ) {
         try (var listeners = new RefCountingListener(listener.map(v -> null))) {
@@ -66,12 +78,12 @@ public class TransportActions {
                     node,
                     action,
                     request,
-                    parentTaskId,
+                    parentTask,
                     TransportRequestOptions.EMPTY,
                     new ActionListenerResponseHandler<>(
                         listeners.acquire(ignored -> {}),
                         (in) -> TransportResponse.Empty.INSTANCE,
-                        executor
+                        responseHandlerExecutor
                     )
                 );
             });

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -612,10 +612,10 @@ public class ReplicationOperation<
         /**
          * Optional custom logic to execute when the primary operation is complete.
          *
-         * @param request                    the operation to perform
+         * @param replicaRequest             the operation that will be performed on replicas
          * @param listener                   callback for handling the response or failure
          */
-        default void onPrimaryOperationComplete(RequestT request, ActionListener<Void> listener) {
+        default void onPrimaryOperationComplete(RequestT replicaRequest, ActionListener<Void> listener) {
             listener.onResponse(null);
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -125,7 +125,7 @@ public class IndexShardRoutingTable {
     }
 
     /**
-     * Returns the primary {@Link ShardRouting}
+     * Returns the primary {@link ShardRouting}
      */
     public ShardRouting primary() {
         return primary;

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -43,22 +43,22 @@ import java.util.Set;
  */
 public class IndexShardRoutingTable {
 
-    final ShardShuffler shuffler;
-    final ShardId shardId;
-    final ShardRouting[] shards;
-    final ShardRouting primary;
-    final List<ShardRouting> replicas;
-    final List<ShardRouting> activeShards;
-    final List<ShardRouting> assignedShards;
-    final List<ShardRouting> unpromotableShards;
+    private final ShardShuffler shuffler;
+    private final ShardId shardId;
+    private final ShardRouting[] shards;
+    private final ShardRouting primary;
+    private final List<ShardRouting> replicas;
+    private final List<ShardRouting> activeShards;
+    private final List<ShardRouting> assignedShards;
+    private final List<ShardRouting> unpromotableShards;
     /**
      * The initializing list, including ones that are initializing on a target node because of relocation.
      * If we can come up with a better variable name, it would be nice...
      */
-    final List<ShardRouting> allInitializingShards;
-    final boolean allShardsStarted;
-    final int activeSearchShardCount;
-    final int totalSearchShardCount;
+    private final List<ShardRouting> allInitializingShards;
+    private final boolean allShardsStarted;
+    private final int activeSearchShardCount;
+    private final int totalSearchShardCount;
 
     IndexShardRoutingTable(ShardId shardId, List<ShardRouting> shards) {
         this.shuffler = new RotationShardShuffler(Randomness.get().nextInt());
@@ -122,6 +122,13 @@ public class IndexShardRoutingTable {
         this.allShardsStarted = allShardsStarted;
         this.activeSearchShardCount = activeSearchShardCount;
         this.totalSearchShardCount = totalSearchShardCount;
+    }
+
+    /**
+     * Returns the primary {@Link ShardRouting}
+     */
+    public ShardRouting primary() {
+        return primary;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -50,6 +50,7 @@ public class IndexShardRoutingTable {
     final List<ShardRouting> replicas;
     final List<ShardRouting> activeShards;
     final List<ShardRouting> assignedShards;
+    final List<ShardRouting> unpromotableShards;
     /**
      * The initializing list, including ones that are initializing on a target node because of relocation.
      * If we can come up with a better variable name, it would be nice...
@@ -68,6 +69,7 @@ public class IndexShardRoutingTable {
         List<ShardRouting> replicas = new ArrayList<>();
         List<ShardRouting> activeShards = new ArrayList<>();
         List<ShardRouting> assignedShards = new ArrayList<>();
+        List<ShardRouting> unpromotableShards = new ArrayList<>();
         List<ShardRouting> allInitializingShards = new ArrayList<>();
         boolean allShardsStarted = true;
         int activeSearchShardCount = 0;
@@ -97,9 +99,15 @@ public class IndexShardRoutingTable {
                 assert shard.assignedToNode() : "relocating from unassigned " + shard;
                 assert shard.getTargetRelocatingShard().assignedToNode() : "relocating to unassigned " + shard.getTargetRelocatingShard();
                 assignedShards.add(shard.getTargetRelocatingShard());
+                if (shard.getTargetRelocatingShard().isPromotableToPrimary() == false) {
+                    unpromotableShards.add(shard.getTargetRelocatingShard());
+                }
             }
             if (shard.assignedToNode()) {
                 assignedShards.add(shard);
+                if (shard.isPromotableToPrimary() == false) {
+                    unpromotableShards.add(shard);
+                }
             }
             if (shard.state() != ShardRoutingState.STARTED) {
                 allShardsStarted = false;
@@ -109,6 +117,7 @@ public class IndexShardRoutingTable {
         this.replicas = CollectionUtils.wrapUnmodifiableOrEmptySingleton(replicas);
         this.activeShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(activeShards);
         this.assignedShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(assignedShards);
+        this.unpromotableShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(unpromotableShards);
         this.allInitializingShards = CollectionUtils.wrapUnmodifiableOrEmptySingleton(allInitializingShards);
         this.allShardsStarted = allShardsStarted;
         this.activeSearchShardCount = activeSearchShardCount;
@@ -160,6 +169,15 @@ public class IndexShardRoutingTable {
      */
     public List<ShardRouting> assignedShards() {
         return this.assignedShards;
+    }
+
+    /**
+     * Returns a {@link List} of assigned unpromotable shards, including relocation targets
+     *
+     * @return a {@link List} of shards
+     */
+    public List<ShardRouting> unpromotableShards() {
+        return this.unpromotableShards;
     }
 
     public ShardIterator shardsRandomIt() {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/OperationRouting.java
@@ -207,7 +207,7 @@ public class OperationRouting {
             }
         }
         // if not, then use it as the index
-        int routingHash = 31 * Murmur3HashFunction.hash(preference) + indexShard.shardId.hashCode();
+        int routingHash = 31 * Murmur3HashFunction.hash(preference) + indexShard.shardId().hashCode();
         return indexShard.activeInitializingShardsIt(routingHash);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingNodes.java
@@ -113,7 +113,7 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
         for (IndexRoutingTable indexRoutingTable : routingTable.indicesRouting().values()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 IndexShardRoutingTable indexShard = indexRoutingTable.shard(shardId);
-                assert indexShard.primary != null;
+                assert indexShard.primary() != null;
                 for (int copy = 0; copy < indexShard.size(); copy++) {
                     final ShardRouting shard = indexShard.shard(copy);
                     // to get all the shards belonging to an index, including the replicas,
@@ -127,7 +127,7 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
                         if (shard.relocating()) {
                             relocatingShards++;
                             ShardRouting targetShardRouting = shard.getTargetRelocatingShard();
-                            addInitialRecovery(targetShardRouting, indexShard.primary);
+                            addInitialRecovery(targetShardRouting, indexShard.primary());
                             // LinkedHashMap to preserve order.
                             // Add the counterpart shard with relocatingNodeId reflecting the source from which it's relocating from.
                             nodesToShards.computeIfAbsent(shard.relocatingNodeId(), createRoutingNode)
@@ -138,7 +138,7 @@ public class RoutingNodes extends AbstractCollection<RoutingNode> {
                                 inactivePrimaryCount++;
                             }
                             inactiveShardCount++;
-                            addInitialRecovery(shard, indexShard.primary);
+                            addInitialRecovery(shard, indexShard.primary());
                         }
                     } else {
                         unassignedShards.add(shard);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/OperationRoutingTests.java
@@ -195,7 +195,7 @@ public class OperationRoutingTests extends ESTestCase {
     private ShardIterator duelGetShards(ClusterState clusterState, ShardId shardId, String sessionId) {
         final IndexShardRoutingTable indexShard = clusterState.getRoutingTable().shardRoutingTable(shardId.getIndexName(), shardId.getId());
         int routingHash = Murmur3HashFunction.hash(sessionId);
-        routingHash = 31 * routingHash + indexShard.shardId.hashCode();
+        routingHash = 31 * routingHash + indexShard.shardId().hashCode();
         return indexShard.activeInitializingShardsIt(routingHash);
     }
 


### PR DESCRIPTION
Introduces:

* IndexShardRoutingTable now lists unpromotable assigned shards.
* New utility TransportActions#broadcastToUnpromotableShards().
* New hook in ReplicationOperation for custom logic when the primary operation completes.
* Refresh action now uses the new hook to broadcast the unpromotable refresh action to all unpromotable shards.

Fixes ES-5454
