### PR TITLE
Revert muting of 140_data_stream_aliases on yamlRestTestV7CompatTest

### DIFF
--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -77,7 +77,6 @@ tasks.named("yamlRestTestV7CompatTest").configure {
     'unsigned_long/50_script_values/Scripted sort values',
     'unsigned_long/50_script_values/script_score query',
     'unsigned_long/50_script_values/Script query',
-    'data_stream/140_data_stream_aliases/Fix IndexNotFoundException error when handling remove alias action',
     'aggregate-metrics/90_tsdb_mappings/aggregate_double_metric with time series mappings',
     'aggregate-metrics/90_tsdb_mappings/aggregate_double_metric with wrong time series mappings',
     'analytics/histogram/histogram with wrong time series mappings',


### PR DESCRIPTION
I couldn't reproduce it locally. Unmuting to see if the issue has been fixed.

Closes [#80405](https://github.com/elastic/elasticsearch/issues/80405)