### PR TITLE
Get stackframes and executables more concurrently

### DIFF
--- a/docs/changelog/93559.yaml
+++ b/docs/changelog/93559.yaml
@@ -1,0 +1,5 @@
+pr: 93559
+summary: Get stackframes and executables more concurrently
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -53,7 +53,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
 
     public static final Setting<Integer> PROFILING_MAX_DETAIL_QUERY_SLICES = Setting.intSetting(
         "xpack.profiling.query.details.max_slices",
-        1,
+        16,
         1,
         Setting.Property.NodeScope
     );


### PR DESCRIPTION
With this commit we raise the default value for
`xpack.profiling.query.details.max_slices` from `1` to `16`. This setting controls how many mget API calls are issued concurrently to retrieve stackframes and executables. While in our initial testing with a single node we did not see much of an improvement with higher concurrency levels, a more realistic deployment consisting of three hot nodes shows a latency reduction by about 14% (from 1374ms 50th percentile latency to 1180ms 50th percentile latency).

Relates elastic/elasticsearch#93448