### PR TITLE
Fix illegal progress update in FrozenIndexInput

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
@@ -40,7 +40,6 @@ import static org.hamcrest.Matchers.hasSize;
 
 public class NodesCachesStatsIntegTests extends BaseFrozenSearchableSnapshotsIntegTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93555")
     public void testNodesCachesStats() throws Exception {
         final String[] nodeNames = internalCluster().getNodeNames();
         // here to ensure no shard relocations after the snapshot is mounted,


### PR DESCRIPTION
Due to recent changes we can have a situation where we end up with an empty buffer after the loop since the file lined up perfectly with buffer size. -> just skip all the magic for writing the last chunk of the file if there's nothing left to be done so we don't do a `0` length progress update.

non-issue since this bug wasn't released.

closes #93555
