### PR TITLE
Use shorter paths for test cluster working directories to avoid issues on Windows

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -271,7 +271,8 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         private boolean canUseSharedDistribution() {
             return OS.current() != WINDOWS // Issues with long file paths on Windows in CI
                 && System.getProperty(TESTS_CLUSTER_FIPS_JAR_PATH_SYSPROP) == null
-                && (distributionDescriptor.getType() == DEFAULT || (getSpec().getPlugins().isEmpty() && getSpec().getModules().isEmpty()));
+                && getSpec().getPlugins().isEmpty()
+                && (distributionDescriptor.getType() == DEFAULT || getSpec().getModules().isEmpty());
         }
 
         private void copyExtraJarFiles() {
@@ -607,7 +608,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
 
         private void runToolScript(String tool, String input, String... args) {
             try {
-                ProcessUtils.exec(
+                int exit = ProcessUtils.exec(
                     input,
                     distributionDir,
                     distributionDir.resolve("bin")
@@ -616,6 +617,10 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                     false,
                     args
                 ).waitFor();
+
+                if (exit != 0) {
+                    throw new RuntimeException("Execution of " + tool + " failed with exit code " + exit);
+                }
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -132,6 +132,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 copyExtraConfigFiles();
             }
 
+            deleteGcLogs();
             writeConfiguration();
             createKeystore();
             addKeystoreSettings();
@@ -211,6 +212,20 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 throw new RuntimeException("Timed out after " + NODE_UP_TIMEOUT + " waiting for ports files for: " + this);
             } catch (ExecutionException e) {
                 throw new RuntimeException("An error occurred while waiting for ports file for: " + this, e);
+            }
+        }
+
+        private void deleteGcLogs() {
+            try (Stream<Path> logs = Files.list(logsDir)) {
+                logs.filter(l -> l.getFileName().toString().startsWith("gc.log")).forEach(path -> {
+                    try {
+                        IOUtils.deleteWithRetry(path);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
         }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalElasticsearchCluster.java
@@ -16,8 +16,6 @@ import org.elasticsearch.test.cluster.util.Version;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import java.nio.file.Path;
-
 public class LocalElasticsearchCluster implements ElasticsearchCluster {
     private final DefaultLocalClusterSpecBuilder builder;
     private LocalClusterSpec spec;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalElasticsearchCluster.java
@@ -35,7 +35,6 @@ public class LocalElasticsearchCluster implements ElasticsearchCluster {
                 try {
                     spec = builder.buildClusterSpec();
                     handle = new LocalClusterFactory(
-                        Path.of(System.getProperty("java.io.tmpdir")).resolve(description.getDisplayName()).toAbsolutePath(),
                         new LocalDistributionResolver(new SnapshotDistributionResolver(new ReleasedDistributionResolver()))
                     ).create(spec);
                     handle.start();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
@@ -68,8 +68,6 @@ public final class ProcessUtils {
         processBuilder.environment().clear();
         processBuilder.environment().putAll(environment);
 
-        LOGGER.info("Executing '{}' in '{}'", command, workingDir);
-
         try {
             process = processBuilder.start();
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -57,7 +58,7 @@ public final class ProcessUtils {
         List<String> command = new ArrayList<>();
         command.addAll(
             OS.conditional(
-                c -> c.onWindows(() -> List.of("cmd", "/c", executable.toString()))
+                c -> c.onWindows(() -> List.of("cmd", "/c", executable.getFileName().toString()))
                     .onUnix(() -> List.of(workingDir.relativize(executable).toString()))
             )
         );
@@ -67,6 +68,7 @@ public final class ProcessUtils {
         processBuilder.directory(workingDir.toFile());
         processBuilder.environment().clear();
         processBuilder.environment().putAll(environment);
+        processBuilder.environment().put("PATH", executable.getParent().toString() + File.pathSeparator + System.getenv("PATH"));
 
         LOGGER.info("Executing '{}' in '{}'", command, workingDir);
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
@@ -13,7 +13,6 @@ import org.apache.logging.log4j.Logger;
 
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -58,7 +57,7 @@ public final class ProcessUtils {
         List<String> command = new ArrayList<>();
         command.addAll(
             OS.conditional(
-                c -> c.onWindows(() -> List.of("cmd", "/c", executable.getFileName().toString()))
+                c -> c.onWindows(() -> List.of("cmd", "/c", workingDir.relativize(executable).toString()))
                     .onUnix(() -> List.of(workingDir.relativize(executable).toString()))
             )
         );
@@ -68,7 +67,6 @@ public final class ProcessUtils {
         processBuilder.directory(workingDir.toFile());
         processBuilder.environment().clear();
         processBuilder.environment().putAll(environment);
-        processBuilder.environment().put("PATH", executable.getParent().toString() + File.pathSeparator + System.getenv("PATH"));
 
         LOGGER.info("Executing '{}' in '{}'", command, workingDir);
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/ProcessUtils.java
@@ -57,7 +57,7 @@ public final class ProcessUtils {
         List<String> command = new ArrayList<>();
         command.addAll(
             OS.conditional(
-                c -> c.onWindows(() -> List.of("cmd", "/c", workingDir.relativize(executable).toString()))
+                c -> c.onWindows(() -> List.of("cmd", "/c", executable.toString()))
                     .onUnix(() -> List.of(workingDir.relativize(executable).toString()))
             )
         );


### PR DESCRIPTION
Windows doesn't like long file paths and there seems to be no way to configure a `ProcessBuilder` such that the command to execute lives in a path longer than MAX_PATH. We're admitting defeat here and simply making the working directories for our test cluster installs shorter.