### PR TITLE
Remove obsolete methods from ConcurrentCollections

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -237,7 +237,7 @@ public final class DateProcessor extends AbstractProcessor {
                 throw new IllegalArgumentException("cache capacity must be a value greater than 0 but was " + capacity);
             }
             this.capacity = capacity;
-            this.map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency(this.capacity);
+            this.map = ConcurrentCollections.newConcurrentMap(this.capacity);
         }
 
         Function<String, ZonedDateTime> getOrCompute(Key key, Supplier<Function<String, ZonedDateTime>> supplier) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchTransportService.java
@@ -88,7 +88,7 @@ public class SearchTransportService {
         Transport.Connection,
         SearchActionListener<? super SearchPhaseResult>,
         ActionListener<? super SearchPhaseResult>> responseWrapper;
-    private final Map<String, Long> clientConnections = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final Map<String, Long> clientConnections = ConcurrentCollections.newConcurrentMap();
 
     public SearchTransportService(
         TransportService transportService,

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/VersionsAndSeqNoResolver.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/VersionsAndSeqNoResolver.java
@@ -27,7 +27,7 @@ import java.util.concurrent.ConcurrentMap;
 public final class VersionsAndSeqNoResolver {
 
     static final ConcurrentMap<IndexReader.CacheKey, CloseableThreadLocal<PerThreadIDVersionAndSeqNoLookup[]>> lookupStates =
-        ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        ConcurrentCollections.newConcurrentMap();
 
     // Evict this reader from lookupStates once it's closed:
     private static final IndexReader.ClosedListener removeLookupState = key -> {

--- a/server/src/main/java/org/elasticsearch/common/util/StringLiteralDeduplicator.java
+++ b/server/src/main/java/org/elasticsearch/common/util/StringLiteralDeduplicator.java
@@ -20,7 +20,7 @@ public final class StringLiteralDeduplicator {
 
     private static final int MAX_SIZE = 1000;
 
-    private final Map<String, String> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final Map<String, String> map = ConcurrentCollections.newConcurrentMap();
 
     public StringLiteralDeduplicator() {}
 

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ConcurrentCollections.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ConcurrentCollections.java
@@ -20,29 +20,12 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedTransferQueue;
 
 public abstract class ConcurrentCollections {
-
-    static final int aggressiveConcurrencyLevel;
-
-    static {
-        aggressiveConcurrencyLevel = Math.max(Runtime.getRuntime().availableProcessors() * 2, 16);
-    }
-
-    /**
-     * Creates a new CHM with an aggressive concurrency level, aimed at high concurrent update rate long living maps.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentMapWithAggressiveConcurrency() {
-        return newConcurrentMapWithAggressiveConcurrency(16);
-    }
-
-    /**
-     * Creates a new CHM with an aggressive concurrency level, aimed at high concurrent update rate long living maps.
-     */
-    public static <K, V> ConcurrentMap<K, V> newConcurrentMapWithAggressiveConcurrency(int initalCapacity) {
-        return new ConcurrentHashMap<>(initalCapacity, 0.75f, aggressiveConcurrencyLevel);
-    }
-
     public static <K, V> ConcurrentMap<K, V> newConcurrentMap() {
         return new ConcurrentHashMap<>();
+    }
+
+    public static <K, V> ConcurrentMap<K, V> newConcurrentMap(int initialCapacity) {
+        return new ConcurrentHashMap<>(initialCapacity);
     }
 
     public static <V> Set<V> newConcurrentSet() {

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
@@ -25,7 +25,7 @@ import java.util.concurrent.locks.ReentrantLock;
  * */
 public final class KeyedLock<T> {
 
-    private final ConcurrentMap<T, KeyLock> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final ConcurrentMap<T, KeyLock> map = ConcurrentCollections.newConcurrentMap();
     private final boolean fair;
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -110,7 +110,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
         }
 
         Maps() {
-            this(new VersionLookup(ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency()), VersionLookup.EMPTY, false);
+            this(new VersionLookup(ConcurrentCollections.newConcurrentMap()), VersionLookup.EMPTY, false);
         }
 
         boolean isSafeAccessMode() {
@@ -129,7 +129,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
          */
         Maps buildTransitionMap() {
             return new Maps(
-                new VersionLookup(ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency(current.size())),
+                new VersionLookup(ConcurrentCollections.newConcurrentMap(current.size())),
                 current,
                 shouldInheritSafeAccess()
             );
@@ -177,7 +177,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
     }
 
     // All deletes also go here, and delete "tombstones" are retained after refresh:
-    private final Map<BytesRef, DeleteVersionValue> tombstones = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final Map<BytesRef, DeleteVersionValue> tombstones = ConcurrentCollections.newConcurrentMap();
 
     private volatile Maps maps = new Maps();
     // we maintain a second map that only receives the updates that we skip on the actual map (unsafe ops)
@@ -209,7 +209,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
 
     static {
         // use the same impl as the Maps does
-        Map<Integer, Integer> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        Map<Integer, Integer> map = ConcurrentCollections.newConcurrentMap();
         map.put(0, 0);
         long chmEntryShallowSize = RamUsageEstimator.shallowSizeOf(map.entrySet().iterator().next());
         // assume a load factor of 50%

--- a/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/LiveVersionMap.java
@@ -128,11 +128,7 @@ final class LiveVersionMap implements ReferenceManager.RefreshListener, Accounta
          * Builds a new map for the refresh transition this should be called in beforeRefresh()
          */
         Maps buildTransitionMap() {
-            return new Maps(
-                new VersionLookup(ConcurrentCollections.newConcurrentMap(current.size())),
-                current,
-                shouldInheritSafeAccess()
-            );
+            return new Maps(new VersionLookup(ConcurrentCollections.newConcurrentMap(current.size())), current, shouldInheritSafeAccess());
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -263,7 +263,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private final AtomicLong idGenerator = new AtomicLong();
 
-    private final Map<Long, ReaderContext> activeReaders = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final Map<Long, ReaderContext> activeReaders = ConcurrentCollections.newConcurrentMap();
 
     private final MultiBucketConsumerService multiBucketConsumerService;
 

--- a/server/src/main/java/org/elasticsearch/tasks/CancellableTasksTracker.java
+++ b/server/src/main/java/org/elasticsearch/tasks/CancellableTasksTracker.java
@@ -30,8 +30,8 @@ public class CancellableTasksTracker<T> {
         this.empty = empty;
     }
 
-    private final Map<Long, T> byTaskId = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
-    private final Map<TaskId, T[]> byParentTaskId = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final Map<Long, T> byTaskId = ConcurrentCollections.newConcurrentMap();
+    private final Map<TaskId, T[]> byParentTaskId = ConcurrentCollections.newConcurrentMap();
 
     /**
      * Add an item for the given task. Should only be called once for each task, and {@code item} must be unique per task too.

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -74,7 +74,7 @@ public class TaskManager implements ClusterStateApplier {
     private final String[] taskHeaders;
     private final ThreadPool threadPool;
 
-    private final Map<Long, Task> tasks = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+    private final Map<Long, Task> tasks = ConcurrentCollections.newConcurrentMap();
 
     private final CancellableTasksTracker<CancellableTaskHolder> cancellableTasks = new CancellableTasksTracker<>(
         new CancellableTaskHolder[0]

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -195,8 +195,7 @@ public interface Transport extends LifecycleComponent {
      * This class is a registry that allows
      */
     final class ResponseHandlers {
-        private final Map<Long, ResponseContext<? extends TransportResponse>> handlers = ConcurrentCollections
-            .newConcurrentMapWithAggressiveConcurrency();
+        private final Map<Long, ResponseContext<? extends TransportResponse>> handlers = ConcurrentCollections.newConcurrentMap();
         private final AtomicLong requestIdGenerator = new AtomicLong();
 
         /**

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -168,7 +168,7 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
         this.snapshotId = Objects.requireNonNull(snapshotId);
         this.indexId = Objects.requireNonNull(indexId);
         this.shardId = Objects.requireNonNull(shardId);
-        this.stats = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
+        this.stats = ConcurrentCollections.newConcurrentMap();
         this.statsCurrentTimeNanosSupplier = Objects.requireNonNull(currentTimeNanosSupplier);
         this.cacheService = Objects.requireNonNull(cacheService);
         this.cacheDir = Objects.requireNonNull(cacheDir);


### PR DESCRIPTION
With this commit we remove obsolete methods from `ConcurrentCollections`:

* `newConcurrentMapWithAggressiveConcurrency`
* `newConcurrentMapWithAggressiveConcurrency(int)`

The first method created a new instance of `ConcurrentHashMap` with a capacity of at most 16. However, the same behavior can be achieved by just calling the default constructor of `ConcurrentHashMap`.

The latter method is meant to be called with an initial capacity. The name "aggressive concurrency" is misleading as the `concurrencyLevel` constructor parameter of `ConcurrentHashMap` is only used to adjust the initial capacity of the map iff the provided capacity is less than that.
