### PR TITLE
QL/Add isDate() method to TypeResolutions

### DIFF
--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/TypeResolutions.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/TypeResolutions.java
@@ -19,6 +19,7 @@ import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.xpack.ql.expression.Expressions.name;
 import static org.elasticsearch.xpack.ql.expression.TypeResolutions.ParamOrdinal.DEFAULT;
 import static org.elasticsearch.xpack.ql.type.DataTypes.BOOLEAN;
+import static org.elasticsearch.xpack.ql.type.DataTypes.DATETIME;
 import static org.elasticsearch.xpack.ql.type.DataTypes.IP;
 import static org.elasticsearch.xpack.ql.type.DataTypes.NULL;
 
@@ -64,6 +65,10 @@ public final class TypeResolutions {
 
     public static TypeResolution isIP(Expression e, String operationName, ParamOrdinal paramOrd) {
         return isType(e, dt -> dt == IP, operationName, paramOrd, "ip");
+    }
+
+    public static TypeResolution isDate(Expression e, String operationName, ParamOrdinal paramOrd) {
+        return isType(e, dt -> dt == DATETIME, operationName, paramOrd, "datetime");
     }
 
     public static TypeResolution isExact(Expression e, String message) {


### PR DESCRIPTION
Add isDate() method to TypeResolutions QL class, that performs resolution for `datetime` type.