### PR TITLE
[Profiling] Reduce GC pressure

### DIFF
--- a/docs/changelog/93590.yaml
+++ b/docs/changelog/93590.yaml
@@ -1,0 +1,5 @@
+pr: 93590
+summary: "[Profiling] Reduce GC pressure"
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
+++ b/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
@@ -24,10 +24,10 @@ public class GetProfilingActionIT extends ProfilingTestCase {
         assertEquals(1, response.getTotalFrames());
         assertNotNull(response.getStackTraces());
         StackTrace stackTrace = response.getStackTraces().get("QjoLteG7HX3VUUXr-J4kHQ");
-        assertArrayEquals(new int[] { 1083999 }, stackTrace.addressOrLines);
-        assertArrayEquals(new String[] { "QCCDqjSg3bMK1C4YRK6Tiw" }, stackTrace.fileIds);
-        assertArrayEquals(new String[] { "QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf" }, stackTrace.frameIds);
-        assertArrayEquals(new int[] { 2 }, stackTrace.typeIds);
+        assertEquals(List.of(1083999), stackTrace.addressOrLines);
+        assertEquals(List.of("QCCDqjSg3bMK1C4YRK6Tiw"), stackTrace.fileIds);
+        assertEquals(List.of("QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf"), stackTrace.frameIds);
+        assertEquals(List.of(2), stackTrace.typeIds);
 
         assertNotNull(response.getStackFrames());
         StackFrame stackFrame = response.getStackFrames().get("QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf");

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -39,7 +39,12 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         this.stackTraces = in.readBoolean()
             ? in.readMap(
                 StreamInput::readString,
-                i -> new StackTrace(i.readIntArray(), i.readStringArray(), i.readStringArray(), i.readIntArray())
+                i -> new StackTrace(
+                    i.readList(StreamInput::readInt),
+                    i.readList(StreamInput::readString),
+                    i.readList(StreamInput::readString),
+                    i.readList(StreamInput::readInt)
+                )
             )
             : null;
         this.stackFrames = in.readBoolean()
@@ -95,10 +100,10 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         if (stackTraces != null) {
             out.writeBoolean(true);
             out.writeMap(stackTraces, StreamOutput::writeString, (o, v) -> {
-                o.writeIntArray(v.addressOrLines);
-                o.writeStringArray(v.fileIds);
-                o.writeStringArray(v.frameIds);
-                o.writeIntArray(v.typeIds);
+                o.writeCollection(v.addressOrLines, StreamOutput::writeInt);
+                o.writeCollection(v.fileIds, StreamOutput::writeString);
+                o.writeCollection(v.frameIds, StreamOutput::writeString);
+                o.writeCollection(v.typeIds, StreamOutput::writeInt);
             });
         } else {
             out.writeBoolean(false);

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackTrace.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackTrace.java
@@ -12,16 +12,19 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 final class StackTrace implements ToXContentObject {
-    int[] addressOrLines;
-    String[] fileIds;
-    String[] frameIds;
-    int[] typeIds;
+    List<Integer> addressOrLines;
+    List<String> fileIds;
+    List<String> frameIds;
+    List<Integer> typeIds;
 
-    StackTrace(int[] addressOrLines, String[] fileIds, String[] frameIds, int[] typeIds) {
+    StackTrace(List<Integer> addressOrLines, List<String> fileIds, List<String> frameIds, List<Integer> typeIds) {
         this.addressOrLines = addressOrLines;
         this.fileIds = fileIds;
         this.frameIds = frameIds;
@@ -60,8 +63,8 @@ final class StackTrace implements ToXContentObject {
      * @return Corresponding numbers that are encoded in the input.
      */
     // package-private for testing
-    static int[] runLengthDecodeBase64Url(String input, int size, int capacity) {
-        int[] output = new int[capacity];
+    static List<Integer> runLengthDecodeBase64Url(String input, int size, int capacity) {
+        Integer[] output = new Integer[capacity];
         int multipleOf8 = size / 8;
         int remainder = size % 8;
 
@@ -125,7 +128,10 @@ final class StackTrace implements ToXContentObject {
             Arrays.fill(output, j, j + count, value);
             j += count;
         }
-        return output;
+        if (j < capacity) {
+            Arrays.fill(output, j, capacity, 0);
+        }
+        return List.of(output);
     }
 
     // package-private for testing
@@ -168,9 +174,9 @@ final class StackTrace implements ToXContentObject {
         String inputFrameTypes = ObjectPath.eval("Stacktrace.frame.types", source);
         int countsFrameIDs = inputFrameIDs.length() / BASE64_FRAME_ID_LENGTH;
 
-        String[] fileIDs = new String[countsFrameIDs];
-        String[] frameIDs = new String[countsFrameIDs];
-        int[] addressOrLines = new int[countsFrameIDs];
+        List<String> fileIDs = new ArrayList<>(countsFrameIDs);
+        List<String> frameIDs = new ArrayList<>(countsFrameIDs);
+        List<Integer> addressOrLines = new ArrayList<>(countsFrameIDs);
 
         // Step 1: Convert the base64-encoded frameID list into two separate
         // lists (frame IDs and file IDs), both of which are also base64-encoded.
@@ -183,13 +189,13 @@ final class StackTrace implements ToXContentObject {
         // address (see diagram in definition of EncodedStackTrace).
         for (int i = 0, pos = 0; i < countsFrameIDs; i++, pos += BASE64_FRAME_ID_LENGTH) {
             String frameID = inputFrameIDs.substring(pos, pos + BASE64_FRAME_ID_LENGTH);
-            frameIDs[i] = frameID;
-            fileIDs[i] = getFileIDFromStackFrameID(frameID);
-            addressOrLines[i] = getAddressFromStackFrameID(frameID);
+            frameIDs.add(frameID);
+            fileIDs.add(getFileIDFromStackFrameID(frameID));
+            addressOrLines.add(getAddressFromStackFrameID(frameID));
         }
 
         // Step 2: Convert the run-length byte encoding into a list of uint8s.
-        int[] typeIDs = runLengthDecodeBase64Url(inputFrameTypes, inputFrameTypes.length(), countsFrameIDs);
+        List<Integer> typeIDs = runLengthDecodeBase64Url(inputFrameTypes, inputFrameTypes.length(), countsFrameIDs);
 
         return new StackTrace(addressOrLines, fileIDs, frameIDs, typeIDs);
     }
@@ -197,35 +203,29 @@ final class StackTrace implements ToXContentObject {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.array("address_or_lines", this.addressOrLines);
-        builder.array("file_ids", this.fileIds);
-        builder.array("frame_ids", this.frameIds);
-        builder.array("type_ids", this.typeIds);
+        builder.field("address_or_lines", this.addressOrLines);
+        builder.field("file_ids", this.fileIds);
+        builder.field("frame_ids", this.frameIds);
+        builder.field("type_ids", this.typeIds);
         builder.endObject();
         return builder;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
+        if (this == o) return true;
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
         StackTrace that = (StackTrace) o;
-        return Arrays.equals(addressOrLines, that.addressOrLines)
-            && Arrays.equals(fileIds, that.fileIds)
-            && Arrays.equals(frameIds, that.frameIds)
-            && Arrays.equals(typeIds, that.typeIds);
+        return addressOrLines.equals(that.addressOrLines)
+            && fileIds.equals(that.fileIds)
+            && frameIds.equals(that.frameIds)
+            && typeIds.equals(that.typeIds);
     }
 
     @Override
     public int hashCode() {
-        int result = Arrays.hashCode(addressOrLines);
-        result = 31 * result + Arrays.hashCode(fileIds);
-        result = 31 * result + Arrays.hashCode(frameIds);
-        result = 31 * result + Arrays.hashCode(typeIds);
-        return result;
+        return Objects.hash(addressOrLines, fileIds, frameIds, typeIds);
     }
 }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackTrace.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackTrace.java
@@ -131,7 +131,7 @@ final class StackTrace implements ToXContentObject {
         if (j < capacity) {
             Arrays.fill(output, j, capacity, 0);
         }
-        return List.of(output);
+        return Arrays.asList(output);
     }
 
     // package-private for testing

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -30,7 +30,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ObjectPath;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -183,7 +182,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
     ) {
         List<String> eventIds = new ArrayList<>(responseBuilder.getStackTraceEvents().keySet());
         List<List<String>> slicedEventIds = sliced(eventIds, desiredSlices);
-        StackTraceHandler handler = new StackTraceHandler(client, responseBuilder, submitListener, slicedEventIds.size());
+        StackTraceHandler handler = new StackTraceHandler(client, responseBuilder, submitListener, eventIds.size(), slicedEventIds.size());
         for (List<String> slice : slicedEventIds) {
             client.prepareMultiGet().setRealtime(realtime).addIds("profiling-stacktraces", slice).execute(new ActionListener<>() {
                 @Override
@@ -221,7 +220,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         private final Client client;
         private final GetProfilingResponseBuilder responseBuilder;
         private final ActionListener<GetProfilingResponse> submitListener;
-        private final Map<String, StackTrace> stackTracePerId = new ConcurrentHashMap<>();
+        private final Map<String, StackTrace> stackTracePerId;
         // sort items lexicographically to access Lucene's term dictionary more efficiently when issuing an mget request.
         // The term dictionary is lexicographically sorted and using the same order reduces the number of page faults
         // needed to load it.
@@ -234,8 +233,10 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             Client client,
             GetProfilingResponseBuilder responseBuilder,
             ActionListener<GetProfilingResponse> submitListener,
+            int stackTraceCount,
             int slices
         ) {
+            this.stackTracePerId = new ConcurrentHashMap<>(stackTraceCount);
             this.remainingSlices = new AtomicInteger(slices);
             this.client = client;
             this.responseBuilder = responseBuilder;
@@ -248,16 +249,22 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
                     String id = trace.getId();
                     StackTrace stacktrace = StackTrace.fromSource(trace.getResponse().getSource());
                     stackTracePerId.put(id, stacktrace);
-                    totalFrames.addAndGet(stacktrace.frameIds.length);
-                    stackFrameIds.addAll(Arrays.asList(stacktrace.frameIds));
-                    executableIds.addAll(Arrays.asList(stacktrace.fileIds));
+                    totalFrames.addAndGet(stacktrace.frameIds.size());
+                    stackFrameIds.addAll(stacktrace.frameIds);
+                    executableIds.addAll(stacktrace.fileIds);
                 }
             }
             if (this.remainingSlices.decrementAndGet() == 0) {
                 responseBuilder.setStackTraces(stackTracePerId);
                 responseBuilder.setTotalFrames(totalFrames.get());
                 log.debug("retrieveStackTraces took [" + (System.nanoTime() - start) / 1_000_000.0d + " ms].");
-                retrieveStackTraceDetails(client, responseBuilder, stackFrameIds, executableIds, submitListener);
+                retrieveStackTraceDetails(
+                    client,
+                    responseBuilder,
+                    new ArrayList<>(stackFrameIds),
+                    new ArrayList<>(executableIds),
+                    submitListener
+                );
             }
         }
     }
@@ -265,15 +272,17 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
     private void retrieveStackTraceDetails(
         Client client,
         GetProfilingResponseBuilder responseBuilder,
-        Set<String> stackFrameIds,
-        Set<String> executableIds,
+        List<String> stackFrameIds,
+        List<String> executableIds,
         ActionListener<GetProfilingResponse> submitListener
     ) {
-        List<List<String>> slicedStackFrameIds = sliced(new ArrayList<>(stackFrameIds), desiredDetailSlices);
-        List<List<String>> slicedExecutableIds = sliced(new ArrayList<>(executableIds), desiredDetailSlices);
+        List<List<String>> slicedStackFrameIds = sliced(stackFrameIds, desiredDetailSlices);
+        List<List<String>> slicedExecutableIds = sliced(executableIds, desiredDetailSlices);
         DetailsHandler handler = new DetailsHandler(
             responseBuilder,
             submitListener,
+            executableIds.size(),
+            stackFrameIds.size(),
             slicedExecutableIds.size(),
             slicedStackFrameIds.size()
         );
@@ -377,13 +386,15 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         private DetailsHandler(
             GetProfilingResponseBuilder builder,
             ActionListener<GetProfilingResponse> submitListener,
+            int executableCount,
+            int stackFrameCount,
             int expectedExecutableSlices,
             int expectedStackFrameSlices
         ) {
             this.builder = builder;
             this.submitListener = submitListener;
-            this.executables = new ConcurrentHashMap<>();
-            this.stackFrames = new ConcurrentHashMap<>();
+            this.executables = new ConcurrentHashMap<>(executableCount);
+            this.stackFrames = new ConcurrentHashMap<>(stackFrameCount);
             this.expectedExecutableSlices = new AtomicInteger(expectedExecutableSlices);
             this.expectedStackFrameSlices = new AtomicInteger(expectedStackFrameSlices);
         }

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.profiler;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Supplier;
 
@@ -29,12 +30,7 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
         Map<String, StackTrace> stackTraces = randomNullable(
             Map.of(
                 "QjoLteG7HX3VUUXr-J4kHQ",
-                new StackTrace(
-                    new int[] { 1083999 },
-                    new String[] { "QCCDqjSg3bMK1C4YRK6Tiw" },
-                    new String[] { "QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf" },
-                    new int[] { 2 }
-                )
+                new StackTrace(List.of(1083999), List.of("QCCDqjSg3bMK1C4YRK6Tiw"), List.of("QCCDqjSg3bMK1C4YRK6TiwAAAAAAEIpf"), List.of(2))
             )
         );
         int maxInlined = randomInt(5);


### PR DESCRIPTION
With this commit we reduce GC pressure in the profiling plugin by:

* Presizing collections to the correct size.
* Avoiding copying data needlessly by already using the collection type required by call sites.