### PR TITLE
Use mmap for temporary files.

### DIFF
--- a/docs/changelog/93595.yaml
+++ b/docs/changelog/93595.yaml
@@ -1,0 +1,5 @@
+pr: 93595
+summary: Use mmap for temporary files
+area: Engine
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
+++ b/server/src/main/java/org/elasticsearch/index/store/FsDirectoryFactory.java
@@ -130,6 +130,16 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
             IOUtils.close(super::close, delegate);
         }
 
+        private static String getExtension(String name) {
+            // Unlike FileSwitchDirectory#getExtension, we treat `tmp` as a normal file extension, which can have its own rules for mmaping.
+            final int lastDotIndex = name.lastIndexOf('.');
+            if (lastDotIndex == -1) {
+                return "";
+            } else {
+                return name.substring(lastDotIndex + 1);
+            }
+        }
+
         static boolean useDelegate(String name, IOContext ioContext) {
             if (ioContext == Store.READONCE_CHECKSUM) {
                 // If we're just reading the footer for the checksum then mmap() isn't really necessary, and it's desperately inefficient
@@ -137,7 +147,7 @@ public class FsDirectoryFactory implements IndexStorePlugin.DirectoryFactory {
                 return false;
             }
 
-            final LuceneFilesExtensions extension = LuceneFilesExtensions.fromExtension(FileSwitchDirectory.getExtension(name));
+            final LuceneFilesExtensions extension = LuceneFilesExtensions.fromExtension(getExtension(name));
             if (extension == null || extension.shouldMmap() == false) {
                 // Other files are either less performance-sensitive (e.g. stored field index, norms metadata)
                 // or are large and have a random access pattern and mmap leads to page cache trashing

--- a/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
+++ b/server/src/main/java/org/elasticsearch/index/store/LuceneFilesExtensions.java
@@ -66,7 +66,9 @@ public enum LuceneFilesExtensions {
     // Lucene 8.6 terms metadata file
     TMD("tmd", "Term Dictionary Metadata", true, false),
     // Temporary Lucene file
-    TMP("tmp", "Temporary File", false, false),
+    // These files are short-lived, usually fit in the page cache, and sometimes accessed in a random access fashion (e.g. stored fields
+    // flushes when index sorting is enabled), which mmap handles more efficiently than niofs.
+    TMP("tmp", "Temporary File", false, true),
     TVD("tvd", "Term Vector Documents", false, false),
     TVF("tvf", "Term Vector Fields", false, false),
     TVM("tvm", "Term Vector Metadata", true, false),

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -55,7 +55,7 @@ public class FsDirectoryFactoryTests extends ESTestCase {
             assertTrue(FsDirectoryFactory.HybridDirectory.useDelegate("foo.kdd", newIOContext(random())));
             assertTrue(FsDirectoryFactory.HybridDirectory.useDelegate("foo.kdi", newIOContext(random())));
             assertFalse(FsDirectoryFactory.HybridDirectory.useDelegate("foo.kdi", Store.READONCE_CHECKSUM));
-            assertFalse(FsDirectoryFactory.HybridDirectory.useDelegate("foo.tmp", newIOContext(random())));
+            assertTrue(FsDirectoryFactory.HybridDirectory.useDelegate("foo.tmp", newIOContext(random())));
             MMapDirectory delegate = hybridDirectory.getDelegate();
             assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));
             FsDirectoryFactory.PreLoadMMapDirectory preLoadMMapDirectory = (FsDirectoryFactory.PreLoadMMapDirectory) delegate;

--- a/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/FsDirectoryFactoryTests.java
@@ -56,6 +56,7 @@ public class FsDirectoryFactoryTests extends ESTestCase {
             assertTrue(FsDirectoryFactory.HybridDirectory.useDelegate("foo.kdi", newIOContext(random())));
             assertFalse(FsDirectoryFactory.HybridDirectory.useDelegate("foo.kdi", Store.READONCE_CHECKSUM));
             assertTrue(FsDirectoryFactory.HybridDirectory.useDelegate("foo.tmp", newIOContext(random())));
+            assertTrue(FsDirectoryFactory.HybridDirectory.useDelegate("foo.fdt__0.tmp", newIOContext(random())));
             MMapDirectory delegate = hybridDirectory.getDelegate();
             assertThat(delegate, Matchers.instanceOf(FsDirectoryFactory.PreLoadMMapDirectory.class));
             FsDirectoryFactory.PreLoadMMapDirectory preLoadMMapDirectory = (FsDirectoryFactory.PreLoadMMapDirectory) delegate;


### PR DESCRIPTION
I was looking at a flamegraph taken during ingestion of TSDB data and a non-negligible time is spent when flushing stored fields in `BufferedIndexInput#refill` because the temporary input file that stores documents in ingested order gets accessed in a random-access fashion, which `NIOFSDirectory` handles not efficiently because it needs to refill its internal buffer every time with a system call, while `MMapDirectary` could directly read the data from the page cache.

Since temporary files are short-lived and usually in the page cache, this doesn't have some of the downsides of `mmap`, namely consuming map regions and trashing the page cache.

This should help with datasets that enable index sorting in general.