### PR TITLE
Remove 8.7 release highlights link to fix docs build

### DIFF
--- a/docs/reference/migration/migrate_8_8.asciidoc
+++ b/docs/reference/migration/migrate_8_8.asciidoc
@@ -7,7 +7,7 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to {es} 8.8.
 
-See also {ref-bare}/8.8/release-highlights.html[What's new in 8.8] and <<es-release-notes>>.
+See also <<release-highlights>> and <<es-release-notes>>.
 
 coming::[8.8.0]
 

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -12,8 +12,7 @@ endif::[]
 // Add previous release to the list
 Other versions:
 
-{ref-bare}/8.7/release-highlights.html[8.7]
-| {ref-bare}/8.6/release-highlights.html[8.6]
+{ref-bare}/8.6/release-highlights.html[8.6]
 | {ref-bare}/8.5/release-highlights.html[8.5]
 | {ref-bare}/8.4/release-highlights.html[8.4]
 | {ref-bare}/8.3/release-highlights.html[8.3]


### PR DESCRIPTION
This is just to fix a [broken docs build](https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/35465/console):

```
12:16:01 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/migrating-8.8.html contains broken links to:
12:16:01 INFO:build_docs:   - en/elasticsearch/reference/8.8/release-highlights.html
12:16:01 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/release-highlights.html contains broken links to:
12:16:01 INFO:build_docs:   - en/elasticsearch/reference/8.7/release-highlights.html
```

@rjernst I'm not at all familiar with the Elasticsearch release process but it would seem that we need the 8.7 branch with `en/elasticsearch/reference/8.7/release-highlights.html` to exist before merging the changes in [your commit](https://github.com/elastic/elasticsearch/commit/05d1011d3de08be8f83f6d179b51d87e95aa04f3). Anyhow, this is just a fix to get the docs build working.