### PR TITLE
[7.17] Use shorter paths for test cluster working directories to avoid issues on Windows (#93570)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -67,16 +67,21 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
     private static final int DEFAULT_DEBUG_PORT = 5007;
 
-    private final Path baseWorkingDir;
     private final DistributionResolver distributionResolver;
+    private Path baseWorkingDir;
 
-    public LocalClusterFactory(Path baseWorkingDir, DistributionResolver distributionResolver) {
-        this.baseWorkingDir = baseWorkingDir;
+    public LocalClusterFactory(DistributionResolver distributionResolver) {
         this.distributionResolver = distributionResolver;
     }
 
     @Override
     public LocalClusterHandle create(LocalClusterSpec spec) {
+        try {
+            this.baseWorkingDir = Files.createTempDirectory(spec.getName());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+
         return new LocalClusterHandle(spec.getName(), spec.getNodes().stream().map(Node::new).toList());
     }
 
@@ -96,7 +101,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
 
         public Node(LocalNodeSpec spec) {
             this.spec = spec;
-            this.workingDir = baseWorkingDir.resolve(spec.getCluster().getName()).resolve(spec.getName());
+            this.workingDir = baseWorkingDir.resolve(spec.getName());
             this.repoDir = baseWorkingDir.resolve("repo");
             this.dataDir = workingDir.resolve("data");
             this.logsDir = workingDir.resolve("logs");
@@ -128,6 +133,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 copyExtraConfigFiles();
             }
 
+            deleteGcLogs();
             writeConfiguration(seedTransportAddress);
             createKeystore();
             addKeystoreSettings();
@@ -207,6 +213,20 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 throw new RuntimeException("Timed out after " + NODE_UP_TIMEOUT + " waiting for ports files for: " + this);
             } catch (ExecutionException e) {
                 throw new RuntimeException("An error occurred while waiting for ports file for: " + this, e);
+            }
+        }
+
+        private void deleteGcLogs() {
+            try (Stream<Path> logs = Files.list(logsDir)) {
+                logs.filter(l -> l.getFileName().toString().startsWith("gc.log")).forEach(path -> {
+                    try {
+                        IOUtils.deleteWithRetry(path);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                });
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
             }
         }
 
@@ -626,7 +646,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
 
         private void runToolScript(String tool, String input, String... args) {
             try {
-                ProcessUtils.exec(
+                int exit = ProcessUtils.exec(
                     input,
                     distributionDir,
                     distributionDir.resolve("bin")
@@ -635,13 +655,17 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                     false,
                     args
                 ).waitFor();
+
+                if (exit != 0) {
+                    throw new RuntimeException("Execution of " + tool + " failed with exit code " + exit);
+                }
             } catch (InterruptedException e) {
                 throw new RuntimeException(e);
             }
         }
 
         private String getServiceName() {
-            return baseWorkingDir.getFileName() + "-" + spec.getCluster().getName() + "-" + spec.getName();
+            return baseWorkingDir.getFileName() + "-" + spec.getName();
         }
 
         @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalElasticsearchCluster.java
@@ -16,8 +16,6 @@ import org.elasticsearch.test.cluster.util.Version;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
-import java.nio.file.Path;
-
 public class LocalElasticsearchCluster implements ElasticsearchCluster {
     private final DefaultLocalClusterSpecBuilder builder;
     private LocalClusterSpec spec;
@@ -35,7 +33,6 @@ public class LocalElasticsearchCluster implements ElasticsearchCluster {
                 try {
                     spec = builder.buildClusterSpec();
                     handle = new LocalClusterFactory(
-                        Path.of(System.getProperty("java.io.tmpdir")).resolve(description.getDisplayName()).toAbsolutePath(),
                         new LocalDistributionResolver(new SnapshotDistributionResolver(new ReleasedDistributionResolver()))
                     ).create(spec);
                     handle.start();


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Use shorter paths for test cluster working directories to avoid issues on Windows (#93570)