### PR TITLE
Update log4j2 LICENSE and NOTICE files

### DIFF
--- a/modules/repository-azure/licenses/log4j-slf4j-impl-NOTICE.txt
+++ b/modules/repository-azure/licenses/log4j-slf4j-impl-NOTICE.txt
@@ -1,8 +1,20 @@
-
-Apache Log4j SLF4J Binding
-Copyright 1999-2017 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
 
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/modules/repository-gcs/licenses/log4j-NOTICE.txt
+++ b/modules/repository-gcs/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/modules/repository-s3/licenses/log4j-NOTICE.txt
+++ b/modules/repository-s3/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/modules/repository-url/licenses/log4j-NOTICE.txt
+++ b/modules/repository-url/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/plugins/discovery-azure-classic/licenses/log4j-NOTICE.txt
+++ b/plugins/discovery-azure-classic/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/plugins/discovery-ec2/licenses/log4j-NOTICE.txt
+++ b/plugins/discovery-ec2/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/plugins/discovery-gce/licenses/log4j-NOTICE.txt
+++ b/plugins/discovery-gce/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/plugins/repository-hdfs/licenses/log4j-NOTICE.txt
+++ b/plugins/repository-hdfs/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/plugins/repository-hdfs/licenses/log4j-slf4j-impl-NOTICE.txt
+++ b/plugins/repository-hdfs/licenses/log4j-slf4j-impl-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/server/licenses/log4j-api-NOTICE.txt
+++ b/server/licenses/log4j-api-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/server/licenses/log4j-core-NOTICE.txt
+++ b/server/licenses/log4j-core-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/x-pack/plugin/core/licenses/log4j-NOTICE.txt
+++ b/x-pack/plugin/core/licenses/log4j-NOTICE.txt
@@ -1,5 +1,20 @@
-Apache log4j
-Copyright 2007 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
+
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
+
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/x-pack/plugin/identity-provider/licenses/log4j-slf4j-impl-LICENSE.txt
+++ b/x-pack/plugin/identity-provider/licenses/log4j-slf4j-impl-LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 1999-2005 The Apache Software Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/x-pack/plugin/identity-provider/licenses/log4j-slf4j-impl-NOTICE.txt
+++ b/x-pack/plugin/identity-provider/licenses/log4j-slf4j-impl-NOTICE.txt
@@ -1,8 +1,20 @@
-
-Apache Log4j SLF4J Binding
-Copyright 1999-2017 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
 
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/x-pack/plugin/security/licenses/log4j-slf4j-impl-LICENSE.txt
+++ b/x-pack/plugin/security/licenses/log4j-slf4j-impl-LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 1999-2005 The Apache Software Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/x-pack/plugin/security/licenses/log4j-slf4j-impl-NOTICE.txt
+++ b/x-pack/plugin/security/licenses/log4j-slf4j-impl-NOTICE.txt
@@ -1,8 +1,20 @@
-
-Apache Log4j SLF4J Binding
-Copyright 1999-2017 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
 
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.

--- a/x-pack/plugin/vector-tile/licenses/log4j-slf4j-impl-LICENSE.txt
+++ b/x-pack/plugin/vector-tile/licenses/log4j-slf4j-impl-LICENSE.txt
@@ -187,7 +187,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 1999-2005 The Apache Software Foundation
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/x-pack/plugin/vector-tile/licenses/log4j-slf4j-impl-NOTICE.txt
+++ b/x-pack/plugin/vector-tile/licenses/log4j-slf4j-impl-NOTICE.txt
@@ -1,8 +1,20 @@
-
-Apache Log4j SLF4J Binding
-Copyright 1999-2017 The Apache Software Foundation
+Apache Log4j
+Copyright 1999-2023 Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).
 
+ResolverUtil.java
+Copyright 2005-2006 Tim Fennell
 
+Dumbster SMTP test server
+Copyright 2004 Jason Paul Kitchen
+
+TypeUtil.java
+Copyright 2002-2012 Ramnivas Laddad, Juergen Hoeller, Chris Beams
+
+picocli (http://picocli.info)
+Copyright 2017 Remko Popma
+
+TimeoutBlockingWaitStrategy.java and parts of Util.java
+Copyright 2011 LMAX Ltd.


### PR DESCRIPTION
I noticed that the LICENSE.txt and NOTICE.txt that we have for many of our log4j dependencies are out of date.

I'm using the files from the top-level of https://github.com/apache/logging-log4j2 for this update.

You could also compare against the most recent download (https://logging.apache.org/log4j/2.x/download.html) -- that one has an out of date copyright year in the NOTICE, though, which is is why I'm sticking with the ones from git directly (see https://github.com/apache/logging-log4j2/commit/0c01699ae2393a3f612e9181de7e72b47cfb51a2).