### PR TITLE
Fix desired balance spec

### DIFF
--- a/qa/smoke-test-multinode/src/yamlRestTest/resources/rest-api-spec/test/smoke_test_multinode/30_desired_balance.yml
+++ b/qa/smoke-test-multinode/src/yamlRestTest/resources/rest-api-spec/test/smoke_test_multinode/30_desired_balance.yml
@@ -72,6 +72,11 @@ setup:
       reason: "Field added in in 8.7.0"
 
   - do:
+      cluster.state: {}
+  - set: { nodes._arbitrary_key_ : node_id }
+  - set: { nodes.$node_id.name : node_name }
+
+  - do:
       _internal.get_desired_balance: { }
 
   - is_true: 'cluster_balance_stats'
@@ -101,8 +106,8 @@ setup:
   - is_true: 'cluster_balance_stats.tiers.data_content.actual_disk_usage.average'
   - is_true: 'cluster_balance_stats.tiers.data_content.actual_disk_usage.std_dev'
   - is_true: 'cluster_balance_stats.nodes'
-  - is_true: 'cluster_balance_stats.nodes.test-cluster-0'
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.shard_count' : 0 }
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.forecast_write_load': 0.0 }
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.forecast_disk_usage_bytes' : 0 }
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.actual_disk_usage_bytes' : 0 }
+  - is_true: 'cluster_balance_stats.nodes.$node_name'
+  - gte: { 'cluster_balance_stats.nodes.$node_name.shard_count' : 0 }
+  - gte: { 'cluster_balance_stats.nodes.$node_name.forecast_write_load': 0.0 }
+  - gte: { 'cluster_balance_stats.nodes.$node_name.forecast_disk_usage_bytes' : 0 }
+  - gte: { 'cluster_balance_stats.nodes.$node_name.actual_disk_usage_bytes' : 0 }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_balance/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_balance/10_basic.yml
@@ -23,11 +23,13 @@ setup:
 "Test cluster_balance_stats":
 
   - skip:
-      version: all
-      reason: 'AwaitsFix: https://github.com/elastic/elasticsearch/issues/93605'
-#  - skip:
-#      version: " - 8.6.99"
-#      reason: "Field added in in 8.7.0"
+      version: " - 8.6.99"
+      reason: "Field added in in 8.7.0"
+
+  - do:
+      cluster.state: {}
+  - set: { nodes._arbitrary_key_ : node_id }
+  - set: { nodes.$node_id.name : node_name }
 
   - do:
       _internal.get_desired_balance: { }
@@ -59,11 +61,11 @@ setup:
   - is_true: 'cluster_balance_stats.tiers.data_content.actual_disk_usage.average'
   - is_true: 'cluster_balance_stats.tiers.data_content.actual_disk_usage.std_dev'
   - is_true: 'cluster_balance_stats.nodes'
-  - is_true: 'cluster_balance_stats.nodes.test-cluster-0'
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.shard_count' : 0 }
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.forecast_write_load': 0.0 }
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.forecast_disk_usage_bytes' : 0 }
-  - gte: { 'cluster_balance_stats.nodes.test-cluster-0.actual_disk_usage_bytes' : 0 }
+  - is_true: 'cluster_balance_stats.nodes.$node_name'
+  - gte: { 'cluster_balance_stats.nodes.$node_name.shard_count' : 0 }
+  - gte: { 'cluster_balance_stats.nodes.$node_name.forecast_write_load': 0.0 }
+  - gte: { 'cluster_balance_stats.nodes.$node_name.forecast_disk_usage_bytes' : 0 }
+  - gte: { 'cluster_balance_stats.nodes.$node_name.actual_disk_usage_bytes' : 0 }
 
 ---
 "Test get desired balance for single shard":


### PR DESCRIPTION
Spec relied on a presence of a node with `test-cluster-0` name. This change reads the name from the cluster state instead.

Closes: #93605 