### PR TITLE
[8.7] Mute testBuildRoleForListOfRoleReferences (#93619)

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersectionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceIntersectionTests.java
@@ -42,6 +42,7 @@ public class RoleReferenceIntersectionTests extends ESTestCase {
         assertThat(future.actionGet(), is(role));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93395")
     public void testBuildRoleForListOfRoleReferences() {
         final int size = randomIntBetween(2, 3);
         final List<RoleReference> roleReferences = new ArrayList<>(size);


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Mute testBuildRoleForListOfRoleReferences (#93619)