### PR TITLE
[ML] Make assertBusy() really wait in full cluster restart tests

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -10,10 +10,10 @@ package org.elasticsearch.xpack.restart;
 import com.carrotsearch.randomizedtesting.annotations.Name;
 
 import org.apache.http.util.EntityUtils;
-import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -110,7 +110,7 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
                 try {
                     assertInfer(modelId);
                     assertNewInfer(modelId);
-                } catch (ElasticsearchStatusException e) {
+                } catch (ResponseException e) {
                     // assertBusy only loops on AssertionErrors, so we have
                     // to convert failure status exceptions to these
                     throw new AssertionError("Inference failed", e);

--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -89,7 +89,6 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93325")
     public void testDeploymentSurvivesRestart() throws Exception {
         assumeTrue("NLP model deployments added in 8.0", getOldClusterVersion().onOrAfter(Version.V_8_0_0));
 


### PR DESCRIPTION
The exception being thrown that we want to ignore for 90 seconds is not an AssertionError, so assertBusy was not looping for it.

Fixes #93325