### PR TITLE
[8.6] [ML] Make assertBusy() really wait in full cluster restart tests (#93641)

### DIFF
--- a/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
+++ b/x-pack/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/xpack/restart/MLModelDeploymentFullClusterRestartIT.java
@@ -13,6 +13,7 @@ import org.apache.http.util.EntityUtils;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
@@ -105,8 +106,14 @@ public class MLModelDeploymentFullClusterRestartIT extends AbstractXpackFullClus
             }));
             waitForDeploymentStarted(modelId);
             assertBusy(() -> {
-                assertInfer(modelId);
-                assertNewInfer(modelId);
+                try {
+                    assertInfer(modelId);
+                    assertNewInfer(modelId);
+                } catch (ResponseException e) {
+                    // assertBusy only loops on AssertionErrors, so we have
+                    // to convert failure status exceptions to these
+                    throw new AssertionError("Inference failed", e);
+                }
             }, 90, TimeUnit.SECONDS);
             stopDeployment(modelId);
         }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [ML] Make assertBusy() really wait in full cluster restart tests (#93641)