### PR TITLE
More useful toString() on transport channels

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/ChannelActionListener.java
@@ -44,12 +44,20 @@ public final class ChannelActionListener<Response extends TransportResponse, Req
             channel.sendResponse(e);
         } catch (Exception sendException) {
             sendException.addSuppressed(e);
-            logger.warn(() -> format("Failed to send error response for action [%s] and request [%s]", actionName, request), sendException);
+            logger.warn(
+                () -> format(
+                    "Failed to send error response on channel [%s] for action [%s] and request [%s]",
+                    channel,
+                    actionName,
+                    request
+                ),
+                sendException
+            );
         }
     }
 
     @Override
     public String toString() {
-        return "ChannelActionListener{" + channel + "}{" + request + "}{" + actionName + "}";
+        return "ChannelActionListener{" + channel + "}{" + actionName + "}{" + request + "}";
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
+++ b/server/src/main/java/org/elasticsearch/transport/RequestHandlerRegistry.java
@@ -67,7 +67,7 @@ public class RequestHandlerRegistry<Request extends TransportRequest> {
                 final Releasable stopTracking = taskManager.startTrackingCancellableChannelTask(tcpChannel, (CancellableTask) task);
                 unregisterTask = Releasables.wrap(unregisterTask, stopTracking);
             }
-            final TaskTransportChannel taskTransportChannel = new TaskTransportChannel(channel, unregisterTask);
+            final TaskTransportChannel taskTransportChannel = new TaskTransportChannel(task.getId(), channel, unregisterTask);
             handler.messageReceived(request, taskTransportChannel, task);
             unregisterTask = null;
         } finally {

--- a/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
@@ -9,16 +9,19 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Releasable;
 
 import java.io.IOException;
 
 public class TaskTransportChannel implements TransportChannel {
 
+    private final long taskId;
     private final TransportChannel channel;
     private final Releasable onTaskFinished;
 
-    TaskTransportChannel(TransportChannel channel, Releasable onTaskFinished) {
+    TaskTransportChannel(long taskId, TransportChannel channel, Releasable onTaskFinished) {
+        this.taskId = taskId;
         this.channel = channel;
         this.onTaskFinished = onTaskFinished;
     }
@@ -58,5 +61,10 @@ public class TaskTransportChannel implements TransportChannel {
 
     public TransportChannel getChannel() {
         return channel;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.format("TaskTransportChannel{task=%d}{%s}", taskId, channel);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransportChannel.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.core.Releasable;
 
 import java.io.IOException;
@@ -94,5 +95,10 @@ public final class TcpTransportChannel implements TransportChannel {
 
     public TcpChannel getChannel() {
         return channel;
+    }
+
+    @Override
+    public String toString() {
+        return Strings.format("TcpTransportChannel{req=%d}{%s}{%s}", requestId, action, channel);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1525,6 +1525,11 @@ public class TransportService extends AbstractLifecycleComponent
         public TransportVersion getVersion() {
             return localNode.getVersion().transportVersion;
         }
+
+        @Override
+        public String toString() {
+            return Strings.format("DirectResponseChannel{req=%d}{%s}", requestId, action);
+        }
     }
 
     /**


### PR DESCRIPTION
Today `TaskTransportChannel` has a default `toString()` implementation, but this appears in logs sometimes and it would be much more useful to include details of the channel such as the action name, the local/remote addresses, and the task/request IDs. This commit does so.