### PR TITLE
[8.7] Only simulate legal desired moves (#93635)

### DIFF
--- a/docs/changelog/93635.yaml
+++ b/docs/changelog/93635.yaml
@@ -1,0 +1,6 @@
+pr: 93635
+summary: Only simulate legal desired moves
+area: Allocation
+type: bug
+issues:
+ - 93271

--- a/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
+++ b/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/SnapshotBasedRecoveryIT.java
@@ -42,7 +42,6 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class SnapshotBasedRecoveryIT extends AbstractRollingTestCase {
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93271")
     public void testSnapshotBasedRecovery() throws Exception {
         final String indexName = "snapshot_based_recovery";
         final String repositoryName = "snapshot_based_recovery_repo";

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputer.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 import org.elasticsearch.cluster.routing.allocation.command.MoveAllocationCommand;
+import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.common.metrics.MeanMetric;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -161,14 +162,21 @@ public class DesiredBalanceComputer {
             // Here existing shards are moved to desired locations before initializing unassigned shards because we prefer not to leave
             // immovable shards allocated to undesirable locations (e.g. a node that is shutting down or an allocation filter which was
             // only recently applied). In contrast, reconciliation prefers to initialize the unassigned shards first.
-            for (final var shardRouting : shardsToRelocate.values()) {
+            relocateToDesiredLocation: for (final var shardRouting : shardsToRelocate.values()) {
                 assert shardRouting.started();
-                if (targetNodesIterator.hasNext()) {
-                    ShardRouting shardToRelocate = routingNodes.relocateShard(shardRouting, targetNodesIterator.next(), 0L, changes).v2();
-                    clusterInfoSimulator.simulateShardStarted(shardToRelocate);
-                    routingNodes.startShard(logger, shardToRelocate, changes, 0L);
-                } else {
-                    break;
+
+                while (targetNodesIterator.hasNext()) {
+                    final var targetNodeId = targetNodesIterator.next();
+                    final var targetNode = routingNodes.node(targetNodeId);
+                    if (targetNode != null
+                        && routingAllocation.deciders()
+                            .canAllocate(shardRouting, targetNode, routingAllocation)
+                            .type() != Decision.Type.NO) {
+                        final var shardToRelocate = routingNodes.relocateShard(shardRouting, targetNodeId, 0L, changes).v2();
+                        clusterInfoSimulator.simulateShardStarted(shardToRelocate);
+                        routingNodes.startShard(logger, shardToRelocate, changes, 0L);
+                        continue relocateToDesiredLocation;
+                    }
                 }
             }
 
@@ -190,9 +198,15 @@ public class DesiredBalanceComputer {
                 final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
                 if (nodeIds != null && nodeIds.isEmpty() == false) {
                     final var nodeId = nodeIds.removeFirst();
-                    final var shardToInitialize = unassignedPrimaryIterator.initialize(nodeId, null, 0L, changes);
-                    clusterInfoSimulator.simulateShardStarted(shardToInitialize);
-                    routingNodes.startShard(logger, shardToInitialize, changes, 0L);
+                    final var routingNode = routingNodes.node(nodeId);
+                    if (routingNode != null
+                        && routingAllocation.deciders()
+                            .canAllocate(shardRouting, routingNode, routingAllocation)
+                            .type() != Decision.Type.NO) {
+                        final var shardToInitialize = unassignedPrimaryIterator.initialize(nodeId, null, 0L, changes);
+                        clusterInfoSimulator.simulateShardStarted(shardToInitialize);
+                        routingNodes.startShard(logger, shardToInitialize, changes, 0L);
+                    }
                 }
             }
         }
@@ -203,10 +217,16 @@ public class DesiredBalanceComputer {
             if (unassignedPrimaries.contains(shardRouting.shardId()) == false) {
                 final var nodeIds = unassignedShardsToInitialize.get(shardRouting);
                 if (nodeIds != null && nodeIds.isEmpty() == false) {
-                    final String nodeId = nodeIds.removeFirst();
-                    ShardRouting shardToInitialize = unassignedReplicaIterator.initialize(nodeId, null, 0L, changes);
-                    clusterInfoSimulator.simulateShardStarted(shardToInitialize);
-                    routingNodes.startShard(logger, shardToInitialize, changes, 0L);
+                    final var nodeId = nodeIds.removeFirst();
+                    final var routingNode = routingNodes.node(nodeId);
+                    if (routingNode != null
+                        && routingAllocation.deciders()
+                            .canAllocate(shardRouting, routingNode, routingAllocation)
+                            .type() != Decision.Type.NO) {
+                        final var shardToInitialize = unassignedReplicaIterator.initialize(nodeId, null, 0L, changes);
+                        clusterInfoSimulator.simulateShardStarted(shardToInitialize);
+                        routingNodes.startShard(logger, shardToInitialize, changes, 0L);
+                    }
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocator.java
@@ -331,13 +331,13 @@ public class DesiredBalanceShardsAllocator implements ShardsAllocator {
             var oldAssignment = old.getAssignment(shardId);
             var updatedAssignment = updated.getAssignment(shardId);
             if (Objects.equals(oldAssignment, updatedAssignment) == false) {
-                builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" --> ").append(updatedAssignment);
+                builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" -> ").append(updatedAssignment);
             }
         }
         for (ShardId shardId : diff) {
             var oldAssignment = old.getAssignment(shardId);
             var updatedAssignment = updated.getAssignment(shardId);
-            builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" --> ").append(updatedAssignment);
+            builder.append(newLine).append(shardId).append(": ").append(oldAssignment).append(" -> ").append(updatedAssignment);
         }
         return builder.append(newLine).toString();
     }

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.shutdown;
+
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+public class DesiredBalanceShutdownIT extends ESIntegTestCase {
+
+    private static final String INDEX = "test-index";
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(ShutdownPlugin.class);
+    }
+
+    public void testDesiredBalanceWithShutdown() throws Exception {
+
+        final var oldNodeName = internalCluster().startNode();
+        final var oldNodeId = internalCluster().getInstance(ClusterService.class, oldNodeName).localNode().getId();
+
+        createIndex(
+            INDEX,
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name", oldNodeName)
+                .build()
+        );
+        ensureGreen(INDEX);
+
+        internalCluster().restartNode(internalCluster().startNode(), new InternalTestCluster.RestartCallback() {
+            @Override
+            public Settings onNodeStopped(String newNodeName) {
+
+                logger.info("--> excluding index from [{}] and concurrently starting replacement with [{}]", oldNodeName, newNodeName);
+
+                final PlainActionFuture<AcknowledgedResponse> excludeFuture = new PlainActionFuture<>();
+                client().admin()
+                    .indices()
+                    .prepareUpdateSettings(INDEX)
+                    .setSettings(
+                        Settings.builder()
+                            .put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", oldNodeName)
+                            .putNull(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name")
+                    )
+                    .execute(excludeFuture);
+
+                assertAcked(
+                    client().execute(
+                        PutShutdownNodeAction.INSTANCE,
+                        new PutShutdownNodeAction.Request(oldNodeId, SingleNodeShutdownMetadata.Type.REPLACE, "test", null, newNodeName)
+                    ).actionGet(10, TimeUnit.SECONDS)
+                );
+
+                excludeFuture.actionGet(10, TimeUnit.SECONDS);
+
+                return Settings.EMPTY;
+            }
+        });
+
+        logger.info("--> waiting for replacement to complete");
+
+        assertBusy(() -> {
+            final var getShutdownResponse = client().execute(GetShutdownStatusAction.INSTANCE, new GetShutdownStatusAction.Request())
+                .actionGet(10, TimeUnit.SECONDS);
+            assertTrue(
+                Strings.toString(getShutdownResponse, true, true),
+                getShutdownResponse.getShutdownStatuses()
+                    .stream()
+                    .allMatch(s -> s.overallStatus() == SingleNodeShutdownMetadata.Status.COMPLETE)
+            );
+        });
+    }
+
+}


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Only simulate legal desired moves (#93635)