### PR TITLE
Update snapshot threadpool size doc

### DIFF
--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -43,8 +43,9 @@ There are several thread pools, but the important ones include:
 
 `snapshot`::
     For snapshot/restore operations. Thread pool type is `scaling` with a
-    keep-alive of `5m` and a max of `min(5, (`<<node.processors,
-    `# of allocated processors`>>`) / 2)`.
+    keep-alive of `5m`. The maximum size of this pool is `10` if the max
+    heap size is at least `750 MB`, otherwise the maximum size is
+    `min(5, (`<<node.processors,`# of allocated processors`>>`) / 2)`.
 
 `snapshot_meta`::
     For snapshot repository metadata read operations. Thread pool type is `scaling` with a

--- a/docs/reference/modules/threadpool.asciidoc
+++ b/docs/reference/modules/threadpool.asciidoc
@@ -43,9 +43,10 @@ There are several thread pools, but the important ones include:
 
 `snapshot`::
     For snapshot/restore operations. Thread pool type is `scaling` with a
-    keep-alive of `5m`. The maximum size of this pool is `10` if the max
-    heap size is at least `750 MB`, otherwise the maximum size is
-    `min(5, (`<<node.processors,`# of allocated processors`>>`) / 2)`.
+    keep-alive of `5m`. On nodes with at least 750MB of heap the maximum size
+    of this pool is `10` by default. On nodes with less than 750MB of heap the
+    maximum size of this pool is `min(5, (`<<node.processors,
+    `# of allocated processors`>>`) / 2)` by default.
 
 `snapshot_meta`::
     For snapshot repository metadata read operations. Thread pool type is `scaling` with a


### PR DESCRIPTION
This has not been updated when we merged https://github.com/elastic/elasticsearch/pull/90282 and https://github.com/elastic/elasticsearch/pull/92392.