### PR TITLE
[8.6] [DOCS] Fixes typo in admonition block

### DIFF
--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -6,6 +6,8 @@
 
 experimental::[]
 
+IMPORTANT: This aggregation is renamed to `frequent item sets` in 8.7.
+
 A bucket aggregation which finds frequent item sets. It is a form of association 
 rules mining that identifies items that often occur together. Items that are 
 frequently purchased together or log events that tend to co-occur are examples 

--- a/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/frequent-items-aggregation.asciidoc
@@ -6,7 +6,7 @@
 
 experimental::[]
 
-IMPORTANT: This aggregation is renamed to `frequent item sets` in 8.7.
+IMPORTANT: This aggregation has been renamed to `frequent item sets` in 8.7.
 
 A bucket aggregation which finds frequent item sets. It is a form of association 
 rules mining that identifies items that often occur together. Items that are 


### PR DESCRIPTION
## Overview

This PR fixes a typo in the admonition block at the top of the frequent items agg page.