### PR TITLE
[7.17] Fixes CORS headers needed by Elastic clients (#85791)

### DIFF
--- a/docs/changelog/85791.yaml
+++ b/docs/changelog/85791.yaml
@@ -1,0 +1,5 @@
+pr: 85791
+summary: Fixes CORS headers needed by Elastic clients
+area: Infra/REST API
+type: bug
+issues: []

--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -117,8 +117,15 @@ Which methods to allow. Defaults to `OPTIONS, HEAD, GET, POST, PUT, DELETE`.
 // tag::http-cors-allow-headers-tag[]
 `http.cors.allow-headers` {ess-icon}::
 (<<static-cluster-setting,Static>>)
-Which headers to allow. Defaults to `X-Requested-With, Content-Type, Content-Length`.
+Which headers to allow. Defaults to `X-Requested-With, Content-Type, Content-Length, Authorization, Accept, User-Agent, X-Elastic-Client-Meta`.
 // end::http-cors-allow-headers-tag[]
+
+[[http-cors-expose-headers]]
+// tag::http-cors-expose-headers-tag[]
+`http.cors.expose-headers` {ess-icon}::
+(<<static-cluster-setting,Static>>)
+Which response headers to expose in the client. Defaults to `X-elastic-product`.
+// end::http-cors-expose-headers-tag[]
 
 [[http-cors-allow-credentials]]
 // tag::http-cors-allow-credentials-tag[]

--- a/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpTransportSettings.java
@@ -44,7 +44,13 @@ public final class HttpTransportSettings {
     );
     public static final Setting<String> SETTING_CORS_ALLOW_HEADERS = new Setting<>(
         "http.cors.allow-headers",
-        "X-Requested-With,Content-Type,Content-Length",
+        "X-Requested-With,Content-Type,Content-Length,Authorization,Accept,User-Agent,X-Elastic-Client-Meta",
+        (value) -> value,
+        Property.NodeScope
+    );
+    public static final Setting<String> SETTING_CORS_EXPOSE_HEADERS = new Setting<>(
+        "http.cors.expose-headers",
+        "X-elastic-product",
         (value) -> value,
         Property.NodeScope
     );

--- a/server/src/test/java/org/elasticsearch/http/CorsHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/CorsHandlerTests.java
@@ -204,7 +204,15 @@ public class CorsHandlerTests extends ESTestCase {
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_METHODS), containsInAnyOrder("HEAD", "OPTIONS", "GET", "DELETE", "POST"));
         assertThat(
             headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_HEADERS),
-            containsInAnyOrder("X-Requested-With", "Content-Type", "Content-Length")
+            containsInAnyOrder(
+                "X-Requested-With",
+                "Content-Type",
+                "Content-Length",
+                "Authorization",
+                "Accept",
+                "User-Agent",
+                "X-Elastic-Client-Meta"
+            )
         );
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_CREDENTIALS), containsInAnyOrder("true"));
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_MAX_AGE), containsInAnyOrder("1728000"));
@@ -232,7 +240,15 @@ public class CorsHandlerTests extends ESTestCase {
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_METHODS), containsInAnyOrder("HEAD", "OPTIONS", "GET", "DELETE", "POST"));
         assertThat(
             headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_HEADERS),
-            containsInAnyOrder("X-Requested-With", "Content-Type", "Content-Length")
+            containsInAnyOrder(
+                "X-Requested-With",
+                "Content-Type",
+                "Content-Length",
+                "Authorization",
+                "Accept",
+                "User-Agent",
+                "X-Elastic-Client-Meta"
+            )
         );
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_CREDENTIALS), containsInAnyOrder("true"));
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_MAX_AGE), containsInAnyOrder("1728000"));
@@ -254,6 +270,7 @@ public class CorsHandlerTests extends ESTestCase {
 
         Map<String, List<String>> headers = response.headers();
         assertNull(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN));
+        assertNull(headers.get(CorsHandler.ACCESS_CONTROL_EXPOSE_HEADERS));
     }
 
     public void testSetResponseHeadersWithWildcardOrigin() {
@@ -270,6 +287,7 @@ public class CorsHandlerTests extends ESTestCase {
 
         Map<String, List<String>> headers = response.headers();
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), containsInAnyOrder("*"));
+        assertThat(headers.get(CorsHandler.ACCESS_CONTROL_EXPOSE_HEADERS), containsInAnyOrder("X-elastic-product"));
         assertNull(headers.get(CorsHandler.VARY));
     }
 
@@ -288,6 +306,7 @@ public class CorsHandlerTests extends ESTestCase {
 
         Map<String, List<String>> headers = response.headers();
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), containsInAnyOrder("valid-origin"));
+        assertThat(headers.get(CorsHandler.ACCESS_CONTROL_EXPOSE_HEADERS), containsInAnyOrder("X-elastic-product"));
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_CREDENTIALS), containsInAnyOrder("true"));
         assertThat(headers.get(CorsHandler.VARY), containsInAnyOrder(CorsHandler.ORIGIN));
     }
@@ -308,6 +327,7 @@ public class CorsHandlerTests extends ESTestCase {
 
         Map<String, List<String>> headers = response.headers();
         assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_ORIGIN), containsInAnyOrder("valid-origin"));
+        assertThat(headers.get(CorsHandler.ACCESS_CONTROL_EXPOSE_HEADERS), containsInAnyOrder("X-elastic-product"));
         assertThat(headers.get(CorsHandler.VARY), containsInAnyOrder(CorsHandler.ORIGIN));
         if (allowCredentials) {
             assertThat(headers.get(CorsHandler.ACCESS_CONTROL_ALLOW_CREDENTIALS), containsInAnyOrder("true"));


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Fixes CORS headers needed by Elastic clients (#85791)](https://github.com/elastic/elasticsearch/pull/85791)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)