### PR TITLE
Remove CompletableFuture from RecoverySourceHandler

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoverySourceHandlerTests.java
@@ -798,7 +798,7 @@ public class RecoverySourceHandlerTests extends MapperServiceTestCase {
         Thread cancelingThread = new Thread(() -> cancellableThreads.cancel("test"));
         cancelingThread.start();
         try {
-            RecoverySourceHandler.runUnderPrimaryPermit(() -> {}, "test", shard, cancellableThreads, logger);
+            RecoverySourceHandler.runUnderPrimaryPermit(() -> {}, "test", shard, cancellableThreads);
         } catch (CancellableThreads.ExecutionCancelledException e) {
             // expected.
         }


### PR DESCRIPTION
In #93290 we added an assertion to verify that
`IndexShard#acquirePrimaryOperationPermit` never completes its listener more than once. We have not seen this assertion trip, nor can we see a way for a double-completion to happen, which means it is ok to replace this use of a `CompletableFuture` with something safer. This commit does so.