### PR TITLE
[8.6] Capture logs and config from junit test clusters in CI (#93661)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -27,10 +27,17 @@ if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(projec
             include("**/*.hprof")
             include("**/build/test-results/**/*.xml")
             include("**/build/testclusters/**")
+            include("**/build/testrun/*/temp/**")
             exclude("**/build/testclusters/**/data/**")
             exclude("**/build/testclusters/**/distro/**")
             exclude("**/build/testclusters/**/repo/**")
             exclude("**/build/testclusters/**/extract/**")
+            exclude("**/build/testclusters/**/tmp/**")
+            exclude("**/build/testrun/*/temp/**/data/**")
+            exclude("**/build/testrun/*/temp/**/distro/**")
+            exclude("**/build/testrun/*/temp/**/repo/**")
+            exclude("**/build/testrun/*/temp/**/extract/**")
+            exclude("**/build/testrun/*/temp/**/tmp/**")
           }
             .files
             .findAll { Files.isRegularFile(it.toPath()) }


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Capture logs and config from junit test clusters in CI (#93661)