### PR TITLE
[7.17] Capture logs and config from junit test clusters in CI (#93661)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -25,15 +25,17 @@ if (buildNumber) {
             include("**/*.hprof")
             include("**/build/test-results/**/*.xml")
             include("**/build/testclusters/**")
-            include("**/build/testrun/**")
+            include("**/build/testrun/*/temp/**")
             exclude("**/build/testclusters/**/data/**")
             exclude("**/build/testclusters/**/distro/**")
             exclude("**/build/testclusters/**/repo/**")
             exclude("**/build/testclusters/**/extract/**")
-            exclude("**/build/testrun/**/data/**")
-            exclude("**/build/testrun/**/distro/**")
-            exclude("**/build/testrun/**/repo/**")
-            exclude("**/build/testrun/**/extract/**")
+            exclude("**/build/testclusters/**/tmp/**")
+            exclude("**/build/testrun/*/temp/**/data/**")
+            exclude("**/build/testrun/*/temp/**/distro/**")
+            exclude("**/build/testrun/*/temp/**/repo/**")
+            exclude("**/build/testrun/*/temp/**/extract/**")
+            exclude("**/build/testrun/*/temp/**/tmp/**")
           }
             .files
             .findAll { Files.isRegularFile(it.toPath()) }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Capture logs and config from junit test clusters in CI (#93661)