### PR TITLE
Ensure proxy mode handshake work correctly with new RCS

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -167,7 +167,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         assert Strings.isEmpty(configuredAddress) == false : "Cannot use proxy connection strategy with no configured addresses";
         this.address = address;
         this.clusterNameValidator = (newConnection, actualProfile, listener) -> transportService.handshake(
-            new RemoteConnectionManager.InternalRemoteConnection(newConnection, clusterAlias),
+            RemoteConnectionManager.wrapConnectionWithClusterAlias(newConnection, clusterAlias),
             actualProfile.getHandshakeTimeout(),
             cn -> true,
             listener.map(resp -> {

--- a/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/ProxyConnectionStrategy.java
@@ -167,7 +167,7 @@ public class ProxyConnectionStrategy extends RemoteConnectionStrategy {
         assert Strings.isEmpty(configuredAddress) == false : "Cannot use proxy connection strategy with no configured addresses";
         this.address = address;
         this.clusterNameValidator = (newConnection, actualProfile, listener) -> transportService.handshake(
-            newConnection,
+            new RemoteConnectionManager.InternalRemoteConnection(newConnection, clusterAlias),
             actualProfile.getHandshakeTimeout(),
             cn -> true,
             listener.map(resp -> {

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -285,7 +285,7 @@ public class RemoteConnectionManager implements ConnectionManager {
         public void onRemoved() {}
     }
 
-    static final class InternalRemoteConnection implements Transport.Connection {
+    private static final class InternalRemoteConnection implements Transport.Connection {
 
         private final Transport.Connection connection;
         private final String clusterAlias;
@@ -369,5 +369,9 @@ public class RemoteConnectionManager implements ConnectionManager {
         public boolean hasReferences() {
             return connection.hasReferences();
         }
+    }
+
+    static InternalRemoteConnection wrapConnectionWithClusterAlias(Transport.Connection connection, String clusterAlias) {
+        return new InternalRemoteConnection(connection, clusterAlias);
     }
 }

--- a/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/RemoteConnectionManager.java
@@ -285,7 +285,7 @@ public class RemoteConnectionManager implements ConnectionManager {
         public void onRemoved() {}
     }
 
-    private static final class InternalRemoteConnection implements Transport.Connection {
+    static final class InternalRemoteConnection implements Transport.Connection {
 
         private final Transport.Connection connection;
         private final String clusterAlias;

--- a/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ProxyConnectionStrategyTests.java
@@ -36,6 +36,10 @@ import java.util.function.Supplier;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.isA;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
 
 public class ProxyConnectionStrategyTests extends ESTestCase {
 
@@ -79,9 +83,20 @@ public class ProxyConnectionStrategyTests extends ESTestCase {
         try (MockTransportService transport1 = startTransport("node1", Version.CURRENT)) {
             TransportAddress address1 = transport1.boundAddress().publishAddress();
 
-            try (MockTransportService localService = MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool)) {
+            try (
+                MockTransportService localService = spy(MockTransportService.createNewService(Settings.EMPTY, Version.CURRENT, threadPool))
+            ) {
                 localService.start();
                 localService.acceptIncomingRequests();
+
+                // Handshake (as part of cluster name validation) should go through the internal remote connection
+                // So it can be intercepted accordingly
+                doAnswer(invocation -> {
+                    final Object connection = invocation.getArgument(0);
+                    assertThat(connection, isA(RemoteConnectionManager.InternalRemoteConnection.class));
+                    invocation.callRealMethod();
+                    return null;
+                }).when(localService).handshake(any(), any(), any(), any());
 
                 final ClusterConnectionManager connectionManager = new ClusterConnectionManager(
                     profile,

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -81,7 +81,7 @@ import java.util.function.Supplier;
  * (for example, @see org.elasticsearch.discovery.HandshakingTransportAddressConnector, which constructs
  * fake DiscoveryNode instances where the publish address is one of the bound addresses).
  */
-public final class MockTransportService extends TransportService {
+public class MockTransportService extends TransportService {
     private static final Logger logger = LogManager.getLogger(MockTransportService.class);
 
     private final Map<DiscoveryNode, List<Transport.Connection>> openConnections = new HashMap<>();

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/SecurityServerTransportInterceptor.java
@@ -74,6 +74,7 @@ public class SecurityServerTransportInterceptor implements TransportInterceptor 
     static final Set<String> REMOTE_ACCESS_ACTION_ALLOWLIST;
     static {
         final Stream<String> actions = Stream.of(
+            TransportService.HANDSHAKE_ACTION_NAME,
             SearchAction.NAME,
             ClusterStateAction.NAME,
             ClusterSearchShardsAction.NAME,


### PR DESCRIPTION
At the end of connecting to a remote cluster, the proxy mode performs a cluster name validation by sending a handshake request to the remote node. This handshake request is sent over via a connection that is not wrapped with InternalRemoteConnection. Hence it is not recognised as a request to a new RCS cluster.

This PR fixes it by wrapping the connection before handshake. It also adds the handshake action to the allowlist so it goes through the new RCS model on both ends.

Relates: https://github.com/elastic/elasticsearch/pull/93412#discussion_r1099618272

