### PR TITLE
Test new RCS with anonymous users

### DIFF
--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -62,12 +62,11 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
     protected static RestClient fulfillingClusterClient;
 
     @Before
-    public void initFulFillingClusterClient() throws IOException {
+    public void initFulfillingClusterClient() throws IOException {
         if (fulfillingClusterClient == null) {
             assert fulfillingCluster != null;
             fulfillingClusterClient = buildClient(fulfillingCluster.getHttpAddresses());
         }
-        assert fulfillingClusterClient != null;
     }
 
     @AfterClass
@@ -86,7 +85,7 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    protected void configureRemoteClusterWithApiKey(String indicesPrivilegesJson) throws IOException {
+    protected void configureRemoteClustersWithApiKey(String indicesPrivilegesJson) throws IOException {
         // Create API key on FC
         final var createApiKeyRequest = new Request("POST", "/_security/api_key");
         createApiKeyRequest.setJsonEntity(Strings.format("""
@@ -99,7 +98,6 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
                 }
               }
             }""", indicesPrivilegesJson));
-        // Index API key so querying cluster can retrieve and add it to its cluster settings
         final Response createApiKeyResponse = performRequestAgainstFulfillingCluster(createApiKeyRequest);
         assertOK(createApiKeyResponse);
         final Map<String, Object> apiKeyMap = responseAsMap(createApiKeyResponse);

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.remotecluster;
+
+import org.apache.http.HttpHost;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.FeatureFlag;
+import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+import org.elasticsearch.test.rest.ESRestTestCase;
+import org.junit.AfterClass;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Map;
+
+public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCase {
+
+    protected static final String USER = "test_user";
+    protected static final SecureString PASS = new SecureString("x-pack-test-password".toCharArray());
+    protected static final String REMOTE_SEARCH_USER = "remote_search_user";
+    protected static final String REMOTE_SEARCH_ROLE = "remote_search";
+
+    protected static LocalClusterConfigProvider commonClusterConfig = cluster -> cluster.module("analysis-common")
+        .feature(FeatureFlag.NEW_RCS_MODE)
+        .setting("xpack.license.self_generated.type", "trial")
+        .setting("xpack.security.enabled", "true")
+        .setting("xpack.security.authc.token.enabled", "true")
+        .setting("xpack.security.authc.api_key.enabled", "true")
+        .setting("xpack.security.http.ssl.enabled", "false")
+        .setting("xpack.security.transport.ssl.enabled", "true")
+        .setting("xpack.security.transport.ssl.key", "transport.key")
+        .setting("xpack.security.transport.ssl.certificate", "transport.crt")
+        .setting("xpack.security.transport.ssl.certificate_authorities", "transport-ca.crt")
+        .setting("xpack.security.transport.ssl.verification_mode", "certificate")
+        .keystore("bootstrap.password", "x-pack-test-password")
+        .keystore("xpack.security.transport.ssl.secure_key_passphrase", "transport-password")
+        .configFile("transport.key", Resource.fromClasspath("ssl/transport.key"))
+        .configFile("transport.crt", Resource.fromClasspath("ssl/transport.crt"))
+        .configFile("transport-ca.crt", Resource.fromClasspath("ssl/transport-ca.crt"))
+        .configFile("remote-cluster.key", Resource.fromClasspath("ssl/remote_cluster.key"))
+        .configFile("remote-cluster.crt", Resource.fromClasspath("ssl/remote_cluster.crt"))
+        .configFile("remote-cluster-ca.crt", Resource.fromClasspath("ssl/remote-cluster-ca.crt"))
+        .user(USER, PASS.toString());
+
+    protected static ElasticsearchCluster fulfillingCluster;
+    protected static ElasticsearchCluster queryCluster;
+    protected static RestClient fulfillingClusterClient;
+
+    @Before
+    public void initFulFillingClusterClient() throws IOException {
+        if (fulfillingClusterClient == null) {
+            assert fulfillingCluster != null;
+            fulfillingClusterClient = buildClient(fulfillingCluster.getHttpAddresses());
+        }
+        assert fulfillingClusterClient != null;
+    }
+
+    @AfterClass
+    public static void closeFulFillingClusterClient() throws IOException {
+        IOUtils.close(fulfillingClusterClient);
+    }
+
+    @Override
+    protected String getTestRestCluster() {
+        return queryCluster.getHttpAddresses();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        final String token = basicAuthHeaderValue(USER, PASS);
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
+    }
+
+    protected void createAndStoreRemoteAccessApiKey(String indicesPrivilegesJson) throws IOException {
+        final var createApiKeyRequest = new Request("POST", "/_security/api_key");
+        createApiKeyRequest.setJsonEntity(Strings.format("""
+            {
+              "name": "remote_access_key",
+              "role_descriptors": {
+                "role": {
+                  "cluster": ["cluster:monitor/state"],
+                  "index": %s
+                }
+              }
+            }""", indicesPrivilegesJson));
+        // Index API key so querying cluster can retrieve and add it to its cluster settings
+        final Response createApiKeyResponse = performRequestAgainstFulfillingCluster(createApiKeyRequest);
+        assertOK(createApiKeyResponse);
+        final Map<String, Object> apiKeyMap = responseAsMap(createApiKeyResponse);
+        final String encodedRemoteAccessApiKey = (String) apiKeyMap.get("encoded");
+        final var indexDocRequest = new Request("POST", "/apikey/_doc?refresh=true");
+        // Store API key credential so that QC can fetch and use it for authentication
+        indexDocRequest.setJsonEntity("{\"apikey\": \"" + encodedRemoteAccessApiKey + "\"}");
+        assertOK(performRequestAgainstFulfillingCluster(indexDocRequest));
+    }
+
+    protected void configureRemoteClusterWithApiKey() throws IOException {
+        final SearchResponse apiKeyResponse = SearchResponse.fromXContent(
+            responseAsParser(performRequestAgainstFulfillingCluster(new Request("GET", "/apikey/_search")))
+        );
+        final String encodedKey = (String) apiKeyResponse.getHits().getHits()[0].getSourceAsMap().get("apikey");
+        updateClusterSettings(
+            Settings.builder()
+                .put("cluster.remote.my_remote_cluster.mode", "proxy")
+                .put("cluster.remote.my_remote_cluster.proxy_address", fulfillingCluster.getRemoteClusterServerEndpoint(0))
+                .put("cluster.remote.my_remote_cluster.authorization", encodedKey)
+                .build()
+        );
+    }
+
+    protected Response performRequestAgainstFulfillingCluster(Request request) throws IOException {
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(USER, PASS)));
+        return fulfillingClusterClient.performRequest(request);
+    }
+
+    private RestClient buildClient(final String url) throws IOException {
+        final int portSeparator = url.lastIndexOf(':');
+        final var httpHost = new HttpHost(
+            url.substring(0, portSeparator),
+            Integer.parseInt(url.substring(portSeparator + 1)),
+            getProtocol()
+        );
+        return buildClient(Settings.EMPTY, new HttpHost[] { httpHost });
+    }
+}

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityAnonymousUserIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityAnonymousUserIT.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.remotecluster;
+
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+import org.junit.ClassRule;
+import org.junit.rules.RuleChain;
+import org.junit.rules.TestRule;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+
+public class RemoteClusterSecurityAnonymousUserIT extends AbstractRemoteClusterSecurityTestCase {
+
+    static {
+        fulfillingCluster = ElasticsearchCluster.local()
+            .name("fulfilling-cluster")
+            .apply(commonClusterConfig)
+            // anonymous user has superuser role, but it won't be applied to remote access users
+            .setting("xpack.security.authc.anonymous.roles", "superuser")
+            .setting("remote_cluster.enabled", "true")
+            .setting("remote_cluster.port", "0")
+            .setting("xpack.security.remote_cluster_server.ssl.enabled", "true")
+            .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")
+            .setting("xpack.security.remote_cluster_server.ssl.certificate", "remote-cluster.crt")
+            .keystore("xpack.security.remote_cluster_server.ssl.secure_key_passphrase", "remote-cluster-password")
+            .build();
+
+        queryCluster = ElasticsearchCluster.local()
+            .name("query-cluster")
+            .apply(commonClusterConfig)
+            .rolesFile(Resource.fromClasspath("roles.yml"))
+            .setting("xpack.security.authc.anonymous.roles", "read_remote_shared_logs")
+            .setting("xpack.security.remote_cluster_client.ssl.enabled", "true")
+            .setting("xpack.security.remote_cluster_client.ssl.certificate_authorities", "remote-cluster-ca.crt")
+            .user(REMOTE_SEARCH_USER, PASS.toString(), "read_remote_shared_metrics")
+            .build();
+    }
+
+    @ClassRule
+    // Use a RuleChain to ensure that fulfilling cluster is started before query cluster
+    public static TestRule clusterRule = RuleChain.outerRule(fulfillingCluster).around(queryCluster);
+
+    public void testAnonymousUserFromQueryClusterWorks() throws Exception {
+        // Fulfilling cluster
+        {
+            createAndStoreRemoteAccessApiKey("""
+                [
+                   {
+                     "names": ["shared-*"],
+                     "privileges": ["read", "read_cross_cluster"]
+                   }
+                 ]""");
+
+            final Request bulkRequest = new Request("POST", "/_bulk?refresh=true");
+            bulkRequest.setJsonEntity(Strings.format("""
+                { "index": { "_index": "shared-logs" } }
+                { "name": "shared-logs" }
+                { "index": { "_index": "shared-metrics" } }
+                { "name": "shared-metrics" }
+                { "index": { "_index": "private-logs" } }
+                { "name": "private-logs" }
+                { "index": { "_index": "private-metrics" } }
+                { "name": "private-metrics" }\n"""));
+            assertOK(performRequestAgainstFulfillingCluster(bulkRequest));
+        }
+
+        // Query cluster
+        {
+            configureRemoteClusterWithApiKey();
+
+            // 1. QC anonymous user can search FC shared-logs because QC anonymous role allows it (and cluster API key allows it)
+            final Response response1 = performAnonymousRequestAgainstQueryCluster(
+                new Request("GET", "/my_remote_cluster:" + randomFrom("*", "shared-*", "shared-logs") + "/_search")
+            );
+            assertOK(response1);
+            final SearchResponse searchResponse1 = SearchResponse.fromXContent(responseAsParser(response1));
+            assertThat(
+                Arrays.stream(searchResponse1.getHits().getHits()).map(SearchHit::getIndex).collect(Collectors.toList()),
+                containsInAnyOrder("shared-logs")
+            );
+
+            // 2. QC anonymous user fails to search more than it is allowed by the QC anonymous role
+            // even when FC anonymous role allows everything
+            final ResponseException e2 = expectThrows(
+                ResponseException.class,
+                () -> performAnonymousRequestAgainstQueryCluster(
+                    new Request("GET", "/my_remote_cluster:" + randomFrom("shared-metrics", "private-logs") + "/_search")
+                )
+            );
+            assertThat(e2.getResponse().getStatusLine().getStatusCode(), equalTo(403));
+            assertThat(
+                e2.getMessage(),
+                containsString("action [indices:data/read/search] is unauthorized for user [_anonymous] on indices [private-logs]")
+            );
+
+            // 3. QC search user can search both FC shared-logs (inherit from anonymous) and shared-metrics (its own role)
+            final Response response3 = performRequestAgainstQueryCluster(
+                new Request(
+                    "GET",
+                    randomFrom(
+                        "/my_remote_cluster:*",
+                        "/my_remote_cluster:shared-*",
+                        "/my_remote_cluster:shared-logs,my_remote_cluster:shared-metrics"
+                    ) + "/_search"
+                )
+            );
+            assertOK(response3);
+            final SearchResponse searchResponse3 = SearchResponse.fromXContent(responseAsParser(response3));
+            assertThat(
+                Arrays.stream(searchResponse3.getHits().getHits()).map(SearchHit::getIndex).collect(Collectors.toList()),
+                containsInAnyOrder("shared-logs", "shared-metrics")
+            );
+        }
+    }
+
+    private Response performAnonymousRequestAgainstQueryCluster(Request request) throws IOException {
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", ""));
+        return client().performRequest(request);
+    }
+
+    private Response performRequestAgainstQueryCluster(Request request) throws IOException {
+        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(REMOTE_SEARCH_USER, PASS)));
+        return client().performRequest(request);
+    }
+}

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityAnonymousUserIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityAnonymousUserIT.java
@@ -98,16 +98,21 @@ public class RemoteClusterSecurityAnonymousUserIT extends AbstractRemoteClusterS
 
             // 2. QC anonymous user fails to search more than it is allowed by the QC anonymous role
             // even when FC anonymous role allows everything
+            final String inaccessibleIndexForAnonymous = randomFrom("shared-metrics", "private-logs");
             final ResponseException e2 = expectThrows(
                 ResponseException.class,
                 () -> performAnonymousRequestAgainstQueryCluster(
-                    new Request("GET", "/my_remote_cluster:" + randomFrom("shared-metrics", "private-logs") + "/_search")
+                    new Request("GET", "/my_remote_cluster:" + inaccessibleIndexForAnonymous + "/_search")
                 )
             );
             assertThat(e2.getResponse().getStatusLine().getStatusCode(), equalTo(403));
             assertThat(
                 e2.getMessage(),
-                containsString("action [indices:data/read/search] is unauthorized for user [_anonymous] on indices [private-logs]")
+                containsString(
+                    "action [indices:data/read/search] is unauthorized for user [_anonymous] on indices ["
+                        + inaccessibleIndexForAnonymous
+                        + "]"
+                )
             );
 
             // 3. QC search user can search both FC shared-logs (inherit from anonymous) and shared-metrics (its own role)

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityAnonymousUserIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityAnonymousUserIT.java
@@ -60,7 +60,7 @@ public class RemoteClusterSecurityAnonymousUserIT extends AbstractRemoteClusterS
     public static TestRule clusterRule = RuleChain.outerRule(fulfillingCluster).around(queryCluster);
 
     public void testAnonymousUserFromQueryClusterWorks() throws Exception {
-        configureRemoteClusterWithApiKey("""
+        configureRemoteClustersWithApiKey("""
             [
                {
                  "names": ["shared-*"],

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
@@ -59,7 +59,7 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
     public static TestRule clusterRule = RuleChain.outerRule(fulfillingCluster).around(queryCluster);
 
     public void testRemoteAccessForCrossClusterSearch() throws Exception {
-        configureRemoteClusterWithApiKey("""
+        configureRemoteClustersWithApiKey("""
             [
                {
                  "names": ["index*", "not_found_index"],

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
@@ -59,16 +59,16 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
     public static TestRule clusterRule = RuleChain.outerRule(fulfillingCluster).around(queryCluster);
 
     public void testRemoteAccessForCrossClusterSearch() throws Exception {
+        configureRemoteClusterWithApiKey("""
+            [
+               {
+                 "names": ["index*", "not_found_index"],
+                 "privileges": ["read", "read_cross_cluster"]
+               }
+             ]""");
+
         // Fulfilling cluster
         {
-            createAndStoreRemoteAccessApiKey("""
-                [
-                   {
-                     "names": ["index*", "not_found_index"],
-                     "privileges": ["read", "read_cross_cluster"]
-                   }
-                 ]""");
-
             // Index some documents, so we can attempt to search them from the querying cluster
             final var indexDocRequest = new Request("POST", "/index1/_doc?refresh=true");
             indexDocRequest.setJsonEntity("{\"foo\": \"bar\"}");
@@ -85,8 +85,6 @@ public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTe
 
         // Query cluster
         {
-            configureRemoteClusterWithApiKey();
-
             // Index some documents, to use them in a mixed-cluster search
             final var indexDocRequest = new Request("POST", "/local_index/_doc?refresh=true");
             indexDocRequest.setJsonEntity("{\"local_foo\": \"local_bar\"}");

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityRestIT.java
@@ -7,26 +7,15 @@
 
 package org.elasticsearch.xpack.remotecluster;
 
-import org.apache.http.HttpHost;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
-import org.elasticsearch.client.RestClient;
 import org.elasticsearch.common.UUIDs;
-import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.concurrent.ThreadContext;
-import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.FeatureFlag;
-import org.elasticsearch.test.cluster.local.LocalClusterConfigProvider;
-import org.elasticsearch.test.cluster.util.resource.Resource;
-import org.elasticsearch.test.rest.ESRestTestCase;
-import org.junit.AfterClass;
-import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
@@ -37,110 +26,48 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
-public class RemoteClusterSecurityRestIT extends ESRestTestCase {
-    private static final String USER = "test_user";
-    private static final SecureString PASS = new SecureString("x-pack-test-password".toCharArray());
-    private static final String REMOTE_SEARCH_USER = "remote_search_user";
-    private static final String REMOTE_SEARCH_ROLE = "remote_search";
+public class RemoteClusterSecurityRestIT extends AbstractRemoteClusterSecurityTestCase {
 
-    private static LocalClusterConfigProvider commonClusterConfig = cluster -> cluster.module("analysis-common")
-        .feature(FeatureFlag.NEW_RCS_MODE)
-        .setting("xpack.license.self_generated.type", "trial")
-        .setting("xpack.security.enabled", "true")
-        .setting("xpack.security.authc.token.enabled", "true")
-        .setting("xpack.security.authc.api_key.enabled", "true")
-        .setting("xpack.security.http.ssl.enabled", "false")
-        .setting("xpack.security.transport.ssl.enabled", "true")
-        .setting("xpack.security.transport.ssl.key", "transport.key")
-        .setting("xpack.security.transport.ssl.certificate", "transport.crt")
-        .setting("xpack.security.transport.ssl.certificate_authorities", "transport-ca.crt")
-        .setting("xpack.security.transport.ssl.verification_mode", "certificate")
-        .keystore("bootstrap.password", "x-pack-test-password")
-        .keystore("xpack.security.transport.ssl.secure_key_passphrase", "transport-password")
-        .configFile("transport.key", Resource.fromClasspath("ssl/transport.key"))
-        .configFile("transport.crt", Resource.fromClasspath("ssl/transport.crt"))
-        .configFile("transport-ca.crt", Resource.fromClasspath("ssl/transport-ca.crt"))
-        .configFile("remote-cluster.key", Resource.fromClasspath("ssl/remote_cluster.key"))
-        .configFile("remote-cluster.crt", Resource.fromClasspath("ssl/remote_cluster.crt"))
-        .configFile("remote-cluster-ca.crt", Resource.fromClasspath("ssl/remote-cluster-ca.crt"))
-        .user(USER, PASS.toString());
+    static {
+        fulfillingCluster = ElasticsearchCluster.local()
+            .name("fulfilling-cluster")
+            .apply(commonClusterConfig)
+            .setting("remote_cluster.enabled", "true")
+            .setting("remote_cluster.port", "0")
+            .setting("xpack.security.remote_cluster_server.ssl.enabled", "true")
+            .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")
+            .setting("xpack.security.remote_cluster_server.ssl.certificate", "remote-cluster.crt")
+            .keystore("xpack.security.remote_cluster_server.ssl.secure_key_passphrase", "remote-cluster-password")
+            .build();
 
-    public static ElasticsearchCluster fulfillingCluster = ElasticsearchCluster.local()
-        .name("fulfilling-cluster")
-        .apply(commonClusterConfig)
-        .setting("remote_cluster.enabled", "true")
-        .setting("remote_cluster.port", "0")
-        .setting("xpack.security.remote_cluster_server.ssl.enabled", "true")
-        .setting("xpack.security.remote_cluster_server.ssl.key", "remote-cluster.key")
-        .setting("xpack.security.remote_cluster_server.ssl.certificate", "remote-cluster.crt")
-        .keystore("xpack.security.remote_cluster_server.ssl.secure_key_passphrase", "remote-cluster-password")
-        .build();
-
-    public static ElasticsearchCluster queryCluster = ElasticsearchCluster.local()
-        .name("query-cluster")
-        .apply(commonClusterConfig)
-        .setting("xpack.security.remote_cluster_client.ssl.enabled", "true")
-        .setting("xpack.security.remote_cluster_client.ssl.certificate_authorities", "remote-cluster-ca.crt")
-        .build();
+        queryCluster = ElasticsearchCluster.local()
+            .name("query-cluster")
+            .apply(commonClusterConfig)
+            .setting("xpack.security.remote_cluster_client.ssl.enabled", "true")
+            .setting("xpack.security.remote_cluster_client.ssl.certificate_authorities", "remote-cluster-ca.crt")
+            .build();
+    }
 
     @ClassRule
     // Use a RuleChain to ensure that fulfilling cluster is started before query cluster
     public static TestRule clusterRule = RuleChain.outerRule(fulfillingCluster).around(queryCluster);
 
-    @Override
-    protected String getTestRestCluster() {
-        return queryCluster.getHttpAddresses();
-    }
-
-    private static RestClient fulfillingClusterClient;
-
-    @Before
-    public void initFulFillingClusterClient() throws IOException {
-        if (fulfillingClusterClient == null) {
-            fulfillingClusterClient = buildClient(fulfillingCluster.getHttpAddresses());
-        }
-        assert fulfillingClusterClient != null;
-    }
-
-    @AfterClass
-    public static void closeFulFillingClusterClient() throws IOException {
-        IOUtils.close(fulfillingClusterClient);
-    }
-
-    @Override
-    protected Settings restClientSettings() {
-        final String token = basicAuthHeaderValue(USER, PASS);
-        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
-    }
-
     public void testRemoteAccessForCrossClusterSearch() throws Exception {
         // Fulfilling cluster
         {
-            final var createApiKeyRequest = new Request("POST", "/_security/api_key");
-            createApiKeyRequest.setJsonEntity("""
-                {
-                  "name": "remote_access_key",
-                  "role_descriptors": {
-                    "role": {
-                      "cluster": ["cluster:monitor/state"],
-                      "index": [
-                        {
-                          "names": ["index*", "not_found_index"],
-                          "privileges": ["read", "read_cross_cluster"]
-                        }
-                      ]
-                    }
-                  }
-                }""");
-            // Index API key so querying cluster can retrieve and add it to its cluster settings
-            createAndIndexRemoteAccessApiKey(createApiKeyRequest);
+            createAndStoreRemoteAccessApiKey("""
+                [
+                   {
+                     "names": ["index*", "not_found_index"],
+                     "privileges": ["read", "read_cross_cluster"]
+                   }
+                 ]""");
 
             // Index some documents, so we can attempt to search them from the querying cluster
             final var indexDocRequest = new Request("POST", "/index1/_doc?refresh=true");
@@ -158,7 +85,7 @@ public class RemoteClusterSecurityRestIT extends ESRestTestCase {
 
         // Query cluster
         {
-            getRemoteAccessApiKeyAndStoreInSettings();
+            configureRemoteClusterWithApiKey();
 
             // Index some documents, to use them in a mixed-cluster search
             final var indexDocRequest = new Request("POST", "/local_index/_doc?refresh=true");
@@ -256,46 +183,6 @@ public class RemoteClusterSecurityRestIT extends ESRestTestCase {
     private Response performRequestWithRemoteAccessUser(final Request request) throws IOException {
         request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(REMOTE_SEARCH_USER, PASS)));
         return client().performRequest(request);
-    }
-
-    private void getRemoteAccessApiKeyAndStoreInSettings() throws IOException {
-        final SearchResponse apiKeyResponse = SearchResponse.fromXContent(
-            responseAsParser(performRequestAgainstFulfillingCluster(new Request("GET", "/apikey/_search")))
-        );
-        final String encodedKey = (String) apiKeyResponse.getHits().getHits()[0].getSourceAsMap().get("apikey");
-        updateClusterSettings(
-            Settings.builder()
-                .put("cluster.remote.my_remote_cluster.mode", "proxy")
-                .put("cluster.remote.my_remote_cluster.proxy_address", fulfillingCluster.getRemoteClusterServerEndpoint(0))
-                .put("cluster.remote.my_remote_cluster.authorization", encodedKey)
-                .build()
-        );
-    }
-
-    private void createAndIndexRemoteAccessApiKey(Request createApiKeyRequest) throws IOException {
-        final Response createApiKeyResponse = performRequestAgainstFulfillingCluster(createApiKeyRequest);
-        assertOK(createApiKeyResponse);
-        final Map<String, Object> apiKeyMap = responseAsMap(createApiKeyResponse);
-        final String encodedRemoteAccessApiKey = (String) apiKeyMap.get("encoded");
-        final var indexDocRequest = new Request("POST", "/apikey/_doc?refresh=true");
-        // Store API key credential so that QC can fetch and use it for authentication
-        indexDocRequest.setJsonEntity("{\"apikey\": \"" + encodedRemoteAccessApiKey + "\"}");
-        assertOK(performRequestAgainstFulfillingCluster(indexDocRequest));
-    }
-
-    private RestClient buildClient(final String url) throws IOException {
-        final int portSeparator = url.lastIndexOf(':');
-        final var httpHost = new HttpHost(
-            url.substring(0, portSeparator),
-            Integer.parseInt(url.substring(portSeparator + 1)),
-            getProtocol()
-        );
-        return buildClient(Settings.EMPTY, new HttpHost[] { httpHost });
-    }
-
-    private Response performRequestAgainstFulfillingCluster(Request request) throws IOException {
-        request.setOptions(RequestOptions.DEFAULT.toBuilder().addHeader("Authorization", basicAuthHeaderValue(USER, PASS)));
-        return fulfillingClusterClient.performRequest(request);
     }
 
     private static String randomEncodedApiKey() {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/resources/roles.yml
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/resources/roles.yml
@@ -1,0 +1,12 @@
+read_remote_shared_logs:
+  remote_indices:
+    - names: [ 'shared-logs' ]
+      privileges: [ 'read', 'read_cross_cluster' ]
+      clusters: [ 'my_*' ]
+
+read_remote_shared_metrics:
+  remote_indices:
+    - names: [ 'shared-metrics' ]
+      privileges: [ 'read', 'read_cross_cluster' ]
+      clusters: [ 'my_*' ]
+


### PR DESCRIPTION
This PR adds tests that show anonymous users work as intended in the new RCS setup.

