### PR TITLE
8.7 release notes bc1 (touchup)

### DIFF
--- a/docs/changelog/91956.yaml
+++ b/docs/changelog/91956.yaml
@@ -12,7 +12,7 @@ highlight:
     over `geo_shape` as well, which completes the long desired need to perform hexagonal aggregations on spatial data.
 
     [role="screenshot"]
-    image::../images/spatial/geogrid_h3_aggregation.png[Kibana map with geohex aggregation inclusing polygons and lines]
+    image::images/spatial/geogrid_h3_aggregation.png[Kibana map with geohex aggregation inclusing polygons and lines]
 
     In 2018 [Uber announced they had open sourced their H3 library](https://www.uber.com/en-SE/blog/h3/),
     enabling hexagonal tiling of the planet for much better analytics of their traffic and regional pricing models.

--- a/docs/changelog/93370.yaml
+++ b/docs/changelog/93370.yaml
@@ -18,5 +18,5 @@ highlight:
     as an hexagonal cell, saving the cell border as a polygon.
 
     [role="screenshot"]
-    image::../images/spatial/geogrid_h3_children.png[Kibana map with three H3 layers: cell, children and intersecting non-children]
+    image::images/spatial/geogrid_h3_children.png[Kibana map with three H3 layers: cell, children and intersecting non-children]
   notable: true

--- a/docs/reference/release-notes/8.7.0.asciidoc
+++ b/docs/reference/release-notes/8.7.0.asciidoc
@@ -22,6 +22,7 @@ Aggregations::
 
 Allocation::
 * Fallback to the actual shard size when forecast is not available {es-pull}93461[#93461]
+* Only simulate legal desired moves {es-pull}93635[#93635] (issue: {es-issue}93271[#93271])
 
 Authentication::
 * -| Correctly remove domain from realm when rewriting `Authentication` for compatibility with node versions that don't support domains {es-pull}93276[#93276]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -30,7 +30,7 @@ to include hexagonal tiles, but for `geo_point` only. Now Elasticsearch 8.7.0 wi
 over `geo_shape` as well, which completes the long desired need to perform hexagonal aggregations on spatial data.
 
 [role="screenshot"]
-image:images/spatial/geogrid_h3_aggregation.png[Kibana map with geohex aggregation inclusing polygons and lines]
+image::images/spatial/geogrid_h3_aggregation.png[Kibana map with geohex aggregation inclusing polygons and lines]
 
 In 2018 [Uber announced they had open sourced their H3 library](https://www.uber.com/en-SE/blog/h3/),
 enabling hexagonal tiling of the planet for much better analytics of their traffic and regional pricing models.
@@ -79,7 +79,7 @@ Several improvements were made to the performance of downsampling.
 All hashmap lookups were removed.
 Also metrics/label producers were modified so that they extract the doc_values directly from the leaves.
 This allows for extra optimizations for cases such as labels/counters that do not extract doc_values
-unless they are consumed.
+unless they are consumed. Those changes yielded a 3x-4x performance improvement of the downsampling operation, as measured by our benchmarks.
 
 {es-pull}92494[#92494]
 
@@ -128,7 +128,6 @@ In this case, the string `4/8/5` does not have spatial meaning, until we interpr
 of a rectangular `geotile`, and save the bounding box defining its border for further use.
 Likewise we can interpret `geohash` strings like `u0` as a tile, and H3 strings like `811fbffffffffff`
 as an hexagonal cell, saving the cell border as a polygon.
-
 
 [role="screenshot"]
 image::images/spatial/geogrid_h3_children.png[Kibana map with three H3 layers: cell, children and intersecting non-children]


### PR DESCRIPTION
The [original release notes](https://github.com/elastic/elasticsearch/pull/93653) for BC1 had two flaws:

* Missing a changelog entry added later (BC1 was generated a day later than scheduled, and one more changelog was merged after the release notes were made, #93650
* The image links in the highlights were incorrect, and this was fixed in https://github.com/elastic/elasticsearch/pull/93671, but that did not fix the source files, so we fix them here
