### PR TITLE
Remove leniency in CountDown

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
@@ -22,7 +22,7 @@ public final class CountDown {
 
     public CountDown(int count) {
         if (count <= 0) {
-            final String message = "count must be greater or equal to 0 but was: " + count;
+            final String message = "count must be greater then 0 but was: " + count;
             assert false : message;
             throw new IllegalArgumentException(message);
         }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
@@ -22,7 +22,7 @@ public final class CountDown {
 
     public CountDown(int count) {
         if (count <= 0) {
-            final String message = "count must be greater then 0 but was: " + count;
+            final String message = "count must be greater than 0 but was: " + count;
             assert false : message;
             throw new IllegalArgumentException(message);
         }

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/CountDown.java
@@ -21,13 +21,10 @@ public final class CountDown {
     private final AtomicInteger countDown;
 
     public CountDown(int count) {
-        // A count of zero was permitted in older versions, but is trappy (requiring explicit special handling) because countDown() and
-        // fastForward() would never return true. This case is now forbidden in tests, forcing callers to handle the special case up-front,
-        // but the older behaviour is preserved when assertions are disabled. See #92196.
-        // TODO drop this leniency once we are confident nothing relies on the older behaviour any more.
-        assert count > 0 : "count must be positive";
-        if (count < 0) {
-            throw new IllegalArgumentException("count must be greater or equal to 0 but was: " + count);
+        if (count <= 0) {
+            final String message = "count must be greater or equal to 0 but was: " + count;
+            assert false : message;
+            throw new IllegalArgumentException(message);
         }
         this.countDown = new AtomicInteger(count);
     }


### PR DESCRIPTION
In #92607 we made `CountDown` require a positive count in tests, but continued to accept a zero count in production Just In Case™. We have encountered no test failures related to this, and the 8.7 branch has been cut, so we can remove this leniency in production too.