### PR TITLE
[8.7] [DOCS] Mention search_after in PIT docs (#93627)

### DIFF
--- a/docs/reference/search/point-in-time-api.asciidoc
+++ b/docs/reference/search/point-in-time-api.asciidoc
@@ -40,17 +40,17 @@ be passed to the `id` of the `pit` parameter of a search request.
 
 [source,console]
 --------------------------------------------------
-POST /_search <1>
+POST /_search  <1>
 {
-    "size": 100,
+    "size": 100,  <2>
     "query": {
         "match" : {
             "title" : "elasticsearch"
         }
     },
     "pit": {
-	    "id":  "46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==", <2>
-	    "keep_alive": "1m"  <3>
+	    "id":  "46ToAwMDaWR5BXV1aWQyKwZub2RlXzMAAAAAAAAAACoBYwADaWR4BXV1aWQxAgZub2RlXzEAAAAAAAAAAAEBYQADaWR5BXV1aWQyKgZub2RlXzIAAAAAAAAAAAwBYgACBXV1aWQyAAAFdXVpZDEAAQltYXRjaF9hbGw_gAAAAA==", <3>
+	    "keep_alive": "1m"  <4>
     }
 }
 --------------------------------------------------
@@ -59,9 +59,12 @@ POST /_search <1>
 <1> A search request with the `pit` parameter must not specify `index`, `routing`,
 and {ref}/search-request-body.html#request-body-search-preference[`preference`]
 as these parameters are copied from the point in time.
-<2> The `id` parameter tells Elasticsearch to execute the request using contexts
+<2> Just like regular searches, you can <<paginate-search-results,use `from` and
+`size` to page through search results>>, up to the first 10,000 hits. If you 
+want to retrieve more hits, use PIT with <<search-after,`search_after`>>.
+<3> The `id` parameter tells Elasticsearch to execute the request using contexts
 from this point in time.
-<3> The `keep_alive` parameter tells Elasticsearch how long it should extend
+<4> The `keep_alive` parameter tells Elasticsearch how long it should extend
 the time to live of the point in time.
 
 IMPORTANT: The open point in time request and each subsequent search request can


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [DOCS] Mention search_after in PIT docs (#93627)