### PR TITLE
[7.17] Limit test port range to below the Linux default ephemeral port range (#92666)

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1739,7 +1739,7 @@ public abstract class ESTestCase extends LuceneTestCase {
     /**
      * Defines the maximum port that test workers should use. See also [NOTE: Port ranges for tests].
      */
-    private static final int MAX_PRIVATE_PORT = 36600;
+    private static final int MAX_PRIVATE_PORT = 32767;
 
     /**
      * Wrap around after reaching this worker ID.


### PR DESCRIPTION
If we use a port range of up to `36600` this means that we have overlap
with Linux' default ephemeral port range starting at 32768. If we get
unlucky there and all ports in a range that overlaps with the ephemeral
ports we will be unable to bind to any port in a node's range and the
test will fail. If we limit the max private port below the ephemeral
range that won't happen at the cost of a slightly higher chance of
collisions due to worker id wraparound, which given that we're still at
600+ids until wrap-around seems rather unlikely while bind failures
have been observed in the real world.

closes #92477
