### PR TITLE
[Profiling] Ensure responses are only sent once

### DIFF
--- a/docs/changelog/93692.yaml
+++ b/docs/changelog/93692.yaml
@@ -1,0 +1,6 @@
+pr: 93692
+summary: "[Profiling] Ensure responses are only sent once"
+area: Search
+type: bug
+issues:
+ - 93691


### PR DESCRIPTION
For performance reasons the profiling plugin issues multiple requests concurrently. It uses internal handler classes to keep track of state. When all responses of dependent requests have arrived, it assembles the response and sends it to the client. The final state handler used two atomic counters to track outstanding requests. This has led to a race condition: When the two code paths finished at the same time, the plugin attempted to send the response twice.

With this commit we simplify state handling by only using a single atomic counter for both code paths. We decrement the counter only in a single place and will send the response iff all dependent requests have finished.

Closes #93691