### PR TITLE
[ML] Text Expansion Query

### DIFF
--- a/docs/changelog/93694.yaml
+++ b/docs/changelog/93694.yaml
@@ -1,0 +1,5 @@
+pr: 93694
+summary: Text Expansion Query
+area: "Search, Machine Learning"
+type: feature
+issues: []

--- a/docs/changelog/93694.yaml
+++ b/docs/changelog/93694.yaml
@@ -1,5 +1,5 @@
 pr: 93694
 summary: Text Expansion Query
-area: "Search, Machine Learning"
+area: "Machine Learning"
 type: feature
 issues: []

--- a/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryRewriteContext.java
@@ -73,7 +73,7 @@ public class QueryRewriteContext {
 
     /**
      * Registers an async action that must be executed before the next rewrite round in order to make progress.
-     * This should be used if a rewriteabel needs to fetch some external resources in order to be executed ie. a document
+     * This should be used if a rewriteable needs to fetch some external resources in order to be executed ie. a document
      * from an index.
      */
     public void registerAsyncAction(BiConsumer<Client, ActionListener<?>> asyncAction) {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -282,7 +282,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
 
     /**
      * Can the test simulate this {@code Method}.
-     * If this function returns true {@link #simulateRequest(Method, Object[])}
+     * If this function returns true {@link #simulateMethod(Method, Object[])}
      * should be implemented provide the expected response.
      *
      * @param method The method being proxied. In practice method will represent a client call.
@@ -296,8 +296,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
     /**
      * Override this to simulate client calls.
      */
-    protected Object simulateRequest(Method method, Object[] args) {
-        throw new UnsupportedOperationException("this test can't simulate [" + method.getName() + "] requests");
+    protected Object simulateMethod(Method method, Object[] args) {
+        throw new UnsupportedOperationException("this test can't simulate method [" + method.getName() + "]");
     }
 
     /**
@@ -346,7 +346,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             } else if (method.equals(Object.class.getMethod("toString"))) {
                 return "MockClient";
             } else if (delegate.canSimulateMethod(method, args)) {
-                return delegate.simulateRequest(method, args);
+                return delegate.simulateMethod(method, args);
             }
             throw new UnsupportedOperationException("this test can't handle calls to: " + method);
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -273,10 +273,31 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
     }
 
     /**
-     * Override this to handle {@link Client#get(GetRequest)} calls from parsers / builders
+     * Override this to handle {@link Client#multiTermVectors(MultiTermVectorsRequest, ActionListener)}
+     * calls from parsers / builders
      */
     protected MultiTermVectorsResponse executeMultiTermVectors(MultiTermVectorsRequest mtvRequest) {
         throw new UnsupportedOperationException("this test can't handle MultiTermVector requests");
+    }
+
+    /**
+     * Can the test simulate this {@code Method}.
+     * If this function returns true {@link #simulateRequest(Method, Object[])}
+     * should be implemented provide the expected response.
+     *
+     * @param method The method being proxied. In practice method will represent a client call.
+     * @param args Method arguments
+     * @return True if simulating the method call is supported
+     */
+    protected boolean canSimulateMethod(Method method, Object[] args) throws NoSuchMethodException {
+        return false;
+    }
+
+    /**
+     * Override this to simulate client calls.
+     */
+    protected Object simulateRequest(Method method, Object[] args) {
+        throw new UnsupportedOperationException("this test can't simulate [" + method.getName() + "] requests");
     }
 
     /**
@@ -324,6 +345,8 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 };
             } else if (method.equals(Object.class.getMethod("toString"))) {
                 return "MockClient";
+            } else if (delegate.canSimulateMethod(method, args)) {
+                return delegate.simulateRequest(method, args);
             }
             throw new UnsupportedOperationException("this test can't handle calls to: " + method);
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/SlimConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/SlimConfigUpdate.java
@@ -29,6 +29,8 @@ public class SlimConfigUpdate extends NlpConfigUpdate {
 
     public static final String NAME = SlimConfig.NAME;
 
+    public static final SlimConfigUpdate EMPTY_UPDATE = new SlimConfigUpdate(null, null);
+
     public static SlimConfigUpdate fromMap(Map<String, Object> map) {
         Map<String, Object> options = new HashMap<>(map);
         String resultsField = (String) options.remove(RESULTS_FIELD.getPreferredName());

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TextExpansionQueryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TextExpansionQueryIT.java
@@ -1,0 +1,252 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.ResponseException;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.containsString;
+
+/**
+ * This test uses a tiny token weight model to simulate a trained
+ * NLP model. The output is an array the size of the highest value
+ * input ID and all tokens have a weight of 1.0.
+ *
+ * The model was created using this simple Python code.
+ * The saved TorchScript model is then base64 encoded and hardcoded
+ * for use in the test.
+ *
+ * ## Start Python
+ * import torch
+ * from torch import Tensor
+ * from typing import Optional
+
+ * class TinyTextExpansion(torch.nn.Module):
+
+    def forward(self,
+         input_ids: Tensor,
+         token_type_ids: Optional[Tensor] = None,
+         position_ids: Optional[Tensor] = None,
+         inputs_embeds: Optional[Tensor] = None):
+
+         torch.random.manual_seed(hash(str(input_ids)))
+
+         weights = torch.zeros(1, input_ids.max() + 1)
+         for i in input_ids:
+             weights[0][i] = 1.0
+
+        return weights
+
+ if __name__ == '__main__':
+     tte = TinyTextExpansion()
+     tte.eval()
+     input_ids = torch.tensor([6, 2, 7, 4, 10])
+     the_rest = torch.ones(11)
+     traced_model =  torch.jit.script(tte, (input_ids, the_rest, the_rest, the_rest))
+     torch.jit.save(traced_model, "simplemodel.pt")
+
+ * ## End Python
+ */
+public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
+
+    static final String BASE_64_ENCODED_MODEL = "UEsDBAAACAgAAAAAAAAAAAAAAAAAA"
+        + "AAAAAAUAA4Ac2ltcGxlbW9kZWwvZGF0YS5wa2xGQgoAWlpaWlpaWlpaWoACY19fdG9yY2hfXwpUaW55VG"
+        + "V4dEV4cGFuc2lvbgpxACmBfShYCAAAAHRyYWluaW5ncQGJWBYAAABfaXNfZnVsbF9iYWNrd2FyZF9ob29"
+        + "rcQJOdWJxAy5QSwcIITmbsFgAAABYAAAAUEsDBBQACAgIAAAAAAAAAAAAAAAAAAAAAAAdAB0Ac2ltcGxl"
+        + "bW9kZWwvY29kZS9fX3RvcmNoX18ucHlGQhkAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWoWRT4+cMAzF7"
+        + "/spfASJomF3e0Ga3nrrn8vcELIyxAzRhAQlpjvbT19DWDrdquqBA/bvPT87nVUxwsm41xPd+PNtUi4a77"
+        + "KvXs+W8voBAHFSQY3EFCIiHKFp1+p57vs/ShyUccZdoIaz93aBTMR+thbPqru+qKBx8P4q/e8TyxRlmwVc"
+        + "tJp66H1YmCyS7WsZwD50A2L5V7pCBADGTTOj0bGGE7noQyqzv5JDfp0o9fZRCWqP37yjhE4+mqX5X3AdF"
+        + "ZHGM/2TzOHDpy1IvQWR+OWo3KwsRiKdpcqg4pBFDtm+QJ7nqwIPckrlnGfFJG0uNhOl38Sjut3pCqg26Qu"
+        + "Zy8BR9In7ScHHrKkKMW0TIucFrGQXCMpdaDO05O6DpOiy8e4kr0Ed/2YKOIhplW8gPr4ntygrd9ixpx3j9"
+        + "UZZVRagl2c6+imWUzBjuf5m+Ch7afphuvvW+r/0dsfn+2N9MZGb9+/SFtCYdhd83CMYp+mGy0LiKNs8y/e"
+        + "UuEA8B/d2z4dfUEsHCFSE3IaCAQAAIAMAAFBLAwQUAAgICAAAAAAAAAAAAAAAAAAAAAAAJwApAHNpbXBsZ"
+        + "W1vZGVsL2NvZGUvX190b3JjaF9fLnB5LmRlYnVnX3BrbEZCJQBaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlp"
+        + "aWlpaWlpaWlpaWlpahZHLbtNAFIZtp03rSVIuLRKXjdk5ojitKJsiFq24lem0KKSqpRIZt55gE9/GM+lNL"
+        + "Fgx4i1Ys2aHhIBXgAVICNggHgNm6rqJN2BZGv36/v/MOWeea/Z5RVHurLfRUsfZXOnccx522itrd53O0vL"
+        + "qbaKYtsAKUe1pcege7hm9JNtzM8+kOOzNApIX0A3xBXE6YE7g0UWjg2OaZAJXbKvALOnj2GEHKc496ykLkt"
+        + "gNt3Jz17hprCUxFqExe7YIpQkNpO1/kfHhPUdtUAdH2/gfmeYiIFW7IkM6IBP2wrDNbMe3Mjf2ksiK3Hjg"
+        + "hg7F2DN9l/omZZl5Mmez2QRk0q4WUUB0+1oh9nDwxGdUXJdXPMRZQs352eGaRPV9s2lcMeZFGWBfKJJiw0Y"
+        + "gbCMLBaRmXyy4flx6a667Fch55q05QOq2Jg2ANOyZwplhNsjiohVApo7aa21QnNGW5+4GXv8gxK1beBeHSR"
+        + "rhmLXWVh+0aBhErZ7bx1ejxMOhlR6QU4ycNqGyk8/yNGCWkwY7/RCD7UEQek4QszCgDJAzZtfErA0VqHBy9"
+        + "ugQP9pUfUmgCjVYgWNwHFbhBJyEOgSwBuuwARWZmoI6J9PwLfzEocpRpPrT8DP8wqHG0b4UX+E3DiscvRgl"
+        + "XIoi81KKPwioHI5x9EooNKWiy0KOc/T6WF4SssrRuzJ9L2VNRXUhJzj6UKYfS4W/q/5wuh/l4M9R9qsU+y2"
+        + "dpoo2hJzkaEET8r6KRONicnRdK9EbUi6raFVIwNGjsrlbpk6ZPi7TbS3fv3LyNjPiEKzG0aG0tvNb6xw90/"
+        + "whe6ONjnJcUxobHDUqQ8bIOW79BVBLBwhfSmPKdAIAAE4EAABQSwMEAAAICAAAAAAAAAAAAAAAAAAAAAAAA"
+        + "BkABQBzaW1wbGVtb2RlbC9jb25zdGFudHMucGtsRkIBAFqAAikuUEsHCG0vCVcEAAAABAAAAFBLAwQAAAgI"
+        + "AAAAAAAAAAAAAAAAAAAAAAAAEwA7AHNpbXBsZW1vZGVsL3ZlcnNpb25GQjcAWlpaWlpaWlpaWlpaWlpaWlp"
+        + "aWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWjMKUEsHCNGeZ1UCAAAAAgAAAFBLAQIAAA"
+        + "AACAgAAAAAAAAhOZuwWAAAAFgAAAAUAAAAAAAAAAAAAAAAAAAAAABzaW1wbGVtb2RlbC9kYXRhLnBrbFBLA"
+        + "QIAABQACAgIAAAAAABUhNyGggEAACADAAAdAAAAAAAAAAAAAAAAAKgAAABzaW1wbGVtb2RlbC9jb2RlL19f"
+        + "dG9yY2hfXy5weVBLAQIAABQACAgIAAAAAABfSmPKdAIAAE4EAAAnAAAAAAAAAAAAAAAAAJICAABzaW1wbGVt"
+        + "b2RlbC9jb2RlL19fdG9yY2hfXy5weS5kZWJ1Z19wa2xQSwECAAAAAAgIAAAAAAAAbS8JVwQAAAAEAAAAGQAA"
+        + "AAAAAAAAAAAAAACEBQAAc2ltcGxlbW9kZWwvY29uc3RhbnRzLnBrbFBLAQIAAAAACAgAAAAAAADRnmdVAgAA"
+        + "AAIAAAATAAAAAAAAAAAAAAAAANQFAABzaW1wbGVtb2RlbC92ZXJzaW9uUEsGBiwAAAAAAAAAHgMtAAAAAAAA"
+        + "AAAABQAAAAAAAAAFAAAAAAAAAGoBAAAAAAAAUgYAAAAAAABQSwYHAAAAALwHAAAAAAAAAQAAAFBLBQYAAAAABQAFAGoBAABSBgAAAAA=";
+
+    static final long RAW_MODEL_SIZE; // size of the model before base64 encoding
+    static {
+        RAW_MODEL_SIZE = Base64.getDecoder().decode(BASE_64_ENCODED_MODEL).length;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testTextExpansionQuery() throws IOException {
+        String modelId = "text-expansion-test";
+        String indexName = modelId + "-index";
+
+        createTextExpansionModel(modelId);
+        putModelDefinition(modelId, BASE_64_ENCODED_MODEL, RAW_MODEL_SIZE);
+        putVocabulary(
+            List.of("these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"),
+            modelId
+        );
+        startDeployment(modelId);
+
+        // All tokens have a weight of 1.0.
+        // By using unique combinations of words the top doc returned
+        // by the search should be the same as the query text
+        List<String> inputs = List.of(
+            "my words comforter",
+            "the machine is leaking",
+            "these are my words",
+            "the octopus comforter smells",
+            "the octopus comforter is leaking",
+            "washing machine smells"
+        );
+
+        List<List<Map<String, Float>>> tokenWeights = new ArrayList<>();
+        // Generate the rank feature weights via the inference API
+        // then index them for search
+        for (var input : inputs) {
+            Response inference = infer(input, modelId);
+            List<Map<String, Object>> responseMap = (List<Map<String, Object>>) entityAsMap(inference).get("inference_results");
+            Map<String, Object> inferenceResult = responseMap.get(0);
+            var idWeights = (List<Map<String, Float>>) inferenceResult.get("predicted_value");
+            tokenWeights.add(idWeights);
+        }
+
+        // index tokens
+        createRankFeaturesIndex(indexName);
+        bulkIndexDocs(inputs, tokenWeights, indexName);
+
+        // Test text expansion search against the indexed rank features
+        for (int i = 0; i < 5; i++) {
+            int randomInput = randomIntBetween(0, inputs.size() - 1);
+            var textExpansionSearchResponse = textExpansionSearch(indexName, inputs.get(randomInput), modelId, "tokens");
+            assertOkWithErrorMessage(textExpansionSearchResponse);
+
+            Map<String, Object> responseMap = responseAsMap(textExpansionSearchResponse);
+            List<Map<String, Object>> hits = (List<Map<String, Object>>) MapHelper.dig("hits.hits", responseMap);
+            Map<String, Object> topHit = hits.get(0);
+            String sourceText = (String) MapHelper.dig("_source.source_text", topHit);
+            assertEquals(inputs.get(randomInput), sourceText);
+        }
+    }
+
+    public void testSearchWithMissingModel() throws IOException {
+        String modelId = "missing-model";
+        String indexName = modelId + "-index";
+
+        var e = expectThrows(ResponseException.class, () -> textExpansionSearch(indexName, "the machine is leaking", modelId, "tokens"));
+        assertThat(e.getMessage(), containsString("Could not find trained model [missing-model]"));
+    }
+
+    protected Response textExpansionSearch(String index, String modelText, String modelId, String fieldName) throws IOException {
+        Request request = new Request("GET", index + "/_search?error_trace=true");
+
+        request.setJsonEntity(Strings.format("""
+            {
+                "query": {
+                  "text_expansion": {
+                    "%s": {
+                      "model_id": "%s",
+                      "model_text": "%s"
+                    }
+                  }
+                }
+            }""", fieldName, modelId, modelText));
+        return client().performRequest(request);
+    }
+
+    protected void createTextExpansionModel(String modelId) throws IOException {
+        // with_special_tokens: false for this test with limited vocab
+        Request request = new Request("PUT", "/_ml/trained_models/" + modelId);
+        request.setJsonEntity("""
+            {
+               "description": "a text expansion model",
+               "model_type": "pytorch",
+               "inference_config": {
+                 "slim": {
+                   "tokenization": {
+                     "bert": {
+                       "with_special_tokens": false
+                     }
+                   }
+                 }
+               }
+             }""");
+        client().performRequest(request);
+    }
+
+    private void createRankFeaturesIndex(String indexName) throws IOException {
+        Request createIndex = new Request("PUT", "/" + indexName);
+        createIndex.setJsonEntity("""
+            {
+              "mappings": {
+                "properties": {
+                  "source_text": {
+                    "type": "text"
+                  },
+                  "tokens": {
+                    "type": "rank_features"
+                  }
+                }
+              }
+            }""");
+        var response = client().performRequest(createIndex);
+        assertOkWithErrorMessage(response);
+    }
+
+    private void bulkIndexDocs(List<String> sourceText, List<List<Map<String, Float>>> tokenWeights, String indexName) throws IOException {
+        String createAction = "{\"create\": {\"_index\": \"" + indexName + "\"}}\n";
+
+        StringBuilder bulkBuilder = new StringBuilder();
+
+        for (int i = 0; i < sourceText.size(); i++) {
+            bulkBuilder.append(createAction);
+            bulkBuilder.append("{\"source_text\": \"").append(sourceText.get(i)).append("\", \"tokens\":[");
+
+            for (int j = 0; j < tokenWeights.get(i).size() - 1; j++) {
+                var entry = tokenWeights.get(i).get(j).entrySet().iterator().next();
+                writeToken(entry, bulkBuilder).append(',');
+            }
+            var entry = tokenWeights.get(i).get(tokenWeights.get(i).size() - 1).entrySet().iterator().next();
+            writeToken(entry, bulkBuilder);
+            bulkBuilder.append("]}\n");
+        }
+
+        Request bulkRequest = new Request("POST", "/_bulk");
+        bulkRequest.setJsonEntity(bulkBuilder.toString());
+        bulkRequest.addParameter("refresh", "true");
+        var bulkResponse = client().performRequest(bulkRequest);
+        assertOkWithErrorMessage(bulkResponse);
+    }
+
+    private StringBuilder writeToken(Map.Entry<String, Float> entry, StringBuilder builder) {
+        return builder.append("{\"").append(entry.getKey()).append("\":").append(entry.getValue()).append("}");
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -49,6 +49,7 @@ import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
+import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.indices.AssociatedIndexDescriptor;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.indices.analysis.AnalysisModule.AnalysisProvider;
@@ -363,6 +364,7 @@ import org.elasticsearch.xpack.ml.process.MlControllerHolder;
 import org.elasticsearch.xpack.ml.process.MlMemoryTracker;
 import org.elasticsearch.xpack.ml.process.NativeController;
 import org.elasticsearch.xpack.ml.process.NativeStorageProvider;
+import org.elasticsearch.xpack.ml.queries.TextExpansionQueryBuilder;
 import org.elasticsearch.xpack.ml.rest.RestDeleteExpiredDataAction;
 import org.elasticsearch.xpack.ml.rest.RestMlInfoAction;
 import org.elasticsearch.xpack.ml.rest.RestMlMemoryAction;
@@ -1556,7 +1558,18 @@ public class MachineLearning extends Plugin
             new QueryVectorBuilderSpec<>(
                 TextEmbeddingQueryVectorBuilder.NAME,
                 TextEmbeddingQueryVectorBuilder::new,
-                TextEmbeddingQueryVectorBuilder.PARSER::apply
+                TextEmbeddingQueryVectorBuilder.PARSER
+            )
+        );
+    }
+
+    @Override
+    public List<QuerySpec<?>> getQueries() {
+        return List.of(
+            new QuerySpec<QueryBuilder>(
+                TextExpansionQueryBuilder.NAME,
+                TextExpansionQueryBuilder::new,
+                TextExpansionQueryBuilder::fromXContent
             )
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -32,6 +32,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
 public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansionQueryBuilder> {
 
     public static final String NAME = "text_expansion";
@@ -133,7 +136,7 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
 
         SetOnce<SlimResults> slimResultsSupplier = new SetOnce<>();
         queryRewriteContext.registerAsyncAction((client, listener) -> {
-            client.execute(InferModelAction.INSTANCE, inferRequest, ActionListener.wrap(inferenceResponse -> {
+            executeAsyncWithOrigin(client, ML_ORIGIN, InferModelAction.INSTANCE, inferRequest, ActionListener.wrap(inferenceResponse -> {
 
                 if (inferenceResponse.getInferenceResults().isEmpty()) {
                     listener.onFailure(new IllegalStateException("inference response contain no results"));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -92,7 +92,7 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return TransportVersion.V_8_7_0;
+        return TransportVersion.V_8_8_0;
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.queries;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.Version;
+import org.elasticsearch.common.ParsingException;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentParser;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansionQueryBuilder> {
+
+    public static final String NAME = "text_expansion";
+    public static final ParseField MODEL_TEXT = new ParseField("model_text");
+    public static final ParseField MODEL_ID = new ParseField("model_id");
+
+    private static final String DEFAULT_MODEL_ID = "slim";
+
+    private final String fieldName;
+    private final String modelText;
+    private final String modelId;
+
+    public TextExpansionQueryBuilder(String fieldName, String modelText, String modelId) {
+        if (fieldName == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires a fieldName");
+        }
+        if (modelText == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires a " + MODEL_TEXT.getPreferredName() + " value");
+        }
+
+        this.fieldName = fieldName;
+        this.modelText = modelText;
+        this.modelId = modelId == null ? DEFAULT_MODEL_ID : modelId;
+    }
+
+    public TextExpansionQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.fieldName = in.readString();
+        this.modelText = in.readString();
+        this.modelId = in.readString();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public Version getMinimalSupportedVersion() {
+        return Version.V_8_7_0;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeString(fieldName);
+        out.writeString(modelText);
+        out.writeString(modelId);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        builder.startObject(fieldName);
+        builder.field(MODEL_TEXT.getPreferredName(), modelText);
+        builder.field(MODEL_ID.getPreferredName(), modelId);
+        boostAndQueryNameToXContent(builder);
+        builder.endObject();
+        builder.endObject();
+    }
+
+    @Override
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+        return null;
+    }
+
+    @Override
+    protected boolean doEquals(TextExpansionQueryBuilder other) {
+        return Objects.equals(fieldName, other.fieldName)
+            && Objects.equals(modelText, other.modelText)
+            && Objects.equals(modelId, other.modelId);
+    }
+
+    @Override
+    protected int doHashCode() {
+        return Objects.hash(fieldName, modelText, modelId);
+    }
+
+    public static TextExpansionQueryBuilder fromXContent(XContentParser parser) throws IOException {
+        String fieldName = null;
+        String modelText = null;
+        String modelId = null;
+        float boost = AbstractQueryBuilder.DEFAULT_BOOST;
+        String queryName = null;
+        String currentFieldName = null;
+        XContentParser.Token token;
+        while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+            if (token == XContentParser.Token.FIELD_NAME) {
+                currentFieldName = parser.currentName();
+            } else if (token == XContentParser.Token.START_OBJECT) {
+                throwParsingExceptionOnMultipleFields(NAME, parser.getTokenLocation(), fieldName, currentFieldName);
+                fieldName = currentFieldName;
+                while ((token = parser.nextToken()) != XContentParser.Token.END_OBJECT) {
+                    if (token == XContentParser.Token.FIELD_NAME) {
+                        currentFieldName = parser.currentName();
+                    } else if (token.isValue()) {
+                        if (MODEL_TEXT.match(currentFieldName, parser.getDeprecationHandler())) {
+                            modelText = parser.text();
+                        } else if (MODEL_ID.match(currentFieldName, parser.getDeprecationHandler())) {
+                            modelId = parser.text();
+                        } else if (AbstractQueryBuilder.BOOST_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            boost = parser.floatValue();
+                        } else if (AbstractQueryBuilder.NAME_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                            queryName = parser.text();
+                        } else {
+                            throw new ParsingException(
+                                parser.getTokenLocation(),
+                                "[" + NAME + "] query does not support [" + currentFieldName + "]"
+                            );
+                        }
+                    } else {
+                        throw new ParsingException(
+                            parser.getTokenLocation(),
+                            "[" + NAME + "] unknown token [" + token + "] after [" + currentFieldName + "]"
+                        );
+                    }
+                }
+            } else {
+                throwParsingExceptionOnMultipleFields(NAME, parser.getTokenLocation(), fieldName, parser.currentName());
+                fieldName = parser.currentName();
+                modelText = parser.text();
+            }
+        }
+
+        if (modelText == null) {
+            throw new ParsingException(parser.getTokenLocation(), "No text specified for text query");
+        }
+
+        if (fieldName == null) {
+            throw new ParsingException(parser.getTokenLocation(), "No fieldname specified for query");
+        }
+
+        TextExpansionQueryBuilder queryBuilder = new TextExpansionQueryBuilder(fieldName, modelText, modelId);
+        queryBuilder.queryName(queryName);
+        queryBuilder.boost(boost);
+        return queryBuilder;
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.queries;
+
+import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.QueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.test.AbstractQueryTestCase;
+import org.elasticsearch.xpack.ml.MachineLearning;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextExpansionQueryBuilder> {
+
+    // /TODO implement createQueryWithInnerQuery() and testMaxNestedDepth??
+
+    @Override
+    protected TextExpansionQueryBuilder doCreateTestQueryBuilder() {
+        var builder = new TextExpansionQueryBuilder(
+            randomAlphaOfLength(4),
+            randomAlphaOfLength(4),
+            randomBoolean() ? null : randomAlphaOfLength(4)
+        );
+        if (randomBoolean()) {
+            builder.boost((float) randomDoubleBetween(0.1, 10.0, true));
+        }
+        if (randomBoolean()) {
+            builder.queryName(randomAlphaOfLength(4));
+        }
+        return builder;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return List.of(MachineLearning.class);
+    }
+
+    @Override
+    protected void doAssertLuceneQuery(TextExpansionQueryBuilder queryBuilder, Query query, SearchExecutionContext context)
+        throws IOException {
+        fail();
+    }
+
+    public void testIllegalValues() {
+        {
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> new TextExpansionQueryBuilder(null, "model text", null)
+            );
+            assertEquals("[text_expansion] requires a fieldName", e.getMessage());
+        }
+        {
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> new TextExpansionQueryBuilder("field name", null, null)
+            );
+            assertEquals("[text_expansion] requires a model_text value", e.getMessage());
+        }
+    }
+
+    public void testToXContentWithDefaults() throws IOException {
+        QueryBuilder query = new TextExpansionQueryBuilder("foo", "bar", null);
+        checkGeneratedJson("""
+            {
+              "text_expansion": {
+                "foo": {
+                  "model_text": "bar",
+                  "model_id": "slim"
+                }
+              }
+            }""", query);
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -64,7 +64,7 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
     }
 
     @Override
-    protected Object simulateRequest(Method method, Object[] args) {
+    protected Object simulateMethod(Method method, Object[] args) {
         InferModelAction.Request request = (InferModelAction.Request) args[1];
 
         var tokens = new ArrayList<SlimResults.WeightedToken>();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.ml.queries;
 
+import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -19,6 +20,7 @@ import org.elasticsearch.test.AbstractQueryTestCase;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
 import org.elasticsearch.xpack.core.ml.inference.results.SlimResults;
 import org.elasticsearch.xpack.ml.MachineLearning;
+import org.hamcrest.Matchers;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
@@ -54,7 +56,7 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
         SearchExecutionContext context = createSearchExecutionContext();
         TextExpansionQueryBuilder builder = new TextExpansionQueryBuilder("foo", "bar", "baz");
         IllegalStateException e = expectThrows(IllegalStateException.class, () -> builder.toQuery(context));
-        assertEquals("terms query must not be null, missing rewrite?", e.getMessage());
+        assertEquals("text_expansion should have been rewritten to another query type", e.getMessage());
     }
 
     @Override
@@ -84,9 +86,22 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
     }
 
     @Override
-    protected void doAssertLuceneQuery(TextExpansionQueryBuilder queryBuilder, Query query, SearchExecutionContext context)
-        throws IOException {
-        fail("what should be asserted here?");
+    protected void doAssertLuceneQuery(TextExpansionQueryBuilder queryBuilder, Query query, SearchExecutionContext context) {
+
+        assertThat(query, Matchers.instanceOf(MatchNoDocsQuery.class));
+
+        // assertThat(query, instanceOf(BooleanQuery.class));
+        // BooleanQuery booleanQuery = (BooleanQuery) query;
+        // assertEquals(booleanQuery.getMinimumNumberShouldMatch(), 1);
+        //
+        // for (var clause : booleanQuery.clauses()) {
+        // assertEquals(BooleanClause.Occur.SHOULD, clause.getOccur());
+        // if (clause.getQuery()instanceof TermQuery termQuery) {
+        // assertThat(termQuery.getTerm().field(), equalTo(expectedFieldName(queryBuilder.getFieldName())));
+        // } else {
+        // assertThat(clause.getQuery(), instanceOf(MatchNoDocsQuery.class));
+        // }
+        // }
     }
 
     public void testIllegalValues() {

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -1,0 +1,113 @@
+# This test uses the simple model defined in
+# TextExpansionQueryIT.java to create the token weights.
+setup:
+  - skip:
+      features: headers
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.create:
+        index: index-with-rank-features
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              source_text:
+                type: keyword
+              tokens:
+                type: rank_features
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      indices.create:
+        index: unrelated
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              source_text:
+                type: keyword
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model:
+        model_id: "text_expansion_model"
+        body: >
+          {
+            "description": "simple model for testing",
+            "model_type": "pytorch",
+            "inference_config": {
+              "slim": {
+                "tokenization": {
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                }
+              }
+            }
+          }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model_vocabulary:
+        model_id: "text_expansion_model"
+        body: >
+          { "vocabulary": ["[PAD]", "[UNK]", "these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"] }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+      ml.put_trained_model_definition_part:
+        model_id: "text_expansion_model"
+        part: 0
+        body: >
+          {
+            "total_definition_length":2078,
+            "definition": "UEsDBAAACAgAAAAAAAAAAAAAAAAAAAAAAAAUAA4Ac2ltcGxlbW9kZWwvZGF0YS5wa2xGQgoAWlpaWlpaWlpaWoACY19fdG9yY2hfXwpUaW55VGV4dEV4cGFuc2lvbgpxACmBfShYCAAAAHRyYWluaW5ncQGJWBYAAABfaXNfZnVsbF9iYWNrd2FyZF9ob29rcQJOdWJxAy5QSwcIITmbsFgAAABYAAAAUEsDBBQACAgIAAAAAAAAAAAAAAAAAAAAAAAdAB0Ac2ltcGxlbW9kZWwvY29kZS9fX3RvcmNoX18ucHlGQhkAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWoWRT4+cMAzF7/spfASJomF3e0Ga3nrrn8vcELIyxAzRhAQlpjvbT19DWDrdquqBA/bvPT87nVUxwsm41xPd+PNtUi4a77KvXs+W8voBAHFSQY3EFCIiHKFp1+p57vs/ShyUccZdoIaz93aBTMR+thbPqru+qKBx8P4q/e8TyxRlmwVctJp66H1YmCyS7WsZwD50A2L5V7pCBADGTTOj0bGGE7noQyqzv5JDfp0o9fZRCWqP37yjhE4+mqX5X3AdFZHGM/2TzOHDpy1IvQWR+OWo3KwsRiKdpcqg4pBFDtm+QJ7nqwIPckrlnGfFJG0uNhOl38Sjut3pCqg26QuZy8BR9In7ScHHrKkKMW0TIucFrGQXCMpdaDO05O6DpOiy8e4kr0Ed/2YKOIhplW8gPr4ntygrd9ixpx3j9UZZVRagl2c6+imWUzBjuf5m+Ch7afphuvvW+r/0dsfn+2N9MZGb9+/SFtCYdhd83CMYp+mGy0LiKNs8y/eUuEA8B/d2z4dfUEsHCFSE3IaCAQAAIAMAAFBLAwQUAAgICAAAAAAAAAAAAAAAAAAAAAAAJwApAHNpbXBsZW1vZGVsL2NvZGUvX190b3JjaF9fLnB5LmRlYnVnX3BrbEZCJQBaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpahZHLbtNAFIZtp03rSVIuLRKXjdk5ojitKJsiFq24lem0KKSqpRIZt55gE9/GM+lNLFgx4i1Ys2aHhIBXgAVICNggHgNm6rqJN2BZGv36/v/MOWeea/Z5RVHurLfRUsfZXOnccx522itrd53O0vLqbaKYtsAKUe1pcege7hm9JNtzM8+kOOzNApIX0A3xBXE6YE7g0UWjg2OaZAJXbKvALOnj2GEHKc496ykLktgNt3Jz17hprCUxFqExe7YIpQkNpO1/kfHhPUdtUAdH2/gfmeYiIFW7IkM6IBP2wrDNbMe3Mjf2ksiK3Hjghg7F2DN9l/omZZl5Mmez2QRk0q4WUUB0+1oh9nDwxGdUXJdXPMRZQs352eGaRPV9s2lcMeZFGWBfKJJiw0YgbCMLBaRmXyy4flx6a667Fch55q05QOq2Jg2ANOyZwplhNsjiohVApo7aa21QnNGW5+4GXv8gxK1beBeHSRrhmLXWVh+0aBhErZ7bx1ejxMOhlR6QU4ycNqGyk8/yNGCWkwY7/RCD7UEQek4QszCgDJAzZtfErA0VqHBy9ugQP9pUfUmgCjVYgWNwHFbhBJyEOgSwBuuwARWZmoI6J9PwLfzEocpRpPrT8DP8wqHG0b4UX+E3DiscvRglXIoi81KKPwioHI5x9EooNKWiy0KOc/T6WF4SssrRuzJ9L2VNRXUhJzj6UKYfS4W/q/5wuh/l4M9R9qsU+y2dpoo2hJzkaEET8r6KRONicnRdK9EbUi6raFVIwNGjsrlbpk6ZPi7TbS3fv3LyNjPiEKzG0aG0tvNb6xw90/whe6ONjnJcUxobHDUqQ8bIOW79BVBLBwhfSmPKdAIAAE4EAABQSwMEAAAICAAAAAAAAAAAAAAAAAAAAAAAABkABQBzaW1wbGVtb2RlbC9jb25zdGFudHMucGtsRkIBAFqAAikuUEsHCG0vCVcEAAAABAAAAFBLAwQAAAgIAAAAAAAAAAAAAAAAAAAAAAAAEwA7AHNpbXBsZW1vZGVsL3ZlcnNpb25GQjcAWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWlpaWjMKUEsHCNGeZ1UCAAAAAgAAAFBLAQIAAAAACAgAAAAAAAAhOZuwWAAAAFgAAAAUAAAAAAAAAAAAAAAAAAAAAABzaW1wbGVtb2RlbC9kYXRhLnBrbFBLAQIAABQACAgIAAAAAABUhNyGggEAACADAAAdAAAAAAAAAAAAAAAAAKgAAABzaW1wbGVtb2RlbC9jb2RlL19fdG9yY2hfXy5weVBLAQIAABQACAgIAAAAAABfSmPKdAIAAE4EAAAnAAAAAAAAAAAAAAAAAJICAABzaW1wbGVtb2RlbC9jb2RlL19fdG9yY2hfXy5weS5kZWJ1Z19wa2xQSwECAAAAAAgIAAAAAAAAbS8JVwQAAAAEAAAAGQAAAAAAAAAAAAAAAACEBQAAc2ltcGxlbW9kZWwvY29uc3RhbnRzLnBrbFBLAQIAAAAACAgAAAAAAADRnmdVAgAAAAIAAAATAAAAAAAAAAAAAAAAANQFAABzaW1wbGVtb2RlbC92ZXJzaW9uUEsGBiwAAAAAAAAAHgMtAAAAAAAAAAAABQAAAAAAAAAFAAAAAAAAAGoBAAAAAAAAUgYAAAAAAABQSwYHAAAAALwHAAAAAAAAAQAAAFBLBQYAAAAABQAFAGoBAABSBgAAAAA=",
+            "total_parts": 1
+          }
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
+      bulk:
+        index: index-with-rank-features
+        refresh: true
+        body: |
+          {"index": {}}
+          {"source_text": "my words comforter", "tokens":[{"4":1.0},{"5":1.0},{"12":1.0}]}
+          {"index": {}}
+          {"source_text": "the machine is leaking", "tokens":[{"6":1.0},{"8":1.0},{"9":1.0},{"10":1.0}]}
+          {"index": {}}
+          {"source_text": "these are my words", "tokens":[{"2":1.0},{"3":1.0},{"4":1.0},{"5":1.0}]}
+          {"index": {}}
+          {"source_text": "the octopus comforter smells", "tokens":[{"6":1.0},{"11":1.0},{"12":1.0},{"13":1.0}]}
+          {"index": {}}
+          {"source_text": "the octopus comforter is leaking", "tokens":[{"6":1.0},{"9":1.0},{"10":1.0},{"11":1.0},{"12":1.0}]}
+          {"index": {}}
+          {"source_text": "washing machine smells", "tokens":[{"7":1.0},{"8":1.0},{"13":1.0}]}
+
+  - do:
+      headers:
+        Authorization: "Basic eF9wYWNrX3Jlc3RfdXNlcjp4LXBhY2stdGVzdC1wYXNzd29yZA==" # run as x_pack_rest_user, i.e. the test setup superuser
+        Content-Type: application/json
+      ml.start_trained_model_deployment:
+        model_id: text_expansion_model
+        wait_for: started
+
+---
+"Test text expansion search":
+  - do:
+      search:
+        index: index-with-rank-features
+        body:
+          query:
+            text_expansion:
+              tokens:
+                model_id: text_expansion_model
+                model_text: "octopus comforter smells"
+  - match: { hits.total.value: 4 }
+  - match: { hits.hits.0._source.source_text: "the octopus comforter smells" }


### PR DESCRIPTION
The `text_expansion` query uses a NLP model to convert the query text into a list of token-weight pairs which are then used in a terms query against a rank features field.

```
"query": {
    "text_expansion": {
        "rank_features_field": {
            "model_id": "the model to produce the token weights",
            "model_text": "the query string"
        }
    }
}
```