### PR TITLE
Fix GetPipelineResponse equality

### DIFF
--- a/docs/changelog/93695.yaml
+++ b/docs/changelog/93695.yaml
@@ -1,0 +1,5 @@
+pr: 93695
+summary: Fix `GetPipelineResponse` equality
+area: Distributed
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -135,6 +135,10 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
                     if (pipeline.equals(otherPipeline) == false) {
                         return false;
                     }
+                    otherPipelineMap.remove(pipeline.getId());
+                }
+                if (otherPipelineMap.isEmpty() == false) {
+                    return false;
                 }
                 return true;
             }


### PR DESCRIPTION
While [improving the test utility that asserts equality and hash code](#93696), `EqualsHashCodeTestUtils`, a potential issue was found in the equals implementation of GetPipelineResponse - the comparison is not symmetric. For example:
  
response1 of :
```
{
   "pipeline_0":{ "set":{  "field":"field_1",  "value":"value_2"  } },
   "pipeline_1":{ "set":{  "field":"field_3",  "value":"value_4"  } }
}
```
response2 of :

```
{
   "pipeline_0":{ "set":{ "field":"field_1",  "value":"value_2"  } }
}
```

`response2.equals(response1) == true`, while
`response1.equals(response2) == false`.

I assume that this is a bug, and unexpected.

The equality of GetPipelineResponse is already covered by existing tests in  `org.elasticsearch.action.ingest.GetPipelineResponseTests`.