### PR TITLE
Improve test utility that asserts equality and hash code

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/ingest/GetPipelineResponse.java
@@ -135,6 +135,10 @@ public class GetPipelineResponse extends ActionResponse implements StatusToXCont
                     if (pipeline.equals(otherPipeline) == false) {
                         return false;
                     }
+                    otherPipelineMap.remove(pipeline.getId());
+                }
+                if (otherPipelineMap.isEmpty() == false) {
+                    return false;
                 }
                 return true;
             }

--- a/test/framework/src/main/java/org/elasticsearch/test/EqualsHashCodeTestUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/EqualsHashCodeTestUtils.java
@@ -71,6 +71,9 @@ public class EqualsHashCodeTestUtils {
             if (mutationFunction != null) {
                 T mutation = mutationFunction.mutate(original);
                 assertThat(objectName + " mutation should not be equal to original", mutation, not(equalTo(original)));
+                // equals is symmetric: for any non-null reference values x and y, x.equals(y) should return true if and only
+                // if y.equals(x) returns true. Conversely, y.equals(x) should return true if and only if x.equals(y)
+                assertThat("original should not be equal to mutation" + objectName, original, not(equalTo(mutation)));
             }
 
             T copy = copyFunction.copy(original);


### PR DESCRIPTION
This change improves the test utility that asserts equality and hash code, `EqualsHashCodeTestUtils`. More specifically, it adds an assertion for the symmetric constraint of Object equality - for any non-null reference values `x` and `y`, `x.equals(y)` should return true if and only if `y.equals(x)` returns true. Conversely, `y.equals(x)` should return true if and only if `x.equals(y)` returns true.

