### PR TITLE
[8.7] [Profiling] Ensure responses are only sent once (#93692)

### DIFF
--- a/docs/changelog/93692.yaml
+++ b/docs/changelog/93692.yaml
@@ -1,0 +1,6 @@
+pr: 93692
+summary: "[Profiling] Ensure responses are only sent once"
+area: Search
+type: bug
+issues:
+ - 93691


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [Profiling] Ensure responses are only sent once (#93692)