### PR TITLE
Improve handling of overlapping multi-geometries in vector tiles

### DIFF
--- a/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
+++ b/x-pack/plugin/vector-tile/src/javaRestTest/java/org/elasticsearch/xpack/vectortile/VectorTileRestIT.java
@@ -915,22 +915,6 @@ public class VectorTileRestIT extends ESRestTestCase {
         assertDoubleTag(metaLayer, metaLayer.getFeatures(0), "aggregations.percentilesAgg.99.9.max", 1.0);
     }
 
-    public void testOverlappingMultipolygon() throws Exception {
-        // Overlapping multipolygon are accepted by Elasticsearch but is invalid for JTS.
-        // This causes an error in the mvt library that gets logged using slf4j
-        final String index = "overlapping_multipolygon";
-        final Rectangle r1 = new Rectangle(-160, 160, 80, -80);
-        final Rectangle r2 = new Rectangle(-159, 161, 79, -81);
-        createIndexAndPutGeometry(index, new MultiPolygon(List.of(toPolygon(r1), toPolygon(r2))), "multi_polygon");
-        final Request mvtRequest = new Request(getHttpMethod(), index + "/_mvt/location/0/0/0?grid_precision=0");
-        final VectorTile.Tile tile = execute(mvtRequest);
-        assertThat(tile.getLayersCount(), Matchers.equalTo(2));
-        assertLayer(tile, HITS_LAYER, 4096, 0, 0);
-        assertLayer(tile, META_LAYER, 4096, 1, 8);
-        final Response response = client().performRequest(new Request(HttpDelete.METHOD_NAME, index));
-        assertThat(response.getStatusLine().getStatusCode(), Matchers.equalTo(HttpStatus.SC_OK));
-    }
-
     public void testGetRuntimeField() throws Exception {
         final Request mvtRequest = new Request(getHttpMethod(), INDEX_POINTS + "/_mvt/location_rf/" + z + "/" + x + "/" + y);
         mvtRequest.setJsonEntity(

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -52,13 +52,7 @@ public class FeatureFactory {
 
     private final IUserDataConverter userDataIgnoreConverter = new UserDataIgnoreConverter();
     private final MvtLayerProps layerProps = new MvtLayerProps();
-    private final JTSGeometryBuilder builder;
-    // extent used for clipping
-    private final org.locationtech.jts.geom.Geometry clipTile;
-    // transforms spherical mercator coordinates into the tile coordinates
-    private final CoordinateSequenceFilter sequenceFilter;
-    // pixel precision of the tile in the mercator projection.
-    private final double pixelPrecision;
+    private final MVTGeometryBuilder mvtGeometryBuilder;
     // optimization for points and rectangles
     private final SimpleFeatureFactory simpleFeatureFactory;
 
@@ -75,16 +69,20 @@ public class FeatureFactory {
      * value is set in SimpleVectorTileFormatter.DEFAULT_BUFFER_PIXELS (currently 5 pixels).
      */
     public FeatureFactory(int z, int x, int y, int extent, int padPixels) {
-        this.pixelPrecision = 2 * SphericalMercatorUtils.MERCATOR_BOUNDS / ((1L << z) * extent);
+        // geometry factory
+        final GeometryFactory geomFactory = new GeometryFactory();
+        // pixel precision of the tile in the mercator projection.
+        final double pixelPrecision = 2 * SphericalMercatorUtils.MERCATOR_BOUNDS / ((1L << z) * extent);
         final Rectangle r = SphericalMercatorUtils.recToSphericalMercator(GeoTileUtils.toBoundingBox(x, y, z));
         final Envelope tileEnvelope = new Envelope(r.getMinX(), r.getMaxX(), r.getMinY(), r.getMaxY());
         final Envelope clipEnvelope = new Envelope(tileEnvelope);
         // expand enough the clip envelope to prevent visual artefacts
-        clipEnvelope.expandBy(padPixels * this.pixelPrecision, padPixels * this.pixelPrecision);
-        final GeometryFactory geomFactory = new GeometryFactory();
-        this.builder = new JTSGeometryBuilder(geomFactory);
-        this.clipTile = geomFactory.toGeometry(clipEnvelope);
-        this.sequenceFilter = new MvtCoordinateSequenceFilter(tileEnvelope, extent);
+        clipEnvelope.expandBy(padPixels * pixelPrecision, padPixels * pixelPrecision);
+        // extent used for clipping
+        final org.locationtech.jts.geom.Geometry clipTile = geomFactory.toGeometry(clipEnvelope);
+        // transforms spherical mercator coordinates into the tile coordinates
+        final CoordinateSequenceFilter sequenceFilter = new MvtCoordinateSequenceFilter(tileEnvelope, extent);
+        this.mvtGeometryBuilder = new MVTGeometryBuilder(geomFactory, clipTile, pixelPrecision, sequenceFilter);
         this.simpleFeatureFactory = new SimpleFeatureFactory(z, x, y, extent);
     }
 
@@ -113,68 +111,28 @@ public class FeatureFactory {
      * Returns a List {@code byte[]} containing the mvt representation of the provided geometry
      */
     public List<byte[]> getFeatures(Geometry geometry) {
-        // Get geometry in spherical mercator
-        final org.locationtech.jts.geom.Geometry jtsGeometry = geometry.visit(builder);
-        // clip the geometry to the tile
-        final List<org.locationtech.jts.geom.Geometry> flatGeometries = clipGeometries(clipTile, JtsAdapter.flatFeatureList(jtsGeometry));
-        // simplify geometry using the pixel precision
-        simplifyGeometry(flatGeometries, pixelPrecision);
-        // convert coordinates to MVT geometry
-        convertToMvtGeometry(flatGeometries, sequenceFilter);
+        // Get geometry in pixel coordinates
+        final org.locationtech.jts.geom.Geometry mvtGeometry = geometry.visit(mvtGeometryBuilder);
+        if (mvtGeometry == null) {
+            return List.of();
+        }
         // MVT geometry to MVT feature
-        final List<VectorTile.Tile.Feature> features = PatchedJtsAdapter.toFeatures(flatGeometries, layerProps, userDataIgnoreConverter);
+        final List<VectorTile.Tile.Feature> features = PatchedJtsAdapter.toFeatures(
+            JtsAdapter.flatFeatureList(mvtGeometry),
+            layerProps,
+            userDataIgnoreConverter
+        );
         final List<byte[]> byteFeatures = new ArrayList<>(features.size());
         features.forEach(f -> byteFeatures.add(f.toByteArray()));
         return byteFeatures;
     }
 
-    private static List<org.locationtech.jts.geom.Geometry> clipGeometries(
-        org.locationtech.jts.geom.Geometry envelope,
-        List<org.locationtech.jts.geom.Geometry> geometries
-    ) {
-        final List<org.locationtech.jts.geom.Geometry> intersected = new ArrayList<>(geometries.size());
-        for (org.locationtech.jts.geom.Geometry geometry : geometries) {
-            try {
-                final IntersectionMatrix matrix = envelope.relate(geometry);
-                if (matrix.isContains()) {
-                    // no need to clip
-                    intersected.add(geometry);
-                } else if (matrix.isWithin()) {
-                    // the clipped geometry is the envelope
-                    intersected.add(envelope.copy());
-                } else if (matrix.isIntersects()) {
-                    // clip it (clone envelope as coordinates are copied by reference)
-                    intersected.add(envelope.copy().intersection(geometry));
-                } else {
-                    // disjoint
-                    assert envelope.copy().intersection(geometry).isEmpty();
-                }
-            } catch (TopologyException e) {
-                // ignore
-            }
-        }
-        return intersected;
-    }
-
-    private static void simplifyGeometry(List<org.locationtech.jts.geom.Geometry> geometries, double precision) {
-        for (int i = 0; i < geometries.size(); i++) {
-            geometries.set(i, TopologyPreservingSimplifier.simplify(geometries.get(i), precision));
-        }
-    }
-
-    private static void convertToMvtGeometry(List<org.locationtech.jts.geom.Geometry> geometries, CoordinateSequenceFilter sequenceFilter) {
-        for (org.locationtech.jts.geom.Geometry geometry : geometries) {
-            geometry.apply(sequenceFilter);
-        }
-    }
-
-    private static class JTSGeometryBuilder implements GeometryVisitor<org.locationtech.jts.geom.Geometry, IllegalArgumentException> {
-
-        private final GeometryFactory geomFactory;
-
-        JTSGeometryBuilder(GeometryFactory geomFactory) {
-            this.geomFactory = geomFactory;
-        }
+    private record MVTGeometryBuilder(
+        GeometryFactory geomFactory,
+        org.locationtech.jts.geom.Geometry clipTile,
+        double pixelPrecision,
+        CoordinateSequenceFilter sequenceFilter
+    ) implements GeometryVisitor<org.locationtech.jts.geom.Geometry, IllegalArgumentException> {
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Circle circle) {
@@ -183,11 +141,7 @@ public class FeatureFactory {
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(GeometryCollection<?> collection) {
-            final org.locationtech.jts.geom.Geometry[] geometries = new org.locationtech.jts.geom.Geometry[collection.size()];
-            for (int i = 0; i < collection.size(); i++) {
-                geometries[i] = collection.get(i).visit(this);
-            }
-            return geomFactory.createGeometryCollection(geometries);
+            return buildCollection(collection);
         }
 
         @Override
@@ -197,103 +151,75 @@ public class FeatureFactory {
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Point point) throws RuntimeException {
-            return buildPoint(point);
+            return toMVTGeometry(buildMercatorPoint(geomFactory, point));
         }
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(MultiPoint multiPoint) throws RuntimeException {
-            final org.locationtech.jts.geom.Point[] points = new org.locationtech.jts.geom.Point[multiPoint.size()];
-            for (int i = 0; i < multiPoint.size(); i++) {
-                points[i] = buildPoint(multiPoint.get(i));
-            }
-            Arrays.sort(
-                points,
-                Comparator.comparingDouble(org.locationtech.jts.geom.Point::getX).thenComparingDouble(org.locationtech.jts.geom.Point::getY)
-            );
-            return geomFactory.createMultiPoint(points);
-        }
-
-        private org.locationtech.jts.geom.Point buildPoint(Point point) {
-            final double x = SphericalMercatorUtils.lonToSphericalMercator(point.getX());
-            final double y = SphericalMercatorUtils.latToSphericalMercator(point.getY());
-            return geomFactory.createPoint(new Coordinate(x, y));
+            return toMVTGeometry(buildMercatorMultiPoint(geomFactory, multiPoint));
         }
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Line line) {
-            return buildLine(line);
+            return toMVTGeometry(buildMercatorLine(geomFactory, line));
         }
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(MultiLine multiLine) throws RuntimeException {
-            final LineString[] lineStrings = new LineString[multiLine.size()];
-            for (int i = 0; i < multiLine.size(); i++) {
-                lineStrings[i] = buildLine(multiLine.get(i));
-            }
-            return geomFactory.createMultiLineString(lineStrings);
-        }
-
-        private LineString buildLine(Line line) {
-            final Coordinate[] coordinates = new Coordinate[line.length()];
-            for (int i = 0; i < line.length(); i++) {
-                final double x = SphericalMercatorUtils.lonToSphericalMercator(line.getX(i));
-                final double y = SphericalMercatorUtils.latToSphericalMercator(line.getY(i));
-                coordinates[i] = new Coordinate(x, y);
-            }
-            return geomFactory.createLineString(coordinates);
+            /*
+             Elasticsearch accepts lines that intersects but this might cause issues on JTS algorithms. It is then
+             important to transform each line individually, therefore we treat it as a collection.
+            */
+            return buildCollection(multiLine);
         }
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Polygon polygon) throws RuntimeException {
-            return buildPolygon(polygon);
+            return toMVTGeometry(buildMercatorPolygon(geomFactory, polygon));
         }
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(MultiPolygon multiPolygon) throws RuntimeException {
-            final org.locationtech.jts.geom.Polygon[] polygons = new org.locationtech.jts.geom.Polygon[multiPolygon.size()];
-            for (int i = 0; i < multiPolygon.size(); i++) {
-                polygons[i] = buildPolygon(multiPolygon.get(i));
-            }
-            return geomFactory.createMultiPolygon(polygons);
-        }
-
-        private org.locationtech.jts.geom.Polygon buildPolygon(Polygon polygon) {
-            final org.locationtech.jts.geom.LinearRing outerShell = buildLinearRing(polygon.getPolygon());
-            if (polygon.getNumberOfHoles() == 0) {
-                return geomFactory.createPolygon(outerShell);
-            }
-            final org.locationtech.jts.geom.LinearRing[] holes = new org.locationtech.jts.geom.LinearRing[polygon.getNumberOfHoles()];
-            for (int i = 0; i < polygon.getNumberOfHoles(); i++) {
-                holes[i] = buildLinearRing(polygon.getHole(i));
-            }
-            return geomFactory.createPolygon(outerShell, holes);
-        }
-
-        private org.locationtech.jts.geom.LinearRing buildLinearRing(LinearRing ring) throws RuntimeException {
-            final Coordinate[] coordinates = new Coordinate[ring.length()];
-            for (int i = 0; i < ring.length(); i++) {
-                final double x = SphericalMercatorUtils.lonToSphericalMercator(ring.getX(i));
-                final double y = SphericalMercatorUtils.latToSphericalMercator(ring.getY(i));
-                coordinates[i] = new Coordinate(x, y);
-            }
-            return geomFactory.createLinearRing(coordinates);
+            /*
+              Elasticsearch accepts polygons that overlap but this causes issues on JTS algorithms. It is then
+              important to transform each polygon individually, therefore we treat it as a collection.
+             */
+            return buildCollection(multiPolygon);
         }
 
         @Override
         public org.locationtech.jts.geom.Geometry visit(Rectangle rectangle) throws RuntimeException {
-            final double xMin = SphericalMercatorUtils.lonToSphericalMercator(rectangle.getMinX());
-            final double yMin = SphericalMercatorUtils.latToSphericalMercator(rectangle.getMinY());
-            final double xMax = SphericalMercatorUtils.lonToSphericalMercator(rectangle.getMaxX());
-            final double yMax = SphericalMercatorUtils.latToSphericalMercator(rectangle.getMaxY());
-            if (rectangle.getMinX() > rectangle.getMaxX()) {
-                // crosses dateline
-                final Envelope westEnvelope = new Envelope(-SphericalMercatorUtils.MERCATOR_BOUNDS, xMax, yMin, yMax);
-                final Envelope eastEnvelope = new Envelope(xMin, SphericalMercatorUtils.MERCATOR_BOUNDS, yMin, yMax);
-                return geomFactory.buildGeometry(List.of(geomFactory.toGeometry(westEnvelope), geomFactory.toGeometry(eastEnvelope)));
-            } else {
-                final Envelope envelope = new Envelope(xMin, xMax, yMin, yMax);
-                return geomFactory.toGeometry(envelope);
+            return toMVTGeometry(buildMercatorRectangle(geomFactory, rectangle));
+        }
+
+        private org.locationtech.jts.geom.Geometry toMVTGeometry(org.locationtech.jts.geom.Geometry geometry) {
+            // clip geometry
+            geometry = clipGeometry(clipTile, geometry);
+            if (geometry == null) {
+                return null;
             }
+            // simplify it
+            geometry = TopologyPreservingSimplifier.simplify(geometry, pixelPrecision);
+            // convert coordinates to MVT geometry
+            geometry.apply(sequenceFilter);
+            return geometry;
+        }
+
+        private org.locationtech.jts.geom.Geometry buildCollection(GeometryCollection<?> collection) {
+            final List<org.locationtech.jts.geom.Geometry> geoms = new ArrayList<>(collection.size());
+            for (int i = 0; i < collection.size(); i++) {
+                final org.locationtech.jts.geom.Geometry geometry = collection.get(i).visit(this);
+                if (geometry != null) {
+                    /*
+                    Simplification can transform simple shae sin multi-shapes, we flat them out here so multi-polygons
+                    and multilines are not transform to geometry collections.
+                     */
+                    for (int j = 0; j < geometry.getNumGeometries(); j++) {
+                        geoms.add(geometry.getGeometryN(j));
+                    }
+                }
+            }
+            return geomFactory.buildGeometry(geoms);
         }
     }
 
@@ -332,6 +258,99 @@ public class FeatureFactory {
 
         private int lon(double lon) {
             return (int) Math.round(pointXScale * lon + pointXTranslate);
+        }
+    }
+
+    private static org.locationtech.jts.geom.Polygon buildMercatorPolygon(GeometryFactory geomFactory, Polygon polygon) {
+        final org.locationtech.jts.geom.LinearRing outerShell = buildMercatorLinearRing(geomFactory, polygon.getPolygon());
+        if (polygon.getNumberOfHoles() == 0) {
+            return geomFactory.createPolygon(outerShell);
+        }
+        final org.locationtech.jts.geom.LinearRing[] holes = new org.locationtech.jts.geom.LinearRing[polygon.getNumberOfHoles()];
+        for (int i = 0; i < polygon.getNumberOfHoles(); i++) {
+            holes[i] = buildMercatorLinearRing(geomFactory, polygon.getHole(i));
+        }
+        return geomFactory.createPolygon(outerShell, holes);
+    }
+
+    private static org.locationtech.jts.geom.LinearRing buildMercatorLinearRing(GeometryFactory geomFactory, LinearRing ring) {
+        return geomFactory.createLinearRing(Mercator(ring));
+    }
+
+    private static LineString buildMercatorLine(GeometryFactory geomFactory, Line line) {
+        return geomFactory.createLineString(Mercator(line));
+    }
+
+    private static Coordinate[] Mercator(Line line) {
+        final Coordinate[] coordinates = new Coordinate[line.length()];
+        for (int i = 0; i < line.length(); i++) {
+            final double x = SphericalMercatorUtils.lonToSphericalMercator(line.getX(i));
+            final double y = SphericalMercatorUtils.latToSphericalMercator(line.getY(i));
+            coordinates[i] = new Coordinate(x, y);
+        }
+        return coordinates;
+    }
+
+    private static org.locationtech.jts.geom.Geometry buildMercatorRectangle(GeometryFactory geomFactory, Rectangle rectangle) {
+        final double xMin = SphericalMercatorUtils.lonToSphericalMercator(rectangle.getMinX());
+        final double yMin = SphericalMercatorUtils.latToSphericalMercator(rectangle.getMinY());
+        final double xMax = SphericalMercatorUtils.lonToSphericalMercator(rectangle.getMaxX());
+        final double yMax = SphericalMercatorUtils.latToSphericalMercator(rectangle.getMaxY());
+        final org.locationtech.jts.geom.Geometry geometry;
+        if (rectangle.getMinX() > rectangle.getMaxX()) {
+            // crosses dateline
+            final Envelope westEnvelope = new Envelope(-SphericalMercatorUtils.MERCATOR_BOUNDS, xMax, yMin, yMax);
+            final Envelope eastEnvelope = new Envelope(xMin, SphericalMercatorUtils.MERCATOR_BOUNDS, yMin, yMax);
+            geometry = geomFactory.buildGeometry(List.of(geomFactory.toGeometry(westEnvelope), geomFactory.toGeometry(eastEnvelope)));
+        } else {
+            final Envelope envelope = new Envelope(xMin, xMax, yMin, yMax);
+            geometry = geomFactory.toGeometry(envelope);
+        }
+        return geometry;
+    }
+
+    private static org.locationtech.jts.geom.Point buildMercatorPoint(GeometryFactory geomFactory, Point point) {
+        final double x = SphericalMercatorUtils.lonToSphericalMercator(point.getX());
+        final double y = SphericalMercatorUtils.latToSphericalMercator(point.getY());
+        return geomFactory.createPoint(new Coordinate(x, y));
+    }
+
+    private static org.locationtech.jts.geom.MultiPoint buildMercatorMultiPoint(GeometryFactory geomFactory, MultiPoint multiPoint) {
+        final org.locationtech.jts.geom.Point[] points = new org.locationtech.jts.geom.Point[multiPoint.size()];
+        for (int i = 0; i < multiPoint.size(); i++) {
+            points[i] = buildMercatorPoint(geomFactory, multiPoint.get(i));
+        }
+        Arrays.sort(
+            points,
+            Comparator.comparingDouble(org.locationtech.jts.geom.Point::getX).thenComparingDouble(org.locationtech.jts.geom.Point::getY)
+        );
+        return geomFactory.createMultiPoint(points);
+    }
+
+    private static org.locationtech.jts.geom.Geometry clipGeometry(
+        org.locationtech.jts.geom.Geometry envelope,
+        org.locationtech.jts.geom.Geometry geometry
+    ) {
+        assert geometry.getNumGeometries() == 1 || geometry instanceof org.locationtech.jts.geom.MultiPoint;
+        try {
+            final IntersectionMatrix matrix = envelope.relate(geometry);
+            if (matrix.isContains()) {
+                // no need to clip
+                return geometry;
+            } else if (matrix.isWithin()) {
+                // the clipped geometry is the envelope
+                return envelope.copy();
+            } else if (matrix.isIntersects()) {
+                // clip it (clone envelope as coordinates are copied by reference)
+                return envelope.copy().intersection(geometry);
+            } else {
+                // disjoint
+                assert envelope.copy().intersection(geometry).isEmpty();
+                return null;
+            }
+        } catch (TopologyException ex) {
+            // we should never get here but just to be super safe because a TopologyException will kill the node
+            throw new IllegalArgumentException(ex);
         }
     }
 }

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactory.java
@@ -331,7 +331,6 @@ public class FeatureFactory {
         org.locationtech.jts.geom.Geometry envelope,
         org.locationtech.jts.geom.Geometry geometry
     ) {
-        assert geometry.getNumGeometries() == 1 || geometry instanceof org.locationtech.jts.geom.MultiPoint;
         try {
             final IntersectionMatrix matrix = envelope.relate(geometry);
             if (matrix.isContains()) {

--- a/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
+++ b/x-pack/plugin/vector-tile/src/test/java/org/elasticsearch/xpack/vectortile/feature/FeatureFactoryTests.java
@@ -104,6 +104,16 @@ public class FeatureFactoryTests extends ESTestCase {
         });
     }
 
+    public void testNestedGeometryCollection() throws IOException {
+        doTestGeometry(this::buildNestedGeometryCollection, features -> {
+            assertThat(features.size(), Matchers.equalTo(4));
+            assertThat(features.get(0).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.LINESTRING));
+            assertThat(features.get(1).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
+            assertThat(features.get(2).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.LINESTRING));
+            assertThat(features.get(3).getType(), Matchers.equalTo(VectorTile.Tile.GeomType.POLYGON));
+        });
+    }
+
     private void doTestGeometry(Function<Rectangle, Geometry> provider, Consumer<List<VectorTile.Tile.Feature>> consumer)
         throws IOException {
         final int z = randomIntBetween(3, 10);
@@ -165,6 +175,10 @@ public class FeatureFactoryTests extends ESTestCase {
 
     private GeometryCollection<Geometry> buildGeometryCollection(Rectangle r) {
         return new GeometryCollection<>(List.of(buildPolygon(r), buildLine(r)));
+    }
+
+    private GeometryCollection<Geometry> buildNestedGeometryCollection(Rectangle r) {
+        return new GeometryCollection<>(List.of(buildPolygon(r), buildLine(r), buildGeometryCollection(r)));
     }
 
     public void testStackOverflowError() throws IOException, ParseException {
@@ -230,7 +244,7 @@ public class FeatureFactoryTests extends ESTestCase {
                 GeoTileUtils.toBoundingBox(2 * x + 1, 2 * y + 1, z + 1)
             )
         );
-        assertThat(builder.getFeatures(withinCollection), iterableWithSize(4));
+        assertThat(builder.getFeatures(withinCollection), iterableWithSize(1));
         // intersecting geometries
         assertThat(builder.getFeatures(expandByHalf(GeoTileUtils.toBoundingBox(2 * x, 2 * y, z + 1))), iterableWithSize(1));
         assertThat(builder.getFeatures(expandByHalf(GeoTileUtils.toBoundingBox(2 * x + 1, 2 * y, z + 1))), iterableWithSize(1));
@@ -242,14 +256,14 @@ public class FeatureFactoryTests extends ESTestCase {
                 expandByHalf(GeoTileUtils.toBoundingBox(2 * x + 1, 2 * y, z + 1))
             )
         );
-        assertThat(builder.getFeatures(intersectCollection), iterableWithSize(2));
+        assertThat(builder.getFeatures(intersectCollection), iterableWithSize(1));
         // contain geometries
         assertThat(builder.getFeatures(GeoTileUtils.toBoundingBox(x / 4, y / 4, z - 2)), iterableWithSize(1));
         assertThat(builder.getFeatures(GeoTileUtils.toBoundingBox(x / 4, y / 4, z - 2)), iterableWithSize(1));
         final GeometryCollection<Geometry> containCollection = new GeometryCollection<>(
             List.of(GeoTileUtils.toBoundingBox(x / 4, y / 4, z - 2), GeoTileUtils.toBoundingBox(x / 4, y / 4, z - 2))
         );
-        assertThat(builder.getFeatures(containCollection), iterableWithSize(2));
+        assertThat(builder.getFeatures(containCollection), iterableWithSize(1));
     }
 
     private Rectangle expandByHalf(Rectangle rectangle) {
@@ -332,6 +346,43 @@ public class FeatureFactoryTests extends ESTestCase {
             windingSum += (xs[j] - xs[numPts]) * (ys[i] - ys[numPts]) - (ys[j] - ys[numPts]) * (xs[i] - xs[numPts]);
         }
         return windingSum;
+    }
+
+    public void testOverlappingMultiPolygon() {
+        // Overlapping multipolygon are accepted by Elasticsearch but is invalid for JTS (not OGC complaint).
+        // Make sure we handle overlapping multi-polygons properly
+        final Rectangle r1 = new Rectangle(-160, 160, 90, -80);
+        final Rectangle r2 = new Rectangle(-159, 161, 79, -81);
+        MultiPolygon multiPolygon = new MultiPolygon(List.of(toPolygon(r1), toPolygon(r2)));
+        final FeatureFactory builder = new FeatureFactory(0, 0, 0, 4096, 5);
+        assertThat(builder.getFeatures(multiPolygon), iterableWithSize(1));
+    }
+
+    public void testIntersectingMultiLine() {
+        // make sure we handle intersecting multi-lines properly
+        final Line l1 = new Line(new double[] { -180, 180 }, new double[] { 90, -90 });
+        final Line l2 = new Line(new double[] { -180, 180 }, new double[] { -90, 90 });
+        MultiLine multiLine = new MultiLine(List.of(l1, l2));
+        final FeatureFactory builder = new FeatureFactory(0, 0, 0, 4096, 5);
+        assertThat(builder.getFeatures(multiLine), iterableWithSize(1));
+    }
+
+    public void testRepeatedMultiPoint() {
+        final Point p1 = new Point(0, 0);
+        final Point p2 = new Point(10, 10);
+        final Point p3 = new Point(0, 0);
+        MultiPoint multiPoint = new MultiPoint(List.of(p1, p2, p3));
+        final FeatureFactory builder = new FeatureFactory(0, 0, 0, 4096, 5);
+        assertThat(builder.getFeatures(multiPoint), iterableWithSize(1));
+    }
+
+    private Polygon toPolygon(Rectangle r) {
+        return new Polygon(
+            new LinearRing(
+                new double[] { r.getMinX(), r.getMaxX(), r.getMaxX(), r.getMinX(), r.getMinX() },
+                new double[] { r.getMinY(), r.getMinY(), r.getMaxY(), r.getMaxY(), r.getMinY() }
+            )
+        );
     }
 
 }


### PR DESCRIPTION
We are using JTS algorithms to transform a geometry into a vector tiles feature. This algorithms seems to fail sometimes if the geometry is a multi-geometry like a multi-polygon. When the algorithm fails in will throw a `TopologyException` which is currently ignored and the geometry will not be added to the tile.  

This PR changes the way we handle multi-polygons and multi-lines so each component is clipped and simplify in its own to prevent such errors.