### PR TITLE
Add origin of synonym rules to exception message

### DIFF
--- a/docs/changelog/93702.yaml
+++ b/docs/changelog/93702.yaml
@@ -1,0 +1,5 @@
+pr: 93702
+summary: Add origin of synonym rules to exception message
+area: Analysis
+type: enhancement
+issues: []

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -42,7 +42,8 @@ public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
         Function<String, TokenFilterFactory> allFilters
     ) {
         final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters);
-        final SynonymMap synonyms = buildSynonyms(analyzer, getRulesFromSettings(environment));
+        ReaderWithOrigin rulesFromSettings = getRulesFromSettings(environment);
+        final SynonymMap synonyms = buildSynonyms(analyzer, rulesFromSettings);
         final String name = name();
         return new TokenFilterFactory() {
             @Override

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymTokenFilterFactory.java
@@ -80,7 +80,8 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         Function<String, TokenFilterFactory> allFilters
     ) {
         final Analyzer analyzer = buildSynonymAnalyzer(tokenizer, charFilters, previousTokenFilters);
-        final SynonymMap synonyms = buildSynonyms(analyzer, getRulesFromSettings(environment));
+        ReaderWithOrigin rulesFromSettings = getRulesFromSettings(environment);
+        final SynonymMap synonyms = buildSynonyms(analyzer, rulesFromSettings);
         final String name = name();
         return new TokenFilterFactory() {
             @Override
@@ -120,37 +121,37 @@ public class SynonymTokenFilterFactory extends AbstractTokenFilterFactory {
         );
     }
 
-    SynonymMap buildSynonyms(Analyzer analyzer, Reader rules) {
+    SynonymMap buildSynonyms(Analyzer analyzer, ReaderWithOrigin rules) {
         try {
             SynonymMap.Builder parser;
             if ("wordnet".equalsIgnoreCase(format)) {
                 parser = new ESWordnetSynonymParser(true, expand, lenient, analyzer);
-                ((ESWordnetSynonymParser) parser).parse(rules);
+                ((ESWordnetSynonymParser) parser).parse(rules.reader);
             } else {
                 parser = new ESSolrSynonymParser(true, expand, lenient, analyzer);
-                ((ESSolrSynonymParser) parser).parse(rules);
+                ((ESSolrSynonymParser) parser).parse(rules.reader);
             }
             return parser.build();
         } catch (Exception e) {
-            throw new IllegalArgumentException("failed to build synonyms", e);
+            throw new IllegalArgumentException("failed to build synonyms from [" + rules.origin + "]", e);
         }
     }
 
-    Reader getRulesFromSettings(Environment env) {
-        Reader rulesReader;
+    protected ReaderWithOrigin getRulesFromSettings(Environment env) {
         if (settings.getAsList("synonyms", null) != null) {
             List<String> rulesList = Analysis.getWordList(env, settings, "synonyms");
             StringBuilder sb = new StringBuilder();
             for (String line : rulesList) {
                 sb.append(line).append(System.lineSeparator());
             }
-            rulesReader = new StringReader(sb.toString());
+            return new ReaderWithOrigin(new StringReader(sb.toString()), "'" + name() + "' analyzer settings");
         } else if (settings.get("synonyms_path") != null) {
-            rulesReader = Analysis.getReaderFromFile(env, settings, "synonyms_path");
+            String synonyms_path = settings.get("synonyms_path", null);
+            return new ReaderWithOrigin(Analysis.getReaderFromFile(env, synonyms_path, "synonyms_path"), synonyms_path);
         } else {
             throw new IllegalArgumentException("synonym requires either `synonyms` or `synonyms_path` to be configured");
         }
-        return rulesReader;
     }
 
+    record ReaderWithOrigin(Reader reader, String origin) {};
 }

--- a/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/Analysis.java
@@ -271,9 +271,7 @@ public class Analysis {
      * @throws IllegalArgumentException
      *          If the Reader can not be instantiated.
      */
-    public static Reader getReaderFromFile(Environment env, Settings settings, String settingPrefix) {
-        String filePath = settings.get(settingPrefix, null);
-
+    public static Reader getReaderFromFile(Environment env, String filePath, String settingPrefix) {
         if (filePath == null) {
             return null;
         }


### PR DESCRIPTION
Currently, most failures to load a synonym file are wrapped into an IAE that doesn't contain much information about which origin the failure comes from (either the analyzer setting or the file name that contains the synonym definition responsible for the error).
This change improves that situation by adding wither the analyzer or the file name we try to load from to the exception message.
