### PR TITLE
Test fix, refresh index before searching watcher history(#93633)

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -60,7 +60,7 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
         assertThat(putWatchResponse.isCreated(), is(true));
 
         assertBusy(() -> {
-            client().admin().indices().prepareRefresh(".watcher-history*");
+            client().admin().indices().prepareRefresh(".watcher-history*").get();
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, is(greaterThanOrEqualTo(1L)));
         }, 30, TimeUnit.SECONDS);


### PR DESCRIPTION
Fixed small bug in test `SingleNodeTests testThatLoadingWithNonExistingIndexWorks`. 

It appears the `.get()` was  missing from the statement `client().admin().indices().prepareRefresh(".watcher-history*")`. When CI was slow, it was possible that the index wasn't initialized when the subsequent search would happen and it would fail. 

We managed to reproduce it, by running it multiple times locally during a zoom call.

Fixes #93633 