### PR TITLE
Allow low level paging in LeafDocLookup

### DIFF
--- a/docs/changelog/93711.yaml
+++ b/docs/changelog/93711.yaml
@@ -1,0 +1,5 @@
+pr: 93711
+summary: Allow low level paging in `LeafDocLookup`
+area: Infra/Scripting
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -18,7 +18,6 @@ import org.elasticsearch.script.field.DocValuesScriptFieldFactory;
 import org.elasticsearch.script.field.Field;
 
 import java.io.IOException;
-import java.lang.reflect.AccessibleObject;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Collection;

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafDocLookup.java
@@ -172,15 +172,15 @@ public class LeafDocLookup implements Map<String, ScriptDocValues<?>> {
 
     // ensures the factory is advanced to the current doc
     private void advanceToDoc(DocValuesScriptFieldFactory factory) {
-        try {
-            // advancing to the current doc could trigger low level paging, network loading, etc, so do so outside scripting privileges
-            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+        // advancing to the current doc could trigger low level paging, network loading, etc, so do so outside scripting privileges
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            try {
                 factory.setNextDocId(docId);
-                return null;
-            });
-        } catch (IOException ioe) {
-            throw ExceptionsHelper.convertToElastic(ioe);
-        }
+            } catch (IOException ioe) {
+                throw ExceptionsHelper.convertToElastic(ioe);
+            }
+            return null;
+        });
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.search.lookup;
 
-import net.bytebuddy.build.AccessControllerPlugin;
-
 import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
@@ -429,9 +427,7 @@ public class LeafDocLookupTests extends ESTestCase {
         nextDocCallback = i -> SpecialPermission.check();
 
         // mimic the untrusted codebase, which gets no permissions
-        var restrictedContext = new AccessControlContext(
-            new ProtectionDomain[] { new ProtectionDomain(null, null) }
-        );
+        var restrictedContext = new AccessControlContext(new ProtectionDomain[] { new ProtectionDomain(null, null) });
         AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
             ScriptDocValues<?> fetchedDocValues = docLookup.get("field");
             assertEquals(docValues, fetchedDocValues);

--- a/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/search/lookup/LeafDocLookupTests.java
@@ -7,6 +7,9 @@
  */
 package org.elasticsearch.search.lookup;
 
+import net.bytebuddy.build.AccessControllerPlugin;
+
+import org.elasticsearch.SpecialPermission;
 import org.elasticsearch.index.fielddata.IndexFieldData;
 import org.elasticsearch.index.fielddata.LeafFieldData;
 import org.elasticsearch.index.fielddata.ScriptDocValues;
@@ -22,8 +25,13 @@ import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.security.AccessControlContext;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.ProtectionDomain;
 import java.util.Map;
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 
 import static org.elasticsearch.index.mapper.MappedFieldType.FielddataOperation.SCRIPT;
 import static org.elasticsearch.index.mapper.MappedFieldType.FielddataOperation.SEARCH;
@@ -36,6 +44,7 @@ import static org.mockito.Mockito.when;
 public class LeafDocLookupTests extends ESTestCase {
     private ScriptDocValues<?> docValues;
     private LeafDocLookup docLookup;
+    private Consumer<Integer> nextDocCallback;
 
     @Override
     @Before
@@ -43,6 +52,7 @@ public class LeafDocLookupTests extends ESTestCase {
         super.setUp();
 
         docValues = mock(ScriptDocValues.class);
+        nextDocCallback = i -> {}; // do nothing by default
 
         MappedFieldType fieldType1 = mock(MappedFieldType.class);
         when(fieldType1.name()).thenReturn("field");
@@ -106,7 +116,7 @@ public class LeafDocLookupTests extends ESTestCase {
         DelegateDocValuesField delegateDocValuesField = new DelegateDocValuesField(scriptDocValues, name) {
             @Override
             public void setNextDocId(int id) {
-                // do nothing
+                nextDocCallback.accept(id);
             }
         };
         LeafFieldData leafFieldData = mock(LeafFieldData.class);
@@ -413,5 +423,19 @@ public class LeafDocLookupTests extends ESTestCase {
         assertEquals(2, leafDocLookup.docFactoryCache.size());
         assertEquals(docFactory, leafDocLookup.docFactoryCache.get(nameDoc));
         assertEquals(docAndSourceDocFactory, leafDocLookup.docFactoryCache.get(nameDocAndSource));
+    }
+
+    public void testLookupPrivilegesAdvanceDoc() {
+        nextDocCallback = i -> SpecialPermission.check();
+
+        // mimic the untrusted codebase, which gets no permissions
+        var restrictedContext = new AccessControlContext(
+            new ProtectionDomain[] { new ProtectionDomain(null, null) }
+        );
+        AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+            ScriptDocValues<?> fetchedDocValues = docLookup.get("field");
+            assertEquals(docValues, fetchedDocValues);
+            return null;
+        }, restrictedContext);
     }
 }


### PR DESCRIPTION
Accessing a field from a script may require lots of low level operations for which scripts do not have access. Initial loading of doc values allows this access with appropriate doPrivileged calls, but advancing to the curent document does not. This commit also protects advancing docs in the same way.
