### PR TITLE
[8.7] Test fix, refresh index before searching watcher history(#93633) (#93710)

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -60,7 +60,7 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
         assertThat(putWatchResponse.isCreated(), is(true));
 
         assertBusy(() -> {
-            client().admin().indices().prepareRefresh(".watcher-history*");
+            client().admin().indices().prepareRefresh(".watcher-history*").get();
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, is(greaterThanOrEqualTo(1L)));
         }, 30, TimeUnit.SECONDS);


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Test fix, refresh index before searching watcher history(#93633) (#93710)