### PR TITLE
Update build scan configuration to support Buildkite

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -121,11 +121,11 @@ buildScan {
       buildScanPublished { scan ->
         // Attach build scan link as build metadata
         // See: https://buildkite.com/docs/pipelines/build-meta-data
-        "buildkite-agent meta-data set build-scan-${System.getenv('BUILDKITE_JOB_ID')} ${scan.buildScanUri}".execute()
+        ['buildkite-agent', 'meta-data', 'set', "build-scan-${System.getenv('BUILDKITE_JOB_ID')}", "${scan.buildScanUri}"].execute()
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        "buildkite-agent annotate --context gradle-build-scans --append --style info 'Gradle build scan `[link](${scan.buildScanUri})`'".execute()
+        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', "Build scan for '${System.getenv('BUILDKITE_LABEL')}': [`gradle ${gradle.startParameter.taskNames.join(' ')}`](${scan.buildScanUri})"].execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        def body = """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> <img class="emoji" title="gradle" alt=":gradle:" draggable="false" src="https://buildkiteassets.com/emojis/img-buildkite-64/gradle.png"> build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+        def body = """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
         ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', body].execute()
       }
     } else {

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -120,7 +120,10 @@ buildScan {
 
       buildScanPublished { scan ->
         // Find existing build scan metadata so we can increment the key index
-        def count = 'buildkite-agent meta-data keys'.execute().text.readLines()
+
+        def text = 'buildkite-agent meta-data keys'.execute().text
+        println text
+        def count = text.readLines()
           .findAll { it.startsWith('build-scan-') }
           .collect { Integer.parseInt(it.substring(11)) }
           .max() ?: -1
@@ -131,7 +134,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        "buildkite-agent annotate --context gradle-build-scans --append --style info \"Gradle build scan for '${System.getenv('BUILDKITE_LABEL')}': [`gradle ${gradle.startParameter.taskNames.join(' ')}`](${scan.buildScanUri})\"".execute()
+        "buildkite-agent annotate --context gradle-build-scans --append --style info \"Gradle build scan '${count}'\"".execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -119,22 +119,13 @@ buildScan {
       }
 
       buildScanPublished { scan ->
-        // Find existing build scan metadata so we can increment the key index
-
-        def text = 'buildkite-agent meta-data keys'.execute().text
-        println text
-        def count = text.readLines()
-          .findAll { it.startsWith('build-scan-') }
-          .collect { Integer.parseInt(it.substring(11)) }
-          .max() ?: -1
-
         // Attach build scan link as build metadata
         // See: https://buildkite.com/docs/pipelines/build-meta-data
-        "buildkite-agent meta-data set build-scan-${count + 1} ${scan.buildScanUri}".execute()
+        "buildkite-agent meta-data set build-scan-${System.getenv('BUILDKITE_STEP_ID')} ${scan.buildScanUri}".execute()
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        "buildkite-agent annotate --context gradle-build-scans --append --style info \"Gradle build scan '${count}'\"".execute()
+        "buildkite-agent annotate --context gradle-build-scans --append --style info 'Gradle build scan ${count}'".execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -132,7 +132,7 @@ buildScan {
         def count = 'buildkite-agent meta-data keys'.execute().text.readLines()
           .findAll { it.startsWith('build-scan-') }
           .collect { Integer.parseInt(it.substring(11)) }
-          .max()
+          .max() ?: -1
         "buildkite-agent meta-data set 'build-scan-${count + 1}' '${scan.buildScanUri}'"
       }
     } else {

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        "buildkite-agent annotate --context gradle-build-scans --append --style info 'Gradle build scan'".execute()
+        "buildkite-agent annotate --context gradle-build-scans --append --style info 'Gradle build scan `[link](${scan.buildScanUri})`'".execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -101,7 +101,7 @@ buildScan {
     } else {
 
       def buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
-      if(buildKiteUrl) {
+      if (buildKiteUrl) {
         // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
         uploadInBackground = false
 

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', """<div class="mb3">Build scan for <span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> <a href="${scan.buildScanUri}"><p><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></p></a></div>"""].execute()
+        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> <span class="bold">Build scan for:</span> <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""].execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -12,6 +12,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import org.gradle.initialization.BuildRequestMetaData
 import org.elasticsearch.gradle.internal.test.rerun.TestRerunPlugin
 import java.util.concurrent.TimeUnit
+import java.util.regex.Matcher
 
 long startTime = project.gradle.services.get(BuildRequestMetaData).getStartTime()
 
@@ -104,7 +105,8 @@ buildScan {
       uploadInBackground = false
 
       def branch = System.getenv('BUILDKITE_BRANCH')
-      def repository = (System.getenv('BUILDKITE_REPO') =~ /(https:\/\/github\.com\/|git@github\.com:)(\S+)\.git/).group(2)
+      def repoMatcher = System.getenv('BUILDKITE_REPO') =~ /(https:\/\/github\.com\/|git@github\.com:)(\S+)\.git/
+      def repository = repoMatcher.matches() ? repoMatcher.group(2) : "<unknown>"
       tag 'CI'
       link 'CI Build', buildKiteUrl
       value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
@@ -118,8 +120,7 @@ buildScan {
         tag "pr/${prId}"
         tag 'pull-request'
         link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
-        def prUrl = "https://github.com/${repository}/pull/${prId}"
-        link 'Pull Request', prUrl
+        link 'Pull Request', "https://github.com/${repository}/pull/${prId}"
       } else {
         value 'Git Commit ID', BuildParams.gitRevision
         link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -100,7 +100,7 @@ buildScan {
       }
     } else {
 
-      URL buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
+      def buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
       if(buildKiteUrl) {
         // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
         uploadInBackground = false

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -119,7 +119,7 @@ buildScan {
           tag "pr/${prId}"
           tag 'pull-request'
           link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
-          def prUrl = "${prBaseUrl}/pulls/${prId}"
+          def prUrl = "${prBaseUrl}/pull/${prId}"
           link 'Pull Request', prUrl
         } else {
           def repoUrl = System.getenv('BUILDKITE_REPO')

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -126,6 +126,15 @@ buildScan {
         link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"
         tag branch
       }
+
+      buildScanPublished { scan ->
+        // Find existing build scan metadata so we can increment the key index
+        def count = 'buildkite-agent meta-data keys'.execute().text.readLines()
+          .findAll { it.startsWith('build-scan-') }
+          .collect { Integer.parseInt(it.substring(11)) }
+          .max()
+        "buildkite-agent meta-data set 'build-scan-${count + 1}' '${scan.buildScanUri}'"
+      }
     } else {
       tag 'LOCAL'
     }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        "buildkite-agent annotate --context gradle-build-scans --append --style info 'Gradle build scan ${count}'".execute()
+        "buildkite-agent annotate --context gradle-build-scans --append --style info 'Gradle build scan'".execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -133,7 +133,7 @@ buildScan {
           .findAll { it.startsWith('build-scan-') }
           .collect { Integer.parseInt(it.substring(11)) }
           .max() ?: -1
-        "buildkite-agent meta-data set 'build-scan-${count + 1}' '${scan.buildScanUri}'"
+        "buildkite-agent meta-data set 'build-scan-${count + 1}' '${scan.buildScanUri}'".execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -121,7 +121,7 @@ buildScan {
       buildScanPublished { scan ->
         // Attach build scan link as build metadata
         // See: https://buildkite.com/docs/pipelines/build-meta-data
-        "buildkite-agent meta-data set build-scan-${System.getenv('BUILDKITE_STEP_ID')} ${scan.buildScanUri}".execute()
+        "buildkite-agent meta-data set build-scan-${System.getenv('BUILDKITE_JOB_ID')} ${scan.buildScanUri}".execute()
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        def body = """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> <span class="bold">Build scan for:</span> <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+        def body = """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> <img class="emoji" title="gradle" alt=":gradle:" draggable="false" src="https://buildkiteassets.com/emojis/img-buildkite-64/gradle.png"> build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
         ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', body].execute()
       }
     } else {

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -17,6 +17,7 @@ long startTime = project.gradle.services.get(BuildRequestMetaData).getStartTime(
 
 buildScan {
   URL jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
+  String buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
 
   // Automatically publish scans from Elasticsearch CI
   if (jenkinsUrl?.host?.endsWith('elastic.co') || jenkinsUrl?.host?.endsWith('elastic.dev')) {
@@ -98,40 +99,36 @@ buildScan {
         value 'Git Commit ID', BuildParams.gitRevision
         link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
       }
-    } else {
+    } else if (buildKiteUrl) {
+      // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
+      uploadInBackground = false
 
-      def buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
-      if (buildKiteUrl) {
-        // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
-        uploadInBackground = false
+      def branch = System.getenv('BUILDKITE_BRANCH')
+      tag 'CI'
+      link 'CI Build', buildKiteUrl
+      tag branch
+      value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
 
-        def branch = System.getenv('BUILDKITE_BRANCH')
-        tag 'CI'
-        link 'CI Build', buildKiteUrl
-        tag branch
-        value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
-
-        // Add SCM information
-        def prId = System.getenv('BUILDKITE_PULL_REQUEST')
-        if (prId) {
-          def prBaseUrl = (System.getenv('BUILDKITE_PULL_REQUEST_REPO') - ".git")
-          value 'Git Commit ID', System.getenv('ghprbActualCommit')
-          tag "pr/${prId}"
-          tag 'pull-request'
-          link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
-          def prUrl = "${prBaseUrl}/pull/${prId}"
-          link 'Pull Request', prUrl
-        } else {
-          def repoUrl = System.getenv('BUILDKITE_REPO')
-          if (repoUrl.startsWith('git@github')) {
-            repoUrl = repoUrl.replaceAll("git\\@github\\.com\\:", "https://github.com/").replaceAll("\\.git", "/tree/$branch")
-          }
-          value 'Git Commit ID', BuildParams.gitRevision
-          link 'Source', "${repoBaseUrl}/tree/${BuildParams.gitRevision}"
-        }
+      // Add SCM information
+      def prId = System.getenv('BUILDKITE_PULL_REQUEST')
+      if (prId) {
+        def prBaseUrl = (System.getenv('BUILDKITE_PULL_REQUEST_REPO') - ".git")
+        value 'Git Commit ID', System.getenv('BUILDKITE_COMMIT')
+        tag "pr/${prId}"
+        tag 'pull-request'
+        link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
+        def prUrl = "${prBaseUrl}/pull/${prId}"
+        link 'Pull Request', prUrl
       } else {
-        tag 'LOCAL'
+        def repoUrl = System.getenv('BUILDKITE_REPO')
+        if (repoUrl.startsWith('git@github')) {
+          repoUrl = repoUrl.replaceAll("git\\@github\\.com\\:", "https://github.com/").replaceAll("\\.git", "/tree/$branch")
+        }
+        value 'Git Commit ID', BuildParams.gitRevision
+        link 'Source', "${repoBaseUrl}/tree/${BuildParams.gitRevision}"
       }
+    } else {
+      tag 'LOCAL'
     }
   }
 }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', "Build scan for '${System.getenv('BUILDKITE_LABEL')}': [`gradle ${gradle.startParameter.taskNames.join(' ')}`](${scan.buildScanUri})"].execute()
+        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', "<p>Build scan for <span class=\"p1 border\">${System.getenv('BUILDKITE_LABEL')}</span>' - [`gradle ${gradle.startParameter.taskNames.join(' ')}`](${scan.buildScanUri})</p>"].execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -10,11 +10,6 @@ import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.gradle.initialization.BuildRequestMetaData
-import org.elasticsearch.gradle.internal.test.rerun.TestRerunPlugin
-import java.util.concurrent.TimeUnit
-import java.util.regex.Matcher
-
-long startTime = project.gradle.services.get(BuildRequestMetaData).getStartTime()
 
 buildScan {
   URL jenkinsUrl = System.getenv('JENKINS_URL') ? new URL(System.getenv('JENKINS_URL')) : null
@@ -48,13 +43,9 @@ buildScan {
 
       // Link to Jenkins worker logs and system metrics
       if (nodeName) {
-        link 'System logs', "https://ci-stats.elastic.co/app/infra#/logs?" +
-                "&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
+        link 'System logs', "https://ci-stats.elastic.co/app/infra#/logs?&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
         buildFinished {
-          link 'System metrics', "https://ci-stats.elastic.co/app/metrics/detail/host/" +
-                  "${nodeName}?_g=()&metricTime=(autoReload:!f,refreshInterval:5000," +
-                  "time:(from:${startTime - TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)},interval:%3E%3D1m," +
-                  "to:${System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)}))"
+          link 'System metrics', "https://ci-stats.elastic.co/app/metrics/detail/host/${nodeName}"
         }
       }
 
@@ -100,7 +91,7 @@ buildScan {
         value 'Git Commit ID', BuildParams.gitRevision
         link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
       }
-    } else if (buildKiteUrl) {
+    } else if (buildKiteUrl) { //Buildkite-specific build scan metadata
       // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
       uploadInBackground = false
 
@@ -133,28 +124,17 @@ buildScan {
           .findAll { it.startsWith('build-scan-') }
           .collect { Integer.parseInt(it.substring(11)) }
           .max() ?: -1
-        "buildkite-agent meta-data set 'build-scan-${count + 1}' '${scan.buildScanUri}'".execute()
+
+        // Attach build scan link as build metadata
+        // See: https://buildkite.com/docs/pipelines/build-meta-data
+        "buildkite-agent meta-data set build-scan-${count + 1} ${scan.buildScanUri}".execute()
+
+        // Add a build annotation
+        // See: https://buildkite.com/docs/agent/v3/cli-annotate
+        "buildkite-agent annotate --context gradle-build-scans --append --style info \"Gradle build scan for '${System.getenv('BUILDKITE_LABEL')}': [`gradle ${gradle.startParameter.taskNames.join(' ')}`](${scan.buildScanUri})\"".execute()
       }
     } else {
       tag 'LOCAL'
     }
-  }
-}
-
-subprojects {
-  project.getPlugins().withType(TestRerunPlugin) {
-    tasks.withType(Test).configureEach(new Action<Test>() {
-      @Override
-      void execute(Test test) {
-        test.doLast(new Action<Test>() {
-          @Override
-          void execute(Test t) {
-            if(t.rerun.didRerun.get() == true) {
-              buildScan.tag 'unexpected-test-jvm-exit'
-            }
-          }
-        })
-      }
-    })
   }
 }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -100,8 +100,11 @@ buildScan {
       }
     } else {
 
-      URL buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? new URL(System.getenv('BUILDKITE_BUILD_URL')) : null
+      URL buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? System.getenv('BUILDKITE_BUILD_URL') : null
       if(buildKiteUrl) {
+        // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
+        uploadInBackground = false
+
         def branch = System.getenv('BUILDKITE_BRANCH')
         tag 'CI'
         link 'CI Build', buildKiteUrl

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', "<p>Build scan for <span class=\"p1 border\">${System.getenv('BUILDKITE_LABEL')}</span>' - [`gradle ${gradle.startParameter.taskNames.join(' ')}`](${scan.buildScanUri})</p>"].execute()
+        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', """<div class="mb3">Build scan for <span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> <a href="${scan.buildScanUri}"><p><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></p></a></div>"""].execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -102,19 +102,27 @@ buildScan {
 
       URL buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? new URL(System.getenv('BUILDKITE_BUILD_URL')) : null
       if(buildKiteUrl) {
-
+        def branch = System.getenv('BUILDKITE_BRANCH')
+        tag 'CI'
+        link 'CI Build', buildKiteUrl
+        tag branch
+        value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
 
         // Add SCM information
-        def prId = System.getenv('BUILDKITE_PULL_REQUEST') != null
-        def repoBaseUrl = (System.getenv('BUILDKITE_PULL_REQUEST_REPO') - ".git")
+        def prId = System.getenv('BUILDKITE_PULL_REQUEST')
         if (prId) {
+          def prBaseUrl = (System.getenv('BUILDKITE_PULL_REQUEST_REPO') - ".git")
           value 'Git Commit ID', System.getenv('ghprbActualCommit')
           tag "pr/${prId}"
           tag 'pull-request'
-          link 'Source', "${repoBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
-          def prUrl = "${repoBaseUrl}/pulls/${prId}"
+          link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
+          def prUrl = "${prBaseUrl}/pulls/${prId}"
           link 'Pull Request', prUrl
         } else {
+          def repoUrl = System.getenv('BUILDKITE_REPO')
+          if (repoUrl.startsWith('git@github')) {
+            repoUrl = repoUrl.replaceAll("git\\@github\\.com\\:", "https://github.com/").replaceAll("\\.git", "/tree/$branch")
+          }
           value 'Git Commit ID', BuildParams.gitRevision
           link 'Source', "${repoBaseUrl}/tree/${BuildParams.gitRevision}"
         }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -104,10 +104,11 @@ buildScan {
       uploadInBackground = false
 
       def branch = System.getenv('BUILDKITE_BRANCH')
+      def repository = (System.getenv('BUILDKITE_REPO') =~ /(https:\/\/github\.com\/|git@github\.com:)(\S+)\.git/).group(2)
       tag 'CI'
       link 'CI Build', buildKiteUrl
-      tag branch
       value 'Job Number', System.getenv('BUILDKITE_BUILD_NUMBER')
+
 
       // Add SCM information
       def prId = System.getenv('BUILDKITE_PULL_REQUEST')
@@ -117,15 +118,12 @@ buildScan {
         tag "pr/${prId}"
         tag 'pull-request'
         link 'Source', "${prBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
-        def prUrl = "${prBaseUrl}/pull/${prId}"
+        def prUrl = "https://github.com/${repository}/pull/${prId}"
         link 'Pull Request', prUrl
       } else {
-        def repoUrl = System.getenv('BUILDKITE_REPO')
-        if (repoUrl.startsWith('git@github')) {
-          repoUrl = repoUrl.replaceAll("git\\@github\\.com\\:", "https://github.com/").replaceAll("\\.git", "/tree/$branch")
-        }
         value 'Git Commit ID', BuildParams.gitRevision
-        link 'Source', "${repoBaseUrl}/tree/${BuildParams.gitRevision}"
+        link 'Source', "https://github.com/${repository}/tree/${BuildParams.gitRevision}"
+        tag branch
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -25,12 +25,6 @@ buildScan {
   }
 
   background {
-    String buildNumber = System.getenv('BUILD_NUMBER')
-    String buildUrl = System.getenv('BUILD_URL')
-    String jobName = System.getenv('JOB_NAME')
-    String nodeName = System.getenv('NODE_NAME')
-    String jobBranch = System.getenv('ghprbTargetBranch') ?: System.getenv('JOB_BRANCH')
-
     tag OS.current().name()
     tag Architecture.current().name()
 
@@ -39,22 +33,28 @@ buildScan {
       tag 'FIPS'
     }
 
-    // Link to Jenkins worker logs and system metrics
-    if (nodeName) {
-      link 'System logs', "https://ci-stats.elastic.co/app/infra#/logs?" +
-        "&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
-      buildFinished {
-        link 'System metrics', "https://ci-stats.elastic.co/app/metrics/detail/host/" +
-          "${nodeName}?_g=()&metricTime=(autoReload:!f,refreshInterval:5000," +
-          "time:(from:${startTime - TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)},interval:%3E%3D1m," +
-          "to:${System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)}))"
-      }
-    }
-
     // Jenkins-specific build scan metadata
     if (jenkinsUrl) {
       // Disable async upload in CI to ensure scan upload completes before CI agent is terminated
       uploadInBackground = false
+
+      String buildNumber = System.getenv('BUILD_NUMBER')
+      String buildUrl = System.getenv('BUILD_URL')
+      String jobName = System.getenv('JOB_NAME')
+      String nodeName = System.getenv('NODE_NAME')
+      String jobBranch = System.getenv('ghprbTargetBranch') ?: System.getenv('JOB_BRANCH')
+
+      // Link to Jenkins worker logs and system metrics
+      if (nodeName) {
+        link 'System logs', "https://ci-stats.elastic.co/app/infra#/logs?" +
+                "&logFilter=(expression:'host.name:${nodeName}',kind:kuery)"
+        buildFinished {
+          link 'System metrics', "https://ci-stats.elastic.co/app/metrics/detail/host/" +
+                  "${nodeName}?_g=()&metricTime=(autoReload:!f,refreshInterval:5000," +
+                  "time:(from:${startTime - TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)},interval:%3E%3D1m," +
+                  "to:${System.currentTimeMillis() + TimeUnit.MILLISECONDS.convert(5, TimeUnit.MINUTES)}))"
+        }
+      }
 
       // Parse job name in the case of matrix builds
       // Matrix job names come in the form of "base-job-name/matrix_param1=value1,matrix_param2=value2"
@@ -99,7 +99,28 @@ buildScan {
         link 'Source', "https://github.com/elastic/elasticsearch/tree/${BuildParams.gitRevision}"
       }
     } else {
-      tag 'LOCAL'
+
+      URL buildKiteUrl = System.getenv('BUILDKITE_BUILD_URL') ? new URL(System.getenv('BUILDKITE_BUILD_URL')) : null
+      if(buildKiteUrl) {
+
+
+        // Add SCM information
+        def prId = System.getenv('BUILDKITE_PULL_REQUEST') != null
+        def repoBaseUrl = (System.getenv('BUILDKITE_PULL_REQUEST_REPO') - ".git")
+        if (prId) {
+          value 'Git Commit ID', System.getenv('ghprbActualCommit')
+          tag "pr/${prId}"
+          tag 'pull-request'
+          link 'Source', "${repoBaseUrl}/tree/${System.getenv('BUILDKITE_COMMIT')}"
+          def prUrl = "${repoBaseUrl}/pulls/${prId}"
+          link 'Pull Request', prUrl
+        } else {
+          value 'Git Commit ID', BuildParams.gitRevision
+          link 'Source', "${repoBaseUrl}/tree/${BuildParams.gitRevision}"
+        }
+      } else {
+        tag 'LOCAL'
+      }
     }
   }
 }

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,8 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> <span class="bold">Build scan for:</span> <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""].execute()
+        def body = """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> <span class="bold">Build scan for:</span> <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+        ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', body].execute()
       }
     } else {
       tag 'LOCAL'

--- a/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-scan.gradle
@@ -125,7 +125,7 @@ buildScan {
 
         // Add a build annotation
         // See: https://buildkite.com/docs/agent/v3/cli-annotate
-        def body = """<div class="mb3"><span class="p1 border rounded build-annotation-info">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
+        def body = """<div class="mb3"><span class="p1 border rounded">${System.getenv('BUILDKITE_LABEL')}</span> :gradle: build ran: <a href="${scan.buildScanUri}"><code>gradle ${gradle.startParameter.taskNames.join(' ')}</code></a></div>"""
         ['buildkite-agent', 'annotate', '--context', 'gradle-build-scans', '--append', '--style', 'info', body].execute()
       }
     } else {

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -112,7 +112,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setGitOrigin(gitInfo.getOrigin());
             params.setBuildDate(ZonedDateTime.now(ZoneOffset.UTC));
             params.setTestSeed(getTestSeed());
-            params.setIsCi(System.getenv("JENKINS_URL") != null);
+            params.setIsCi(System.getenv("JENKINS_URL") != null || System.getenv("BUILDKITE_BUILD_URL") != null);
             params.setDefaultParallel(ParallelDetector.findDefaultParallel(project));
             params.setInFipsJvm(Util.getBooleanProperty("tests.fips.enabled", false));
             params.setIsSnapshotBuild(Util.getBooleanProperty("build.snapshot", true));


### PR DESCRIPTION
This adds some buildkite-specific logic to our build-scan configuration for tags, links, etc, as well as adds a callback to add metadata and annotations to the buildkite job for later lookup.