### PR TITLE
Remove workaround in repository-azure for bug now fixed in Azure SDK

### DIFF
--- a/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
+++ b/modules/repository-azure/src/main/java/org/elasticsearch/repositories/azure/AzureClientProvider.java
@@ -33,10 +33,7 @@ import com.azure.core.util.logging.ClientLogger;
 import com.azure.storage.blob.BlobServiceAsyncClient;
 import com.azure.storage.blob.BlobServiceClient;
 import com.azure.storage.blob.BlobServiceClientBuilder;
-import com.azure.storage.common.StorageSharedKeyCredential;
-import com.azure.storage.common.implementation.connectionstring.StorageAuthenticationSettings;
 import com.azure.storage.common.implementation.connectionstring.StorageConnectionString;
-import com.azure.storage.common.implementation.connectionstring.StorageEndpoint;
 import com.azure.storage.common.policy.RequestRetryOptions;
 
 import org.apache.logging.log4j.LogManager;
@@ -183,30 +180,17 @@ class AzureClientProvider extends AbstractLifecycleComponent {
         final HttpClient httpClient = new NettyAsyncHttpClientBuilder(nettyHttpClient).disableBufferCopy(true).proxy(proxyOptions).build();
 
         final String connectionString = settings.getConnectString();
-        final StorageConnectionString storageConnectionString = StorageConnectionString.create(connectionString, clientLogger);
-        final StorageEndpoint endpoint = storageConnectionString.getBlobEndpoint();
-        final StorageAuthenticationSettings authSettings = storageConnectionString.getStorageAuthSettings();
-
-        BlobServiceClientBuilder builder = new BlobServiceClientBuilder().endpoint(endpoint.getPrimaryUri())
+        BlobServiceClientBuilder builder = new BlobServiceClientBuilder().connectionString(connectionString)
             .httpClient(httpClient)
             .retryOptions(retryOptions);
-
-        if (authSettings.getType() == StorageAuthenticationSettings.Type.ACCOUNT_NAME_KEY) {
-            builder.credential(
-                new StorageSharedKeyCredential(authSettings.getAccount().getName(), authSettings.getAccount().getAccessKey())
-            );
-        } else if (authSettings.getType() == StorageAuthenticationSettings.Type.SAS_TOKEN) {
-            // Notice that we used the SAS token as it is provided in settings,
-            // this avoids going through the SDK SAS token sanitation process
-            // which can provide an invalid signature (see #88140)
-            builder.sasToken(settings.getSasToken());
-        }
 
         if (successfulRequestConsumer != null) {
             builder.addPolicy(new SuccessfulRequestTracker(successfulRequestConsumer));
         }
 
         if (locationMode.isSecondary()) {
+            // TODO: maybe extract this logic so we don't need to have a client logger around?
+            StorageConnectionString storageConnectionString = StorageConnectionString.create(connectionString, clientLogger);
             String secondaryUri = storageConnectionString.getBlobEndpoint().getSecondaryUri();
             if (secondaryUri == null) {
                 throw new IllegalArgumentException(

--- a/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSasTokenTests.java
+++ b/modules/repository-azure/src/test/java/org/elasticsearch/repositories/azure/AzureSasTokenTests.java
@@ -17,6 +17,8 @@ import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.rest.RestStatus;
 
 import java.io.InputStream;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Locale;
 
 import static org.elasticsearch.repositories.azure.AzureStorageSettings.ACCOUNT_SETTING;
@@ -42,12 +44,9 @@ public class AzureSasTokenTests extends AbstractAzureServerTestCase {
 
         httpServer.createContext("/account/container/sas_test", exchange -> {
             try {
-                final var queryParams = exchange.getRequestURI().getRawQuery();
-                if (sasToken.startsWith("?")) {
-                    assertThat(queryParams, is(equalTo(sasToken.substring(1))));
-                } else {
-                    assertThat(queryParams, is(equalTo(sasToken)));
-                }
+                final var queryParams = queryParams(exchange.getRequestURI().getRawQuery());
+                final var expectedParams = queryParams(sasToken.startsWith("?") ? sasToken.substring(1) : sasToken);
+                assertThat(queryParams, is(equalTo(expectedParams)));
 
                 Streams.readFully(exchange.getRequestBody());
                 if ("HEAD".equals(exchange.getRequestMethod())) {
@@ -68,6 +67,9 @@ public class AzureSasTokenTests extends AbstractAzureServerTestCase {
                     exchange.sendResponseHeaders(RestStatus.OK.getStatus(), length);
                     exchange.getResponseBody().write(bytes, rangeStart, length);
                 }
+            } catch (Throwable t) {
+                logger.warn(t); // ensure that assertions are not silently swallowed
+                throw t;
             } finally {
                 exchange.close();
             }
@@ -77,5 +79,9 @@ public class AzureSasTokenTests extends AbstractAzureServerTestCase {
         try (InputStream inputStream = blobContainer.readBlob("sas_test")) {
             assertArrayEquals(bytes, BytesReference.toBytes(Streams.readFully(inputStream)));
         }
+    }
+
+    static List<String> queryParams(String queryParamString) {
+        return Arrays.stream(queryParamString.split("&")).sorted().toList();
     }
 }


### PR DESCRIPTION
This commit simply applies an anti-delta of a code change in Elasticsearch that was added to workaround a bug in the Azure Storage SDK, which has since been fixed.

The original Elasticsearch PR that applied the workaround (to allow a sas token with a leading ? in connection string) is #88155. The issue that fixed the underlying bug in Azure is https://github.com/Azure/azure-sdk-for-java/pull/30003, which has been merged into [12.18.0](https://github.com/Azure/azure-sdk-for-java/blob/main/sdk/storage/azure-storage-common/CHANGELOG.md#12180-2022-08-12). The Elasticsearch repository-azure component has been updated to 12.20.1, by #92119, so the workaround is no longer needed.

This change effectively just applies the suggestion that arose during the review of #88155, see https://github.com/elastic/elasticsearch/pull/88155/files#r924596359

FYI - I ran across this issue when analysing module dependencies for future Modularization work, see #78744. There is still a dependency on the internals of the Azure SDK, but that can be tackled in a follow-up issue.