### PR TITLE
Finer control over authentication metadata serialization

### DIFF
--- a/docs/changelog/93726.yaml
+++ b/docs/changelog/93726.yaml
@@ -1,0 +1,5 @@
+pr: 93726
+summary: Finer control over authentication metadata serialization
+area: Authentication
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RemoteAccessAuthentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/RemoteAccessAuthentication.java
@@ -139,11 +139,7 @@ public final class RemoteAccessAuthentication {
         assert false == getAuthentication().isRemoteAccess()
             : "authentication included in remote access header cannot itself be remote access";
         final Map<String, Object> copy = new HashMap<>(authenticationMetadata);
-        try {
-            copy.put(AuthenticationField.REMOTE_ACCESS_AUTHENTICATION_KEY, getAuthentication().encode());
-        } catch (IOException e) {
-            throw new UncheckedIOException(e);
-        }
+        copy.put(AuthenticationField.REMOTE_ACCESS_AUTHENTICATION_KEY, getAuthentication());
         copy.put(AuthenticationField.REMOTE_ACCESS_ROLE_DESCRIPTORS_KEY, getRoleDescriptorsBytesList());
         return Collections.unmodifiableMap(copy);
     }
@@ -159,6 +155,10 @@ public final class RemoteAccessAuthentication {
 
         public RoleDescriptorsBytes(StreamInput streamInput) throws IOException {
             this(streamInput.readBytesReference());
+        }
+
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBytesReference(rawBytes);
         }
 
         public static RoleDescriptorsBytes fromRoleDescriptors(final Set<RoleDescriptor> roleDescriptors) throws IOException {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReference.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/RoleReference.java
@@ -130,9 +130,7 @@ public interface RoleReference {
         public RoleKey id() {
             // Hashing can be expensive. memorize the result in case the method is called multiple times.
             if (id == null) {
-                final String roleDescriptorsHash = MessageDigests.toHexString(
-                    MessageDigests.digest(roleDescriptorsBytes, MessageDigests.sha256())
-                );
+                final String roleDescriptorsHash = roleDescriptorsBytes.digest();
                 id = new RoleKey(Set.of("remote_access:" + roleDescriptorsHash), "remote_access");
             }
             return id;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.security.authc.Authentication.RealmRef;
-import org.elasticsearch.xpack.core.security.authc.RemoteAccessAuthentication.RoleDescriptorsBytes;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.service.ServiceAccountSettings;
@@ -32,7 +31,6 @@ import org.elasticsearch.xpack.core.security.user.User;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -43,7 +41,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isA;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -486,13 +483,12 @@ public class AuthenticationTests extends ESTestCase {
             hasEntry(AuthenticationField.REMOTE_ACCESS_ROLE_DESCRIPTORS_KEY, remoteAccessAuthentication.getRoleDescriptorsBytesList())
         );
 
+        // Serialization round-trip
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             authentication.writeTo(out);
             final StreamInput in = out.bytes().streamInput();
             final Authentication deserialized = new Authentication(in);
             assertThat(deserialized, equalTo(authentication));
-            ((List<?>) deserialized.getAuthenticatingSubject().getMetadata().get(AuthenticationField.REMOTE_ACCESS_ROLE_DESCRIPTORS_KEY))
-                .forEach(item -> assertThat(item, isA(RoleDescriptorsBytes.class)));
         }
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -491,10 +491,6 @@ public class AuthenticationTests extends ESTestCase {
             final StreamInput in = out.bytes().streamInput();
             final Authentication deserialized = new Authentication(in);
             assertThat(deserialized, equalTo(authentication));
-            assertThat(
-                deserialized.getAuthenticatingSubject().getMetadata().get(AuthenticationField.REMOTE_ACCESS_AUTHENTICATION_KEY),
-                isA(Authentication.class)
-            );
             ((List<?>) deserialized.getAuthenticatingSubject().getMetadata().get(AuthenticationField.REMOTE_ACCESS_ROLE_DESCRIPTORS_KEY))
                 .forEach(item -> assertThat(item, isA(RoleDescriptorsBytes.class)));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RemoteAccessAuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/RemoteAccessAuthenticationTests.java
@@ -41,8 +41,8 @@ public class RemoteAccessAuthenticationTests extends ESTestCase {
 
         assertThat(actual.getAuthentication(), equalTo(expectedRemoteAccessAuthentication.getAuthentication()));
         final List<Set<RoleDescriptor>> roleDescriptorsList = new ArrayList<>();
-        for (BytesReference bytesReference : actual.getRoleDescriptorsBytesList()) {
-            Set<RoleDescriptor> roleDescriptors = new RemoteAccessAuthentication.RoleDescriptorsBytes(bytesReference).toRoleDescriptors();
+        for (RemoteAccessAuthentication.RoleDescriptorsBytes rdb : actual.getRoleDescriptorsBytesList()) {
+            Set<RoleDescriptor> roleDescriptors = rdb.toRoleDescriptors();
             roleDescriptorsList.add(roleDescriptors);
         }
         final var actualRoleDescriptorsIntersection = new RoleDescriptorsIntersection(roleDescriptorsList);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/RoleReferenceTests.java
@@ -71,10 +71,7 @@ public class RoleReferenceTests extends ESTestCase {
         final var remoteAccessRoleReference = new RoleReference.RemoteAccessRoleReference(roleDescriptorsBytes);
 
         final RoleKey roleKey = remoteAccessRoleReference.id();
-        assertThat(
-            roleKey.getNames(),
-            hasItem("remote_access:" + MessageDigests.toHexString(MessageDigests.digest(roleDescriptorsBytes, MessageDigests.sha256())))
-        );
+        assertThat(roleKey.getNames(), hasItem("remote_access:" + roleDescriptorsBytes.digest()));
         assertThat(roleKey.getSource(), equalTo("remote_access"));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RemoteAccessAuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RemoteAccessAuthenticationService.java
@@ -38,6 +38,8 @@ import static org.elasticsearch.xpack.security.transport.SecurityServerTransport
 
 public class RemoteAccessAuthenticationService {
 
+    public static final TransportVersion VERSION_REMOTE_ACCESS_AUTHENTICATION = TransportVersion.V_8_8_0;
+
     public static final RoleDescriptor CROSS_CLUSTER_INTERNAL_ROLE = new RoleDescriptor(
         "_cross_cluster_internal",
         new String[] { ClusterStateAction.NAME },
@@ -70,12 +72,12 @@ public class RemoteAccessAuthenticationService {
         final ThreadContext threadContext = authcContext.getThreadContext();
 
         // TODO revisit this once Node's Version is refactored
-        if (getMinNodeTransportVersion().before(Authentication.VERSION_REMOTE_ACCESS_REALM)) {
+        if (getMinNodeTransportVersion().before(VERSION_REMOTE_ACCESS_AUTHENTICATION)) {
             withRequestProcessingFailure(
                 authcContext,
                 new IllegalArgumentException(
                     "all nodes must have version ["
-                        + Authentication.VERSION_REMOTE_ACCESS_REALM
+                        + VERSION_REMOTE_ACCESS_AUTHENTICATION
                         + "] or higher to support cross cluster requests through the dedicated remote cluster port"
                 ),
                 listener

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RemoteAccessAuthenticationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/RemoteAccessAuthenticationServiceTests.java
@@ -22,6 +22,7 @@ import org.mockito.Mockito;
 
 import java.util.concurrent.ExecutionException;
 
+import static org.elasticsearch.xpack.security.authc.RemoteAccessAuthenticationService.VERSION_REMOTE_ACCESS_AUTHENTICATION;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.mockito.ArgumentMatchers.any;
@@ -44,7 +45,7 @@ public class RemoteAccessAuthenticationServiceTests extends ESTestCase {
     }
 
     public void testAuthenticateThrowsOnUnsupportedMinVersions() {
-        clusterService = mockClusterServiceWithMinNodeVersion(VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_7_0));
+        clusterService = mockClusterServiceWithMinNodeVersion(VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_8_0));
         final var authcContext = mock(Authenticator.Context.class, Mockito.RETURNS_DEEP_STUBS);
         final var threadContext = new ThreadContext(Settings.EMPTY);
         when(authcContext.getThreadContext()).thenReturn(threadContext);
@@ -67,7 +68,7 @@ public class RemoteAccessAuthenticationServiceTests extends ESTestCase {
             actual.getCause().getCause().getMessage(),
             equalTo(
                 "all nodes must have version ["
-                    + Authentication.VERSION_REMOTE_ACCESS_REALM
+                    + VERSION_REMOTE_ACCESS_AUTHENTICATION
                     + "] or higher to support cross cluster requests through the dedicated remote cluster port"
             )
         );


### PR DESCRIPTION
Today authentication metadata serialization is simply handled as a generic map. This works for pre-defined types, but falls short for undefined types or sub-types of pre-defined types. With the introduction of remote authentication, we need better control over how some metadata values are de/serialized. This PR updates the code to lookup the value reader/writer based on its key and only falls back to read/write generic value if the key is unknown.

