### PR TITLE
Improve serialization and deserialization of empty TDigest histograms

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.aggregations.metrics;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.search.DocValueFormat;
@@ -23,6 +24,10 @@ import java.util.Map;
 import java.util.Objects;
 
 abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetricsAggregation.MultiValue {
+
+    // NOTE: using compression = 1.0 empty histograms will track just about 5 centroids.
+    // This reduces the amount of data to serialize and deserialize.
+    private static final TDigestState EMPTY_HISTOGRAM = new TDigestState(1.0D);
 
     protected final double[] keys;
     protected final TDigestState state;
@@ -48,7 +53,15 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     protected AbstractInternalTDigestPercentiles(StreamInput in) throws IOException {
         super(in);
         keys = in.readDoubleArray();
-        state = TDigestState.read(in);
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
+            if (in.readBoolean()) {
+                state = TDigestState.read(in);
+            } else {
+                state = null;
+            }
+        } else {
+            state = TDigestState.read(in);
+        }
         keyed = in.readBoolean();
     }
 
@@ -56,7 +69,17 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
     protected void doWriteTo(StreamOutput out) throws IOException {
         out.writeNamedWriteable(format);
         out.writeDoubleArray(keys);
-        TDigestState.write(state, out);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
+            if (this.state != null) {
+                out.writeBoolean(true);
+                TDigestState.write(state, out);
+            } else {
+                out.writeBoolean(false);
+            }
+        } else {
+            TDigestState state = this.state != null ? this.state : EMPTY_HISTOGRAM;
+            TDigestState.write(state, out);
+        }
         out.writeBoolean(keyed);
     }
 
@@ -109,12 +132,38 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
         TDigestState merged = null;
         for (InternalAggregation aggregation : aggregations) {
             final AbstractInternalTDigestPercentiles percentiles = (AbstractInternalTDigestPercentiles) aggregation;
+            if (percentiles.state == null) {
+                continue;
+            }
             if (merged == null) {
                 merged = new TDigestState(percentiles.state.compression());
             }
-            merged.add(percentiles.state);
+            merged = merge(merged, percentiles.state);
+        }
+        if (merged == null) {
+            merged = EMPTY_HISTOGRAM;
         }
         return createReduced(getName(), keys, merged, keyed, getMetadata());
+    }
+
+    /**
+     * Merges two {@link TDigestState}s such that we always merge the one with smaller
+     * compression into the one with larger compression.
+     * This prevents producing a result that has lower than expected precision.
+     *
+     * @param digest1 The first histogram to merge
+     * @param digest2 The second histogram to merge
+     * @return One of the input histograms such that the one with larger compression is used as the one for merging
+     */
+    private TDigestState merge(final TDigestState digest1, final TDigestState digest2) {
+        TDigestState largerCompression = digest1;
+        TDigestState smallerCompression = digest2;
+        if (digest2.compression() > digest1.compression()) {
+            largerCompression = digest2;
+            smallerCompression = digest1;
+        }
+        largerCompression.add(smallerCompression);
+        return largerCompression;
     }
 
     @Override
@@ -132,6 +181,7 @@ abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetrics
 
     @Override
     public XContentBuilder doXContentBody(XContentBuilder builder, Params params) throws IOException {
+        TDigestState state = this.state != null ? this.state : EMPTY_HISTOGRAM;
         if (keyed) {
             builder.startObject(CommonFields.VALUES.getPreferredName());
             for (int i = 0; i < keys.length; ++i) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
@@ -54,6 +54,6 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTDigestPercentiles(name, keys, new TDigestState(compression), keyed, formatter, metadata());
+        return new InternalTDigestPercentiles(name, keys, null, keyed, formatter, metadata());
     }
 }


### PR DESCRIPTION
When an empty aggregations uses a TDigest object the underlying arrays
used by the AvlTree TDigest implementation is eagerly allocated. If the
aggregation produces no result, we serialize and deserialize an array which
might be large if the compression value is large. So, no matter the precision
requested by setting the compression value, we always serialize and deserialize 
an array whose size depends on the value of the 'compression' parameter. 
This also happens if the result is empty.

Here we use a null value for empty aggregations while building the result TDigest
object and, later on, use a static empty TDigest object at reduce time  merging it
with non-empty results. This static object just uses 1.0 as the compression value,
which is enough for empty results. If a larger compression value is required to
compute the final global result there will be a non-empty TDigest result using a
larger compression value, which will be used at merging time and provide a result
with the expected precision.