### PR TITLE
[ML] Use long inference timeout at ingest

### DIFF
--- a/docs/changelog/93731.yaml
+++ b/docs/changelog/93731.yaml
@@ -1,0 +1,5 @@
+pr: 93731
+summary: Use long inference timeout at ingest
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -75,7 +75,8 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             return builder;
         }
 
-        public static final TimeValue DEFAULT_TIMEOUT = TimeValue.timeValueSeconds(10);
+        public static final TimeValue DEFAULT_TIMEOUT_FOR_API = TimeValue.timeValueSeconds(10);
+        public static final TimeValue DEFAULT_TIMEOUT_FOR_INGEST = TimeValue.MAX_VALUE;
 
         private final String modelId;
         private final List<Map<String, Object>> objectsToInfer;
@@ -87,7 +88,13 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         // input and so cannot construct a document.
         private final List<String> textInput;
 
-        public static Request forDocs(
+        /**
+         * Build a request from a list of documents as maps.
+         * The inference timeout (how long the request waits in
+         * the inference queue for) is set to a high value {@code #DEFAULT_TIMEOUT_FOR_INGEST}
+         * to prefer slow ingest over dropping documents.
+         */
+        public static Request forIngestDocs(
             String modelId,
             List<Map<String, Object>> docs,
             InferenceConfigUpdate update,
@@ -98,18 +105,24 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
                 update,
                 ExceptionsHelper.requireNonNull(Collections.unmodifiableList(docs), DOCS),
                 null,
-                DEFAULT_TIMEOUT,
+                DEFAULT_TIMEOUT_FOR_INGEST,
                 previouslyLicensed
             );
         }
 
+        /**
+         * Build a request from a list of strings, each string
+         * is one evaluation of the model.
+         * The inference timeout (how long the request waits in
+         * the inference queue for) is set to {@code #DEFAULT_TIMEOUT_FOR_API}
+         */
         public static Request forTextInput(String modelId, InferenceConfigUpdate update, List<String> textInput) {
             return new Request(
                 modelId,
                 update,
                 List.of(),
                 ExceptionsHelper.requireNonNull(textInput, "inference text input"),
-                DEFAULT_TIMEOUT,
+                DEFAULT_TIMEOUT_FOR_API,
                 false
             );
         }
@@ -180,8 +193,9 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             return inferenceTimeout;
         }
 
-        public void setInferenceTimeout(TimeValue inferenceTimeout) {
+        public Request setInferenceTimeout(TimeValue inferenceTimeout) {
             this.inferenceTimeout = inferenceTimeout;
+            return this;
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
@@ -49,7 +49,7 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
     @Override
     protected Request createTestInstance() {
         return randomBoolean()
-            ? Request.forDocs(
+            ? Request.forIngestDocs(
                 randomAlphaOfLength(10),
                 Stream.generate(InferModelActionRequestTests::randomMap).limit(randomInt(10)).collect(Collectors.toList()),
                 randomInferenceConfigUpdate(),

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/license/MachineLearningLicensingIT.java
@@ -664,12 +664,12 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         PlainActionFuture<InferModelAction.Response> inferModelSuccess = PlainActionFuture.newFuture();
         client().execute(
             InferModelAction.INSTANCE,
-            InferModelAction.Request.forDocs(
+            InferModelAction.Request.forIngestDocs(
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 RegressionConfigUpdate.EMPTY_PARAMS,
                 false
-            ),
+            ).setInferenceTimeout(TimeValue.timeValueSeconds(5)),
             inferModelSuccess
         );
         InferModelAction.Response response = inferModelSuccess.actionGet();
@@ -685,12 +685,12 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, () -> {
             client().execute(
                 InferModelAction.INSTANCE,
-                InferModelAction.Request.forDocs(
+                InferModelAction.Request.forIngestDocs(
                     modelId,
                     Collections.singletonList(Collections.emptyMap()),
                     RegressionConfigUpdate.EMPTY_PARAMS,
                     false
-                )
+                ).setInferenceTimeout(TimeValue.timeValueSeconds(5))
             ).actionGet();
         });
         assertThat(e.status(), is(RestStatus.FORBIDDEN));
@@ -701,12 +701,12 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         inferModelSuccess = PlainActionFuture.newFuture();
         client().execute(
             InferModelAction.INSTANCE,
-            InferModelAction.Request.forDocs(
+            InferModelAction.Request.forIngestDocs(
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 RegressionConfigUpdate.EMPTY_PARAMS,
                 true
-            ),
+            ).setInferenceTimeout(TimeValue.timeValueSeconds(5)),
             inferModelSuccess
         );
         response = inferModelSuccess.actionGet();
@@ -721,12 +721,12 @@ public class MachineLearningLicensingIT extends BaseMlIntegTestCase {
         PlainActionFuture<InferModelAction.Response> listener = PlainActionFuture.newFuture();
         client().execute(
             InferModelAction.INSTANCE,
-            InferModelAction.Request.forDocs(
+            InferModelAction.Request.forIngestDocs(
                 modelId,
                 Collections.singletonList(Collections.emptyMap()),
                 RegressionConfigUpdate.EMPTY_PARAMS,
                 false
-            ),
+            ).setInferenceTimeout(TimeValue.timeValueSeconds(5)),
             listener
         );
         assertThat(listener.actionGet().getInferenceResults(), is(not(empty())));

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ModelInferenceActionIT.java
@@ -171,14 +171,19 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         });
 
         // Test regression
-        InferModelAction.Request request = InferModelAction.Request.forDocs(modelId1, toInfer, RegressionConfigUpdate.EMPTY_PARAMS, true);
+        InferModelAction.Request request = InferModelAction.Request.forIngestDocs(
+            modelId1,
+            toInfer,
+            RegressionConfigUpdate.EMPTY_PARAMS,
+            true
+        );
         InferModelAction.Response response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults().stream().map(i -> ((SingleValueInferenceResults) i).value()).collect(Collectors.toList()),
             contains(1.3, 1.25)
         );
 
-        request = InferModelAction.Request.forDocs(modelId1, toInfer2, RegressionConfigUpdate.EMPTY_PARAMS, true);
+        request = InferModelAction.Request.forIngestDocs(modelId1, toInfer2, RegressionConfigUpdate.EMPTY_PARAMS, true);
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults().stream().map(i -> ((SingleValueInferenceResults) i).value()).collect(Collectors.toList()),
@@ -186,7 +191,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         );
 
         // Test classification
-        request = InferModelAction.Request.forDocs(modelId2, toInfer, ClassificationConfigUpdate.EMPTY_PARAMS, true);
+        request = InferModelAction.Request.forIngestDocs(modelId2, toInfer, ClassificationConfigUpdate.EMPTY_PARAMS, true);
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults()
@@ -197,7 +202,12 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         );
 
         // Get top classes
-        request = InferModelAction.Request.forDocs(modelId2, toInfer, new ClassificationConfigUpdate(2, null, null, null, null), true);
+        request = InferModelAction.Request.forIngestDocs(
+            modelId2,
+            toInfer,
+            new ClassificationConfigUpdate(2, null, null, null, null),
+            true
+        );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
 
         ClassificationInferenceResults classificationInferenceResults = (ClassificationInferenceResults) response.getInferenceResults()
@@ -220,7 +230,12 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         );
 
         // Test that top classes restrict the number returned
-        request = InferModelAction.Request.forDocs(modelId2, toInfer2, new ClassificationConfigUpdate(1, null, null, null, null), true);
+        request = InferModelAction.Request.forIngestDocs(
+            modelId2,
+            toInfer2,
+            new ClassificationConfigUpdate(1, null, null, null, null),
+            true
+        );
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
 
         classificationInferenceResults = (ClassificationInferenceResults) response.getInferenceResults().get(0);
@@ -319,7 +334,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         });
 
         // Test regression
-        InferModelAction.Request request = InferModelAction.Request.forDocs(
+        InferModelAction.Request request = InferModelAction.Request.forIngestDocs(
             modelId,
             toInfer,
             ClassificationConfigUpdate.EMPTY_PARAMS,
@@ -334,7 +349,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             contains("option_0", "option_2")
         );
 
-        request = InferModelAction.Request.forDocs(modelId, toInfer2, ClassificationConfigUpdate.EMPTY_PARAMS, true);
+        request = InferModelAction.Request.forIngestDocs(modelId, toInfer2, ClassificationConfigUpdate.EMPTY_PARAMS, true);
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
         assertThat(
             response.getInferenceResults()
@@ -345,7 +360,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
         );
 
         // Get top classes
-        request = InferModelAction.Request.forDocs(modelId, toInfer, new ClassificationConfigUpdate(3, null, null, null, null), true);
+        request = InferModelAction.Request.forIngestDocs(modelId, toInfer, new ClassificationConfigUpdate(3, null, null, null, null), true);
         response = client().execute(InferModelAction.INSTANCE, request).actionGet();
 
         ClassificationInferenceResults classificationInferenceResults = (ClassificationInferenceResults) response.getInferenceResults()
@@ -363,7 +378,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
 
     public void testInferMissingModel() {
         String model = "test-infer-missing-model";
-        InferModelAction.Request request = InferModelAction.Request.forDocs(
+        InferModelAction.Request request = InferModelAction.Request.forIngestDocs(
             model,
             Collections.emptyList(),
             RegressionConfigUpdate.EMPTY_PARAMS,
@@ -409,7 +424,7 @@ public class ModelInferenceActionIT extends MlSingleNodeTestCase {
             }
         });
 
-        InferModelAction.Request request = InferModelAction.Request.forDocs(
+        InferModelAction.Request request = InferModelAction.Request.forIngestDocs(
             modelId,
             toInferMissingField,
             RegressionConfigUpdate.EMPTY_PARAMS,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -152,7 +152,7 @@ public class InferenceProcessor extends AbstractProcessor {
             fields.put(INGEST_KEY, ingestDocument.getIngestMetadata());
         }
         LocalModel.mapFieldsIfNecessary(fields, fieldMap);
-        return InferModelAction.Request.forDocs(modelId, List.of(fields), inferenceConfig, previouslyLicensed);
+        return InferModelAction.Request.forIngestDocs(modelId, List.of(fields), inferenceConfig, previouslyLicensed);
     }
 
     void auditWarningAboutLicenseIfNecessary() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelAction.java
@@ -49,7 +49,7 @@ public class RestInferTrainedModelAction extends BaseRestHandler {
         if (restRequest.hasParam(InferModelAction.Request.TIMEOUT.getPreferredName())) {
             TimeValue inferTimeout = restRequest.paramAsTime(
                 InferModelAction.Request.TIMEOUT.getPreferredName(),
-                InferModelAction.Request.DEFAULT_TIMEOUT
+                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API
             );
             request.setInferenceTimeout(inferTimeout);
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestInferTrainedModelDeploymentAction.java
@@ -68,7 +68,7 @@ public class RestInferTrainedModelDeploymentAction extends BaseRestHandler {
         if (restRequest.hasParam(InferModelAction.Request.TIMEOUT.getPreferredName())) {
             TimeValue inferTimeout = restRequest.paramAsTime(
                 InferModelAction.Request.TIMEOUT.getPreferredName(),
-                InferModelAction.Request.DEFAULT_TIMEOUT
+                InferModelAction.Request.DEFAULT_TIMEOUT_FOR_API
             );
             requestBuilder.setInferenceTimeout(inferTimeout);
         }


### PR DESCRIPTION
The refactoring in #92359 accidentally changed the inference timeout as used by the inference processor from `TimeValue.MAX_VALUE` to `TimeValue.timeValueSeconds(10)`. If a large chunk size is used at ingest this could result in many requests timing out.  