### PR TITLE
Fix AsyncShardFetchTests#testTwoNodesRemoveOne

### DIFF
--- a/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static java.util.Collections.emptySet;
@@ -335,7 +336,6 @@ public class AsyncShardFetchTests extends ESTestCase {
         assertThat(fetchData.getData().get(node1), sameInstance(response1_2));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93729")
     public void testTwoNodesRemoveOne() throws Exception {
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).add(node2).build();
         test.addSimulation(node1.getId(), response1);
@@ -357,7 +357,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         test.fireSimulationAndWait(node1.getId());
         // there is still another on going request, so no data
         assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
-        fetchData = test.fetchData(nodes, emptySet());
+        fetchData = test.fetchData(newNodes, emptySet());
         assertThat(fetchData.hasData(), equalTo(false));
 
         // fire the second simulation, this should allow us to get the data
@@ -450,9 +450,10 @@ public class AsyncShardFetchTests extends ESTestCase {
         }
 
         public void fireSimulationAndWait(String nodeId) throws InterruptedException {
-            simulations.get(nodeId).executeLatch.countDown();
-            simulations.get(nodeId).waitLatch.await();
-            simulations.remove(nodeId);
+            final var entry = simulations.get(nodeId);
+            entry.executeLatch.countDown();
+            assertTrue(entry.waitLatch.await(10, TimeUnit.SECONDS));
+            assertSame(entry, simulations.remove(nodeId));
         }
 
         @Override
@@ -464,34 +465,24 @@ public class AsyncShardFetchTests extends ESTestCase {
         protected void asyncFetch(DiscoveryNode[] nodes, long fetchingRound) {
             for (final DiscoveryNode node : nodes) {
                 final String nodeId = node.getId();
-                threadPool.generic().execute(new Runnable() {
-                    @Override
-                    public void run() {
-                        Entry entry = null;
-                        try {
-                            entry = simulations.get(nodeId);
-                            if (entry == null) {
-                                // we are simulating a master node switch, wait for it to not be null
-                                assertBusy(() -> assertTrue(simulations.containsKey(nodeId)));
-                            }
-                            assert entry != null;
-                            entry.executeLatch.await();
-                            if (entry.failure != null) {
-                                processAsyncFetch(
-                                    null,
-                                    Collections.singletonList(new FailedNodeException(nodeId, "unexpected", entry.failure)),
-                                    fetchingRound
-                                );
-                            } else {
-                                processAsyncFetch(Collections.singletonList(entry.response), null, fetchingRound);
-                            }
-                        } catch (Exception e) {
-                            logger.error("unexpected failure", e);
-                        } finally {
-                            if (entry != null) {
-                                entry.waitLatch.countDown();
-                            }
+                final Entry entry = simulations.get(nodeId);
+                assertNotNull(node.descriptionWithoutAttributes(), entry);
+                threadPool.generic().execute(() -> {
+                    try {
+                        assertTrue(entry.executeLatch.await(10, TimeUnit.SECONDS));
+                        if (entry.failure != null) {
+                            processAsyncFetch(
+                                null,
+                                Collections.singletonList(new FailedNodeException(nodeId, "unexpected", entry.failure)),
+                                fetchingRound
+                            );
+                        } else {
+                            processAsyncFetch(Collections.singletonList(entry.response), null, fetchingRound);
                         }
+                    } catch (Exception e) {
+                        throw new AssertionError("unexpected failure", e);
+                    } finally {
+                        entry.waitLatch.countDown();
                     }
                 });
             }


### PR DESCRIPTION
This test was using the wrong `DiscoveryNodes`, but that mistake was hidden by other leniency elsewhere in this test suite. This commit fixes the test bug and also makes the test suite stricter.

Closes #93729