### PR TITLE
[8.7] Avoid NPE in DiskThresholdMonitor (#93699)

### DIFF
--- a/docs/changelog/93699.yaml
+++ b/docs/changelog/93699.yaml
@@ -1,0 +1,5 @@
+pr: 93699
+summary: Skip `DiskThresholdMonitor` when cluster state is not recovered
+area: Allocation
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorTests.java
@@ -38,6 +38,8 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Releasable;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
@@ -1279,6 +1281,92 @@ public class DiskThresholdMonitorTests extends ESAllocationTestCase {
     @TestLogging(value = "org.elasticsearch.cluster.routing.allocation.DiskThresholdMonitor:INFO", reason = "testing INFO/WARN logging")
     public void testDiskMonitorLoggingWithMaxHeadrooms() throws IllegalAccessException {
         doTestDiskMonitorLogging(true);
+    }
+
+    public void testSkipDiskThresholdMonitorWhenStateNotRecovered() {
+        Metadata.Builder metadataBuilder = Metadata.builder()
+            .put(IndexMetadata.builder("test").settings(settings(Version.CURRENT)).numberOfShards(1).numberOfReplicas(1));
+        boolean shutdownMetadataInState = randomBoolean();
+        if (shutdownMetadataInState) {
+            metadataBuilder.putCustom(
+                NodesShutdownMetadata.TYPE,
+                new NodesShutdownMetadata(
+                    Collections.singletonMap(
+                        "node1",
+                        SingleNodeShutdownMetadata.builder()
+                            .setNodeId("node1")
+                            .setReason("testing")
+                            .setType(SingleNodeShutdownMetadata.Type.REPLACE)
+                            .setTargetNodeName("node3")
+                            .setStartedAtMillis(randomNonNegativeLong())
+                            .build()
+                    )
+                )
+            );
+        }
+        Metadata metadata = metadataBuilder.build();
+        RoutingTable routingTable = RoutingTable.builder(TestShardRoutingRoleStrategies.DEFAULT_ROLE_ONLY)
+            .addAsNew(metadata.index("test"))
+            .build();
+        DiscoveryNodes.Builder discoveryNodes = DiscoveryNodes.builder()
+            .add(newNormalNode("node1", "node1"))
+            .add(newNormalNode("node2", "node2"));
+        // node3 which is to replace node1 may or may not be in the cluster
+        if (shutdownMetadataInState && randomBoolean()) {
+            discoveryNodes.add(newNormalNode("node3", "node3"));
+        }
+        final ClusterState clusterState = applyStartedShardsUntilNoChange(
+            ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+                .metadata(metadata)
+                .routingTable(routingTable)
+                .nodes(discoveryNodes)
+                .build(),
+            createAllocationService(Settings.EMPTY)
+        );
+        Map<String, DiskUsage> diskUsages = new HashMap<>();
+        diskUsages.put("node1", new DiskUsage("node1", "node1", "/foo/bar", 100, between(0, 4)));
+        diskUsages.put("node2", new DiskUsage("node2", "node2", "/foo/bar", 100, between(0, 4)));
+        final ClusterInfo clusterInfo = clusterInfo(diskUsages);
+        var result = runDiskThresholdMonitor(clusterState, clusterInfo);
+        assertTrue(result.v1()); // reroute on new nodes
+        assertEquals(Set.of("test"), result.v2());
+
+        final ClusterState blockedClusterState = ClusterState.builder(ClusterName.CLUSTER_NAME_SETTING.getDefault(Settings.EMPTY))
+            .metadata(metadata)
+            .nodes(discoveryNodes)
+            .blocks(ClusterBlocks.builder().addGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK).build())
+            .build();
+        var result2 = runDiskThresholdMonitor(blockedClusterState, clusterInfo);
+        assertFalse(result2.v1());
+        assertNull(result2.v2());
+    }
+
+    // Runs a disk threshold monitor with a given cluster state and cluster info and returns whether a reroute should
+    // happen and any indices that should be marked as read-only.
+    private Tuple<Boolean, Set<String>> runDiskThresholdMonitor(ClusterState clusterState, ClusterInfo clusterInfo) {
+        AtomicBoolean reroute = new AtomicBoolean(false);
+        AtomicReference<Set<String>> indices = new AtomicReference<>();
+        DiskThresholdMonitor monitor = new DiskThresholdMonitor(
+            Settings.EMPTY,
+            () -> clusterState,
+            new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS),
+            null,
+            System::currentTimeMillis,
+            (reason, priority, listener) -> {
+                reroute.set(true);
+                listener.onResponse(null);
+            }
+        ) {
+
+            @Override
+            protected void updateIndicesReadOnly(Set<String> indicesToMarkReadOnly, Releasable onCompletion, boolean readOnly) {
+                assertTrue(readOnly);
+                indices.set(indicesToMarkReadOnly);
+                onCompletion.close();
+            }
+        };
+        monitor.onNewInfo(clusterInfo);
+        return Tuple.tuple(reroute.get(), indices.get());
     }
 
     private void assertNoLogging(DiskThresholdMonitor monitor, Map<String, DiskUsage> diskUsages) throws IllegalAccessException {


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Avoid NPE in DiskThresholdMonitor (#93699)