### PR TITLE
[8.7] Fixing our docs for vector sizing calculation (#93703)

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -34,7 +34,8 @@ most vector data is held in memory. You should ensure that data nodes have at
 least enough RAM to hold the vector data and index structures. To check the
 size of the vector data, you can use the <<indices-disk-usage>> API. As a
 loose rule of thumb, and assuming the default HNSW options, the bytes used will
-be `num_vectors * 4 * (num_dimensions + 32)` plus a small buffer. Note that
+be `num_vectors * 4 * (num_dimensions + 12)`. When using the `byte` <<dense-vector-element-type,`element_type`>>
+the space required will be closer to  `num_vectors * (num_dimensions + 12)`. Note that
 the required RAM is for the filesystem cache, which is separate from the Java
 heap.
 

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -99,6 +99,7 @@ Dense vector fields cannot be indexed if they are within
 
 The following mapping parameters are accepted:
 
+[[dense-vector-element-type]]
 `element_type`::
 (Optional, string)
 The data type used to encode vectors. The supported data types are


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fixing our docs for vector sizing calculation (#93703)