### PR TITLE
Fix Gradle project evaluation when runtime java home is unset

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -48,8 +48,8 @@ configure(allprojects) {
   project.plugins.withType(RestTestBasePlugin) {
     tasks.withType(StandaloneRestIntegTestTask).configureEach {
       if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
-        dependsOn(project.jdks.provisioned_runtime)
-        nonInputProperties.systemProperty("tests.runtime.java", "${-> project.jdks.provisioned_runtime.javaHomePath}")
+        dependsOn(rootProject.jdks.provisioned_runtime)
+        nonInputProperties.systemProperty("tests.runtime.java", "${-> rootProject.jdks.provisioned_runtime.javaHomePath}")
       }
     }
   }


### PR DESCRIPTION
Fix a mistaken reference to the current project instead of the _root_ project when resolving the runtime JDK to be used for test execution.