### PR TITLE
[7.17] Avoid NPE in DiskThresholdMonitor (#93699)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -48,8 +48,8 @@ configure(allprojects) {
   project.plugins.withType(RestTestBasePlugin) {
     tasks.withType(StandaloneRestIntegTestTask).configureEach {
       if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
-        dependsOn(project.jdks.provisioned_runtime)
-        nonInputProperties.systemProperty("tests.runtime.java", "${-> project.jdks.provisioned_runtime.javaHomePath}")
+        dependsOn(rootProject.jdks.provisioned_runtime)
+        nonInputProperties.systemProperty("tests.runtime.java", "${-> rootProject.jdks.provisioned_runtime.javaHomePath}")
       }
     }
   }

--- a/docs/changelog/93699.yaml
+++ b/docs/changelog/93699.yaml
@@ -1,0 +1,5 @@
+pr: 93699
+summary: Skip `DiskThresholdMonitor` when cluster state is not recovered
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -39,12 +39,14 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.index.Index;
 
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
@@ -129,6 +131,12 @@ public class DiskThresholdMonitor {
     }
 
     public void onNewInfo(ClusterInfo info) {
+        final ClusterState state = clusterStateSupplier.get();
+        if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            logger.debug("skipping monitor as the cluster state is not recovered yet");
+            return;
+        }
+
         // TODO find a better way to limit concurrent updates (and potential associated reroutes) while allowing tests to ensure that
         // all ClusterInfo updates are processed and never ignored
         if (checkInProgress.compareAndSet(false, true) == false) {
@@ -155,7 +163,6 @@ public class DiskThresholdMonitor {
         cleanUpRemovedNodes(nodes, nodesOverHighThreshold);
         cleanUpRemovedNodes(nodes, nodesOverHighThresholdAndRelocating);
 
-        final ClusterState state = clusterStateSupplier.get();
         final Set<String> indicesToMarkReadOnly = new HashSet<>();
         RoutingNodes routingNodes = state.getRoutingNodes();
         Set<String> indicesNotToAutoRelease = new HashSet<>();
@@ -382,6 +389,7 @@ public class DiskThresholdMonitor {
             .stream()
             .filter(meta -> meta.getType() == SingleNodeShutdownMetadata.Type.REPLACE)
             .flatMap(meta -> Stream.of(meta.getNodeId(), nodeNameToId.get(meta.getTargetNodeName())))
+            .filter(Objects::nonNull)  // The REPLACE target node might not still be in RoutingNodes
             .collect(Collectors.toSet());
 
         // Generate a set of all the indices that exist on either the target or source of a node replacement


### PR DESCRIPTION
Backports the following commits to 7.17:

- Avoid NPE in DiskThresholdMonitor (https://github.com/elastic/elasticsearch/pull/93699)