### PR TITLE
Always report dimension and time series metric attributes in field caps api

### DIFF
--- a/docs/changelog/93749.yaml
+++ b/docs/changelog/93749.yaml
@@ -1,0 +1,5 @@
+pr: 93749
+summary: Always report dimension and time series metric attributes in field caps api
+area: TSDB
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -180,7 +180,7 @@ can't shadow metrics:
 # Test that _tsid field is not added if an index is not a time-series index
 no _tsid in standard indices:
   - skip:
-      version: " - 8.6.99"
+      version: " - 8.7.99"
       reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -180,8 +180,8 @@ can't shadow metrics:
 # Test that _tsid field is not added if an index is not a time-series index
 no _tsid in standard indices:
   - skip:
-      version: " - 8.4.99"
-      reason: time series params only on time series indices introduced in 8.5.0
+      version: " - 8.6.99"
+      reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:
       indices.create:
@@ -209,7 +209,7 @@ no _tsid in standard indices:
   - is_false: fields.metricset.keyword.non_searchable_indices
   - is_false: fields.metricset.keyword.non_aggregatable_indices
   - is_false: fields._tsid  # _tsid metadata field must not exist in non-time-series indices
-  - is_false: fields.metricset.keyword.time_series_dimension # time_series_dimension param is ignored in non-time-series indices
+  - match: {fields.metricset.keyword.time_series_dimension: true}
 
 ---
 no nested dimensions:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/110_field_caps.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/110_field_caps.yml
@@ -151,8 +151,8 @@ field caps on time_series indices:
 ---
 field caps on standard indices:
   - skip:
-      version: " - 8.3.99"
-      reason: metric params only on time series indexes introduced in 8.4.0
+      version: " - 8.6.99"
+      reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:
       field_caps:
@@ -162,7 +162,7 @@ field caps on standard indices:
   - match: { fields.metricset.keyword.type: keyword }
   - match: { fields.metricset.keyword.searchable: true }
   - match: { fields.metricset.keyword.aggregatable: true }
-  - is_false: fields.metricset.keyword.time_series_dimension
+  - match: { fields.metricset.keyword.time_series_dimension: true }
   - is_false: fields.metricset.keyword.non_dimension_indices
   - is_false: fields.metricset.keyword.indices
   - is_false: fields.metricset.keyword.non_searchable_indices
@@ -173,7 +173,7 @@ field caps on standard indices:
   - match: { fields.k8s\.pod\.network\.rx.long.type: long }
   - match: { fields.k8s\.pod\.network\.rx.long.searchable: true }
   - match: { fields.k8s\.pod\.network\.rx.long.aggregatable: true }
-  - is_false: fields.k8s\.pod\.network\.rx.long.time_series_metric
+  - match: { fields.k8s\.pod\.network\.rx.long.time_series_metric: gauge }
   - is_false: fields.k8s\.pod\.network\.rx.long.metric_conflicts_indices
   - is_false: fields.k8s\.pod\.network\.rx.long.indices
   - is_false: fields.k8s\.pod\.network\.rx.long.non_searchable_indices
@@ -183,7 +183,7 @@ field caps on standard indices:
   - match: { fields.k8s\.pod\.network\.tx.long.type: long }
   - match: { fields.k8s\.pod\.network\.tx.long.searchable: true }
   - match: { fields.k8s\.pod\.network\.tx.long.aggregatable: true }
-  - is_false: fields.k8s\.pod\.network\.tx.long.time_series_metric
+  - match: { fields.k8s\.pod\.network\.tx.long.time_series_metric: counter }
   - is_false: fields.k8s\.pod\.network\.tx.long.metric_conflicts_indices
   - is_false: fields.k8s\.pod\.network\.tx.long.indices
   - is_false: fields.k8s\.pod\.network\.tx.long.non_searchable_indices
@@ -194,8 +194,8 @@ field caps on standard indices:
 ---
 field caps on mixed indices:
   - skip:
-      version: " - 8.3.99"
-      reason: metric params only on time series indexes introduced in 8.4.0
+      version: " - 8.6.99"
+      reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:
       field_caps:
@@ -205,8 +205,8 @@ field caps on mixed indices:
   - match: { fields.metricset.keyword.type: keyword }
   - match: { fields.metricset.keyword.searchable: true }
   - match: { fields.metricset.keyword.aggregatable: true }
-  - is_false: fields.metricset.keyword.time_series_dimension
-  - match: { fields.metricset.keyword.non_dimension_indices: [ "test_non_time_series" ] }
+  - match: { fields.metricset.keyword.time_series_dimension: true }
+  - is_false: fields.metricset.keyword.non_dimension_indices
   - is_false: fields.metricset.keyword.indices
   - is_false: fields.metricset.keyword.non_searchable_indices
   - is_false: fields.metricset.keyword.non_aggregatable_indices
@@ -214,8 +214,8 @@ field caps on mixed indices:
   - match: { fields.k8s\.pod\.network\.rx.long.type: long }
   - match: { fields.k8s\.pod\.network\.rx.long.searchable: true }
   - match: { fields.k8s\.pod\.network\.rx.long.aggregatable: true }
-  - match: { fields.k8s\.pod\.network\.rx.long.metric_conflicts_indices: [ "test_non_time_series", "test_time_series" ] }
-  - is_false: fields.k8s\.pod\.network\.rx.long.time_series_metric
+  - is_false: fields.k8s\.pod\.network\.rx.long.metric_conflicts_indices
+  - match: { fields.k8s\.pod\.network\.rx.long.time_series_metric: gauge }
   - is_false: fields.k8s\.pod\.network\.rx.long.non_searchable_indices
   - is_false: fields.k8s\.pod\.network\.rx.long.non_aggregatable_indices
   - is_false: fields.k8s\.pod\.network\.rx.long.indices
@@ -223,8 +223,8 @@ field caps on mixed indices:
   - match: { fields.k8s\.pod\.network\.tx.long.type: long }
   - match: { fields.k8s\.pod\.network\.tx.long.searchable: true }
   - match: { fields.k8s\.pod\.network\.tx.long.aggregatable: true }
-  - match: { fields.k8s\.pod\.network\.tx.long.metric_conflicts_indices: [ "test_non_time_series", "test_time_series" ] }
-  - is_false: fields.k8s\.pod\.network\.tx.long.time_series_metric
+  - is_false: fields.k8s\.pod\.network\.tx.long.metric_conflicts_indices
+  - match: { fields.k8s\.pod\.network\.tx.long.time_series_metric: counter }
   - is_false: fields.k8s\.pod\.network\.tx.long.non_searchable_indices
   - is_false: fields.k8s\.pod\.network\.tx.long.non_aggregatable_indices
   - is_false: fields.k8s\.pod\.network\.tx.long.indices

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/110_field_caps.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/110_field_caps.yml
@@ -151,7 +151,7 @@ field caps on time_series indices:
 ---
 field caps on standard indices:
   - skip:
-      version: " - 8.6.99"
+      version: " - 8.7.99"
       reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:
@@ -194,7 +194,7 @@ field caps on standard indices:
 ---
 field caps on mixed indices:
   - skip:
-      version: " - 8.6.99"
+      version: " - 8.7.99"
       reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFetcher.java
@@ -112,7 +112,6 @@ class FieldCapabilitiesFetcher {
         boolean includeParentObjects = checkIncludeParents(filters);
 
         Predicate<MappedFieldType> filter = buildFilter(indexFieldfilter, filters, types, context);
-        boolean isTimeSeriesIndex = context.getIndexSettings().getTimestampBounds() != null;
         Map<String, IndexFieldCapabilities> responseMap = new HashMap<>();
         for (String field : fieldNames) {
             MappedFieldType ft = context.getFieldType(field);
@@ -123,8 +122,8 @@ class FieldCapabilitiesFetcher {
                     context.isMetadataField(field),
                     ft.isSearchable(),
                     ft.isAggregatable(),
-                    isTimeSeriesIndex ? ft.isDimension() : false,
-                    isTimeSeriesIndex ? ft.getMetricType() : null,
+                    ft.isDimension(),
+                    ft.getMetricType(),
                     ft.meta()
                 );
                 responseMap.put(field, fieldCap);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/110_field_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/110_field_caps.yml
@@ -195,10 +195,10 @@ field caps on all indices:
   - match: { fields.metric.double.searchable: true }
   - match: { fields.metric.double.aggregatable: true }
   - match: { fields.metric.double.indices: [ "test_non_time_series", "test_time_series" ] }
-  - match: { fields.metric.double.metric_conflicts_indices: [ "test_non_time_series", "test_time_series" ] }
+  - is_false: fields.metric.double.metric_conflicts_indices
   - is_false: fields.metric.double.non_searchable_indices
   - is_false: fields.metric.double.non_aggregatable_indices
-  - is_false: fields.metric.double.time_series_metric
+  - match: { fields.metric.double.time_series_metric: gauge }
 
   - match: { fields.metric.aggregate_metric_double.type: aggregate_metric_double }
   - match: { fields.metric.aggregate_metric_double.searchable: true }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/110_field_caps.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/aggregate-metrics/110_field_caps.yml
@@ -183,8 +183,8 @@ field caps on time series indices:
 # Test field_caps on mixed standard and time-series (mix of raw and rollup) indices
 field caps on all indices:
   - skip:
-      version: " - 8.4.99"
-      reason: metric params only on time series indices introduced in 8.5.0
+      version: " - 8.7.99"
+      reason: field caps api was changed to include time series attributes in non tsdb indices
 
   - do:
       field_caps:


### PR DESCRIPTION
The `time_series_dimension` and `time_series_metric` attributes can be defined on non tsdb indices. The field caps only reports both attributes on tsdb indices. This change alters the field caps api to also return these attributes when specified on non tsdb indices.

Relates to #93539