### PR TITLE
Revert YAML tests changes related to index sorting

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -1,16 +1,13 @@
 ---
 "Index Sort":
 
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/93599"
-
   - do:
       indices.create:
         index: test
         body:
           settings:
             number_of_shards: 1
+            number_of_replicas: 0
             index.sort.field: rank
           mappings:
             properties:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
@@ -15,6 +15,7 @@
                 type: date
           settings:
             number_of_shards: 1
+            number_of_replicas: 0
 
   # 1st segment
   - do:
@@ -43,8 +44,8 @@
 ---
 "Test that index segments are NOT sorted on timestamp field when @timestamp field is dynamically added":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/93572"
+      version: " - 7.99.99"
+      reason: "sorting segments was added in 7.16"
       features: allowed_warnings
 
   - do:
@@ -53,6 +54,7 @@
         body:
           settings:
             number_of_shards: 1
+            number_of_replicas: 0
 
   # 1st segment
   - do:
@@ -112,6 +114,7 @@
                 type: date
           settings:
             number_of_shards: 1
+            number_of_replicas: 0
 
   # 1st segment missing @timestamp field
   - do:


### PR DESCRIPTION
In  #93386 we adjusted some YAML tests to allow their execution on a 2 nodes cluster where every index has at least 1 replica, but this caused test failures for single or multi node clusters.

This pull request reverts the changes that was made. Those tests will be muted for the 2 nodes cluster.

Closes #93572
Closes #93599

