### PR TITLE
Clarify `wait_for_completion` doc in the Task API

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -51,7 +51,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 `wait_for_completion`::
-(Optional, Boolean) If `true`, the request blocks until the operation is complete.
+(Optional, Boolean) If `true`, the request blocks until all found tasks are complete.
 Defaults to `false`.
 
 [[tasks-api-response-codes]]


### PR DESCRIPTION
Bumped into this while checking something else and was surprised that the code comment for `wait_for_completion` is way more clear than the doc. (I understand that https://github.com/elastic/elasticsearch/pull/90977 has made the implications of misunderstanding this less sever!)
