### PR TITLE
Fix rank_features parsing for dots in feature name

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureQueryBuilder.java
@@ -383,17 +383,13 @@ public final class RankFeatureQueryBuilder extends AbstractQueryBuilder<RankFeat
         if (ft instanceof final RankFeatureFieldType fft) {
             return scoreFunction.toQuery(RankFeatureMetaFieldMapper.NAME, field, fft.positiveScoreImpact());
         } else if (ft == null) {
-            // for fields of RankFeaturesFieldType need to find where the feature name starts
-            int featureNameStart = field.lastIndexOf('.');
-            while (featureNameStart != -1) {
-                final String parentField = field.substring(0, featureNameStart);
+            final int lastDotIndex = field.lastIndexOf('.');
+            if (lastDotIndex != -1) {
+                final String parentField = field.substring(0, lastDotIndex);
                 final MappedFieldType parentFt = context.getFieldType(parentField);
                 if (parentFt instanceof RankFeaturesFieldType) {
-                    return scoreFunction.toQuery(parentField, field.substring(featureNameStart + 1), true);
+                    return scoreFunction.toQuery(parentField, field.substring(lastDotIndex + 1), true);
                 }
-                // if we haven't found a RankFeaturesFieldType parent field yet, this could be because
-                // the feature name contains one or multiple dots. In this case, repeat the above for the remaining prefix
-                featureNameStart = field.substring(0, featureNameStart).lastIndexOf('.');
             }
             return new MatchNoDocsQuery(); // unmapped field
         } else {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
@@ -161,6 +161,11 @@ public class RankFeaturesFieldMapper extends FieldMapper {
             for (Token token = context.parser().nextToken(); token != Token.END_OBJECT; token = context.parser().nextToken()) {
                 if (token == Token.FIELD_NAME) {
                     feature = context.parser().currentName();
+                    if (feature.contains(".")) {
+                        throw new IllegalArgumentException(
+                            "[rank_features] fields do not support dots in feature names but found [" + feature + "]"
+                        );
+                    }
                 } else if (token == Token.VALUE_NULL) {
                     // ignore feature, this is consistent with numeric fields
                 } else if (token == Token.VALUE_NUMBER || token == Token.VALUE_STRING) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapper.java
@@ -155,33 +155,39 @@ public class RankFeaturesFieldMapper extends FieldMapper {
         }
 
         String feature = null;
-        for (Token token = context.parser().nextToken(); token != Token.END_OBJECT; token = context.parser().nextToken()) {
-            if (token == Token.FIELD_NAME) {
-                feature = context.parser().currentName();
-            } else if (token == Token.VALUE_NULL) {
-                // ignore feature, this is consistent with numeric fields
-            } else if (token == Token.VALUE_NUMBER || token == Token.VALUE_STRING) {
-                final String key = name() + "." + feature;
-                float value = context.parser().floatValue(true);
-                if (context.doc().getByKey(key) != null) {
+        try {
+            // make sure that we don't expand dots in field names while parsing
+            context.path().setWithinLeafObject(true);
+            for (Token token = context.parser().nextToken(); token != Token.END_OBJECT; token = context.parser().nextToken()) {
+                if (token == Token.FIELD_NAME) {
+                    feature = context.parser().currentName();
+                } else if (token == Token.VALUE_NULL) {
+                    // ignore feature, this is consistent with numeric fields
+                } else if (token == Token.VALUE_NUMBER || token == Token.VALUE_STRING) {
+                    final String key = name() + "." + feature;
+                    float value = context.parser().floatValue(true);
+                    if (context.doc().getByKey(key) != null) {
+                        throw new IllegalArgumentException(
+                            "[rank_features] fields do not support indexing multiple values for the same "
+                                + "rank feature ["
+                                + key
+                                + "] in the same document"
+                        );
+                    }
+                    if (positiveScoreImpact == false) {
+                        value = 1 / value;
+                    }
+                    context.doc().addWithKey(key, new FeatureField(name(), feature, value));
+                } else {
                     throw new IllegalArgumentException(
-                        "[rank_features] fields do not support indexing multiple values for the same "
-                            + "rank feature ["
-                            + key
-                            + "] in the same document"
+                        "[rank_features] fields take hashes that map a feature to a strictly positive "
+                            + "float, but got unexpected token "
+                            + token
                     );
                 }
-                if (positiveScoreImpact == false) {
-                    value = 1 / value;
-                }
-                context.doc().addWithKey(key, new FeatureField(name(), feature, value));
-            } else {
-                throw new IllegalArgumentException(
-                    "[rank_features] fields take hashes that map a feature to a strictly positive "
-                        + "float, but got unexpected token "
-                        + token
-                );
             }
+        } finally {
+            context.path().setWithinLeafObject(false);
         }
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
@@ -128,25 +128,12 @@ public class RankFeaturesFieldMapperTests extends MapperTestCase {
 
     public void testDotinFieldname() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
-        ParsedDocument doc1 = mapper.parse(source(b -> b.field("field", Map.of("politi.cs", 10, "sports", 20))));
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertThat(fields[0], Matchers.instanceOf(FeatureField.class));
-        FeatureField featureField1 = null;
-        FeatureField featureField2 = null;
-        for (IndexableField field : fields) {
-            if (field.stringValue().equals("politi.cs")) {
-                featureField1 = (FeatureField) field;
-            } else if (field.stringValue().equals("sports")) {
-                featureField2 = (FeatureField) field;
-            } else {
-                throw new UnsupportedOperationException();
-            }
-        }
-
-        int freq1 = RankFeatureFieldMapperTests.getFrequency(featureField1.tokenStream(null, null));
-        int freq2 = RankFeatureFieldMapperTests.getFrequency(featureField2.tokenStream(null, null));
-        assertTrue(freq1 < freq2);
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> mapper.parse(source(b -> b.field("field", Map.of("politi.cs", 10, "sports", 20))))
+        );
+        assertThat(ex.getCause().getMessage(), containsString("do not support dots in feature names"));
+        assertThat(ex.getCause().getMessage(), containsString("politi.cs"));
     }
 
     public void testRejectMultiValuedFields() throws MapperParsingException, IOException {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
@@ -126,6 +126,29 @@ public class RankFeaturesFieldMapperTests extends MapperTestCase {
         assertTrue(freq1 > freq2);
     }
 
+    public void testDotinFieldname() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        ParsedDocument doc1 = mapper.parse(source(b -> b.field("field", Map.of("politi.cs", 10, "sports", 20))));
+        IndexableField[] fields = doc1.rootDoc().getFields("field");
+        assertEquals(2, fields.length);
+        assertThat(fields[0], Matchers.instanceOf(FeatureField.class));
+        FeatureField featureField1 = null;
+        FeatureField featureField2 = null;
+        for (IndexableField field : fields) {
+            if (field.stringValue().equals("politi.cs")) {
+                featureField1 = (FeatureField) field;
+            } else if (field.stringValue().equals("sports")) {
+                featureField2 = (FeatureField) field;
+            } else {
+                throw new UnsupportedOperationException();
+            }
+        }
+
+        int freq1 = RankFeatureFieldMapperTests.getFrequency(featureField1.tokenStream(null, null));
+        int freq2 = RankFeatureFieldMapperTests.getFrequency(featureField2.tokenStream(null, null));
+        assertTrue(freq1 < freq2);
+    }
+
     public void testRejectMultiValuedFields() throws MapperParsingException, IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("field").field("type", "rank_features").endObject();

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
@@ -23,7 +23,6 @@ setup:
           tags:
             foo: 3
             bar: 5
-            bazz.dot: 10
           negative_reviews:
             1star: 10
             2star: 1
@@ -36,7 +35,6 @@ setup:
           tags:
             bar: 6
             quux: 10
-            bazz.dot: 20
           negative_reviews:
             1star: 1
             2star: 10
@@ -172,23 +170,14 @@ setup:
 "Dot in feature name":
 
   - do:
-      search:
+      catch: /\[rank_features\] fields do not support dots in feature names but found \[qu\.ux\]/
+      index:
         index: test
+        id: "3"
         body:
-          query:
-            rank_feature:
-              field: tags.bazz.dot
-              linear: {}
-
-  - match:
-      hits.total.value: 2
-
-  - match:
-      hits.hits.0._id: "2"
-  - match:
-      hits.hits.0._score: 20.0
-
-  - match:
-      hits.hits.1._id: "1"
-  - match:
-      hits.hits.1._score: 10.0
+          tags:
+            bar: 6
+            qu.ux: 10
+          negative_reviews:
+            1star: 1
+            2star: 10

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
@@ -14,6 +14,7 @@ setup:
                    positive_score_impact: false
 
 
+
   - do:
       index:
         index: test
@@ -22,6 +23,7 @@ setup:
           tags:
             foo: 3
             bar: 5
+            bazz.dot: 10
           negative_reviews:
             1star: 10
             2star: 1
@@ -34,6 +36,7 @@ setup:
           tags:
             bar: 6
             quux: 10
+            bazz.dot: 20
           negative_reviews:
             1star: 1
             2star: 10
@@ -164,3 +167,28 @@ setup:
       hits.hits.0._id: "1"
   - match:
       hits.hits.1._id: "2"
+
+---
+"Dot in feature name":
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            rank_feature:
+              field: tags.bazz.dot
+              linear: {}
+
+  - match:
+      hits.total.value: 2
+
+  - match:
+      hits.hits.0._id: "2"
+  - match:
+      hits.hits.0._score: 20.0
+
+  - match:
+      hits.hits.1._id: "1"
+  - match:
+      hits.hits.1._score: 10.0


### PR DESCRIPTION
Currently, parsing a rank_features field where the key of the feature contains a
dot leads to parsing errors because we interpret it as a start of a new object.
This change fixes the parsing logic in RankFeaturesFieldMapper and also modifies
the feature key lookup in the RankFeatureQueryBuilder to account for potential
dots in the feature name.