### PR TITLE
[8.6] Support providing test cluster keystore settings via lazy evaluation (#93765)

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -32,6 +32,7 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
     private final Set<String> modules = new HashSet<>();
     private final Set<String> plugins = new HashSet<>();
     private final Set<FeatureFlag> features = new HashSet<>();
+    private final List<SettingsProvider> keystoreProviders = new ArrayList<>();
     private final Map<String, String> keystoreSettings = new HashMap<>();
     private final Map<String, Resource> keystoreFiles = new HashMap<>();
     private final Map<String, Resource> extraConfigFiles = new HashMap<>();
@@ -149,6 +150,16 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
 
     public Map<String, Resource> getKeystoreFiles() {
         return inherit(() -> parent.getKeystoreFiles(), keystoreFiles);
+    }
+
+    @Override
+    public T keystore(String key, Supplier<String> supplier) {
+        this.keystoreProviders.add(s -> Map.of(key, supplier.get()));
+        return cast(this);
+    }
+
+    public List<SettingsProvider> getKeystoreProviders() {
+        return inherit(() -> parent.getKeystoreProviders(), keystoreProviders);
     }
 
     @Override

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -176,6 +176,7 @@ public class DefaultLocalClusterSpecBuilder extends AbstractLocalSpecBuilder<Loc
                 getPlugins(),
                 Optional.ofNullable(getDistributionType()).orElse(DistributionType.INTEG_TEST),
                 getFeatures(),
+                getKeystoreProviders(),
                 getKeystoreSettings(),
                 getKeystoreFiles(),
                 getKeystorePassword(),

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -363,7 +363,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         }
 
         private void addKeystoreSettings() {
-            spec.getKeystoreSettings().forEach((key, value) -> {
+            spec.resolveKeystore().forEach((key, value) -> {
                 String input = spec.getKeystorePassword() == null || spec.getKeystorePassword().isEmpty()
                     ? value
                     : spec.getKeystorePassword() + "\n" + value;

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -77,6 +77,7 @@ public class LocalClusterSpec implements ClusterSpec {
         private final Set<String> plugins;
         private final DistributionType distributionType;
         private final Set<FeatureFlag> features;
+        private final List<SettingsProvider> keystoreProviders;
         private final Map<String, String> keystoreSettings;
         private final Map<String, Resource> keystoreFiles;
         private final String keystorePassword;
@@ -96,6 +97,7 @@ public class LocalClusterSpec implements ClusterSpec {
             Set<String> plugins,
             DistributionType distributionType,
             Set<FeatureFlag> features,
+            List<SettingsProvider> keystoreProviders,
             Map<String, String> keystoreSettings,
             Map<String, Resource> keystoreFiles,
             String keystorePassword,
@@ -113,6 +115,7 @@ public class LocalClusterSpec implements ClusterSpec {
             this.plugins = plugins;
             this.distributionType = distributionType;
             this.features = features;
+            this.keystoreProviders = keystoreProviders;
             this.keystoreSettings = keystoreSettings;
             this.keystoreFiles = keystoreFiles;
             this.keystorePassword = keystorePassword;
@@ -160,10 +163,6 @@ public class LocalClusterSpec implements ClusterSpec {
             return features;
         }
 
-        public Map<String, String> getKeystoreSettings() {
-            return keystoreSettings;
-        }
-
         public Map<String, Resource> getKeystoreFiles() {
             return keystoreFiles;
         }
@@ -199,7 +198,7 @@ public class LocalClusterSpec implements ClusterSpec {
         public String getSetting(String setting, String defaultValue) {
             Map<String, String> allSettings = new HashMap<>();
             allSettings.putAll(resolveSettings());
-            allSettings.putAll(keystoreSettings);
+            allSettings.putAll(resolveKeystore());
 
             return allSettings.getOrDefault(setting, defaultValue);
         }
@@ -217,9 +216,27 @@ public class LocalClusterSpec implements ClusterSpec {
          */
         public Map<String, String> resolveSettings() {
             Map<String, String> resolvedSettings = new HashMap<>();
-            settingsProviders.forEach(p -> resolvedSettings.putAll(p.get(getFilteredSpec(p))));
+            settingsProviders.forEach(p -> resolvedSettings.putAll(p.get(getFilteredSpec(p, null))));
             resolvedSettings.putAll(settings);
             return resolvedSettings;
+        }
+
+        /**
+         * Resolve secure keystore settings. Order of precedence is as follows:
+         * <ol>
+         *     <li>Keystore from cluster configured {@link SettingsProvider}</li>
+         *     <li>Keystore from node configured {@link SettingsProvider}</li>
+         *     <li>Explicit cluster secure settings</li>
+         *     <li>Explicit node secure settings</li>
+         * </ol>
+         *
+         * @return resolved settings for node
+         */
+        public Map<String, String> resolveKeystore() {
+            Map<String, String> resolvedKeystore = new HashMap<>();
+            keystoreProviders.forEach(p -> resolvedKeystore.putAll(p.get(getFilteredSpec(null, p))));
+            resolvedKeystore.putAll(keystoreSettings);
+            return resolvedKeystore;
         }
 
         /**
@@ -241,13 +258,14 @@ public class LocalClusterSpec implements ClusterSpec {
         }
 
         /**
-         * Returns a new {@link LocalNodeSpec} without the given {@link SettingsProvider}. This is needed when resolving settings from a
+         * Returns a new {@link LocalNodeSpec} without the given {@link SettingsProvider}s. This is needed when resolving settings from a
          * settings provider to avoid infinite recursion.
          *
          * @param filteredProvider the provider to omit from the new node spec
+         * @param filteredKeystoreProvider the keystore provider to omit from the new node spec
          * @return a new local node spec
          */
-        private LocalNodeSpec getFilteredSpec(SettingsProvider filteredProvider) {
+        private LocalNodeSpec getFilteredSpec(SettingsProvider filteredProvider, SettingsProvider filteredKeystoreProvider) {
             LocalClusterSpec newCluster = new LocalClusterSpec(cluster.name, cluster.users, cluster.roleFiles);
 
             List<LocalNodeSpec> nodeSpecs = cluster.nodes.stream()
@@ -264,6 +282,7 @@ public class LocalClusterSpec implements ClusterSpec {
                         n.plugins,
                         n.distributionType,
                         n.features,
+                        n.keystoreProviders.stream().filter(s -> s != filteredKeystoreProvider).toList(),
                         n.keystoreSettings,
                         n.keystoreFiles,
                         n.keystorePassword,

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
@@ -75,6 +75,11 @@ interface LocalSpecBuilder<T extends LocalSpecBuilder<?>> {
     T keystore(String key, Resource file);
 
     /**
+     * Add a secure setting computed by the given supplier.
+     */
+    T keystore(String key, Supplier<String> supplier);
+
+    /**
      * Sets the security setting keystore password.
      */
     T keystorePassword(String password);


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Support providing test cluster keystore settings via lazy evaluation (#93765)