### PR TITLE
[ML] Prioritise inference for search requests over ingest

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -87,6 +87,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         // and do know which field the model expects to find its
         // input and so cannot construct a document.
         private final List<String> textInput;
+        private boolean highPriority;
 
         /**
          * Build a request from a list of documents as maps.
@@ -159,6 +160,9 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             } else {
                 textInput = null;
             }
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                highPriority = in.readBoolean();
+            }
         }
 
         public int numberOfDocuments() {
@@ -198,6 +202,14 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             return this;
         }
 
+        public boolean isHighPriority() {
+            return highPriority;
+        }
+
+        public void setHighPriority(boolean highPriority) {
+            this.highPriority = highPriority;
+        }
+
         @Override
         public ActionRequestValidationException validate() {
             return null;
@@ -216,6 +228,9 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
                 out.writeOptionalStringCollection(textInput);
             }
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                out.writeBoolean(highPriority);
+            }
         }
 
         @Override
@@ -228,7 +243,8 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
                 && Objects.equals(previouslyLicensed, that.previouslyLicensed)
                 && Objects.equals(inferenceTimeout, that.inferenceTimeout)
                 && Objects.equals(objectsToInfer, that.objectsToInfer)
-                && Objects.equals(textInput, that.textInput);
+                && Objects.equals(textInput, that.textInput)
+                && (highPriority == that.highPriority);
         }
 
         @Override
@@ -238,7 +254,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, objectsToInfer, update, previouslyLicensed, inferenceTimeout, textInput);
+            return Objects.hash(modelId, objectsToInfer, update, previouslyLicensed, inferenceTimeout, textInput, highPriority);
         }
 
         public static class Builder {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -97,7 +97,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         private final List<Map<String, Object>> docs;
         private final InferenceConfigUpdate update;
         private final TimeValue inferenceTimeout;
-        private boolean skipQueue = false;
+        private boolean highPriority = false;
         // textInput added for uses that accept a query string
         // and do know which field the model expects to find its
         // input and so cannot construct a document.
@@ -141,7 +141,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             InferenceConfigUpdate update,
             List<Map<String, Object>> docs,
             List<String> textInput,
-            boolean skipQueue,
+            boolean highPriority,
             TimeValue inferenceTimeout
         ) {
             this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
@@ -149,7 +149,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             this.textInput = textInput;
             this.update = update;
             this.inferenceTimeout = inferenceTimeout;
-            this.skipQueue = skipQueue;
+            this.highPriority = highPriority;
         }
 
         public Request(StreamInput in) throws IOException {
@@ -159,7 +159,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             update = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
             inferenceTimeout = in.readOptionalTimeValue();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
-                skipQueue = in.readBoolean();
+                highPriority = in.readBoolean();
             }
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
                 textInput = in.readOptionalStringList();
@@ -202,12 +202,12 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             return null;
         }
 
-        public void setSkipQueue(boolean skipQueue) {
-            this.skipQueue = skipQueue;
+        public void setHighPriority(boolean highPriority) {
+            this.highPriority = highPriority;
         }
 
-        public boolean isSkipQueue() {
-            return skipQueue;
+        public boolean isHighPriority() {
+            return highPriority;
         }
 
         @Override
@@ -231,7 +231,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             out.writeOptionalNamedWriteable(update);
             out.writeOptionalTimeValue(inferenceTimeout);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_3_0)) {
-                out.writeBoolean(skipQueue);
+                out.writeBoolean(highPriority);
             }
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
                 out.writeOptionalStringCollection(textInput);
@@ -252,13 +252,13 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
                 && Objects.equals(docs, that.docs)
                 && Objects.equals(update, that.update)
                 && Objects.equals(inferenceTimeout, that.inferenceTimeout)
-                && Objects.equals(skipQueue, that.skipQueue)
+                && Objects.equals(highPriority, that.highPriority)
                 && Objects.equals(textInput, that.textInput);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, update, docs, inferenceTimeout, skipQueue, textInput);
+            return Objects.hash(modelId, update, docs, inferenceTimeout, highPriority, textInput);
         }
 
         @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
@@ -48,7 +48,7 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
 
     @Override
     protected Request createTestInstance() {
-        return randomBoolean()
+        var request = randomBoolean()
             ? Request.forIngestDocs(
                 randomAlphaOfLength(10),
                 Stream.generate(InferModelActionRequestTests::randomMap).limit(randomInt(10)).collect(Collectors.toList()),
@@ -60,11 +60,61 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
                 randomInferenceConfigUpdate(),
                 Arrays.asList(generateRandomStringArray(3, 5, false))
             );
+
+        request.setHighPriority(randomBoolean());
+        return request;
     }
 
     @Override
     protected Request mutateInstance(Request instance) {
-        return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+
+        var modelId = instance.getModelId();
+        var objectsToInfer = instance.getObjectsToInfer();
+        var highPriority = instance.isHighPriority();
+        var textInput = instance.getTextInput();
+        var update = instance.getUpdate();
+        var previouslyLicensed = instance.isPreviouslyLicensed();
+        var timeout = instance.getInferenceTimeout();
+
+        int change = randomIntBetween(0, 6);
+        switch (change) {
+            case 0:
+                modelId = modelId + "foo";
+                break;
+            case 1:
+                var newDocs = new ArrayList<>(objectsToInfer);
+                newDocs.add(randomMap());
+                objectsToInfer = newDocs;
+                break;
+            case 2:
+                highPriority = highPriority == false;
+                break;
+            case 3:
+                var newInput = new ArrayList<>(textInput == null ? List.of() : textInput);
+                newInput.add((randomAlphaOfLength(4)));
+                textInput = newInput;
+                break;
+            case 4:
+                var newUpdate = randomInferenceConfigUpdate();
+                while (newUpdate.getName().equals(update.getName())) {
+                    newUpdate = randomInferenceConfigUpdate();
+                }
+                update = newUpdate;
+                break;
+            case 5:
+                previouslyLicensed = previouslyLicensed == false;
+                break;
+            case 6:
+                timeout = TimeValue.timeValueSeconds(timeout.getSeconds() - 1);
+                break;
+            default:
+                throw new IllegalStateException();
+        }
+
+        var r = new Request(modelId, update, objectsToInfer, textInput, timeout, previouslyLicensed);
+        r.setHighPriority(highPriority);
+        r.setInferenceTimeout(timeout);
+        return r;
     }
 
     private static InferenceConfigUpdate randomInferenceConfigUpdate() {
@@ -147,6 +197,17 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
                 instance.getInferenceTimeout(),
                 instance.isPreviouslyLicensed()
             );
+        } else if (version.before(Version.V_8_8_0)) {
+            var r = new Request(
+                instance.getModelId(),
+                adjustedUpdate,
+                instance.getObjectsToInfer(),
+                instance.getTextInput(),
+                instance.getInferenceTimeout(),
+                instance.isPreviouslyLicensed()
+            );
+            r.setHighPriority(false);
+            return r;
         }
 
         return instance;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInferTrainedModelDeploymentAction.java
@@ -108,7 +108,7 @@ public class TransportInferTrainedModelDeploymentAction extends TransportTasksAc
 
         GroupedActionListener<InferenceResults> groupedListener = new GroupedActionListener<>(nlpInputs.size(), collectingListener);
         for (var input : nlpInputs) {
-            task.infer(input, request.getUpdate(), request.isSkipQueue(), request.getInferenceTimeout(), actionTask, groupedListener);
+            task.infer(input, request.getUpdate(), request.isHighPriority(), request.getInferenceTimeout(), actionTask, groupedListener);
         }
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportInternalInferModelAction.java
@@ -267,6 +267,7 @@ public class TransportInternalInferModelAction extends HandledTransportAction<Re
                     request.getInferenceTimeout()
                 );
             }
+            deploymentRequest.setHighPriority(request.isHighPriority());
             deploymentRequest.setNodes(node.v1());
             deploymentRequest.setParentTask(parentTaskId);
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -126,6 +126,7 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
             SlimConfigUpdate.EMPTY_UPDATE,
             List.of(modelText)
         );
+        inferRequest.setHighPriority(true);
 
         SetOnce<SlimResults> slimResultsSupplier = new SetOnce<>();
         queryRewriteContext.registerAsyncAction((client, listener) -> {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
@@ -95,6 +95,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
             TextEmbeddingConfigUpdate.EMPTY_INSTANCE,
             List.of(modelText)
         );
+        inferRequest.setHighPriority(true);
 
         executeAsyncWithOrigin(client, ML_ORIGIN, InferModelAction.INSTANCE, inferRequest, ActionListener.wrap(response -> {
             if (response.getInferenceResults().isEmpty()) {


### PR DESCRIPTION
#86571 introduced a priority queue for inference requests. All requests go into the queue but high priority requests skip ahead of normal priority requests. For the low latency search use case requests are _high_ priority and will be processed before the _normal_ priority ingest requests.

The new text_embedding and text_expansion searches both make high priority requests.