### PR TITLE
[8.7] Support for GCS proxies everywhere in the GCS API (#92192)

### DIFF
--- a/docs/changelog/92192.yaml
+++ b/docs/changelog/92192.yaml
@@ -1,0 +1,6 @@
+pr: 92192
+summary: Support for GCS proxies everywhere in the GCS API
+area: Snapshot/Restore
+type: bug
+issues:
+ - 91952

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/ForwardedViaProxyHandler.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/ForwardedViaProxyHandler.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.repositories.gcs;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.IOException;
+
+@SuppressForbidden(reason = "Tests that all requests come via a proxy")
+class ForwardedViaProxyHandler implements HttpHandler {
+
+    private final HttpHandler delegateHandler;
+
+    ForwardedViaProxyHandler(HttpHandler delegateHandler) {
+        this.delegateHandler = delegateHandler;
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        assert "test-web-proxy-server".equals(exchange.getRequestHeaders().getFirst("X-Via"));
+        delegateHandler.handle(exchange);
+    }
+}

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GcsProxyIntegrationTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GcsProxyIntegrationTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.repositories.gcs;
+
+import fixture.gcs.FakeOAuth2HttpHandler;
+import fixture.gcs.GoogleCloudStorageHttpHandler;
+import fixture.gcs.TestUtils;
+
+import com.sun.net.httpserver.HttpServer;
+
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.mocksocket.MockHttpServer;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.util.Collection;
+import java.util.List;
+
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.CREDENTIALS_FILE_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.ENDPOINT_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROXY_HOST_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROXY_PORT_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.PROXY_TYPE_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageClientSettings.TOKEN_URI_SETTING;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.BUCKET;
+import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CLIENT_NAME;
+
+@SuppressForbidden(reason = "We start an HTTP proxy server to test proxy support for GCS")
+public class GcsProxyIntegrationTests extends ESBlobStoreRepositoryIntegTestCase {
+
+    private static HttpServer upstreamServer;
+    private static WebProxyServer proxyServer;
+
+    @BeforeClass
+    public static void startServers() throws Exception {
+        upstreamServer = MockHttpServer.createHttp(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        upstreamServer.start();
+        proxyServer = new WebProxyServer();
+    }
+
+    @AfterClass
+    public static void stopServers() throws IOException {
+        upstreamServer.stop(0);
+        proxyServer.close();
+    }
+
+    @Before
+    public void setUpHttpServer() {
+        upstreamServer.createContext("/", new ForwardedViaProxyHandler(new GoogleCloudStorageHttpHandler("bucket")));
+        upstreamServer.createContext("/token", new ForwardedViaProxyHandler(new FakeOAuth2HttpHandler()));
+    }
+
+    @After
+    public void tearDownHttpServer() {
+        upstreamServer.removeContext("/");
+        upstreamServer.removeContext("/token");
+    }
+
+    @Override
+    protected String repositoryType() {
+        return GoogleCloudStorageRepository.TYPE;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return List.of(GoogleCloudStoragePlugin.class);
+    }
+
+    @Override
+    protected Settings repositorySettings(String repoName) {
+        return Settings.builder()
+            .put(super.repositorySettings(repoName))
+            .put(BUCKET.getKey(), "bucket")
+            .put(CLIENT_NAME.getKey(), "test")
+            .build();
+    }
+
+    @Override
+    protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
+        var secureSettings = new MockSecureSettings();
+        secureSettings.setFile(
+            CREDENTIALS_FILE_SETTING.getConcreteSettingForNamespace("test").getKey(),
+            TestUtils.createServiceAccount(random())
+        );
+        String upstreamServerUrl = "http://" + upstreamServer.getAddress().getHostString() + ":" + upstreamServer.getAddress().getPort();
+        return Settings.builder()
+            .put(super.nodeSettings(nodeOrdinal, otherSettings))
+            .put(ENDPOINT_SETTING.getConcreteSettingForNamespace("test").getKey(), upstreamServerUrl)
+            .put(TOKEN_URI_SETTING.getConcreteSettingForNamespace("test").getKey(), upstreamServerUrl + "/token")
+            .put(PROXY_HOST_SETTING.getConcreteSettingForNamespace("test").getKey(), proxyServer.getHost())
+            .put(PROXY_PORT_SETTING.getConcreteSettingForNamespace("test").getKey(), proxyServer.getPort())
+            .put(PROXY_TYPE_SETTING.getConcreteSettingForNamespace("test").getKey(), "http")
+            .setSecureSettings(secureSettings)
+            .build();
+    }
+}

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/WebProxyServer.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/WebProxyServer.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.repositories.gcs;
+
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.SuppressForbidden;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static java.nio.charset.StandardCharsets.ISO_8859_1;
+
+/**
+ * Emulates a <a href="https://en.wikipedia.org/wiki/Proxy_server#Web_proxy_servers">Web Proxy Server</a>
+ */
+class WebProxyServer extends MockHttpProxyServer {
+
+    private static final Set<String> BLOCKED_HEADERS = Stream.of("Host", "Proxy-Connection", "Proxy-Authenticate")
+        .collect(Collectors.toCollection(() -> new TreeSet<>(String.CASE_INSENSITIVE_ORDER)));
+
+    WebProxyServer() throws IOException {
+        super(WebProxyServer::handle);
+    }
+
+    @SuppressForbidden(reason = "Proxy makes requests to the upstream HTTP server")
+    private static void handle(InputStream is, OutputStream os) throws IOException {
+        // We can't make a com.sun.net.httpserver act as an HTTP proxy, so we have to do work with
+        // raw sockets and do HTTP parsing ourselves
+        String requestLine = readLine(is);
+        String[] parts = requestLine.split(" ");
+        String requestMethod = parts[0];
+        String originUrl = parts[1];
+
+        var upstreamHttpConnection = (HttpURLConnection) URI.create(originUrl).toURL().openConnection();
+        upstreamHttpConnection.setRequestMethod(requestMethod);
+        upstreamHttpConnection.setRequestProperty("X-Via", "test-web-proxy-server");
+
+        int requestContentLength = -1;
+        boolean chunkedRequest = false;
+        while (true) {
+            String requestHeader = readLine(is);
+            if (requestHeader.isEmpty()) {
+                // End of the headers block
+                break;
+            }
+            String[] headerParts = requestHeader.split(":");
+            String headerName = headerParts[0].trim();
+            String headerValue = headerParts[1].trim();
+            if (headerName.equalsIgnoreCase("Content-Length")) {
+                requestContentLength = Integer.parseInt(headerValue);
+            } else if (headerName.equalsIgnoreCase("Transfer-Encoding") && headerValue.equalsIgnoreCase("chunked")) {
+                chunkedRequest = true;
+            }
+            if (BLOCKED_HEADERS.contains(headerName) == false) {
+                upstreamHttpConnection.setRequestProperty(headerName, headerValue);
+            }
+        }
+        if (requestContentLength > 0) {
+            upstreamHttpConnection.setDoOutput(true);
+            try (var uos = upstreamHttpConnection.getOutputStream()) {
+                uos.write(is.readNBytes(requestContentLength));
+            }
+        } else if (chunkedRequest) {
+            upstreamHttpConnection.setDoOutput(true);
+            upstreamHttpConnection.setChunkedStreamingMode(0);
+            try (var uos = upstreamHttpConnection.getOutputStream()) {
+                while (true) {
+                    int chunkSize = Integer.parseInt(readLine(is), 16);
+                    if (chunkSize == 0) {
+                        // End of the chunked body
+                        break;
+                    }
+                    uos.write(is.readNBytes(chunkSize));
+                    if (is.read() != '\r' || is.read() != '\n') {
+                        throw new IllegalStateException("Not CRLF");
+                    }
+                }
+            }
+        }
+        upstreamHttpConnection.connect();
+
+        String upstreamStatusLine = Strings.format(
+            "HTTP/1.1 %s %s\r\n",
+            upstreamHttpConnection.getResponseCode(),
+            upstreamHttpConnection.getResponseMessage()
+        );
+        os.write(upstreamStatusLine.getBytes(ISO_8859_1));
+        StringBuilder responseHeaders = new StringBuilder();
+        for (var upstreamHeader : upstreamHttpConnection.getHeaderFields().entrySet()) {
+            if (upstreamHeader.getKey() == null) {
+                continue;
+            }
+            responseHeaders.append(upstreamHeader.getKey()).append(": ");
+            for (int i = 0; i < upstreamHeader.getValue().size(); i++) {
+                responseHeaders.append(upstreamHeader.getValue().get(i));
+                if (i < upstreamHeader.getValue().size() - 1) {
+                    responseHeaders.append(",");
+                }
+            }
+            responseHeaders.append("\r\n");
+        }
+        responseHeaders.append("\r\n");
+        os.write(responseHeaders.toString().getBytes(ISO_8859_1));
+        // HttpURLConnection handles chunked and fixed-length responses transparently
+        try (var uis = upstreamHttpConnection.getInputStream()) {
+            uis.transferTo(os);
+        }
+    }
+
+    private static String readLine(InputStream is) throws IOException {
+        ByteArrayOutputStream os = new ByteArrayOutputStream();
+        while (true) {
+            int b = is.read();
+            if (b == -1) {
+                break;
+            }
+            if (b == '\r') {
+                if (is.read() != '\n') {
+                    throw new IllegalStateException("Not CRLF");
+                }
+                break;
+            }
+            os.write(b);
+        }
+        return os.toString(ISO_8859_1);
+    }
+}

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -16,12 +16,19 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.Proxy;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Base64;
@@ -179,5 +186,26 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
         assertEquals(-1, GoogleCloudStorageService.toTimeout(null).intValue());
         assertEquals(-1, GoogleCloudStorageService.toTimeout(TimeValue.ZERO).intValue());
         assertEquals(0, GoogleCloudStorageService.toTimeout(TimeValue.MINUS_ONE).intValue());
+    }
+
+    public void testGetDefaultProjectIdViaProxy() throws Exception {
+        String proxyProjectId = randomAlphaOfLength(16);
+        var proxyServer = new MockHttpProxyServer((is, os) -> {
+            try (
+                var reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                var writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)
+            ) {
+                assertEquals("GET http://metadata.google.internal/computeMetadata/v1/project/project-id HTTP/1.1", reader.readLine());
+                writer.write(Strings.format("""
+                    HTTP/1.1 200 OK\r
+                    Content-Length: %s\r
+                    \r
+                    %s""", proxyProjectId.length(), proxyProjectId));
+            }
+        }).await();
+        try (proxyServer) {
+            var proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(InetAddress.getLoopbackAddress(), proxyServer.getPort()));
+            assertEquals(proxyProjectId, SocketAccess.doPrivilegedIOException(() -> GoogleCloudStorageService.getDefaultProjectId(proxy)));
+        }
     }
 }

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockHttpProxyServer.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockHttpProxyServer.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.repositories.gcs;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.common.network.NetworkAddress;
+import org.elasticsearch.mocksocket.MockServerSocket;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.net.SocketException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * A mock HTTP Proxy server for testing of support of HTTP proxies in various SDKs
+ */
+class MockHttpProxyServer implements Closeable {
+
+    private static final Logger log = LogManager.getLogger(MockHttpProxyServer.class);
+
+    private final MockServerSocket serverSocket;
+    private final Thread serverThread;
+    private final CountDownLatch latch;
+    private final ExecutorService executorService = Executors.newCachedThreadPool();
+
+    MockHttpProxyServer(SocketRequestHandler handler) throws IOException {
+        // Emulate a proxy HTTP server with plain sockets because MockHttpServer doesn't work as a proxy
+        serverSocket = new MockServerSocket(0);
+        latch = new CountDownLatch(1);
+        serverThread = new Thread(() -> {
+            latch.countDown();
+            while (Thread.currentThread().isInterrupted() == false) {
+                Socket socket;
+                try {
+                    socket = serverSocket.accept();
+                } catch (SocketException e) {
+                    // Server socket is closed
+                    break;
+                } catch (IOException e) {
+                    log.error("Unable to accept socket request", e);
+                    break;
+                }
+                executorService.submit(() -> {
+                    try (
+                        socket;
+                        var is = new BufferedInputStream(socket.getInputStream());
+                        var os = new BufferedOutputStream(socket.getOutputStream())
+                    ) {
+                        // Don't handle keep-alive connections to keep things simple
+                        handler.handle(is, os);
+                    } catch (IOException e) {
+                        log.error("Unable to handle socket request", e);
+                    }
+                });
+            }
+        });
+        serverThread.start();
+    }
+
+    MockHttpProxyServer await() throws InterruptedException {
+        latch.await();
+        return this;
+    }
+
+    int getPort() {
+        return serverSocket.getLocalPort();
+    }
+
+    String getHost() {
+        return NetworkAddress.format(serverSocket.getInetAddress());
+    }
+
+    @Override
+    public void close() throws IOException {
+        executorService.shutdown();
+        serverThread.interrupt();
+        serverSocket.close();
+    }
+
+    @FunctionalInterface
+    interface SocketRequestHandler {
+        void handle(InputStream is, OutputStream os) throws IOException;
+    }
+}

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockHttpProxyServerTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockHttpProxyServerTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.repositories.gcs;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.DefaultProxyRoutePlanner;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.net.InetAddress;
+import java.nio.charset.StandardCharsets;
+
+public class MockHttpProxyServerTests extends ESTestCase {
+
+    public void testProxyServerWorks() throws Exception {
+        String httpBody = randomAlphaOfLength(32);
+        var proxyServer = new MockHttpProxyServer((is, os) -> {
+            try (
+                var reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
+                var writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)
+            ) {
+                assertEquals("GET http://googleapis.com/ HTTP/1.1", reader.readLine());
+                writer.write(Strings.format("""
+                    HTTP/1.1 200 OK\r
+                    Content-Length: %s\r
+                    \r
+                    %s""", httpBody.length(), httpBody));
+            }
+        }).await();
+        var httpClient = HttpClients.custom()
+            .setRoutePlanner(new DefaultProxyRoutePlanner(new HttpHost(InetAddress.getLoopbackAddress(), proxyServer.getPort())))
+            .build();
+        try (
+            proxyServer;
+            httpClient;
+            var httpResponse = SocketAccess.doPrivilegedIOException(() -> httpClient.execute(new HttpGet("http://googleapis.com/")))
+        ) {
+            assertEquals(httpBody.length(), httpResponse.getEntity().getContentLength());
+            assertEquals(httpBody, EntityUtils.toString(httpResponse.getEntity()));
+        }
+    }
+}


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Support for GCS proxies everywhere in the GCS API (#92192)