### PR TITLE
Fix off-by-one error in TransportVersionUtils.getNextVersion

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -103,7 +103,7 @@ public class TransportVersionUtils {
             place++;
         }
 
-        if (place <= 0) {
+        if (place <= 0 || place >= ALL_VERSIONS.size()) {
             throw new IllegalArgumentException("couldn't find any released versions after [" + version + "]");
         }
         return ALL_VERSIONS.get(place);

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -86,6 +86,7 @@ public class TransportVersionUtils {
             // version does not exist - need the item before the index this version should be inserted
             place = -(place + 1);
         }
+
         if (place <= 1) {
             throw new IllegalArgumentException("couldn't find any released versions before [" + version + "]");
         }
@@ -97,11 +98,15 @@ public class TransportVersionUtils {
         if (place < 0) {
             // version does not exist - need the item at the index this version should be inserted
             place = -(place + 1);
+        } else {
+            // need the *next* version
+            place++;
         }
-        if (place <= 1) {
+
+        if (place <= 0) {
             throw new IllegalArgumentException("couldn't find any released versions after [" + version + "]");
         }
-        return ALL_VERSIONS.get(place + 1);
+        return ALL_VERSIONS.get(place);
     }
 
     /** Returns a random {@link Version} from all available versions, that is compatible with the given version. */

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -87,7 +87,7 @@ public class TransportVersionUtils {
             place = -(place + 1);
         }
 
-        if (place <= 1) {
+        if (place < 1) {
             throw new IllegalArgumentException("couldn't find any released versions before [" + version + "]");
         }
         return ALL_VERSIONS.get(place - 1);
@@ -103,7 +103,7 @@ public class TransportVersionUtils {
             place++;
         }
 
-        if (place <= 0 || place >= ALL_VERSIONS.size()) {
+        if (place < 0 || place >= ALL_VERSIONS.size()) {
             throw new IllegalArgumentException("couldn't find any released versions after [" + version + "]");
         }
         return ALL_VERSIONS.get(place);


### PR DESCRIPTION
This fixes #93774 