### PR TITLE
[7.17] Revert YAML tests changes related to index sorting (#93753)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -1,11 +1,6 @@
 ---
 "Index Sort":
 
-
-  - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/93599"
-
   - do:
       indices.create:
         index: test


### PR DESCRIPTION
Backport of #93753