### PR TITLE
[DOCS] Adds semantic search section to kNN search page

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -431,10 +431,13 @@ against an index containing dense vectors created with the same text embedding
 [IMPORTANT]
 =====================
 To perform semantic search:
+
 * you need an index that contains the dens vector representation of the input 
 data to search against,
+
 * you must use the same text embedding model for search that you used to create 
 the dens vectors from the input data,
+
 * the text embedding NLP model deployment must be started.
 =====================
 

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -432,11 +432,11 @@ against an index containing dense vectors created with the same text embedding
 =====================
 To perform semantic search:
 
-* you need an index that contains the dens vector representation of the input 
+* you need an index that contains the dense vector representation of the input 
 data to search against,
 
 * you must use the same text embedding model for search that you used to create 
-the dens vectors from the input data,
+the dense vectors from the input data,
 
 * the text embedding NLP model deployment must be started.
 =====================

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -418,7 +418,7 @@ calculated on the combined set of `knn` and `query` matches.
 ==== Perform semantic search
 
 KNN search enables you to perform semantic search by using a previously deployed 
-{ml-docs}ml-nlp-search-compare.html#ml-nlp-text-embedding[text embedding model]. 
+{ml-docs}/ml-nlp-search-compare.html#ml-nlp-text-embedding[text embedding model]. 
 You can use semantic search to retrieve results based on the intent and the 
 contextual meaning of the search query not only the literal matches of the 
 keywords.
@@ -470,7 +470,7 @@ representation.
 
 For more information on how to deploy a trained model and use it to create text 
 embeddings, refer to this 
-{ml-docs}ml-nlp-text-emb-vector-search-example.html[end-to-end example].
+{ml-docs}/ml-nlp-text-emb-vector-search-example.html[end-to-end example].
 
 
 [discrete]

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -417,14 +417,13 @@ calculated on the combined set of `knn` and `query` matches.
 [[semantic-search]]
 ==== Perform semantic search
 
-KNN search enables you to perform semantic search by using a previously deployed 
+kNN search enables you to perform semantic search by using a previously deployed 
 {ml-docs}/ml-nlp-search-compare.html#ml-nlp-text-embedding[text embedding model]. 
-You can use semantic search to retrieve results based on the intent and the 
-contextual meaning of the search query not only the literal matches of the 
-keywords.
+Instead of literal matching on search terms, semantic search retrieves results
+based on the intent and the contextual meaning of a search query.
 
 Under the hood, the text embedding NLP model generates a dense vector from the 
-input query string called `model_text` you provided. Then, it is searched 
+input query string called `model_text` you provide. Then, it is searched 
 against an index containing dense vectors created with the same text embedding 
 {ml} model. The search results are semantically similar as learned by the model.
 

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -407,10 +407,68 @@ each score in the sum. In the example above, the scores will be calculated as
 score = 0.9 * match_score + 0.1 * knn_score
 ```
 
-The `knn` option can also be used with <<search-aggregations, `aggregations`>>. In general, {es} computes aggregations
-over all documents that match the search. So for approximate kNN search, aggregations are calculated on the top `k`
-nearest documents. If the search also includes a `query`, then aggregations are calculated on the combined set of `knn`
-and `query` matches.
+The `knn` option can also be used with <<search-aggregations, `aggregations`>>. 
+In general, {es} computes aggregations over all documents that match the search. 
+So for approximate kNN search, aggregations are calculated on the top `k` 
+nearest documents. If the search also includes a `query`, then aggregations are 
+calculated on the combined set of `knn` and `query` matches.
+
+[discrete]
+==== Perform semantic search
+
+KNN search enables you to perform semantic search by using a previously deployed 
+{ml-docs}ml-nlp-search-compare.html#ml-nlp-text-embedding[text embedding model]. 
+You can use semantic search to retrieve results based on the intent and the 
+contextual meaning of the search query not only the literal matches of the 
+keywords.
+
+Under the hood, the text embedding NLP model generates a dense vector from the 
+input query string called `model_text` you provided. Then, it is searched 
+against an index containing dense vectors created with the same text embedding 
+{ml} model. The search results are semantically similar as learned by the model.
+
+[IMPORTANT]
+=====================
+To perform semantic search:
+* you need an index that contains the dens vector representation of the input 
+data to search against,
+* you must use the same text embedding model for search that you used to create 
+the dens vectors from the input data,
+* the text embedding NLP model deployment must be started.
+=====================
+
+Reference the deployed text embedding model in the `query_vector_builder` object 
+and provide the search query as `model_text`:
+
+[source,js]
+----
+(...)
+{
+  "knn": {
+    "field": "dense-vector-field",
+    "k": 10,
+    "num_candidates": 100,
+    "query_vector_builder": {
+      "text_embedding": { <1>
+        "model_id": "my-text-embedding-model", <2>
+        "model_text": "The opposite of blue" <3>
+      }
+    }
+  }
+}
+(...)
+----
+<1> The {nlp} task to perform. It must be `text_embedding`.
+<2> The ID of the text embedding model to use to generate the dense vectors from 
+the query string. Use the same model that generated the embeddings from the 
+input text in the index you search against.
+<3> The query string from which the model generates the dense vector 
+representation.
+
+For more information on how to deploy a trained model and use it to create text 
+embeddings, refer to this 
+{ml-docs}ml-nlp-text-emb-vector-search-example.html[end-to-end example].
+
 
 [discrete]
 ==== Search multiple kNN fields

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -459,6 +459,8 @@ and provide the search query as `model_text`:
 }
 (...)
 ----
+// NOTCONSOLE
+
 <1> The {nlp} task to perform. It must be `text_embedding`.
 <2> The ID of the text embedding model to use to generate the dense vectors from 
 the query string. Use the same model that generated the embeddings from the 

--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -414,6 +414,7 @@ nearest documents. If the search also includes a `query`, then aggregations are
 calculated on the combined set of `knn` and `query` matches.
 
 [discrete]
+[[semantic-search]]
 ==== Perform semantic search
 
 KNN search enables you to perform semantic search by using a previously deployed 

--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -511,8 +511,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=knn-query-vector]
 
 `query_vector_builder`::
 (Optional, object)
-A configuration object indicating how to build a query_vector before executing the request. You must provide
-a `query_vector_builder` or `query_vector`, but not both.
+A configuration object indicating how to build a query_vector before executing 
+the request. You must provide a `query_vector_builder` or `query_vector`, but 
+not both. Refer to <<semantic-search>> to learn more.
 
 ====
 


### PR DESCRIPTION
## Overview

This PR adds a section about how to perform semantic search by using kNN to the kNN search page.
The end-to-end example in the `stack-docs` repo will be updated accordingly.

### Preview

[Performing semantic search](https://elasticsearch_93782.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/knn-search.html#semantic-search)