### PR TITLE
[8.7] Adding another section to the SAML troubleshooting docs (#93493)

### DIFF
--- a/x-pack/docs/en/security/troubleshooting.asciidoc
+++ b/x-pack/docs/en/security/troubleshooting.asciidoc
@@ -107,7 +107,7 @@ The role definition might be missing or invalid.
 
 |======================
 
-To help track down these possibilities, enable additional logging to troubleshoot further. 
+To help track down these possibilities, enable additional logging to troubleshoot further.
 You can enable debug logging by configuring the following persistent setting:
 
 [source, console]
@@ -120,7 +120,7 @@ PUT /_cluster/settings
 }
 ----
 
-Alternatively, you can add the following lines to the end of 
+Alternatively, you can add the following lines to the end of
 the `log4j2.properties` configuration file in the `ES_PATH_CONF`:
 
 [source,properties]
@@ -710,6 +710,32 @@ If you want your users to be able to use local credentials to authenticate to
 {kib} in addition to using the SAML realm for Single Sign-On, you must enable
 the `basic` `authProvider` in {kib}. The process is documented in the
 <<saml-kibana-basic, SAML Guide>>
+
+--
+
+. *Symptoms:*
++
+--
+No SAML request ID values are being passed from {kib} to {es}:
+
+....
+Caused by org.elasticsearch.ElasticsearchSecurityException: SAML content is in-response-to [_A1B2C3D4E5F6G8H9I0] but expected one of []
+....
+
+*Resolution:*
+This error indicates that {es} received a SAML response tied to a particular SAML request, but {kib}
+didn't explicitly specify ID of that request. This usually means that {kib} cannot find the user session where
+it previously stored the SAML request ID.
+
+To resolve this issue, ensure that in your {kib} configuration `xpack.security.sameSiteCookies` is not set to `Strict`.
+Depending on your configuration, you may be able to rely on the default value or explicitly set the value to `None`.
+
+For further information,
+please read https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[MDN SameSite cookies]
+
+If you serve multiple {kib} installations behind a load balancer make sure to use the
+https://www.elastic.co/guide/en/kibana/current/production.html#load-balancing-kibana[same security configuration]
+for all installations.
 --
 
 *Logging:*


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Adding another section to the SAML troubleshooting docs (#93493)](https://github.com/elastic/elasticsearch/pull/93493)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)