### PR TITLE
[8.6] Fix ZonedDateTime example code (#93235)

### DIFF
--- a/docs/painless/painless-guide/painless-datetime.asciidoc
+++ b/docs/painless/painless-guide/painless-datetime.asciidoc
@@ -661,7 +661,7 @@ preferred as there is no need to parse it for comparison.
 ----
 long now = params['now'];
 ZonedDateTime inputDateTime = doc['input_datetime'];
-long millisDateTime = zdt.toInstant().toEpochMilli();
+long millisDateTime = inputDateTime.toInstant().toEpochMilli();
 long elapsedTime = now - millisDateTime;
 ----
 +


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix ZonedDateTime example code (#93235)