### PR TITLE
[8.7] Better error mesage for parsing dots in rank_features feature name (#93756)

### DIFF
--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
@@ -126,6 +126,16 @@ public class RankFeaturesFieldMapperTests extends MapperTestCase {
         assertTrue(freq1 > freq2);
     }
 
+    public void testDotinFieldname() throws Exception {
+        DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
+        MapperParsingException ex = expectThrows(
+            MapperParsingException.class,
+            () -> mapper.parse(source(b -> b.field("field", Map.of("politi.cs", 10, "sports", 20))))
+        );
+        assertThat(ex.getCause().getMessage(), containsString("do not support dots in feature names"));
+        assertThat(ex.getCause().getMessage(), containsString("politi.cs"));
+    }
+
     public void testRejectMultiValuedFields() throws MapperParsingException, IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {
             b.startObject("field").field("type", "rank_features").endObject();

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_features/10_basic.yml
@@ -14,6 +14,7 @@ setup:
                    positive_score_impact: false
 
 
+
   - do:
       index:
         index: test
@@ -164,3 +165,19 @@ setup:
       hits.hits.0._id: "1"
   - match:
       hits.hits.1._id: "2"
+
+---
+"Dot in feature name":
+
+  - do:
+      catch: /\[rank_features\] fields do not support dots in feature names but found \[qu\.ux\]/
+      index:
+        index: test
+        id: "3"
+        body:
+          tags:
+            bar: 6
+            qu.ux: 10
+          negative_reviews:
+            1star: 1
+            2star: 10


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix rank_features parsing for dots in feature name (#93756)