### PR TITLE
Avoid deserializing responses in proxy node

### DIFF
--- a/docs/changelog/93799.yaml
+++ b/docs/changelog/93799.yaml
@@ -1,0 +1,5 @@
+pr: 93799
+summary: Avoid deserializing responses in proxy node
+area: Network
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/ReleasableBytesReference.java
@@ -148,14 +148,28 @@ public final class ReleasableBytesReference implements RefCounted, Releasable, B
     public StreamInput streamInput() throws IOException {
         assert hasReferences();
         return new BytesReferenceStreamInput(this) {
-            @Override
-            public ReleasableBytesReference readReleasableBytesReference() throws IOException {
-                final int len = readArraySize();
+            private ReleasableBytesReference retainAndSkip(int len) throws IOException {
                 // instead of reading the bytes from a stream we just create a slice of the underlying bytes
                 final ReleasableBytesReference result = retainedSlice(offset(), len);
                 // move the stream manually since creating the slice didn't move it
                 skip(len);
                 return result;
+            }
+
+            @Override
+            public ReleasableBytesReference readReleasableBytesReference() throws IOException {
+                final int len = readArraySize();
+                return retainAndSkip(len);
+            }
+
+            @Override
+            public ReleasableBytesReference readAllToReleasableBytesReference() throws IOException {
+                return retainAndSkip(length() - offset());
+            }
+
+            @Override
+            public boolean supportReadAllToReleasableBytesReference() {
+                return true;
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/FilterStreamInput.java
@@ -41,6 +41,17 @@ public abstract class FilterStreamInput extends StreamInput {
     }
 
     @Override
+    public boolean supportReadAllToReleasableBytesReference() {
+        return delegate.supportReadAllToReleasableBytesReference();
+    }
+
+    @Override
+    public ReleasableBytesReference readAllToReleasableBytesReference() throws IOException {
+        assert supportReadAllToReleasableBytesReference() : "This InputStream doesn't support readAllToReleasableBytesReference";
+        return delegate.readAllToReleasableBytesReference();
+    }
+
+    @Override
     public short readShort() throws IOException {
         return delegate.readShort();
     }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -132,6 +132,26 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
+     * Checks if this {@link InputStream} supports {@link #readAllToReleasableBytesReference()}.
+     */
+    public boolean supportReadAllToReleasableBytesReference() {
+        return false;
+    }
+
+    /**
+     * Reads all remaining bytes in the stream as a releasable bytes reference.
+     * Similarly to {@link #readReleasableBytesReference} the returned bytes reference may reference bytes in a
+     * pooled buffer and must be explicitly released via {@link ReleasableBytesReference#close()} once no longer used.
+     * However, unlike {@link #readReleasableBytesReference()}, this method doesn't have the prefix size.
+     * <p>
+     * NOTE: Always check {@link #supportReadAllToReleasableBytesReference()} before calling this method.
+     */
+    public ReleasableBytesReference readAllToReleasableBytesReference() throws IOException {
+        assert false : "This InputStream doesn't support readAllToReleasableBytesReference";
+        throw new UnsupportedOperationException("This InputStream doesn't support readAllToReleasableBytesReference");
+    }
+
+    /**
      * Reads an optional bytes reference from this stream. It might hold an actual reference to the underlying bytes of the stream. Use this
      * only if you must differentiate null from empty. Use {@link StreamInput#readBytesReference()} and
      * {@link StreamOutput#writeBytesReference(BytesReference)} if you do not.

--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.bytes.ReleasableBytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -53,12 +54,35 @@ public final class TransportActionProxy {
             assert assertConsistentTaskType(task, wrappedRequest);
             TaskId taskId = task.taskInfo(service.localNode.getId(), false).taskId();
             wrappedRequest.setParentTask(taskId);
-            service.sendRequest(
-                targetNode,
-                action,
-                wrappedRequest,
-                new ProxyResponseHandler<>(channel, responseFunction.apply(wrappedRequest))
-            );
+            service.sendRequest(targetNode, action, wrappedRequest, new TransportResponseHandler<>() {
+                @Override
+                public void handleResponse(TransportResponse response) {
+                    try {
+                        response.incRef();
+                        channel.sendResponse(response);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+
+                @Override
+                public void handleException(TransportException exp) {
+                    try {
+                        channel.sendResponse(exp);
+                    } catch (IOException e) {
+                        throw new UncheckedIOException(e);
+                    }
+                }
+
+                @Override
+                public TransportResponse read(StreamInput in) throws IOException {
+                    if (in.getTransportVersion().equals(channel.getVersion()) && in.supportReadAllToReleasableBytesReference()) {
+                        return new BytesTransportResponse(in);
+                    } else {
+                        return responseFunction.apply(wrappedRequest).read(in);
+                    }
+                }
+            });
         }
 
         private static boolean assertConsistentTaskType(Task proxyTask, TransportRequest wrapped) {
@@ -76,38 +100,32 @@ public final class TransportActionProxy {
         }
     }
 
-    private static class ProxyResponseHandler<T extends TransportResponse> implements TransportResponseHandler<T> {
+    static final class BytesTransportResponse extends TransportResponse {
+        final ReleasableBytesReference bytes;
 
-        private final Writeable.Reader<T> reader;
-        private final TransportChannel channel;
-
-        ProxyResponseHandler(TransportChannel channel, Writeable.Reader<T> reader) {
-            this.reader = reader;
-            this.channel = channel;
+        BytesTransportResponse(StreamInput in) throws IOException {
+            super(in);
+            this.bytes = in.readAllToReleasableBytesReference();
         }
 
         @Override
-        public T read(StreamInput in) throws IOException {
-            return reader.read(in);
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBytes(bytes.array(), bytes.arrayOffset(), bytes.length());
         }
 
         @Override
-        public void handleResponse(T response) {
-            try {
-                response.incRef();
-                channel.sendResponse(response);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+        public void incRef() {
+            bytes.incRef();
         }
 
         @Override
-        public void handleException(TransportException exp) {
-            try {
-                channel.sendResponse(exp);
-            } catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+        public boolean tryIncRef() {
+            return bytes.tryIncRef();
+        }
+
+        @Override
+        public boolean decRef() {
+            return bytes.decRef();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -27,11 +28,17 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.junit.Before;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
 public class TransportActionProxyTests extends ESTestCase {
@@ -50,6 +57,9 @@ public class TransportActionProxyTests extends ESTestCase {
     protected DiscoveryNode nodeC;
     protected MockTransportService serviceC;
 
+    protected DiscoveryNode nodeD;
+    protected MockTransportService serviceD;
+
     @Override
     @Before
     public void setUp() throws Exception {
@@ -61,12 +71,14 @@ public class TransportActionProxyTests extends ESTestCase {
         nodeB = serviceB.getLocalDiscoNode();
         serviceC = buildService(version1); // this one doesn't support dynamic tracer updates
         nodeC = serviceC.getLocalDiscoNode();
+        serviceD = buildService(version1);
+        nodeD = serviceD.getLocalDiscoNode();
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
-        IOUtils.close(serviceA, serviceB, serviceC, () -> { terminate(threadPool); });
+        IOUtils.close(serviceA, serviceB, serviceC, serviceD, () -> { terminate(threadPool); });
     }
 
     private MockTransportService buildService(final Version version) {
@@ -106,39 +118,99 @@ public class TransportActionProxyTests extends ESTestCase {
         });
 
         TransportActionProxy.registerProxyAction(serviceC, "internal:test", cancellable, SimpleTestResponse::new);
+        // Node A -> Node B -> Node C: different versions - serialize the response
+        {
+            final List<TransportMessage> responses = Collections.synchronizedList(new ArrayList<>());
+            final CountDownLatch latch = new CountDownLatch(1);
+            serviceB.addRequestHandlingBehavior(
+                TransportActionProxy.getProxyAction("internal:test"),
+                (handler, request, channel, task) -> handler.messageReceived(
+                    request,
+                    new CapturingTransportChannel(channel, responses::add),
+                    task
+                )
+            );
+            serviceA.sendRequest(
+                nodeB,
+                TransportActionProxy.getProxyAction("internal:test"),
+                TransportActionProxy.wrapRequest(nodeC, new SimpleTestRequest("TS_A", cancellable)),
+                new TransportResponseHandler<SimpleTestResponse>() {
+                    @Override
+                    public SimpleTestResponse read(StreamInput in) throws IOException {
+                        return new SimpleTestResponse(in);
+                    }
 
-        final CountDownLatch latch = new CountDownLatch(1);
-        // Node A -> Node B -> Node C
-        serviceA.sendRequest(
-            nodeB,
-            TransportActionProxy.getProxyAction("internal:test"),
-            TransportActionProxy.wrapRequest(nodeC, new SimpleTestRequest("TS_A", cancellable)),
-            new TransportResponseHandler<SimpleTestResponse>() {
-                @Override
-                public SimpleTestResponse read(StreamInput in) throws IOException {
-                    return new SimpleTestResponse(in);
-                }
+                    @Override
+                    public void handleResponse(SimpleTestResponse response) {
+                        try {
+                            assertEquals("TS_C", response.targetNode);
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
 
-                @Override
-                public void handleResponse(SimpleTestResponse response) {
-                    try {
-                        assertEquals("TS_C", response.targetNode);
-                    } finally {
-                        latch.countDown();
+                    @Override
+                    public void handleException(TransportException exp) {
+                        try {
+                            throw new AssertionError(exp);
+                        } finally {
+                            latch.countDown();
+                        }
                     }
                 }
+            );
+            latch.await();
+            assertThat(responses, hasSize(1));
+            assertThat(responses.get(0), instanceOf(SimpleTestResponse.class));
+            serviceB.clearAllRules();
+        }
+        // Node D -> node B -> Node C: the same version - do not serialize the responses
+        {
+            AbstractSimpleTransportTestCase.connectToNode(serviceD, nodeB);
+            final CountDownLatch latch = new CountDownLatch(1);
+            final List<TransportMessage> responses = Collections.synchronizedList(new ArrayList<>());
+            serviceB.addRequestHandlingBehavior(
+                TransportActionProxy.getProxyAction("internal:test"),
+                (handler, request, channel, task) -> handler.messageReceived(
+                    request,
+                    new CapturingTransportChannel(channel, responses::add),
+                    task
+                )
+            );
+            serviceD.sendRequest(
+                nodeB,
+                TransportActionProxy.getProxyAction("internal:test"),
+                TransportActionProxy.wrapRequest(nodeC, new SimpleTestRequest("TS_A", cancellable)),
+                new TransportResponseHandler<SimpleTestResponse>() {
+                    @Override
+                    public SimpleTestResponse read(StreamInput in) throws IOException {
+                        return new SimpleTestResponse(in);
+                    }
 
-                @Override
-                public void handleException(TransportException exp) {
-                    try {
-                        throw new AssertionError(exp);
-                    } finally {
-                        latch.countDown();
+                    @Override
+                    public void handleResponse(SimpleTestResponse response) {
+                        try {
+                            assertEquals("TS_C", response.targetNode);
+                        } finally {
+                            latch.countDown();
+                        }
+                    }
+
+                    @Override
+                    public void handleException(TransportException exp) {
+                        try {
+                            throw new AssertionError(exp);
+                        } finally {
+                            latch.countDown();
+                        }
                     }
                 }
-            }
-        );
-        latch.await();
+            );
+            latch.await();
+            assertThat(responses, hasSize(1));
+            assertThat(responses.get(0), instanceOf(TransportActionProxy.BytesTransportResponse.class));
+            serviceB.clearAllRules();
+        }
     }
 
     public void testSendLocalRequest() throws Exception {
@@ -363,5 +435,41 @@ public class TransportActionProxyTests extends ESTestCase {
     public void testIsProxyRequest() {
         assertTrue(TransportActionProxy.isProxyRequest(new TransportActionProxy.ProxyRequest<>(TransportRequest.Empty.INSTANCE, null)));
         assertFalse(TransportActionProxy.isProxyRequest(TransportRequest.Empty.INSTANCE));
+    }
+
+    static class CapturingTransportChannel implements TransportChannel {
+        final TransportChannel in;
+        final Consumer<TransportResponse> onResponse;
+
+        CapturingTransportChannel(TransportChannel in, Consumer<TransportResponse> onResponse) {
+            this.in = in;
+            this.onResponse = onResponse;
+        }
+
+        @Override
+        public String getProfileName() {
+            return in.getProfileName();
+        }
+
+        @Override
+        public String getChannelType() {
+            return in.getChannelType();
+        }
+
+        @Override
+        public void sendResponse(TransportResponse response) throws IOException {
+            onResponse.accept(response);
+            in.sendResponse(response);
+        }
+
+        @Override
+        public void sendResponse(Exception exception) throws IOException {
+            in.sendResponse(exception);
+        }
+
+        @Override
+        public TransportVersion getVersion() {
+            return in.getVersion();
+        }
     }
 }


### PR DESCRIPTION
We can forward the responses using the network buffer directly to the calling node on a proxy node if all the calling, proxy, and handling nodes are on the same version. This enhancement should speed up CCS and CCR as it avoids deserialization/deserialization and helps GC.