### PR TITLE
Fleet: Add new mappings for .fleet-actions signing

### DIFF
--- a/docs/changelog/93802.yaml
+++ b/docs/changelog/93802.yaml
@@ -1,0 +1,5 @@
+pr: 93802
+summary: "Fleet: Add new mappings for .fleet-actions signing"
+area: DefendWorkflows
+type: enhancement
+issues: []

--- a/docs/changelog/93802.yaml
+++ b/docs/changelog/93802.yaml
@@ -1,5 +1,5 @@
 pr: 93802
 summary: "Fleet: Add new mappings for .fleet-actions signing"
-area: DefendWorkflows
+area: Security
 type: enhancement
 issues: []

--- a/x-pack/plugin/core/src/main/resources/fleet-actions.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-actions.json
@@ -45,6 +45,16 @@
         },
         "user_id" : {
           "type": "keyword"
+        },
+        "signed" : {
+          "properties": {
+            "data" : {
+              "type": "binary"
+            },
+            "signature" : {
+              "type": "binary"
+            }
+          }
         }
       }
     }


### PR DESCRIPTION
## What does this PR do?

Adds new ```signed``` mapping with ```data``` and ```signature``` in order to support the .fleet-actions documents signing.
This is a part of the the Agent Tamper Protection effort by the "Security Defends Workflows" team.

## Screenshots

Verified the ```signed``` mappings:
<img width="1350" alt="Screenshot 2023-02-14 at 3 30 27 PM" src="https://user-images.githubusercontent.com/872351/218857471-77a540db-c40b-41c8-8551-f6f405f74be8.png">

Verified the document is stored with the new properties correctly:
<img width="1353" alt="Screenshot 2023-02-14 at 3 29 55 PM" src="https://user-images.githubusercontent.com/872351/218857530-044d241a-b127-4374-a94c-cb75a4bb36ec.png">
