### PR TITLE
Add TransportVersion to DiscoveryNode

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -11,6 +11,8 @@ package org.elasticsearch;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -44,7 +46,7 @@ import java.util.TreeMap;
  * So the minimum compatible version needs to be hard-coded as the transport version of the minimum compatible node version.
  * That variable should be updated appropriately whenever we do a major version release.
  */
-public class TransportVersion implements Comparable<TransportVersion> {
+public class TransportVersion implements Comparable<TransportVersion>, ToXContentFragment {
     public static final TransportVersion ZERO = new TransportVersion(0, "00000000-0000-0000-0000-000000000000");
     public static final TransportVersion V_7_0_0 = new TransportVersion(7_00_00_99, "7505fd05-d982-43ce-a63f-ff4c6c8bdeec");
     public static final TransportVersion V_7_0_1 = new TransportVersion(7_00_01_99, "ae772780-e6f9-46a1-b0a0-20ed0cae37f7");
@@ -285,6 +287,11 @@ public class TransportVersion implements Comparable<TransportVersion> {
     @Override
     public int compareTo(TransportVersion other) {
         return Integer.compare(this.id, other.id);
+    }
+
+    @Override
+    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+        return builder.value(toString());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/JoinValidationService.java
@@ -302,14 +302,14 @@ public class JoinValidationService {
             assert discoveryNode.getVersion().onOrAfter(Version.V_8_3_0) : discoveryNode.getVersion();
             // NB these things never run concurrently to each other, or to the cache cleaner (see IMPLEMENTATION NOTES above) so it is safe
             // to do these (non-atomic) things to the (unsynchronized) statesByVersion map.
-            final var cachedBytes = statesByVersion.get(discoveryNode.getVersion().transportVersion);
+            final var cachedBytes = statesByVersion.get(discoveryNode.getTransportVersion());
             final var bytes = Objects.requireNonNullElseGet(cachedBytes, () -> serializeClusterState(discoveryNode));
             assert bytes.hasReferences() : "already closed";
             bytes.incRef();
             transportService.sendRequest(
                 discoveryNode,
                 JOIN_VALIDATE_ACTION_NAME,
-                new BytesTransportRequest(bytes, discoveryNode.getVersion().transportVersion),
+                new BytesTransportRequest(bytes, discoveryNode.getTransportVersion()),
                 REQUEST_OPTIONS,
                 new CleanableResponseHandler<>(
                     listener,
@@ -344,7 +344,7 @@ public class JoinValidationService {
         var success = false;
         try {
             final var clusterState = clusterStateSupplier.get();
-            final var version = discoveryNode.getVersion().transportVersion;
+            final var version = discoveryNode.getTransportVersion();
             try (
                 var stream = new OutputStreamStreamOutput(
                     CompressorFactory.COMPRESSOR.threadLocalOutputStream(Streams.flushOnCloseStream(bytesStream))

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -159,7 +159,14 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      */
     @Deprecated(forRemoval = true)
     public DiscoveryNode(final String id, TransportAddress address, Version nodeVersion) {
-        this(id, address, Collections.emptyMap(), DiscoveryNodeRole.roles(), nodeVersion, nodeVersion.transportVersion);
+        this(
+            id,
+            address,
+            Collections.emptyMap(),
+            DiscoveryNodeRole.roles(),
+            nodeVersion,
+            nodeVersion != null ? nodeVersion.transportVersion : null
+        );
     }
 
     /**
@@ -204,7 +211,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         Set<DiscoveryNodeRole> roles,
         Version nodeVersion
     ) {
-        this("", id, address, attributes, roles, nodeVersion, nodeVersion.transportVersion);
+        this("", id, address, attributes, roles, nodeVersion, nodeVersion != null ? nodeVersion.transportVersion : null);
     }
 
     /**
@@ -270,7 +277,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             attributes,
             roles,
             nodeVersion,
-            nodeVersion.transportVersion
+            nodeVersion != null ? nodeVersion.transportVersion : null
         );
     }
 
@@ -399,7 +406,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             attributes,
             roles,
             nodeVersion,
-            nodeVersion.transportVersion,
+            nodeVersion != null ? nodeVersion.transportVersion : null,
             null
         );
     }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -779,6 +779,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             stringBuilder.append('}');
         }
         stringBuilder.append('{').append(nodeVersion).append('}');
+        stringBuilder.append('{').append(transportVersion).append('}');
     }
 
     public String descriptionWithoutAttributes() {
@@ -801,6 +802,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         }
         builder.endArray();
         builder.field("version", nodeVersion);
+        builder.field("transportVersion", transportVersion);
         builder.endObject();
         return builder;
     }

--- a/server/src/main/java/org/elasticsearch/transport/Transport.java
+++ b/server/src/main/java/org/elasticsearch/transport/Transport.java
@@ -134,7 +134,7 @@ public interface Transport extends LifecycleComponent {
          * Returns the version of the data to communicate in this channel.
          */
         default TransportVersion getTransportVersion() {
-            return getVersion().transportVersion;
+            return getNode().getTransportVersion();
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -1523,7 +1523,7 @@ public class TransportService extends AbstractLifecycleComponent
 
         @Override
         public TransportVersion getVersion() {
-            return localNode.getVersion().transportVersion;
+            return localNode.getTransportVersion();
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -137,7 +137,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
                 if (compressor != null) {
                     in = new InputStreamStreamInput(compressor.threadLocalInputStream(in));
                 }
-                in.setTransportVersion(node.getVersion().transportVersion);
+                in.setTransportVersion(node.getTransportVersion());
                 return in.readBoolean() == false;
             } finally {
                 IOUtils.close(in);

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodeTests.java
@@ -46,7 +46,8 @@ public class DiscoveryNodeTests extends ESTestCase {
             new TransportAddress(TransportAddress.META_ADDRESS, 9200),
             emptyMap(),
             roles,
-            Version.CURRENT
+            Version.CURRENT,
+            TransportVersion.CURRENT
         );
         DiscoveryNodeRole previous = null;
         for (final DiscoveryNodeRole current : node.getRoles()) {
@@ -63,7 +64,15 @@ public class DiscoveryNodeTests extends ESTestCase {
             ? InetAddress.getByName("192.0.2.1")
             : InetAddress.getByAddress("name1", new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
         TransportAddress transportAddress = new TransportAddress(inetAddress, randomIntBetween(0, 65535));
-        DiscoveryNode node = new DiscoveryNode("name1", "id1", transportAddress, emptyMap(), emptySet(), Version.CURRENT);
+        DiscoveryNode node = new DiscoveryNode(
+            "name1",
+            "id1",
+            transportAddress,
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT,
+            TransportVersion.CURRENT
+        );
         assertEquals(transportAddress.address().getHostString(), node.getHostName());
         assertEquals(transportAddress.getAddress(), node.getHostAddress());
     }
@@ -71,7 +80,15 @@ public class DiscoveryNodeTests extends ESTestCase {
     public void testDiscoveryNodeSerializationKeepsHost() throws Exception {
         InetAddress inetAddress = InetAddress.getByAddress("name1", new byte[] { (byte) 192, (byte) 168, (byte) 0, (byte) 1 });
         TransportAddress transportAddress = new TransportAddress(inetAddress, randomIntBetween(0, 65535));
-        DiscoveryNode node = new DiscoveryNode("name1", "id1", transportAddress, emptyMap(), emptySet(), Version.CURRENT);
+        DiscoveryNode node = new DiscoveryNode(
+            "name1",
+            "id1",
+            transportAddress,
+            emptyMap(),
+            emptySet(),
+            Version.CURRENT,
+            TransportVersion.CURRENT
+        );
 
         BytesStreamOutput streamOutput = new BytesStreamOutput();
         streamOutput.setTransportVersion(TransportVersion.CURRENT);
@@ -98,7 +115,8 @@ public class DiscoveryNodeTests extends ESTestCase {
             transportAddress,
             emptyMap(),
             Collections.singleton(customRole),
-            Version.CURRENT
+            Version.CURRENT,
+            TransportVersion.CURRENT
         );
 
         {
@@ -165,7 +183,8 @@ public class DiscoveryNodeTests extends ESTestCase {
             buildNewFakeTransportAddress(),
             Map.of("test-attr", "val"),
             DiscoveryNodeRole.roles(),
-            Version.CURRENT
+            Version.CURRENT,
+            TransportVersion.CURRENT
         );
         final StringBuilder stringBuilder = new StringBuilder();
         node.appendDescriptionWithoutAttributes(stringBuilder);
@@ -188,6 +207,7 @@ public class DiscoveryNodeTests extends ESTestCase {
             Map.of("test-attr", "val"),
             DiscoveryNodeRole.roles(),
             Version.CURRENT,
+            TransportVersion.CURRENT,
             withExternalId ? "test-external-id" : null
         );
 
@@ -217,9 +237,10 @@ public class DiscoveryNodeTests extends ESTestCase {
                   "transform",
                   "voting_only"
                 ],
-                "version" : "%s"
+                "version" : "%s",
+                "transportVersion" : "%s"
               }
-            }""", transportAddress, withExternalId ? "test-external-id" : "test-name", Version.CURRENT)));
+            }""", transportAddress, withExternalId ? "test-external-id" : "test-name", Version.CURRENT, TransportVersion.CURRENT)));
     }
 
     public void testDiscoveryNodeToString() {
@@ -228,7 +249,8 @@ public class DiscoveryNodeTests extends ESTestCase {
             buildNewFakeTransportAddress(),
             Map.of("test-attr", "val"),
             DiscoveryNodeRole.roles(),
-            Version.CURRENT
+            Version.CURRENT,
+            TransportVersion.CURRENT
         );
         var toString = node.toString();
 
@@ -237,6 +259,7 @@ public class DiscoveryNodeTests extends ESTestCase {
         assertThat(toString, containsString("{" + node.getAddress() + "}"));
         assertThat(toString, containsString("{IScdfhilmrstvw}"));// roles
         assertThat(toString, containsString("{" + node.getVersion() + "}"));
+        assertThat(toString, containsString("{" + node.getTransportVersion() + "}"));
         assertThat(toString, containsString("{test-attr=val}"));// attributes
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterInfoSimulatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterInfoSimulatorTests.java
@@ -316,15 +316,7 @@ public class ClusterInfoSimulatorTests extends ESTestCase {
     }
 
     private static DiscoveryNode createDiscoveryNode(String id, Set<DiscoveryNodeRole> roles) {
-        return new DiscoveryNode(
-            id,
-            id,
-            UUIDs.randomBase64UUID(random()),
-            buildNewFakeTransportAddress(),
-            Map.of(),
-            roles,
-            Version.CURRENT
-        );
+        return new DiscoveryNode(id, id, UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Map.of(), roles, null, null);
     }
 
     private static void addIndex(Metadata.Builder metadataBuilder, RoutingTable.Builder routingTableBuilder, ShardRouting shardRouting) {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceComputerTests.java
@@ -1014,15 +1014,7 @@ public class DesiredBalanceComputerTests extends ESTestCase {
     }
 
     private static DiscoveryNode createDiscoveryNode(String id, Set<DiscoveryNodeRole> roles) {
-        return new DiscoveryNode(
-            id,
-            id,
-            UUIDs.randomBase64UUID(random()),
-            buildNewFakeTransportAddress(),
-            Map.of(),
-            roles,
-            Version.CURRENT
-        );
+        return new DiscoveryNode(id, id, UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Map.of(), roles, null, null);
     }
 
     /**


### PR DESCRIPTION
Add a `getTransportVersion` to `DiscoveryNode`, to be propagated alongside node version, to represent the transport version used to communicate with the node.

Migrate an initial set of callsites away from `Version.transportVersion`