### PR TITLE
Include node ID in balance API

### DIFF
--- a/docs/reference/cluster/get-desired-balance.asciidoc
+++ b/docs/reference/cluster/get-desired-balance.asciidoc
@@ -97,21 +97,21 @@ The API returns the following result:
     },
     "nodes": {
       "node-1": {
-        "id": "UPYt8VwWTt-IADAEbqpLxA",
+        "node_id": "UPYt8VwWTt-IADAEbqpLxA",
         "shard_count": 10,
         "forecast_write_load": 8.5,
         "forecast_disk_usage_bytes": 498435,
         "actual_disk_usage_bytes": 498435
       },
       "node-2": {
-        "id": "bgC66tboTIeFQ0VgRGI4Gg",
+        "node_id": "bgC66tboTIeFQ0VgRGI4Gg",
         "shard_count": 15,
         "forecast_write_load": 3.25,
         "forecast_disk_usage_bytes": 384935,
         "actual_disk_usage_bytes": 384935
       },
       "node-3": {
-        "id": "2x1VTuSOQdeguXPdN73yRw",
+        "node_id": "2x1VTuSOQdeguXPdN73yRw",
         "shard_count": 12,
         "forecast_write_load": 6.0,
         "forecast_disk_usage_bytes": 648766,

--- a/docs/reference/cluster/get-desired-balance.asciidoc
+++ b/docs/reference/cluster/get-desired-balance.asciidoc
@@ -97,18 +97,21 @@ The API returns the following result:
     },
     "nodes": {
       "node-1": {
+        "id": "UPYt8VwWTt-IADAEbqpLxA",
         "shard_count": 10,
         "forecast_write_load": 8.5,
         "forecast_disk_usage_bytes": 498435,
         "actual_disk_usage_bytes": 498435
       },
       "node-2": {
+        "id": "bgC66tboTIeFQ0VgRGI4Gg",
         "shard_count": 15,
         "forecast_write_load": 3.25,
         "forecast_disk_usage_bytes": 384935,
         "actual_disk_usage_bytes": 384935
       },
       "node-3": {
+        "id": "2x1VTuSOQdeguXPdN73yRw",
         "shard_count": 12,
         "forecast_write_load": 6.0,
         "forecast_disk_usage_bytes": 648766,

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_balance/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_balance/10_basic.yml
@@ -68,6 +68,24 @@ setup:
   - gte: { 'cluster_balance_stats.nodes.$node_name.actual_disk_usage_bytes' : 0 }
 
 ---
+"Test cluster_balance_stats contains node ID":
+
+  - skip:
+      version: " - 8.7.99"
+      reason: "Node ID added in in 8.8.0"
+
+  - do:
+      cluster.state: {}
+  - set: { nodes._arbitrary_key_ : node_id }
+  - set: { nodes.$node_id.name : node_name }
+
+  - do:
+      _internal.get_desired_balance: { }
+
+  - is_true: 'cluster_balance_stats.nodes.$node_name'
+  - is_true: 'cluster_balance_stats.nodes.$node_name.id'
+
+---
 "Test get desired balance for single shard":
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_balance/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.desired_balance/10_basic.yml
@@ -83,7 +83,7 @@ setup:
       _internal.get_desired_balance: { }
 
   - is_true: 'cluster_balance_stats.nodes.$node_name'
-  - is_true: 'cluster_balance_stats.nodes.$node_name.id'
+  - is_true: 'cluster_balance_stats.nodes.$node_name.node_id'
 
 ---
 "Test get desired balance for single shard":

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -170,10 +171,12 @@ public record ClusterBalanceStats(Map<String, TierBalanceStats> tiers, Map<Strin
         }
     }
 
-    public record NodeBalanceStats(int shards, double forecastWriteLoad, long forecastShardSize, long actualShardSize)
+    public record NodeBalanceStats(String nodeId, int shards, double forecastWriteLoad, long forecastShardSize, long actualShardSize)
         implements
             Writeable,
             ToXContentObject {
+
+        private static final String UNKNOWN_NODE_ID = "UNKNOWN";
 
         private static NodeBalanceStats createFrom(
             RoutingNode routingNode,
@@ -194,15 +197,24 @@ public record ClusterBalanceStats(Map<String, TierBalanceStats> tiers, Map<Strin
                 actualShardSize += shardSize;
             }
 
-            return new NodeBalanceStats(routingNode.size(), forecastWriteLoad, forecastShardSize, actualShardSize);
+            return new NodeBalanceStats(routingNode.nodeId(), routingNode.size(), forecastWriteLoad, forecastShardSize, actualShardSize);
         }
 
         public static NodeBalanceStats readFrom(StreamInput in) throws IOException {
-            return new NodeBalanceStats(in.readInt(), in.readDouble(), in.readLong(), in.readLong());
+            return new NodeBalanceStats(
+                in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0) ? in.readString() : UNKNOWN_NODE_ID,
+                in.readInt(),
+                in.readDouble(),
+                in.readLong(),
+                in.readLong()
+            );
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                out.writeString(nodeId);
+            }
             out.writeInt(shards);
             out.writeDouble(forecastWriteLoad);
             out.writeLong(forecastShardSize);
@@ -211,8 +223,11 @@ public record ClusterBalanceStats(Map<String, TierBalanceStats> tiers, Map<Strin
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            return builder.startObject()
-                .field("shard_count", shards)
+            builder.startObject();
+            if (UNKNOWN_NODE_ID.equals(nodeId) == false) {
+                builder.field("node_id", nodeId);
+            }
+            return builder.field("shard_count", shards)
                 .field("forecast_write_load", forecastWriteLoad)
                 .humanReadableField("forecast_disk_usage_bytes", "forecast_disk_usage", ByteSizeValue.ofBytes(forecastShardSize))
                 .humanReadableField("actual_disk_usage_bytes", "actual_disk_usage", ByteSizeValue.ofBytes(actualShardSize))

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
@@ -82,6 +82,7 @@ public class DesiredBalanceResponseTests extends AbstractWireSerializingTestCase
 
     private ClusterBalanceStats.NodeBalanceStats randomNodeBalanceStats() {
         return new ClusterBalanceStats.NodeBalanceStats(
+            randomAlphaOfLength(10),
             randomIntBetween(0, Integer.MAX_VALUE),
             randomDouble(),
             randomLongBetween(0, Long.MAX_VALUE),
@@ -228,7 +229,7 @@ public class DesiredBalanceResponseTests extends AbstractWireSerializingTestCase
             Map<String, Object> nodesStats = (Map<String, Object>) nodes.get(entry.getKey());
             assertThat(
                 nodesStats.keySet(),
-                containsInAnyOrder("shard_count", "forecast_write_load", "forecast_disk_usage_bytes", "actual_disk_usage_bytes")
+                containsInAnyOrder("node_id", "shard_count", "forecast_write_load", "forecast_disk_usage_bytes", "actual_disk_usage_bytes")
             );
 
             assertEquals(nodesStats.get("shard_count"), entry.getValue().shards());

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStatsTests.java
@@ -72,9 +72,9 @@ public class ClusterBalanceStatsTests extends ESAllocationTestCase {
                         )
                     ),
                     Map.ofEntries(
-                        Map.entry("node-1", new ClusterBalanceStats.NodeBalanceStats(2, 0.0, 4L, 4L)),
-                        Map.entry("node-2", new ClusterBalanceStats.NodeBalanceStats(2, 0.0, 3L, 3L)),
-                        Map.entry("node-3", new ClusterBalanceStats.NodeBalanceStats(2, 0.0, 5L, 5L))
+                        Map.entry("node-1", new ClusterBalanceStats.NodeBalanceStats("node-1", 2, 0.0, 4L, 4L)),
+                        Map.entry("node-2", new ClusterBalanceStats.NodeBalanceStats("node-2", 2, 0.0, 3L, 3L)),
+                        Map.entry("node-3", new ClusterBalanceStats.NodeBalanceStats("node-3", 2, 0.0, 5L, 5L))
                     )
                 )
             )
@@ -116,9 +116,9 @@ public class ClusterBalanceStatsTests extends ESAllocationTestCase {
                         )
                     ),
                     Map.ofEntries(
-                        Map.entry("node-1", new ClusterBalanceStats.NodeBalanceStats(2, 3.5, 14L, 4L)),
-                        Map.entry("node-2", new ClusterBalanceStats.NodeBalanceStats(2, 4.0, 12L, 3L)),
-                        Map.entry("node-3", new ClusterBalanceStats.NodeBalanceStats(2, 4.5, 10L, 5L))
+                        Map.entry("node-1", new ClusterBalanceStats.NodeBalanceStats("node-1", 2, 3.5, 14L, 4L)),
+                        Map.entry("node-2", new ClusterBalanceStats.NodeBalanceStats("node-2", 2, 4.0, 12L, 3L)),
+                        Map.entry("node-3", new ClusterBalanceStats.NodeBalanceStats("node-3", 2, 4.5, 10L, 5L))
                     )
                 )
             )
@@ -185,12 +185,12 @@ public class ClusterBalanceStatsTests extends ESAllocationTestCase {
                         )
                     ),
                     Map.ofEntries(
-                        Map.entry("node-hot-1", new ClusterBalanceStats.NodeBalanceStats(3, 8.5, 16L, 15L)),
-                        Map.entry("node-hot-2", new ClusterBalanceStats.NodeBalanceStats(2, 6.0, 10L, 9L)),
-                        Map.entry("node-hot-3", new ClusterBalanceStats.NodeBalanceStats(2, 6.5, 10L, 10L)),
-                        Map.entry("node-warm-1", new ClusterBalanceStats.NodeBalanceStats(1, 0.0, 12L, 12L)),
-                        Map.entry("node-warm-2", new ClusterBalanceStats.NodeBalanceStats(1, 0.0, 12L, 12L)),
-                        Map.entry("node-warm-3", new ClusterBalanceStats.NodeBalanceStats(1, 0.0, 18L, 18L))
+                        Map.entry("node-hot-1", new ClusterBalanceStats.NodeBalanceStats("node-hot-1", 3, 8.5, 16L, 15L)),
+                        Map.entry("node-hot-2", new ClusterBalanceStats.NodeBalanceStats("node-hot-2", 2, 6.0, 10L, 9L)),
+                        Map.entry("node-hot-3", new ClusterBalanceStats.NodeBalanceStats("node-hot-3", 2, 6.5, 10L, 10L)),
+                        Map.entry("node-warm-1", new ClusterBalanceStats.NodeBalanceStats("node-warm-1", 1, 0.0, 12L, 12L)),
+                        Map.entry("node-warm-2", new ClusterBalanceStats.NodeBalanceStats("node-warm-2", 1, 0.0, 12L, 12L)),
+                        Map.entry("node-warm-3", new ClusterBalanceStats.NodeBalanceStats("node-warm-3", 1, 0.0, 18L, 18L))
                     )
                 )
             )
@@ -225,9 +225,9 @@ public class ClusterBalanceStatsTests extends ESAllocationTestCase {
                         )
                     ),
                     Map.ofEntries(
-                        Map.entry("node-1", new ClusterBalanceStats.NodeBalanceStats(0, 0.0, 0L, 0L)),
-                        Map.entry("node-2", new ClusterBalanceStats.NodeBalanceStats(0, 0.0, 0L, 0L)),
-                        Map.entry("node-3", new ClusterBalanceStats.NodeBalanceStats(0, 0.0, 0L, 0L))
+                        Map.entry("node-1", new ClusterBalanceStats.NodeBalanceStats("node-1", 0, 0.0, 0L, 0L)),
+                        Map.entry("node-2", new ClusterBalanceStats.NodeBalanceStats("node-2", 0, 0.0, 0L, 0L)),
+                        Map.entry("node-3", new ClusterBalanceStats.NodeBalanceStats("node-3", 0, 0.0, 0L, 0L))
                     )
                 )
             )


### PR DESCRIPTION
Today we report node stats by name, but the desired nodes work in terms of node IDs. This commit adds a mapping between node name and ID to make the output easier to interpret.