### PR TITLE
Rename ActionListener#wrap to #running

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -229,7 +229,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
             } catch (Exception e) {
                 throw new AssertionError(e);
             }
-        }, ActionListener.running(() -> {}));
+        }, ActionListener.noop());
         barrier.await(10, TimeUnit.SECONDS);
 
         // drop the victim from the cluster with a network disruption

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -229,7 +229,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
             } catch (Exception e) {
                 throw new AssertionError(e);
             }
-        }, ActionListener.wrap(() -> {}));
+        }, ActionListener.running(() -> {}));
         barrier.await(10, TimeUnit.SECONDS);
 
         // drop the victim from the cluster with a network disruption

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -308,7 +308,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             // put a new lease
             currentRetentionLeases.put(
                 id,
-                primary.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.wrap(latch::countDown))
+                primary.addRetentionLease(id, retainingSequenceNumber, source, ActionListener.running(latch::countDown))
             );
             latch.await();
             // now renew all existing leases; we expect to see these synced to the replicas

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -141,7 +141,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         assertTrue(shard.isSearchIdle());
         CountDownLatch refreshLatch = new CountDownLatch(1);
         // async on purpose to make sure it happens concurrently
-        client().admin().indices().prepareRefresh().execute(ActionListener.wrap(refreshLatch::countDown));
+        client().admin().indices().prepareRefresh().execute(ActionListener.running(refreshLatch::countDown));
         assertHitCount(client().prepareSearch().get(), 1);
         client().prepareIndex("test").setId("1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         assertFalse(shard.scheduledRefresh());
@@ -153,7 +153,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
             .indices()
             .prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1).build())
-            .execute(ActionListener.wrap(updateSettingsLatch::countDown));
+            .execute(ActionListener.running(updateSettingsLatch::countDown));
         assertHitCount(client().prepareSearch().get(), 2);
         // wait for both to ensure we don't have in-flight operations
         updateSettingsLatch.await();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
@@ -142,7 +142,7 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
                             if (Glob.globMatch(indexPattern, index)) {
                                 logger.info("request {} intercepted for index {}", requestId, index);
                                 onIntercept.run();
-                                release.addListener(ActionListener.wrap(() -> {
+                                release.addListener(ActionListener.running(() -> {
                                     logger.info("request {} released for index {}", requestId, index);
                                     try {
                                         connection.sendRequest(requestId, action, request, options);

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/decider/EnableAssignmentDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/decider/EnableAssignmentDeciderIT.java
@@ -57,7 +57,7 @@ public class EnableAssignmentDeciderIT extends ESIntegTestCase {
                 "task_" + i,
                 TestPersistentTasksExecutor.NAME,
                 new TestParams(randomAlphaOfLength(10)),
-                ActionListener.wrap(latch::countDown)
+                ActionListener.running(latch::countDown)
             );
         }
         latch.await();

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/get/TransportGetTaskAction.java
@@ -177,7 +177,7 @@ public class TransportGetTaskAction extends HandledTransportAction<GetTaskReques
                         requireNonNullElse(request.getTimeout(), DEFAULT_WAIT_FOR_COMPLETION_TIMEOUT),
                         ThreadPool.Names.SAME
                     );
-                    future.addListener(ActionListener.wrap(failByTimeout::cancel));
+                    future.addListener(ActionListener.running(failByTimeout::cancel));
                 }
             } else {
                 TaskInfo info = runningTask.taskInfo(clusterService.localNode().getId(), true);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -142,7 +142,7 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
                     requireNonNullElse(request.getTimeout(), DEFAULT_WAIT_FOR_COMPLETION_TIMEOUT),
                     ThreadPool.Names.SAME
                 );
-                future.addListener(ActionListener.wrap(cancellable::cancel));
+                future.addListener(ActionListener.running(cancellable::cancel));
             }
         } else {
             super.processTasks(request, operation, nodeOperation);

--- a/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/InternalClusterInfoService.java
@@ -385,7 +385,7 @@ public class InternalClusterInfoService implements ClusterInfoService, ClusterSt
     private class RefreshScheduler {
 
         ActionListener<ClusterInfo> getListener() {
-            return ActionListener.wrap(() -> {
+            return ActionListener.running(() -> {
                 if (shouldRefresh()) {
                     threadPool.scheduleUnlessShuttingDown(updateFrequency, ThreadPool.Names.SAME, () -> {
                         if (shouldRefresh()) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/BatchedRerouteService.java
@@ -152,7 +152,7 @@ public class BatchedRerouteService implements RerouteService {
 
                 @Override
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
-                    future.addListener(ActionListener.wrap(() -> ActionListener.onResponse(currentListeners, newState)));
+                    future.addListener(ActionListener.running(() -> ActionListener.onResponse(currentListeners, newState)));
                 }
             });
         } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayService.java
@@ -228,7 +228,7 @@ public class GatewayService extends AbstractLifecycleComponent implements Cluste
             logger.info("recovered [{}] indices into cluster_state", newState.metadata().indices().size());
             // reset flag even though state recovery completed, to ensure that if we subsequently become leader again based on a
             // not-recovered state, that we again do another state recovery.
-            rerouteService.reroute("state recovered", Priority.NORMAL, ActionListener.wrap(GatewayService.this::resetRecoveredFlags));
+            rerouteService.reroute("state recovered", Priority.NORMAL, ActionListener.running(GatewayService.this::resetRecoveredFlags));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -331,7 +331,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
         boolean addedOnThisCall = httpChannels.add(httpChannel);
         assert addedOnThisCall : "Channel should only be added to http channel set once";
         refCounted.incRef();
-        httpChannel.addCloseListener(ActionListener.wrap(() -> {
+        httpChannel.addCloseListener(ActionListener.running(() -> {
             httpChannels.remove(httpChannel);
             refCounted.decRef();
         }));
@@ -484,7 +484,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
 
     private static ActionListener<Void> earlyResponseListener(HttpRequest request, HttpChannel httpChannel) {
         if (HttpUtils.shouldCloseConnection(request)) {
-            return ActionListener.wrap(() -> CloseableChannel.closeChannel(httpChannel));
+            return ActionListener.running(() -> CloseableChannel.closeChannel(httpChannel));
         } else {
             return ActionListener.noop();
         }

--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -151,7 +151,7 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
             restResponse.getHeaders()
                 .forEach((key, values) -> tracer.setAttribute(traceId, "http.response.headers." + key, String.join("; ", values)));
 
-            ActionListener<Void> listener = ActionListener.wrap(() -> Releasables.close(toClose));
+            ActionListener<Void> listener = ActionListener.running(() -> Releasables.close(toClose));
             try (ThreadContext.StoredContext existing = threadContext.stashContext()) {
                 httpChannel.sendResponse(httpResponse, listener);
             }

--- a/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
@@ -89,7 +89,7 @@ public class HttpClientStatsTracker {
                 threadPool.absoluteTimeInMillis()
             )
         );
-        httpChannel.addCloseListener(ActionListener.wrap(() -> {
+        httpChannel.addCloseListener(ActionListener.running(() -> {
             try {
                 final ClientStatsBuilder disconnectedClientStats = httpChannelStats.remove(httpChannel);
                 if (disconnectedClientStats != null) {

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexManager.java
@@ -117,7 +117,7 @@ public class SystemIndexManager implements ClusterStateListener {
                 // The failures are logged in upgradeIndexMetadata(), so we don't actually care about them here.
                 ActionListener<AcknowledgedResponse> listener = new GroupedActionListener<>(
                     descriptors.size(),
-                    ActionListener.wrap(() -> isUpgradeInProgress.set(false))
+                    ActionListener.running(() -> isUpgradeInProgress.set(false))
                 );
 
                 descriptors.forEach(descriptor -> upgradeIndexMetadata(descriptor, listener));

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -967,7 +967,7 @@ public class RecoverySourceHandler {
             // to notify the listener about the cancellation
             final CountDown pendingRequestsCountDown = new CountDown(pendingRequests.size());
             for (ListenableFuture<Void> outstandingFuture : pendingRequests) {
-                outstandingFuture.addListener(ActionListener.wrap(() -> {
+                outstandingFuture.addListener(ActionListener.running(() -> {
                     if (pendingRequestsCountDown.countDown()) {
                         listener.onFailure(e);
                     }

--- a/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskCancellationService.java
@@ -122,7 +122,7 @@ public class TaskCancellationService {
 
             // We remove bans after all child tasks are completed although in theory we can do it on a per-connection basis.
             completedListener.addListener(
-                ActionListener.wrap(
+                ActionListener.running(
                     transportService.getThreadPool()
                         .getThreadContext()
                         // If we start unbanning when the last child task completed and that child task executed with a specific user, then

--- a/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ClusterConnectionManager.java
@@ -227,13 +227,13 @@ public class ClusterConnectionManager implements ConnectionManager {
                             try {
                                 connectionListener.onNodeConnected(node, conn);
                             } finally {
-                                conn.addCloseListener(ActionListener.wrap(() -> {
+                                conn.addCloseListener(ActionListener.running(() -> {
                                     connectedNodes.remove(node, conn);
                                     connectionListener.onNodeDisconnected(node, conn);
                                     managerRefs.decRef();
                                 }));
 
-                                conn.addCloseListener(ActionListener.wrap(() -> {
+                                conn.addCloseListener(ActionListener.running(() -> {
                                     if (connectingRefCounter.hasReferences() == false) {
                                         logger.trace("connection manager shut down, closing transport connection to [{}]", node);
                                     } else if (conn.hasReferences()) {
@@ -366,7 +366,7 @@ public class ClusterConnectionManager implements ConnectionManager {
             try {
                 connectionListener.onConnectionOpened(connection);
             } finally {
-                connection.addCloseListener(ActionListener.wrap(() -> connectionListener.onConnectionClosed(connection)));
+                connection.addCloseListener(ActionListener.running(() -> connectionListener.onConnectionClosed(connection)));
             }
             if (connection.isClosed()) {
                 throw new ConnectTransportException(node, "a channel closed while connecting");

--- a/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
+++ b/server/src/main/java/org/elasticsearch/transport/OutboundHandler.java
@@ -185,7 +185,7 @@ final class OutboundHandler {
                 release.close();
             }
         }
-        internalSend(channel, message, networkMessage, ActionListener.wrap(release::close));
+        internalSend(channel, message, networkMessage, ActionListener.running(release::close));
     }
 
     private void internalSend(

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -760,7 +760,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                     outboundHandler.sendBytes(
                         channel,
                         new BytesArray(e.getMessage().getBytes(StandardCharsets.UTF_8)),
-                        ActionListener.wrap(() -> CloseableChannel.closeChannel(channel))
+                        ActionListener.running(() -> CloseableChannel.closeChannel(channel))
                     );
                     closeChannel = false;
                 }
@@ -791,7 +791,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         assert addedOnThisCall : "Channel should only be added to accepted channel set once";
         // Mark the channel init time
         channel.getChannelStats().markAccessed(threadPool.relativeTimeInMillis());
-        channel.addCloseListener(ActionListener.wrap(() -> acceptedChannels.remove(channel)));
+        channel.addCloseListener(ActionListener.running(() -> acceptedChannels.remove(channel)));
         logger.trace(() -> format("Tcp transport channel accepted: %s", channel));
     }
 
@@ -1127,7 +1127,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                         nodeChannels.channels.forEach(ch -> {
                             // Mark the channel init time
                             ch.getChannelStats().markAccessed(relativeMillisTime);
-                            ch.addCloseListener(ActionListener.wrap(nodeChannels::close));
+                            ch.addCloseListener(running(nodeChannels::close));
                         });
                         keepAlive.registerNodeConnection(nodeChannels.channels, connectionProfile);
                         nodeChannels.addCloseListener(new ChannelCloseLogger(node, connectionId, relativeMillisTime));

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -1127,7 +1127,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
                         nodeChannels.channels.forEach(ch -> {
                             // Mark the channel init time
                             ch.getChannelStats().markAccessed(relativeMillisTime);
-                            ch.addCloseListener(running(nodeChannels::close));
+                            ch.addCloseListener(ActionListener.running(nodeChannels::close));
                         });
                         keepAlive.registerNodeConnection(nodeChannels.channels, connectionProfile);
                         nodeChannels.addCloseListener(new ChannelCloseLogger(node, connectionId, relativeMillisTime));

--- a/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportHandshaker.java
@@ -149,7 +149,7 @@ final class TransportHandshaker {
         final HandshakeResponseHandler handler = new HandshakeResponseHandler(requestId, version, listener);
         pendingHandshakes.put(requestId, handler);
         channel.addCloseListener(
-            ActionListener.wrap(() -> handler.handleLocalException(new TransportException("handshake failed because connection reset")))
+            ActionListener.running(() -> handler.handleLocalException(new TransportException("handshake failed because connection reset")))
         );
         boolean success = false;
         try {

--- a/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportKeepAlive.java
@@ -75,7 +75,7 @@ final class TransportKeepAlive implements Closeable {
 
         for (TcpChannel channel : nodeChannels) {
             scheduledPing.addChannel(channel);
-            channel.addCloseListener(ActionListener.wrap(() -> scheduledPing.removeChannel(channel)));
+            channel.addCloseListener(ActionListener.running(() -> scheduledPing.removeChannel(channel)));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ActionListenerTests.java
@@ -80,7 +80,7 @@ public class ActionListenerTests extends ESTestCase {
 
     public void testWrapRunnable() {
         var executed = new AtomicBoolean();
-        var listener = ActionListener.wrap(new Runnable() {
+        var listener = ActionListener.running(new Runnable() {
             @Override
             public void run() {
                 assertTrue(executed.compareAndSet(false, true));
@@ -102,7 +102,7 @@ public class ActionListenerTests extends ESTestCase {
 
         expectThrows(
             AssertionError.class,
-            () -> ActionListener.wrap(() -> { throw new UnsupportedOperationException(); }).onResponse(null)
+            () -> ActionListener.running(() -> { throw new UnsupportedOperationException(); }).onResponse(null)
         );
     }
 
@@ -314,7 +314,7 @@ public class ActionListenerTests extends ESTestCase {
 
     public void testNotifyOnceReleasesDelegate() {
         final var reachabilityChecker = new ReachabilityChecker();
-        final var listener = ActionListener.notifyOnce(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        final var listener = ActionListener.notifyOnce(reachabilityChecker.register(ActionListener.running(() -> {})));
         reachabilityChecker.checkReachable();
         listener.onResponse(null);
         reachabilityChecker.ensureUnreachable();
@@ -501,7 +501,7 @@ public class ActionListenerTests extends ESTestCase {
             ? ActionListener.runBefore(throwingListener, makeCheckedRunnable(description))
             : ActionListener.runAfter(throwingListener, makeRunnable(description));
 
-        final ActionListener<Void> wrappedListener = ActionListener.wrap(new AbstractRunnable() {
+        final ActionListener<Void> wrappedListener = ActionListener.running(new AbstractRunnable() {
             @Override
             public void onFailure(Exception e) {
                 runBeforeOrAfterListener.onFailure(e);

--- a/server/src/test/java/org/elasticsearch/action/StepListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/StepListenerTests.java
@@ -171,7 +171,7 @@ public class StepListenerTests extends ESTestCase {
         final ReachabilityChecker reachabilityChecker = new ReachabilityChecker();
 
         for (int i = between(1, 3); i > 0; i--) {
-            step.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+            step.addListener(reachabilityChecker.register(ActionListener.running(() -> {})));
         }
         reachabilityChecker.checkReachable();
         if (randomBoolean()) {
@@ -181,7 +181,7 @@ public class StepListenerTests extends ESTestCase {
         }
         reachabilityChecker.ensureUnreachable();
 
-        step.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        step.addListener(reachabilityChecker.register(ActionListener.running(() -> {})));
         reachabilityChecker.ensureUnreachable();
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TransportTasksActionTests.java
@@ -487,7 +487,7 @@ public class TransportTasksActionTests extends TaskManagerTestCase {
         connectNodes(testNodes);
         CountDownLatch checkLatch = new CountDownLatch(1);
         CountDownLatch responseLatch = new CountDownLatch(1);
-        Task task = startBlockingTestNodesAction(checkLatch, ActionListener.wrap(responseLatch::countDown));
+        Task task = startBlockingTestNodesAction(checkLatch, ActionListener.running(responseLatch::countDown));
         String actionName = "internal:testAction"; // only pick the main action
 
         // Try to cancel main task using action name

--- a/server/src/test/java/org/elasticsearch/action/support/ListenableActionFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ListenableActionFutureTests.java
@@ -167,7 +167,7 @@ public class ListenableActionFutureTests extends ESTestCase {
         final ReachabilityChecker reachabilityChecker = new ReachabilityChecker();
 
         for (int i = between(1, 3); i > 0; i--) {
-            future.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+            future.addListener(reachabilityChecker.register(ActionListener.running(() -> {})));
         }
         reachabilityChecker.checkReachable();
         if (randomBoolean()) {
@@ -177,7 +177,7 @@ public class ListenableActionFutureTests extends ESTestCase {
         }
         reachabilityChecker.ensureUnreachable();
 
-        future.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        future.addListener(reachabilityChecker.register(ActionListener.running(() -> {})));
         reachabilityChecker.ensureUnreachable();
     }
 }

--- a/server/src/test/java/org/elasticsearch/action/support/RefCountingListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/RefCountingListenerTests.java
@@ -162,7 +162,7 @@ public class RefCountingListenerTests extends ESTestCase {
 
     public void testValidation() {
         final var callCount = new AtomicInteger();
-        final var refs = new RefCountingListener(Integer.MAX_VALUE, ActionListener.wrap(callCount::incrementAndGet));
+        final var refs = new RefCountingListener(Integer.MAX_VALUE, ActionListener.running(callCount::incrementAndGet));
         refs.close();
         assertEquals(1, callCount.get());
 
@@ -184,7 +184,7 @@ public class RefCountingListenerTests extends ESTestCase {
 
     public void testJavaDocExample() {
         final var flag = new AtomicBoolean();
-        runExample(ActionListener.wrap(() -> assertTrue(flag.compareAndSet(false, true))));
+        runExample(ActionListener.running(() -> assertTrue(flag.compareAndSet(false, true))));
         assertTrue(flag.get());
     }
 

--- a/server/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/ThreadedActionListenerTests.java
@@ -50,7 +50,7 @@ public class ThreadedActionListenerTests extends ESTestCase {
                     final var listener = new ThreadedActionListener<Void>(
                         threadPool.executor(pool),
                         (pool.equals("fixed-bounded-queue") || pool.startsWith("scaling")) && rarely(),
-                        ActionListener.wrap(countdownLatch::countDown)
+                        ActionListener.running(countdownLatch::countDown)
                     );
                     synchronized (closeFlag) {
                         if (closeFlag.get() && shutdownUnsafePools.contains(pool)) {

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardFailedClusterStateTaskExecutorTests.java
@@ -357,6 +357,6 @@ public class ShardFailedClusterStateTaskExecutorTests extends ESAllocationTestCa
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return ActionListener.wrap(() -> { throw new AssertionError("task should not complete"); });
+        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/shard/ShardStartedClusterStateTaskExecutorTests.java
@@ -408,6 +408,6 @@ public class ShardStartedClusterStateTaskExecutorTests extends ESAllocationTestC
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return ActionListener.wrap(() -> { throw new AssertionError("task should not complete"); });
+        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -66,7 +66,7 @@ import static org.mockito.Mockito.when;
 
 public class NodeJoinExecutorTests extends ESTestCase {
 
-    private static final ActionListener<Void> NOT_COMPLETED_LISTENER = ActionListener.wrap(
+    private static final ActionListener<Void> NOT_COMPLETED_LISTENER = ActionListener.running(
         () -> { throw new AssertionError("should not complete publication"); }
     );
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -443,7 +443,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             context0.sendPublishRequest(
                 otherNode,
                 new PublishRequest(clusterState0),
-                ActionListener.wrap(() -> assertTrue(completed.compareAndSet(false, true)))
+                ActionListener.running(() -> assertTrue(completed.compareAndSet(false, true)))
             );
             assertTrue(completed.getAndSet(false));
             receivedState0 = receivedStateRef.getAndSet(null);
@@ -484,7 +484,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
             context1.sendPublishRequest(
                 otherNode,
                 new PublishRequest(clusterState1),
-                ActionListener.wrap(() -> assertTrue(completed.compareAndSet(false, true)))
+                ActionListener.running(() -> assertTrue(completed.compareAndSet(false, true)))
             );
             assertTrue(completed.getAndSet(false));
             var receivedState1 = receivedStateRef.getAndSet(null);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataMappingServiceTests.java
@@ -112,7 +112,7 @@ public class MetadataMappingServiceTests extends ESSingleNodeTestCase {
         return Collections.singletonList(
             new MetadataMappingService.PutMappingClusterStateUpdateTask(
                 request,
-                ActionListener.wrap(() -> { throw new AssertionError("task should not complete publication"); })
+                ActionListener.running(() -> { throw new AssertionError("task should not complete publication"); })
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/BatchedRerouteServiceTests.java
@@ -71,7 +71,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             batchedRerouteService.reroute(
                 "iteration " + i,
                 randomFrom(EnumSet.allOf(Priority.class)),
-                ActionListener.wrap(countDownLatch::countDown)
+                ActionListener.running(countDownLatch::countDown)
             );
         }
         assertTrue(countDownLatch.await(10, TimeUnit.SECONDS));
@@ -117,7 +117,7 @@ public class BatchedRerouteServiceTests extends ESTestCase {
             try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
                 final String contextValue = randomAlphaOfLength(10);
                 threadContext.putHeader(contextHeader, contextValue);
-                batchedRerouteService.reroute("reroute at " + priority, priority, ActionListener.wrap(() -> {
+                batchedRerouteService.reroute("reroute at " + priority, priority, ActionListener.running(() -> {
                     assertTrue(alreadyRun.compareAndSet(false, true));
                     assertThat(threadContext.getHeader(contextHeader), equalTo(contextValue));
                     tasksCompletedCountDown.countDown();

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/InSyncAllocationIdTests.java
@@ -423,6 +423,6 @@ public class InSyncAllocationIdTests extends ESAllocationTestCase {
     }
 
     private static <T> ActionListener<T> createTestListener() {
-        return ActionListener.wrap(() -> { throw new AssertionError("task should not complete"); });
+        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationActionMultiListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationActionMultiListenerTests.java
@@ -143,7 +143,7 @@ public class AllocationActionMultiListenerTests extends ESTestCase {
             for (int i = between(0, 5); i > 0; i--) {
                 var expectedVal = new Object();
                 var delayedListener = listener.delay(
-                    ActionListener.releaseAfter(ActionListener.wrap(Assert::fail).delegateFailure((l, val) -> {
+                    ActionListener.releaseAfter(ActionListener.running(Assert::fail).delegateFailure((l, val) -> {
                         assertSame(expectedVal, val);
                         assertEquals(expectedRequestHeader, context.getHeader(requestHeaderName));
                         assertEquals(List.of(expectedResponseHeader), context.getResponseHeaders().get(responseHeaderName));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueueTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/PendingListenersQueueTests.java
@@ -24,9 +24,9 @@ public class PendingListenersQueueTests extends ESTestCase {
         var queue = new PendingListenersQueue(threadPool);
         var executed = new CountDownLatch(2);
 
-        queue.add(1, ActionListener.wrap(executed::countDown));
-        queue.add(2, ActionListener.wrap(executed::countDown));
-        queue.add(3, ActionListener.wrap(() -> fail("Should not complete in test")));
+        queue.add(1, ActionListener.running(executed::countDown));
+        queue.add(2, ActionListener.running(executed::countDown));
+        queue.add(3, ActionListener.running(() -> fail("Should not complete in test")));
         queue.complete(2);
 
         try {
@@ -41,9 +41,9 @@ public class PendingListenersQueueTests extends ESTestCase {
         var queue = new PendingListenersQueue(threadPool);
         var executed = new CountDownLatch(2);
 
-        queue.add(1, ActionListener.wrap(executed::countDown));
-        queue.add(2, ActionListener.wrap(executed::countDown));
-        queue.add(3, ActionListener.wrap(() -> fail("Should not complete in test")));
+        queue.add(1, ActionListener.running(executed::countDown));
+        queue.add(2, ActionListener.running(executed::countDown));
+        queue.add(3, ActionListener.running(() -> fail("Should not complete in test")));
         queue.complete(2);
         queue.complete(1);
 

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/ListenableFutureTests.java
@@ -40,7 +40,7 @@ public class ListenableFutureTests extends ESTestCase {
         AtomicInteger notifications = new AtomicInteger(0);
         final int numberOfListeners = scaledRandomIntBetween(1, 12);
         for (int i = 0; i < numberOfListeners; i++) {
-            future.addListener(ActionListener.wrap(notifications::incrementAndGet), EsExecutors.DIRECT_EXECUTOR_SERVICE, threadContext);
+            future.addListener(ActionListener.running(notifications::incrementAndGet), EsExecutors.DIRECT_EXECUTOR_SERVICE, threadContext);
         }
 
         future.onResponse("");
@@ -132,7 +132,7 @@ public class ListenableFutureTests extends ESTestCase {
         final ReachabilityChecker reachabilityChecker = new ReachabilityChecker();
 
         for (int i = between(1, 3); i > 0; i--) {
-            future.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+            future.addListener(reachabilityChecker.register(ActionListener.running(() -> {})));
         }
         reachabilityChecker.checkReachable();
         if (randomBoolean()) {
@@ -142,7 +142,7 @@ public class ListenableFutureTests extends ESTestCase {
         }
         reachabilityChecker.ensureUnreachable();
 
-        future.addListener(reachabilityChecker.register(ActionListener.wrap(() -> {})));
+        future.addListener(reachabilityChecker.register(ActionListener.running(() -> {})));
         reachabilityChecker.ensureUnreachable();
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2651,7 +2651,7 @@ public class InternalEngineTests extends EngineTestCase {
                 gcpTracker.addPeerRecoveryRetentionLease(
                     initializingReplica.currentNodeId(),
                     SequenceNumbers.NO_OPS_PERFORMED,
-                    ActionListener.wrap(countDownLatch::countDown)
+                    ActionListener.running(countDownLatch::countDown)
                 );
                 countDownLatch.await();
             }

--- a/server/src/test/java/org/elasticsearch/index/replication/RetentionLeasesReplicationTests.java
+++ b/server/src/test/java/org/elasticsearch/index/replication/RetentionLeasesReplicationTests.java
@@ -44,13 +44,13 @@ public class RetentionLeasesReplicationTests extends ESIndexLevelReplicationTest
                 if (leases.isEmpty() == false && rarely()) {
                     RetentionLease leaseToRemove = randomFrom(leases);
                     leases.remove(leaseToRemove);
-                    group.removeRetentionLease(leaseToRemove.id(), ActionListener.wrap(latch::countDown));
+                    group.removeRetentionLease(leaseToRemove.id(), ActionListener.running(latch::countDown));
                 } else {
                     RetentionLease newLease = group.addRetentionLease(
                         Integer.toString(i),
                         randomNonNegativeLong(),
                         "test-" + i,
-                        ActionListener.wrap(latch::countDown)
+                        ActionListener.running(latch::countDown)
                     );
                     leases.add(newLease);
                 }

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -3875,7 +3875,7 @@ public class IndexShardTests extends IndexShardTestCase {
         if (randomBoolean()) {
             primary.addRefreshListener(doc.getTranslogLocation(), r -> latch1.countDown());
         } else {
-            primary.addRefreshListener(doc.getSeqNo(), ActionListener.wrap(latch1::countDown));
+            primary.addRefreshListener(doc.getSeqNo(), ActionListener.running(latch1::countDown));
         }
         assertEquals(1, latch1.getCount());
         assertTrue(primary.getEngine().refreshNeeded());

--- a/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesServiceTests.java
@@ -412,7 +412,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             .numberOfReplicas(0)
             .build();
         CountDownLatch latch = new CountDownLatch(1);
-        dangling.allocateDangled(Arrays.asList(indexMetadata), ActionListener.wrap(latch::countDown));
+        dangling.allocateDangled(Arrays.asList(indexMetadata), ActionListener.running(latch::countDown));
         latch.await();
         assertThat(clusterService.state(), equalTo(originalState));
 
@@ -421,7 +421,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
 
         // now try importing a dangling index with the same name as the alias, it should succeed.
         latch = new CountDownLatch(1);
-        dangling.allocateDangled(Arrays.asList(indexMetadata), ActionListener.wrap(latch::countDown));
+        dangling.allocateDangled(Arrays.asList(indexMetadata), ActionListener.running(latch::countDown));
         latch.await();
         assertThat(clusterService.state(), not(originalState));
         assertNotNull(clusterService.state().getMetadata().index(alias));
@@ -443,7 +443,7 @@ public class IndicesServiceTests extends ESSingleNodeTestCase {
             .numberOfReplicas(0)
             .build();
         CountDownLatch latch = new CountDownLatch(1);
-        dangling.allocateDangled(Arrays.asList(indexMetadataLater), ActionListener.wrap(latch::countDown));
+        dangling.allocateDangled(Arrays.asList(indexMetadataLater), ActionListener.running(latch::countDown));
         latch.await();
         assertThat(clusterService.state(), equalTo(originalState));
     }

--- a/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
+++ b/server/src/test/java/org/elasticsearch/indices/cluster/ClusterStateChanges.java
@@ -410,7 +410,7 @@ public class ClusterStateChanges {
                 JoinTask.singleNode(
                     discoveryNode,
                     DUMMY_REASON,
-                    ActionListener.wrap(() -> { throw new AssertionError("should not complete publication"); }),
+                    ActionListener.running(() -> { throw new AssertionError("should not complete publication"); }),
                     clusterState.term()
                 )
             )
@@ -428,7 +428,7 @@ public class ClusterStateChanges {
                             node -> new JoinTask.NodeJoinTask(
                                 node,
                                 DUMMY_REASON,
-                                ActionListener.wrap(() -> { throw new AssertionError("should not complete publication"); })
+                                ActionListener.running(() -> { throw new AssertionError("should not complete publication"); })
                             )
                         ),
                     clusterState.term() + between(1, 10)
@@ -544,6 +544,6 @@ public class ClusterStateChanges {
     }
 
     private ActionListener<TransportResponse.Empty> createTestListener() {
-        return ActionListener.wrap(() -> { throw new AssertionError("task should not complete"); });
+        return ActionListener.running(() -> { throw new AssertionError("task should not complete"); });
     }
 }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -2372,7 +2372,7 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private static List<IngestService.PipelineClusterStateUpdateTask> oneTask(DeletePipelineRequest request) {
-        return List.of(new IngestService.DeletePipelineClusterStateUpdateTask(ActionListener.wrap(() -> fail("not called")), request));
+        return List.of(new IngestService.DeletePipelineClusterStateUpdateTask(ActionListener.running(() -> fail("not called")), request));
     }
 
     private static ClusterState executeDelete(DeletePipelineRequest request, ClusterState clusterState) {
@@ -2388,7 +2388,7 @@ public class IngestServiceTests extends ESTestCase {
     }
 
     private static List<IngestService.PipelineClusterStateUpdateTask> oneTask(PutPipelineRequest request) {
-        return List.of(new IngestService.PutPipelineClusterStateUpdateTask(ActionListener.wrap(() -> fail("not called")), request));
+        return List.of(new IngestService.PutPipelineClusterStateUpdateTask(ActionListener.running(() -> fail("not called")), request));
     }
 
     private static ClusterState executePut(PutPipelineRequest request, ClusterState clusterState) {

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -437,7 +437,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         int noOfFiles = randomIntBetween(10, 100);
         BlockingQueue<BlobStoreIndexShardSnapshot.FileInfo> files = new LinkedBlockingQueue<>(noOfFiles);
         PlainActionFuture<Void> listenerCalled = PlainActionFuture.newFuture();
-        ActionListener<Collection<Void>> allFilesUploadListener = ActionListener.wrap(() -> listenerCalled.onResponse(null));
+        ActionListener<Collection<Void>> allFilesUploadListener = ActionListener.running(() -> listenerCalled.onResponse(null));
         for (int i = 0; i < noOfFiles; i++) {
             files.add(ShardSnapshotTaskRunnerTests.dummyFileInfo());
         }

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -473,7 +473,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
             testClusterNodes.randomDataNodeSafe().client.admin()
                 .cluster()
                 .prepareDeleteSnapshot(repoName, snapshotName)
-                .execute(ActionListener.wrap(() -> snapshotDeleteResponded.set(true)));
+                .execute(ActionListener.running(() -> snapshotDeleteResponded.set(true)));
         });
 
         runUntil(
@@ -1011,7 +1011,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
                             testClusterNodes.randomDataNodeSafe().client.admin()
                                 .cluster()
                                 .prepareCreateSnapshot(repoName, snapshotName)
-                                .execute(ActionListener.wrap(() -> {
+                                .execute(ActionListener.running(() -> {
                                     createdSnapshot.set(true);
                                     testClusterNodes.randomDataNodeSafe().client.admin()
                                         .cluster()

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotsServiceTests.java
@@ -441,7 +441,7 @@ public class SnapshotsServiceTests extends ESTestCase {
             shardId,
             null,
             successfulShardStatus(nodeId),
-            ActionListener.wrap(() -> fail("should not complete publication"))
+            ActionListener.running(() -> fail("should not complete publication"))
         );
     }
 
@@ -451,7 +451,7 @@ public class SnapshotsServiceTests extends ESTestCase {
             null,
             shardId,
             successfulShardStatus(nodeId),
-            ActionListener.wrap(() -> fail("should not complete publication"))
+            ActionListener.running(() -> fail("should not complete publication"))
         );
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -277,7 +277,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                         assertThat(threadContext.getHeader(contextHeader), equalTo(contextValue));
 
                         assertTrue(pendingCloses.tryAcquire());
-                        connectionManager.getConnection(node).addRemovedListener(ActionListener.wrap(pendingCloses::release));
+                        connectionManager.getConnection(node).addRemovedListener(ActionListener.running(pendingCloses::release));
 
                         if (randomBoolean()) {
                             releasables[threadIndex] = c;
@@ -622,7 +622,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
                 if (closePermits.tryAcquire() && closingRefs.tryIncRef()) {
                     try {
                         var connection = connectionManager.getConnection(node);
-                        connection.addRemovedListener(ActionListener.wrap(this::runAgain));
+                        connection.addRemovedListener(ActionListener.running(this::runAgain));
                         connection.close();
                     } catch (NodeNotConnectedException e) {
                         closePermits.release();

--- a/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundHandlerTests.java
@@ -230,7 +230,7 @@ public class InboundHandlerTests extends ESTestCase {
 
         try {
             final AtomicBoolean isClosed = new AtomicBoolean();
-            channel.addCloseListener(ActionListener.wrap(() -> assertTrue(isClosed.compareAndSet(false, true))));
+            channel.addCloseListener(ActionListener.running(() -> assertTrue(isClosed.compareAndSet(false, true))));
 
             final TransportVersion remoteVersion = TransportVersion.fromId(
                 randomIntBetween(0, version.minimumCompatibilityVersion().id - 1)

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -667,7 +667,7 @@ public class MockTransportService extends TransportService {
         super.openConnection(node, connectionProfile, listener.delegateFailure((l, connection) -> {
             synchronized (openConnections) {
                 openConnections.computeIfAbsent(node, n -> new CopyOnWriteArrayList<>()).add(connection);
-                connection.addCloseListener(ActionListener.wrap(() -> {
+                connection.addCloseListener(ActionListener.running(() -> {
                     synchronized (openConnections) {
                         List<Transport.Connection> connections = openConnections.get(node);
                         boolean remove = connections.remove(connection);

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -535,7 +535,7 @@ public class DisruptableMockTransportTests extends ESTestCase {
                     service1,
                     node2,
                     new CleanableResponseHandler<>(
-                        ActionListener.wrap(() -> assertFalse(responseHandlerCalled.getAndSet(true))),
+                        ActionListener.running(() -> assertFalse(responseHandlerCalled.getAndSet(true))),
                         TestResponse::new,
                         ThreadPool.Names.SAME,
                         () -> assertFalse(responseHandlerReleased.getAndSet(true))

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -207,7 +207,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
             searchTask.getExecutionId().getDocId(),
             threadContext.getResponseHeaders(),
             response,
-            ActionListener.wrap(() -> {
+            ActionListener.running(() -> {
                 taskManager.unregister(searchTask);
                 nextAction.run();
             })

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/common/SparseFileTrackerTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/common/SparseFileTrackerTests.java
@@ -53,7 +53,7 @@ public class SparseFileTrackerTests extends ESTestCase {
         final SparseFileTracker sparseFileTracker = new SparseFileTracker("test", length);
 
         final AtomicBoolean invoked = new AtomicBoolean(false);
-        final ActionListener<Void> listener = ActionListener.wrap(() -> invoked.set(true));
+        final ActionListener<Void> listener = ActionListener.running(() -> invoked.set(true));
         assertThat(invoked.get(), is(false));
 
         IllegalArgumentException e = expectThrows(

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRepositoryIT.java
@@ -441,7 +441,7 @@ public class CcrRepositoryIT extends CcrIntegTestCase {
         Runnable updateMappings = () -> {
             if (updateSent.compareAndSet(false, true)) {
                 leaderClient().admin().indices().preparePutMapping(leaderIndex).setSource("""
-                    {"properties":{"k":{"type":"long"}}}""", XContentType.JSON).execute(ActionListener.wrap(latch::countDown));
+                    {"properties":{"k":{"type":"long"}}}""", XContentType.JSON).execute(ActionListener.running(latch::countDown));
             }
             try {
                 latch.await();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -315,7 +315,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                         response,
                         e,
                         // at end, we should report a failure to the listener
-                        ActionListener.wrap(() -> newListener.onFailure(e))
+                        ActionListener.running(() -> newListener.onFailure(e))
                     );
                 } else {
                     listener.onFailure(e);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskMaintenanceService.java
@@ -130,7 +130,7 @@ public class AsyncTaskMaintenanceService extends AbstractLifecycleComponent impl
             DeleteByQueryRequest toDelete = new DeleteByQueryRequest(index).setQuery(
                 QueryBuilders.rangeQuery(EXPIRATION_TIME_FIELD).lte(nowInMillis)
             );
-            clientWithOrigin.execute(DeleteByQueryAction.INSTANCE, toDelete, ActionListener.wrap(this::scheduleNextCleanup));
+            clientWithOrigin.execute(DeleteByQueryAction.INSTANCE, toDelete, ActionListener.running(this::scheduleNextCleanup));
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/StoredAsyncTask.java
@@ -98,6 +98,6 @@ public abstract class StoredAsyncTask<Response extends ActionResponse> extends C
 
     @Override
     public void cancelTask(TaskManager taskManager, Runnable runnable, String reason) {
-        taskManager.cancelTaskAndDescendants(this, reason, true, ActionListener.wrap(runnable));
+        taskManager.cancelTaskAndDescendants(this, reason, true, ActionListener.running(runnable));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/async/AsyncResultsServiceTests.java
@@ -83,7 +83,7 @@ public class AsyncResultsServiceTests extends ESSingleNodeTestCase {
 
         @Override
         public void cancelTask(TaskManager taskManager, Runnable runnable, String reason) {
-            taskManager.cancelTaskAndDescendants(this, reason, true, ActionListener.wrap(runnable));
+            taskManager.cancelTaskAndDescendants(this, reason, true, ActionListener.running(runnable));
         }
 
         public long getExpirationTime() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/SecondaryAuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/support/SecondaryAuthenticationTests.java
@@ -172,7 +172,7 @@ public class SecondaryAuthenticationTests extends ESTestCase {
                 assertThat(securityContext.getUser().principal(), equalTo("u2"));
                 ActionListener<Void> listener = new ContextPreservingActionListener<>(
                     threadContext.newRestorableContext(false),
-                    ActionListener.wrap(() -> listenerUser.set(securityContext.getUser()))
+                    ActionListener.running(() -> listenerUser.set(securityContext.getUser()))
                 );
                 originalContext.restore();
                 threadPool.generic().execute(() -> {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
@@ -142,7 +142,7 @@ public class EnrichPolicyExecutor {
         GetTaskRequest getTaskRequest = new GetTaskRequest();
         getTaskRequest.setTaskId(taskId);
         getTaskRequest.setWaitForCompletion(true);
-        client.admin().cluster().getTask(getTaskRequest, ActionListener.wrap(policyLock::close));
+        client.admin().cluster().getTask(getTaskRequest, ActionListener.running(policyLock::close));
     }
 
     private Runnable createPolicyRunner(

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/CoordinatorTests.java
@@ -370,7 +370,7 @@ public class CoordinatorTests extends ESTestCase {
                 threadPool.generic().execute(() -> {
                     while (schedulePermits.tryAcquire()) {
                         final AtomicBoolean completed = new AtomicBoolean();
-                        coordinator.schedule(new SearchRequest("index"), ActionListener.wrap(() -> {
+                        coordinator.schedule(new SearchRequest("index"), ActionListener.running(() -> {
                             assertTrue(completed.compareAndSet(false, true)); // no double-completion
                             completionCountdown.countDown();
                         }));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleRunner.java
@@ -635,7 +635,7 @@ class IndexLifecycleRunner {
             final Tuple<Index, StepKey> dedupKey = Tuple.tuple(task.index, task.currentStepKey);
             // index+step-key combination on a best-effort basis to skip checking for more work for an index on CS application
             busyIndices.add(dedupKey);
-            task.addListener(ActionListener.wrap(() -> {
+            task.addListener(ActionListener.running(() -> {
                 final boolean removed = executingTasks.remove(task);
                 busyIndices.remove(dedupKey);
                 assert removed : "tried to unregister unknown task [" + task + "]";

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -183,7 +183,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                     }
 
                     // Finally, delete the snapshots that need to be deleted
-                    deleteSnapshots(snapshotsToBeDeleted, slmStats, ActionListener.wrap(() -> {
+                    deleteSnapshots(snapshotsToBeDeleted, slmStats, running(() -> {
                         updateStateWithStats(slmStats);
                         logger.info("SLM retention snapshot cleanup task complete");
                     }));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SnapshotRetentionTask.java
@@ -183,7 +183,7 @@ public class SnapshotRetentionTask implements SchedulerEngine.Listener {
                     }
 
                     // Finally, delete the snapshots that need to be deleted
-                    deleteSnapshots(snapshotsToBeDeleted, slmStats, running(() -> {
+                    deleteSnapshots(snapshotsToBeDeleted, slmStats, ActionListener.running(() -> {
                         updateStateWithStats(slmStats);
                         logger.info("SLM retention snapshot cleanup task complete");
                     }));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -687,7 +687,7 @@ public class DestinationIndexTests extends ESTestCase {
 
         ElasticsearchStatusException e = expectThrows(
             ElasticsearchStatusException.class,
-            () -> DestinationIndex.updateMappingsToDestIndex(client, config, getIndexResponse, ActionListener.wrap(Assert::fail))
+            () -> DestinationIndex.updateMappingsToDestIndex(client, config, getIndexResponse, ActionListener.running(Assert::fail))
         );
         assertThat(
             e.getMessage(),

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementService.java
@@ -215,7 +215,7 @@ public class AsyncTaskManagementService<
                     storeResults(
                         searchTask,
                         new StoredAsyncResponse<>(response, threadPool.absoluteTimeInMillis() + keepAlive.getMillis()),
-                        ActionListener.wrap(() -> acquiredListener.onResponse(response))
+                        ActionListener.running(() -> acquiredListener.onResponse(response))
                     );
                 } else {
                     taskManager.unregister(searchTask);
@@ -235,7 +235,7 @@ public class AsyncTaskManagementService<
                     storeResults(
                         searchTask,
                         new StoredAsyncResponse<>(e, threadPool.absoluteTimeInMillis() + keepAlive.getMillis()),
-                        ActionListener.wrap(() -> acquiredListener.onFailure(e))
+                        ActionListener.running(() -> acquiredListener.onFailure(e))
                     );
                 } else {
                     taskManager.unregister(searchTask);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
@@ -446,7 +446,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
                 ByteRange.of(i, i + length),
                 new BytesArray(bytes, 0, length),
                 creationTimeInEpochMillis,
-                ActionListener.wrap(latch::countDown)
+                ActionListener.running(latch::countDown)
             );
         }
         try {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -821,7 +821,7 @@ public class Security extends Plugin
             getSslService(),
             client,
             environment,
-            (runnable -> nodeStartedListenable.addListener(ActionListener.wrap(runnable))),
+            (runnable -> nodeStartedListenable.addListener(ActionListener.running(runnable))),
             threadPool
         );
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformIndexer.java
@@ -853,7 +853,7 @@ public abstract class TransformIndexer extends AsyncTwoPhaseIndexer<TransformInd
                 CountDownLatch latch = new CountDownLatch(1);
                 logger.debug("[{}] persisting stop at checkpoint", getJobId());
 
-                persistState(newTransformState, ActionListener.wrap(() -> latch.countDown()));
+                persistState(newTransformState, ActionListener.running(() -> latch.countDown()));
 
                 if (latch.await(PERSIST_STOP_AT_CHECKPOINT_TIMEOUT_SEC, TimeUnit.SECONDS) == false) {
                     logger.error(


### PR DESCRIPTION
There are three overloads of `ActionListener#wrap`, two of which "wrap" the `onResponse` handler in a `try...catch` which feeds exceptions into the `onFailure` handler. The overload which accepts a bare `Runnable` does not have this behaviour, so it's kind of confusing to use the same terminology. Following the pattern started by `releasing(Releasable)` this commit renames this method to `running(Runnable)`.