### PR TITLE
[8.1] [doc] Mention dates_nanos in dates field type page (#93828)

### DIFF
--- a/docs/reference/mapping/types/date.asciidoc
+++ b/docs/reference/mapping/types/date.asciidoc
@@ -16,6 +16,8 @@ formatted date to represent dates before 1970.
 Internally, dates are converted to UTC (if the time-zone is specified) and
 stored as a long number representing milliseconds-since-the-epoch.
 
+NOTE: Use the <<date_nanos,date_nanos>> field type if a nanosecond resolution is expected.
+
 Queries on dates are internally converted to range queries on this long
 representation, and the result of aggregations and stored fields is converted
 back to a string depending on the date format that is associated with the field.


### PR DESCRIPTION
Backports the following commits to 8.1:
 - [doc] Mention dates_nanos in dates field type page (#93828)