### PR TITLE
Bug-fix: Include the forceMerge flag in the equals of SearchableSnapshotAction

### DIFF
--- a/docs/changelog/93847.yaml
+++ b/docs/changelog/93847.yaml
@@ -1,5 +1,5 @@
 pr: 93847
-summary: "Bug-fix: Include the `forceMerge` flag in the equals of `SearchableSnapshotAction`"
+summary: "Fixed changing only the `forceMerge` flag in `SearchableSnapshotAction` wouldn't update the policy"
 area: ILM+SLM
 type: bug
-issues: []
+issues: [93845]

--- a/docs/changelog/93847.yaml
+++ b/docs/changelog/93847.yaml
@@ -1,5 +1,6 @@
 pr: 93847
-summary: "Fixed changing only the `forceMerge` flag in `SearchableSnapshotAction` wouldn't update the policy"
+summary: Fixed changing only the `forceMerge` flag in `SearchableSnapshotAction` wouldn't
+  update the policy
 area: ILM+SLM
 type: bug
-issues: [93845]
+issues: []

--- a/docs/changelog/93847.yaml
+++ b/docs/changelog/93847.yaml
@@ -1,0 +1,5 @@
+pr: 93847
+summary: "Bug-fix: Include the `forceMerge` flag in the equals of `SearchableSnapshotAction`"
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -395,11 +395,11 @@ public class SearchableSnapshotAction implements LifecycleAction {
             return false;
         }
         SearchableSnapshotAction that = (SearchableSnapshotAction) o;
-        return Objects.equals(snapshotRepository, that.snapshotRepository);
+        return Objects.equals(snapshotRepository, that.snapshotRepository) && Objects.equals(forceMergeIndex, that.forceMergeIndex);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotRepository);
+        return Objects.hash(snapshotRepository, forceMergeIndex);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -75,7 +75,6 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
     }
 
     public void testPrefixAndStorageTypeDefaults() {
-        SearchableSnapshotAction action = new SearchableSnapshotAction("repo", randomBoolean());
         StepKey nonFrozenKey = new StepKey(randomFrom("hot", "warm", "cold", "delete"), randomAlphaOfLength(5), randomAlphaOfLength(5));
         StepKey frozenKey = new StepKey("frozen", randomAlphaOfLength(5), randomAlphaOfLength(5));
 
@@ -159,7 +158,11 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
 
     @Override
     protected SearchableSnapshotAction mutateInstance(SearchableSnapshotAction instance) {
-        return randomInstance();
+        return switch (randomIntBetween(0, 1)) {
+            case 0 -> new SearchableSnapshotAction(randomAlphaOfLengthBetween(5, 10), instance.isForceMergeIndex());
+            case 1 -> new SearchableSnapshotAction(instance.getSnapshotRepository(), instance.isForceMergeIndex() == false);
+            default -> throw new IllegalArgumentException("Invalid mutation branch");
+        };
     }
 
     static SearchableSnapshotAction randomInstance() {


### PR DESCRIPTION
**Expected behavior:**
When we change the `forcemerge` flag in the searchable snapshot action of in an ILM lifecycle policy we expect the policy to be updated.

**Observed behaviour**
If the `forcemerge` flag in the searchable snapshot action of in an ILM lifecycle policy is the only change then the update is a no-op.

**Reproduction path**
```
# test create policy 
PUT /_ilm/policy/test
{
  "policy": {
    "phases": {
      "cold": {
        "min_age": "5d",
        "actions": {
          "searchable_snapshot": {
            "snapshot_repository": "found-snapshots",
            "force_merge_index": true
          },
          "set_priority": {
            "priority": 0
          }
        }
      },
      "warm": {
        "min_age": "3d",
        "actions": {
          "forcemerge": {
            "max_num_segments": 1
          },
          "set_priority": {
            "priority": 50
          }
        }
      },
      "hot": {
        "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_primary_shard_size": "50gb",
            "max_age": "30d"
          },
          "set_priority": {
            "priority": 100
          }
        }
      },
      "frozen": {
        "min_age": "25d",
        "actions": {
          "searchable_snapshot": {
            "snapshot_repository": "found-snapshots",
            "force_merge_index": true
          }
        }
      }
    }
  }
}


# check policy
GET /_ilm/policy/test

# update policy to have force merge set to false for cold and frozen phases
PUT /_ilm/policy/test
{
  "policy": {
    "phases": {
      "cold": {
        "min_age": "5d",
        "actions": {
          "searchable_snapshot": {
            "snapshot_repository": "found-snapshots",
            "force_merge_index": false
          },
          "set_priority": {
            "priority": 0
          }
        }
      },
      "warm": {
        "min_age": "3d",
        "actions": {
          "forcemerge": {
            "max_num_segments": 1
          },
          "set_priority": {
            "priority": 50
          }
        }
      },
      "hot": {
        "min_age": "0ms",
        "actions": {
          "rollover": {
            "max_primary_shard_size": "50gb",
            "max_age": "30d"
          },
          "set_priority": {
            "priority": 100
          }
        }
      },
      "frozen": {
        "min_age": "25d",
        "actions": {
          "searchable_snapshot": {
            "snapshot_repository": "found-snapshots",
            "force_merge_index": false
          }
        }
      }
    }
  }
}

# check policy - version is still 1 and no changes have taken affect.
GET /_ilm/policy/test
```

**Fix**
Include the `forcemerge` flag in the equality and hash of the `SearchableSnapshotAction`.

Fixes: #93845