### PR TITLE
[8.7] Bug-fix: Include the forceMerge flag in the equals of SearchableSnapshotAction (#93847)

### DIFF
--- a/docs/changelog/93847.yaml
+++ b/docs/changelog/93847.yaml
@@ -1,0 +1,6 @@
+pr: 93847
+summary: Fixed changing only the `forceMerge` flag in `SearchableSnapshotAction` wouldn't
+  update the policy
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotAction.java
@@ -395,11 +395,11 @@ public class SearchableSnapshotAction implements LifecycleAction {
             return false;
         }
         SearchableSnapshotAction that = (SearchableSnapshotAction) o;
-        return Objects.equals(snapshotRepository, that.snapshotRepository);
+        return Objects.equals(snapshotRepository, that.snapshotRepository) && Objects.equals(forceMergeIndex, that.forceMergeIndex);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(snapshotRepository);
+        return Objects.hash(snapshotRepository, forceMergeIndex);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SearchableSnapshotActionTests.java
@@ -75,7 +75,6 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
     }
 
     public void testPrefixAndStorageTypeDefaults() {
-        SearchableSnapshotAction action = new SearchableSnapshotAction("repo", randomBoolean());
         StepKey nonFrozenKey = new StepKey(randomFrom("hot", "warm", "cold", "delete"), randomAlphaOfLength(5), randomAlphaOfLength(5));
         StepKey frozenKey = new StepKey("frozen", randomAlphaOfLength(5), randomAlphaOfLength(5));
 
@@ -159,7 +158,11 @@ public class SearchableSnapshotActionTests extends AbstractActionTestCase<Search
 
     @Override
     protected SearchableSnapshotAction mutateInstance(SearchableSnapshotAction instance) {
-        return randomInstance();
+        return switch (randomIntBetween(0, 1)) {
+            case 0 -> new SearchableSnapshotAction(randomAlphaOfLengthBetween(5, 10), instance.isForceMergeIndex());
+            case 1 -> new SearchableSnapshotAction(instance.getSnapshotRepository(), instance.isForceMergeIndex() == false);
+            default -> throw new IllegalArgumentException("Invalid mutation branch");
+        };
     }
 
     static SearchableSnapshotAction randomInstance() {


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Bug-fix: Include the forceMerge flag in the equals of SearchableSnapshotAction (#93847)