### PR TITLE
[DOCS] Add 'total' object for io_stats in nodes stats response

### DIFF
--- a/docs/reference/cluster/nodes-stats.asciidoc
+++ b/docs/reference/cluster/nodes-stats.asciidoc
@@ -1860,6 +1860,13 @@ The total time in milliseconds spent performing I/O operations for the device
 since starting {es}.
 ========
 
+`total` (Linux only)::
+(object)
+The sum of the disk metrics for all devices that back an {es} data path.
++
+.Properties of `total`
+[%collapsible%open]
+========
 `operations` (Linux only)::
     (integer)
     The total number of read and write operations across all devices used by
@@ -1889,6 +1896,8 @@ since starting {es}.
     (integer)
     The total time in milliseconds spent performing I/O operations across all
     devices used by {es} since starting {es}.
+========
+
 =======
 ======
 


### PR DESCRIPTION
The `io_stats` object in the output of `_node/stats` contains total stats, that are wrapped in a `total` object. That `total` object was missing in the documentation. This PR corrects that.

Closes https://github.com/elastic/elasticsearch/issues/85974