### PR TITLE
[DOCS] JDBC Driver troubleshooting params

### DIFF
--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -166,7 +166,7 @@ the underlying exception (default).
 
 `debug` (default `false`):: Setting it to `true` will enable the debug logging.
 
-`debug.out` (default `out`):: The destination of the debug logs produced by the JDBC Driver. By default, they are sent to standard output. The setting can be also a file path.
+`debug.output` (default `err`):: The destination of the debug logs. By default, they are sent to standard error. Value `out` will redirect the logging to standard output. A file path can also be specified.
 
 [discrete]
 ==== Additional

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -162,6 +162,13 @@ experimental:[] See <<modules-cross-cluster-search,{ccs}>>.
 the underlying exception (default).
 
 [discrete]
+==== Troubleshooting
+
+`debug` (default `false`):: Whether to produce debug logs or not.
+
+`debug.out` (default `out`):: The destination of the debug logs produced by the JDBC Driver. By default, they are sent to standard output. The setting can be also a file path.
+
+[discrete]
 ==== Additional
 
 `validate.properties` (default `true`):: If disabled, it will ignore any misspellings or unrecognizable properties. When enabled, an exception

--- a/docs/reference/sql/endpoints/jdbc.asciidoc
+++ b/docs/reference/sql/endpoints/jdbc.asciidoc
@@ -164,7 +164,7 @@ the underlying exception (default).
 [discrete]
 ==== Troubleshooting
 
-`debug` (default `false`):: Whether to produce debug logs or not.
+`debug` (default `false`):: Setting it to `true` will enable the debug logging.
 
 `debug.out` (default `out`):: The destination of the debug logs produced by the JDBC Driver. By default, they are sent to standard output. The setting can be also a file path.
 


### PR DESCRIPTION
Lists parameters which can be useful for troubleshooting the Elasticsearch JDBC Driver.

The PR should be backported to any applicable version.

If you're aware of other params which might help to generate even more detailed logs, please feel free to amend