### PR TITLE
bugfix: `final_pipeline` is executed twice

### DIFF
--- a/docs/changelog/93863.yaml
+++ b/docs/changelog/93863.yaml
@@ -1,0 +1,6 @@
+pr: 93863
+summary: "`final_pipeline` is executed only once in the case there's document re-routing"
+area: Ingest Node
+type: bug
+issues:
+ - 83653

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
@@ -1,4 +1,31 @@
 ---
+setup:
+  - do:
+      indices.put_template:
+        name: add_final_pipeline
+        body:
+          index_patterns: foo
+          settings:
+            final_pipeline: "final_pipeline"
+
+  - do:
+      ingest.put_pipeline:
+        id: "final_pipeline"
+        body:  >
+          {
+            "processors": [
+              {
+                "append" : {
+                  "field" : "accumulator",
+                  "value" : [
+                    "non-repeated-value"
+                  ]
+                }
+              }
+            ]
+          }
+
+---
 teardown:
 - do:
     ingest.delete_pipeline:
@@ -8,6 +35,11 @@ teardown:
 - do:
     indices.delete:
       index: foo
+
+- do:
+    ingest.delete_pipeline:
+      id: final_pipeline
+      ignore: 404
 
 ---
 "Test Change Target Index with Explicit Pipeline":
@@ -49,7 +81,7 @@ teardown:
     get:
       index: foo
       id: "1"
-- match: { _source.a: true }
+- match: { _source: { a: true, accumulator: ["non-repeated-value"]} }
 
 # only the foo index
 - do:
@@ -107,7 +139,7 @@ teardown:
     get:
       index: foo
       id: "1"
-- match: { _source.a: true }
+- match: { _source: { a: true, accumulator: ["non-repeated-value"]} }
 
 # only the foo index
 - do:

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -259,7 +259,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
                 IngestService.updateIndexRequestWithPipelines(actionRequest, indexRequest, metadata);
-                hasIndexRequestsWithPipelines |= IngestService.indexRequestHasPipeline(indexRequest);
+                hasIndexRequestsWithPipelines |= IngestService.hasPipeline(indexRequest);
             }
 
             if (actionRequest instanceof IndexRequest ir) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -258,7 +258,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
-                IngestService.updateIndexRequestWithPipelines(actionRequest, indexRequest, metadata);
+                IngestService.resolvePipelinesAndUpdateIndexRequest(actionRequest, indexRequest, metadata);
                 hasIndexRequestsWithPipelines |= IngestService.hasPipeline(indexRequest);
             }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -258,9 +258,8 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
         for (DocWriteRequest<?> actionRequest : bulkRequest.requests) {
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
-                // Each index request needs to be evaluated, because this method also modifies the IndexRequest
-                boolean indexRequestHasPipeline = IngestService.updateIndexRequestWithPipelines(actionRequest, indexRequest, metadata);
-                hasIndexRequestsWithPipelines |= indexRequestHasPipeline;
+                IngestService.updateIndexRequestWithPipelines(actionRequest, indexRequest, metadata);
+                hasIndexRequestsWithPipelines |= IngestService.indexRequestHasPipeline(indexRequest);
             }
 
             if (actionRequest instanceof IndexRequest ir) {

--- a/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/TransportBulkAction.java
@@ -259,7 +259,7 @@ public class TransportBulkAction extends HandledTransportAction<BulkRequest, Bul
             IndexRequest indexRequest = getIndexWriteRequest(actionRequest);
             if (indexRequest != null) {
                 // Each index request needs to be evaluated, because this method also modifies the IndexRequest
-                boolean indexRequestHasPipeline = IngestService.resolvePipelines(actionRequest, indexRequest, metadata);
+                boolean indexRequestHasPipeline = IngestService.updateIndexRequestWithPipelines(actionRequest, indexRequest, metadata);
                 hasIndexRequestsWithPipelines |= indexRequestHasPipeline;
             }
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1244,4 +1244,14 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return NOOP_PIPELINE_NAME.equals(indexRequest.getPipeline()) == false
             || NOOP_PIPELINE_NAME.equals(indexRequest.getFinalPipeline()) == false;
     }
+
+    record Pipelines(String defaultPipeline, String finalPipeline) {
+
+        public static final Pipelines NO_PIPELINES_DEFINED = new Pipelines(NOOP_PIPELINE_NAME, NOOP_PIPELINE_NAME);
+
+        public Pipelines {
+            defaultPipeline = Objects.requireNonNullElse(defaultPipeline, NOOP_PIPELINE_NAME);
+            finalPipeline = Objects.requireNonNullElse(finalPipeline, NOOP_PIPELINE_NAME);
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -200,22 +200,22 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
      * @param indexRequest    The {@link org.elasticsearch.action.index.IndexRequest} object to update.
      * @param clusterMetadata Cluster metadata from where the pipeline information could be derived.
      */
-    public static boolean updateIndexRequestWithPipelines(
+    public static void updateIndexRequestWithPipelines(
         final DocWriteRequest<?> originalRequest,
         final IndexRequest indexRequest,
         final Metadata clusterMetadata
     ) {
-        return updateIndexRequestWithPipelines(originalRequest, indexRequest, clusterMetadata, System.currentTimeMillis());
+        updateIndexRequestWithPipelines(originalRequest, indexRequest, clusterMetadata, System.currentTimeMillis());
     }
 
-    static boolean updateIndexRequestWithPipelines(
+    static void updateIndexRequestWithPipelines(
         final DocWriteRequest<?> originalRequest,
         final IndexRequest indexRequest,
         final Metadata clusterMetadata,
         final long epochMillis
     ) {
         if (indexRequest.isPipelineResolved()) {
-            return indexRequestHasPipeline(indexRequest);
+            return;
         }
 
         final String requestPipeline = indexRequest.getPipeline();
@@ -290,8 +290,6 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
          * pipeline parameter too.
          */
         indexRequest.isPipelineResolved(true);
-
-        return indexRequestHasPipeline(indexRequest);
     }
 
     public ClusterService getClusterService() {
@@ -1238,7 +1236,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return indexMetadata;
     }
 
-    private static boolean indexRequestHasPipeline(IndexRequest indexRequest) {
+    public static boolean indexRequestHasPipeline(IndexRequest indexRequest) {
         return NOOP_PIPELINE_NAME.equals(indexRequest.getPipeline()) == false
             || NOOP_PIPELINE_NAME.equals(indexRequest.getFinalPipeline()) == false;
     }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -201,15 +201,15 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
      * @param indexRequest    The {@link org.elasticsearch.action.index.IndexRequest} object to update.
      * @param clusterMetadata Cluster metadata from where the pipeline information could be derived.
      */
-    public static void updateIndexRequestWithPipelines(
+    public static void resolvePipelinesAndUpdateIndexRequest(
         final DocWriteRequest<?> originalRequest,
         final IndexRequest indexRequest,
         final Metadata clusterMetadata
     ) {
-        updateIndexRequestWithPipelines(originalRequest, indexRequest, clusterMetadata, System.currentTimeMillis());
+        resolvePipelinesAndUpdateIndexRequest(originalRequest, indexRequest, clusterMetadata, System.currentTimeMillis());
     }
 
-    static void updateIndexRequestWithPipelines(
+    static void resolvePipelinesAndUpdateIndexRequest(
         final DocWriteRequest<?> originalRequest,
         final IndexRequest indexRequest,
         final Metadata clusterMetadata,
@@ -792,7 +792,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                         return; // document failed!
                     } else {
                         indexRequest.isPipelineResolved(false);
-                        updateIndexRequestWithPipelines(null, indexRequest, state.metadata());
+                        resolvePipelinesAndUpdateIndexRequest(null, indexRequest, state.metadata());
                         if (IngestService.NOOP_PIPELINE_NAME.equals(indexRequest.getFinalPipeline()) == false) {
                             newPipelineIds = Collections.singleton(indexRequest.getFinalPipeline()).iterator();
                             newHasFinalPipeline = true;

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -253,7 +253,11 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
                 indexRequest.setPipeline(Objects.requireNonNullElse(defaultPipeline, NOOP_PIPELINE_NAME));
                 indexRequest.setFinalPipeline(Objects.requireNonNullElse(finalPipeline, NOOP_PIPELINE_NAME));
             } else {
-                List<IndexTemplateMetadata> templates = MetadataIndexTemplateService.findV1Templates(clusterMetadata, indexRequest.index(), null);
+                List<IndexTemplateMetadata> templates = MetadataIndexTemplateService.findV1Templates(
+                    clusterMetadata,
+                    indexRequest.index(),
+                    null
+                );
                 // order of templates are highest order first
                 for (final IndexTemplateMetadata template : templates) {
                     final Settings settings = template.settings();

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -221,8 +221,8 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
         var requestPipeline = indexRequest.getPipeline();
 
-        var pipelines = findPipelinesFromMetadata(originalRequest, indexRequest, clusterMetadata, epochMillis).or(
-            () -> findPipelinesFromIndexTemplates(indexRequest, clusterMetadata)
+        var pipelines = resolvePipelinesFromMetadata(originalRequest, indexRequest, clusterMetadata, epochMillis).or(
+            () -> resolvePipelinesFromIndexTemplates(indexRequest, clusterMetadata)
         ).orElse(Pipelines.NO_PIPELINES_DEFINED);
 
         indexRequest.setPipeline(pipelines.defaultPipeline);
@@ -1160,7 +1160,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         }
     }
 
-    private static Optional<Pipelines> findPipelinesFromMetadata(
+    private static Optional<Pipelines> resolvePipelinesFromMetadata(
         DocWriteRequest<?> originalRequest,
         IndexRequest indexRequest,
         Metadata clusterMetadata,
@@ -1206,7 +1206,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return Optional.of(new Pipelines(defaultPipeline, finalPipeline));
     }
 
-    private static Optional<Pipelines> findPipelinesFromIndexTemplates(IndexRequest indexRequest, Metadata clusterMetadata) {
+    private static Optional<Pipelines> resolvePipelinesFromIndexTemplates(IndexRequest indexRequest, Metadata clusterMetadata) {
         String defaultPipeline = null;
         String finalPipeline = null;
 

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -1240,7 +1240,7 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
         return indexMetadata;
     }
 
-    public static boolean indexRequestHasPipeline(IndexRequest indexRequest) {
+    public static boolean hasPipeline(IndexRequest indexRequest) {
         return NOOP_PIPELINE_NAME.equals(indexRequest.getPipeline()) == false
             || NOOP_PIPELINE_NAME.equals(indexRequest.getFinalPipeline()) == false;
     }

--- a/server/src/main/java/org/elasticsearch/ingest/IngestService.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestService.java
@@ -221,9 +221,9 @@ public class IngestService implements ClusterStateApplier, ReportingService<Inge
 
         var requestPipeline = indexRequest.getPipeline();
 
-        var pipelines = findPipelinesFromMetadata(originalRequest, indexRequest, clusterMetadata, epochMillis)
-            .or(() -> findPipelinesFromIndexTemplates(indexRequest, clusterMetadata))
-            .orElse(Pipelines.NO_PIPELINES_DEFINED);
+        var pipelines = findPipelinesFromMetadata(originalRequest, indexRequest, clusterMetadata, epochMillis).or(
+            () -> findPipelinesFromIndexTemplates(indexRequest, clusterMetadata)
+        ).orElse(Pipelines.NO_PIPELINES_DEFINED);
 
         indexRequest.setPipeline(pipelines.defaultPipeline);
         indexRequest.setFinalPipeline(pipelines.finalPipeline);

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1884,18 +1884,18 @@ public class IngestServiceTests extends ESTestCase {
         verifyNoInteractions(mockedRequest, mockedMetadata);
     }
 
-    public void testIndexRequestHasAPipeline() {
+    public void testHasAPipeline() {
         var indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline(NOOP_PIPELINE_NAME);
-        assertFalse(IngestService.indexRequestHasPipeline(indexRequest));
+        assertFalse(IngestService.hasPipeline(indexRequest));
 
         indexRequest = new IndexRequest("idx").setPipeline("some-pipeline").setFinalPipeline(NOOP_PIPELINE_NAME);
-        assertTrue(IngestService.indexRequestHasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
 
         indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline("some-final-pipeline");
-        assertTrue(IngestService.indexRequestHasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
 
         indexRequest = new IndexRequest("idx").setPipeline("some-pipeline").setFinalPipeline("some-final-pipeline");
-        assertTrue(IngestService.indexRequestHasPipeline(indexRequest));
+        assertTrue(IngestService.hasPipeline(indexRequest));
     }
 
     public void testResolveRequiredOrDefaultPipelineDefaultPipeline() {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1877,14 +1877,14 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+        boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
@@ -1895,7 +1895,7 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
@@ -1911,7 +1911,7 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+        boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
@@ -1919,7 +1919,7 @@ public class IngestServiceTests extends ESTestCase {
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
@@ -1931,7 +1931,7 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(Version.CURRENT).put(IndexSettings.FINAL_PIPELINE.getKey(), "final-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
@@ -1949,7 +1949,7 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("<idx-{now/d}>");
-        boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata, epochMillis);
+        boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata, epochMillis);
         assertThat(result, is(true));
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
@@ -1961,7 +1961,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(false));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
@@ -1971,7 +1971,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(true));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
@@ -1985,7 +1985,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(true));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
@@ -1999,7 +1999,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(true));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
@@ -2189,7 +2189,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(IngestService.NOOP_PIPELINE_NAME);
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(false));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
@@ -2203,7 +2203,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(false));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
@@ -2217,7 +2217,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(true));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
@@ -2231,7 +2231,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(IngestService.NOOP_PIPELINE_NAME);
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(false));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
@@ -2245,7 +2245,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(IngestService.NOOP_PIPELINE_NAME);
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(true));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
@@ -2260,7 +2260,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            boolean result = IngestService.resolvePipelines(indexRequest, indexRequest, metadata);
+            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(result, is(true));
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -92,6 +92,7 @@ import java.util.stream.Collectors;
 import static org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils.executeAndAssertSuccessful;
 import static org.elasticsearch.core.Tuple.tuple;
 import static org.elasticsearch.ingest.IngestService.NOOP_PIPELINE_NAME;
+import static org.elasticsearch.ingest.IngestService.hasPipeline;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -1886,16 +1887,16 @@ public class IngestServiceTests extends ESTestCase {
 
     public void testHasAPipeline() {
         var indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline(NOOP_PIPELINE_NAME);
-        assertFalse(IngestService.hasPipeline(indexRequest));
+        assertFalse(hasPipeline(indexRequest));
 
         indexRequest = new IndexRequest("idx").setPipeline("some-pipeline").setFinalPipeline(NOOP_PIPELINE_NAME);
-        assertTrue(IngestService.hasPipeline(indexRequest));
+        assertTrue(hasPipeline(indexRequest));
 
         indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline("some-final-pipeline");
-        assertTrue(IngestService.hasPipeline(indexRequest));
+        assertTrue(hasPipeline(indexRequest));
 
         indexRequest = new IndexRequest("idx").setPipeline("some-pipeline").setFinalPipeline("some-final-pipeline");
-        assertTrue(IngestService.hasPipeline(indexRequest));
+        assertTrue(hasPipeline(indexRequest));
     }
 
     public void testResolveRequiredOrDefaultPipelineDefaultPipeline() {
@@ -1909,13 +1910,15 @@ public class IngestServiceTests extends ESTestCase {
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
         // index name matches with ITMD:
@@ -1925,7 +1928,8 @@ public class IngestServiceTests extends ESTestCase {
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
     }
 
@@ -1940,14 +1944,16 @@ public class IngestServiceTests extends ESTestCase {
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
 
@@ -1958,7 +1964,8 @@ public class IngestServiceTests extends ESTestCase {
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
     }
@@ -1975,7 +1982,8 @@ public class IngestServiceTests extends ESTestCase {
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("<idx-{now/d}>");
         IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, epochMillis);
-        assertThat(indexRequest.isPipelineResolved(), is(true));
+        assertTrue(hasPipeline(indexRequest));
+        assertTrue(indexRequest.isPipelineResolved());
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
     }
@@ -1986,7 +1994,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertFalse(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
@@ -1995,7 +2004,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertTrue(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
         }
 
@@ -2008,7 +2018,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertTrue(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
         }
 
@@ -2021,7 +2032,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertTrue(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
         }
@@ -2210,7 +2222,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertFalse(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
@@ -2223,7 +2236,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertFalse(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
@@ -2236,7 +2250,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertTrue(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
         }
 
@@ -2249,7 +2264,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertFalse(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
@@ -2262,7 +2278,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertTrue(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
         }
@@ -2276,7 +2293,8 @@ public class IngestServiceTests extends ESTestCase {
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
             IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
-            assertThat(indexRequest.isPipelineResolved(), is(true));
+            assertTrue(hasPipeline(indexRequest));
+            assertTrue(indexRequest.isPipelineResolved());
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
             assertThat(indexRequest.getFinalPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -91,6 +91,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils.executeAndAssertSuccessful;
 import static org.elasticsearch.core.Tuple.tuple;
+import static org.elasticsearch.ingest.IngestService.NOOP_PIPELINE_NAME;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyIterable;
@@ -1970,7 +1971,7 @@ public class IngestServiceTests extends ESTestCase {
             IndexRequest indexRequest = new IndexRequest("idx");
             IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
-            assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
+            assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
         // request pipeline:
@@ -2194,26 +2195,26 @@ public class IngestServiceTests extends ESTestCase {
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
             IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
-            assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
+            assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
         // _none default pipeline:
         {
             IndexMetadata.Builder builder = IndexMetadata.builder("idx")
-                .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), IngestService.NOOP_PIPELINE_NAME))
+                .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), NOOP_PIPELINE_NAME))
                 .numberOfShards(1)
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx");
             IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
-            assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
+            assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
         // _none default pipeline with request pipeline:
         {
             IndexMetadata.Builder builder = IndexMetadata.builder("idx")
-                .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), IngestService.NOOP_PIPELINE_NAME))
+                .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), NOOP_PIPELINE_NAME))
                 .numberOfShards(1)
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
@@ -2233,7 +2234,7 @@ public class IngestServiceTests extends ESTestCase {
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
             IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
-            assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
+            assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
 
         // _none request pipeline with final pipeline:
@@ -2246,14 +2247,14 @@ public class IngestServiceTests extends ESTestCase {
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
             IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
-            assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
+            assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
         }
 
         // _none final pipeline:
         {
             IndexMetadata.Builder builder = IndexMetadata.builder("idx")
-                .settings(settings(Version.CURRENT).put(IndexSettings.FINAL_PIPELINE.getKey(), IngestService.NOOP_PIPELINE_NAME))
+                .settings(settings(Version.CURRENT).put(IndexSettings.FINAL_PIPELINE.getKey(), NOOP_PIPELINE_NAME))
                 .numberOfShards(1)
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
@@ -2261,7 +2262,7 @@ public class IngestServiceTests extends ESTestCase {
             IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
-            assertThat(indexRequest.getFinalPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
+            assertThat(indexRequest.getFinalPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -2300,6 +2300,23 @@ public class IngestServiceTests extends ESTestCase {
         }
     }
 
+    public void testPipelinesRecord() {
+        {
+            var pipelines = new IngestService.Pipelines("default", "final");
+            assertEquals(pipelines.defaultPipeline(), "default");
+            assertEquals(pipelines.finalPipeline(), "final");
+            assertTrue(pipelines.hasDefaultPipeline());
+            assertTrue(pipelines.hasFinalPipeline());
+        }
+        {
+            var pipelines = new IngestService.Pipelines(null, null);
+            assertEquals(pipelines.defaultPipeline(), NOOP_PIPELINE_NAME);
+            assertEquals(pipelines.finalPipeline(), NOOP_PIPELINE_NAME);
+            assertFalse(pipelines.hasDefaultPipeline());
+            assertFalse(pipelines.hasFinalPipeline());
+        }
+    }
+
     private static Tuple<String, Object> randomMapEntry() {
         return tuple(randomAlphaOfLength(5), randomObject());
     }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -113,6 +113,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 public class IngestServiceTests extends ESTestCase {
@@ -1866,6 +1868,20 @@ public class IngestServiceTests extends ESTestCase {
         assertThat(indexRequest6.getRawTimestamp(), equalTo(10));
         assertThat(indexRequest7.getRawTimestamp(), equalTo(100));
         assertThat(indexRequest8.getRawTimestamp(), equalTo(100));
+    }
+
+    public void testUpdateIndexRequestWithPipelinesShouldShortCircuitExecution() {
+        var mockedRequest = mock(DocWriteRequest.class);
+        var mockedIndexRequest = mock(IndexRequest.class);
+        var mockedMetadata = mock(Metadata.class);
+
+        when(mockedIndexRequest.isPipelineResolved()).thenReturn(true);
+
+        IngestService.updateIndexRequestWithPipelines(mockedRequest, mockedIndexRequest, mockedMetadata);
+
+        verify(mockedIndexRequest, times(1)).isPipelineResolved();
+        verifyNoMoreInteractions(mockedIndexRequest);
+        verifyNoInteractions(mockedRequest, mockedMetadata);
     }
 
     public void testIndexRequestHasAPipeline() {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1877,7 +1877,7 @@ public class IngestServiceTests extends ESTestCase {
 
         when(mockedIndexRequest.isPipelineResolved()).thenReturn(true);
 
-        IngestService.updateIndexRequestWithPipelines(mockedRequest, mockedIndexRequest, mockedMetadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(mockedRequest, mockedIndexRequest, mockedMetadata);
 
         verify(mockedIndexRequest, times(1)).isPipelineResolved();
         verifyNoMoreInteractions(mockedIndexRequest);
@@ -1908,13 +1908,13 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
@@ -1924,7 +1924,7 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
     }
@@ -1939,14 +1939,14 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -1957,7 +1957,7 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(Version.CURRENT).put(IndexSettings.FINAL_PIPELINE.getKey(), "final-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -1974,7 +1974,7 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("<idx-{now/d}>");
-        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata, epochMillis);
+        IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata, epochMillis);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -1985,7 +1985,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
@@ -1994,7 +1994,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
         }
@@ -2007,7 +2007,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
         }
@@ -2020,7 +2020,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2209,7 +2209,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
@@ -2222,7 +2222,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
@@ -2235,7 +2235,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
         }
@@ -2248,7 +2248,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
         }
@@ -2261,7 +2261,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2275,7 +2275,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
+            IngestService.resolvePipelinesAndUpdateIndexRequest(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
             assertThat(indexRequest.getFinalPipeline(), equalTo(NOOP_PIPELINE_NAME));

--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -1867,6 +1867,20 @@ public class IngestServiceTests extends ESTestCase {
         assertThat(indexRequest8.getRawTimestamp(), equalTo(100));
     }
 
+    public void testIndexRequestHasAPipeline() {
+        var indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline(NOOP_PIPELINE_NAME);
+        assertFalse(IngestService.indexRequestHasPipeline(indexRequest));
+
+        indexRequest = new IndexRequest("idx").setPipeline("some-pipeline").setFinalPipeline(NOOP_PIPELINE_NAME);
+        assertTrue(IngestService.indexRequestHasPipeline(indexRequest));
+
+        indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME).setFinalPipeline("some-final-pipeline");
+        assertTrue(IngestService.indexRequestHasPipeline(indexRequest));
+
+        indexRequest = new IndexRequest("idx").setPipeline("some-pipeline").setFinalPipeline("some-final-pipeline");
+        assertTrue(IngestService.indexRequestHasPipeline(indexRequest));
+    }
+
     public void testResolveRequiredOrDefaultPipelineDefaultPipeline() {
         IndexMetadata.Builder builder = IndexMetadata.builder("idx")
             .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default-pipeline"))
@@ -1877,15 +1891,13 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
 
@@ -1895,8 +1907,7 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(Version.CURRENT).put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("default-pipeline"));
     }
@@ -1911,16 +1922,14 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("idx");
-        boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
 
         // alias name matches with IDM:
         indexRequest = new IndexRequest("alias");
-        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -1931,8 +1940,7 @@ public class IngestServiceTests extends ESTestCase {
             .settings(settings(Version.CURRENT).put(IndexSettings.FINAL_PIPELINE.getKey(), "final-pipeline"));
         metadata = Metadata.builder().put(templateBuilder).build();
         indexRequest = new IndexRequest("idx");
-        result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -1949,8 +1957,7 @@ public class IngestServiceTests extends ESTestCase {
 
         // index name matches with IDM:
         IndexRequest indexRequest = new IndexRequest("<idx-{now/d}>");
-        boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata, epochMillis);
-        assertThat(result, is(true));
+        IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata, epochMillis);
         assertThat(indexRequest.isPipelineResolved(), is(true));
         assertThat(indexRequest.getPipeline(), equalTo("_none"));
         assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -1961,8 +1968,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(false));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
         }
@@ -1971,8 +1977,7 @@ public class IngestServiceTests extends ESTestCase {
         {
             Metadata metadata = Metadata.builder().build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(true));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
         }
@@ -1985,8 +1990,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(true));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
         }
@@ -1999,8 +2003,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("request-pipeline");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(true));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("request-pipeline"));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2188,9 +2191,8 @@ public class IngestServiceTests extends ESTestCase {
         // _none request pipeline:
         {
             Metadata metadata = Metadata.builder().build();
-            IndexRequest indexRequest = new IndexRequest("idx").setPipeline(IngestService.NOOP_PIPELINE_NAME);
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(false));
+            IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
         }
@@ -2203,8 +2205,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(false));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
         }
@@ -2217,8 +2218,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(true));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
         }
@@ -2230,9 +2230,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfShards(1)
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
-            IndexRequest indexRequest = new IndexRequest("idx").setPipeline(IngestService.NOOP_PIPELINE_NAME);
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(false));
+            IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
         }
@@ -2244,9 +2243,8 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfShards(1)
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
-            IndexRequest indexRequest = new IndexRequest("idx").setPipeline(IngestService.NOOP_PIPELINE_NAME);
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(true));
+            IndexRequest indexRequest = new IndexRequest("idx").setPipeline(NOOP_PIPELINE_NAME);
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));
             assertThat(indexRequest.getFinalPipeline(), equalTo("final-pipeline"));
@@ -2260,8 +2258,7 @@ public class IngestServiceTests extends ESTestCase {
                 .numberOfReplicas(0);
             Metadata metadata = Metadata.builder().put(builder).build();
             IndexRequest indexRequest = new IndexRequest("idx").setPipeline("pipeline1");
-            boolean result = IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
-            assertThat(result, is(true));
+            IngestService.updateIndexRequestWithPipelines(indexRequest, indexRequest, metadata);
             assertThat(indexRequest.isPipelineResolved(), is(true));
             assertThat(indexRequest.getPipeline(), equalTo("pipeline1"));
             assertThat(indexRequest.getFinalPipeline(), equalTo(IngestService.NOOP_PIPELINE_NAME));


### PR DESCRIPTION
### What?

From issue #83653: if the pipeline associated with an indexRequest has a re-routing action (changing the `_index` property of a document) **and then** the new index has a `final_pipeline` associated (through index templates), the `final_pipeline` is executed twice. This leads to an overuse of resources and, in case the `final_pipeline` makes additive operations (like an `append`), the final document will have duplicated information.

### Why?

Calls to `updateIndexRequestWithPipelines` override the `final_pipeline` property of the index request (from `_none` -> `<some-final-pipeline>`), so later, when checking whether the indexRequest has or not any pipeline, it was incorrectly deducted that there's still a pipeline to be executed.


### How?

This change makes the derivation of pipelines side-effects free, ensuring that later derivations of pipelines from indexRequests are rightly made, by hence the `final_pipeline` is only executed once


Follow-up of #93821 
Closes #83653 