### PR TITLE
[DOCS] Removes 'coming in 8.6.2' from 8.6.2 release notes

### DIFF
--- a/docs/reference/release-notes/8.6.2.asciidoc
+++ b/docs/reference/release-notes/8.6.2.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.6.2]]
 == {es} version 8.6.2
 
-coming[8.6.2]
-
 Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 [[bug-8.6.2]]


### PR DESCRIPTION
This PR removes the 'coming in 8.6.2' admonition from the 8.6.2 release notes.

@julio-santana Maybe you can merge this before forward porting the release notes to later branches?