### PR TITLE
Fix explain and hybrid search scoring bug

### DIFF
--- a/docs/changelog/93871.yaml
+++ b/docs/changelog/93871.yaml
@@ -1,0 +1,5 @@
+pr: 93871
+summary: Fix explain and hybrid search scoring bug
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
@@ -73,8 +73,13 @@ class KnnScoreDocQuery extends Query {
         }
         return new Weight(this) {
             @Override
+            public int count(LeafReaderContext context) {
+                return segmentStarts[context.ord + 1] - segmentStarts[context.ord];
+            }
+
+            @Override
             public Explanation explain(LeafReaderContext context, int doc) {
-                int found = Arrays.binarySearch(docs, doc);
+                int found = Arrays.binarySearch(docs, doc + context.docBase);
                 if (found < 0) {
                     return Explanation.noMatch("not in top k documents");
                 }
@@ -83,7 +88,11 @@ class KnnScoreDocQuery extends Query {
 
             @Override
             public Scorer scorer(LeafReaderContext context) {
-
+                // Segment starts indicate how many docs are in the segment,
+                //   upper equalling lower indicates no documents for this segment
+                if (segmentStarts[context.ord] == segmentStarts[context.ord + 1]) {
+                    return null;
+                }
                 return new Scorer(this) {
                     final int lower = segmentStarts[context.ord];
                     final int upper = segmentStarts[context.ord + 1];
@@ -121,9 +130,13 @@ class KnnScoreDocQuery extends Query {
 
                     @Override
                     public float getMaxScore(int docId) {
-                        docId += context.docBase;
+                        // NO_MORE_DOCS indicates the maximum score for all docs in this segment
+                        // Anything less than must be accounted for via the docBase.
+                        if (docId != NO_MORE_DOCS) {
+                            docId += context.docBase;
+                        }
                         float maxScore = 0;
-                        for (int idx = Math.max(0, upTo); idx < upper && docs[idx] <= docId; idx++) {
+                        for (int idx = Math.max(lower, upTo); idx < upper && docs[idx] <= docId; idx++) {
                             maxScore = Math.max(maxScore, scores[idx] * boost);
                         }
                         return maxScore;

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
@@ -89,7 +89,7 @@ class KnnScoreDocQuery extends Query {
             @Override
             public Scorer scorer(LeafReaderContext context) {
                 // Segment starts indicate how many docs are in the segment,
-                //   upper equalling lower indicates no documents for this segment
+                // upper equalling lower indicates no documents for this segment
                 if (segmentStarts[context.ord] == segmentStarts[context.ord + 1]) {
                     return null;
                 }

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilderTests.java
@@ -12,11 +12,15 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Scorer;
 import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TotalHits;
+import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.elasticsearch.index.query.MatchNoneQueryBuilder;
@@ -32,6 +36,8 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
+import static org.hamcrest.Matchers.greaterThan;
 
 public class KnnScoreDocQueryBuilderTests extends AbstractQueryTestCase<KnnScoreDocQueryBuilder> {
 
@@ -176,18 +182,26 @@ public class KnnScoreDocQueryBuilderTests extends AbstractQueryTestCase<KnnScore
                 ScoreDoc[] scoreDocs = scoreDocsList.toArray(new ScoreDoc[0]);
 
                 KnnScoreDocQueryBuilder queryBuilder = new KnnScoreDocQueryBuilder(scoreDocs);
-                Query query = queryBuilder.doToQuery(context);
+                final Query query = queryBuilder.doToQuery(context);
+                final Weight w = query.createWeight(searcher, ScoreMode.TOP_SCORES, 1.0f);
 
                 TopDocs topDocs = searcher.search(query, 100);
                 assertEquals(scoreDocs.length, topDocs.totalHits.value);
                 assertEquals(TotalHits.Relation.EQUAL_TO, topDocs.totalHits.relation);
-
                 Arrays.sort(topDocs.scoreDocs, Comparator.comparingInt(scoreDoc -> scoreDoc.doc));
                 assertEquals(scoreDocs.length, topDocs.scoreDocs.length);
                 for (int i = 0; i < scoreDocs.length; i++) {
                     assertEquals(scoreDocs[i].doc, topDocs.scoreDocs[i].doc);
                     assertEquals(scoreDocs[i].score, topDocs.scoreDocs[i].score, 0.0001f);
+                    assertTrue(searcher.explain(query, scoreDocs[i].doc).isMatch());
+                }
 
+                for (LeafReaderContext leafReaderContext : searcher.getLeafContexts()) {
+                    Scorer scorer = w.scorer(leafReaderContext);
+                    // If we have matching docs, the score should always be greater than 0 for that segment
+                    if (scorer != null) {
+                        assertThat(leafReaderContext.toString(), scorer.getMaxScore(NO_MORE_DOCS), greaterThan(0.0f));
+                    }
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilderTests.java
@@ -36,6 +36,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+
 import static org.apache.lucene.search.DocIdSetIterator.NO_MORE_DOCS;
 import static org.hamcrest.Matchers.greaterThan;
 


### PR DESCRIPTION
This PR addresses bugs with KNN search.

First, when searching with KNN, using `explain: true` would give strange results. 

Even though a document obviously matches because of its score, the explanation would indicate that it did NOT match. This bug was because our explanation check was not accounting for the leaf-segment's docBase.

Second, when there are multiple segments, and KNN is used in hybrid search, some documents may go unscored by KNN.

The main issue here is the disjunction logic within `BoolQuery`. All hybrid queries with `knn` are pure disjunction queries under the hood. And Lucene does its best to optimize the documents it gathers in these types of queries.

Consequently, it will look for the maximum possible score for an entire segment leaf. However, the underlying KNN query would ALWAYS increment this passed docId by the segment's docBase (this is fairly ironic given the `explain` bug :D). This would cause the `docId` for calculating the maximum score to roll over to the negatives and thus knn would indicate its maximum score to be `0` for certain segments with higher docBase values.

closes: https://github.com/elastic/elasticsearch/issues/93830