### PR TITLE
[8.7] Replace rollup usages in downsample code. (#93697)

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
@@ -36,7 +36,7 @@ public record LifecycleExecutionState(
     String snapshotName,
     String shrinkIndexName,
     String snapshotIndexName,
-    String rollupIndexName
+    String downsampleIndexName
 ) {
 
     public static final String ILM_CUSTOM_METADATA_KEY = "ilm";
@@ -57,7 +57,7 @@ public record LifecycleExecutionState(
     private static final String SNAPSHOT_REPOSITORY = "snapshot_repository";
     private static final String SNAPSHOT_INDEX_NAME = "snapshot_index_name";
     private static final String SHRINK_INDEX_NAME = "shrink_index_name";
-    private static final String ROLLUP_INDEX_NAME = "rollup_index_name";
+    private static final String DOWNSAMPLE_INDEX_NAME = "rollup_index_name";
 
     public static final LifecycleExecutionState EMPTY_STATE = LifecycleExecutionState.builder().build();
 
@@ -81,7 +81,7 @@ public record LifecycleExecutionState(
             .setSnapshotName(state.snapshotName)
             .setShrinkIndexName(state.shrinkIndexName)
             .setSnapshotIndexName(state.snapshotIndexName)
-            .setRollupIndexName(state.rollupIndexName)
+            .setRollupIndexName(state.downsampleIndexName)
             .setStepTime(state.stepTime);
     }
 
@@ -187,7 +187,7 @@ public record LifecycleExecutionState(
         if (snapshotIndexName != null) {
             builder.setSnapshotIndexName(snapshotIndexName);
         }
-        String rollupIndexName = customData.get(ROLLUP_INDEX_NAME);
+        String rollupIndexName = customData.get(DOWNSAMPLE_INDEX_NAME);
         if (rollupIndexName != null) {
             builder.setRollupIndexName(rollupIndexName);
         }
@@ -250,8 +250,8 @@ public record LifecycleExecutionState(
         if (snapshotIndexName != null) {
             result.put(SNAPSHOT_INDEX_NAME, snapshotIndexName);
         }
-        if (rollupIndexName != null) {
-            result.put(ROLLUP_INDEX_NAME, rollupIndexName);
+        if (downsampleIndexName != null) {
+            result.put(DOWNSAMPLE_INDEX_NAME, downsampleIndexName);
         }
         return Collections.unmodifiableMap(result);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackClientPlugin.java
@@ -39,7 +39,7 @@ import org.elasticsearch.xpack.core.archive.ArchiveFeatureSetUsage;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.ccr.AutoFollowMetadata;
 import org.elasticsearch.xpack.core.datastreams.DataStreamFeatureSetUsage;
-import org.elasticsearch.xpack.core.downsample.RollupIndexerAction;
+import org.elasticsearch.xpack.core.downsample.DownsampleIndexerAction;
 import org.elasticsearch.xpack.core.enrich.EnrichFeatureSetUsage;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
 import org.elasticsearch.xpack.core.eql.EqlFeatureSetUsage;
@@ -410,7 +410,7 @@ public class XPackClientPlugin extends Plugin implements ActionPlugin, NetworkPl
             // Terms enum API
             TermsEnumAction.INSTANCE,
             // TSDB Downsampling
-            RollupIndexerAction.INSTANCE,
+            DownsampleIndexerAction.INSTANCE,
             org.elasticsearch.xpack.core.downsample.DownsampleAction.INSTANCE
         );
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/downsample/DownsampleAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/downsample/DownsampleAction.java
@@ -67,7 +67,7 @@ public class DownsampleAction extends ActionType<AcknowledgedResponse> {
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new RollupTask(id, type, action, parentTaskId, targetIndex, downsampleConfig, headers);
+            return new DownsampleTask(id, type, action, parentTaskId, targetIndex, downsampleConfig, headers);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/downsample/DownsampleTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/downsample/DownsampleTask.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.downsample;
 import org.elasticsearch.tasks.CancellableTask;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.xpack.core.rollup.RollupField;
-import org.elasticsearch.xpack.core.rollup.job.RollupJobStatus;
 
 import java.util.Map;
 
@@ -17,40 +16,30 @@ import java.util.Map;
  * This class contains the high-level logic that drives the rollup job. The allocated task contains transient state
  * which drives the indexing, and periodically updates it's parent PersistentTask with the indexing's current position.
  */
-public class RollupTask extends CancellableTask {
-    private String rollupIndex;
-    private DownsampleConfig config;
-    private RollupJobStatus status;
+public class DownsampleTask extends CancellableTask {
+    private final String downsampleIndex;
+    private final DownsampleConfig config;
 
-    RollupTask(
+    DownsampleTask(
         long id,
         String type,
         String action,
         TaskId parentTask,
-        String rollupIndex,
+        String downsampleIndex,
         DownsampleConfig config,
         Map<String, String> headers
     ) {
-        super(id, type, action, RollupField.NAME + "_" + rollupIndex, parentTask, headers);
-        this.rollupIndex = rollupIndex;
+        super(id, type, action, RollupField.NAME + "_" + downsampleIndex, parentTask, headers);
+        this.downsampleIndex = downsampleIndex;
         this.config = config;
     }
 
-    public String getRollupIndex() {
-        return rollupIndex;
+    public String getDownsampleIndex() {
+        return downsampleIndex;
     }
 
     public DownsampleConfig config() {
         return config;
     }
 
-    @Override
-    public Status getStatus() {
-        return status;
-    }
-
-    @Override
-    public void onCancelled() {
-        // TODO(talevy): make things cancellable
-    }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UpdateRollupIndexPolicyStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/UpdateRollupIndexPolicyStep.java
@@ -52,8 +52,8 @@ public class UpdateRollupIndexPolicyStep extends AsyncActionStep {
         final String policyName = indexMetadata.getLifecyclePolicyName();
         final String indexName = indexMetadata.getIndex().getName();
         final LifecycleExecutionState lifecycleState = indexMetadata.getLifecycleExecutionState();
-        final String rollupIndexName = lifecycleState.rollupIndexName();
-        if (Strings.hasText(rollupIndexName) == false) {
+        final String downsampleIndexName = lifecycleState.downsampleIndexName();
+        if (Strings.hasText(downsampleIndexName) == false) {
             listener.onFailure(
                 new IllegalStateException(
                     "rollup index name was not generated for policy [" + policyName + "] and index [" + indexName + "]"
@@ -62,7 +62,7 @@ public class UpdateRollupIndexPolicyStep extends AsyncActionStep {
             return;
         }
         Settings settings = Settings.builder().put(LifecycleSettings.LIFECYCLE_NAME, rollupPolicy).build();
-        UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(rollupIndexName).masterNodeTimeout(TimeValue.MAX_VALUE)
+        UpdateSettingsRequest updateSettingsRequest = new UpdateSettingsRequest(downsampleIndexName).masterNodeTimeout(TimeValue.MAX_VALUE)
             .settings(settings);
         getClient().admin().indices().updateSettings(updateSettingsRequest, ActionListener.wrap(response -> {
             if (response.isAcknowledged()) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
@@ -81,10 +81,10 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
 
         assertTrue(steps.get(4) instanceof GenerateUniqueIndexNameStep);
         assertThat(steps.get(4).getKey().name(), equalTo(GENERATE_DOWNSAMPLE_STEP_NAME));
-        assertThat(steps.get(4).getNextStepKey().name(), equalTo(RollupStep.NAME));
+        assertThat(steps.get(4).getNextStepKey().name(), equalTo(DownsampleStep.NAME));
 
-        assertTrue(steps.get(5) instanceof RollupStep);
-        assertThat(steps.get(5).getKey().name(), equalTo(RollupStep.NAME));
+        assertTrue(steps.get(5) instanceof DownsampleStep);
+        assertThat(steps.get(5).getKey().name(), equalTo(DownsampleStep.NAME));
         assertThat(steps.get(5).getNextStepKey().name(), equalTo(WaitForIndexColorStep.NAME));
 
         assertTrue(steps.get(6) instanceof ClusterStateWaitUntilThresholdStep);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleStepTests.java
@@ -32,18 +32,18 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
-public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
+public class DownsampleStepTests extends AbstractStepTestCase<DownsampleStep> {
 
     @Override
-    public RollupStep createRandomInstance() {
+    public DownsampleStep createRandomInstance() {
         StepKey stepKey = randomStepKey();
         StepKey nextStepKey = randomStepKey();
         DateHistogramInterval fixedInterval = ConfigTestHelpers.randomInterval();
-        return new RollupStep(stepKey, nextStepKey, client, fixedInterval);
+        return new DownsampleStep(stepKey, nextStepKey, client, fixedInterval);
     }
 
     @Override
-    public RollupStep mutateInstance(RollupStep instance) {
+    public DownsampleStep mutateInstance(DownsampleStep instance) {
         StepKey key = instance.getKey();
         StepKey nextKey = instance.getNextStepKey();
         DateHistogramInterval fixedInterval = instance.getFixedInterval();
@@ -55,15 +55,15 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
             default -> throw new AssertionError("Illegal randomisation branch");
         }
 
-        return new RollupStep(key, nextKey, instance.getClient(), fixedInterval);
+        return new DownsampleStep(key, nextKey, instance.getClient(), fixedInterval);
     }
 
     @Override
-    public RollupStep copyInstance(RollupStep instance) {
-        return new RollupStep(instance.getKey(), instance.getNextStepKey(), instance.getClient(), instance.getFixedInterval());
+    public DownsampleStep copyInstance(DownsampleStep instance) {
+        return new DownsampleStep(instance.getKey(), instance.getNextStepKey(), instance.getClient(), instance.getFixedInterval());
     }
 
-    private IndexMetadata getIndexMetadata(String index, String lifecycleName, RollupStep step) {
+    private IndexMetadata getIndexMetadata(String index, String lifecycleName, DownsampleStep step) {
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(step.getKey().phase());
         lifecycleState.setAction(step.getKey().action());
@@ -87,7 +87,7 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
 
     public void testPerformAction() throws Exception {
         String lifecycleName = randomAlphaOfLength(5);
-        RollupStep step = createRandomInstance();
+        DownsampleStep step = createRandomInstance();
         String index = randomAlphaOfLength(5);
 
         IndexMetadata indexMetadata = getIndexMetadata(index, lifecycleName, step);
@@ -99,7 +99,7 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
 
     public void testPerformActionFailureInvalidExecutionState() {
         String lifecycleName = randomAlphaOfLength(5);
-        RollupStep step = createRandomInstance();
+        DownsampleStep step = createRandomInstance();
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(step.getKey().phase());
@@ -134,7 +134,7 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
     }
 
     public void testPerformActionOnDataStream() throws Exception {
-        RollupStep step = createRandomInstance();
+        DownsampleStep step = createRandomInstance();
         String lifecycleName = randomAlphaOfLength(5);
         String dataStreamName = "test-datastream";
         String backingIndexName = DataStream.getDefaultBackingIndexName(dataStreamName, 1);
@@ -154,7 +154,7 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
     public void testPerformActionCompletedRollupIndexExists() {
         String sourceIndexName = randomAlphaOfLength(10);
         String lifecycleName = randomAlphaOfLength(5);
-        RollupStep step = createRandomInstance();
+        DownsampleStep step = createRandomInstance();
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(step.getKey().phase());
@@ -204,7 +204,7 @@ public class RollupStepTests extends AbstractStepTestCase<RollupStep> {
     public void testPerformActionRollupInProgressIndexExists() {
         String sourceIndexName = randomAlphaOfLength(10);
         String lifecycleName = randomAlphaOfLength(5);
-        RollupStep step = createRandomInstance();
+        DownsampleStep step = createRandomInstance();
 
         LifecycleExecutionState.Builder lifecycleState = LifecycleExecutionState.builder();
         lifecycleState.setPhase(step.getKey().phase());

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
@@ -181,7 +181,7 @@ public class LifecycleExecutionStateTests extends ESTestCase {
                 newState.setSnapshotName(randomValueOtherThan(toMutate.snapshotName(), () -> randomAlphaOfLengthBetween(5, 20)));
                 break;
             case 14:
-                newState.setRollupIndexName(randomValueOtherThan(toMutate.rollupIndexName(), () -> randomAlphaOfLengthBetween(5, 20)));
+                newState.setRollupIndexName(randomValueOtherThan(toMutate.downsampleIndexName(), () -> randomAlphaOfLengthBetween(5, 20)));
                 break;
             case 15:
                 newState.setIsAutoRetryableError(randomValueOtherThan(toMutate.isAutoRetryableError(), ESTestCase::randomBoolean));

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleService.java
@@ -35,11 +35,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.ilm.CheckShrinkReadyStep;
+import org.elasticsearch.xpack.core.ilm.DownsampleStep;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
-import org.elasticsearch.xpack.core.ilm.RollupStep;
 import org.elasticsearch.xpack.core.ilm.SetSingleNodeAllocateStep;
 import org.elasticsearch.xpack.core.ilm.ShrinkAction;
 import org.elasticsearch.xpack.core.ilm.ShrinkStep;
@@ -75,7 +75,7 @@ public class IndexLifecycleService
         IndexEventListener,
         ShutdownAwarePlugin {
     private static final Logger logger = LogManager.getLogger(IndexLifecycleService.class);
-    private static final Set<String> IGNORE_STEPS_MAINTENANCE_REQUESTED = Set.of(ShrinkStep.NAME, RollupStep.NAME);
+    private static final Set<String> IGNORE_STEPS_MAINTENANCE_REQUESTED = Set.of(ShrinkStep.NAME, DownsampleStep.NAME);
     private volatile boolean isMaster = false;
     private volatile TimeValue pollInterval;
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/AbstractDownsampleFieldProducer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/AbstractDownsampleFieldProducer.java
@@ -14,12 +14,12 @@ import java.io.IOException;
 /**
  * Base class that reads fields from the source index and produces their downsampled values
  */
-abstract class AbstractRollupFieldProducer implements RollupFieldSerializer {
+abstract class AbstractDownsampleFieldProducer implements DownsampleFieldSerializer {
 
     private final String name;
     protected boolean isEmpty;
 
-    AbstractRollupFieldProducer(String name) {
+    AbstractDownsampleFieldProducer(String name) {
         this.name = name;
         this.isEmpty = true;
     }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldSerializer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldSerializer.java
@@ -12,17 +12,17 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.util.Collection;
 
-public class AggregateMetricFieldSerializer implements RollupFieldSerializer {
-    private final Collection<AbstractRollupFieldProducer> producers;
+public class AggregateMetricFieldSerializer implements DownsampleFieldSerializer {
+    private final Collection<AbstractDownsampleFieldProducer> producers;
     private final String name;
 
     /**
      * @param name the name of the aggregate_metric_double field as it will be serialized
      *             in the downsampled index
-     * @param producers a collection of {@link AbstractRollupFieldProducer} instances with the subfields
+     * @param producers a collection of {@link AbstractDownsampleFieldProducer} instances with the subfields
      *                  of the aggregate_metric_double field.
      */
-    public AggregateMetricFieldSerializer(String name, Collection<AbstractRollupFieldProducer> producers) {
+    public AggregateMetricFieldSerializer(String name, Collection<AbstractDownsampleFieldProducer> producers) {
         this.name = name;
         this.producers = producers;
     }
@@ -34,7 +34,7 @@ public class AggregateMetricFieldSerializer implements RollupFieldSerializer {
         }
 
         builder.startObject(name);
-        for (AbstractRollupFieldProducer rollupFieldProducer : producers) {
+        for (AbstractDownsampleFieldProducer rollupFieldProducer : producers) {
             assert name.equals(rollupFieldProducer.name()) : "producer has a different name";
             if (rollupFieldProducer.isEmpty() == false) {
                 if (rollupFieldProducer instanceof MetricFieldProducer metricFieldProducer) {
@@ -55,7 +55,7 @@ public class AggregateMetricFieldSerializer implements RollupFieldSerializer {
     }
 
     private boolean isEmpty() {
-        for (AbstractRollupFieldProducer p : producers) {
+        for (AbstractDownsampleFieldProducer p : producers) {
             if (p.isEmpty() == false) {
                 return false;
             }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/AggregateMetricFieldValueFetcher.java
@@ -19,7 +19,7 @@ public class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
 
     private AggregateDoubleMetricFieldType aggMetricFieldType;
 
-    private final AbstractRollupFieldProducer rollupFieldProducer;
+    private final AbstractDownsampleFieldProducer rollupFieldProducer;
 
     protected AggregateMetricFieldValueFetcher(
         MappedFieldType fieldType,
@@ -31,11 +31,11 @@ public class AggregateMetricFieldValueFetcher extends FieldValueFetcher {
         this.rollupFieldProducer = createRollupFieldProducer();
     }
 
-    public AbstractRollupFieldProducer rollupFieldProducer() {
+    public AbstractDownsampleFieldProducer rollupFieldProducer() {
         return rollupFieldProducer;
     }
 
-    private AbstractRollupFieldProducer createRollupFieldProducer() {
+    private AbstractDownsampleFieldProducer createRollupFieldProducer() {
         AggregateDoubleMetricFieldMapper.Metric metric = null;
         for (var e : aggMetricFieldType.getMetricFields().entrySet()) {
             NumberFieldMapper.NumberFieldType metricSubField = e.getValue();

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/DownsampleFieldSerializer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/DownsampleFieldSerializer.java
@@ -11,7 +11,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 
-public interface RollupFieldSerializer {
+public interface DownsampleFieldSerializer {
 
     /**
      * Serialize the downsampled value of the field.

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -27,7 +27,7 @@ class FieldValueFetcher {
 
     private final MappedFieldType fieldType;
     private final IndexFieldData<?> fieldData;
-    private final AbstractRollupFieldProducer rollupFieldProducer;
+    private final AbstractDownsampleFieldProducer rollupFieldProducer;
 
     protected FieldValueFetcher(MappedFieldType fieldType, IndexFieldData<?> fieldData) {
         this.fieldType = fieldType;
@@ -48,11 +48,11 @@ class FieldValueFetcher {
         return fieldData.load(context).getFormattedValues(format);
     }
 
-    public AbstractRollupFieldProducer rollupFieldProducer() {
+    public AbstractDownsampleFieldProducer rollupFieldProducer() {
         return rollupFieldProducer;
     }
 
-    private AbstractRollupFieldProducer createRollupFieldProducer() {
+    private AbstractDownsampleFieldProducer createRollupFieldProducer() {
         if (fieldType.getMetricType() != null) {
             return switch (fieldType.getMetricType()) {
                 case GAUGE -> new MetricFieldProducer.GaugeMetricFieldProducer(name());

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/LabelFieldProducer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/LabelFieldProducer.java
@@ -19,7 +19,7 @@ import java.util.List;
 /**
  * Class that produces values for a label field.
  */
-abstract class LabelFieldProducer extends AbstractRollupFieldProducer {
+abstract class LabelFieldProducer extends AbstractDownsampleFieldProducer {
 
     LabelFieldProducer(String name) {
         super(name);

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/MetricFieldProducer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/MetricFieldProducer.java
@@ -21,7 +21,7 @@ import java.util.List;
  * values. Based on the supported metric types, the subclasses of this class compute values for
  * gauge and metric types.
  */
-abstract class MetricFieldProducer extends AbstractRollupFieldProducer {
+abstract class MetricFieldProducer extends AbstractDownsampleFieldProducer {
     /**
      * a list of metrics that will be computed for the field
      */

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RollupShardIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RollupShardIndexer.java
@@ -48,7 +48,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.downsample.DownsampleConfig;
-import org.elasticsearch.xpack.core.downsample.RollupIndexerAction;
+import org.elasticsearch.xpack.core.downsample.DownsampleIndexerAction;
 import org.elasticsearch.xpack.core.rollup.action.RollupShardTask;
 
 import java.io.Closeable;
@@ -138,7 +138,7 @@ class RollupShardIndexer {
         }
     }
 
-    public RollupIndexerAction.ShardRollupResponse execute() throws IOException {
+    public DownsampleIndexerAction.ShardDownsampleResponse execute() throws IOException {
         long startTime = System.currentTimeMillis();
         BulkProcessor bulkProcessor = createBulkProcessor();
         try (searcher; bulkProcessor) {
@@ -171,7 +171,7 @@ class RollupShardIndexer {
             );
         }
 
-        return new RollupIndexerAction.ShardRollupResponse(indexShard.shardId(), task.getNumIndexed());
+        return new DownsampleIndexerAction.ShardDownsampleResponse(indexShard.shardId(), task.getNumIndexed());
     }
 
     private void checkCancelled() {
@@ -250,7 +250,7 @@ class RollupShardIndexer {
 
         TimeSeriesBucketCollector(BulkProcessor bulkProcessor) {
             this.bulkProcessor = bulkProcessor;
-            List<AbstractRollupFieldProducer> rollupFieldProducers = fieldValueFetchers.stream()
+            List<AbstractDownsampleFieldProducer> rollupFieldProducers = fieldValueFetchers.stream()
                 .map(FieldValueFetcher::rollupFieldProducer)
                 .toList();
             this.rollupBucketBuilder = new RollupBucketBuilder(rollupFieldProducers);
@@ -263,7 +263,7 @@ class RollupShardIndexer {
             docCountProvider.setLeafReaderContext(ctx);
 
             // For each field, return a tuple with the rollup field producer and the field value leaf
-            final List<Tuple<AbstractRollupFieldProducer, FormattedDocValues>> fieldValueTuples = fieldValueFetchers.stream()
+            final List<Tuple<AbstractDownsampleFieldProducer, FormattedDocValues>> fieldValueTuples = fieldValueFetchers.stream()
                 .map(fetcher -> Tuple.tuple(fetcher.rollupFieldProducer(), fetcher.getLeaf(ctx)))
                 .toList();
 
@@ -333,8 +333,8 @@ class RollupShardIndexer {
                     final int docCount = docCountProvider.getDocCount(docId);
                     rollupBucketBuilder.collectDocCount(docCount);
                     // Iterate over all field values and collect the doc_values for this docId
-                    for (Tuple<AbstractRollupFieldProducer, FormattedDocValues> tuple : fieldValueTuples) {
-                        AbstractRollupFieldProducer rollupFieldProducer = tuple.v1();
+                    for (Tuple<AbstractDownsampleFieldProducer, FormattedDocValues> tuple : fieldValueTuples) {
+                        AbstractDownsampleFieldProducer rollupFieldProducer = tuple.v1();
                         FormattedDocValues docValues = tuple.v2();
                         rollupFieldProducer.collect(docValues, docId);
                     }
@@ -384,9 +384,9 @@ class RollupShardIndexer {
         private int tsidOrd = -1;
         private long timestamp;
         private int docCount;
-        private final List<AbstractRollupFieldProducer> rollupFieldProducers;
+        private final List<AbstractDownsampleFieldProducer> rollupFieldProducers;
 
-        RollupBucketBuilder(List<AbstractRollupFieldProducer> rollupFieldProducers) {
+        RollupBucketBuilder(List<AbstractDownsampleFieldProducer> rollupFieldProducers) {
             this.rollupFieldProducers = rollupFieldProducers;
         }
 
@@ -405,7 +405,7 @@ class RollupShardIndexer {
         public RollupBucketBuilder resetTimestamp(long timestamp) {
             this.timestamp = timestamp;
             this.docCount = 0;
-            this.rollupFieldProducers.forEach(AbstractRollupFieldProducer::reset);
+            this.rollupFieldProducers.forEach(AbstractDownsampleFieldProducer::reset);
             if (logger.isTraceEnabled()) {
                 logger.trace(
                     "New bucket for _tsid: [{}], @timestamp: [{}]",
@@ -444,8 +444,8 @@ class RollupShardIndexer {
              * name. If grouping yields multiple rollup field producers, we delegate serialization to
              * the AggregateMetricFieldSerializer class.
              */
-            List<RollupFieldSerializer> groupedProducers = rollupFieldProducers.stream()
-                .collect(groupingBy(AbstractRollupFieldProducer::name))
+            List<DownsampleFieldSerializer> groupedProducers = rollupFieldProducers.stream()
+                .collect(groupingBy(AbstractDownsampleFieldProducer::name))
                 .entrySet()
                 .stream()
                 .map(e -> {
@@ -458,7 +458,7 @@ class RollupShardIndexer {
                 .toList();
 
             // Serialize fields
-            for (RollupFieldSerializer fieldProducer : groupedProducers) {
+            for (DownsampleFieldSerializer fieldProducer : groupedProducers) {
                 fieldProducer.write(builder);
             }
 

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/Rollup.java
@@ -39,7 +39,7 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.core.action.XPackInfoFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.downsample.DownsampleAction;
-import org.elasticsearch.xpack.core.downsample.RollupIndexerAction;
+import org.elasticsearch.xpack.core.downsample.DownsampleIndexerAction;
 import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.rollup.action.DeleteRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.GetRollupCapsAction;
@@ -51,8 +51,8 @@ import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.action.StopRollupJobAction;
 import org.elasticsearch.xpack.core.scheduler.SchedulerEngine;
 import org.elasticsearch.xpack.downsample.RestDownsampleAction;
-import org.elasticsearch.xpack.downsample.TransportRollupAction;
-import org.elasticsearch.xpack.downsample.TransportRollupIndexerAction;
+import org.elasticsearch.xpack.downsample.TransportDownsampleAction;
+import org.elasticsearch.xpack.downsample.TransportDownsampleIndexerAction;
 import org.elasticsearch.xpack.rollup.action.TransportDeleteRollupJobAction;
 import org.elasticsearch.xpack.rollup.action.TransportGetRollupCapsAction;
 import org.elasticsearch.xpack.rollup.action.TransportGetRollupIndexCapsAction;
@@ -155,8 +155,8 @@ public class Rollup extends Plugin implements ActionPlugin, PersistentTaskPlugin
             new ActionHandler<>(GetRollupIndexCapsAction.INSTANCE, TransportGetRollupIndexCapsAction.class),
             new ActionHandler<>(XPackUsageFeatureAction.ROLLUP, RollupUsageTransportAction.class),
             new ActionHandler<>(XPackInfoFeatureAction.ROLLUP, RollupInfoTransportAction.class),
-            new ActionHandler<>(RollupIndexerAction.INSTANCE, TransportRollupIndexerAction.class),
-            new ActionHandler<>(DownsampleAction.INSTANCE, TransportRollupAction.class)
+            new ActionHandler<>(DownsampleIndexerAction.INSTANCE, TransportDownsampleIndexerAction.class),
+            new ActionHandler<>(DownsampleAction.INSTANCE, TransportDownsampleAction.class)
         );
     }
 

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleTransportFailureTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleTransportFailureTests.java
@@ -37,7 +37,7 @@ import org.elasticsearch.xpack.aggregatemetric.AggregateMetricMapperPlugin;
 import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
 import org.elasticsearch.xpack.core.downsample.DownsampleAction;
 import org.elasticsearch.xpack.core.downsample.DownsampleConfig;
-import org.elasticsearch.xpack.core.downsample.RollupIndexerAction;
+import org.elasticsearch.xpack.core.downsample.DownsampleIndexerAction;
 import org.elasticsearch.xpack.rollup.Rollup;
 import org.junit.Before;
 
@@ -57,7 +57,7 @@ import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 2, numClientNodes = 1, supportsDedicatedMasters = false)
 public class DownsampleTransportFailureTests extends ESIntegTestCase {
 
-    public static final String ROLLUP_INDEXER_SHARD_ACTION = RollupIndexerAction.NAME + "[s]";
+    public static final String ROLLUP_INDEXER_SHARD_ACTION = DownsampleIndexerAction.NAME + "[s]";
 
     private static class TestClusterHelper {
         private final InternalTestCluster cluster;


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Replace rollup usages in downsample code. (#93697)