### PR TITLE
[8.7] Don't treat counter fields in outside of tsdb as counters. (#93800)

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/script/ScriptScoreBenchmark.java
@@ -82,7 +82,7 @@ public class ScriptScoreBenchmark {
     private final ScriptModule scriptModule = new ScriptModule(Settings.EMPTY, pluginsService.filterPlugins(ScriptPlugin.class));
 
     private final Map<String, MappedFieldType> fieldTypes = Map.ofEntries(
-        Map.entry("n", new NumberFieldType("n", NumberType.LONG, false, false, true, true, null, Map.of(), null, false, null))
+        Map.entry("n", new NumberFieldType("n", NumberType.LONG, false, false, true, true, null, Map.of(), null, false, null, null))
     );
     private final IndexFieldDataCache fieldDataCache = new IndexFieldDataCache.None();
     private final Map<String, Set<String>> sourcePaths = Map.of("n", Set.of("n"));

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -192,7 +192,8 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 meta.getValue(),
                 scalingFactor.getValue(),
                 nullValue.getValue(),
-                metric.getValue()
+                metric.getValue(),
+                indexMode
             );
             return new ScaledFloatFieldMapper(name, type, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
@@ -205,6 +206,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         private final double scalingFactor;
         private final Double nullValue;
         private final TimeSeriesParams.MetricType metricType;
+        private final IndexMode indexMode;
 
         public ScaledFloatFieldType(
             String name,
@@ -214,12 +216,14 @@ public class ScaledFloatFieldMapper extends FieldMapper {
             Map<String, String> meta,
             double scalingFactor,
             Double nullValue,
-            TimeSeriesParams.MetricType metricType
+            TimeSeriesParams.MetricType metricType,
+            IndexMode indexMode
         ) {
             super(name, indexed, stored, hasDocValues, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
             this.scalingFactor = scalingFactor;
             this.nullValue = nullValue;
             this.metricType = metricType;
+            this.indexMode = indexMode;
         }
 
         public ScaledFloatFieldType(String name, double scalingFactor) {
@@ -227,7 +231,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         public ScaledFloatFieldType(String name, double scalingFactor, boolean indexed) {
-            this(name, indexed, false, true, Collections.emptyMap(), scalingFactor, null, null);
+            this(name, indexed, false, true, Collections.emptyMap(), scalingFactor, null, null, null);
         }
 
         public double getScalingFactor() {
@@ -302,7 +306,7 @@ public class ScaledFloatFieldMapper extends FieldMapper {
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = metricType == TimeSeriesParams.MetricType.COUNTER
+            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER
                 ? TimeSeriesValuesSourceType.COUNTER
                 : IndexNumericFieldData.NumericType.LONG.getValuesSourceType();
             if ((operation == FielddataOperation.SEARCH || operation == FielddataOperation.SCRIPT) && hasDocValues()) {

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/TokenCountFieldMapper.java
@@ -113,6 +113,7 @@ public class TokenCountFieldMapper extends FieldMapper {
                 meta,
                 null,
                 false,
+                null,
                 null
             );
         }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -91,6 +91,7 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
             Collections.emptyMap(),
             0.1 + randomDouble() * 100,
             null,
+            null,
             null
         );
         Directory dir = newDirectory();

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/120_counter_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/120_counter_fields.yml
@@ -1,0 +1,53 @@
+---
+"avg aggregation on counter field":
+  - skip:
+      version: " - 8.7.99"
+      reason: "counter field support added in 8.7"
+
+  - do:
+      indices.create:
+        index: myindex1
+        body:
+          mappings:
+            properties:
+              counter_field:
+                type : long
+                time_series_metric: counter
+  - do:
+      indices.create:
+        index: myindex2
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ keyword_field ]
+              time_series:
+                start_time: 2023-01-01T00:00:00Z
+                end_time: 2024-01-01T00:00:00Z
+          mappings:
+            properties:
+              keyword_field:
+                type: keyword
+                time_series_dimension: true
+              counter_field:
+                type : long
+                time_series_metric: counter
+  - do:
+      search:
+        index: myindex1
+        body:
+          aggs:
+            the_counter_avg:
+              avg:
+                field: counter_field
+  - match: { aggregations.the_counter_avg.value: null }
+
+  - do:
+      catch: /Field \[counter_field\] of type \[long\] is not supported for aggregation \[avg\]/
+      search:
+        index: myindex2
+        body:
+          aggs:
+            the_counter_avg:
+              avg:
+                field: counter_field

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/120_counter_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/120_counter_fields.yml
@@ -1,7 +1,7 @@
 ---
 "avg aggregation on counter field":
   - skip:
-      version: " - 8.7.99"
+      version: " - 8.6.99"
       reason: "counter field support added in 8.7"
 
   - do:

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -1465,6 +1465,7 @@ public class NumberFieldMapper extends FieldMapper {
         private final FieldValues<Number> scriptValues;
         private final boolean isDimension;
         private final MetricType metricType;
+        private final IndexMode indexMode;
 
         public NumberFieldType(
             String name,
@@ -1477,7 +1478,8 @@ public class NumberFieldMapper extends FieldMapper {
             Map<String, String> meta,
             FieldValues<Number> script,
             boolean isDimension,
-            MetricType metricType
+            MetricType metricType,
+            IndexMode indexMode
         ) {
             super(name, isIndexed, isStored, hasDocValues, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
             this.type = Objects.requireNonNull(type);
@@ -1486,6 +1488,7 @@ public class NumberFieldMapper extends FieldMapper {
             this.scriptValues = script;
             this.isDimension = isDimension;
             this.metricType = metricType;
+            this.indexMode = indexMode;
         }
 
         NumberFieldType(String name, Builder builder) {
@@ -1500,7 +1503,8 @@ public class NumberFieldMapper extends FieldMapper {
                 builder.meta.getValue(),
                 builder.scriptValues(),
                 builder.dimension.getValue(),
-                builder.metric.getValue()
+                builder.metric.getValue(),
+                builder.indexMode
             );
         }
 
@@ -1509,7 +1513,7 @@ public class NumberFieldMapper extends FieldMapper {
         }
 
         public NumberFieldType(String name, NumberType type, boolean isIndexed) {
-            this(name, type, isIndexed, false, true, true, null, Collections.emptyMap(), null, false, null);
+            this(name, type, isIndexed, false, true, true, null, Collections.emptyMap(), null, false, null, null);
         }
 
         @Override
@@ -1589,7 +1593,7 @@ public class NumberFieldMapper extends FieldMapper {
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = metricType == TimeSeriesParams.MetricType.COUNTER
+            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER
                 ? TimeSeriesValuesSourceType.COUNTER
                 : type.numericType.getValuesSourceType();
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/IndexFieldDataServiceTests.java
@@ -332,7 +332,20 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
     public void testRequireDocValuesOnLongs() {
         doTestRequireDocValues(new NumberFieldMapper.NumberFieldType("field", LONG));
         doTestRequireDocValues(
-            new NumberFieldMapper.NumberFieldType("field", LONG, true, false, false, false, null, Collections.emptyMap(), null, false, null)
+            new NumberFieldMapper.NumberFieldType(
+                "field",
+                LONG,
+                true,
+                false,
+                false,
+                false,
+                null,
+                Collections.emptyMap(),
+                null,
+                false,
+                null,
+                null
+            )
         );
     }
 
@@ -350,6 +363,7 @@ public class IndexFieldDataServiceTests extends ESSingleNodeTestCase {
                 Collections.emptyMap(),
                 null,
                 false,
+                null,
                 null
             )
         );

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -127,7 +127,20 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
     }
 
     private static MappedFieldType unsearchable() {
-        return new NumberFieldType("field", NumberType.LONG, false, false, false, true, null, Collections.emptyMap(), null, false, null);
+        return new NumberFieldType(
+            "field",
+            NumberType.LONG,
+            false,
+            false,
+            false,
+            true,
+            null,
+            Collections.emptyMap(),
+            null,
+            false,
+            null,
+            null
+        );
     }
 
     public void testTermQuery() {

--- a/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/AggregatorBaseTests.java
@@ -89,6 +89,7 @@ public class AggregatorBaseTests extends MapperServiceTestCase {
             Collections.emptyMap(),
             null,
             false,
+            null,
             null
         );
         return ValuesSourceConfig.resolveFieldOnly(ft, context);

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/filter/FiltersAggregatorTests.java
@@ -1512,6 +1512,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
             Map.of(),
             null,
             false,
+            null,
             null
         );
         docValuesFieldExistsTestCase(new ExistsQueryBuilder("f"), ft, true, i -> {
@@ -1534,6 +1535,7 @@ public class FiltersAggregatorTests extends AggregatorTestCase {
                 Map.of(),
                 null,
                 false,
+                null,
                 null
             )
         );

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/RangeAggregatorTests.java
@@ -309,6 +309,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
                     Collections.emptyMap(),
                     null,
                     false,
+                    null,
                     null
                 )
             )
@@ -423,6 +424,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             null,
             false,
+            null,
             null
         );
 
@@ -708,6 +710,7 @@ public class RangeAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             null,
             false,
+            null,
             null
         );
         RangeAggregationBuilder aggregationBuilder = new RangeAggregationBuilder("test_range_agg");

--- a/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/collapse/CollapseBuilderTests.java
@@ -152,6 +152,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 Collections.emptyMap(),
                 null,
                 false,
+                null,
                 null
             );
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);
@@ -169,6 +170,7 @@ public class CollapseBuilderTests extends AbstractXContentSerializingTestCase<Co
                 Collections.emptyMap(),
                 null,
                 false,
+                null,
                 null
             );
             when(searchExecutionContext.getFieldType("field")).thenReturn(numberFieldType);

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/rate/TimeSeriesRateAggregatorTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.aggregations.AggregationsPlugin;
 import org.elasticsearch.aggregations.bucket.timeseries.InternalTimeSeries;
 import org.elasticsearch.aggregations.bucket.timeseries.TimeSeriesAggregationBuilder;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.index.IndexMode;
 import org.elasticsearch.index.mapper.DateFieldMapper;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.NumberFieldMapper;
@@ -136,7 +137,8 @@ public class TimeSeriesRateAggregatorTests extends AggregatorTestCase {
             Collections.emptyMap(),
             null,
             false,
-            TimeSeriesParams.MetricType.COUNTER
+            TimeSeriesParams.MetricType.COUNTER,
+            IndexMode.TIME_SERIES
         );
     }
 

--- a/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/main/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapper.java
@@ -200,7 +200,8 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 parsedNullValue(),
                 meta.getValue(),
                 dimension.getValue(),
-                metric.getValue()
+                metric.getValue(),
+                indexMode
             );
             return new UnsignedLongFieldMapper(name, fieldType, multiFieldsBuilder.build(this, context), copyTo.build(), this);
         }
@@ -213,6 +214,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
         private final Number nullValueFormatted;
         private final boolean isDimension;
         private final MetricType metricType;
+        private final IndexMode indexMode;
 
         public UnsignedLongFieldType(
             String name,
@@ -222,16 +224,18 @@ public class UnsignedLongFieldMapper extends FieldMapper {
             Number nullValueFormatted,
             Map<String, String> meta,
             boolean isDimension,
-            MetricType metricType
+            MetricType metricType,
+            IndexMode indexMode
         ) {
             super(name, indexed, isStored, hasDocValues, TextSearchInfo.SIMPLE_MATCH_WITHOUT_TERMS, meta);
             this.nullValueFormatted = nullValueFormatted;
             this.isDimension = isDimension;
             this.metricType = metricType;
+            this.indexMode = indexMode;
         }
 
         public UnsignedLongFieldType(String name) {
-            this(name, true, false, true, null, Collections.emptyMap(), false, null);
+            this(name, true, false, true, null, Collections.emptyMap(), false, null, null);
         }
 
         @Override
@@ -316,7 +320,7 @@ public class UnsignedLongFieldMapper extends FieldMapper {
                 failIfNoDocValues();
             }
 
-            ValuesSourceType valuesSourceType = metricType == TimeSeriesParams.MetricType.COUNTER
+            ValuesSourceType valuesSourceType = indexMode == IndexMode.TIME_SERIES && metricType == TimeSeriesParams.MetricType.COUNTER
                 ? TimeSeriesValuesSourceType.COUNTER
                 : IndexNumericFieldData.NumericType.LONG.getValuesSourceType();
 

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldTypeTests.java
@@ -62,6 +62,7 @@ public class UnsignedLongFieldTypeTests extends FieldTypeTestCase {
             null,
             Collections.emptyMap(),
             false,
+            null,
             null
         );
 


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Don't treat counter fields in outside of tsdb as counters. (#93800)