### PR TITLE
[8.7]Mute NativePrivilegeStoreCacheTests testRolesCacheIsClearedWhenPrivilegesIsChanged (#93901)

### DIFF
--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/store/NativePrivilegeStoreCacheTests.java
@@ -297,6 +297,7 @@ public class NativePrivilegeStoreCacheTests extends SecuritySingleNodeTestCase {
         );
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93447")
     public void testRolesCacheIsClearedWhenPrivilegesIsChanged() {
         final Client client = client();
 


### PR DESCRIPTION
Backports the following commits to 8.7:
 - mute (#93901)