### PR TITLE
Fix unhandled exception when blobstore repository contains unexpected file

### DIFF
--- a/docs/changelog/93914.yaml
+++ b/docs/changelog/93914.yaml
@@ -1,0 +1,5 @@
+pr: 93914
+summary: Fix unhandled exception when blobstore repository contains unexpected file
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1298,7 +1298,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 return allSnapshotIds.contains(foundUUID) == false;
             } else if (blob.startsWith(INDEX_FILE_PREFIX)) {
                 // TODO: Include the current generation here once we remove keeping index-(N-1) around from #writeIndexGen
-                return repositoryData.getGenId() > Long.parseLong(blob.substring(INDEX_FILE_PREFIX.length()));
+                try {
+                    return repositoryData.getGenId() > Long.parseLong(blob.substring(INDEX_FILE_PREFIX.length()));
+                } catch (NumberFormatException nfe) {
+                    // odd case of an extra file with the index- prefix that we can't identify
+                    return false;
+                }
             }
             return false;
         }).toList();


### PR DESCRIPTION
If there's any file with the `index-` prefix but not a number after that at the repo root we must not throw here. If we do, we will end up throwing an unexpected exception that is not properly handled by `org.elasticsearch.snapshots.SnapshotsService#failAllListenersOnMasterFailOver`, leading to the repository generation not getting correctly set in the cluster state down the line.

Just like with other unexpected files in the repository, we should be able to deal with this one transparently.
