### PR TITLE
[6.4][DOCS] Changes URL to use branch variable instead of master. (#93916)

### DIFF
--- a/docs/java-rest/high-level/ingest/simulate_pipeline.asciidoc
+++ b/docs/java-rest/high-level/ingest/simulate_pipeline.asciidoc
@@ -5,7 +5,7 @@
 ==== Simulate Pipeline Request
 
 A `SimulatePipelineRequest` requires a source and a `XContentType`. The source consists
-of the request body. See the https://www.elastic.co/guide/en/elasticsearch/reference/master/simulate-pipeline-api.html[docs]
+of the request body. See the https://www.elastic.co/guide/en/elasticsearch/reference/{branch}/simulate-pipeline-api.html[docs]
 for more details on the request body.
 
 ["source","java",subs="attributes,callouts,macros"]


### PR DESCRIPTION
Backports the following commits to 6.4:
 - [7.17][DOCS] Changes URL to use branch variable instead of master. (#93916)