### PR TITLE
[8.6] updated correct API to get index templates etc (#93793)

### DIFF
--- a/docs/reference/monitoring/indices.asciidoc
+++ b/docs/reference/monitoring/indices.asciidoc
@@ -9,15 +9,15 @@ You can retrieve the templates through the `_template` API:
 
 [source,console]
 ----------------------------------
-GET /_template/.monitoring-*
+GET /_index_template/.monitoring-es-mb*
 ----------------------------------
 
 By default, the template configures one shard and one replica for the
 monitoring indices. To override the default settings, add your own template:
 
-. Set the `template` patterns to match existing `.monitoring-{product}-7-*` indices.
-. Set the template `order` to `1`. This ensures your template is
-applied after the default template, which has an order of 0.
+. Set `index_patterns` to match existing `.monitoring-{product}-8-*` indices.
+. Set the template `priority` to `1`. This ensures your template is
+applied after the default template, which has an priority of 0.
 . Specify the `number_of_shards` and/or `number_of_replicas` in the `settings`
 section.
 
@@ -26,14 +26,21 @@ and the number of replicas to two.
 
 [source,console]
 ----------------------------------
-PUT /_template/custom_monitoring
+PUT /_index_template/custom_monitoring
 {
-  "index_patterns": [".monitoring-beats-7-*", ".monitoring-es-7-*", ".monitoring-kibana-7-*", ".monitoring-logstash-7-*"],
-  "order": 1,
-  "settings": {
-    "number_of_shards": 5,
-    "number_of_replicas": 2
-  }
+  "index_patterns": [
+  ".monitoring-beats-8-*",
+  ".monitoring-es-8-*",
+  ".monitoring-kibana-8-*",
+  ".monitoring-logstash-8-*"
+  ],
+  "priority": 1,
+  "template": {
+    "settings": {
+      "number_of_shards": 5,
+      "number_of_replicas": 2
+    }
+  } 
 }
 ----------------------------------
 
@@ -41,7 +48,7 @@ PUT /_template/custom_monitoring
 
 [source,console]
 --------------------------------------------------
-DELETE /_template/custom_monitoring
+DELETE /_index_template/custom_monitoring
 --------------------------------------------------
 // TEST[continued]
 


### PR DESCRIPTION
Backports the following commits to 8.6:
 - updated correct API to get index templates etc (#93793)