### PR TITLE
[8.7] Fix unhandled exception when blobstore repository contains unexpected file (#93914)

### DIFF
--- a/docs/changelog/93914.yaml
+++ b/docs/changelog/93914.yaml
@@ -1,0 +1,5 @@
+pr: 93914
+summary: Fix unhandled exception when blobstore repository contains unexpected file
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -1298,7 +1298,12 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 return allSnapshotIds.contains(foundUUID) == false;
             } else if (blob.startsWith(INDEX_FILE_PREFIX)) {
                 // TODO: Include the current generation here once we remove keeping index-(N-1) around from #writeIndexGen
-                return repositoryData.getGenId() > Long.parseLong(blob.substring(INDEX_FILE_PREFIX.length()));
+                try {
+                    return repositoryData.getGenId() > Long.parseLong(blob.substring(INDEX_FILE_PREFIX.length()));
+                } catch (NumberFormatException nfe) {
+                    // odd case of an extra file with the index- prefix that we can't identify
+                    return false;
+                }
             }
             return false;
         }).toList();


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix unhandled exception when blobstore repository contains unexpected file (#93914)