### PR TITLE
Support position time_series_metric on geo_point fields

### DIFF
--- a/docs/changelog/93946.yaml
+++ b/docs/changelog/93946.yaml
@@ -1,0 +1,5 @@
+pr: 93946
+summary: Support position `time_series_metric` on `geo_point` fields
+area: "TSDB, Geo"
+type: enhancement
+issues: []

--- a/docs/changelog/93946.yaml
+++ b/docs/changelog/93946.yaml
@@ -1,5 +1,5 @@
 pr: 93946
 summary: Support position `time_series_metric` on `geo_point` fields
-area: "TSDB, Geo"
+area: "TSDB"
 type: enhancement
 issues: []

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -299,7 +299,7 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
     }
 
     public void testTimeSeriesIndexDefault() throws Exception {
-        var randomMetricType = randomFrom(TimeSeriesParams.MetricType.values());
+        var randomMetricType = randomFrom(TimeSeriesParams.MetricType.scalar());
         var indexSettings = getIndexSettingsBuilder().put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dimension_field");
         var mapperService = createMapperService(indexSettings.build(), fieldMapping(b -> {

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
@@ -1,5 +1,8 @@
 ---
 setup:
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       indices.create:
         index: locations
@@ -47,6 +50,9 @@ setup:
 
 ---
 multi-valued fields unsupported:
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       bulk:
         index: locations
@@ -66,6 +72,9 @@ multi-valued fields unsupported:
 
 ---
 "avg aggregation on position field unsupported":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       catch: /Field \[location\] of type \[geo_point\] is not supported for aggregation \[avg\]/
       search:
@@ -79,6 +88,8 @@ multi-valued fields unsupported:
 ---
 "geo_bounds on position field":
   - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
       features: close_to
 
   - do:
@@ -113,6 +124,9 @@ multi-valued fields unsupported:
 
 ---
 "geo bounding box query":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       search:
         index: locations
@@ -130,6 +144,9 @@ multi-valued fields unsupported:
 
 ---
 "geo shape intersects query":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       search:
         index: locations
@@ -144,6 +161,9 @@ multi-valued fields unsupported:
 
 ---
 "geo shape within query":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       search:
         index: locations
@@ -159,6 +179,9 @@ multi-valued fields unsupported:
 
 ---
 "geo shape disjoint query":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       search:
         index: locations
@@ -174,6 +197,9 @@ multi-valued fields unsupported:
 
 ---
 "geo shape contains query":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       search:
         index: locations
@@ -189,6 +215,9 @@ multi-valued fields unsupported:
 
 ---
 "geo distance query":
+  - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
   - do:
       search:
         index: locations
@@ -204,6 +233,8 @@ multi-valued fields unsupported:
 ---
 "bounds agg":
   - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
       features: close_to
 
   - do:
@@ -224,6 +255,8 @@ multi-valued fields unsupported:
 ---
 "geo_distance sort":
   - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
       features: close_to
 
   - do:
@@ -253,6 +286,8 @@ multi-valued fields unsupported:
 ---
 "distance_feature query":
   - skip:
+      version: " - 8.7.99"
+      reason: position metric introduced in 8.8.0
       features: close_to
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
@@ -1,0 +1,262 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: locations
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [ city, name ]
+              time_series:
+                start_time: 2023-01-01T00:00:00Z
+                end_time: 2024-01-01T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              city:
+                type: keyword
+                time_series_dimension: true
+              name:
+                type: keyword
+                time_series_dimension: true
+              location:
+                type: geo_point
+                time_series_metric: position
+
+  - do:
+      bulk:
+        index: locations
+        refresh: true
+        body: |
+          {"index":{}}
+          {"@timestamp": "2023-01-01T12:00:00Z", "location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}
+          {"index":{}}
+          {"@timestamp": "2023-01-02T12:00:00Z", "location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}
+          {"index":{}}
+          {"@timestamp": "2023-01-03T12:00:00Z", "location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}
+          {"index":{}}
+          {"@timestamp": "2023-01-04T12:00:00Z", "location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}
+          {"index":{}}
+          {"@timestamp": "2023-01-05T12:00:00Z", "location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}
+          {"index":{}}
+          {"@timestamp": "2023-01-06T12:00:00Z", "location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}
+  - do:
+      indices.refresh: { }
+
+---
+"avg aggregation on position field unsupported":
+  - do:
+      catch: /Field \[location\] of type \[geo_point\] is not supported for aggregation \[avg\]/
+      search:
+        index: locations
+        body:
+          aggs:
+            avg_location:
+              avg:
+                field: location
+
+---
+"geo_bounds on position field":
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: locations
+        rest_total_hits_as_int: true
+        body:
+          aggregations:
+            view_port:
+              geo_bounds:
+                field: location
+                wrap_longitude: true
+  - match: { hits.total: 6 }
+  - close_to: { aggregations.view_port.bounds.top_left.lat: { value: 52.374081, error: 0.00001 } }
+  - close_to: { aggregations.view_port.bounds.top_left.lon: { value: 2.327000, error: 0.00001 } }
+  - close_to: { aggregations.view_port.bounds.bottom_right.lat: { value: 48.860000, error: 0.00001 } }
+  - close_to: { aggregations.view_port.bounds.bottom_right.lon: { value: 4.914722, error: 0.00001 } }
+
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        body:
+          aggregations:
+            centroid:
+              geo_centroid:
+                field: location
+  - match: { hits.total: 6 }
+  - match: { aggregations.centroid.location.lat: 51.00982965203002 }
+  - match: { aggregations.centroid.location.lon: 3.9662131341174245 }
+  - match: { aggregations.centroid.count: 6 }
+
+
+---
+"geo bounding box query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            geo_bounding_box:
+              location:
+                top_left:
+                  lat: 53
+                  lon: 4
+                bottom_right:
+                  lat: 50
+                  lon: 5
+  - match: { hits.total.value: 4 }
+
+---
+"geo shape intersects query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            geo_shape:
+              location:
+                shape:
+                  type: "envelope"
+                  coordinates: [ [ 0, 50 ], [ 4, 45 ] ]
+  - match: { hits.total.value: 2 }
+
+---
+"geo shape within query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            geo_shape:
+              location:
+                shape:
+                  type: "envelope"
+                  coordinates: [ [ 0, 50 ], [ 4, 45 ] ]
+                relation: within
+  - match: { hits.total.value: 2 }
+
+---
+"geo shape disjoint query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            geo_shape:
+              location:
+                shape:
+                  type: "envelope"
+                  coordinates: [ [ 0, 50 ], [ 4, 45 ] ]
+                relation: disjoint
+  - match: { hits.total.value: 4 }
+
+---
+"geo shape contains query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            geo_shape:
+              location:
+                shape:
+                  type: "envelope"
+                  coordinates: [ [ 0, 50 ], [ 4, 45 ] ]
+                relation: contains
+  - match: { hits.total.value: 0 }
+
+---
+"geo distance query":
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            geo_distance:
+              distance: "100km"
+              location:
+                lat: 52
+                lon: 5
+  - match: { hits.total.value: 4 }
+
+---
+"bounds agg":
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: locations
+        body:
+          aggs:
+            bounds:
+              geo_bounds:
+                field: "location"
+                wrap_longitude: false
+  - match: { hits.total.value: 6 }
+  - close_to: { aggregations.bounds.bounds.top_left.lat: { value: 52.374081, error: 0.00001 } }
+  - close_to: { aggregations.bounds.bounds.top_left.lon: { value: 2.327000, error: 0.00001 } }
+  - close_to: { aggregations.bounds.bounds.bottom_right.lat: { value: 48.860000, error: 0.00001 } }
+  - close_to: { aggregations.bounds.bounds.bottom_right.lon: { value: 4.914722, error: 0.00001 } }
+
+---
+"geo_distance sort":
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: locations
+        body:
+          sort:
+            _geo_distance:
+              location:
+                lat: 52.0
+                lon: 5.0
+  - match: { hits.total.value: 6 }
+  - close_to: { hits.hits.0._source.location.lat: { value: 52.369219, error: 0.00001 } }
+  - close_to: { hits.hits.0._source.location.lon: { value: 4.901618, error: 0.00001 } }
+  - close_to: { hits.hits.1._source.location.lat: { value: 52.371667, error: 0.00001 } }
+  - close_to: { hits.hits.1._source.location.lon: { value: 4.914722, error: 0.00001 } }
+  - close_to: { hits.hits.2._source.location.lat: { value: 52.374081, error: 0.00001 } }
+  - close_to: { hits.hits.2._source.location.lon: { value: 4.912350, error: 0.00001 } }
+  - close_to: { hits.hits.3._source.location.lat: { value: 51.222900, error: 0.00001 } }
+  - close_to: { hits.hits.3._source.location.lon: { value: 4.405200, error: 0.00001 } }
+  - close_to: { hits.hits.4._source.location.lat: { value: 48.861111, error: 0.00001 } }
+  - close_to: { hits.hits.4._source.location.lon: { value: 2.336389, error: 0.00001 } }
+  - close_to: { hits.hits.5._source.location.lat: { value: 48.860000, error: 0.00001 } }
+  - close_to: { hits.hits.5._source.location.lon: { value: 2.327000, error: 0.00001 } }
+
+
+---
+"distance_feature query":
+  - skip:
+      features: close_to
+
+  - do:
+      search:
+        index: locations
+        body:
+          query:
+            bool:
+              should:
+                distance_feature:
+                  field: "location"
+                  pivot: "100km"
+                  origin: [ 5.0, 52.0 ]
+  - match: { hits.total.value: 6 }
+  - close_to: { hits.hits.0._source.location.lat: { value: 52.369219, error: 0.00001 } }
+  - close_to: { hits.hits.0._source.location.lon: { value: 4.901618, error: 0.00001 } }
+  - close_to: { hits.hits.1._source.location.lat: { value: 52.371667, error: 0.00001 } }
+  - close_to: { hits.hits.1._source.location.lon: { value: 4.914722, error: 0.00001 } }
+  - close_to: { hits.hits.2._source.location.lat: { value: 52.374081, error: 0.00001 } }
+  - close_to: { hits.hits.2._source.location.lon: { value: 4.912350, error: 0.00001 } }
+  - close_to: { hits.hits.3._source.location.lat: { value: 51.222900, error: 0.00001 } }
+  - close_to: { hits.hits.3._source.location.lon: { value: 4.405200, error: 0.00001 } }
+  - close_to: { hits.hits.4._source.location.lat: { value: 48.861111, error: 0.00001 } }
+  - close_to: { hits.hits.4._source.location.lon: { value: 2.336389, error: 0.00001 } }
+  - close_to: { hits.hits.5._source.location.lat: { value: 48.860000, error: 0.00001 } }
+  - close_to: { hits.hits.5._source.location.lon: { value: 2.327000, error: 0.00001 } }

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/130_position_fields.yml
@@ -46,6 +46,25 @@ setup:
       indices.refresh: { }
 
 ---
+multi-valued fields unsupported:
+  - do:
+      bulk:
+        index: locations
+        refresh: true
+        body: |
+          {"index" : {}}
+          {"@timestamp": "2023-01-01T12:00:00Z", "city": "Rock", "name": "On", "location": {"lat": 13.0, "lon" : 34.0} }
+          {"index" : {}}
+          {"@timestamp": "2023-01-01T12:00:00Z", "city": "Hey", "name": "There", "location": [{"lat": 13.0, "lon" : 34.0}] }
+          {"index" : {}}
+          {"@timestamp": "2023-01-01T12:00:00Z", "city": "Boo", "name": "Hoo", "location": [{"lat": 13.0, "lon" : 34.0}, {"lat": 14.0, "lon" : 35.0}] }
+  - match: { errors: true }
+  - match: { items.0.index.result: "created" }
+  - match: { items.1.index.result: "created" }
+  - match: { items.2.index.error.reason: "failed to parse" }
+  - match: { items.2.index.error.caused_by.reason: "field type for [location] does not accept more than single value" }
+
+---
 "avg aggregation on position field unsupported":
   - do:
       catch: /Field \[location\] of type \[geo_point\] is not supported for aggregation \[avg\]/

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -1,7 +1,7 @@
 ecs style:
   - skip:
       version: " - 8.0.99"
-      reason: introduced in 8.1.0
+      reason: index.mode and routing_path introduced in 8.1.0
 
   - do:
       indices.create:
@@ -538,8 +538,8 @@ source include/exclude:
 ---
 Unsupported metric type position:
   - skip:
-      version: "8.8.0 - "
-      reason: "position introduced in 8.8.0"
+      version: " - 8.0.99, 8.8.0 - "
+      reason: index.mode and routing_path introduced in 8.1.0 and time series metric position introduced in 8.8.0
 
   - do:
       catch: '/unknown parameter \[time_series_metric\] on mapper \[location\] of type \[geo_point\]/'

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -534,3 +534,64 @@ source include/exclude:
                       uid:
                         type: keyword
                         time_series_dimension: true
+
+---
+Unsupported metric type position:
+  - skip:
+      version: "8.8.0 - "
+      reason: "position introduced in 8.8.0"
+
+  - do:
+      catch: '/unknown parameter \[time_series_metric\] on mapper \[location\] of type \[geo_point\]/'
+      indices.create:
+        index: test_position
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              mode: time_series
+              routing_path: [metricset]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              location:
+                type: geo_point
+                time_series_metric: position
+
+---
+Supported metric type position:
+  - skip:
+      version: " - 8.7.99"
+      reason: "position introduced in 8.8.0"
+
+  - do:
+      indices.create:
+        index: test_position
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              mode: time_series
+              routing_path: [metricset]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              location:
+                type: geo_point
+                time_series_metric: position

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -233,7 +233,6 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
     private final Builder builder;
     private final FieldValues<GeoPoint> scriptValues;
     private final Version indexCreatedVersion;
-    /** The metric type (gauge, counter, summary) if  field is a time series metric */
     private final TimeSeriesParams.MetricType metricType;
     private final IndexMode indexMode;
     private final boolean indexed;

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -186,7 +186,8 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
                 (parser) -> GeoUtils.parseGeoPoint(parser, ignoreZValue.get().value()),
                 nullValue.get(),
                 ignoreZValue.get().value(),
-                ignoreMalformed.get().value()
+                ignoreMalformed.get().value(),
+                metric.get() != TimeSeriesParams.MetricType.POSITION
             );
             GeoPointFieldType ft = new GeoPointFieldType(
                 context.buildFullName(name),
@@ -503,9 +504,10 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
             CheckedFunction<XContentParser, GeoPoint, IOException> objectParser,
             GeoPoint nullValue,
             boolean ignoreZValue,
-            boolean ignoreMalformed
+            boolean ignoreMalformed,
+            boolean allowMultipleValues
         ) {
-            super(field, objectParser, nullValue, ignoreZValue, ignoreMalformed);
+            super(field, objectParser, nullValue, ignoreZValue, ignoreMalformed, allowMultipleValues);
         }
 
         protected GeoPoint validate(GeoPoint in) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/GeoPointFieldMapper.java
@@ -89,6 +89,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
         private final ScriptCompiler scriptCompiler;
         private final Version indexCreatedVersion;
         private final Parameter<TimeSeriesParams.MetricType> metric;  // either null, or POSITION if this is a time series metric
+        private final Parameter<Boolean> dimension; // can only support time_series_dimension: false
         private final IndexMode indexMode;  // either STANDARD or TIME_SERIES
 
         public Builder(
@@ -123,6 +124,14 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
                     );
                 }
             });
+            // We allow `time_series_dimension` parameter to be parsed, but only allow it to be `false`
+            this.dimension = TimeSeriesParams.dimensionParam(m -> false).addValidator(v -> {
+                if (v) {
+                    throw new IllegalArgumentException(
+                        "Parameter [" + TimeSeriesParams.TIME_SERIES_DIMENSION_PARAM + "] cannot be set to geo_point"
+                    );
+                }
+            });
         }
 
         private Parameter<TimeSeriesParams.MetricType> getMetric() {
@@ -141,6 +150,7 @@ public class GeoPointFieldMapper extends AbstractPointGeometryFieldMapper<GeoPoi
                 script,
                 onScriptError,
                 meta,
+                dimension,
                 metric };
         }
 

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -55,12 +55,7 @@ public final class TimeSeriesParams {
 
         /** an array of metrics representing simple numerical values, like GAUGE and COUNTER */
         public static MetricType[] scalar() {
-            Object[] objs = Arrays.stream(MetricType.values()).filter(m -> m.scalar).toArray();
-            MetricType[] scalar = new MetricType[objs.length];
-            for (int i = 0; i < scalar.length; i++) {
-                scalar[i] = (MetricType) objs[i];
-            }
-            return scalar;
+            return Arrays.stream(MetricType.values()).filter(m -> m.scalar).toArray(MetricType[]::new);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -23,10 +23,18 @@ public final class TimeSeriesParams {
 
     private TimeSeriesParams() {}
 
+    /**
+     * There are various types of metric used in time-series aggregations and downsampling.
+     * Each supports different field types and different calculations.
+     * Two of these, the COUNTER and GAUGE apply to most numerical types, mapping a single number,
+     * while the POSITION metric applies only to geo_point and therefor a pair of numbers (lat,lon).
+     * To simplify code that depends on this difference, we use the parameter `scalar==true` for
+     * single number metrics, and `false` for the POSITION metric.
+     */
     public enum MetricType {
         GAUGE(new String[] { "max", "min", "value_count", "sum" }),
         COUNTER(new String[] { "last_value" }),
-        POSITION(new String[] { "last_value", "geo_line" }, false);
+        POSITION(new String[] {}, false);
 
         private final String[] supportedAggs;
         private final boolean scalar;
@@ -40,10 +48,12 @@ public final class TimeSeriesParams {
             this.scalar = scalar;
         }
 
+        /** list of aggregations supported for downsampling this metric */
         public String[] supportedAggs() {
             return supportedAggs;
         }
 
+        /** an array of metrics representing simple numerical values, like GAUGE and COUNTER */
         public static MetricType[] scalar() {
             Object[] objs = Arrays.stream(MetricType.values()).filter(m -> m.scalar).toArray();
             MetricType[] scalar = new MetricType[objs.length];

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -26,16 +26,31 @@ public final class TimeSeriesParams {
     public enum MetricType {
         GAUGE(new String[] { "max", "min", "value_count", "sum" }),
         COUNTER(new String[] { "last_value" }),
-        POSITION(new String[] { "last_value", "geo_line" });
+        POSITION(new String[] { "last_value", "geo_line" }, false);
 
         private final String[] supportedAggs;
+        private final boolean scalar;
 
         MetricType(String[] supportedAggs) {
+            this(supportedAggs, true);
+        }
+
+        MetricType(String[] supportedAggs, boolean scalar) {
             this.supportedAggs = supportedAggs;
+            this.scalar = scalar;
         }
 
         public String[] supportedAggs() {
             return supportedAggs;
+        }
+
+        public static MetricType[] scalar() {
+            Object[] objs = Arrays.stream(MetricType.values()).filter(m -> m.scalar).toArray();
+            MetricType[] scalar = new MetricType[objs.length];
+            for (int i = 0; i < scalar.length; i++) {
+                scalar[i] = (MetricType) objs[i];
+            }
+            return scalar;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TimeSeriesParams.java
@@ -25,7 +25,8 @@ public final class TimeSeriesParams {
 
     public enum MetricType {
         GAUGE(new String[] { "max", "min", "value_count", "sum" }),
-        COUNTER(new String[] { "last_value" });
+        COUNTER(new String[] { "last_value" }),
+        POSITION(new String[] { "last_value", "geo_line" });
 
         private final String[] supportedAggs;
 

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractFieldDataTestCase.java
@@ -155,7 +155,7 @@ public abstract class AbstractFieldDataTestCase extends ESSingleNodeTestCase {
                 null
             ).docValues(docValues).build(context).fieldType();
         } else if (type.equals("geo_point")) {
-            fieldType = new GeoPointFieldMapper.Builder(fieldName, ScriptCompiler.NONE, false, Version.CURRENT).docValues(docValues)
+            fieldType = new GeoPointFieldMapper.Builder(fieldName, ScriptCompiler.NONE, false, Version.CURRENT, null).docValues(docValues)
                 .build(context)
                 .fieldType();
         } else if (type.equals("binary")) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -12,11 +12,14 @@ import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.geo.GeoEncodingUtils;
 import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.geo.GeoPoint;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.geo.GeometryTestUtils;
 import org.elasticsearch.geometry.Point;
+import org.elasticsearch.index.IndexMode;
+import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
@@ -30,6 +33,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.TreeMap;
 
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
@@ -41,6 +45,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -85,6 +90,23 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
         assertAggregatableConsistency(mapperService.fieldType("field"));
     }
 
+    public void testDimension() throws IOException {
+        // Test default setting
+        MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
+        GeoPointFieldMapper.GeoPointFieldType ft = (GeoPointFieldMapper.GeoPointFieldType) mapperService.fieldType("field");
+        assertFalse(ft.isDimension());
+
+        // dimension = false is allowed
+        assertDimension(false, GeoPointFieldMapper.GeoPointFieldType::isDimension);
+
+        // dimension = true is not allowed
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("time_series_dimension", true);
+        })));
+        assertThat(e.getCause().getMessage(), containsString("Parameter [time_series_dimension] cannot be set"));
+    }
+
     public void testMetricType() throws IOException {
         // Test default setting
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
@@ -124,6 +146,27 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
         }));
         assertExistsQuery(mapperService);
         assertParseMinimalWarnings();
+    }
+
+    public void testTimeSeriesIndexDefault() throws Exception {
+        var positionMetricType = TimeSeriesParams.MetricType.POSITION;
+        var indexSettings = getIndexSettingsBuilder().put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
+            .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dimension_field");
+        var mapperService = createMapperService(indexSettings.build(), fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("time_series_metric", positionMetricType.toString());
+        }));
+        var ft = (GeoPointFieldMapper.GeoPointFieldType) mapperService.fieldType("field");
+        assertThat(ft.getMetricType(), equalTo(positionMetricType));
+        assertThat(ft.isIndexed(), is(false));
+    }
+
+    public void testMetricAndDocvalues() {
+        Exception e = expectThrows(MapperParsingException.class, () -> createDocumentMapper(fieldMapping(b -> {
+            minimalMapping(b);
+            b.field("time_series_metric", "position").field("doc_values", false);
+        })));
+        assertThat(e.getCause().getMessage(), containsString("Field [time_series_metric] requires that [doc_values] is true"));
     }
 
     public void testGeoHashValue() throws Exception {
@@ -301,7 +344,6 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
     public void testKeywordWithGeopointSubfield() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "keyword").field("doc_values", false);
-            ;
             b.startObject("fields");
             {
                 b.startObject("geopoint").field("type", "geo_point").field("doc_values", false).endObject();
@@ -387,7 +429,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
         doc = mapper.parse(source(b -> b.startArray("field").nullValue().value("3, 4").endArray()));
         assertMap(
-            Arrays.stream(doc.rootDoc().getFields("field")).map(IndexableField::binaryValue).filter(v -> v != null).toList(),
+            Arrays.stream(doc.rootDoc().getFields("field")).map(IndexableField::binaryValue).filter(Objects::nonNull).toList(),
             matchesList().item(equalTo(defaultValue)).item(equalTo(threeFour))
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldTypeTests.java
@@ -24,9 +24,9 @@ public class GeoPointFieldTypeTests extends FieldTypeTestCase {
 
     public void testFetchSourceValue() throws IOException {
         boolean ignoreMalformed = randomBoolean();
-        MappedFieldType mapper = new GeoPointFieldMapper.Builder("field", ScriptCompiler.NONE, ignoreMalformed, Version.CURRENT).build(
-            MapperBuilderContext.root(false)
-        ).fieldType();
+        MappedFieldType mapper = new GeoPointFieldMapper.Builder("field", ScriptCompiler.NONE, ignoreMalformed, Version.CURRENT, null)
+            .build(MapperBuilderContext.root(false))
+            .fieldType();
 
         Map<String, Object> jsonPoint = Map.of("type", "Point", "coordinates", List.of(42.0, 27.1));
         Map<String, Object> otherJsonPoint = Map.of("type", "Point", "coordinates", List.of(30.0, 50.0));
@@ -84,7 +84,7 @@ public class GeoPointFieldTypeTests extends FieldTypeTestCase {
     }
 
     public void testFetchVectorTile() throws IOException {
-        MappedFieldType mapper = new GeoPointFieldMapper.Builder("field", ScriptCompiler.NONE, false, Version.CURRENT).build(
+        MappedFieldType mapper = new GeoPointFieldMapper.Builder("field", ScriptCompiler.NONE, false, Version.CURRENT, null).build(
             MapperBuilderContext.root(false)
         ).fieldType();
         final int z = randomIntBetween(1, 10);

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldMapperTests.java
@@ -293,7 +293,7 @@ public abstract class NumberFieldMapperTests extends MapperTestCase {
     }
 
     public void testTimeSeriesIndexDefault() throws Exception {
-        var randomMetricType = randomFrom(TimeSeriesParams.MetricType.values());
+        var randomMetricType = randomFrom(TimeSeriesParams.MetricType.scalar());
         var indexSettings = getIndexSettingsBuilder().put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dimension_field");
         var mapperService = createMapperService(indexSettings.build(), fieldMapping(b -> {

--- a/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
+++ b/x-pack/plugin/mapper-unsigned-long/src/test/java/org/elasticsearch/xpack/unsignedlong/UnsignedLongFieldMapperTests.java
@@ -317,7 +317,7 @@ public class UnsignedLongFieldMapperTests extends MapperTestCase {
     }
 
     public void testTimeSeriesIndexDefault() throws Exception {
-        var randomMetricType = randomFrom(TimeSeriesParams.MetricType.values());
+        var randomMetricType = randomFrom(TimeSeriesParams.MetricType.scalar());
         var indexSettings = getIndexSettingsBuilder().put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES.getName())
             .put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "dimension_field");
         var mapperService = createMapperService(indexSettings.build(), fieldMapping(b -> {

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/FieldValueFetcher.java
@@ -57,6 +57,8 @@ class FieldValueFetcher {
             return switch (fieldType.getMetricType()) {
                 case GAUGE -> new MetricFieldProducer.GaugeMetricFieldProducer(name());
                 case COUNTER -> new MetricFieldProducer.CounterMetricFieldProducer(name());
+                // TODO: Support POSITION in downsampling
+                case POSITION -> throw new IllegalArgumentException("Unsupported metric type [position] for down-sampling");
             };
         } else {
             // If field is not a metric, we downsample it as a label

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapper.java
@@ -236,7 +236,7 @@ public class PointFieldMapper extends AbstractPointGeometryFieldMapper<Cartesian
             boolean ignoreZValue,
             boolean ignoreMalformed
         ) {
-            super(field, objectParser, nullValue, ignoreZValue, ignoreMalformed);
+            super(field, objectParser, nullValue, ignoreZValue, ignoreMalformed, true);
         }
 
         @Override


### PR DESCRIPTION
Support a new metric, similar to `GAUGE` called `POSITION`, using the same syntax as any other metric:

```
PUT my-geo-time-series
{
  "mappings": {
    "properties": {
      "location": {
        "type": "geo_point",
        "time_series_metric": "position" 
       }
    }
  }
}
```

The API should throw an error if the user tries to index more than one value per document.

Tasks:

* [x] Add new metric
* [x] Add yaml rest tests for specified behaviour
* [x] Ensure exception thrown on multi-valued fields
* [x] Ensure unit test coverage

What this PR does not do, and will be tacked in followup PRs:

* No support for field caps
* No support for rollup/downsampling
* No support for time-series aggregations
