### PR TITLE
[ML] Shared NLP model definitions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelType.java
@@ -64,7 +64,7 @@ public enum TrainedModelType {
     public TrainedModelLocation getDefaultLocation(String modelId) {
         return switch (this) {
             case TREE_ENSEMBLE, LANG_IDENT -> new IndexLocation(InferenceIndexConstants.LATEST_INDEX_NAME);
-            case PYTORCH -> new IndexLocation(InferenceIndexConstants.nativeDefinitionStore());
+            case PYTORCH -> IndexLocation.forDefaultIndex(modelId);
         };
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TrainedModelLocation.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TrainedModelLocation.java
@@ -12,5 +12,5 @@ import org.elasticsearch.xpack.core.ml.utils.NamedXContentObject;
 
 public interface TrainedModelLocation extends NamedXContentObject, NamedWriteable {
 
-    String getResourceName();
+    String getLocationName();
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -72,8 +72,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
     public static TrainedModelConfig.Builder createTestInstance(String modelId, boolean lenient) {
 
         InferenceConfig[] inferenceConfigs = lenient ?
-            // Because of vocab config validations on parse, only test on lenient
-            new InferenceConfig[]{
+        // Because of vocab config validations on parse, only test on lenient
+            new InferenceConfig[] {
                 ClassificationConfigTests.randomClassificationConfig(),
                 RegressionConfigTests.randomRegressionConfig(),
                 NerConfigTests.createRandom(),
@@ -82,10 +82,10 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
                 FillMaskConfigTests.createRandom(),
                 TextEmbeddingConfigTests.createRandom(),
                 QuestionAnsweringConfigTests.createRandom(),
-                TextSimilarityConfigTests.createRandom()}
-            : new InferenceConfig[]{
-            ClassificationConfigTests.randomClassificationConfig(),
-            RegressionConfigTests.randomRegressionConfig()};
+                TextSimilarityConfigTests.createRandom() }
+            : new InferenceConfig[] {
+                ClassificationConfigTests.randomClassificationConfig(),
+                RegressionConfigTests.randomRegressionConfig() };
         List<String> tags = Arrays.asList(generateRandomStringArray(randomIntBetween(0, 5), 15, false));
         return TrainedModelConfig.builder()
             .setInput(TrainedModelInputTests.createRandomInput())
@@ -184,8 +184,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
             randomBoolean()
                 ? null
                 : Stream.generate(() -> randomAlphaOfLength(10))
-                .limit(randomIntBetween(1, 10))
-                .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
+                    .limit(randomIntBetween(1, 10))
+                    .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
             randomFrom(ClassificationConfigTests.randomClassificationConfig(), RegressionConfigTests.randomRegressionConfig()),
             null
         );
@@ -233,8 +233,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
             randomBoolean()
                 ? null
                 : Stream.generate(() -> randomAlphaOfLength(10))
-                .limit(randomIntBetween(1, 10))
-                .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
+                    .limit(randomIntBetween(1, 10))
+                    .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
             randomFrom(ClassificationConfigTests.randomClassificationConfig(), RegressionConfigTests.randomRegressionConfig()),
             null
         );
@@ -367,14 +367,14 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
 
     public void testSerializationWithCompressedLazyDefinition() throws IOException {
         xContentTester(this::createParser, () -> {
-                try {
-                    BytesReference bytes = InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
-                    return createTestInstance(randomAlphaOfLength(10), lenient).setDefinitionFromBytes(bytes).build();
-                } catch (IOException ex) {
-                    fail(ex.getMessage());
-                    return null;
-                }
-            },
+            try {
+                BytesReference bytes = InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
+                return createTestInstance(randomAlphaOfLength(10), lenient).setDefinitionFromBytes(bytes).build();
+            } catch (IOException ex) {
+                fail(ex.getMessage());
+                return null;
+            }
+        },
             new ToXContent.MapParams(Collections.singletonMap(TrainedModelConfig.DECOMPRESS_DEFINITION, "false")),
             (p) -> TrainedModelConfig.fromXContent(p, true).build()
         ).numberOfTestRuns(NUMBER_OF_TEST_RUNS)
@@ -401,11 +401,11 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
         if (version.before(TrainedModelConfig.VERSION_3RD_PARTY_CONFIG_ADDED)) {
             builder.setModelType(null);
             builder.setLocation(null);
-        } else if (version.before(Version.V_8_7_0) && instance.getLocation() != null) {
+        } else if (version.before(TransportVersion.V_8_7_0) && instance.getLocation() != null) {
             // take the model id out of the location
             builder.setLocation(new IndexLocation(((IndexLocation) instance.getLocation()).getIndexName()));
         }
-        if (instance.getInferenceConfig() instanceof NlpConfig nlpConfig) {
+        if (instance.getInferenceConfig()instanceof NlpConfig nlpConfig) {
             builder.setInferenceConfig(InferenceConfigItemTestCase.mutateForVersion(nlpConfig, version));
         }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfigTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ml.AbstractBWCSerializationTestCase;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ClassificationConfigTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.FillMaskConfigTests;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocationTests;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.NerConfigTests;
@@ -71,8 +72,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
     public static TrainedModelConfig.Builder createTestInstance(String modelId, boolean lenient) {
 
         InferenceConfig[] inferenceConfigs = lenient ?
-        // Because of vocab config validations on parse, only test on lenient
-            new InferenceConfig[] {
+            // Because of vocab config validations on parse, only test on lenient
+            new InferenceConfig[]{
                 ClassificationConfigTests.randomClassificationConfig(),
                 RegressionConfigTests.randomRegressionConfig(),
                 NerConfigTests.createRandom(),
@@ -81,10 +82,10 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
                 FillMaskConfigTests.createRandom(),
                 TextEmbeddingConfigTests.createRandom(),
                 QuestionAnsweringConfigTests.createRandom(),
-                TextSimilarityConfigTests.createRandom() }
-            : new InferenceConfig[] {
-                ClassificationConfigTests.randomClassificationConfig(),
-                RegressionConfigTests.randomRegressionConfig() };
+                TextSimilarityConfigTests.createRandom()}
+            : new InferenceConfig[]{
+            ClassificationConfigTests.randomClassificationConfig(),
+            RegressionConfigTests.randomRegressionConfig()};
         List<String> tags = Arrays.asList(generateRandomStringArray(randomIntBetween(0, 5), 15, false));
         return TrainedModelConfig.builder()
             .setInput(TrainedModelInputTests.createRandomInput())
@@ -183,8 +184,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
             randomBoolean()
                 ? null
                 : Stream.generate(() -> randomAlphaOfLength(10))
-                    .limit(randomIntBetween(1, 10))
-                    .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
+                .limit(randomIntBetween(1, 10))
+                .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
             randomFrom(ClassificationConfigTests.randomClassificationConfig(), RegressionConfigTests.randomRegressionConfig()),
             null
         );
@@ -232,8 +233,8 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
             randomBoolean()
                 ? null
                 : Stream.generate(() -> randomAlphaOfLength(10))
-                    .limit(randomIntBetween(1, 10))
-                    .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
+                .limit(randomIntBetween(1, 10))
+                .collect(Collectors.toMap(Function.identity(), (k) -> randomAlphaOfLength(10))),
             randomFrom(ClassificationConfigTests.randomClassificationConfig(), RegressionConfigTests.randomRegressionConfig()),
             null
         );
@@ -366,14 +367,14 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
 
     public void testSerializationWithCompressedLazyDefinition() throws IOException {
         xContentTester(this::createParser, () -> {
-            try {
-                BytesReference bytes = InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
-                return createTestInstance(randomAlphaOfLength(10), lenient).setDefinitionFromBytes(bytes).build();
-            } catch (IOException ex) {
-                fail(ex.getMessage());
-                return null;
-            }
-        },
+                try {
+                    BytesReference bytes = InferenceToXContentCompressor.deflate(TrainedModelDefinitionTests.createRandomBuilder().build());
+                    return createTestInstance(randomAlphaOfLength(10), lenient).setDefinitionFromBytes(bytes).build();
+                } catch (IOException ex) {
+                    fail(ex.getMessage());
+                    return null;
+                }
+            },
             new ToXContent.MapParams(Collections.singletonMap(TrainedModelConfig.DECOMPRESS_DEFINITION, "false")),
             (p) -> TrainedModelConfig.fromXContent(p, true).build()
         ).numberOfTestRuns(NUMBER_OF_TEST_RUNS)
@@ -400,10 +401,14 @@ public class TrainedModelConfigTests extends AbstractBWCSerializationTestCase<Tr
         if (version.before(TrainedModelConfig.VERSION_3RD_PARTY_CONFIG_ADDED)) {
             builder.setModelType(null);
             builder.setLocation(null);
+        } else if (version.before(Version.V_8_7_0) && instance.getLocation() != null) {
+            // take the model id out of the location
+            builder.setLocation(new IndexLocation(((IndexLocation) instance.getLocation()).getIndexName()));
         }
-        if (instance.getInferenceConfig()instanceof NlpConfig nlpConfig) {
+        if (instance.getInferenceConfig() instanceof NlpConfig nlpConfig) {
             builder.setInferenceConfig(InferenceConfigItemTestCase.mutateForVersion(nlpConfig, version));
         }
+
         return builder.build();
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/IndexLocationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/IndexLocationTests.java
@@ -18,7 +18,11 @@ public class IndexLocationTests extends AbstractXContentSerializingTestCase<Inde
     private final boolean lenient = randomBoolean();
 
     public static IndexLocation randomInstance() {
-        return new IndexLocation(randomAlphaOfLength(7));
+        if (randomBoolean()) {
+            return new IndexLocation(randomAlphaOfLength(7));
+        } else {
+            return new IndexLocation(randomAlphaOfLength(7), randomAlphaOfLength(7));
+        }
     }
 
     @Override
@@ -38,7 +42,8 @@ public class IndexLocationTests extends AbstractXContentSerializingTestCase<Inde
 
     @Override
     protected IndexLocation mutateInstance(IndexLocation instance) {
-        return null;// TODO implement https://github.com/elastic/elasticsearch/issues/25929
+        var id = instance.getModelId() == null ? null : instance.getModelId()  + "foo";
+        return new IndexLocation(instance.getIndexName() + "bar", id);
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/IndexLocationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/IndexLocationTests.java
@@ -42,7 +42,7 @@ public class IndexLocationTests extends AbstractXContentSerializingTestCase<Inde
 
     @Override
     protected IndexLocation mutateInstance(IndexLocation instance) {
-        var id = instance.getModelId() == null ? null : instance.getModelId()  + "foo";
+        var id = instance.getModelId() == null ? null : instance.getModelId() + "foo";
         return new IndexLocation(instance.getIndexName() + "bar", id);
     }
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelRestorerIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelRestorerIT.java
@@ -19,6 +19,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.inference.persistence.ChunkedTrainedModelRestorer;
@@ -51,7 +52,7 @@ public class ChunkedTrainedModelRestorerIT extends MlSingleNodeTestCase {
         putModelDefinitions(expectedDocs, InferenceIndexConstants.LATEST_INDEX_NAME, 0);
 
         ChunkedTrainedModelRestorer restorer = new ChunkedTrainedModelRestorer(
-            modelId,
+            new IndexLocation(InferenceIndexConstants.LATEST_INDEX_NAME, modelId),
             client(),
             client().threadPool().executor(MachineLearning.UTILITY_THREAD_POOL_NAME),
             xContentRegistry()
@@ -87,7 +88,7 @@ public class ChunkedTrainedModelRestorerIT extends MlSingleNodeTestCase {
         putModelDefinitions(expectedDocs, InferenceIndexConstants.LATEST_INDEX_NAME, 0);
 
         ChunkedTrainedModelRestorer restorer = new ChunkedTrainedModelRestorer(
-            modelId,
+            new IndexLocation(InferenceIndexConstants.LATEST_INDEX_NAME, modelId),
             client(),
             client().threadPool().executor(MachineLearning.UTILITY_THREAD_POOL_NAME),
             xContentRegistry()
@@ -152,13 +153,12 @@ public class ChunkedTrainedModelRestorerIT extends MlSingleNodeTestCase {
         putModelDefinitions(expectedDocs.subList(splitPoint, numDocs), index2, splitPoint);
 
         ChunkedTrainedModelRestorer restorer = new ChunkedTrainedModelRestorer(
-            modelId,
+            new IndexLocation("foo-*", modelId),
             client(),
             client().threadPool().executor(MachineLearning.UTILITY_THREAD_POOL_NAME),
             xContentRegistry()
         );
         restorer.setSearchSize(10);
-        restorer.setSearchIndex("foo-*");
 
         AtomicReference<Exception> exceptionHolder = new AtomicReference<>();
         CountDownLatch latch = new CountDownLatch(1);

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
@@ -90,7 +90,7 @@ public class JobsAndModelsIT extends BaseMlIntegTestCase {
             .setModelType(TrainedModelType.PYTORCH)
             .setModelSize((long) (0.3 * maxNativeBytesPerNode))
             .setInferenceConfig(new PassThroughConfig(new VocabularyConfig(InferenceIndexConstants.nativeDefinitionStore()), null, null))
-            .setLocation(new IndexLocation(InferenceIndexConstants.nativeDefinitionStore()))
+            .setLocation(new IndexLocation(InferenceIndexConstants.nativeDefinitionStore(), "test_model"))
             .build();
 
         TrainedModelDefinitionDoc modelDefinitionDoc = new TrainedModelDefinitionDoc(

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/PyTorchStateStreamerIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/PyTorchStateStreamerIT.java
@@ -17,6 +17,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelDefinitionDoc;
@@ -58,7 +59,11 @@ public class PyTorchStateStreamerIT extends MlSingleNodeTestCase {
         AtomicReference<Boolean> onSuccess = new AtomicReference<>();
         AtomicReference<Exception> onFailure = new AtomicReference<>();
         blockingCall(
-            listener -> stateStreamer.writeStateToStream(modelId, InferenceIndexConstants.LATEST_INDEX_NAME, outputStream, listener),
+            listener -> stateStreamer.writeStateToStream(
+                new IndexLocation(InferenceIndexConstants.LATEST_INDEX_NAME, modelId),
+                outputStream,
+                listener
+            ),
             onSuccess,
             onFailure
         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -236,12 +236,11 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
 
     private void getModelBytes(TrainedModelConfig trainedModelConfig, ActionListener<Long> listener) {
         ChunkedTrainedModelRestorer restorer = new ChunkedTrainedModelRestorer(
-            trainedModelConfig.getModelId(),
+            trainedModelConfig.getIndexLocation(),
             client,
             threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME),
             xContentRegistry
         );
-        restorer.setSearchIndex(trainedModelConfig.getLocation().getResourceName());
         restorer.setSearchSize(1);
         restorer.restoreModelDefinition(doc -> {
             // The in-memory size of the model was found to be approximately equal
@@ -310,7 +309,9 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             listener.onResponse(null);
             return;
         }
-        final String modelId = config.getModelId();
+
+        IndexLocation indexLocation = (IndexLocation) config.getLocation();
+        final String modelId = indexLocation.getModelId() == null ? config.getModelId() : indexLocation.getModelId();
         final String[] requiredSourceFields = new String[] {
             TrainedModelDefinitionDoc.DEFINITION_LENGTH.getPreferredName(),
             TrainedModelDefinitionDoc.DOC_NUM.getPreferredName(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -75,6 +75,7 @@ import org.elasticsearch.xpack.core.ml.inference.InferenceToXContentCompressor;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.TrainedModelType;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModelLocation;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.VocabularyConfig;
@@ -520,7 +521,7 @@ public class TrainedModelProvider {
 
         List<TrainedModelDefinitionDoc> docs = new ArrayList<>();
         ChunkedTrainedModelRestorer modelRestorer = new ChunkedTrainedModelRestorer(
-            modelId,
+            new IndexLocation(InferenceIndexConstants.INDEX_PATTERN, modelId),
             client,
             client.threadPool().executor(MachineLearning.UTILITY_THREAD_POOL_NAME),
             xContentRegistry

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/BlackHolePyTorchProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/BlackHolePyTorchProcess.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.pytorch.process;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
 import org.elasticsearch.xpack.ml.process.BlackHoleResultIterator;
 
@@ -29,7 +30,7 @@ public class BlackHolePyTorchProcess implements PyTorchProcess {
     }
 
     @Override
-    public void loadModel(String modelId, String index, PyTorchStateStreamer stateStreamer, ActionListener<Boolean> listener) {
+    public void loadModel(IndexLocation indexLocation, PyTorchStateStreamer stateStreamer, ActionListener<Boolean> listener) {
         listener.onResponse(true);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcess.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ml.inference.pytorch.process;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
 import org.elasticsearch.xpack.ml.process.AbstractNativeProcess;
 import org.elasticsearch.xpack.ml.process.NativeController;
@@ -56,8 +57,8 @@ public class NativePyTorchProcess extends AbstractNativeProcess implements PyTor
     }
 
     @Override
-    public void loadModel(String modelId, String index, PyTorchStateStreamer stateStreamer, ActionListener<Boolean> listener) {
-        stateStreamer.writeStateToStream(modelId, index, processRestoreStream(), listener);
+    public void loadModel(IndexLocation indexLocation, PyTorchStateStreamer stateStreamer, ActionListener<Boolean> listener) {
+        stateStreamer.writeStateToStream(indexLocation, processRestoreStream(), listener);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchProcess.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchProcess.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.inference.pytorch.process;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.IndexLocation;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchResult;
 import org.elasticsearch.xpack.ml.process.NativeProcess;
 
@@ -22,12 +23,11 @@ public interface PyTorchProcess extends NativeProcess {
 
     /**
      * Load the model into the process
-     * @param modelId the model id
-     * @param index the index where the model is stored
+     * @param indexLocation the index where the model is stored and model id
      * @param stateStreamer the pytorch state streamer
      * @param listener a listener that gets notified when the loading has completed
      */
-    void loadModel(String modelId, String index, PyTorchStateStreamer stateStreamer, ActionListener<Boolean> listener);
+    void loadModel(IndexLocation indexLocation, PyTorchStateStreamer stateStreamer, ActionListener<Boolean> listener);
 
     /**
      * @return stream of pytorch results

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -379,3 +379,114 @@ setup:
         model_alias: "pytorch"
         model_id: "another_test_model"
         reassign: true
+
+---
+"Test 2 deployments with the same model definition":
+  - skip:
+      features: allowed_warnings
+  - do:
+      ml.put_trained_model:
+        model_id: model-for-ingest
+        body: >
+          {
+            "description": "model used in an ingest pipeline",
+            "model_type": "pytorch",
+            "inference_config": {
+              "pass_through": {
+                "tokenization": {
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                }
+              }
+            },
+            "location": {
+              "index": {
+                "model_id": "test_model"
+              }
+            }
+          }
+
+  - do:
+      ml.put_trained_model:
+        model_id: model-for-search
+        body: >
+          {
+            "description": "model used at search",
+            "model_type": "pytorch",
+            "inference_config": {
+              "pass_through": {
+                "tokenization": {
+                  "bert": {
+                    "with_special_tokens": false
+                  }
+                }
+              }
+            },
+            "location": {
+              "index": {
+                "model_id": "test_model"
+              }
+            }
+          }
+  - do:
+      ml.get_trained_models:
+        model_id: model-for-ingest
+  - match: { trained_model_configs.0.location.index.model_id: test_model }
+
+  - do:
+      ml.start_trained_model_deployment:
+        model_id: model-for-ingest
+        wait_for: started
+  - match: {assignment.assignment_state: started}
+
+  - do:
+      ml.start_trained_model_deployment:
+        model_id: model-for-search
+        wait_for: started
+  - match: {assignment.assignment_state: started}
+
+  - do:
+      allowed_warnings:
+        - '[POST /_ml/trained_models/{model_id}/deployment/_infer] is deprecated! Use [POST /_ml/trained_models/{model_id}/_infer] instead.'
+      ml.infer_trained_model:
+        model_id: model-for-ingest
+        body: >
+          {
+            "docs": [
+              { "input": "words" }
+            ]
+          }
+  - do:
+      allowed_warnings:
+        - '[POST /_ml/trained_models/{model_id}/deployment/_infer] is deprecated! Use [POST /_ml/trained_models/{model_id}/_infer] instead.'
+      ml.infer_trained_model:
+        model_id: model-for-ingest
+        body: >
+          {
+            "docs": [
+              { "input": "these are" }
+            ]
+          }
+  - do:
+      allowed_warnings:
+        - '[POST /_ml/trained_models/{model_id}/deployment/_infer] is deprecated! Use [POST /_ml/trained_models/{model_id}/_infer] instead.'
+      ml.infer_trained_model:
+        model_id: model-for-search
+        body: >
+          {
+            "docs": [
+              { "input": "words" }
+            ]
+          }
+
+  - do:
+      ml.get_trained_models_stats:
+        model_id: model-for-ingest
+  - match: { count: 1 }
+  - match: { trained_model_stats.0.deployment_stats.nodes.0.inference_count: 2 }
+  - do:
+      ml.get_trained_models_stats:
+        model_id: model-for-search
+  - match: { count: 1 }
+  - match: { trained_model_stats.0.deployment_stats.nodes.0.inference_count: 1 }


### PR DESCRIPTION
#93947 describes a strategy for using dedicated NLP model deployments for specific tasks such as search or ingest. The solution involves uploading a NLP model multiple times, we can save some disk space and remove the upload step by allowing a model definition to reference an existing one.

NLP model configurations already have a `location` setting describing where the model definition can be found. Previously this has not been directly settable by the user and defaults to be the index where the model is stored. By relaxing that restriction and allowing an existing model to be referenced a new model can be created in one API call (no separate upload of the model definition).

```
PUT _ml/trained_models/model-for-search
{
    "description": "references an existing model",
    "model_type": "pytorch",
    "inference_config": {
        "ner": {
        }
    },
    "location": {
      "index": {
        "model_id": "previously-uploaded
      }
    }
}
```


