### PR TITLE
[8.7] Fix explain for kNN search matches (#93876)

### DIFF
--- a/docs/changelog/93876.yaml
+++ b/docs/changelog/93876.yaml
@@ -1,0 +1,5 @@
+pr: 93876
+summary: Fix explain for kNN search matches
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
@@ -74,7 +74,7 @@ class KnnScoreDocQuery extends Query {
         return new Weight(this) {
             @Override
             public Explanation explain(LeafReaderContext context, int doc) {
-                int found = Arrays.binarySearch(docs, doc);
+                int found = Arrays.binarySearch(docs, doc + context.docBase);
                 if (found < 0) {
                     return Explanation.noMatch("not in top k documents");
                 }

--- a/server/src/test/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/KnnScoreDocQueryBuilderTests.java
@@ -187,7 +187,7 @@ public class KnnScoreDocQueryBuilderTests extends AbstractQueryTestCase<KnnScore
                 for (int i = 0; i < scoreDocs.length; i++) {
                     assertEquals(scoreDocs[i].doc, topDocs.scoreDocs[i].doc);
                     assertEquals(scoreDocs[i].score, topDocs.scoreDocs[i].score, 0.0001f);
-
+                    assertTrue(searcher.explain(query, scoreDocs[i].doc).isMatch());
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix explain for kNN search matches (#93876)