### PR TITLE
[Profiling] Parallelize response handling

### DIFF
--- a/docs/changelog/93960.yaml
+++ b/docs/changelog/93960.yaml
@@ -1,0 +1,5 @@
+pr: 93960
+summary: "[Profiling] Parallelize response handling"
+area: Search
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
@@ -22,6 +22,8 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
+import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.ActionPlugin;
@@ -30,6 +32,8 @@ import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.threadpool.ExecutorBuilder;
+import org.elasticsearch.threadpool.ScalingExecutorBuilder;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -49,6 +53,8 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         true,
         Setting.Property.NodeScope
     );
+    public static final String PROFILING_THREAD_POOL_NAME = "profiling";
+
     private final boolean enabled;
 
     public ProfilingPlugin(Settings settings) {
@@ -114,6 +120,22 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
             TransportGetProfilingAction.PROFILING_MAX_DETAIL_QUERY_SLICES,
             TransportGetProfilingAction.PROFILING_QUERY_REALTIME
         );
+    }
+
+    @Override
+    public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
+        return List.of(responseExecutorBuilder(settings));
+    }
+
+    /**
+     * @param settings Current settings.
+     * @return <p>An <code>ExecutorBuilder</code> that creates an executor to offload internal query response processing from the
+     * transport thread. The executor will occupy no thread by default to avoid using resources when the plugin is not needed but once used,
+     * it will hold onto allocated pool threads for 30 minutes by default to keep response times low.</p>
+     */
+    public static ExecutorBuilder<?> responseExecutorBuilder(Settings settings) {
+        int maxThreads = Math.max(8, EsExecutors.allocatedProcessors(settings) / 4);
+        return new ScalingExecutorBuilder(PROFILING_THREAD_POOL_NAME, 0, maxThreads, TimeValue.timeValueMinutes(30L), false);
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
@@ -22,7 +22,6 @@ import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -124,18 +123,16 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
 
     @Override
     public List<ExecutorBuilder<?>> getExecutorBuilders(Settings settings) {
-        return List.of(responseExecutorBuilder(settings));
+        return List.of(responseExecutorBuilder());
     }
 
     /**
-     * @param settings Current settings.
      * @return <p>An <code>ExecutorBuilder</code> that creates an executor to offload internal query response processing from the
      * transport thread. The executor will occupy no thread by default to avoid using resources when the plugin is not needed but once used,
      * it will hold onto allocated pool threads for 30 minutes by default to keep response times low.</p>
      */
-    public static ExecutorBuilder<?> responseExecutorBuilder(Settings settings) {
-        int maxThreads = Math.max(8, EsExecutors.allocatedProcessors(settings) / 4);
-        return new ScalingExecutorBuilder(PROFILING_THREAD_POOL_NAME, 0, maxThreads, TimeValue.timeValueMinutes(30L), false);
+    public static ExecutorBuilder<?> responseExecutorBuilder() {
+        return new ScalingExecutorBuilder(PROFILING_THREAD_POOL_NAME, 0, 1, TimeValue.timeValueMinutes(30L), false);
     }
 
     @Override


### PR DESCRIPTION
The profiling plugin issues several queries via the node client. Some of the responses are large and in our experiments we have observed that response handling blocks a transport thread for up to 80ms. Furthermore, all responses are handled by the same transport thread. This leads to reduced responsiveness and wasted resources. With this commit we introduce a new scaling thread pool `profiling` to offload response processing. We set the core thread pool size to zero to only allocate resources once stack traces are retrieved.

Relates #93559