### PR TITLE
[ML] Improve error message formatting

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -505,7 +505,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
 
         if (assignment.getNodeRoutingTable().isEmpty()) {
             String msg = "Could not start deployment because no suitable nodes were found, allocation explanation ["
-                + assignment.getReason()
+                + assignment.getReason().orElse("none")
                 + "]";
             logger.warn("[{}] {}", modelId, msg);
             Exception detail = new IllegalStateException(msg);


### PR DESCRIPTION
The trained model assignment code can include an `Optional<String>` in an error message. This looks unsightly, because it's rendering the `Optional`, not the `String` it might contain. This PR changes the error message so that it contains a `String`.