### PR TITLE
Fix test bug with extra small complex geometries

### DIFF
--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonGeometryRelationVisitorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/fielddata/LatLonGeometryRelationVisitorTests.java
@@ -164,10 +164,18 @@ public class LatLonGeometryRelationVisitorTests extends ESTestCase {
     }
 
     private boolean isIdenticalPoint(Geometry geometry, LatLonGeometry latLonGeometry) {
-        if (geometry instanceof org.elasticsearch.geometry.Point point) {
-            if (latLonGeometry instanceof Point latLonPoint) {
+        if (latLonGeometry instanceof Point latLonPoint) {
+            if (geometry instanceof org.elasticsearch.geometry.Point point) {
                 return encodeLatitude(point.getLat()) == encodeLatitude(latLonPoint.getLat())
                     && encodeLongitude(point.getLon()) == encodeLongitude(latLonPoint.getLon());
+            } else if (geometry instanceof org.elasticsearch.geometry.Line line) {
+                for (int i = 0; i < line.length(); i++) {
+                    if (encodeLatitude(line.getLat(i)) != encodeLatitude(latLonPoint.getLat())
+                        || encodeLongitude(line.getLon(i)) != encodeLongitude(latLonPoint.getLon())) {
+                        return false;
+                    }
+                }
+                return true;
             }
         }
         return false;


### PR DESCRIPTION
If the complex geometry contains only points that all resolve (quantize) to the same single point, then the entire geometry is identical to a single point, and the point and the geometry are both inside and contain each other.

Fixes #93889 
