### PR TITLE
Remove replicas spec in search_shards YAML tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search_shards/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search_shards/10_basic.yml
@@ -20,7 +20,6 @@
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
           mappings:
             properties:
               field:


### PR DESCRIPTION
Remove the number of replicas setting to enable these tests to run with the stateless.