### PR TITLE
[TEST] Fix locale handling in SAML metadata

### DIFF
--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlIdpMetadataBuilder.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlIdpMetadataBuilder.java
@@ -29,6 +29,7 @@ import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 /**
  * This class is designed to support building IdP Metadata in test scenarios.
@@ -75,7 +76,14 @@ public class SamlIdpMetadataBuilder {
     }
 
     public String asString() throws CertificateEncodingException {
-        return SamlUtils.getXmlContent(build(), false);
+        var oldLocale = Locale.getDefault();
+        try {
+            // KeyDescriptorMarshaller calls toString on the SIGNING enum and that may not generate the correct value in other locales
+            Locale.setDefault(Locale.ROOT);
+            return SamlUtils.getXmlContent(build(), false);
+        } finally {
+            Locale.setDefault(oldLocale);
+        }
     }
 
     public EntityDescriptor build() throws CertificateEncodingException {

--- a/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
+++ b/x-pack/plugin/security/qa/saml-rest-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/saml/SamlServiceProviderMetadataIT.java
@@ -24,11 +24,11 @@ import org.elasticsearch.test.cluster.ElasticsearchCluster;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 import org.elasticsearch.test.junit.RunnableTestRuleAdapter;
 import org.elasticsearch.test.rest.ESRestTestCase;
+import org.elasticsearch.test.rest.ObjectPath;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
-import org.junit.Ignore;
 import org.junit.rules.RuleChain;
 import org.junit.rules.TestRule;
 
@@ -190,7 +190,6 @@ public class SamlServiceProviderMetadataIT extends ESRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).put(CERTIFICATE_AUTHORITIES, caPath).build();
     }
 
-    @Ignore("https://github.com/elastic/elasticsearch/issues/93908")
     public void testAuthenticationWhenMetadataIsUnreliable() throws Exception {
         // Start with no metadata available
         assertAllMetadataUnavailable();
@@ -233,6 +232,7 @@ public class SamlServiceProviderMetadataIT extends ESRestTestCase {
         req.setJsonEntity(Strings.toString(JsonXContent.contentBuilder().map(body)));
         var resp = entityAsMap(client().performRequest(req));
         assertThat(resp.get("username"), equalTo(username));
+        assertThat(ObjectPath.evaluate(resp, "authentication.authentication_realm.name"), equalTo("saml" + realmNumber));
     }
 
     private static Path getDataResource(String relativePath) throws URISyntaxException {


### PR DESCRIPTION
KeyDescriptorMarshaller calls

    (UsageType.SIGNING).toString().toLowerCase()

Which on some locales might produce `sıgnıng` rather than `signing`

This change works around that bug by forcing the locale to ROOT before converting the XML object to a String.

See also: SamlTestCase.setupSaml
(you'd think I'd have learnt this lesson by now)

Closes: #93908
