### PR TITLE
[8.7] [ML] Make text_embedding query vector builder experimental for first release

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -417,6 +417,8 @@ calculated on the combined set of `knn` and `query` matches.
 [[semantic-search]]
 ==== Perform semantic search
 
+experimental[]
+
 kNN search enables you to perform semantic search by using a previously deployed 
 {ml-docs}/ml-nlp-search-compare.html#ml-nlp-text-embedding[text embedding model]. 
 Instead of literal matching on search terms, semantic search retrieves results


### PR DESCRIPTION
The text_embedding query vector builder that can be used with KNN search to deliver a semantic search solution will be experimental for its first release.

Backport of #93979