### PR TITLE
Fix get data stream documentation

### DIFF
--- a/docs/reference/indices/get-data-stream.asciidoc
+++ b/docs/reference/indices/get-data-stream.asciidoc
@@ -170,14 +170,14 @@ the stream's backing indices.
 .Values for `status`
 [%collapsible%open]
 =====
-`green`:::
+`GREEN`:::
 All shards are assigned.
 
-`yellow`:::
+`YELLOW`:::
 All primary shards are assigned, but one or more replica shards are
 unassigned.
 
-`red`:::
+`RED`:::
 One or more primary shards are unassigned, so some data is unavailable.
 =====
 


### PR DESCRIPTION
The documentation specifies the possible values for the status of the response. This endpoint is inconsistent with most others that expose the health status as it returns the values as uppercase strings rather than lowercase. 

This PR fixes the cases in the documentation to align with the actual values returned in the response body.

Potentially we want to backport to all 8.x branches. I'm unsure if there's a specific rule for fixes to docs and how far back we go?