### PR TITLE
Setup yaml rest test for the Enterprise Search x-pack module

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/build.gradle
+++ b/x-pack/plugin/ent-search/qa/rest/build.gradle
@@ -1,0 +1,21 @@
+apply plugin: 'elasticsearch.legacy-yaml-rest-test'
+apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
+
+dependencies {
+  yamlRestTestImplementation(testArtifact(project(xpackModule('core'))))
+}
+
+restResources {
+  restApi {
+    include '_common', 'cluster', 'nodes', 'indices', 'index'
+  }
+}
+
+testClusters.configureEach {
+  testDistribution = 'DEFAULT'
+  setting 'xpack.security.enabled', 'true'
+  setting 'xpack.license.self_generated.type', 'trial'
+  extraConfigFile 'roles.yml', file('roles.yml')
+  user username: 'entsearch-admin', password: 'entsearch-admin-password', role: 'superuser'
+  user username: 'entsearch-user', password: 'entsearch-user-password', role: 'entsearch'
+}

--- a/x-pack/plugin/ent-search/qa/rest/roles.yml
+++ b/x-pack/plugin/ent-search/qa/rest/roles.yml
@@ -1,0 +1,3 @@
+entsearch:
+  cluster:
+    - manage

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/entsearch/EnterpriseSearchRestIT.java
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/entsearch/EnterpriseSearchRestIT.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch;
+
+import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
+
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.rest.yaml.ClientYamlTestCandidate;
+import org.elasticsearch.test.rest.yaml.ESClientYamlSuiteTestCase;
+
+import static org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken.basicAuthHeaderValue;
+
+public class EnterpriseSearchRestIT extends ESClientYamlSuiteTestCase {
+
+    public EnterpriseSearchRestIT(final ClientYamlTestCandidate testCandidate) {
+        super(testCandidate);
+    }
+
+    @ParametersFactory
+    public static Iterable<Object[]> parameters() throws Exception {
+        return createParameters();
+    }
+
+    @Override
+    protected Settings restAdminSettings() {
+        final String value = basicAuthHeaderValue("entsearch-admin", new SecureString("entsearch-admin-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", value).build();
+    }
+
+    @Override
+    protected Settings restClientSettings() {
+        final String value = basicAuthHeaderValue("entsearch-user", new SecureString("entsearch-user-password".toCharArray()));
+        return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", value).build();
+    }
+
+}

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/10_basic.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/10_basic.yml
@@ -1,0 +1,14 @@
+"Enterprise Search loaded":
+    - skip:
+          reason: "contains is a newly added assertion"
+          features: contains
+    - do:
+          cluster.state: {}
+
+    # Get master node id
+    - set: { master_node: master }
+
+    - do:
+          nodes.info: {}
+
+    - contains:  { nodes.$master.modules: { name: x-pack-ent-search } }


### PR DESCRIPTION
QA setup for yaml rest tests.

Tested with:
`./gradlew :x-pack:plugin:ent-search:check`