### PR TITLE
Fix issue with mutating authentication metadata map

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Authentication.java
@@ -1087,7 +1087,7 @@ public final class Authentication implements ToXContentObject {
             }
             if (authentication.getEffectiveSubject().getTransportVersion().onOrAfter(VERSION_API_KEY_ROLES_AS_BYTES)
                 && streamVersion.before(VERSION_API_KEY_ROLES_AS_BYTES)) {
-                metadata = metadata instanceof HashMap ? metadata : new HashMap<>(metadata);
+                metadata = new HashMap<>(metadata);
                 metadata.put(
                     AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY,
                     convertRoleDescriptorsBytesToMap((BytesReference) metadata.get(AuthenticationField.API_KEY_ROLE_DESCRIPTORS_KEY))


### PR DESCRIPTION
This PR reverts the initial change which aimed to avoid copying a metadata.
Not copying the metadata introduced a side-effect where 
original authentication's metadata would be mutated.

Fixes #94014