### PR TITLE
Adding initial public and internal serverless scopes to Analytics-Geo REST handlers

### DIFF
--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java
@@ -21,7 +21,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-@ServerlessScope(Scope.PUBLIC)
+@ServerlessScope(Scope.INTERNAL)
 public class RestDownsampleAction extends BaseRestHandler {
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RestDownsampleAction.java
@@ -10,6 +10,8 @@ package org.elasticsearch.xpack.downsample;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.core.downsample.DownsampleAction;
 import org.elasticsearch.xpack.core.downsample.DownsampleConfig;
@@ -19,6 +21,7 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
+@ServerlessScope(Scope.PUBLIC)
 public class RestDownsampleAction extends BaseRestHandler {
 
     @Override


### PR DESCRIPTION
#93607 added the ability to run Elasticsearch in "Serverless" mode, where access to REST endpoints could be restricted so that the full Elasticsearch API is not available (since a lot of it does not make sense in Servlerless). By default no endpoints are available, but they can be exposed with `ServerlessScope` annotations.
This PR follows up on #93607 by adding PUBLIC and INTERNAL annotations to the rest handlers owned by the Analytics/Geo team. There are several rest endpoints still under discussion. This PR does not label those, so they remain unavailable in Serverless mode.