### PR TITLE
Fix failing test by making warning message deterministic

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -122,11 +122,11 @@ import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -527,7 +527,7 @@ public class ApiKeyService {
         final String... apiKeyIds
     ) {
         if (version.before(Authentication.VERSION_API_KEYS_WITH_REMOTE_INDICES)) {
-            final Set<String> affectedRoles = new LinkedHashSet<>();
+            final Set<String> affectedRoles = new TreeSet<>();
             final Set<RoleDescriptor> result = userRoleDescriptors.stream().map(roleDescriptor -> {
                 if (roleDescriptor.hasRemoteIndicesPrivileges()) {
                     affectedRoles.add(roleDescriptor.getName());
@@ -547,15 +547,14 @@ public class ApiKeyService {
             }).collect(Collectors.toSet());
 
             if (false == affectedRoles.isEmpty()) {
-                final List<String> sortedAffectedRoles = affectedRoles.stream().sorted().toList();
                 logger.info(
                     "removed remote indices privileges from role(s) {} for API key(s) [{}]",
-                    sortedAffectedRoles,
+                    affectedRoles,
                     buildDelimitedStringWithLimit(10, apiKeyIds)
                 );
                 HeaderWarning.addWarning(
                     "Removed API key's remote indices privileges from role(s) "
-                        + sortedAffectedRoles
+                        + affectedRoles
                         + ". Remote indices are not supported by all nodes in the cluster. "
                         + "Use the update API Key API to re-assign remote indices to the API key(s), after the cluster upgrade is complete."
                 );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyService.java
@@ -547,16 +547,16 @@ public class ApiKeyService {
             }).collect(Collectors.toSet());
 
             if (false == affectedRoles.isEmpty()) {
+                final List<String> sortedAffectedRoles = affectedRoles.stream().sorted().toList();
                 logger.info(
-                    "removed remote indices privileges from role(s) [{}] for API key(s) [{}]",
-                    affectedRoles,
+                    "removed remote indices privileges from role(s) {} for API key(s) [{}]",
+                    sortedAffectedRoles,
                     buildDelimitedStringWithLimit(10, apiKeyIds)
                 );
-
                 HeaderWarning.addWarning(
-                    "Removed API key's remote indices privileges from role(s) ["
-                        + affectedRoles
-                        + "]. Remote indices are not supported by all nodes in the cluster. "
+                    "Removed API key's remote indices privileges from role(s) "
+                        + sortedAffectedRoles
+                        + ". Remote indices are not supported by all nodes in the cluster. "
                         + "Use the update API Key API to re-assign remote indices to the API key(s), after the cluster upgrade is complete."
                 );
             }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -2033,7 +2033,7 @@ public class ApiKeyServiceTests extends ESTestCase {
     public void testMaybeRemoveRemoteIndicesPrivilegesWithUnsupportedVersion() {
         final String apiKeyId = randomAlphaOfLengthBetween(5, 8);
         final Set<RoleDescriptor> userRoleDescriptors = Set.copyOf(
-            randomList(1, 3, () -> RoleDescriptorTests.randomRoleDescriptor(randomBoolean(), randomBoolean()))
+            randomList(2, 5, () -> RoleDescriptorTests.randomRoleDescriptor(randomBoolean(), randomBoolean()))
         );
 
         // Selecting random unsupported version.
@@ -2050,16 +2050,17 @@ public class ApiKeyServiceTests extends ESTestCase {
         assertThat(result.size(), equalTo(userRoleDescriptors.size()));
 
         // Roles for which warning headers are added.
-        final String[] userRoleNamesWithRemoteIndicesPrivileges = userRoleDescriptors.stream()
+        final List<String> userRoleNamesWithRemoteIndicesPrivileges = userRoleDescriptors.stream()
             .filter(RoleDescriptor::hasRemoteIndicesPrivileges)
             .map(RoleDescriptor::getName)
-            .toArray(String[]::new);
+            .sorted()
+            .toList();
 
-        if (userRoleNamesWithRemoteIndicesPrivileges.length > 0) {
+        if (false == userRoleNamesWithRemoteIndicesPrivileges.isEmpty()) {
             assertWarnings(
-                "Removed API key's remote indices privileges from role(s) ["
-                    + Arrays.stream(userRoleNamesWithRemoteIndicesPrivileges).collect(Collectors.toSet())
-                    + "]. Remote indices are not supported by all nodes in the cluster. "
+                "Removed API key's remote indices privileges from role(s) "
+                    + userRoleNamesWithRemoteIndicesPrivileges
+                    + ". Remote indices are not supported by all nodes in the cluster. "
                     + "Use the update API Key API to re-assign remote indices to the API key(s), after the cluster upgrade is complete."
             );
         }


### PR DESCRIPTION
This commit makes a warning message deterministic by sorting affected role names before including them in the message.
