### PR TITLE
[8.6] [doc] Add known issue to all affected versions due to jackson parsing bug (#93915)

### DIFF
--- a/docs/reference/release-notes/8.0.0.asciidoc
+++ b/docs/reference/release-notes/8.0.0.asciidoc
@@ -31,6 +31,12 @@ Then, create an enrollment token for {kib} with the
 bin/elasticsearch-create-enrollment-token -s kibana
 ----
 --
+// tag::jackson-filtering-bug[]
+* Parsing a request when the last element in an array is filtered out
+(for instance using `_source_includes`) fails. This
+is due to https://github.com/FasterXML/jackson-core/issues/882[a bug in Jackson parser].
+Fixed in {es} 8.6.1 ({es-pull}92480[#91456])
+// end::jackson-filtering-bug[]
 
 
 [[breaking-8.0.0]]

--- a/docs/reference/release-notes/8.0.1.asciidoc
+++ b/docs/reference/release-notes/8.0.1.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.0.1
 
 Also see <<breaking-changes-8.0,Breaking changes in 8.0>>.
+[[known-issues-8.0.1]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.0.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.1.0.asciidoc
+++ b/docs/reference/release-notes/8.1.0.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.1.0
 
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
+[[known-issues-8.1.0]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[breaking-8.1.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.1.1.asciidoc
+++ b/docs/reference/release-notes/8.1.1.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.1.1
 
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
+[[known-issues-8.1.1]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.1.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.1.2.asciidoc
+++ b/docs/reference/release-notes/8.1.2.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.1.2
 
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
+[[known-issues-8.1.2]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.1.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.1.3.asciidoc
+++ b/docs/reference/release-notes/8.1.3.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.1.3
 
 Also see <<breaking-changes-8.1,Breaking changes in 8.1>>.
+[[known-issues-8.1.3]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.1.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.2.0.asciidoc
+++ b/docs/reference/release-notes/8.2.0.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.2.0
 
 // Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+[[known-issues-8.2.0]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.2.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.2.1.asciidoc
+++ b/docs/reference/release-notes/8.2.1.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.2.1
 
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+[[known-issues-8.2.1]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.2.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.2.2.asciidoc
+++ b/docs/reference/release-notes/8.2.2.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.2.2
 
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+[[known-issues-8.2.2]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.2.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.2.3.asciidoc
+++ b/docs/reference/release-notes/8.2.3.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.2.3
 
 Also see <<breaking-changes-8.2,Breaking changes in 8.2>>.
+[[known-issues-8.2.3]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.2.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.3.0.asciidoc
+++ b/docs/reference/release-notes/8.3.0.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.3.0
 
 Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
+[[known-issues-8.3.0]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.3.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.3.1.asciidoc
+++ b/docs/reference/release-notes/8.3.1.asciidoc
@@ -2,7 +2,11 @@
 == {es} version 8.3.1
 
 Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
+[[known-issues-8.3.1]]
+[float]
+=== Known issues
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.3.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.3.2.asciidoc
+++ b/docs/reference/release-notes/8.3.2.asciidoc
@@ -5,6 +5,12 @@ Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
 
 {es} 8.3.2 is a version compatibility release for the {stack}.
 
+[[known-issues-8.3.2]]
+[float]
+=== Known issues
+
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
 [[bug-8.3.2]]
 [float]
 === Bug fixes
@@ -17,4 +23,4 @@ Geo::
 === New features
 
 Heath::
-* Add user action for the `instance_has_master` indicator {es-pull}87963[#87963] 
+* Add user action for the `instance_has_master` indicator {es-pull}87963[#87963]

--- a/docs/reference/release-notes/8.3.3.asciidoc
+++ b/docs/reference/release-notes/8.3.3.asciidoc
@@ -3,6 +3,13 @@
 
 Also see <<breaking-changes-8.3,Breaking changes in 8.3>>.
 
+[[known-issues-8.3.3]]
+[float]
+=== Known issues
+
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+
 [[bug-8.3.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.0.asciidoc
+++ b/docs/reference/release-notes/8.4.0.asciidoc
@@ -11,7 +11,7 @@ Also see <<breaking-changes-8.4,Breaking changes in 8.4>>.
 * {ml-cap} {dfeeds} cannot be listed if any are not modified since version 6.x
 +
 If you have a {dfeed} that was created in version 5.x or 6.x and has not
-been updated since 7.0, it is not possible to list {dfeeds} in 
+been updated since 7.0, it is not possible to list {dfeeds} in
 8.4 and 8.5. This means that {anomaly-jobs} cannot be managed using
 {kib}. This issue is fixed in 8.6.0.
 +
@@ -27,6 +27,8 @@ encounter deadlocks during master elections (issue: {es-issue}92812[#92812])
 To resolve the deadlock, remove the `settings.json` file and restart the
 affected node.
 // end::file-based-settings-deadlock-known-issue[]
+
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
 [[bug-8.4.0]]
 [float]

--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -15,6 +15,8 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
 [[bug-8.4.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -24,6 +24,8 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
 [[bug-8.4.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -15,6 +15,8 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
 [[bug-8.4.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -18,6 +18,8 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
 [[breaking-8.5.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.5.1.asciidoc
+++ b/docs/reference/release-notes/8.5.1.asciidoc
@@ -12,6 +12,7 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.5.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.2.asciidoc
+++ b/docs/reference/release-notes/8.5.2.asciidoc
@@ -12,6 +12,7 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.5.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -11,6 +11,7 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 [[bug-8.5.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -9,6 +9,8 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
+include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
 [[bug-8.6.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.1.asciidoc
+++ b/docs/reference/release-notes/8.6.1.asciidoc
@@ -10,6 +10,8 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 Data streams::
 * Fix wildcard expansion for delete-by-query on data streams {es-pull}92891[#92891]
 * Fix wildcard expansion for update-by-query on data streams {es-pull}92717[#92717] (issue: {es-issue}90272[#90272])
+* Patch jackson-core with locally modified class #92984
+This fixes an issue in jackson parsing (issue: {es-issue}92480[#92480])
 
 Distributed::
 * Fix `ByteArrayIndexInput` with nonzero offset {es-pull}93205[#93205]


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [doc] Add known issue to all affected versions due to jackson parsing bug (#93915)