### PR TITLE
[monitoring] Add total_time.ms alias for Metricbeat monitoring

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -2378,6 +2378,10 @@
                 "start_time_in_millis": {
                   "path": "elasticsearch.index.recovery.start_time.ms",
                   "type": "alias"
+                },
+                "total_time_in_millis": {
+                  "path": "elasticsearch.index.recovery.total_time.ms",
+                  "type": "alias"
                 }
               }
             }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 5;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 6;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Related issue: https://github.com/elastic/beats/issues/34427

The mappings were missing the alias for `elasticsearch.index.recovery.total_time.ms` to `index_recovery.shards.total_time_in_millis`.

Related PRs:
https://github.com/elastic/beats/pull/34653
https://github.com/elastic/integrations/pull/5367
https://github.com/elastic/kibana/pull/151983