### PR TITLE
Enterprise Search Engines PUT API - Tests

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -189,6 +189,7 @@ public final class ClientHelper {
     public static final String SEARCHABLE_SNAPSHOTS_ORIGIN = "searchable_snapshots";
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
+    public static final String ENT_SEARCH_ENGINE_ORIGIN = "engine";
 
     private ClientHelper() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -189,7 +189,7 @@ public final class ClientHelper {
     public static final String SEARCHABLE_SNAPSHOTS_ORIGIN = "searchable_snapshots";
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
-    public static final String ENT_SEARCH_ENGINE_ORIGIN = "engine";
+    public static final String ENT_SEARCH_ORIGIN = "engine";
 
     private ClientHelper() {}
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ClientHelper.java
@@ -189,7 +189,7 @@ public final class ClientHelper {
     public static final String SEARCHABLE_SNAPSHOTS_ORIGIN = "searchable_snapshots";
     public static final String LOGSTASH_MANAGEMENT_ORIGIN = "logstash_management";
     public static final String FLEET_ORIGIN = "fleet";
-    public static final String ENT_SEARCH_ORIGIN = "engine";
+    public static final String ENT_SEARCH_ORIGIN = "enterprise_search";
 
     private ClientHelper() {}
 

--- a/x-pack/plugin/ent-search/build.gradle
+++ b/x-pack/plugin/ent-search/build.gradle
@@ -19,3 +19,8 @@ dependencies {
 }
 
 addQaCheckDependencies(project)
+
+testClusters.configureEach {
+  setting 'xpack.ent-search.enabled', 'true'
+}
+

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.SystemIndexDescriptor;
@@ -110,7 +111,12 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         if (enabled == false) {
             return Collections.emptyList();
         }
-        final EngineIndexService engineService = new EngineIndexService(client, clusterService, namedWriteableRegistry, null);
+        final EngineIndexService engineService = new EngineIndexService(
+            client,
+            clusterService,
+            namedWriteableRegistry,
+            BigArrays.NON_RECYCLING_INSTANCE
+        );
         return Collections.singletonList(engineService);
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -51,6 +51,8 @@ import java.util.List;
 import java.util.function.Supplier;
 
 public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemIndexPlugin {
+    public static final String ENGINE_API_ENDPOINT = "_engine";
+
     private static final Logger logger = LogManager.getLogger(EnterpriseSearch.class);
 
     public static final String FEATURE_NAME = "ent_search";
@@ -70,7 +72,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         if (enabled == false) {
             return Collections.emptyList();
         }
-        // Register new actions here
         return List.of(new ActionHandler<>(PutEngineAction.INSTANCE, TransportPutEngineAction.class));
     }
 
@@ -88,7 +89,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         if (enabled == false) {
             return Collections.emptyList();
         }
-        // Register new actions here
         return List.of(new RestPutEngineAction());
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -195,6 +195,7 @@ public class EngineIndexService {
                     )
                     .endObject();
             }
+            // TODO Validate indices exist?
             final IndexRequest indexRequest = new IndexRequest(ENGINE_ALIAS_NAME).opType(DocWriteRequest.OpType.INDEX)
                 .id(engine.name())
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -60,6 +60,7 @@ import java.util.Collections;
 
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.entsearch.engine.Engine.BINARY_CONTENT_FIELD;
 import static org.elasticsearch.xpack.entsearch.engine.Engine.INDICES_FIELD;
 import static org.elasticsearch.xpack.entsearch.engine.Engine.NAME_FIELD;
@@ -74,7 +75,6 @@ public class EngineIndexService {
     public static final String ENGINE_ALIAS_NAME = ".engine";
     public static final String ENGINE_CONCRETE_INDEX_NAME = ".engine-1";
     public static final String ENGINE_INDEX_NAME_PATTERN = ".engine-*";
-    public static final String ENGINE_ORIGIN = "engine";
 
     private final Client clientWithOrigin;
     private final ClusterService clusterService;
@@ -87,7 +87,7 @@ public class EngineIndexService {
         NamedWriteableRegistry namedWriteableRegistry,
         BigArrays bigArrays
     ) {
-        this.clientWithOrigin = new OriginSettingClient(client, ENGINE_ORIGIN);
+        this.clientWithOrigin = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
         this.clusterService = clusterService;
         this.namedWriteableRegistry = namedWriteableRegistry;
         this.bigArrays = bigArrays;
@@ -107,7 +107,7 @@ public class EngineIndexService {
             .setSettings(getIndexSettings())
             .setAliasName(ENGINE_ALIAS_NAME)
             .setVersionMetaKey("version")
-            .setOrigin(ENGINE_ORIGIN)
+            .setOrigin(ENT_SEARCH_ORIGIN)
             .setThreadPools(ExecutorNames.DEFAULT_SYSTEM_INDEX_THREAD_POOLS)
             .build();
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+
+public class PutEngineAction extends ActionType<PutEngineAction.Response> {
+
+    public static final PutEngineAction INSTANCE = new PutEngineAction();
+    public static final String NAME = "cluster:admin/engine/put";
+
+    public PutEngineAction() {
+        super(NAME, PutEngineAction.Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String engineId;
+        private final BytesReference content;
+
+        private final XContentType contentType;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.engineId = in.readString();
+            this.content = in.readBytesReference();
+            this.contentType = in.readEnum(XContentType.class);
+        }
+
+        public Request(String engineId, BytesReference content, XContentType contentType) {
+            this.engineId = engineId;
+            this.content = content;
+            this.contentType = contentType;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+
+            Map<String, Object> sourceMap = XContentHelper.convertToMap(content, false, contentType).v2();
+            if (sourceMap.containsKey("indices") == false) {
+                validationException = addValidationError("indices are missing", validationException);
+            } else {
+                if (sourceMap.get("indices") instanceof Map == false) {
+                    validationException = addValidationError("indices should be an array", validationException);
+                }
+            }
+
+            return validationException;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(engineId);
+            out.writeBytesReference(content);
+            XContentHelper.writeTo(out, contentType);
+        }
+
+        public String getEngineId() {
+            return engineId;
+        }
+
+        public BytesReference getContent() {
+            return content;
+        }
+
+        public XContentType getContentType() {
+            return contentType;
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        final DocWriteResponse.Result result;
+
+        public Response(StreamInput in) throws IOException {
+            super(in);
+            result = DocWriteResponse.Result.readFrom(in);
+        }
+
+        public Response(DocWriteResponse.Result result) {
+            this.result = result;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            this.result.writeTo(out);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            builder.startObject();
+            builder.field("result", this.result.getLowercase());
+            builder.endObject();
+            return builder;
+        }
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
-import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
@@ -41,11 +40,7 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            String engineId = in.readString();
-            final BytesReference bytesReference = in.readBytesReference();
-            xContentType = in.readEnum(XContentType.class);
-
-            this.engine = Engine.fromXContentBytes(engineId, bytesReference, xContentType);
+            this.engine = new Engine(in);
         }
 
         public Request(String engineId, BytesReference content, XContentType contentType) {
@@ -68,7 +63,6 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             engine.writeTo(out);
-            XContentHelper.writeTo(out, xContentType);
         }
 
         public Engine getEngine() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -12,6 +12,8 @@ import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.DocWriteResponse;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -27,16 +29,15 @@ import static org.elasticsearch.action.ValidateActions.addValidationError;
 public class PutEngineAction extends ActionType<PutEngineAction.Response> {
 
     public static final PutEngineAction INSTANCE = new PutEngineAction();
-    public static final String NAME = "cluster:admin/engine/put";
+    public static final String NAME = "indices:admin/engine/put";
 
     public PutEngineAction() {
         super(NAME, PutEngineAction.Response::new);
     }
 
-    public static class Request extends ActionRequest {
+    public static class Request extends ActionRequest implements IndicesRequest {
 
         private final Engine engine;
-        private XContentType xContentType = XContentType.JSON;
 
         public Request(StreamInput in) throws IOException {
             super(in);
@@ -45,7 +46,6 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
 
         public Request(String engineId, BytesReference content, XContentType contentType) {
             this.engine = Engine.fromXContentBytes(engineId, content, contentType);
-            xContentType = contentType;
         }
 
         @Override
@@ -63,6 +63,16 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             engine.writeTo(out);
+        }
+
+        @Override
+        public String[] indices() {
+            return engine.indices();
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return IndicesOptions.fromOptions(false, false, false, false, false, false, false, false);
         }
 
         public Engine getEngine() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -11,6 +11,7 @@ import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,8 +20,6 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 
 public class RestPutEngineAction extends BaseRestHandler {
 
-    public static final String ENDPOINT = "_engine";
-
     @Override
     public String getName() {
         return "engine_put_action";
@@ -28,7 +27,7 @@ public class RestPutEngineAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(PUT, "/" + ENDPOINT + "/{engine_id}"));
+        return List.of(new Route(PUT, "/" + EnterpriseSearch.ENGINE_API_ENDPOINT + "/{engine_id}"));
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.PUT;
+
+public class RestPutEngineAction extends BaseRestHandler {
+
+    public static final String ENDPOINT = "_engine";
+
+    @Override
+    public String getName() {
+        return "engine_put_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(PUT, "/" + ENDPOINT + "/{engine_id}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        PutEngineAction.Request request = new PutEngineAction.Request(
+            restRequest.param("engine_id"),
+            restRequest.content(),
+            restRequest.getXContentType()
+        );
+        return channel -> client.execute(PutEngineAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.entsearch.engine.action;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
 
@@ -37,6 +38,11 @@ public class RestPutEngineAction extends BaseRestHandler {
             restRequest.content(),
             restRequest.getXContentType()
         );
-        return channel -> client.execute(PutEngineAction.INSTANCE, request, new RestToXContentListener<>(channel));
+        return channel -> client.execute(PutEngineAction.INSTANCE, request, new RestToXContentListener<>(channel) {
+            @Override
+            protected RestStatus getStatus(PutEngineAction.Response response) {
+                return response.status();
+            }
+        });
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.entsearch.engine.Engine;
+import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
+
+public class TransportPutEngineAction extends HandledTransportAction<PutEngineAction.Request, PutEngineAction.Response> {
+
+    private final EngineIndexService engineIndexService;
+
+    @Inject
+    public TransportPutEngineAction(TransportService transportService, ActionFilters actionFilters, EngineIndexService engineIndexService) {
+        super(PutEngineAction.NAME, transportService, actionFilters, PutEngineAction.Request::new);
+        this.engineIndexService = engineIndexService;
+    }
+
+    @Override
+    protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
+        Engine engine = Engine.fromXContentBytes(request.getEngineId(), request.getContent(), request.getContentType());
+        engineIndexService.putEngine(engine, new ActionListener<>() {
+            @Override
+            public void onResponse(IndexResponse indexResponse) {
+                listener.onResponse(new PutEngineAction.Response(indexResponse.getResult()));
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                listener.onFailure(e);
+            }
+        });
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.entsearch.engine.action;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
@@ -30,16 +29,6 @@ public class TransportPutEngineAction extends HandledTransportAction<PutEngineAc
     @Override
     protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
         Engine engine = request.getEngine();
-        engineIndexService.putEngine(engine, new ActionListener<>() {
-            @Override
-            public void onResponse(IndexResponse indexResponse) {
-                listener.onResponse(new PutEngineAction.Response(indexResponse.getResult()));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                listener.onFailure(e);
-            }
-        });
+        engineIndexService.putEngine(engine, listener.map(r -> new PutEngineAction.Response(r.getResult())));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
@@ -29,7 +29,7 @@ public class TransportPutEngineAction extends HandledTransportAction<PutEngineAc
 
     @Override
     protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
-        Engine engine = Engine.fromXContentBytes(request.getEngineId(), request.getContent(), request.getContentType());
+        Engine engine = request.getEngine();
         engineIndexService.putEngine(engine, new ActionListener<>() {
             @Override
             public void onResponse(IndexResponse indexResponse) {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
@@ -36,13 +36,18 @@ import static org.elasticsearch.xpack.entsearch.engine.EngineIndexService.ENGINE
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class EngineIndexServiceTests extends ESSingleNodeTestCase {
+    private static final int NUM_INDICES = 10;
+
     private EngineIndexService engineService;
 
     @Before
-    public void setup() {
+    public void setup() throws Exception {
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         BigArrays bigArrays = getInstanceFromNode(BigArrays.class);
         this.engineService = new EngineIndexService(client(), clusterService, writableRegistry(), bigArrays);
+        for (int i = 0; i < NUM_INDICES; i++) {
+            client().admin().indices().prepareCreate("index_" + i).execute().get();
+        }
     }
 
     @Override
@@ -74,7 +79,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
             assertThat(getEngine, equalTo(engine));
         }
 
-        final Engine engine = new Engine("my_engine", new String[] { "index_1", "index_2" }, "my_engine_analytics_collection");
+        final Engine engine = new Engine("my_engine", new String[] { "index_3", "index_4" }, "my_engine_analytics_collection");
         IndexResponse newResp = awaitPutEngine(engine);
         assertThat(newResp.status(), equalTo(RestStatus.OK));
         assertThat(newResp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
@@ -28,9 +29,11 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.entsearch.engine.EngineIndexService.ENGINE_CONCRETE_INDEX_NAME;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -39,10 +42,11 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     private static final int NUM_INDICES = 10;
 
     private EngineIndexService engineService;
+    private ClusterService clusterService;
 
     @Before
     public void setup() throws Exception {
-        ClusterService clusterService = getInstanceFromNode(ClusterService.class);
+        clusterService = getInstanceFromNode(ClusterService.class);
         BigArrays bigArrays = getInstanceFromNode(BigArrays.class);
         this.engineService = new EngineIndexService(client(), clusterService, writableRegistry(), bigArrays);
         for (int i = 0; i < NUM_INDICES; i++) {
@@ -66,6 +70,18 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
 
         Engine getEngine = awaitGetEngine(engine.name());
         assertThat(getEngine, equalTo(engine));
+        checkAliases(engine);
+    }
+
+    private void checkAliases(Engine engine) {
+        Metadata metadata = clusterService.state().metadata();
+        final String aliasName = "engine-" + engine.name();
+        assertTrue(metadata.hasAlias(aliasName));
+        final Set<String> aliasedIndices = metadata.aliasedIndices(aliasName)
+            .stream()
+            .map(index -> index.getName())
+            .collect(Collectors.toSet());
+        assertThat(aliasedIndices, equalTo(Set.of(engine.indices())));
     }
 
     public void testUpdateEngine() throws Exception {
@@ -85,10 +101,11 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(newResp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         Engine getNewEngine = awaitGetEngine(engine.name());
         assertThat(engine, equalTo(getNewEngine));
+        checkAliases(engine);
     }
 
     public void testListEngine() throws Exception {
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < NUM_INDICES; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
             IndexResponse resp = awaitPutEngine(engine);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
@@ -102,7 +119,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
             assertThat(resp.getHits().getTotalHits().value, equalTo(10L));
 
             SearchHits searchHits = resp.getHits();
-            for (int i = 0; i < 10; i++) {
+            for (int i = 0; i < NUM_INDICES; i++) {
                 SearchHit hit = searchHits.getAt(i);
                 assertNotNull(hit.getFields().get("name"));
                 assertThat(hit.getFields().get("name").getValues(), equalTo(Arrays.asList("my_engine_" + i)));

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -382,6 +382,7 @@ public class Constants {
         "indices:admin/data_stream/modify",
         "indices:admin/data_stream/promote",
         "indices:admin/delete",
+        "indices:admin/engine/put",
         "indices:admin/flush",
         "indices:admin/flush[s]",
         "indices:admin/forcemerge",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -28,7 +28,7 @@ import static org.elasticsearch.persistent.PersistentTasksService.PERSISTENT_TAS
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.DEPRECATION_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
-import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ENGINE_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.FLEET_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.IDP_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
@@ -139,7 +139,7 @@ public final class AuthorizationUtils {
             case SEARCHABLE_SNAPSHOTS_ORIGIN:
             case LOGSTASH_MANAGEMENT_ORIGIN:
             case FLEET_ORIGIN:
-            case ENT_SEARCH_ENGINE_ORIGIN:
+            case ENT_SEARCH_ORIGIN:
             case TASKS_ORIGIN:   // TODO use a more limited user for tasks
                 securityContext.executeAsInternalUser(XPackUser.INSTANCE, version, consumer);
                 break;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authz/AuthorizationUtils.java
@@ -28,6 +28,7 @@ import static org.elasticsearch.persistent.PersistentTasksService.PERSISTENT_TAS
 import static org.elasticsearch.xpack.core.ClientHelper.ASYNC_SEARCH_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.DEPRECATION_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ENGINE_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.FLEET_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.IDP_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.INDEX_LIFECYCLE_ORIGIN;
@@ -138,6 +139,7 @@ public final class AuthorizationUtils {
             case SEARCHABLE_SNAPSHOTS_ORIGIN:
             case LOGSTASH_MANAGEMENT_ORIGIN:
             case FLEET_ORIGIN:
+            case ENT_SEARCH_ENGINE_ORIGIN:
             case TASKS_ORIGIN:   // TODO use a more limited user for tasks
                 securityContext.executeAsInternalUser(XPackUser.INSTANCE, version, consumer);
                 break;


### PR DESCRIPTION
## Closes https://github.com/elastic/enterprise-search-team/issues/3928

Add PUT API for upserting engines:

```
PUT /_engine/test-engine
{
  "indices": ["test1", "test2"]
}
```

The API creates the Engine doc into the .engine system index, and adds an engine-<engine-name> alias for all indices.

As the alias is created, user needs to have manage permissions on both the alias and the indices.

Updating the engine indices updates the aliases as needed.