### PR TITLE
Change the settings of the index template test for DLM

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -109,8 +109,11 @@ setup:
   - skip:
       version: " - 8.7.99"
       reason: "Data lifecycle in index templates was added after 8.7"
+      features: allowed_warnings
 
   - do:
+      allowed_warnings:
+        - "index template [test-lifecycle] has index patterns [data-stream-with-lifecycle-*] matching patterns from existing older templates [global] with patterns (global => [*]); this template [test-lifecycle] will take precedence during new index creation"
       indices.put_index_template:
         name: test-lifecycle
         body:
@@ -118,7 +121,6 @@ setup:
           template:
             settings:
               number_of_shards: 1
-              number_of_replicas: 0
             mappings:
               properties:
                 field:
@@ -132,7 +134,7 @@ setup:
 
   - match: {index_templates.0.name: test-lifecycle}
   - match: {index_templates.0.index_template.index_patterns: ["data-stream-with-lifecycle-*"]}
-  - match: {index_templates.0.index_template.template.settings: {index: {number_of_shards: '1', number_of_replicas: '0'}}}
+  - match: {index_templates.0.index_template.template.settings: {index: {number_of_shards: '1'}}}
   - match: {index_templates.0.index_template.template.mappings: {properties: {field: {type: keyword}}}}
 
 ---
@@ -149,7 +151,6 @@ setup:
           template:
             settings:
               number_of_shards: 1
-              number_of_replicas: 0
             mappings:
               properties:
                 field:


### PR DESCRIPTION
In this PR we are updating test `indices.get_index_template/10_basic/Add data lifecycle` to handle a warning and to not set the replicas since it's not essential to test this feature.
