### PR TITLE
[ML] correcting PyTorch model size limit checks

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamer.java
@@ -22,7 +22,7 @@ import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 
@@ -38,15 +38,18 @@ public class PyTorchStateStreamer {
     private static final Logger logger = LogManager.getLogger(PyTorchStateStreamer.class);
 
     /** The size of the data written before the model definition */
-    private static final int NUM_BYTES_IN_PRELUDE = 4;
+    static final int NUM_BYTES_IN_PRELUDE = 4;
+
+    // This is the unsigned integer max that the native side can support.
+    static final long UNSIGNED_INT_MAX = (2L << 31) - 1;
 
     private final OriginSettingClient client;
     private final ExecutorService executorService;
     private final NamedXContentRegistry xContentRegistry;
     private volatile boolean isCancelled;
-    private volatile int modelSize = -1;
+    private volatile long modelSize = -1;
     // model bytes only, does not include the prelude
-    private final AtomicInteger modelBytesWritten = new AtomicInteger();
+    private final AtomicLong modelBytesWritten = new AtomicLong();
 
     public PyTorchStateStreamer(Client client, ExecutorService executorService, NamedXContentRegistry xContentRegistry) {
         this.client = new OriginSettingClient(Objects.requireNonNull(client), ML_ORIGIN);
@@ -109,7 +112,7 @@ public class PyTorchStateStreamer {
         return true;
     }
 
-    private int writeModelSize(String modelId, Long modelSizeBytes, OutputStream outputStream) throws IOException {
+    private long writeModelSize(String modelId, Long modelSizeBytes, OutputStream outputStream) throws IOException {
         if (modelSizeBytes == null) {
             String message = String.format(
                 Locale.ROOT,
@@ -135,23 +138,25 @@ public class PyTorchStateStreamer {
             throw new IllegalStateException(message);
         }
 
-        if (modelSizeBytes > Integer.MAX_VALUE) {
-            // TODO use a long in case models are larger than 2^31 bytes
+        // Model size bytes should never be larger than unsigned int
+        if (modelSizeBytes > UNSIGNED_INT_MAX) {
             String message = String.format(
                 Locale.ROOT,
                 "model [%s] has a size [%s] larger than the max size [%s]",
                 modelId,
                 modelSizeBytes,
-                Integer.MAX_VALUE
+                UNSIGNED_INT_MAX
             );
             logger.error(message);
             throw new IllegalStateException(message);
         }
 
         ByteBuffer lengthBuffer = ByteBuffer.allocate(NUM_BYTES_IN_PRELUDE);
+        // We are deliberately allowing this to roll over since for all size bytes > Integer.MAX_VALUE will be negative.
+        // But, it will be read as unsigned on the native side.
         lengthBuffer.putInt(modelSizeBytes.intValue());
         outputStream.write(lengthBuffer.array());
 
-        return modelSizeBytes.intValue();
+        return modelSizeBytes;
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchStateStreamerTests.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.inference.pytorch.process;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchStateStreamer.NUM_BYTES_IN_PRELUDE;
+import static org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchStateStreamer.UNSIGNED_INT_MAX;
+
+public class PyTorchStateStreamerTests extends ESTestCase {
+    public void testModelSizeExtremes() {
+        // Longs are 8 bytes but we should only use 4
+        ByteBuffer longByteBuffer = ByteBuffer.allocate(NUM_BYTES_IN_PRELUDE * 2);
+        ByteBuffer byteBuffer = ByteBuffer.allocate(NUM_BYTES_IN_PRELUDE);
+        for (Long value : List.of(
+            0L,
+            (long) Integer.MAX_VALUE - 1,
+            (long) Integer.MAX_VALUE,
+            Integer.MAX_VALUE + 1L,
+            Integer.MAX_VALUE + 10L,
+            Integer.MAX_VALUE + 13L,
+            UNSIGNED_INT_MAX
+        )) {
+            byteBuffer.putInt(value.intValue());
+            longByteBuffer.putLong(value);
+            // check the BIG_ENDIAN arrays are exactly the same
+            assertArrayEquals(Arrays.copyOfRange(longByteBuffer.array(), 4, 8), byteBuffer.array());
+            // Check that the other bytes are all `0`
+            assertArrayEquals(Arrays.copyOfRange(longByteBuffer.array(), 0, 4), new byte[] { 0, 0, 0, 0 });
+            byteBuffer.clear();
+            longByteBuffer.clear();
+        }
+    }
+}


### PR DESCRIPTION
The actual model size limit on the native size is `unsigned int`. Java doesn't have such an idea, so we store model size as long and write signed int bytes. But we ensure the model limit adheres to the unsigned int limit of `(2L << 31) - 1`.