### PR TITLE
Update juniversalchardet NOTICE file to include link to source

### DIFF
--- a/modules/ingest-attachment/licenses/juniversalchardet-NOTICE.txt
+++ b/modules/ingest-attachment/licenses/juniversalchardet-NOTICE.txt
@@ -1,0 +1,1 @@
+Original MPL-covered source can be found here: https://github.com/albfernandez/juniversalchardet/tree/v1.0.3


### PR DESCRIPTION
Per open-source working group guidance on appropriate attribution for Mozilla Public License code, adding link to MPL source.
-open source issue `348` for reference.