### PR TITLE
Mute ingest-geoip internal cluster tests on Windows

### DIFF
--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -7,6 +7,7 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.OS
 
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
@@ -58,6 +59,10 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     // See https://github.com/maxmind/MaxMind-DB-Reader-java#file-lock-on-windows for more information
     systemProperty 'es.geoip.load_db_on_heap', 'true'
   }
+}
+
+tasks.named("internalClusterTest") {
+  onlyIf { OS.current() != OS.WINDOWS }
 }
 
 tasks.named("forbiddenPatterns").configure {


### PR DESCRIPTION
The introduction of #93488 means that we are now running these tests on Windows. They are clearly incompatible, and since we weren't running them on that platform before let's go ahead and mute for now, we can decide whether it's worthwhile coverage later. In the mean time, the YAML REST tests _do_ pass on Windows, so overall it's a net _increase_ in test coverage on Windows.

Relates to #94098
