### PR TITLE
[8.6] Mute ingest-geoip internal cluster tests on Windows (#94099)

### DIFF
--- a/modules/ingest-geoip/build.gradle
+++ b/modules/ingest-geoip/build.gradle
@@ -7,6 +7,7 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.elasticsearch.gradle.OS
 
 apply plugin: 'elasticsearch.internal-yaml-rest-test'
 apply plugin: 'elasticsearch.yaml-rest-compat-test'
@@ -58,6 +59,10 @@ if (Os.isFamily(Os.FAMILY_WINDOWS)) {
     // See https://github.com/maxmind/MaxMind-DB-Reader-java#file-lock-on-windows for more information
     systemProperty 'es.geoip.load_db_on_heap', 'true'
   }
+}
+
+tasks.named("internalClusterTest") {
+  onlyIf { OS.current() != OS.WINDOWS }
 }
 
 tasks.named("forbiddenPatterns").configure {


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Mute ingest-geoip internal cluster tests on Windows (#94099)