### PR TITLE
Remove obsolete code in GeoContextMapping

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -201,7 +201,7 @@ public class GeoPoint implements SpatialPoint, ToXContentFragment {
     }
 
     /** reset the point using Lucene encoded format for lat and lon */
-    public GeoPoint resetFromEncoded(int encodedLat, int encodedLon) {
+    private GeoPoint resetFromEncoded(int encodedLat, int encodedLon) {
         return reset(GeoEncodingUtils.decodeLatitude(encodedLat), GeoEncodingUtils.decodeLongitude(encodedLon));
     }
 

--- a/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
+++ b/server/src/main/java/org/elasticsearch/common/geo/GeoPoint.java
@@ -8,12 +8,8 @@
 
 package org.elasticsearch.common.geo;
 
-import org.apache.lucene.document.LatLonDocValuesField;
-import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.geo.GeoEncodingUtils;
-import org.apache.lucene.index.IndexableField;
 import org.apache.lucene.util.BitUtil;
-import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.common.geo.GeoUtils.EffectivePoint;
 import org.elasticsearch.geometry.Geometry;
@@ -27,7 +23,6 @@ import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Locale;
 
 public class GeoPoint implements SpatialPoint, ToXContentFragment {
@@ -144,20 +139,6 @@ public class GeoPoint implements SpatialPoint, ToXContentFragment {
         return this;
     }
 
-    // todo this is a crutch because LatLonPoint doesn't have a helper for returning .stringValue()
-    // todo remove with next release of lucene
-    public GeoPoint resetFromIndexableField(IndexableField field) {
-        if (field instanceof LatLonPoint) {
-            BytesRef br = field.binaryValue();
-            byte[] bytes = Arrays.copyOfRange(br.bytes, br.offset, br.length);
-            return this.reset(GeoEncodingUtils.decodeLatitude(bytes, 0), GeoEncodingUtils.decodeLongitude(bytes, Integer.BYTES));
-        } else if (field instanceof LatLonDocValuesField) {
-            long encoded = (long) (field.numericValue());
-            return this.reset(GeoEncodingUtils.decodeLatitude((int) (encoded >>> 32)), GeoEncodingUtils.decodeLongitude((int) encoded));
-        }
-        return resetFromIndexHash(Long.parseLong(field.stringValue()));
-    }
-
     public GeoPoint resetFromGeoHash(String geohash) {
         final long hash;
         try {
@@ -216,7 +197,12 @@ public class GeoPoint implements SpatialPoint, ToXContentFragment {
 
     /** reset the point using Lucene encoded format used to stored points as doc values */
     public GeoPoint resetFromEncoded(long encoded) {
-        return reset(GeoEncodingUtils.decodeLatitude((int) (encoded >>> 32)), GeoEncodingUtils.decodeLongitude((int) encoded));
+        return resetFromEncoded((int) (encoded >>> 32), (int) encoded);
+    }
+
+    /** reset the point using Lucene encoded format for lat and lon */
+    public GeoPoint resetFromEncoded(int encodedLat, int encodedLon) {
+        return reset(GeoEncodingUtils.decodeLatitude(encodedLat), GeoEncodingUtils.decodeLongitude(encodedLon));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -11,8 +11,9 @@ package org.elasticsearch.search.suggest.completion.context;
 import org.apache.lucene.document.LatLonDocValuesField;
 import org.apache.lucene.document.LatLonPoint;
 import org.apache.lucene.document.StringField;
-import org.apache.lucene.index.DocValuesType;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.util.BytesRef;
+import org.apache.lucene.util.NumericUtils;
 import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.geo.GeoPoint;
@@ -177,30 +178,20 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
         if (fieldName != null) {
             IndexableField[] fields = document.getFields(fieldName);
             GeoPoint spare = new GeoPoint();
-            if (fields.length == 0) {
-                IndexableField[] lonFields = document.getFields(fieldName + ".lon");
-                IndexableField[] latFields = document.getFields(fieldName + ".lat");
-                if (lonFields.length > 0 && latFields.length > 0) {
-                    for (int i = 0; i < lonFields.length; i++) {
-                        IndexableField lonField = lonFields[i];
-                        IndexableField latField = latFields[i];
-                        assert lonField.fieldType().docValuesType() == latField.fieldType().docValuesType();
-                        // we write doc values fields differently: one field for all values, so we need to only care about indexed fields
-                        if (lonField.fieldType().docValuesType() == DocValuesType.NONE) {
-                            spare.reset(latField.numericValue().doubleValue(), lonField.numericValue().doubleValue());
-                            geohashes.add(stringEncode(spare.getLon(), spare.getLat(), precision));
-                        }
-                    }
-                }
-            } else {
-                for (IndexableField field : fields) {
-                    if (field instanceof StringField) {
-                        spare.resetFromString(field.stringValue());
-                        geohashes.add(spare.geohash());
-                    } else if (field instanceof LatLonPoint || field instanceof LatLonDocValuesField) {
-                        spare.resetFromIndexableField(field);
-                        geohashes.add(spare.geohash());
-                    }
+            for (IndexableField field : fields) {
+                if (field instanceof StringField) {
+                    spare.resetFromString(field.stringValue());
+                    geohashes.add(spare.geohash());
+                } else if (field instanceof LatLonDocValuesField) {
+                    spare.resetFromEncoded(field.numericValue().longValue());
+                    geohashes.add(spare.geohash());
+                } else if (field instanceof LatLonPoint) {
+                    BytesRef bytes = field.binaryValue();
+                    spare.reset(
+                        NumericUtils.sortableBytesToInt(bytes.bytes, bytes.offset),
+                        NumericUtils.sortableBytesToInt(bytes.bytes, bytes.offset + Integer.BYTES)
+                    );
+                    geohashes.add(spare.geohash());
                 }
             }
         }


### PR DESCRIPTION
GeoContextMapping is checking for point indexed fields prior to BKD tree. That is being gone for quite a while and it can be removed. In addition this Pr removed #resetFromIndexableField from GeoPoint and gives the responsibility of reading those indexed fields to GeoContextMapping.