### PR TITLE
[8.6] Fix DesiredNodeTests.testDesiredNodeIsCompatible (#94108)

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DesiredNodeTests.java
@@ -208,7 +208,7 @@ public class DesiredNodeTests extends ESTestCase {
         {
             final var desiredNode = new DesiredNode(
                 settings,
-                randomIntBetween(0, 10) + randomDouble(),
+                randomIntBetween(0, 10) + randomDoubleBetween(0.00001, 0.99999, true),
                 ByteSizeValue.ofGb(1),
                 ByteSizeValue.ofGb(1),
                 Version.CURRENT


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Fix DesiredNodeTests.testDesiredNodeIsCompatible (#94108)