### PR TITLE
Fix dynamic mapping detection for invalid dates

### DIFF
--- a/docs/changelog/94115.yaml
+++ b/docs/changelog/94115.yaml
@@ -1,0 +1,6 @@
+pr: 94115
+summary: Fix dynamic mapping detection for invalid dates
+area: Mapping
+type: bug
+issues:
+ - 93888

--- a/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DocumentParser.java
@@ -313,7 +313,7 @@ public final class DocumentParser {
                     break;
                 default:
                     if (token.isValue()) {
-                        parseValue(context, mapper, currentFieldName, token);
+                        parseValue(context, mapper, currentFieldName);
                     }
                     break;
             }
@@ -551,7 +551,7 @@ public final class DocumentParser {
                 throwEOFOnParseArray(mapper, arrayFieldName);
             } else {
                 assert token.isValue();
-                parseValue(context, mapper, lastFieldName, token);
+                parseValue(context, mapper, lastFieldName);
             }
         }
     }
@@ -566,12 +566,8 @@ public final class DocumentParser {
         );
     }
 
-    private static void parseValue(
-        final DocumentParserContext context,
-        ObjectMapper parentMapper,
-        String currentFieldName,
-        XContentParser.Token token
-    ) throws IOException {
+    private static void parseValue(final DocumentParserContext context, ObjectMapper parentMapper, String currentFieldName)
+        throws IOException {
         if (currentFieldName == null) {
             throwOnNoFieldName(context, parentMapper);
         }
@@ -579,7 +575,7 @@ public final class DocumentParser {
         if (mapper != null) {
             parseObjectOrField(context, mapper);
         } else {
-            parseDynamicValue(context, parentMapper, currentFieldName, token);
+            parseDynamicValue(context, parentMapper, currentFieldName);
         }
     }
 
@@ -605,12 +601,8 @@ public final class DocumentParser {
         }
     }
 
-    private static void parseDynamicValue(
-        final DocumentParserContext context,
-        ObjectMapper parentMapper,
-        String currentFieldName,
-        XContentParser.Token token
-    ) throws IOException {
+    private static void parseDynamicValue(final DocumentParserContext context, ObjectMapper parentMapper, String currentFieldName)
+        throws IOException {
         ObjectMapper.Dynamic dynamic = dynamicOrDefault(parentMapper, context);
         if (dynamic == ObjectMapper.Dynamic.STRICT) {
             throw new StrictDynamicMappingException(parentMapper.fullPath(), currentFieldName);
@@ -619,7 +611,7 @@ public final class DocumentParser {
             failIfMatchesRoutingPath(context, parentMapper, currentFieldName);
             return;
         }
-        dynamic.getDynamicFieldsBuilder().createDynamicFieldFromValue(context, token, currentFieldName);
+        dynamic.getDynamicFieldsBuilder().createDynamicFieldFromValue(context, currentFieldName);
     }
 
     private static void failIfMatchesRoutingPath(DocumentParserContext context, ObjectMapper parentMapper, String currentFieldName) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicFieldsBuilder.java
@@ -18,7 +18,7 @@ import org.elasticsearch.script.ScriptCompiler;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
-import java.time.format.DateTimeParseException;
+import java.time.DateTimeException;
 import java.util.Map;
 
 /**
@@ -44,7 +44,8 @@ final class DynamicFieldsBuilder {
      * delegates to the appropriate strategy which depends on the current dynamic mode.
      * The strategy defines if fields are going to be mapped as ordinary or runtime fields.
      */
-    void createDynamicFieldFromValue(final DocumentParserContext context, XContentParser.Token token, String name) throws IOException {
+    void createDynamicFieldFromValue(final DocumentParserContext context, String name) throws IOException {
+        XContentParser.Token token = context.parser().currentToken();
         if (token == XContentParser.Token.VALUE_STRING) {
             String text = context.parser().text();
 
@@ -84,8 +85,8 @@ final class DynamicFieldsBuilder {
                 // `epoch_millis` or `YYYY`
                 for (DateFormatter dateTimeFormatter : context.root().dynamicDateTimeFormatters()) {
                     try {
-                        dateTimeFormatter.parse(text);
-                    } catch (ElasticsearchParseException | DateTimeParseException | IllegalArgumentException e) {
+                        dateTimeFormatter.parseMillis(text);
+                    } catch (DateTimeException | ElasticsearchParseException | IllegalArgumentException e) {
                         // failure to parse this, continue
                         continue;
                     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
@@ -47,7 +47,6 @@ public class DynamicFieldsBuilderTests extends ESTestCase {
                 return parser;
             }
         };
-        ctx.root().numericDetection();
 
         // position the parser on the value
         ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicFieldsBuilderTests.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+
+public class DynamicFieldsBuilderTests extends ESTestCase {
+
+    public void testCreateDynamicField() throws IOException {
+        assertCreateFieldType("f1", "foobar", "text");
+        assertCreateFieldType("f1", "true", "text");
+        assertCreateFieldType("f1", true, "boolean");
+        assertCreateFieldType("f1", 123456, "long");
+        assertCreateFieldType("f1", 123.456, "float");
+        // numeric detection for strings is off by default
+        assertCreateFieldType("f1", "123456", "text");
+        assertCreateFieldType("f1", "2023-02-25", "date");
+        // illegal dates should result in text field mapping
+        assertCreateFieldType("f1", "2023-51", "text");
+    }
+
+    public void assertCreateFieldType(String fieldname, Object value, String expectedType) throws IOException {
+        if (value instanceof String) {
+            value = "\"" + value + "\"";
+        }
+        String source = "{\"" + fieldname + "\": " + value + "}";
+        XContentParser parser = createParser(JsonXContent.jsonXContent, source);
+        SourceToParse sourceToParse = new SourceToParse("test", new BytesArray(source), XContentType.JSON);
+        DocumentParserContext ctx = new TestDocumentParserContext(MappingLookup.EMPTY, sourceToParse) {
+            @Override
+            public XContentParser parser() {
+                return parser;
+            }
+        };
+        ctx.root().numericDetection();
+
+        // position the parser on the value
+        ensureExpectedToken(XContentParser.Token.START_OBJECT, parser.nextToken(), parser);
+        ensureExpectedToken(XContentParser.Token.FIELD_NAME, parser.nextToken(), parser);
+        parser.nextToken();
+        assertTrue(parser.currentToken().isValue());
+        DynamicFieldsBuilder.DYNAMIC_TRUE.createDynamicFieldFromValue(ctx, fieldname);
+        List<Mapper> dynamicMappers = ctx.getDynamicMappers();
+        assertEquals(1, dynamicMappers.size());
+        assertEquals(fieldname, dynamicMappers.get(0).name());
+        assertEquals(expectedType, dynamicMappers.get(0).typeName());
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/TestDocumentParserContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/TestDocumentParserContext.java
@@ -10,7 +10,15 @@ package org.elasticsearch.index.mapper;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.analysis.AnalyzerScope;
+import org.elasticsearch.index.analysis.IndexAnalyzers;
+import org.elasticsearch.index.analysis.NamedAnalyzer;
 import org.elasticsearch.xcontent.XContentParser;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.elasticsearch.index.analysis.AnalysisRegistry.DEFAULT_ANALYZER_NAME;
 
 /**
  * Simplified version of {@link DocumentParserContext} to be used in tests.
@@ -45,7 +53,11 @@ public class TestDocumentParserContext extends DocumentParserContext {
                 Version.CURRENT,
                 () -> null,
                 null,
-                null,
+                new IndexAnalyzers(
+                    Map.of(DEFAULT_ANALYZER_NAME, new NamedAnalyzer("default", AnalyzerScope.INDEX, null)),
+                    Collections.emptyMap(),
+                    Collections.emptyMap()
+                ),
                 MapperTestCase.createIndexSettings(Version.CURRENT, Settings.EMPTY),
                 null
             ),


### PR DESCRIPTION
Invalid dates like "2021-51" are currently detected wrong as date field by the dynamic mapping detection. Trying to parse the invalid value then throws an error and no new mapping is created. The current way of parsing the value via the data formatters "parse" method is not sufficient to trigger an error, but changing this parsing check to "parseMillis" results in a DateTimeException which we then can ignore properly and fall back to the "text" field mapping.

Closes #93888