### PR TITLE
[8.7] Fix maxScore calculation for kNN search (#93875)

### DIFF
--- a/docs/changelog/93875.yaml
+++ b/docs/changelog/93875.yaml
@@ -1,0 +1,5 @@
+pr: 93875
+summary: Fix `maxScore` calculation for kNN search
+area: Vector Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
+++ b/server/src/main/java/org/elasticsearch/search/vectors/KnnScoreDocQuery.java
@@ -121,9 +121,13 @@ class KnnScoreDocQuery extends Query {
 
                     @Override
                     public float getMaxScore(int docId) {
-                        docId += context.docBase;
+                        // NO_MORE_DOCS indicates the maximum score for all docs in this segment
+                        // Anything less than must be accounted for via the docBase.
+                        if (docId != NO_MORE_DOCS) {
+                            docId += context.docBase;
+                        }
                         float maxScore = 0;
-                        for (int idx = Math.max(0, upTo); idx < upper && docs[idx] <= docId; idx++) {
+                        for (int idx = Math.max(lower, upTo); idx < upper && docs[idx] <= docId; idx++) {
                             maxScore = Math.max(maxScore, scores[idx] * boost);
                         }
                         return maxScore;


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Fix maxScore calculation for kNN search (#93875)](https://github.com/elastic/elasticsearch/pull/93875)