### PR TITLE
Enable synthetic source for malformed booleans

### DIFF
--- a/docs/changelog/94121.yaml
+++ b/docs/changelog/94121.yaml
@@ -1,0 +1,5 @@
+pr: 94121
+summary: Enable synthetic source for malformed booleans
+area: Mapping
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -135,7 +135,15 @@ public class BooleanFieldMapper extends FieldMapper {
                 scriptValues(),
                 meta.getValue()
             );
-            return new BooleanFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), context.isSourceSynthetic(),this);        }
+            return new BooleanFieldMapper(
+                name,
+                ft,
+                multiFieldsBuilder.build(this, context),
+                copyTo.build(),
+                context.isSourceSynthetic(),
+                this
+            );
+        }
 
         private FieldValues<Boolean> scriptValues() {
             if (script.get() == null) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BooleanFieldMapper.java
@@ -135,9 +135,7 @@ public class BooleanFieldMapper extends FieldMapper {
                 scriptValues(),
                 meta.getValue()
             );
-
-            return new BooleanFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), this);
-        }
+            return new BooleanFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), context.isSourceSynthetic(),this);        }
 
         private FieldValues<Boolean> scriptValues() {
             if (script.get() == null) {
@@ -377,11 +375,14 @@ public class BooleanFieldMapper extends FieldMapper {
     private final Explicit<Boolean> ignoreMalformed;
     private final boolean ignoreMalformedByDefault;
 
+    private final boolean storeMalformedFields;
+
     protected BooleanFieldMapper(
         String simpleName,
         MappedFieldType mappedFieldType,
         MultiFields multiFields,
         CopyTo copyTo,
+        boolean storeMalformedFields,
         Builder builder
     ) {
         super(simpleName, mappedFieldType, multiFields, copyTo, builder.script.get() != null, builder.onScriptError.getValue());
@@ -395,6 +396,7 @@ public class BooleanFieldMapper extends FieldMapper {
         this.indexCreatedVersion = builder.indexCreatedVersion;
         this.ignoreMalformed = builder.ignoreMalformed.getValue();
         this.ignoreMalformedByDefault = builder.ignoreMalformed.getDefaultValue().value();
+        this.storeMalformedFields = storeMalformedFields;
     }
 
     @Override
@@ -425,6 +427,10 @@ public class BooleanFieldMapper extends FieldMapper {
             } catch (IllegalArgumentException e) {
                 if (ignoreMalformed.value() && context.parser().currentToken().isValue()) {
                     context.addIgnoredField(mappedFieldType.name());
+                    if (storeMalformedFields) {
+                        // Save a copy of the field so synthetic source can load it
+                        context.doc().add(IgnoreMalformedStoredValues.storedField(name(), context.parser()));
+                    }
                 } else {
                     throw e;
                 }
@@ -488,11 +494,6 @@ public class BooleanFieldMapper extends FieldMapper {
         if (copyTo.copyToFields().isEmpty() != true) {
             throw new IllegalArgumentException(
                 "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it declares copy_to"
-            );
-        }
-        if (ignoreMalformed.value()) {
-            throw new IllegalArgumentException(
-                "field [" + name() + "] of type [" + typeName() + "] doesn't support synthetic source because it ignores malformed values"
             );
         }
         return new SortedNumericDocValuesSyntheticFieldLoader(name(), simpleName(), ignoreMalformed.value()) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -214,7 +214,6 @@ public class BooleanFieldMapperTests extends MapperTestCase {
 
     @Override
     protected SyntheticSourceSupport syntheticSourceSupport(boolean ignoreMalformed) {
-        assumeFalse("boolean doesn't support ignore_malformed with synthetic source", ignoreMalformed);
         return new SyntheticSourceSupport() {
             Boolean nullValue = usually() ? null : randomBoolean();
 
@@ -244,6 +243,7 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                 if (nullValue != null) {
                     b.field("null_value", nullValue);
                 }
+                b.field("ignore_malformed", ignoreMalformed);
             }
 
             @Override
@@ -252,10 +252,6 @@ public class BooleanFieldMapperTests extends MapperTestCase {
                     new SyntheticSourceInvalidExample(
                         equalTo("field [field] of type [boolean] doesn't support synthetic source because it doesn't have doc values"),
                         b -> b.field("type", "boolean").field("doc_values", false)
-                    ),
-                    new SyntheticSourceInvalidExample(
-                        equalTo("field [field] of type [boolean] doesn't support synthetic source because it ignores malformed values"),
-                        b -> b.field("type", "boolean").field("ignore_malformed", true)
                     )
                 );
             }


### PR DESCRIPTION
Synthetic source support currently doesn't work for boolean field values when `ignore_malformed` is true.
This change adds this capability and changes the corresponding tests.