### PR TITLE
FileBasedSettings: Wait for readiness port in test

### DIFF
--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -254,6 +254,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
      * @param listener
      */
     public synchronized void addBoundAddressListener(BoundAddressListener listener) {
+        // this expects that setupSocket is called within a synchronized method
         var b = boundAddress();
         if (b != null) {
             listener.addressBound(b);

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -253,7 +253,11 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
      * Add a listener for bound readiness service address.
      * @param listener
      */
-    public void addBoundAddressListener(BoundAddressListener listener) {
+    synchronized public void addBoundAddressListener(BoundAddressListener listener) {
+        var b = boundAddress();
+        if (b != null) {
+            listener.addressBound(b);
+        }
         boundAddressListeners.add(listener);
     }
 

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -253,7 +253,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
      * Add a listener for bound readiness service address.
      * @param listener
      */
-    synchronized public void addBoundAddressListener(BoundAddressListener listener) {
+    public synchronized void addBoundAddressListener(BoundAddressListener listener) {
         var b = boundAddress();
         if (b != null) {
             listener.addressBound(b);


### PR DESCRIPTION
Wait for the readiness port to be bound before probing in `testReadyAfterCorrectFileSettings`.

Fixes: #93903