### PR TITLE
Porting watcher over to BulkProcessor2

### DIFF
--- a/docs/changelog/94133.yaml
+++ b/docs/changelog/94133.yaml
@@ -1,0 +1,5 @@
+pr: 94133
+summary: Porting watcher over to `BulkProcessor2`
+area: Watcher
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
@@ -234,12 +234,13 @@ public class BulkProcessor2 {
      *
      * @param timeout The maximum time to wait for the bulk requests to complete
      * @param unit    The time unit of the {@code timeout} argument
+     * @return True if the bulk processor was able to be closed in the given time, false otherwise
      * @throws InterruptedException If the current thread is interrupted
      */
-    public void awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
+    public boolean awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
         synchronized (mutex) {
             if (closed) {
-                return;
+                return true;
             }
             closed = true;
 
@@ -250,7 +251,7 @@ public class BulkProcessor2 {
             if (bulkRequestUnderConstruction.numberOfActions() > 0) {
                 execute();
             }
-            this.retry.awaitClose(timeout, unit);
+            return this.retry.awaitClose(timeout, unit);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/bulk/Retry2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/Retry2.java
@@ -118,8 +118,9 @@ class Retry2 {
      * listeners.
      * @param timeout
      * @param unit
+     * @return True if all outstanding requests complete in the given time, false otherwise
      */
-    void awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
+    boolean awaitClose(long timeout, TimeUnit unit) throws InterruptedException {
         isClosing = true;
         /*
          * This removes the party that was placed in the phaser at initialization so that the phaser will terminate once all in-flight
@@ -128,8 +129,10 @@ class Retry2 {
         inFlightRequestsPhaser.arriveAndDeregister();
         try {
             inFlightRequestsPhaser.awaitAdvanceInterruptibly(0, timeout, unit);
+            return true;
         } catch (TimeoutException e) {
             logger.debug("Timed out waiting for all requests to complete during awaitClose");
+            return false;
         }
     }
 

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationChecks.java
@@ -91,7 +91,8 @@ public class DeprecationChecks {
                 NodeDeprecationChecks::checkEnforceDefaultTierPreferenceSetting,
                 NodeDeprecationChecks::checkLifecyleStepMasterTimeoutSetting,
                 NodeDeprecationChecks::checkEqlEnabledSetting,
-                NodeDeprecationChecks::checkNodeAttrData
+                NodeDeprecationChecks::checkNodeAttrData,
+                NodeDeprecationChecks::checkWatcherBulkConcurrentRequestsSetting
             );
 
     static List<Function<IndexMetadata, DeprecationIssue>> INDEX_SETTINGS_CHECKS = List.of(

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/NodeDeprecationChecks.java
@@ -944,4 +944,29 @@ public class NodeDeprecationChecks {
             null
         );
     }
+
+    static DeprecationIssue checkWatcherBulkConcurrentRequestsSetting(
+        final Settings settings,
+        final PluginsAndModules pluginsAndModules,
+        final ClusterState clusterState,
+        final XPackLicenseState licenseState
+    ) {
+        Setting<Integer> deprecatedSetting = Setting.intSetting(
+            "xpack.watcher.bulk.concurrent_requests",
+            0,
+            0,
+            20,
+            Setting.Property.NodeScope,
+            Setting.Property.Deprecated
+        );
+        String url = "https://ela.st/es-deprecation-8-watcher-bulk-concurrency-setting";
+        return checkRemovedSetting(
+            clusterState.metadata().settings(),
+            settings,
+            deprecatedSetting,
+            url,
+            "As of 8.8.0 this setting is ignored.",
+            DeprecationIssue.Level.WARNING
+        );
+    }
 }

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
@@ -27,6 +27,7 @@ import static org.elasticsearch.xpack.watcher.client.WatchSourceBuilders.watchBu
 import static org.elasticsearch.xpack.watcher.input.InputBuilders.simpleInput;
 import static org.elasticsearch.xpack.watcher.trigger.TriggerBuilders.schedule;
 import static org.elasticsearch.xpack.watcher.trigger.schedule.Schedules.interval;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.oneOf;
 
@@ -45,6 +46,7 @@ public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTest
         assertThat(putWatchResponse.isCreated(), is(true));
 
         timeWarp().trigger(id);
+
         assertHistoryEntryExecuted(id);
 
         timeWarp().clock().fastForward(TimeValue.timeValueMillis(4000));
@@ -83,31 +85,31 @@ public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTest
         assertTotalHistoryEntries(id, 3);
     }
 
-    private void assertHistoryEntryExecuted(String id) {
-        Map<String, Object> map = assertLatestHistoryEntry(id);
-        String actionStatus = ObjectPath.eval("result.actions.0.status", map);
-        assertThat(actionStatus, is("success"));
+    private void assertHistoryEntryExecuted(String id) throws Exception {
+        assertLatestHistoryEntry(id, "success");
     }
 
-    private void assertHistoryEntryThrottled(String id) {
-        Map<String, Object> map = assertLatestHistoryEntry(id);
-        String actionStatus = ObjectPath.eval("result.actions.0.status", map);
-        assertThat(actionStatus, is("throttled"));
+    private void assertHistoryEntryThrottled(String id) throws Exception {
+        assertLatestHistoryEntry(id, "throttled");
     }
 
-    private Map<String, Object> assertLatestHistoryEntry(String id) {
-        refresh(HistoryStoreField.DATA_STREAM + "*");
+    private void assertLatestHistoryEntry(String id, String expectedValue) throws Exception {
+        assertBusy(() -> {
+            refresh(HistoryStoreField.DATA_STREAM + "*");
 
-        SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
-            .setSize(1)
-            .setSource(new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(termQuery("watch_id", id))))
-            .addSort(SortBuilders.fieldSort("result.execution_time").order(SortOrder.DESC))
-            .get();
-
-        Map<String, Object> map = searchResponse.getHits().getHits()[0].getSourceAsMap();
-        String actionId = ObjectPath.eval("result.actions.0.id", map);
-        assertThat(actionId, is("my-logging-action"));
-        return map;
+            SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
+                .setSize(1)
+                .setSource(new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(termQuery("watch_id", id))))
+                .addSort(SortBuilders.fieldSort("result.execution_time").order(SortOrder.DESC))
+                .get();
+            assertThat(searchResponse.getHits().getHits().length, greaterThan(0));
+            Map<String, Object> map = searchResponse.getHits().getHits()[0].getSourceAsMap();
+            assertNotNull(map);
+            String actionId = ObjectPath.eval("result.actions.0.id", map);
+            assertThat(actionId, is("my-logging-action"));
+            String actionStatus = ObjectPath.eval("result.actions.0.status", map);
+            assertThat(actionStatus, is(expectedValue));
+        });
     }
 
     private void assertTotalHistoryEntries(String id, long expectedCount) {

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
@@ -46,7 +46,6 @@ public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTest
         assertThat(putWatchResponse.isCreated(), is(true));
 
         timeWarp().trigger(id);
-
         assertHistoryEntryExecuted(id);
 
         timeWarp().clock().fastForward(TimeValue.timeValueMillis(4000));

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/ExecutionVarsIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/ExecutionVarsIntegrationTests.java
@@ -133,42 +133,43 @@ public class ExecutionVarsIntegrationTests extends AbstractWatcherIntegrationTes
         timeWarp().trigger(watchId);
 
         flush();
-        refresh();
+        assertBusy(() -> {
+            refresh();
+            SearchResponse searchResponse = searchWatchRecords(builder -> {
+                // defaults to match all;
+            });
 
-        SearchResponse searchResponse = searchWatchRecords(builder -> {
-            // defaults to match all;
-        });
+            assertHitCount(searchResponse, 1L);
 
-        assertHitCount(searchResponse, 1L);
+            Map<String, Object> source = searchResponse.getHits().getAt(0).getSourceAsMap();
 
-        Map<String, Object> source = searchResponse.getHits().getAt(0).getSourceAsMap();
+            assertValue(source, "watch_id", is(watchId));
+            assertValue(source, "state", is("executed"));
 
-        assertValue(source, "watch_id", is(watchId));
-        assertValue(source, "state", is("executed"));
+            // we don't store the computed vars in history
+            assertValue(source, "vars", nullValue());
 
-        // we don't store the computed vars in history
-        assertValue(source, "vars", nullValue());
+            assertValue(source, "result.condition.status", is("success"));
+            assertValue(source, "result.transform.status", is("success"));
 
-        assertValue(source, "result.condition.status", is("success"));
-        assertValue(source, "result.transform.status", is("success"));
-
-        List<Map<String, Object>> actions = ObjectPath.eval("result.actions", source);
-        for (Map<String, Object> action : actions) {
-            String id = (String) action.get("id");
-            switch (id) {
-                case "a1" -> {
-                    assertValue(action, "status", is("success"));
-                    assertValue(action, "transform.status", is("success"));
-                    assertValue(action, "transform.payload.a1_transformed_value", equalTo(25));
+            List<Map<String, Object>> actions = ObjectPath.eval("result.actions", source);
+            for (Map<String, Object> action : actions) {
+                String id = (String) action.get("id");
+                switch (id) {
+                    case "a1" -> {
+                        assertValue(action, "status", is("success"));
+                        assertValue(action, "transform.status", is("success"));
+                        assertValue(action, "transform.payload.a1_transformed_value", equalTo(25));
+                    }
+                    case "a2" -> {
+                        assertValue(action, "status", is("success"));
+                        assertValue(action, "transform.status", is("success"));
+                        assertValue(action, "transform.payload.a2_transformed_value", equalTo(35));
+                    }
+                    default -> fail("there should not be an action result for action with an id other than a1 or a2");
                 }
-                case "a2" -> {
-                    assertValue(action, "status", is("success"));
-                    assertValue(action, "transform.status", is("success"));
-                    assertValue(action, "transform.payload.a2_transformed_value", equalTo(35));
-                }
-                default -> fail("there should not be an action result for action with an id other than a1 or a2");
             }
-        }
+        });
     }
 
     public void testVarsManual() throws Exception {

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -103,9 +103,11 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         new ExecuteWatchRequestBuilder(client()).setId("test_watch").setRecordExecution(true).get();
 
-        refresh(".watcher-history*");
-        SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
-        assertHitCount(searchResponse, 1);
+        assertBusy(() -> {
+            refresh(".watcher-history*");
+            SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
+            assertHitCount(searchResponse, 1);
+        });
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
         GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
@@ -147,9 +149,11 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         new ExecuteWatchRequestBuilder(client()).setId("test_watch").setRecordExecution(true).get();
 
-        refresh(".watcher-history*");
-        SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
-        assertHitCount(searchResponse, 1);
+        assertBusy(() -> {
+            refresh(".watcher-history*");
+            SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
+            assertHitCount(searchResponse, 1);
+        });
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
         GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -71,9 +71,11 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         new ExecuteWatchRequestBuilder(client()).setId("test_watch").setRecordExecution(true).get();
 
-        flushAndRefresh(".watcher-history-*");
-        SearchResponse searchResponse = client().prepareSearch(".watcher-history-*").get();
-        assertHitCount(searchResponse, 1);
+        assertBusy(() -> {
+            flushAndRefresh(".watcher-history-*");
+            SearchResponse searchResponse = client().prepareSearch(".watcher-history-*").get();
+            assertHitCount(searchResponse, 1);
+        });
     }
 
     // See https://github.com/elastic/x-plugins/issues/2913

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/WatchMetadataTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/WatchMetadataTests.java
@@ -79,6 +79,7 @@ public class WatchMetadataTests extends AbstractWatcherIntegrationTestCase {
                     throw e;
                 }
             }
+            assertNotNull(searchResponse);
             assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
         });
     }

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/WatchMetadataTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/WatchMetadataTests.java
@@ -6,6 +6,8 @@
  */
 package org.elasticsearch.xpack.watcher.test.integration;
 
+import org.elasticsearch.action.NoShardAvailableActionException;
+import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.xcontent.ObjectPath;
@@ -62,11 +64,23 @@ public class WatchMetadataTests extends AbstractWatcherIntegrationTestCase {
 
         timeWarp().trigger("_name");
 
-        refresh();
-        SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
-            .setQuery(termQuery("metadata.foo", "bar"))
-            .get();
-        assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+        assertBusy(() -> {
+            refresh();
+            SearchResponse searchResponse;
+            try {
+                searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
+                    .setQuery(termQuery("metadata.foo", "bar"))
+                    .get();
+            } catch (SearchPhaseExecutionException e) {
+                if (e.getCause() instanceof NoShardAvailableActionException) {
+                    // Nothing has created the index yet
+                    searchResponse = null;
+                } else {
+                    throw e;
+                }
+            }
+            assertThat(searchResponse.getHits().getTotalHits().value, greaterThan(0L));
+        });
     }
 
     public void testWatchMetadataAvailableAtExecution() throws Exception {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.bootstrap.BootstrapCheck;
@@ -237,12 +237,14 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         NodeScope
     );
     private static final Setting<Integer> SETTING_BULK_ACTIONS = Setting.intSetting("xpack.watcher.bulk.actions", 1, 1, 10000, NodeScope);
+    @Deprecated(forRemoval = true) // This setting is no longer used
     private static final Setting<Integer> SETTING_BULK_CONCURRENT_REQUESTS = Setting.intSetting(
         "xpack.watcher.bulk.concurrent_requests",
         0,
         0,
         20,
-        NodeScope
+        NodeScope,
+        Setting.Property.Deprecated
     );
     private static final Setting<TimeValue> SETTING_BULK_FLUSH_INTERVAL = Setting.timeSetting(
         "xpack.watcher.bulk.flush_interval",
@@ -269,7 +271,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
     private static final Logger logger = LogManager.getLogger(Watcher.class);
     private WatcherIndexingListener listener;
     private HttpClient httpClient;
-    private BulkProcessor bulkProcessor;
+    private BulkProcessor2 bulkProcessor;
 
     protected final Settings settings;
     protected final boolean enabled;
@@ -413,7 +415,7 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
         final InputRegistry inputRegistry = new InputRegistry(inputFactories);
         inputFactories.put(ChainInput.TYPE, new ChainInputFactory(inputRegistry));
 
-        bulkProcessor = BulkProcessor.builder(new OriginSettingClient(client, WATCHER_ORIGIN)::bulk, new BulkProcessor.Listener() {
+        bulkProcessor = BulkProcessor2.builder(new OriginSettingClient(client, WATCHER_ORIGIN)::bulk, new BulkProcessor2.Listener() {
             @Override
             public void beforeBulk(long executionId, BulkRequest request) {}
 
@@ -462,14 +464,13 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
             }
 
             @Override
-            public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+            public void afterBulk(long executionId, BulkRequest request, Exception failure) {
                 logger.error("error executing bulk", failure);
             }
-        }, "watcher")
+        }, client.threadPool())
             .setFlushInterval(SETTING_BULK_FLUSH_INTERVAL.get(settings))
             .setBulkActions(SETTING_BULK_ACTIONS.get(settings))
             .setBulkSize(SETTING_BULK_SIZE.get(settings))
-            .setConcurrentRequests(SETTING_BULK_CONCURRENT_REQUESTS.get(settings))
             .build();
 
         HistoryStore historyStore = new HistoryStore(bulkProcessor);
@@ -745,9 +746,6 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
 
     @Override
     public void close() throws IOException {
-        if (enabled) {
-            bulkProcessor.flush();
-        }
         IOUtils.closeWhileHandlingException(httpClient);
         try {
             if (enabled && bulkProcessor.awaitClose(10, TimeUnit.SECONDS) == false) {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/ExecutionService.java
@@ -171,7 +171,6 @@ public class ExecutionService {
         assert stoppedListener != null;
         int cancelledTaskCount = executor.queue().drainTo(new ArrayList<>());
         this.clearExecutions(stoppedListener);
-        historyStore.flush();
         return cancelledTaskCount;
     }
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStore.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStore.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -61,9 +61,9 @@ public class TriggeredWatchStore {
 
     private final TimeValue defaultBulkTimeout;
     private final TimeValue defaultSearchTimeout;
-    private final BulkProcessor bulkProcessor;
+    private final BulkProcessor2 bulkProcessor;
 
-    public TriggeredWatchStore(Settings settings, Client client, TriggeredWatch.Parser triggeredWatchParser, BulkProcessor bulkProcessor) {
+    public TriggeredWatchStore(Settings settings, Client client, TriggeredWatch.Parser triggeredWatchParser, BulkProcessor2 bulkProcessor) {
         this.scrollSize = settings.getAsInt("xpack.watcher.execution.scroll.size", 1000);
         this.client = ClientHelper.clientWithOrigin(client, WATCHER_ORIGIN);
         this.scrollTimeout = settings.getAsTime("xpack.watcher.execution.scroll.timeout", TimeValue.timeValueMinutes(5));

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/history/HistoryStore.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/history/HistoryStore.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.watcher.history;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.DocWriteRequest;
-import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -28,9 +28,9 @@ public class HistoryStore {
 
     private static final Logger logger = LogManager.getLogger(HistoryStore.class);
 
-    private final BulkProcessor bulkProcessor;
+    private final BulkProcessor2 bulkProcessor;
 
-    public HistoryStore(BulkProcessor bulkProcessor) {
+    public HistoryStore(BulkProcessor2 bulkProcessor) {
         this.bulkProcessor = bulkProcessor;
     }
 
@@ -79,9 +79,5 @@ public class HistoryStore {
         return indexMetadata == null
             || (indexMetadata.getState() == IndexMetadata.State.OPEN
                 && state.routingTable().index(indexMetadata.getIndex()).allPrimaryShardsActive());
-    }
-
-    public void flush() {
-        bulkProcessor.flush();
     }
 }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/execution/TriggeredWatchStoreTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.action.admin.indices.refresh.RefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.RefreshResponse;
 import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexResponse;
@@ -102,7 +102,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
     private TriggeredWatch.Parser parser;
     private TriggeredWatchStore triggeredWatchStore;
     private final Map<BulkRequest, BulkResponse> bulks = new LinkedHashMap<>();
-    private BulkProcessor.Listener listener = new BulkProcessor.Listener() {
+    private BulkProcessor2.Listener listener = new BulkProcessor2.Listener() {
         @Override
         public void beforeBulk(long executionId, BulkRequest request) {}
 
@@ -112,7 +112,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         }
 
         @Override
-        public void afterBulk(long executionId, BulkRequest request, Throwable failure) {
+        public void afterBulk(long executionId, BulkRequest request, Exception failure) {
             throw new ElasticsearchException(failure);
         }
     };
@@ -126,10 +126,7 @@ public class TriggeredWatchStoreTests extends ESTestCase {
         when(client.settings()).thenReturn(settings);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(Settings.EMPTY));
         parser = mock(TriggeredWatch.Parser.class);
-        BulkProcessor bulkProcessor = BulkProcessor.builder(client::bulk, listener, "TriggeredWatchStoreTests")
-            .setConcurrentRequests(0)
-            .setBulkActions(1)
-            .build();
+        BulkProcessor2 bulkProcessor = BulkProcessor2.builder(client::bulk, listener, client.threadPool()).setBulkActions(1).build();
         triggeredWatchStore = new TriggeredWatchStore(settings, client, parser, bulkProcessor);
     }
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryStoreTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/history/HistoryStoreTests.java
@@ -11,7 +11,7 @@ import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest.OpType;
 import org.elasticsearch.action.bulk.BulkItemResponse;
-import org.elasticsearch.action.bulk.BulkProcessor;
+import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
@@ -71,11 +71,8 @@ public class HistoryStoreTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
         when(client.settings()).thenReturn(settings);
         when(threadPool.getThreadContext()).thenReturn(new ThreadContext(settings));
-        BulkProcessor.Listener listener = mock(BulkProcessor.Listener.class);
-        BulkProcessor bulkProcessor = BulkProcessor.builder(client::bulk, listener, "HistoryStoreTests")
-            .setConcurrentRequests(0)
-            .setBulkActions(1)
-            .build();
+        BulkProcessor2.Listener listener = mock(BulkProcessor2.Listener.class);
+        BulkProcessor2 bulkProcessor = BulkProcessor2.builder(client::bulk, listener, threadPool).setBulkActions(1).build();
         historyStore = new HistoryStore(bulkProcessor);
     }
 

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/60_watcher.yml
@@ -48,21 +48,6 @@
   - match: { _id: "my_watch" }
   - match: { status.state.active: true }
 
-  # check watch history entry
-  - do:
-      indices.refresh:
-        index: .watcher-history-*
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        index: .watcher-history-*
-        body:
-          {
-            "query": { "term": { "_id": "$record_id" } }
-          }
-  - match: { hits.total: 1 }
-
 ---
 "Test watcher stats output":
   - do:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/old_cluster/60_watcher.yml
@@ -50,21 +50,6 @@
   - match: { watch_record.status.execution_state: "executed" }
   - match: { watch_record.status.state.active: true }
 
-  # check watch history entry
-  - do:
-      indices.refresh:
-        index: .watcher-history-*
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        index: .watcher-history-*
-        body:
-          {
-            "query" : { "term" : { "_id" : "$record_id" } }
-          }
-  - match: { hits.total: 1 }
-
   # deactivate watch, check with GET API as well
   - do:
       watcher.deactivate_watch:

--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/upgraded_cluster/60_watcher.yml
@@ -22,21 +22,6 @@
   - match: { watch_record.status.execution_state: "executed" }
   - match: { watch_record.status.state.active: true }
 
-  # check watch history entry
-  - do:
-      indices.refresh:
-        index: .watcher-history-*
-
-  - do:
-      search:
-        rest_total_hits_as_int: true
-        index: .watcher-history-*
-        body:
-          {
-            "query" : { "term" : { "_id" : "$record_id" } }
-          }
-  - match: { hits.total: 1 }
-
   # deactivate watch, check with GET API as well
   - do:
       watcher.deactivate_watch:


### PR DESCRIPTION
In #91238 we rewrote BulkProcessor to avoid deadlock that had been seen in the IlmHistoryStore. This PR ports watcher over to the new BulkProcessor2 implementation. The only real change is that watcher history documents are now indexed asynchronously instead of in a blocking way, meaning that tests had to change to account for this.