### PR TITLE
Increase the merge factor to 32 for time-based data.

### DIFF
--- a/docs/changelog/94134.yaml
+++ b/docs/changelog/94134.yaml
@@ -1,0 +1,5 @@
+pr: 94134
+summary: Increase the merge factor to 32 for time-based data
+area: Engine
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
+++ b/server/src/main/java/org/elasticsearch/index/MergePolicyConfig.java
@@ -120,13 +120,13 @@ public final class MergePolicyConfig {
     public static final ByteSizeValue DEFAULT_MAX_TIME_BASED_MERGED_SEGMENT = new ByteSizeValue(100, ByteSizeUnit.GB);
     public static final double DEFAULT_SEGMENTS_PER_TIER = 10.0d;
     /**
-     * A default value for {@link LogByteSizeMergePolicy}'s merge factor: 16. This default value differs from the Lucene default of 10 in
-     * order to account for the fact that Elasticsearch uses {@link LogByteSizeMergePolicy} for time-based data, where it usually makes
-     * sense to merge data less aggressively, and because {@link LogByteSizeMergePolicy} merges segments more aggressively than
-     * {@link TieredMergePolicy} for the same number of segments per tier / merge factor because {@link TieredMergePolicy} makes decisions
-     * at the whole index level, while {@link LogByteSizeMergePolicy} makes decisions on a per-tier basis.
+     * A default value for {@link LogByteSizeMergePolicy}'s merge factor: 32. This default value differs from the Lucene default of 10 in
+     * order to account for the fact that Elasticsearch uses {@link LogByteSizeMergePolicy} for time-based data, where adjacent segment
+     * merging ensures that segments have mostly non-overlapping time ranges if data gets ingested in timestamp order. In turn, this allows
+     * range queries on the timestamp to remain efficient with high numbers of segments since most segments either don't match the query
+     * range or are fully contained by the query range.
      */
-    public static final int DEFAULT_MERGE_FACTOR = 16;
+    public static final int DEFAULT_MERGE_FACTOR = 32;
     public static final double DEFAULT_DELETES_PCT_ALLOWED = 20.0d;
     private static final String INDEX_COMPOUND_FORMAT_SETTING_KEY = "index.compound_format";
     public static final Setting<CompoundFileThreshold> INDEX_COMPOUND_FORMAT_SETTING = new Setting<>(

--- a/server/src/test/java/org/elasticsearch/index/MergePolicyConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/index/MergePolicyConfigTests.java
@@ -113,10 +113,7 @@ public class MergePolicyConfigTests extends ESTestCase {
         );
         assertThat(indexSettings.getMergePolicy(randomBoolean()), Matchers.instanceOf(TieredMergePolicy.class));
         indexSettings.updateIndexMetadata(
-            newIndexMeta(
-                "index",
-                Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_TYPE_SETTING.getKey(), "time_based").build()
-            )
+            newIndexMeta("index", Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_TYPE_SETTING.getKey(), "time_based").build())
         );
         assertThat(indexSettings.getMergePolicy(randomBoolean()), Matchers.instanceOf(LogByteSizeMergePolicy.class));
     }

--- a/server/src/test/java/org/elasticsearch/index/MergePolicyConfigTests.java
+++ b/server/src/test/java/org/elasticsearch/index/MergePolicyConfigTests.java
@@ -115,7 +115,7 @@ public class MergePolicyConfigTests extends ESTestCase {
         indexSettings.updateIndexMetadata(
             newIndexMeta(
                 "index",
-                Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_TYPE_SETTING.getKey(), "log_byte_size").build()
+                Settings.builder().put(MergePolicyConfig.INDEX_MERGE_POLICY_TYPE_SETTING.getKey(), "time_based").build()
             )
         );
         assertThat(indexSettings.getMergePolicy(randomBoolean()), Matchers.instanceOf(LogByteSizeMergePolicy.class));


### PR DESCRIPTION
This is a follow-up to #92684. #92684 switched from `TieredMergePolicy` to `LogByteSizeMergePolicy` for time-based data, trying to retain similar numbers of segments in shards. This change goes further, and takes advantage of the fact that adjacent segment merging gives segments (mostly) non-overlapping time ranges, to reduce merging overhead without hurting the efficiency of range queries on the timestamp field.

In general the trade-off of this change is that it yields:
 - Faster ingestion thanks to reduced merging overhead.
 - Similar performance for range queries on the timestamp field.
 - Very slightly degraded performance of term queries due to the increased number of segments. This should be hardly noticeable in most cases.
 - Possibly degraded performance of fuzzy, wildcard queries, as well as range queries on other fields than the timestamp field.