### PR TITLE
Add template not found exception support.

### DIFF
--- a/docs/changelog/94135.yaml
+++ b/docs/changelog/94135.yaml
@@ -1,0 +1,5 @@
+pr: 94135
+summary: Add template not found exception support.
+area: Template API
+type: enhancement
+issues: [93125]

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/IndexTemplateNotFoundIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/IndexTemplateNotFoundIT.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.template;
+
+import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesResponse;
+import org.elasticsearch.action.admin.indices.template.get.TemplateNotFoundException;
+import org.elasticsearch.test.ESSingleNodeTestCase;
+
+import java.util.Collections;
+
+public class IndexTemplateNotFoundIT extends ESSingleNodeTestCase {
+
+    public void testTemplateNotFound() {
+        getNotFoundTemplateWithException("template_not_found", "template_not_found");
+
+        createTemplate("template_1");
+        createTemplate("template_2");
+
+        assertEquals("template_1",
+            getTemplate("template_1").getIndexTemplates().get(0).getName());
+
+        assertEquals(2, getTemplate("template_*").getIndexTemplates().size());
+
+        getNotFoundTemplateWithException("template_not_found", "template_1", "template_2", "template_not_found");
+    }
+
+    private void getNotFoundTemplateWithException(String notFoundTemplate, String... name) {
+        // expect exception throws
+        expectThrows(TemplateNotFoundException.class,
+            () -> getTemplate(name));
+
+        // expect exception message correct
+        try {
+            getTemplate(name);
+        } catch (TemplateNotFoundException e) {
+            assertEquals(notFoundTemplate, e.getTemplate());
+            assertEquals("no such template [" + notFoundTemplate +"]", e.getMessage());
+        }
+    }
+
+    private void createTemplate(String template) {
+        client().admin().indices().preparePutTemplate(template)
+            .setPatterns(Collections.singletonList("te*"))
+            .setMapping("type", "type=keyword", "field", "type=text").get();
+    }
+
+    private GetIndexTemplatesResponse getTemplate(String... name) {
+        return client().admin().indices().prepareGetTemplates(name).get();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch;
 
+import org.elasticsearch.action.admin.indices.template.get.TemplateNotFoundException;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -74,6 +75,7 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     private static final String SHARD_METADATA_KEY = "es.shard";
     private static final String RESOURCE_METADATA_TYPE_KEY = "es.resource.type";
     private static final String RESOURCE_METADATA_ID_KEY = "es.resource.id";
+    private static final String TEMPLATE_METADATA_KEY = "es.template";
 
     private static final String TYPE = "type";
     private static final String REASON = "reason";
@@ -1580,6 +1582,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             UnsupportedAggregationOnDownsampledIndex::new,
             167,
             TransportVersion.V_8_5_0
+        ),
+        TEMPLATE_NOT_FOUND_EXCEPTION(
+            TemplateNotFoundException.class,
+            TemplateNotFoundException::new,
+            168,
+            TransportVersion.V_8_8_0
         );
 
         final Class<? extends ElasticsearchException> exceptionClass;
@@ -1634,6 +1642,14 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
         );
     }
 
+    public String getTemplate() {
+        List<String> template = getMetadata(TEMPLATE_METADATA_KEY);
+        if (template != null && template.isEmpty() == false) {
+            return template.get(0);
+        }
+        return null;
+    }
+
     public Index getIndex() {
         List<String> index = getMetadata(INDEX_METADATA_KEY);
         if (index != null && index.isEmpty() == false) {
@@ -1650,6 +1666,12 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
             return new ShardId(getIndex(), Integer.parseInt(shard.get(0)));
         }
         return null;
+    }
+
+    public void setTemplate(String template) {
+        if (template != null) {
+            addMetadata(TEMPLATE_METADATA_KEY, template);
+        }
     }
 
     public void setIndex(Index index) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TemplateNotFoundException.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TemplateNotFoundException.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.action.admin.indices.template.get;
+
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.common.io.stream.StreamInput;
+
+import java.io.IOException;
+
+public final class TemplateNotFoundException extends ResourceNotFoundException {
+
+    public TemplateNotFoundException(String template) {
+        this(template, null);
+    }
+
+    public TemplateNotFoundException(String template, Throwable cause) {
+        super("no such template [" + template + "]", cause);
+        setTemplate(template);
+    }
+
+    public TemplateNotFoundException(StreamInput in) throws IOException {
+        super(in);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/TransportGetIndexTemplatesAction.java
@@ -79,6 +79,8 @@ public class TransportGetIndexTemplatesAction extends TransportMasterNodeReadAct
                 }
             } else if (state.metadata().templates().containsKey(name)) {
                 results.add(state.metadata().templates().get(name));
+            } else {
+                listener.onFailure(new TemplateNotFoundException(name));
             }
         }
 


### PR DESCRIPTION
This PR is going to fix https://github.com/elastic/elasticsearch/issues/93125.
Support template not found exception in `_cat/template` and `_template` API.