### PR TITLE
feat: optimize AsyncFetch cache with init size

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -159,7 +159,7 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
         void start() {
             try {
                 for (Tuple<ShardId, String> shard : shards) {
-                    new InternalAsyncFetch(logger, "shard_stores", shard.v1(), shard.v2(), this.nodes.getSize()).fetchData(
+                    new InternalAsyncFetch(logger, "shard_stores", shard.v1(), shard.v2(), routingNodes.size()).fetchData(
                         nodes,
                         Collections.emptySet()
                     );
@@ -187,8 +187,8 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
 
             private final Releasable ref = refs.acquire();
 
-            InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath, int nodeNumber) {
-                super(logger, type, shardId, customDataPath, nodeNumber);
+            InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath, int expectedSize) {
+                super(logger, type, shardId, customDataPath, expectedSize);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresAction.java
@@ -159,7 +159,10 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
         void start() {
             try {
                 for (Tuple<ShardId, String> shard : shards) {
-                    new InternalAsyncFetch(logger, "shard_stores", shard.v1(), shard.v2()).fetchData(nodes, Collections.emptySet());
+                    new InternalAsyncFetch(logger, "shard_stores", shard.v1(), shard.v2(), this.nodes.getSize()).fetchData(
+                        nodes,
+                        Collections.emptySet()
+                    );
                 }
             } finally {
                 refs.close();
@@ -184,8 +187,8 @@ public class TransportIndicesShardStoresAction extends TransportMasterNodeReadAc
 
             private final Releasable ref = refs.acquire();
 
-            InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath) {
-                super(logger, type, shardId, customDataPath);
+            InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath, int nodeNumber) {
+                super(logger, type, shardId, customDataPath, nodeNumber);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.support.nodes.BaseNodesResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
@@ -60,13 +61,13 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     private volatile int fetchingCount;
 
     @SuppressWarnings("unchecked")
-    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, String customDataPath, int nodeNumber) {
+    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, String customDataPath, int expectedSize) {
         this.logger = logger;
         this.type = type;
         this.shardId = Objects.requireNonNull(shardId);
         this.customDataPath = Objects.requireNonNull(customDataPath);
         this.fetchingCount = 0;
-        this.cache = new HashMap<>(nodeNumber);
+        this.cache = Maps.newHashMapWithExpectedSize(expectedSize);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -53,19 +53,20 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     protected final String type;
     protected final ShardId shardId;
     protected final String customDataPath;
-    private final Map<String, NodeEntry<T>> cache = new HashMap<>();
+    private final Map<String, NodeEntry<T>> cache;
     private final Set<String> nodesToIgnore = new HashSet<>();
     private final AtomicLong round = new AtomicLong();
     private boolean closed;
     private volatile int fetchingCount;
 
     @SuppressWarnings("unchecked")
-    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, String customDataPath) {
+    protected AsyncShardFetch(Logger logger, String type, ShardId shardId, String customDataPath, int nodeNumber) {
         this.logger = logger;
         this.type = type;
         this.shardId = Objects.requireNonNull(shardId);
         this.customDataPath = Objects.requireNonNull(customDataPath);
         this.fetchingCount = 0;
+        this.cache = new HashMap<>(nodeNumber);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -213,8 +213,8 @@ public class GatewayAllocator implements ExistingShardsAllocator {
 
     abstract class InternalAsyncFetch<T extends BaseNodeResponse> extends AsyncShardFetch<T> {
 
-        InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath, int nodeNumber) {
-            super(logger, type, shardId, customDataPath, nodeNumber);
+        InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath, int expectedSize) {
+            super(logger, type, shardId, customDataPath, expectedSize);
         }
 
         @Override
@@ -250,7 +250,7 @@ public class GatewayAllocator implements ExistingShardsAllocator {
                     "shard_started",
                     shardId,
                     IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings()),
-                    allocation.nodes().getSize()
+                    allocation.routingNodes().size()
                 ) {
                     @Override
                     protected void list(
@@ -297,7 +297,7 @@ public class GatewayAllocator implements ExistingShardsAllocator {
                     "shard_store",
                     shard.shardId(),
                     IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings()),
-                    allocation.nodes().getSize()
+                    allocation.routingNodes().size()
                 ) {
                     @Override
                     protected void list(

--- a/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
+++ b/server/src/main/java/org/elasticsearch/gateway/GatewayAllocator.java
@@ -213,8 +213,8 @@ public class GatewayAllocator implements ExistingShardsAllocator {
 
     abstract class InternalAsyncFetch<T extends BaseNodeResponse> extends AsyncShardFetch<T> {
 
-        InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath) {
-            super(logger, type, shardId, customDataPath);
+        InternalAsyncFetch(Logger logger, String type, ShardId shardId, String customDataPath, int nodeNumber) {
+            super(logger, type, shardId, customDataPath, nodeNumber);
         }
 
         @Override
@@ -249,7 +249,8 @@ public class GatewayAllocator implements ExistingShardsAllocator {
                     logger,
                     "shard_started",
                     shardId,
-                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings())
+                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings()),
+                    allocation.nodes().getSize()
                 ) {
                     @Override
                     protected void list(
@@ -295,7 +296,8 @@ public class GatewayAllocator implements ExistingShardsAllocator {
                     logger,
                     "shard_store",
                     shard.shardId(),
-                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings())
+                    IndexMetadata.INDEX_DATA_PATH_SETTING.get(allocation.metadata().index(shard.index()).getSettings()),
+                    allocation.nodes().getSize()
                 ) {
                     @Override
                     protected void list(

--- a/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -427,7 +427,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         private final AtomicInteger reroute = new AtomicInteger();
 
         TestFetch(ThreadPool threadPool) {
-            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "");
+            super(LogManager.getLogger(TestFetch.class), "test", new ShardId("test", "_na_", 1), "", 2);
             this.threadPool = threadPool;
         }
 


### PR DESCRIPTION
At most of times, we know the cache size of the AsyncFetch. But we don't use this information for speed up the cache allocation. When we have lots of nodes, cache resize is time consuming. For example, when we have 200 nodes, and with 0.75 HashMap load factor, we might need more than 7 times HashMap resize to get an array with length 512.
In this change, we will init cache with size of nodes that we know already. It's might not very correct but can't be worse, I think