### PR TITLE
Propagate timestamp format and convert nanoseconds to milliseconds

### DIFF
--- a/docs/changelog/94141.yaml
+++ b/docs/changelog/94141.yaml
@@ -1,0 +1,6 @@
+pr: 94141
+summary: Propagate timestamp format and convert nanoseconds to milliseconds
+area: Rollup
+type: bug
+issues:
+ - 94085

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -751,3 +751,110 @@ setup:
   - match: { rollup-test-timestamp.mappings.properties.@timestamp.format: "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSX" }
   - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.fixed_interval: 1h }
   - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.time_zone: UTC }
+
+---
+"Downsample using coarse grained timestamp":
+  - skip:
+      version: " - 8.6.99"
+      reason: "Downsample GA version 8.7.0"
+
+  - do:
+      indices.create:
+        index: test-timestamp-daily
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              mode: time_series
+              routing_path: [ metricset, k8s.pod.uid ]
+              time_series:
+                start_time: 2023-02-23T00:00:00Z
+                end_time: 2023-02-27T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+                format: "uuuu-MM-dd"
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      value:
+                        type: integer
+                        time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test-timestamp-daily
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 10 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-24", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 12 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-25", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 8 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-26", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 9 }}}'
+
+  - do:
+      indices.put_settings:
+        index: test-timestamp-daily
+        body:
+          index.blocks.write: true
+
+  - is_true: acknowledged
+
+  - do:
+      indices.downsample:
+        index: test-timestamp-daily
+        target_index: rollup-test-timestamp-hourly
+        body: >
+          {
+            "fixed_interval": "1h"
+          }
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: rollup-test-timestamp-hourly
+        body:
+          sort: [ "_tsid", "@timestamp" ]
+
+  - length: { hits.hits: 4 }
+  - match: { hits.hits.0._source._doc_count: 1 }
+  - match: { hits.hits.0._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.0._source.metricset: pod }
+  - match: { hits.hits.0._source.@timestamp: 2023-02-23 }
+  - match: { hits.hits.0._source.k8s.pod.value.min: 10.0 }
+  - match: { hits.hits.0._source.k8s.pod.value.max: 10.0 }
+  - match: { hits.hits.0._source.k8s.pod.value.sum: 10.0 }
+  - match: { hits.hits.1._source._doc_count: 1 }
+  - match: { hits.hits.1._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.1._source.metricset: pod }
+  - match: { hits.hits.1._source.@timestamp: 2023-02-24 }
+  - match: { hits.hits.1._source.k8s.pod.value.min: 12.0 }
+  - match: { hits.hits.1._source.k8s.pod.value.max: 12.0 }
+  - match: { hits.hits.1._source.k8s.pod.value.sum: 12.0 }
+  - match: { hits.hits.2._source._doc_count: 1 }
+  - match: { hits.hits.2._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.2._source.metricset: pod }
+  - match: { hits.hits.2._source.@timestamp: 2023-02-25 }
+  - match: { hits.hits.2._source.k8s.pod.value.min: 8.0 }
+  - match: { hits.hits.2._source.k8s.pod.value.max: 8.0 }
+  - match: { hits.hits.2._source.k8s.pod.value.sum: 8.0 }
+  - match: { hits.hits.3._source._doc_count: 1 }
+  - match: { hits.hits.3._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.3._source.metricset: pod }
+  - match: { hits.hits.3._source.@timestamp: 2023-02-26 }
+  - match: { hits.hits.3._source.k8s.pod.value.min: 9.0 }
+  - match: { hits.hits.3._source.k8s.pod.value.max: 9.0 }
+  - match: { hits.hits.3._source.k8s.pod.value.sum: 9.0 }

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -753,6 +753,109 @@ setup:
   - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.time_zone: UTC }
 
 ---
+"Downsample date timestamp field using strict_date_optional_time_nanos format":
+  - skip:
+      version: " - 8.7.99"
+      reason: "Bug fixed in 8.8.0"
+
+  - do:
+      indices.create:
+        index: test-timestamp
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              mode: time_series
+              routing_path: [ metricset, k8s.pod.uid ]
+              time_series:
+                start_time: 2023-02-23T00:00:00Z
+                end_time: 2023-02-24T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+                format: strict_date_optional_time_nanos
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      value:
+                        type: integer
+                        time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test-timestamp
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T12:47:14.622Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 10 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T12:52:21.615Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 12 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T12:57:34.567Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 8 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T13:02:52.323Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 9 }}}'
+
+  - do:
+      indices.put_settings:
+        index: test-timestamp
+        body:
+          index.blocks.write: true
+
+  - is_true: acknowledged
+
+  - do:
+      indices.downsample:
+        index: test-timestamp
+        target_index: rollup-test-timestamp
+        body: >
+          {
+            "fixed_interval": "1h"
+          }
+
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: rollup-test-timestamp
+        body:
+          sort: [ "_tsid", "@timestamp" ]
+
+  - length: { hits.hits: 2 }
+  - match: { hits.hits.0._source._doc_count: 3 }
+  - match: { hits.hits.0._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.0._source.metricset: pod }
+  - match: { hits.hits.0._source.@timestamp: 2023-02-23T12:00:00.000Z }
+  - match: { hits.hits.0._source.k8s.pod.value.min: 8.0 }
+  - match: { hits.hits.0._source.k8s.pod.value.max: 12.0 }
+  - match: { hits.hits.0._source.k8s.pod.value.sum: 30.0 }
+  - match: { hits.hits.1._source._doc_count: 1 }
+  - match: { hits.hits.1._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.1._source.metricset: pod }
+  - match: { hits.hits.1._source.@timestamp: 2023-02-23T13:00:00.000Z }
+  - match: { hits.hits.1._source.k8s.pod.value.min: 9.0 }
+  - match: { hits.hits.1._source.k8s.pod.value.max: 9.0 }
+  - match: { hits.hits.1._source.k8s.pod.value.sum: 9.0 }
+
+  - do:
+      indices.get_mapping:
+        index: rollup-test-timestamp
+
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.type: date }
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.format: strict_date_optional_time_nanos }
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.fixed_interval: 1h }
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.time_zone: UTC }
+
+---
 "Downsample using coarse grained timestamp":
   - skip:
       version: " - 8.6.99"

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -700,7 +700,7 @@ setup:
           - '{"index": {}}'
           - '{"@timestamp": "2023-02-23T12:57:34.567776432Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 8 }}}'
           - '{"index": {}}'
-          - '{"@timestamp": "2023-02-23T13:02:52.3233412122Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 9 }}}'
+          - '{"@timestamp": "2023-02-23T13:02:52.323341212Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 9 }}}'
 
   - do:
       indices.put_settings:
@@ -727,7 +727,7 @@ setup:
         body:
           sort: [ "_tsid", "@timestamp" ]
 
-  - length: { hits.hits: 1 }
+  - length: { hits.hits: 2 }
   - match: { hits.hits.0._source._doc_count: 3 }
   - match: { hits.hits.0._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
   - match: { hits.hits.0._source.metricset: pod }
@@ -735,6 +735,13 @@ setup:
   - match: { hits.hits.0._source.k8s.pod.value.min: 8.0 }
   - match: { hits.hits.0._source.k8s.pod.value.max: 12.0 }
   - match: { hits.hits.0._source.k8s.pod.value.sum: 30.0 }
+  - match: { hits.hits.1._source._doc_count: 1 }
+  - match: { hits.hits.1._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.1._source.metricset: pod }
+  - match: { hits.hits.1._source.@timestamp: 2023-02-23T13:00:00.000000000Z }
+  - match: { hits.hits.1._source.k8s.pod.value.min: 9.0 }
+  - match: { hits.hits.1._source.k8s.pod.value.max: 9.0 }
+  - match: { hits.hits.1._source.k8s.pod.value.sum: 9.0 }
 
   - do:
       indices.get_mapping:

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -648,3 +648,99 @@ setup:
   - match:  { hits.hits.3._source.k8s.pod.latency.values.1: 10.0 }
   - match:  { hits.hits.3._source.k8s.pod.latency.values.2: 100.0 }
   - match:  { hits.hits.3._source.k8s.pod.latency.values.3: 1000.0 }
+
+---
+"Downsample date_nanos timestamp field using custom format":
+  - skip:
+      version: " - 8.7.99"
+      reason: "Bug fixed in 8.8.0"
+
+  - do:
+      indices.create:
+        index: test-timestamp
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              mode: time_series
+              routing_path: [ metricset, k8s.pod.uid ]
+              time_series:
+                start_time: 2023-02-23T00:00:00Z
+                end_time: 2023-02-24T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date_nanos
+                format: "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSX"
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              k8s:
+                properties:
+                  pod:
+                    properties:
+                      uid:
+                        type: keyword
+                        time_series_dimension: true
+                      name:
+                        type: keyword
+                      value:
+                        type: integer
+                        time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test-timestamp
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T12:47:14.622123123Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 10 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T12:52:21.615662688Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 12 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T12:57:34.567776432Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 8 }}}'
+          - '{"index": {}}'
+          - '{"@timestamp": "2023-02-23T13:02:52.3233412122Z", "metricset": "pod", "k8s": {"pod": {"name": "cat", "uid":"947e4ced-1786-4e53-9e0c-5c447e959507", "value": 9 }}}'
+
+  - do:
+      indices.put_settings:
+        index: test-timestamp
+        body:
+          index.blocks.write: true
+
+  - is_true: acknowledged
+
+  - do:
+      indices.downsample:
+        index: test-timestamp
+        target_index: rollup-test-timestamp
+        body: >
+          {
+            "fixed_interval": "1h"
+          }
+
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: rollup-test-timestamp
+        body:
+          sort: [ "_tsid", "@timestamp" ]
+
+  - length: { hits.hits: 1 }
+  - match: { hits.hits.0._source._doc_count: 3 }
+  - match: { hits.hits.0._source.k8s.pod.uid: 947e4ced-1786-4e53-9e0c-5c447e959507 }
+  - match: { hits.hits.0._source.metricset: pod }
+  - match: { hits.hits.0._source.@timestamp: 2023-02-23T12:00:00.000000000Z }
+  - match: { hits.hits.0._source.k8s.pod.value.min: 8.0 }
+  - match: { hits.hits.0._source.k8s.pod.value.max: 12.0 }
+  - match: { hits.hits.0._source.k8s.pod.value.sum: 30.0 }
+
+  - do:
+      indices.get_mapping:
+        index: rollup-test-timestamp
+
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.type: date_nanos }
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.format: "uuuu-MM-dd'T'HH:mm:ss.SSSSSSSSSX" }
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.fixed_interval: 1h }
+  - match: { rollup-test-timestamp.mappings.properties.@timestamp.meta.time_zone: UTC }

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RollupShardIndexer.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/RollupShardIndexer.java
@@ -58,7 +58,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -119,9 +118,7 @@ class RollupShardIndexer {
             this.timestampField = (DateFieldMapper.DateFieldType) searchExecutionContext.getFieldType(config.getTimestampField());
             this.timestampFormat = timestampField.docValueFormat(null, null);
             this.rounding = config.createRounding();
-            this.millisecondsSupplier = DateFieldMapper.Resolution.MILLISECONDS.equals(this.timestampField.resolution())
-                ? Function.identity()
-                : TimeUnit.NANOSECONDS::toMillis;
+            this.millisecondsSupplier = timestamp -> timestampField.resolution().roundDownToMillis(timestamp);
 
             List<FieldValueFetcher> fetchers = new ArrayList<>(metricFields.length + labelFields.length);
             fetchers.addAll(FieldValueFetcher.create(searchExecutionContext, metricFields));


### PR DESCRIPTION
Here we do two things:
* make sure that the same timestamp field type and format of the downsample source index is used also for the downsample target index so that indexing documents in the downsample target index does not fail due to parsing errors
* make sure we convert nanoseconds to milliseconds if the resolution of the the downsample source index timestamp field is nanoseconds, which happens if the type of the timestamp field is 'date_nanos'

Resolves #94085 