### PR TITLE
Increase interval for change interval test to prevent stalls failing the test

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/AbstractAsyncTaskTests.java
@@ -187,9 +187,9 @@ public class AbstractAsyncTaskTests extends ESTestCase {
         assertFalse(task.isScheduled());
         task.rescheduleIfNecessary();
         assertTrue(task.isScheduled());
-        task.setInterval(TimeValue.timeValueMillis(1));
+        task.setInterval(TimeValue.timeValueMillis(10));
         assertTrue(task.isScheduled());
-        // This should only take 2 milliseconds in ideal conditions, but allow 10 seconds in case of VM stalls
+        // This should only take 20 milliseconds in ideal conditions, but allow 10 seconds in case of VM stalls
         assertTrue(latch.await(10, TimeUnit.SECONDS));
         assertBusy(() -> assertFalse(task.isScheduled()));
         task.close();


### PR DESCRIPTION
This fixes #93581.

I believe the failure is due to the test thread stalling, so the task completes before the third `isScheduled` check is run. Increasing the interval to ensure the task doesn't complete before the schedule check.