### PR TITLE
Fix data lifecycle tests for non-snapshot builds

### DIFF
--- a/modules/data-streams/build.gradle
+++ b/modules/data-streams/build.gradle
@@ -1,3 +1,4 @@
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.test-with-dependencies'
@@ -26,6 +27,7 @@ testClusters.configureEach {
   setting 'xpack.security.enabled', 'true'
   keystore 'bootstrap.password', 'x-pack-test-password'
   user username: "x_pack_rest_user", password: "x-pack-test-password"
+  requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.8.0")
 }
 
 testClusters.matching { it.name == "javaRestTest" }.configureEach {

--- a/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
+++ b/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
@@ -29,6 +29,7 @@ public class ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
     public static ElasticsearchCluster cluster = ElasticsearchCluster.local()
         .module("mapper-extras")
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .feature(FeatureFlag.DLM_ENABLED)
         .build();
 
     public ClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/FeatureFlag.java
@@ -16,7 +16,8 @@ import org.elasticsearch.test.cluster.util.Version;
  */
 public enum FeatureFlag {
     TIME_SERIES_MODE("es.index_mode_feature_flag_registered=true", Version.fromString("8.0.0"), null),
-    NEW_RCS_MODE("es.untrusted_remote_cluster_feature_flag_registered=true", Version.fromString("8.5.0"), null);
+    NEW_RCS_MODE("es.untrusted_remote_cluster_feature_flag_registered=true", Version.fromString("8.5.0"), null),
+    DLM_ENABLED("es.dlm_feature_flag_enabled=true", Version.fromString("8.8.0"), null);
 
     public final String systemProperty;
     public final Version from;


### PR DESCRIPTION
This fixes yaml tests when `-Dbuild.snapshot` is `false`.

The data lifecycle functionality is not enabled unless the feature flag
is configured. 
This makes the yaml tests enable the feature flag for non-snapshot builds
(it's always enabled for snapshot builds)

Fixes #94144
Fixes https://github.com/elastic/elasticsearch/issues/94143