### PR TITLE
Date-histogram calendar offset

### DIFF
--- a/docs/changelog/94163.yaml
+++ b/docs/changelog/94163.yaml
@@ -2,4 +2,5 @@ pr: 94163
 summary: Date-histogram calendar offset
 area: Aggregations
 type: feature
-issues: []
+issues:
+ - 93418

--- a/docs/changelog/94163.yaml
+++ b/docs/changelog/94163.yaml
@@ -1,0 +1,5 @@
+pr: 94163
+summary: Date-histogram calendar offset
+area: Aggregations
+type: feature
+issues: []

--- a/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/TimeValue.java
@@ -368,7 +368,7 @@ public class TimeValue implements Comparable<TimeValue> {
         }
     }
 
-    private static long parse(final String initialInput, final String normalized, final String suffix, String settingName) {
+    protected static long parse(final String initialInput, final String normalized, final String suffix, String settingName) {
         final String s = normalized.substring(0, normalized.length() - suffix.length()).trim();
         try {
             final long value = Long.parseLong(s);

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/date_histogram.yml
@@ -436,6 +436,58 @@ setup:
   - match: { aggregations.date_histogram_daily.buckets.1.key_as_string: "2020-03-09T00:00:00.000-04:00" }
   - match: { aggregations.date_histogram_daily.buckets.1.key: 1583726400000 }
   - match: { aggregations.date_histogram_daily.buckets.1.doc_count: 5 }
+---
+
+"Daylight with 25h offset date_histogram test":
+  - skip:
+      version: "- 7.16.99"
+      reason: Bug fixed before 7.16.99
+
+  - do:
+      search:
+        index: timezone_daylight_test
+        body:
+          size: 0
+          aggs:
+            date_histogram_daily:
+              date_histogram:
+                field: "date"
+                calendar_interval: "1d"
+                time_zone: "America/New_York"
+                offset: "+25h"
+
+  - match:  { hits.total.value: 6 }
+  - length: { aggregations.date_histogram_daily.buckets: 2 }
+  - match: { aggregations.date_histogram_daily.buckets.0.key_as_string: "2020-03-08T01:00:00.000-05:00" }
+  - match: { aggregations.date_histogram_daily.buckets.0.key: 1583647200000 }
+  - match: { aggregations.date_histogram_daily.buckets.0.doc_count: 3 }
+  - match: { aggregations.date_histogram_daily.buckets.1.key_as_string: "2020-03-09T02:00:00.000-04:00" }
+  - match: { aggregations.date_histogram_daily.buckets.1.key: 1583733600000 }
+  - match: { aggregations.date_histogram_daily.buckets.1.doc_count: 3 }
+
+---
+"Daylight with 24h offset date_histogram test":
+  - do:
+      search:
+        index: timezone_daylight_test
+        body:
+          size: 0
+          aggs:
+            date_histogram_daily:
+              date_histogram:
+                field: "date"
+                calendar_interval: "1d"
+                time_zone: "America/New_York"
+                offset: "+24h"
+
+  - match:  { hits.total.value: 6 }
+  - length: { aggregations.date_histogram_daily.buckets: 2 }
+  - match: { aggregations.date_histogram_daily.buckets.0.key_as_string: "2020-03-08T00:00:00.000-05:00" }
+  - match: { aggregations.date_histogram_daily.buckets.0.key: 1583643600000 }
+  - match: { aggregations.date_histogram_daily.buckets.0.doc_count: 2 }
+  - match: { aggregations.date_histogram_daily.buckets.1.key_as_string: "2020-03-09T01:00:00.000-04:00" }
+  - match: { aggregations.date_histogram_daily.buckets.1.key: 1583730000000 }
+  - match: { aggregations.date_histogram_daily.buckets.1.doc_count: 4 }
 
 ---
 "Date histogram with contradicting filters":

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregationBuilderTests.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.bucket.histogram;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class DateHistogramAggregationBuilderTests extends ESTestCase {
+    public void testParseStringOffset_Zero() {
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("0"), equalTo(0L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("0ms"), equalTo(0L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("0s"), equalTo(0L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("0m"), equalTo(0L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("0h"), equalTo(0L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("0d"), equalTo(0L));
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("0w"); });
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("0M"); });
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("0Y"); });
+    }
+
+    public void testParseStringOffset_Positive() {
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("5"); });
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("5ms"), equalTo(5L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("5s"), equalTo(TimeUnit.SECONDS.toMillis(5)));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("5m"), equalTo(TimeUnit.MINUTES.toMillis(5)));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("5h"), equalTo(TimeUnit.HOURS.toMillis(5)));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("5d"), equalTo(TimeUnit.DAYS.toMillis(5)));
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("5w"); });
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("5M"); });
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("5Y"); });
+    }
+
+    public void testParseStringOffset_Negative() {
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("-5"); });
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("-5ms"), equalTo(-5L));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("-5s"), equalTo(-TimeUnit.SECONDS.toMillis(5)));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("-5m"), equalTo(-TimeUnit.MINUTES.toMillis(5)));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("-5h"), equalTo(-TimeUnit.HOURS.toMillis(5)));
+        assertThat(DateHistogramAggregationBuilder.parseStringOffset("-5d"), equalTo(-TimeUnit.DAYS.toMillis(5)));
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("-5w"); });
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("-5M"); });
+        expectThrows(IllegalArgumentException.class, () -> { DateHistogramAggregationBuilder.parseStringOffset("-5Y"); });
+    }
+
+    public void testParseStringCompoundOffset() {
+        for (String offset : new String[] {
+            "0",
+            "1ms",
+            "1s",
+            "+1s",
+            "-1s",
+            "1ms+1s",
+            "+1ms +1s",
+            "+1s+1s",
+            "-1s+1s",
+            "+1s-1s",
+            "-1s-1s",
+            "1s 1s",
+            "1d 1d",
+            "1w 1d",
+            "1M 1d",
+            "1Y 1d",
+            "-1s 1s",
+            "-1d 1d",
+            "-1w 1d",
+            "-1M 1d",
+            "-1Y 1d" }) {
+            System.out.println("Testing offset: " + offset);
+            DateHistogramAggregationBuilder.Offset compoundOffset = DateHistogramAggregationBuilder.parseStringCompoundOffset(offset);
+            System.out.println("Converted offset[" + offset + "] into '" + compoundOffset + "'");
+            assertThat(
+                "Testing re-parsing of '" + compoundOffset + "'",
+                DateHistogramAggregationBuilder.parseStringCompoundOffset(compoundOffset.toString()),
+                equalTo(compoundOffset)
+            );
+        }
+    }
+
+    public void testDateHistogramAggregationBuilder_Offset() {
+    }
+}

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -48,6 +48,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.stream.IntStream;
 
@@ -689,7 +690,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         );
     }
 
-    public void testFixedWithCalendar() throws IOException {
+    public void testFixedWithCalendar() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testSearchCase(
@@ -709,7 +710,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         );
     }
 
-    public void testCalendarWithFixed() throws IOException {
+    public void testCalendarWithFixed() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testSearchCase(
@@ -723,7 +724,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         assertThat(e.getMessage(), equalTo("The supplied interval [5d] could not be parsed as a calendar interval."));
     }
 
-    public void testCalendarAndThenFixed() throws IOException {
+    public void testCalendarAndThenFixed() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testSearchCase(
@@ -739,7 +740,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         assertThat(e.getMessage(), equalTo("Cannot use [fixed_interval] with [calendar_interval] configuration option."));
     }
 
-    public void testFixedAndThenCalendar() throws IOException {
+    public void testFixedAndThenCalendar() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testSearchCase(
@@ -1035,6 +1036,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         aggregationImplementationChoiceTestCase(ft, data, data, builder, usesFromRange);
     }
 
+    @SuppressWarnings("deprecation")
     private void aggregationImplementationChoiceTestCase(
         DateFieldMapper.DateFieldType ft,
         List<String> data,
@@ -1081,7 +1083,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         }
     }
 
-    public void testIllegalInterval() throws IOException {
+    public void testIllegalInterval() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
             () -> testSearchCase(
@@ -1121,12 +1123,12 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
             (searcher, aggregator) -> {
                 InternalDateHistogram histo = (InternalDateHistogram) aggregator.buildEmptyAggregation();
                 /*
-                 * There was a time where we including the offset in the
+                 * There was a time when we included the offset in the
                  * rounding in the emptyBucketInfo which would cause us to
                  * include the offset twice. This verifies that we don't do
                  * that.
                  */
-                assertThat(histo.emptyBucketInfo.rounding.prepareForUnknown().round(0), equalTo(0L));
+                assertThat(Objects.requireNonNull(histo.emptyBucketInfo).rounding.prepareForUnknown().round(0), equalTo(0L));
             },
             aggregableDateFieldType(false, true)
         );
@@ -1142,6 +1144,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
         testSearchCase(query, dataset, configure, verify, 10000, useNanosecondResolution);
     }
 
+    @SuppressWarnings("SameParameterValue")
     private void testSearchCase(
         Query query,
         List<String> dataset,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/transform/transforms/pivot/DateHistogramGroupSourceTests.java
@@ -61,7 +61,7 @@ public class DateHistogramGroupSourceTests extends AbstractXContentSerializingTe
         } else {
             field = fieldPrefix + randomAlphaOfLengthBetween(1, 20);
         }
-        boolean missingBucket = version.onOrAfter(Version.V_7_10_0) ? randomBoolean() : false;
+        boolean missingBucket = version.onOrAfter(Version.V_7_10_0) && randomBoolean();
         Long offset = version.onOrAfter(Version.V_8_7_0) ? randomOffset() : null;
 
         DateHistogramGroupSource dateHistogramGroupSource;


### PR DESCRIPTION
Investigation/prototyping calendar offset

DateHistogram has issues with fixed offsets longer than calendar
intervals. Notably the use case with a calendar_interval of quarter
and fixed offset longer than a single month.

Fixes https://github.com/elastic/elasticsearch/issues/93418
