### PR TITLE
Avoid NPE in Stateless Get/mGet

### DIFF
--- a/docs/changelog/94164.yaml
+++ b/docs/changelog/94164.yaml
@@ -1,0 +1,5 @@
+pr: 94164
+summary: Avoid NPE in Stateless Get/mGet
+area: CRUD
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
+++ b/server/src/main/java/org/elasticsearch/action/get/TransportShardMultiGetAction.java
@@ -85,17 +85,20 @@ public class TransportShardMultiGetAction extends TransportSingleShardAction<Mul
 
     @Override
     protected ShardIterator shards(ClusterState state, InternalRequest request) {
-        ShardIterator shards = clusterService.operationRouting()
+        ShardIterator iterator = clusterService.operationRouting()
             .getShards(state, request.request().index(), request.request().shardId(), request.request().preference());
+        if (iterator == null) {
+            return null;
+        }
         // If it is stateless, only route promotable shards. This is a temporary workaround until a more cohesive solution can be
         // implemented for search shards.
         if (DiscoveryNode.isStateless(clusterService.getSettings())) {
             return new PlainShardIterator(
-                shards.shardId(),
-                shards.getShardRoutings().stream().filter(ShardRouting::isPromotableToPrimary).collect(Collectors.toList())
+                iterator.shardId(),
+                iterator.getShardRoutings().stream().filter(ShardRouting::isPromotableToPrimary).collect(Collectors.toList())
             );
         } else {
-            return shards;
+            return iterator;
         }
     }
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/93612 we introduce a 
workaround for real-time get/mget for stateless. However there is a 
null-check missing there (or maybe an assert). 