### PR TITLE
More aggressively check for snapshot abort

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -170,6 +170,12 @@ public class IndexShardSnapshotStatus {
         return stage.get() == Stage.ABORTED;
     }
 
+    public void ensureNotAborted() {
+        if (stage.get() == Stage.ABORTED) {
+            throw new AbortedSnapshotException();
+        }
+    }
+
     /**
      * Increments number of processed files
      */

--- a/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
+++ b/server/src/main/java/org/elasticsearch/index/snapshots/IndexShardSnapshotStatus.java
@@ -171,7 +171,7 @@ public class IndexShardSnapshotStatus {
     }
 
     public void ensureNotAborted() {
-        if (stage.get() == Stage.ABORTED) {
+        if (isAborted()) {
             throw new AbortedSnapshotException();
         }
     }

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -347,9 +347,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
         ActionListener<ShardSnapshotResult> resultListener
     ) {
         ActionListener.run(resultListener, listener -> {
-            if (snapshotStatus.isAborted()) {
-                throw new AbortedSnapshotException();
-            }
+            snapshotStatus.ensureNotAborted();
             final IndexShard indexShard = indicesService.indexServiceSafe(shardId.getIndex()).getShard(shardId.id());
             if (indexShard.routingEntry().primary() == false) {
                 throw new IndexShardSnapshotFailedException(shardId, "snapshot should be performed only on primary");
@@ -369,6 +367,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
             Engine.IndexCommitRef snapshotRef = null;
             try {
                 snapshotRef = indexShard.acquireIndexCommitForSnapshot();
+                snapshotStatus.ensureNotAborted();
                 repository.snapshotShard(
                     new SnapshotShardContext(
                         indexShard.store(),


### PR DESCRIPTION
We can check for snapshot aborts a bit more aggressively, avoiding a few spots where we could miss the abort before doing IO or enqueuing a task on the snapshot pool, leading to a shard lock not getting released for a deleted and hence aborted index for longer than necessary.
