### PR TITLE
[8.7] Reset ML feature state when ML is disabled (#94130)

### DIFF
--- a/x-pack/plugin/ml/qa/disabled/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlPluginDisabledIT.java
+++ b/x-pack/plugin/ml/qa/disabled/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlPluginDisabledIT.java
@@ -7,13 +7,17 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.ResponseException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 
+import java.io.IOException;
+
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
 
 public class MlPluginDisabledIT extends ESRestTestCase {
 
@@ -63,5 +67,11 @@ public class MlPluginDisabledIT extends ESRestTestCase {
         assertThat(exception.getMessage(), containsString("method [PUT]"));
         assertThat(exception.getMessage(), containsString("URI [/_ml/anomaly_detectors/foo]"));
         assertThat(exception.getMessage(), containsString("400 Bad Request"));
+    }
+
+    public void testMlFeatureReset() throws IOException {
+        Request request = new Request("POST", "/_features/_reset");
+        Response response = client().performRequest(request);
+        assertThat(response.getStatusLine().getStatusCode(), equalTo(200));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -1853,6 +1853,12 @@ public class MachineLearning extends Plugin
         Client unwrappedClient,
         ActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> finalListener
     ) {
+        if (this.enabled == false) {
+            // if ML is disabled, the custom cleanup can fail, but we can still clean up indices
+            // by calling the superclass cleanup method
+            SystemIndexPlugin.super.cleanUpFeature(clusterService, unwrappedClient, finalListener);
+            return;
+        }
         logger.info("Starting machine learning feature reset");
         OriginSettingClient client = new OriginSettingClient(unwrappedClient, ML_ORIGIN);
 


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Reset ML feature state when ML is disabled (#94130)