### PR TITLE
DELETE Engine API call 

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/engine.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/engine.delete.json
@@ -1,0 +1,35 @@
+{
+  "engine.delete": {
+    "documentation": {
+      "url": "http://todo.com/tbd",
+      "description": "Deletes an engine."
+    },
+    "stability": "experimental",
+    "visibility": "feature_flag",
+    "feature_flag": "xpack.ent-search.enabled",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_engine/{engine_id}",
+          "methods": [
+            "DELETE"
+          ],
+          "parts": {
+            "engine_id": {
+              "type": "string",
+              "description": "The name of the engine"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_engine_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_engine_delete.yml
@@ -21,6 +21,11 @@ setup:
 
   - match: { acknowledged: true }
 
+  - do:
+      catch: "missing"
+      engine.get:
+        engine_id: test-engine-to-delete
+
 ---
 "Delete Engine - Index does not exist":
   - do:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_engine_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_engine_delete.yml
@@ -1,0 +1,30 @@
+setup:
+  - do:
+      indices.create:
+        index: test-index
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+  - do:
+      engine.put:
+        engine_id: test-engine-to-delete
+        body:
+          indices: ["test-index"]
+
+---
+"Delete Engine":
+  - do:
+      engine.delete:
+        engine_id: test-engine-to-delete
+
+  - match: { acknowledged: true }
+
+---
+"Delete Engine - Index does not exist":
+  - do:
+      catch: "missing"
+      engine.put:
+        engine_id: test-nonexistent-engine
+

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_engine_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/40_engine_delete.yml
@@ -25,6 +25,6 @@ setup:
 "Delete Engine - Index does not exist":
   - do:
       catch: "missing"
-      engine.put:
+      engine.delete:
         engine_id: test-nonexistent-engine
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -41,14 +41,14 @@ import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.entsearch.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
-import org.elasticsearch.xpack.entsearch.engine.action.GetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.DeleteEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.GetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.PutEngineAction;
-import org.elasticsearch.xpack.entsearch.engine.action.RestGetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestDeleteEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.RestGetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestPutEngineAction;
-import org.elasticsearch.xpack.entsearch.engine.action.TransportGetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportDeleteEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.TransportGetEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportPutEngineAction;
 
 import java.util.Arrays;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -42,10 +42,13 @@ import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.entsearch.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
 import org.elasticsearch.xpack.entsearch.engine.action.GetEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.DeleteEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.PutEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestGetEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.RestDeleteEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestPutEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportGetEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.TransportDeleteEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportPutEngineAction;
 
 import java.util.Arrays;
@@ -78,7 +81,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         }
         return List.of(
             new ActionPlugin.ActionHandler<>(GetEngineAction.INSTANCE, TransportGetEngineAction.class),
-            new ActionHandler<>(PutEngineAction.INSTANCE, TransportPutEngineAction.class)
+            new ActionHandler<>(PutEngineAction.INSTANCE, TransportPutEngineAction.class),
+            new ActionHandler<>(DeleteEngineAction.INSTANCE, TransportDeleteEngineAction.class)
         );
     }
 
@@ -96,7 +100,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         if (enabled == false) {
             return Collections.emptyList();
         }
-        return List.of(new RestGetEngineAction(), new RestPutEngineAction());
+        return List.of(new RestGetEngineAction(), new RestPutEngineAction(), new RestDeleteEngineAction());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/Engine.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/Engine.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.entsearch.engine;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.ReleasableBytesStreamOutput;
@@ -41,11 +42,13 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
 public class Engine implements Writeable, ToXContentObject {
 
     public static final String ENGINE_ALIAS_PREFIX = "engine-";
+    // Shared indices options for Engines API requests that require every specified index to exist, do not expand wildcards,
+    // don't allow that no indices are resolved from wildcard expressions and resolve the expressions only against indices
+    public static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(false, false, false, false, true, false, true, false);
     private final String name;
     private final String[] indices;
     private long updatedAtMillis = System.currentTimeMillis();
     private final String analyticsCollectionName;
-
     private final String engineAlias;
 
     /**

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -294,6 +294,7 @@ public class EngineIndexService {
     public void deleteEngine(String engineName, ActionListener<DeleteResponse> listener) {
 
         try {
+            // TODO Delete alias when Engine is deleted
             final DeleteRequest deleteRequest = new DeleteRequest(ENGINE_ALIAS_NAME).id(engineName)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
+import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequest;
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesRequestBuilder;
 import org.elasticsearch.action.delete.DeleteRequest;
@@ -254,6 +255,12 @@ public class EngineIndexService {
         return aliasesRequestBuilder;
     }
 
+    private IndicesAliasesRequestBuilder removeAllAliasIndices(String engineAliasName) {
+        IndicesAliasesRequestBuilder aliasesRequestBuilder = clientWithOrigin.admin().indices().prepareAliases();
+        aliasesRequestBuilder.addAliasAction(IndicesAliasesRequest.AliasActions.remove().alias(engineAliasName));
+        return aliasesRequestBuilder;
+    }
+
     private void updateEngine(Engine engine, ActionListener<IndexResponse> listener) {
         try (ReleasableBytesStreamOutput buffer = new ReleasableBytesStreamOutput(0, bigArrays.withCircuitBreaking())) {
             try (XContentBuilder source = XContentFactory.jsonBuilder(buffer)) {
@@ -285,24 +292,22 @@ public class EngineIndexService {
      *
      */
     public void deleteEngine(String engineName, ActionListener<DeleteResponse> listener) {
-        try {
-            // TODO Delete alias when Engine is deleted
-            getEngine(engineName, new ActionListener<>() {
-                @Override
-                public void onResponse(Engine engine) {
-                    final DeleteRequest deleteRequest = new DeleteRequest(ENGINE_ALIAS_NAME).id(engineName)
-                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-                    clientWithOrigin.delete(deleteRequest, listener);
-                }
 
-                @Override
-                public void onFailure(Exception e) {
-                    listener.onFailure(e);
+        try {
+            final DeleteRequest deleteRequest = new DeleteRequest(ENGINE_ALIAS_NAME).id(engineName)
+                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+
+            clientWithOrigin.delete(deleteRequest, listener.delegateFailure((delegate, deleteResponse) -> {
+                if (deleteResponse.getResult() == DocWriteResponse.Result.NOT_FOUND) {
+                    delegate.onFailure(new ResourceNotFoundException(engineName));
+                    return;
                 }
-            });
+                delegate.onResponse(deleteResponse);
+            }));
         } catch (Exception e) {
             listener.onFailure(e);
         }
+
     }
 
     /**

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -287,9 +287,19 @@ public class EngineIndexService {
     public void deleteEngine(String engineName, ActionListener<DeleteResponse> listener) {
         try {
             // TODO Delete alias when Engine is deleted
-            final DeleteRequest deleteRequest = new DeleteRequest(ENGINE_ALIAS_NAME).id(engineName)
-                .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
-            clientWithOrigin.delete(deleteRequest, listener);
+            getEngine(engineName, new ActionListener<>() {
+                @Override
+                public void onResponse(Engine engine) {
+                    final DeleteRequest deleteRequest = new DeleteRequest(ENGINE_ALIAS_NAME).id(engineName)
+                        .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
+                    clientWithOrigin.delete(deleteRequest, listener);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    listener.onFailure(e);
+                }
+            });
         } catch (Exception e) {
             listener.onFailure(e);
         }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineAction.java
@@ -15,12 +15,12 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xpack.entsearch.engine.Engine;
 
 import java.io.IOException;
 import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
-import static org.elasticsearch.xpack.entsearch.engine.EngineIndexService.ENGINE_CONCRETE_INDEX_NAME;
 
 public class DeleteEngineAction extends ActionType<AcknowledgedResponse> {
 
@@ -35,7 +35,7 @@ public class DeleteEngineAction extends ActionType<AcknowledgedResponse> {
 
         public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
 
-        private String[] names = new String[] { ENGINE_CONCRETE_INDEX_NAME };
+        private String[] names;
         private final IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
 
         private final String engineId;
@@ -43,10 +43,12 @@ public class DeleteEngineAction extends ActionType<AcknowledgedResponse> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.engineId = in.readString();
+            names = new String[] { Engine.getEngineAliasName(this.engineId) };
         }
 
         public Request(String engineId) {
             this.engineId = engineId;
+            names = new String[] { Engine.getEngineAliasName(engineId) };
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineAction.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+import static org.elasticsearch.action.ValidateActions.addValidationError;
+import static org.elasticsearch.xpack.entsearch.engine.EngineIndexService.ENGINE_CONCRETE_INDEX_NAME;
+
+public class DeleteEngineAction extends ActionType<AcknowledgedResponse> {
+
+    public static final DeleteEngineAction INSTANCE = new DeleteEngineAction();
+    public static final String NAME = "indices:admin/engine/delete";
+
+    private DeleteEngineAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
+
+        public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
+
+        private String[] names = new String[] { ENGINE_CONCRETE_INDEX_NAME };
+        private final IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
+
+        private final String engineId;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.engineId = in.readString();
+        }
+
+        public Request(String engineId) {
+            this.engineId = engineId;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            ActionRequestValidationException validationException = null;
+
+            if (engineId == null || engineId.isEmpty()) {
+                validationException = addValidationError("engineId missing", validationException);
+            }
+
+            return validationException;
+        }
+
+        public String getEngineId() {
+            return engineId;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(engineId);
+        }
+
+        @Override
+        public String[] indices() {
+            return names;
+        }
+
+        @Override
+        public IndicesRequest indices(String... indices) {
+            this.names = indices;
+            return this;
+        }
+
+        @Override
+        public IndicesOptions indicesOptions() {
+            return indicesOptions;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request that = (Request) o;
+            return Objects.equals(engineId, that.engineId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(engineId);
+        }
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineAction.java
@@ -31,12 +31,10 @@ public class DeleteEngineAction extends ActionType<AcknowledgedResponse> {
         super(NAME, AcknowledgedResponse::readFrom);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
+    public static class Request extends ActionRequest implements IndicesRequest {
 
-        public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
-
-        private String[] names;
-        private final IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
+        private final String[] names;
+        private final IndicesOptions indicesOptions = Engine.INDICES_OPTIONS;
 
         private final String engineId;
 
@@ -75,12 +73,6 @@ public class DeleteEngineAction extends ActionType<AcknowledgedResponse> {
         @Override
         public String[] indices() {
             return names;
-        }
-
-        @Override
-        public IndicesRequest indices(String... indices) {
-            this.names = indices;
-            return this;
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/GetEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/GetEngineAction.java
@@ -33,12 +33,10 @@ public class GetEngineAction extends ActionType<GetEngineAction.Response> {
         super(NAME, GetEngineAction.Response::new);
     }
 
-    public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
+    public static class Request extends ActionRequest implements IndicesRequest {
 
-        public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpen();
-
-        private String[] names;
-        private final IndicesOptions indicesOptions = DEFAULT_INDICES_OPTIONS;
+        private final String[] names;
+        private final IndicesOptions indicesOptions = Engine.INDICES_OPTIONS;
 
         private final String engineId;
 
@@ -85,12 +83,6 @@ public class GetEngineAction extends ActionType<GetEngineAction.Response> {
         @Override
         public int hashCode() {
             return Objects.hash(engineId);
-        }
-
-        @Override
-        public IndicesRequest indices(String... indices) {
-            this.names = indices;
-            return this;
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/GetEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/GetEngineAction.java
@@ -50,7 +50,7 @@ public class GetEngineAction extends ActionType<GetEngineAction.Response> {
 
         public Request(String engineId) {
             this.engineId = engineId;
-            names = new String[] { Engine.getEngineAliasName(this.engineId) };
+            names = new String[] { Engine.getEngineAliasName(engineId) };
         }
 
         @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -32,26 +32,13 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
 
     public static final PutEngineAction INSTANCE = new PutEngineAction();
     public static final String NAME = "indices:admin/engine/put";
+    public static final IndicesOptions INDICES_OPTIONS = Engine.INDICES_OPTIONS;
 
     public PutEngineAction() {
         super(NAME, PutEngineAction.Response::new);
     }
 
     public static class Request extends ActionRequest implements IndicesRequest.Replaceable {
-
-        // indices options that require every specified index to exist, do not expand wildcards,
-        // don't allow that no indices are resolved from wildcard expressions and resolve the
-        // expressions only against indices
-        private static final IndicesOptions INDICES_OPTIONS = IndicesOptions.fromOptions(
-            false,
-            false,
-            false,
-            false,
-            true,
-            false,
-            true,
-            false
-        );
 
         private final Engine engine;
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestDeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestDeleteEngineAction.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+public class RestDeleteEngineAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "engine_delete_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, "/" + EnterpriseSearch.ENGINE_API_ENDPOINT + "/{engine_id}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        DeleteEngineAction.Request request = new DeleteEngineAction.Request(restRequest.param("engine_id"));
+        return channel -> client.execute(PutEngineAction.INSTANCE, request, new RestToXContentListener<>(channel) {
+            @Override
+            protected RestStatus getStatus(PutEngineAction.Response response) {
+                return response.status();
+            }
+        });
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestDeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestDeleteEngineAction.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.entsearch.engine.action;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
 
@@ -33,11 +32,6 @@ public class RestDeleteEngineAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         DeleteEngineAction.Request request = new DeleteEngineAction.Request(restRequest.param("engine_id"));
-        return channel -> client.execute(PutEngineAction.INSTANCE, request, new RestToXContentListener<>(channel) {
-            @Override
-            protected RestStatus getStatus(PutEngineAction.Response response) {
-                return response.status();
-            }
-        });
+        return channel -> client.execute(DeleteEngineAction.INSTANCE, request, new RestToXContentListener<>(channel));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportDeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportDeleteEngineAction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
+
+public class TransportDeleteEngineAction extends HandledTransportAction<DeleteEngineAction.Request, AcknowledgedResponse> {
+
+    private final EngineIndexService engineIndexService;
+
+    @Inject
+    public TransportDeleteEngineAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        EngineIndexService engineIndexService
+    ) {
+        super(PutEngineAction.NAME, transportService, actionFilters, DeleteEngineAction.Request::new);
+        this.engineIndexService = engineIndexService;
+    }
+
+    @Override
+    protected void doExecute(Task task, DeleteEngineAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        String engineId = request.getEngineId();
+        engineIndexService.deleteEngine(engineId, listener.map(v -> AcknowledgedResponse.TRUE));
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportDeleteEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportDeleteEngineAction.java
@@ -26,7 +26,7 @@ public class TransportDeleteEngineAction extends HandledTransportAction<DeleteEn
         ActionFilters actionFilters,
         EngineIndexService engineIndexService
     ) {
-        super(PutEngineAction.NAME, transportService, actionFilters, DeleteEngineAction.Request::new);
+        super(DeleteEngineAction.NAME, transportService, actionFilters, DeleteEngineAction.Request::new);
         this.engineIndexService = engineIndexService;
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineActionRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/DeleteEngineActionRequestSerializingTests.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+public class DeleteEngineActionRequestSerializingTests extends AbstractWireSerializingTestCase<DeleteEngineAction.Request> {
+
+    @Override
+    protected Writeable.Reader<DeleteEngineAction.Request> instanceReader() {
+        return DeleteEngineAction.Request::new;
+    }
+
+    @Override
+    protected DeleteEngineAction.Request createTestInstance() {
+        return new DeleteEngineAction.Request(randomAlphaOfLengthBetween(1, 10));
+    }
+
+    @Override
+    protected DeleteEngineAction.Request mutateInstance(DeleteEngineAction.Request instance) {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -382,6 +382,7 @@ public class Constants {
         "indices:admin/data_stream/modify",
         "indices:admin/data_stream/promote",
         "indices:admin/delete",
+        "indices:admin/engine/delete",
         "indices:admin/engine/get",
         "indices:admin/engine/put",
         "indices:admin/flush",


### PR DESCRIPTION
Closes https://github.com/elastic/enterprise-search-team/issues/3919

This PR implements the DELETE Engine REST call. 

To use this call: 

Create an engine with a command like: 
```
PUT /_engine/puggles
{
    "indices": ["puggles-1", "puggles-2"],
    "analytics_collection_name": "puggle-data",
    "engine_alias": "new_alias_name"
}
```
Issue a DELETE command: 
```
DELETE /_engine/puggles
```
Verify via a GET command that the engine no longer exists: 
```
GET /_engine/puggles
```
Verify the alias: 
```
GET /_alias/engine-puggles
```