### PR TITLE
Fix mutating DataStream & Response.DataStreamInfo

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsResponseTests.java
@@ -50,11 +50,13 @@ public class GetDataStreamsResponseTests extends AbstractWireSerializingTestCase
         var ilmPolicyName = instance.getIlmPolicy();
         var timeSeries = instance.getTimeSeries();
         switch (randomIntBetween(0, 4)) {
-            case 0 -> dataStream = DataStreamTestHelper.randomInstance();
+            case 0 -> dataStream = randomValueOtherThan(dataStream, DataStreamTestHelper::randomInstance);
             case 1 -> status = randomValueOtherThan(status, () -> randomFrom(ClusterHealthStatus.values()));
             case 2 -> indexTemplate = randomBoolean() && indexTemplate != null ? null : randomAlphaOfLengthBetween(2, 10);
             case 3 -> ilmPolicyName = randomBoolean() && ilmPolicyName != null ? null : randomAlphaOfLengthBetween(2, 10);
-            case 4 -> timeSeries = randomBoolean() && timeSeries != null ? null : new Response.TimeSeries(generateRandomTimeSeries());
+            case 4 -> timeSeries = randomBoolean() && timeSeries != null
+                ? null
+                : randomValueOtherThan(timeSeries, () -> new Response.TimeSeries(generateRandomTimeSeries()));
         }
         return new Response.DataStreamInfo(dataStream, status, indexTemplate, ilmPolicyName, timeSeries);
     }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/DataStreamTests.java
@@ -73,7 +73,7 @@ public class DataStreamTests extends AbstractXContentSerializingTestCase<DataStr
         var lifecycle = instance.getLifecycle();
         switch (between(0, 9)) {
             case 0 -> name = randomAlphaOfLength(10);
-            case 1 -> indices = DataStreamTestHelper.randomIndexInstances();
+            case 1 -> indices = randomValueOtherThan(List.of(), DataStreamTestHelper::randomIndexInstances);
             case 2 -> generation = instance.getGeneration() + randomIntBetween(1, 10);
             case 3 -> metadata = randomBoolean() && metadata != null ? null : Map.of("key", randomAlphaOfLength(10));
             case 4 -> {


### PR DESCRIPTION
Recently we implemented the `mutateInstance` methods for `DataStream` & `Response.DataStreamInfo`, in both cases something was missed:

- `DataStream`: the `DataStreamTestHelper::randomIndexInstances` can generate an empty list of backing indices which is invalid (test failure https://github.com/elastic/elasticsearch/issues/94173)
- ` Response.DataStreamInfo`: when generating time series, we generate time series with size from 0 to 3 and add as limits the current time. However, when the size is 0, there are no time frames which means that we can generate the same empty time series with higher probability that we originally thought. (test failure https://github.com/elastic/elasticsearch/issues/94071)

Both issues are fixed in this PR.
Closes: #94173 
Closes: #94071 