### PR TITLE
Teach 'contains' yaml test directive to match substrings

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/README.asciidoc
@@ -305,6 +305,11 @@ contains:  { nodes.$master.plugins: { name: painless-whitelist } }
 
 Asserts the plugins array contains an object with a `name` property with the value `painless-whitelist`
 
+Alternatively, this can be used to assert that a string response contains a certain substring:
+
+...
+contains: { items.0.index.error.reason: "must be mapped" }
+
 ==== `transform_and_set`
 
 Supports the `transform_and_set` operator as described in this document.

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -271,6 +271,7 @@ runtime field matching routing path:
 ---
 "dynamic: false matches routing_path":
   - skip:
+      features: contains
       version: " - 8.1.99"
       reason: tsdb indexing changed in 8.2.0
 

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -302,8 +302,8 @@ runtime field matching routing path:
           - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim": {"foo": "a"}}'
           - '{"index": {}}'
           - '{"@timestamp": "2021-04-28T18:50:04.467Z", "dim": {"foo": {"bar": "a"}}}'
-  - match: {items.0.index.error.reason: "All fields matching [routing_path] must be mapped but [dim.foo] was declared as [dynamic: false]"}
-  - match: {items.1.index.error.reason: "All fields matching [routing_path] must be mapped but [dim.foo] was declared as [dynamic: false]"}
+  - contains: {items.0.index.error.reason: "All fields matching [routing_path] must be mapped but [dim.foo] was declared as [dynamic: false]"}
+  - contains: {items.1.index.error.reason: "All fields matching [routing_path] must be mapped but [dim.foo] was declared as [dynamic: false]"}
 
 ---
 nested dimensions:

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ContainsAssertion.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/ContainsAssertion.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -64,8 +65,10 @@ public class ContainsAssertion extends Assertion {
                 getField() + " expected to be a list with at least on object that matches " + expectedMap + " but was " + actualValues,
                 actualValues.stream().anyMatch(each -> each.entrySet().containsAll(expectedMap.entrySet()))
             );
+        } else if (expectedValue instanceof String && actualValue instanceof String) {
+            assertThat((String) actualValue, containsString((String) expectedValue));
         } else {
-            fail("'contains' only supports checking an object against a list of objects");
+            fail("'contains' only supports checking an object against a list of objects or a string against a string");
         }
     }
 }

--- a/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ContainsAssertionTests.java
+++ b/test/yaml-rest-runner/src/test/java/org/elasticsearch/test/rest/yaml/section/ContainsAssertionTests.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.rest.yaml.section;
+
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentLocation;
+
+public class ContainsAssertionTests extends ESTestCase {
+
+    public void testStringContains() {
+        XContentLocation location = new XContentLocation(0, 0);
+        ContainsAssertion containsAssertion = new ContainsAssertion(location, "field", "part");
+        containsAssertion.doAssert("partial match", "l m");
+        expectThrows(AssertionError.class, () -> containsAssertion.doAssert("partial match", "foo"));
+    }
+}


### PR DESCRIPTION
In many cases, matching a simple substring is sufficient for testing and is
easier than building a regex match.