### PR TITLE
Remove unneeded argument from ShardLimitValidator

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -49,10 +49,11 @@ public class ShardLimitValidator {
         Setting.Property.NodeScope
     );
     public static final String FROZEN_GROUP = "frozen";
-    static final Set<String> VALID_GROUPS = Set.of("normal", FROZEN_GROUP);
+    public static final String NORMAL_GROUP = "normal";
+    static final Set<String> VALID_GROUPS = Set.of(NORMAL_GROUP, FROZEN_GROUP);
     public static final Setting<String> INDEX_SETTING_SHARD_LIMIT_GROUP = Setting.simpleString(
         "index.shard_limit.group",
-        "normal",
+        NORMAL_GROUP,
         value -> {
             if (VALID_GROUPS.contains(value) == false) {
                 throw new IllegalArgumentException("[" + value + "] is not a valid shard limit group");
@@ -186,7 +187,7 @@ public class ShardLimitValidator {
         // against such mixed nodes for production use anyway.
         int frozenNodeCount = nodeCount(state, ShardLimitValidator::hasFrozen);
         int normalNodeCount = nodeCount(state, ShardLimitValidator::hasNonFrozen);
-        return checkShardLimit(newShards, state, getShardLimitPerNode(), normalNodeCount, "normal").or(
+        return checkShardLimit(newShards, state, getShardLimitPerNode(), normalNodeCount, NORMAL_GROUP).or(
             () -> checkShardLimit(newFrozenShards, state, shardLimitPerNodeFrozen.get(), frozenNodeCount, "frozen")
         );
     }
@@ -197,21 +198,16 @@ public class ShardLimitValidator {
      * "cluster.max_shards_per_node" setting if the shards are going on normal nodes. This check does not guarantee that the number of
      * shards can be added, just that there is theoretically room to add them without exceeding the shards per node configuration.
      * @param numberOfNewShards The number of primary shards that we want to be able to add to the cluster
-     * @param replicas The number of replcas of the primary shards that we want to be able to add to the cluster
-     * @param state The cluster state, used to get cluster settings and to get the number of open shards already in the cluster
-     * @param frozenNodes If true, check whether there is room to put these shards onto frozen nodes. If false, check whether there is room
-     *                    to put these shards onto normal nodes.
+     * @param replicas          The number of replicas of the primary shards that we want to be able to add to the cluster
+     * @param state             The cluster state, used to get cluster settings and to get the number of open shards already in the cluster
      * @return True if there is room to add the requested number of shards to the cluster, and false if there is not
      */
-    public static boolean canAddShardsToCluster(int numberOfNewShards, int replicas, ClusterState state, boolean frozenNodes) {
-        Settings clusterSettings = state.getMetadata().settings();
-        int maxShardsPerNode = frozenNodes
-            ? SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.get(clusterSettings)
-            : SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(clusterSettings);
-        int nodeCount = nodeCount(state, frozenNodes ? ShardLimitValidator::hasFrozen : ShardLimitValidator::hasNonFrozen);
-        String nodeGroup = frozenNodes ? FROZEN_GROUP : "normal";
-        Optional<String> errorMessage = checkShardLimit(numberOfNewShards * (1 + replicas), state, maxShardsPerNode, nodeCount, nodeGroup);
-        return errorMessage.isPresent() == false;
+    public static boolean canAddShardsToCluster(int numberOfNewShards, int replicas, ClusterState state) {
+        var clusterSettings = state.getMetadata().settings();
+        var maxShardsPerNode = SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(clusterSettings);
+        var nodeCount = nodeCount(state, ShardLimitValidator::hasNonFrozen);
+        var errorMessage = checkShardLimit(numberOfNewShards * (1 + replicas), state, maxShardsPerNode, nodeCount, NORMAL_GROUP);
+        return errorMessage.isEmpty();
     }
 
     // package-private for testing

--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -194,9 +194,9 @@ public class ShardLimitValidator {
 
     /**
      * This method decides whether there is enough room in the cluster to add the given number of shards with the given number of replicas
-     * without exceeding the "cluster.max_shards_per_node.frozen" setting if the shards are going on frozen nodes or the
-     * "cluster.max_shards_per_node" setting if the shards are going on normal nodes. This check does not guarantee that the number of
-     * shards can be added, just that there is theoretically room to add them without exceeding the shards per node configuration.
+     * without exceeding the "cluster.max_shards_per_node" setting if the shards are going on normal nodes. This check does not guarantee
+     * that the number of shards can be added, just that there is theoretically room to add them without exceeding the shards per node
+     * configuration.
      * @param numberOfNewShards The number of primary shards that we want to be able to add to the cluster
      * @param replicas          The number of replicas of the primary shards that we want to be able to add to the cluster
      * @param state             The cluster state, used to get cluster settings and to get the number of open shards already in the cluster

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -77,14 +77,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
                 + " shards open",
             errorMessage.get()
         );
-        assertFalse(
-            ShardLimitValidator.canAddShardsToCluster(
-                counts.getFailingIndexShards(),
-                counts.getFailingIndexReplicas(),
-                state,
-                ShardLimitValidator.FROZEN_GROUP.equals(group)
-            )
-        );
+        assertFalse(ShardLimitValidator.canAddShardsToCluster(counts.getFailingIndexShards(), counts.getFailingIndexReplicas(), state));
     }
 
     public void testUnderShardLimit() {
@@ -112,7 +105,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
 
         assertFalse(errorMessage.isPresent());
-        assertTrue(ShardLimitValidator.canAddShardsToCluster(shardsToAdd, 0, state, ShardLimitValidator.FROZEN_GROUP.equals(group)));
+        assertTrue(ShardLimitValidator.canAddShardsToCluster(shardsToAdd, 0, state));
     }
 
     public void testValidateShardLimitOpenIndices() {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -14,22 +14,20 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.util.Locale;
 
 public class ClusterDeprecationChecks {
-
-    private static final int SHARDS_IN_FUTURE_NEW_SMALL_INDEX = 5;
-    private static final int REPLICAS_FOR_FUTURE_INDEX = 1;
-
     /**
-     * Upgrading can require the addition of one are more small indices. This method checks that based on configuration we have the room
+     * Upgrading can require the addition of one or more small indices. This method checks that based on configuration we have the room
      * to add a small number of additional shards to the cluster. The goal is to prevent a failure during upgrade.
      * @param clusterState The cluster state, used to get settings and information about nodes
      * @return A deprecation issue if there is not enough room in this cluster to add a few more shards, or null otherwise
      */
     static DeprecationIssue checkShards(ClusterState clusterState) {
         // Make sure we have room to add a small non-frozen index if needed
-        if (ShardLimitValidator.canAddShardsToCluster(SHARDS_IN_FUTURE_NEW_SMALL_INDEX, REPLICAS_FOR_FUTURE_INDEX, clusterState)) {
+        final int shardsInFutureNewSmallIndex = 5;
+        final int replicasForFutureIndex = 1;
+        if (ShardLimitValidator.canAddShardsToCluster(shardsInFutureNewSmallIndex, replicasForFutureIndex, clusterState)) {
             return null;
         } else {
-            final int totalShardsToAdd = SHARDS_IN_FUTURE_NEW_SMALL_INDEX * (1 + REPLICAS_FOR_FUTURE_INDEX);
+            final int totalShardsToAdd = shardsInFutureNewSmallIndex * (1 + replicasForFutureIndex);
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
                 "The cluster has too many shards to be able to upgrade",

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -14,20 +14,22 @@ import org.elasticsearch.xpack.core.deprecation.DeprecationIssue;
 import java.util.Locale;
 
 public class ClusterDeprecationChecks {
+
+    private static final int SHARDS_IN_FUTURE_NEW_SMALL_INDEX = 5;
+    private static final int REPLICAS_FOR_FUTURE_INDEX = 1;
+
     /**
-     * Upgrading can require the addition of one ore more small indices. This method checks that based on configuration we have the room
+     * Upgrading can require the addition of one are more small indices. This method checks that based on configuration we have the room
      * to add a small number of additional shards to the cluster. The goal is to prevent a failure during upgrade.
      * @param clusterState The cluster state, used to get settings and information about nodes
      * @return A deprecation issue if there is not enough room in this cluster to add a few more shards, or null otherwise
      */
     static DeprecationIssue checkShards(ClusterState clusterState) {
         // Make sure we have room to add a small non-frozen index if needed
-        final int shardsInFutureNewSmallIndex = 5;
-        final int replicasForFutureIndex = 1;
-        if (ShardLimitValidator.canAddShardsToCluster(shardsInFutureNewSmallIndex, replicasForFutureIndex, clusterState, false)) {
+        if (ShardLimitValidator.canAddShardsToCluster(SHARDS_IN_FUTURE_NEW_SMALL_INDEX, REPLICAS_FOR_FUTURE_INDEX, clusterState)) {
             return null;
         } else {
-            final int totalShardsToAdd = shardsInFutureNewSmallIndex * (1 + replicasForFutureIndex);
+            final int totalShardsToAdd = SHARDS_IN_FUTURE_NEW_SMALL_INDEX * (1 + REPLICAS_FOR_FUTURE_INDEX);
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
                 "The cluster has too many shards to be able to upgrade",


### PR DESCRIPTION
The argument `frozenNodes` is always false, so we can simplify a bit the code here.

it'll help to simplify the PR #94116