### PR TITLE
Use double wildcards for filtered excludes properly

### DIFF
--- a/docs/changelog/94195.yaml
+++ b/docs/changelog/94195.yaml
@@ -1,0 +1,6 @@
+pr: 94195
+summary: Use double wildcards for filtered excludes properly
+area: Infra/Core
+type: bug
+issues:
+ - 92632

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentParserConfigurationImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentParserConfigurationImpl.java
@@ -118,12 +118,6 @@ public class XContentParserConfigurationImpl implements XContentParserConfigurat
     public JsonParser filter(JsonParser parser) {
         JsonParser filtered = parser;
         if (excludes != null) {
-            for (FilterPath e : excludes) {
-                if (e.hasDoubleWildcard()) {
-                    // Fixed in Jackson 2.13 - https://github.com/FasterXML/jackson-core/issues/700
-                    throw new UnsupportedOperationException("double wildcards are not supported in filtered excludes");
-                }
-            }
             filtered = new FilteringParserDelegate(
                 filtered,
                 new FilterPathBasedFilter(excludes, false, filtersMatchFieldNamesWithDots),

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/support/filtering/AbstractXContentFilteringTestCase.java
@@ -305,7 +305,6 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/92632")
     public void testDotsAndDoubleWildcardInExcludedFieldName() throws IOException {
         testFilter(
             builder -> builder.startObject().endObject(),
@@ -408,7 +407,9 @@ public abstract class AbstractXContentFilteringTestCase extends AbstractFilterin
             return filterOnBuilder(sample, includes, excludes);
         }
         FilterPath[] excludesFilter = FilterPath.compile(excludes);
-        if (excludesFilter != null && Arrays.stream(excludesFilter).anyMatch(FilterPath::hasDoubleWildcard)) {
+        if (excludesFilter != null
+            && Arrays.stream(excludesFilter).anyMatch(FilterPath::hasDoubleWildcard)
+            && matchFieldNamesWithDots == false) {
             return filterOnBuilder(sample, includes, excludes);
         }
         return filterOnParser(sample, includes, excludes, matchFieldNamesWithDots);


### PR DESCRIPTION
This fixes #92632.

Now we're on jackson 2.13, we can properly use double wildcard filters in tests