### PR TITLE
Avoid building test fixtures when building release artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -353,6 +353,7 @@ tasks.register("buildReleaseArtifacts").configure {
     it.path.startsWith(':distribution:docker') == false
       && it.path.startsWith(':ml-cpp') == false
       && it.path.startsWith(':distribution:bwc') == false
+      && it.path.startsWith(':test:fixture') == false
   }
     .collect { GradleUtils.findByName(it.tasks, 'assemble') }
     .findAll { it != null }


### PR DESCRIPTION
We don't want to build test fixture projects when building our release artifacts.