### PR TITLE
[7.17] Avoid building test fixtures when building release artifacts (#94200)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -346,6 +346,7 @@ tasks.register("buildReleaseArtifacts").configure {
     it.path.startsWith(':distribution:docker') == false
       && it.path.startsWith(':ml-cpp') == false
       && it.path.startsWith(':distribution:bwc') == false
+      && it.path.startsWith(':test:fixture') == false
   }
     .collect { GradleUtils.findByName(it.tasks, 'assemble') }
     .findAll { it != null }


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Avoid building test fixtures when building release artifacts (#94200)