### PR TITLE
Mute disruption tests for jdk20+

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -226,6 +226,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * following another elected master node. These nodes should reject this cluster state and prevent them from following the stale master.
      */
     public void testStaleMasterNotHijackingMajority() throws Exception {
+        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
         final List<String> nodes = internalCluster().startNodes(
             3,
             Settings.builder()
@@ -333,6 +334,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * @throws Exception
      */
     public void testRepeatedMasterChanges(String expectedMasterStabilitySymptomSubstring) throws Exception {
+        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
         final List<String> nodes = internalCluster().startNodes(
             3,
             Settings.builder()
@@ -422,6 +424,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
     }
 
     public void testRepeatedNullMasterRecognizedAsGreenIfMasterDoesNotKnowItIsUnstable() throws Exception {
+        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
         /*
          * In this test we have a single master-eligible node. We pause it repeatedly (simulating a long GC pause for example) so that
          * other nodes decide it is no longer the master. However since there is no other master-eligible node, another node is never

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
 
 import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
@@ -38,6 +39,11 @@ public class LongGCDisruptionTests extends ESTestCase {
                 lock.unlock();
             }
         }
+    }
+
+    @BeforeClass
+    public static void ignoreJdk20Plus() {
+        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
     }
 
     public void testBlockingTimeout() throws Exception {


### PR DESCRIPTION
In JDK 20 Thread suspend/resume is soft removed (they now throw UnsupportedOperationException). Many ES disruption tests simulate GC pauses with suspend/resume. As that strategy will no longer work, this commit mutes those tests for jdk20+.

relates #94206
closes #93707