### PR TITLE
Draft: Create POST Create Engine API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/engine.post.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/engine.post.json
@@ -1,0 +1,39 @@
+{
+  "engine.post": {
+    "documentation": {
+      "url": "http://todo.com/tbd",
+      "description": "Creates an engine."
+    },
+    "stability": "experimental",
+    "visibility": "feature_flag",
+    "feature_flag": "xpack.ent-search.enabled",
+    "headers": {
+      "accept": [
+        "application/json"
+      ],
+      "content_type": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_engine/{engine_id}",
+          "methods": [
+            "POST"
+          ],
+          "parts": {
+            "engine_id": {
+              "type": "string",
+              "description": "The name of the engine to be created or updated"
+            }
+          }
+        }
+      ]
+    },
+    "body": {
+      "description": "The engine configuration, including `indices`",
+      "required": true
+    }
+  }
+}

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_engine_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_engine_post.yml
@@ -1,0 +1,47 @@
+setup:
+  - do:
+      indices.create:
+        index: test-index1
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+  - do:
+      indices.create:
+        index: test-index2
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+              number_of_replicas: 0
+
+---
+"Create Engine":
+  - do:
+      engine.post:
+        engine_id: test-new-engine
+        body:
+          indices: [ "test-index1", "test-index2" ]
+
+  - match: { result: "created" }
+
+---
+"Create Engine - Engine already exists":
+  - do:
+      catch: conflict
+      engine.post:
+        engine_id: test-new-engine
+        body:
+          indices: [ "test-index1", "test-index2" ]
+
+---
+"Create Engine - Index does not exist":
+  - do:
+      catch: bad_request
+      engine.put:
+        engine_id: test-nonexistent-engine
+        body:
+          indices: [ "test-index1", "index-does-not-exist" ]
+

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/EnterpriseSearch.java
@@ -43,12 +43,15 @@ import org.elasticsearch.xpack.entsearch.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
 import org.elasticsearch.xpack.entsearch.engine.action.DeleteEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.GetEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.PostEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.PutEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestDeleteEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestGetEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.RestPostEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.RestPutEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportDeleteEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportGetEngineAction;
+import org.elasticsearch.xpack.entsearch.engine.action.TransportPostEngineAction;
 import org.elasticsearch.xpack.entsearch.engine.action.TransportPutEngineAction;
 
 import java.util.Arrays;
@@ -82,7 +85,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         return List.of(
             new ActionPlugin.ActionHandler<>(GetEngineAction.INSTANCE, TransportGetEngineAction.class),
             new ActionHandler<>(PutEngineAction.INSTANCE, TransportPutEngineAction.class),
-            new ActionHandler<>(DeleteEngineAction.INSTANCE, TransportDeleteEngineAction.class)
+            new ActionHandler<>(DeleteEngineAction.INSTANCE, TransportDeleteEngineAction.class),
+            new ActionHandler<>(PostEngineAction.INSTANCE, TransportPostEngineAction.class)
         );
     }
 
@@ -100,7 +104,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         if (enabled == false) {
             return Collections.emptyList();
         }
-        return List.of(new RestGetEngineAction(), new RestPutEngineAction(), new RestDeleteEngineAction());
+        return List.of(new RestGetEngineAction(), new RestPutEngineAction(), new RestDeleteEngineAction(), new RestPostEngineAction());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -232,12 +232,7 @@ public class EngineIndexService {
 
             @Override
             public void onFailure(Exception e) {
-                // Convert index not found failure from the alias API into an illegal argument
-                Exception failException = e;
-                if (e instanceof IndexNotFoundException) {
-                    failException = new IllegalArgumentException(e.getMessage(), e);
-                }
-                listener.onFailure(failException);
+                listener.onFailure(e);
             }
         });
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PostEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PostEngineAction.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionType;
+
+public class PostEngineAction extends ActionType<PutEngineAction.Response> {
+
+    public static final PostEngineAction INSTANCE = new PostEngineAction();
+    public static final String NAME = "indices:admin/engine/post";
+
+    public PostEngineAction() {
+        super(NAME, PutEngineAction.Response::new);
+    }
+
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -133,6 +133,7 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
             return builder;
         }
 
+        // TODO: How do I return RestStatus.CONFLICT here?
         @Override
         public RestStatus status() {
             return switch (result) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPostEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPostEngineAction.java
@@ -14,32 +14,30 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
 
-import java.io.IOException;
 import java.util.List;
 
-import static org.elasticsearch.rest.RestRequest.Method.PUT;
+import static org.elasticsearch.rest.RestRequest.Method.POST;
 
-public class RestPutEngineAction extends BaseRestHandler {
+public class RestPostEngineAction extends BaseRestHandler {
 
     @Override
     public String getName() {
-        return "engine_put_action";
+        return "engine_post_action";
     }
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(PUT, "/" + EnterpriseSearch.ENGINE_API_ENDPOINT + "/{engine_id}"));
+        return List.of(new Route(POST, "/" + EnterpriseSearch.ENGINE_API_ENDPOINT + "/{engine_id}"));
     }
 
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         PutEngineAction.Request request = new PutEngineAction.Request(
             restRequest.param("engine_id"),
             restRequest.content(),
             restRequest.getXContentType()
         );
-
-        return channel -> client.execute(PutEngineAction.INSTANCE, request, new RestToXContentListener<>(channel) {
+        return channel -> client.execute(PostEngineAction.INSTANCE, request, new RestToXContentListener<>(channel) {
             @Override
             protected RestStatus getStatus(PutEngineAction.Response response) {
                 return response.status();

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPostEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPostEngineAction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.entsearch.engine.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.entsearch.engine.Engine;
+import org.elasticsearch.xpack.entsearch.engine.EngineIndexService;
+
+public class TransportPostEngineAction extends HandledTransportAction<PutEngineAction.Request, PutEngineAction.Response> {
+
+    private final EngineIndexService engineIndexService;
+
+    @Inject
+    public TransportPostEngineAction(TransportService transportService, ActionFilters actionFilters, EngineIndexService engineIndexService) {
+        super(PostEngineAction.NAME, transportService, actionFilters, PutEngineAction.Request::new);
+        this.engineIndexService = engineIndexService;
+    }
+
+    @Override
+    protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
+        Engine engine = request.getEngine();
+        engineIndexService.postEngine(engine, listener.map(r -> new PutEngineAction.Response(r.getResult())));
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -384,6 +384,7 @@ public class Constants {
         "indices:admin/delete",
         "indices:admin/engine/delete",
         "indices:admin/engine/get",
+        "indices:admin/engine/post",
         "indices:admin/engine/put",
         "indices:admin/flush",
         "indices:admin/flush[s]",


### PR DESCRIPTION
The Rails API had a POST command to create an Engine but return a 409 conflict if it didn't exist. This was requested by Kibana developers to avoid having to check if an engine already existed on creation. 
