### PR TITLE
Mute DataLifecycleServiceTests where snapshot.build=false

### DIFF
--- a/modules/dlm/src/test/java/org/elasticsearch/dlm/DataLifecycleServiceTests.java
+++ b/modules/dlm/src/test/java/org/elasticsearch/dlm/DataLifecycleServiceTests.java
@@ -87,6 +87,7 @@ public class DataLifecycleServiceTests extends ESTestCase {
     }
 
     public void testOperationsExecutedOnce() {
+        assumeTrue("https://github.com/elastic/elasticsearch/issues/94214", Boolean.parseBoolean(System.getProperty("build.snapshot")));
         String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         int numBackingIndices = 3;
         Metadata.Builder builder = Metadata.builder();
@@ -119,6 +120,7 @@ public class DataLifecycleServiceTests extends ESTestCase {
     }
 
     public void testRetentionNotConfigured() {
+        assumeTrue("https://github.com/elastic/elasticsearch/issues/94214", Boolean.parseBoolean(System.getProperty("build.snapshot")));
         String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         int numBackingIndices = 3;
         Metadata.Builder builder = Metadata.builder();
@@ -138,6 +140,7 @@ public class DataLifecycleServiceTests extends ESTestCase {
     }
 
     public void testRetentionNotExecutedDueToAge() {
+        assumeTrue("https://github.com/elastic/elasticsearch/issues/94214", Boolean.parseBoolean(System.getProperty("build.snapshot")));
         String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         int numBackingIndices = 3;
         Metadata.Builder builder = Metadata.builder();


### PR DESCRIPTION
relates to https://github.com/elastic/elasticsearch/issues/94214