### PR TITLE
fix ShardLimitValidator flaky test

### DIFF
--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -33,6 +33,7 @@ import java.util.Set;
 import static org.elasticsearch.cluster.metadata.MetadataIndexStateServiceTests.addClosedIndex;
 import static org.elasticsearch.cluster.metadata.MetadataIndexStateServiceTests.addOpenedIndex;
 import static org.elasticsearch.cluster.shards.ShardCounts.forDataNodeCount;
+import static org.elasticsearch.indices.ShardLimitValidator.NORMAL_GROUP;
 import static org.elasticsearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -42,14 +43,12 @@ public class ShardLimitValidatorTests extends ESTestCase {
     public void testOverShardLimit() {
         int nodesInCluster = randomIntBetween(1, 90);
         ShardCounts counts = forDataNodeCount(nodesInCluster);
-
-        String group = randomFrom(ShardLimitValidator.VALID_GROUPS);
         ClusterState state = createClusterForShardLimitTest(
             nodesInCluster,
             counts.getFirstIndexShards(),
             counts.getFirstIndexReplicas(),
             counts.getShardsPerNode(),
-            group
+            NORMAL_GROUP
         );
 
         int shardsToAdd = counts.getFailingIndexShards() * (1 + counts.getFailingIndexReplicas());
@@ -58,7 +57,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
             state,
             counts.getShardsPerNode(),
             nodesInCluster,
-            group
+            NORMAL_GROUP
         );
 
         int totalShards = counts.getFailingIndexShards() * (1 + counts.getFailingIndexReplicas());
@@ -73,7 +72,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
                 + "]/["
                 + maxShards
                 + "] maximum "
-                + group
+                + NORMAL_GROUP
                 + " shards open",
             errorMessage.get()
         );
@@ -84,14 +83,12 @@ public class ShardLimitValidatorTests extends ESTestCase {
         int nodesInCluster = randomIntBetween(2, 90);
         // Calculate the counts for a cluster 1 node smaller than we have to ensure we have headroom
         ShardCounts counts = forDataNodeCount(nodesInCluster - 1);
-
-        String group = randomFrom(ShardLimitValidator.VALID_GROUPS);
         ClusterState state = createClusterForShardLimitTest(
             nodesInCluster,
             counts.getFirstIndexShards(),
             counts.getFirstIndexReplicas(),
             counts.getShardsPerNode(),
-            group
+            NORMAL_GROUP
         );
 
         int existingShards = counts.getFirstIndexShards() * (1 + counts.getFirstIndexReplicas());
@@ -101,7 +98,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
             state,
             counts.getShardsPerNode(),
             nodesInCluster,
-            group
+            NORMAL_GROUP
         );
 
         assertFalse(errorMessage.isPresent());

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -79,7 +79,6 @@ public class ShardLimitValidatorTests extends ESTestCase {
         assertFalse(ShardLimitValidator.canAddShardsToCluster(counts.getFailingIndexShards(), counts.getFailingIndexReplicas(), state));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94215")
     public void testUnderShardLimit() {
         int nodesInCluster = randomIntBetween(2, 90);
         // Calculate the counts for a cluster 1 node smaller than we have to ensure we have headroom


### PR DESCRIPTION
Previously the method `canAddShardsToCluster` had a flag to do calculations over frozen or normal nodes. Since we never used the flag to calculate for the frozen nodes, I removed that flag to simplify the code but forgot to update the tests.

Running the test 1000 times, no fails.

```bash
./gradlew ':server:test' -Dtests.iters=1000  --tests "org.elasticsearch.indices.ShardLimitValidatorTests"
[...]
> Task :server:test
[...]

BUILD SUCCESSFUL in 19s
61 actionable tasks: 1 executed, 1 from cache, 59 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/qfakm5cpfrbfm
```

The same with a seed that was previously failing:

```bash
➜  elasticsearch git:(94215-fix-shard-limits-flaky-test) ✗ ./gradlew ':server:test' --tests "org.elasticsearch.indices.ShardLimitValidatorTests.testUnderShardLimit" -Dtests.seed=4DA3C21DEAD617F0
[...]
> Task :server:test
[...]
61 actionable tasks: 2 executed, 59 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/fklejfsezspy4
```

Closes #94215
Relates to #94193