### PR TITLE
[DOCS] Improve watermark troubleshooting documentation

### DIFF
--- a/docs/reference/index-modules/blocks.asciidoc
+++ b/docs/reference/index-modules/blocks.asciidoc
@@ -43,7 +43,8 @@ settings, and removes the block automatically when the disk utilization falls
 under the high watermark, controlled by the
 <<cluster-routing-flood-stage,cluster.routing.allocation.disk.watermark.high>>
 and <<cluster-routing-flood-stage,cluster.routing.allocation.disk.watermark.high.max_headroom>>
-settings.
+settings. Refer to <<fix-watermark-errors,Fix watermark errors>> to resolve 
+watermark issues.
 
 `index.blocks.read`::
 

--- a/docs/reference/modules/cluster/disk_allocator.asciidoc
+++ b/docs/reference/modules/cluster/disk_allocator.asciidoc
@@ -38,7 +38,8 @@ a last resort, once the disk usage reaches the _flood-stage_ watermark {es}
 will block writes to indices with a shard on the affected node. It will also
 continue to move shards onto the other nodes in the cluster. When disk usage
 on the affected node drops below the high watermark, {es} automatically removes
-the write block.
+the write block. Refer to <<fix-watermark-errors,Fix watermark errors>> to 
+resolve persistent watermark errors.
 
 [[disk-based-shard-allocation-does-not-balance]]
 [TIP]

--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1876,3 +1876,8 @@ This example has been removed, as the Meetup.com streaming API has been
 discontinued.
 
 Refer to <<example-watches>> for other Watcher examples.
+
+[role="exclude",id="disk-usage-exceeded"]
+=== Fix watermark errors
+
+Refer to <<fix-watermark-errors>>.

--- a/docs/reference/troubleshooting.asciidoc
+++ b/docs/reference/troubleshooting.asciidoc
@@ -16,6 +16,7 @@ fix problems that an {es} deployment might encounter.
 [discrete]
 [[troubleshooting-data]]
 === Data
+* <<fix-watermark-errors,Fix watermark errors caused by low disk space>>
 * <<add-tier,Add a missing tier to the system>>
 * <<allow-all-cluster-allocation,Allow Elasticsearch to allocate the data in the system>>
 * <<allow-all-index-allocation,Allow Elasticsearch to allocate the index>>

--- a/docs/reference/troubleshooting/common-issues/disk-usage-exceeded.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/disk-usage-exceeded.asciidoc
@@ -1,11 +1,18 @@
-[[disk-usage-exceeded]]
-=== Error: disk usage exceeded flood-stage watermark, index has read-only-allow-delete block
+[[fix-watermark-errors]]
+=== Fix watermark errors
 
-This error indicates a data node is critically low on disk space and has reached
-the <<cluster-routing-flood-stage,flood-stage disk usage watermark>>. To prevent
-a full disk, when a node reaches this watermark, {es} blocks writes to any index
-with a shard on the node. If the block affects related system indices, {kib} and
-other {stack} features may become unavailable.
+++++
+<titleabbrev>Watermark errors</titleabbrev>
+++++
+:keywords: {es}, high watermark, low watermark, full disk
+
+When a data node is critically low on disk space and has reached the
+<<cluster-routing-flood-stage,flood-stage disk usage watermark>>, the following
+error is logged: `Error: disk usage exceeded flood-stage watermark, index has read-only-allow-delete block`. 
+
+To prevent a full disk, when a node reaches this watermark, {es} blocks writes
+to any index with a shard on the node. If the block affects related system
+indices, {kib} and other {stack} features may become unavailable.
 
 {es} will automatically remove the write block when the affected node's disk
 usage goes below the <<cluster-routing-watermark-high,high disk watermark>>. To

--- a/docs/reference/troubleshooting/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/troubleshooting/fix-common-cluster-issues.asciidoc
@@ -3,9 +3,9 @@
 
 This guide describes how to fix common errors and problems with {es} clusters.
 
-<<disk-usage-exceeded,Error: disk usage exceeded flood-stage watermark, index has read-only-allow-delete block>>::
-This error indicates a data node is critically low on disk space and has reached
-the flood-stage disk usage watermark.
+<<fix-watermark-errors,Watermark errors>>::
+Fix watermark errors that occur when a data node is critically low on disk space
+and has reached the flood-stage disk usage watermark.
 
 <<circuit-breaker-errors,Circuit breaker errors>>::
 {es} uses circuit breakers to prevent nodes from running out of JVM heap memory.


### PR DESCRIPTION
Watermark issues are common, but the troubleshooting documentation is not prominent and does not score high in Google results for a query on "watermark". This PR makes some SEO improvements that should help users find this page more easily:

- improving the title
- improving the URL
- linking to it from the main troubleshooting page
- linking to it from other relevant pages

Related to https://github.com/elastic/elasticsearch/issues/85741
