### PR TITLE
[ML] Span and merge long docs for the text expansion model

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/SlimConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/SlimConfig.java
@@ -77,14 +77,6 @@ public class SlimConfig implements NlpConfig {
                 this.tokenization.getName()
             );
         }
-        // TODO support spanning
-        if (this.tokenization.span != -1) {
-            throw ExceptionsHelper.badRequestException(
-                "[{}] does not support windowing long text sequences; configured span [{}]",
-                NAME,
-                this.tokenization.span
-            );
-        }
         this.resultsField = resultsField;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -60,7 +60,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             try {
                 cancellableTask.ensureNotCancelled();
             } catch (TaskCancelledException ex) {
-                logger.debug(() -> format("[%s] %s", getModelId(), ex.getMessage()));
+                logger.warn(() -> format("[%s] %s", getModelId(), ex.getMessage()));
                 return true;
             }
         }
@@ -90,7 +90,8 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             NlpConfig nlpConfig = (NlpConfig) config;
             NlpTask.Request request = processor.getRequestBuilder(nlpConfig)
                 .buildRequest(text, requestIdStr, nlpConfig.getTokenization().getTruncate(), nlpConfig.getTokenization().getSpan());
-            logger.debug(() -> "Inference Request " + request.processInput().utf8ToString());
+            logger.debug(() -> format("handling request [%s]", requestIdStr));
+            logger.trace(() -> "Inference Request " + request.processInput().utf8ToString());
             if (request.tokenization().anyTruncated()) {
                 logger.debug("[{}] [{}] input truncated", getModelId(), getRequestId());
             }
@@ -140,7 +141,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             return;
         }
         InferenceResults results = inferenceResultsProcessor.processResult(tokenization, pyTorchResult.inferenceResult());
-        logger.debug(() -> format("[%s] processed result for request [%s]", getModelId(), getRequestId()));
+        logger.trace(() -> format("[%s] processed result for request [%s]", getModelId(), getRequestId()));
         onSuccess(results);
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/SlimProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/SlimProcessorTests.java
@@ -36,4 +36,23 @@ public class SlimProcessorTests extends ESTestCase {
         assertEquals(new SlimResults.WeightedToken(3, 3.0f), weightedTokens.get(1));
         assertEquals(new SlimResults.WeightedToken(4, 4.0f), weightedTokens.get(2));
     }
+
+    public void testProcessResultMultipleVectors() {
+        double[][][] pytorchResult = new double[][][] { { { 0.0, 1.0, 0.0, 1.0, 4.0, 0.0, 0.0 }, { 1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.1 } } };
+
+        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of(), List.of(), 0);
+
+        var inferenceResult = SlimProcessor.processResult(tokenizationResult, new PyTorchInferenceResult(pytorchResult), "foo");
+        assertThat(inferenceResult, instanceOf(SlimResults.class));
+        var slimResults = (SlimResults) inferenceResult;
+        assertEquals(slimResults.getResultsField(), "foo");
+
+        var weightedTokens = slimResults.getWeightedTokens();
+        assertThat(weightedTokens, hasSize(5));
+        assertEquals(new SlimResults.WeightedToken(0, 1.0f), weightedTokens.get(0));
+        assertEquals(new SlimResults.WeightedToken(1, 2.0f), weightedTokens.get(1));
+        assertEquals(new SlimResults.WeightedToken(3, 3.0f), weightedTokens.get(2));
+        assertEquals(new SlimResults.WeightedToken(4, 4.0f), weightedTokens.get(3));
+        assertEquals(new SlimResults.WeightedToken(6, 0.1f), weightedTokens.get(4));
+    }
 }


### PR DESCRIPTION
When configured with a non-negative value for `tokenization.span` long documents are split into multiple overlapping sections. The final tokens and weights are a merged from the split sections taking the max weight in each case. 

Non issue as covered by #93694

In addition there are some small logging changes to put some very verbose messages at trace level and an update to some tests.