### PR TITLE
[8.6] Update tsds.asciidoc (#94208)

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -29,7 +29,7 @@ logs or traces, use a regular data stream.
 A TSDS works like a regular data stream with some key differences:
 
 * The matching index template for a TSDS requires a `data_stream` object with
-the <<time-series-mode,`index_mode: time_series`>> option. This option enables
+the <<time-series-mode,`index.mode: time_series`>> option. This option enables
 most TSDS-related functionality.
 
 * In addition to a `@timestamp`, each document in a TSDS must contain one or


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.6`:
 - [Update tsds.asciidoc (#94208)](https://github.com/elastic/elasticsearch/pull/94208)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)