### PR TITLE
Ensure refresh to return the latest commit generation

### DIFF
--- a/docs/changelog/94249.yaml
+++ b/docs/changelog/94249.yaml
@@ -1,0 +1,5 @@
+pr: 94249
+summary: Ensure refresh to return the latest commit generation
+area: Engine
+type: bug
+issues: []


### PR DESCRIPTION
While debugging the sliced scroll tests with stateless, I noticed that some search engines didn't have the latest data. After some investigation, I discovered that the index engine was propagating the previous index commit generation due to a Lucene bug (as described here: https://github.com/apache/lucene/pull/12177). Specifically, if a scheduled refresh occurs while a flush is in progress, the generation of the refreshed reader is the generation of the previous index commit.

This PR adds a workaround for this issue until we have a Lucene snapshot with the bug fix.