### PR TITLE
Mute disruption tests for jdk20+ (#94207)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/StableMasterDisruptionIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Tuple;
+import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.disruption.LongGCDisruption;
@@ -172,6 +173,7 @@ public class StableMasterDisruptionIT extends ESIntegTestCase {
      * following another elected master node. These nodes should reject this cluster state and prevent them from following the stale master.
      */
     public void testStaleMasterNotHijackingMajority() throws Exception {
+        assumeFalse("jdk20 removed thread suspend/resume", JavaVersion.current().compareTo(JavaVersion.parse("20")) >= 0);
         final List<String> nodes = internalCluster().startNodes(
             3,
             Settings.builder()

--- a/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/disruption/LongGCDisruptionTests.java
@@ -8,7 +8,9 @@
 package org.elasticsearch.test.disruption;
 
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.jdk.JavaVersion;
 import org.elasticsearch.test.ESTestCase;
+import org.junit.BeforeClass;
 
 import java.lang.management.ThreadInfo;
 import java.util.ArrayList;
@@ -38,6 +40,11 @@ public class LongGCDisruptionTests extends ESTestCase {
                 lock.unlock();
             }
         }
+    }
+
+    @BeforeClass
+    public static void ignoreJdk20Plus() {
+        assumeFalse("jdk20 removed thread suspend/resume", JavaVersion.current().compareTo(JavaVersion.parse("20")) >= 0);
     }
 
     public void testBlockingTimeout() throws Exception {


### PR DESCRIPTION
In JDK 20 Thread suspend/resume is soft removed (they now throw UnsupportedOperationException). Many ES disruption tests simulate GC pauses with suspend/resume. As that strategy will no longer work, this commit mutes those tests for jdk20+.

relates #94206
closes #93707
