### PR TITLE
Add create flag to PUT Engine call

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/engine.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/engine.put.json
@@ -31,6 +31,12 @@
         }
       ]
     },
+    "params": {
+      "create": {
+        "type": "boolean",
+        "description": "If true, requires that an engine with the specified engine_id does not already exist. (default: false)"
+      }
+    },
     "body": {
       "description": "The engine configuration, including `indices`",
       "required": true

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_engine_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_engine_put.yml
@@ -70,3 +70,24 @@ setup:
         body:
           indices: [ "test-index1", "index-does-not-exist" ]
 
+---
+"Create Engine - Engine already exists":
+  - do:
+      engine.put:
+        engine_id: test-re-creating-engine
+        create: true
+        body:
+          indices: [ "test-index1" ]
+
+  - match: { result: "created" }
+
+  - do:
+      catch: conflict
+      engine.put:
+        engine_id: test-re-creating-engine
+        create: true
+        body:
+          indices: [ "test-index1" ]
+
+  - match: { error.type: "version_conflict_engine_exception" }
+

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -194,6 +194,7 @@ public class EngineIndexService {
      * Creates or updates the {@link Engine} in the underlying index.
      *
      * @param engine The engine object.
+     * @param create If true, the engine must not already exist
      * @param listener The action listener to invoke on response/failure.
      */
     public void putEngine(Engine engine, boolean create, ActionListener<IndexResponse> listener) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -196,11 +196,11 @@ public class EngineIndexService {
      * @param engine The engine object.
      * @param listener The action listener to invoke on response/failure.
      */
-    public void putEngine(Engine engine, DocWriteRequest.OpType opType, ActionListener<IndexResponse> listener) {
+    public void putEngine(Engine engine, boolean create, ActionListener<IndexResponse> listener) {
         createOrUpdateAlias(engine, new ActionListener<>() {
             @Override
             public void onResponse(AcknowledgedResponse acknowledgedResponse) {
-                updateEngine(engine, opType, listener);
+                updateEngine(engine, create, listener);
             }
 
             @Override
@@ -261,7 +261,7 @@ public class EngineIndexService {
         return aliasesRequestBuilder;
     }
 
-    private void updateEngine(Engine engine, DocWriteRequest.OpType opType, ActionListener<IndexResponse> listener) {
+    private void updateEngine(Engine engine, boolean create, ActionListener<IndexResponse> listener) {
         try (ReleasableBytesStreamOutput buffer = new ReleasableBytesStreamOutput(0, bigArrays.withCircuitBreaking())) {
             try (XContentBuilder source = XContentFactory.jsonBuilder(buffer)) {
                 source.startObject()
@@ -273,7 +273,9 @@ public class EngineIndexService {
                     )
                     .endObject();
             }
-            final IndexRequest indexRequest = new IndexRequest(ENGINE_ALIAS_NAME).id(engine.name())
+            DocWriteRequest.OpType opType = (create ? DocWriteRequest.OpType.CREATE : DocWriteRequest.OpType.INDEX);
+            final IndexRequest indexRequest = new IndexRequest(ENGINE_ALIAS_NAME).opType(DocWriteRequest.OpType.INDEX)
+                .id(engine.name())
                 .opType(opType)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(buffer.bytes(), XContentType.JSON);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexService.java
@@ -196,11 +196,11 @@ public class EngineIndexService {
      * @param engine The engine object.
      * @param listener The action listener to invoke on response/failure.
      */
-    public void putEngine(Engine engine, boolean create, ActionListener<IndexResponse> listener) {
+    public void putEngine(Engine engine, DocWriteRequest.OpType opType, ActionListener<IndexResponse> listener) {
         createOrUpdateAlias(engine, new ActionListener<>() {
             @Override
             public void onResponse(AcknowledgedResponse acknowledgedResponse) {
-                updateEngine(engine, create, listener);
+                updateEngine(engine, opType, listener);
             }
 
             @Override
@@ -261,7 +261,7 @@ public class EngineIndexService {
         return aliasesRequestBuilder;
     }
 
-    private void updateEngine(Engine engine, boolean create, ActionListener<IndexResponse> listener) {
+    private void updateEngine(Engine engine, DocWriteRequest.OpType opType, ActionListener<IndexResponse> listener) {
         try (ReleasableBytesStreamOutput buffer = new ReleasableBytesStreamOutput(0, bigArrays.withCircuitBreaking())) {
             try (XContentBuilder source = XContentFactory.jsonBuilder(buffer)) {
                 source.startObject()
@@ -273,9 +273,7 @@ public class EngineIndexService {
                     )
                     .endObject();
             }
-            DocWriteRequest.OpType opType = (create ? DocWriteRequest.OpType.CREATE : DocWriteRequest.OpType.INDEX);
-            final IndexRequest indexRequest = new IndexRequest(ENGINE_ALIAS_NAME).opType(DocWriteRequest.OpType.INDEX)
-                .id(engine.name())
+            final IndexRequest indexRequest = new IndexRequest(ENGINE_ALIAS_NAME).id(engine.name())
                 .opType(opType)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(buffer.bytes(), XContentType.JSON);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -38,18 +38,22 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
     public static class Request extends ActionRequest {
 
         private final Engine engine;
+        private final boolean create;
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.engine = new Engine(in);
+            this.create = false; // TODO What's the best way of initializing this?
         }
 
-        public Request(String engineId, BytesReference content, XContentType contentType) {
+        public Request(String engineId, boolean create, BytesReference content, XContentType contentType) {
             this.engine = Engine.fromXContentBytes(engineId, content, contentType);
+            this.create = create;
         }
 
-        public Request(Engine engine) {
+        public Request(Engine engine, boolean create) {
             this.engine = engine;
+            this.create = create;
         }
 
         @Override
@@ -73,17 +77,21 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
             return engine;
         }
 
+        public boolean create() {
+            return create;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request that = (Request) o;
-            return Objects.equals(engine, that.engine);
+            return Objects.equals(engine, that.engine) && create == that.create;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(engine);
+            return Objects.hash(engine, create);
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineAction.java
@@ -43,7 +43,7 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
         public Request(StreamInput in) throws IOException {
             super(in);
             this.engine = new Engine(in);
-            this.create = false; // TODO What's the best way of initializing this?
+            this.create = in.readBoolean();
         }
 
         public Request(String engineId, boolean create, BytesReference content, XContentType contentType) {
@@ -71,6 +71,7 @@ public class PutEngineAction extends ActionType<PutEngineAction.Response> {
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             engine.writeTo(out);
+            out.writeBoolean(create);
         }
 
         public Engine getEngine() {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.entsearch.engine.action;
 
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -14,7 +15,6 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
 
-import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -32,10 +32,10 @@ public class RestPutEngineAction extends BaseRestHandler {
     }
 
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         PutEngineAction.Request request = new PutEngineAction.Request(
             restRequest.param("engine_id"),
-            restRequest.paramAsBoolean("create", false),
+            DocWriteRequest.OpType.fromString(restRequest.param("op_type", "index")),
             restRequest.content(),
             restRequest.getXContentType()
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.entsearch.engine.action;
 
-import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
@@ -15,6 +14,7 @@ import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xpack.entsearch.EnterpriseSearch;
 
+import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.PUT;
@@ -32,10 +32,10 @@ public class RestPutEngineAction extends BaseRestHandler {
     }
 
     @Override
-    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         PutEngineAction.Request request = new PutEngineAction.Request(
             restRequest.param("engine_id"),
-            DocWriteRequest.OpType.fromString(restRequest.param("op_type", "index")),
+            restRequest.paramAsBoolean("create", false),
             restRequest.content(),
             restRequest.getXContentType()
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/RestPutEngineAction.java
@@ -35,6 +35,7 @@ public class RestPutEngineAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         PutEngineAction.Request request = new PutEngineAction.Request(
             restRequest.param("engine_id"),
+            restRequest.paramAsBoolean("create", false),
             restRequest.content(),
             restRequest.getXContentType()
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
@@ -29,6 +29,7 @@ public class TransportPutEngineAction extends HandledTransportAction<PutEngineAc
     @Override
     protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
         Engine engine = request.getEngine();
-        engineIndexService.putEngine(engine, listener.map(r -> new PutEngineAction.Response(r.getResult())));
+        boolean create = request.create();
+        engineIndexService.putEngine(engine, create, listener.map(r -> new PutEngineAction.Response(r.getResult())));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.entsearch.engine.action;
 
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
@@ -30,7 +29,7 @@ public class TransportPutEngineAction extends HandledTransportAction<PutEngineAc
     @Override
     protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
         Engine engine = request.getEngine();
-        DocWriteRequest.OpType opType = request.opType();
-        engineIndexService.putEngine(engine, opType, listener.map(r -> new PutEngineAction.Response(r.getResult())));
+        boolean create = request.create();
+        engineIndexService.putEngine(engine, create, listener.map(r -> new PutEngineAction.Response(r.getResult())));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/entsearch/engine/action/TransportPutEngineAction.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.entsearch.engine.action;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.common.inject.Inject;
@@ -29,7 +30,7 @@ public class TransportPutEngineAction extends HandledTransportAction<PutEngineAc
     @Override
     protected void doExecute(Task task, PutEngineAction.Request request, ActionListener<PutEngineAction.Response> listener) {
         Engine engine = request.getEngine();
-        boolean create = request.create();
-        engineIndexService.putEngine(engine, create, listener.map(r -> new PutEngineAction.Response(r.getResult())));
+        DocWriteRequest.OpType opType = request.opType();
+        engineIndexService.putEngine(engine, opType, listener.map(r -> new PutEngineAction.Response(r.getResult())));
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.entsearch.engine;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchResponse;
@@ -66,7 +65,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testCreateEngine() throws Exception {
         final Engine engine = new Engine("my_engine", new String[] { "index_1" }, null);
 
-        IndexResponse resp = awaitPutEngine(engine, DocWriteRequest.OpType.CREATE);
+        IndexResponse resp = awaitPutEngine(engine, true);
         assertThat(resp.status(), equalTo(RestStatus.CREATED));
         assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
 
@@ -89,7 +88,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testUpdateEngine() throws Exception {
         {
             final Engine engine = new Engine("my_engine", new String[] { "index_1", "index_2" }, null);
-            IndexResponse resp = awaitPutEngine(engine, DocWriteRequest.OpType.INDEX);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
 
@@ -98,7 +97,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
         }
 
         final Engine engine = new Engine("my_engine", new String[] { "index_3", "index_4" }, "my_engine_analytics_collection");
-        IndexResponse newResp = awaitPutEngine(engine, DocWriteRequest.OpType.INDEX);
+        IndexResponse newResp = awaitPutEngine(engine, false);
         assertThat(newResp.status(), equalTo(RestStatus.OK));
         assertThat(newResp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         Engine getNewEngine = awaitGetEngine(engine.name());
@@ -109,7 +108,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testListEngine() throws Exception {
         for (int i = 0; i < NUM_INDICES; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
-            IndexResponse resp = awaitPutEngine(engine, DocWriteRequest.OpType.INDEX);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         }
@@ -151,7 +150,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testListEngineWithQuery() throws Exception {
         for (int i = 0; i < 10; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
-            IndexResponse resp = awaitPutEngine(engine, DocWriteRequest.OpType.INDEX);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         }
@@ -183,7 +182,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testDeleteEngine() throws Exception {
         for (int i = 0; i < 5; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
-            IndexResponse resp = awaitPutEngine(engine, DocWriteRequest.OpType.INDEX);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
 
@@ -212,11 +211,11 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
         }
     }
 
-    private IndexResponse awaitPutEngine(Engine engine, DocWriteRequest.OpType opType) throws Exception {
+    private IndexResponse awaitPutEngine(Engine engine, boolean create) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<IndexResponse> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        engineService.putEngine(engine, opType, new ActionListener<>() {
+        engineService.putEngine(engine, create, new ActionListener<>() {
             @Override
             public void onResponse(IndexResponse indexResponse) {
                 resp.set(indexResponse);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.index.engine.VersionConflictEngineException;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
@@ -72,6 +73,8 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
         Engine getEngine = awaitGetEngine(engine.name());
         assertThat(getEngine, equalTo(engine));
         checkAliases(engine);
+
+        expectThrows(VersionConflictEngineException.class, () -> awaitPutEngine(engine, true));
     }
 
     private void checkAliases(Engine engine) {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/EngineIndexServiceTests.java
@@ -65,7 +65,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testCreateEngine() throws Exception {
         final Engine engine = new Engine("my_engine", new String[] { "index_1" }, null);
 
-        IndexResponse resp = awaitPutEngine(engine);
+        IndexResponse resp = awaitPutEngine(engine, true);
         assertThat(resp.status(), equalTo(RestStatus.CREATED));
         assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
 
@@ -88,7 +88,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testUpdateEngine() throws Exception {
         {
             final Engine engine = new Engine("my_engine", new String[] { "index_1", "index_2" }, null);
-            IndexResponse resp = awaitPutEngine(engine);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
 
@@ -97,7 +97,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
         }
 
         final Engine engine = new Engine("my_engine", new String[] { "index_3", "index_4" }, "my_engine_analytics_collection");
-        IndexResponse newResp = awaitPutEngine(engine);
+        IndexResponse newResp = awaitPutEngine(engine, false);
         assertThat(newResp.status(), equalTo(RestStatus.OK));
         assertThat(newResp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         Engine getNewEngine = awaitGetEngine(engine.name());
@@ -108,7 +108,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testListEngine() throws Exception {
         for (int i = 0; i < NUM_INDICES; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
-            IndexResponse resp = awaitPutEngine(engine);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         }
@@ -150,7 +150,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testListEngineWithQuery() throws Exception {
         for (int i = 0; i < 10; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
-            IndexResponse resp = awaitPutEngine(engine);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
         }
@@ -182,7 +182,7 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
     public void testDeleteEngine() throws Exception {
         for (int i = 0; i < 5; i++) {
             final Engine engine = new Engine("my_engine_" + i, new String[] { "index_" + i }, null);
-            IndexResponse resp = awaitPutEngine(engine);
+            IndexResponse resp = awaitPutEngine(engine, false);
             assertThat(resp.status(), equalTo(RestStatus.CREATED));
             assertThat(resp.getIndex(), equalTo(ENGINE_CONCRETE_INDEX_NAME));
 
@@ -211,11 +211,11 @@ public class EngineIndexServiceTests extends ESSingleNodeTestCase {
         }
     }
 
-    private IndexResponse awaitPutEngine(Engine engine) throws Exception {
+    private IndexResponse awaitPutEngine(Engine engine, boolean create) throws Exception {
         CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<IndexResponse> resp = new AtomicReference<>(null);
         final AtomicReference<Exception> exc = new AtomicReference<>(null);
-        engineService.putEngine(engine, new ActionListener<>() {
+        engineService.putEngine(engine, create, new ActionListener<>() {
             @Override
             public void onResponse(IndexResponse indexResponse) {
                 resp.set(indexResponse);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
@@ -29,7 +29,7 @@ public class PutEngineActionRequestSerializingTests extends AbstractWireSerializ
 
     @Override
     protected PutEngineAction.Request createTestInstance() {
-        return new PutEngineAction.Request(randomEngine(), false); // TODO change to randomBoolean()
+        return new PutEngineAction.Request(randomEngine(), randomBoolean());
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
@@ -29,7 +29,7 @@ public class PutEngineActionRequestSerializingTests extends AbstractWireSerializ
 
     @Override
     protected PutEngineAction.Request createTestInstance() {
-        return new PutEngineAction.Request(randomEngine());
+        return new PutEngineAction.Request(randomEngine(), false); // TODO change to randomBoolean()
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.entsearch.engine.action;
 
-import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
@@ -30,7 +29,7 @@ public class PutEngineActionRequestSerializingTests extends AbstractWireSerializ
 
     @Override
     protected PutEngineAction.Request createTestInstance() {
-        return new PutEngineAction.Request(randomEngine(), randomFrom(DocWriteRequest.OpType.CREATE, DocWriteRequest.OpType.INDEX));
+        return new PutEngineAction.Request(randomEngine(), false); // TODO change to randomBoolean()
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/entsearch/engine/action/PutEngineActionRequestSerializingTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.entsearch.engine.action;
 
+import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
@@ -29,7 +30,7 @@ public class PutEngineActionRequestSerializingTests extends AbstractWireSerializ
 
     @Override
     protected PutEngineAction.Request createTestInstance() {
-        return new PutEngineAction.Request(randomEngine(), randomBoolean());
+        return new PutEngineAction.Request(randomEngine(), randomFrom(DocWriteRequest.OpType.CREATE, DocWriteRequest.OpType.INDEX));
     }
 
     @Override


### PR DESCRIPTION
Adds a boolean flag `create` (default false) to the `PUT Engine` command. 

```
http://localhost:9200/_engine/puggles?create
```

- Returns `created` if the Engine does not exist
- Returns `version_conflict_engine_exception` if Engine exists. 