### PR TITLE
Default to bundled JDK for all runtime test execution

### DIFF
--- a/.ci/java-versions-aarch64.properties
+++ b/.ci/java-versions-aarch64.properties
@@ -5,4 +5,3 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 ES_BUILD_JAVA=jdk17
-ES_RUNTIME_JAVA=jdk17

--- a/.ci/java-versions-fips.properties
+++ b/.ci/java-versions-fips.properties
@@ -5,4 +5,3 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 ES_BUILD_JAVA=openjdk17
-ES_RUNTIME_JAVA=openjdk17

--- a/.ci/java-versions.properties
+++ b/.ci/java-versions.properties
@@ -5,4 +5,3 @@
 # are 'java' or 'openjdk' followed by the major release number.
 
 ES_BUILD_JAVA=openjdk17
-ES_RUNTIME_JAVA=openjdk17

--- a/.ci/jobs.t/elastic+elasticsearch+dra-snapshot.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+dra-snapshot.yml
@@ -10,7 +10,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
             #!/usr/local/bin/runbld --redirect-stderr
             WORKFLOW="snapshot"

--- a/.ci/jobs.t/elastic+elasticsearch+dra-staging.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+dra-staging.yml
@@ -10,7 +10,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
             #!/usr/local/bin/runbld --redirect-stderr
 

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-unix.yml
@@ -34,7 +34,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           ./.ci/scripts/packaging-test.sh --build-cache -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/ destructivePackagingTest

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-upgrade.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-upgrade.yml
@@ -25,7 +25,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+packaging-tests-windows.yml
@@ -22,7 +22,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
       - batch: |
           del /f /s /q %USERPROFILE%\.gradle\init.d\*.*
           mkdir %USERPROFILE%\.gradle\init.d

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-arm.yml
@@ -31,7 +31,6 @@
           properties-content: |
             COMPOSE_HTTP_TIMEOUT=120
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/jdk11
             JAVA16_HOME=$HOME/.java/jdk16
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-unix.yml
@@ -37,7 +37,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+platform-support-windows.yml
@@ -35,7 +35,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11
             JAVA16_HOME=$USERPROFILE\\.java\\openjdk16
       - batch: |

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-azure-sas.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-azure-sas.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             azure_storage_container=elasticsearch-ci-thirdparty-sas
             azure_storage_base_path=%BRANCH%
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-azure.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-azure.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             azure_storage_container=elasticsearch-ci-thirdparty
             azure_storage_base_path=%BRANCH%
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-gcs.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-gcs.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             google_storage_bucket=elasticsearch-ci-thirdparty
             google_storage_base_path=%BRANCH%
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-geoip.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-geoip.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           $WORKSPACE/.ci/scripts/run-gradle.sh :modules:ingest-geoip:internalClusterTest -Dgeoip_use_service=true

--- a/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-s3.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+multijob+third-party-tests-s3.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             amazon_s3_bucket=elasticsearch-ci.us-west-2
             amazon_s3_base_path=%BRANCH%
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+ear.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+eql-correctness.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+eql-correctness.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           set +x

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix.yml
@@ -18,7 +18,7 @@
       - axis:
           type: yaml
           filename: ".ci/matrix-runtime-javas-fips.yml"
-          name: "ES_RUNTIME_JAVA"
+          name: "RUNTIME_JAVA_HOME"
       # We shred out these jobs to avoid running out of memory given since we use a ramdisk workspace
       - axis:
           type: user-defined

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+java-fips-matrix.yml
@@ -34,7 +34,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+java-matrix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+java-matrix.yml
@@ -18,7 +18,7 @@
       - axis:
           type: yaml
           filename: ".ci/matrix-runtime-javas.yml"
-          name: "ES_RUNTIME_JAVA"
+          name: "RUNTIME_JAVA_HOME"
       # We shred out these jobs to avoid running out of memory given since we use a ramdisk workspace
       - axis:
           type: user-defined
@@ -34,7 +34,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+release-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+release-tests.yml
@@ -11,7 +11,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+single-processor-node-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+single-processor-node-tests.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr

--- a/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           set -euo pipefail

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part1.yml
@@ -38,7 +38,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+build-benchmark-part2.yml
@@ -38,7 +38,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
       - shell: |
@@ -46,5 +45,5 @@
          $WORKSPACE/.ci/scripts/run-gradle.sh :build-tools-internal:bootstrapPerformanceTests
          $WORKSPACE/.ci/scripts/install-gradle-profiler.sh
          $WORKSPACE/.ci/scripts/run-gradle-profiler.sh --benchmark --scenario-file build-tools-internal/build/performanceTests/elasticsearch-build-benchmark-part2.scenarios --project-dir . --output-dir profile-out
-         mkdir $WORKSPACE/build  
+         mkdir $WORKSPACE/build
          tar -czf $WORKSPACE/build/${BUILD_NUMBER}.tar.bz2 profile-out

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots-windows.yml
@@ -43,7 +43,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11
             JAVA16_HOME=$USERPROFILE\\.java\\openjdk16
       - batch: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+bwc-snapshots.yml
@@ -40,7 +40,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+cloud-deploy.yml
@@ -30,7 +30,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           $WORKSPACE/.ci/scripts/run-gradle.sh buildCloudDockerImage

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+docs-check.yml
@@ -29,7 +29,6 @@
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           $WORKSPACE/.ci/scripts/run-gradle.sh -Dignore.tests.seed precommit :docs:check

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+eql-correctness.yml
@@ -29,7 +29,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           set +x

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+example-plugins.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+example-plugins.yml
@@ -30,7 +30,6 @@
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           cd plugins/examples

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+full-bwc.yml
@@ -41,7 +41,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix-sample.yml
@@ -45,7 +45,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           ./.ci/scripts/packaging-test.sh --build-cache -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/ $PACKAGING_TASK

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-unix.yml
@@ -60,7 +60,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr
           ./.ci/scripts/packaging-test.sh --build-cache -Dorg.elasticsearch.build.cache.url=https://gradle-enterprise.elastic.co/cache/ $PACKAGING_TASK

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-nojdk.yml
@@ -51,7 +51,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
       - batch: |
           del /f /s /q %USERPROFILE%\.gradle\init.d\*.*
           mkdir %USERPROFILE%\.gradle\init.d

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample-nojdk.yml
@@ -47,7 +47,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
       - batch: |
           del /f /s /q %USERPROFILE%\.gradle\init.d\*.*
           mkdir %USERPROFILE%\.gradle\init.d

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows-sample.yml
@@ -45,7 +45,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
       - batch: |
           del /f /s /q %USERPROFILE%\.gradle\init.d\*.*
           mkdir %USERPROFILE%\.gradle\init.d

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-tests-windows.yml
@@ -50,7 +50,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
       - batch: |
           del /f /s /q %USERPROFILE%\.gradle\init.d\*.*
           mkdir %USERPROFILE%\.gradle\init.d

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+packaging-upgrade-tests.yml
@@ -44,7 +44,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-fips.yml
@@ -32,7 +32,6 @@
           properties-file: '.ci/java-versions-fips.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-1-windows.yml
@@ -32,7 +32,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11
             JAVA16_HOME=$USERPROFILE\\.java\\openjdk16
             GRADLE_TASK=checkPart1

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-fips.yml
@@ -32,7 +32,6 @@
           properties-file: '.ci/java-versions-fips.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-2-windows.yml
@@ -32,7 +32,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11
             JAVA16_HOME=$USERPROFILE\\.java\\openjdk16
             GRADLE_TASK=checkPart2

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-fips.yml
@@ -33,7 +33,6 @@
           properties-file: '.ci/java-versions-fips.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |
           #!/usr/local/bin/runbld --redirect-stderr

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3-windows.yml
@@ -33,7 +33,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$USERPROFILE\\.java\\$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$USERPROFILE\\.java\\$ES_RUNTIME_JAVA
             JAVA11_HOME=$USERPROFILE\\.java\\java11
             JAVA16_HOME=$USERPROFILE\\.java\\openjdk16
             GRADLE_TASK=checkPart3

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+part-3.yml
@@ -30,7 +30,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+precommit.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+precommit.yml
@@ -25,7 +25,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
       - shell: |

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+release-tests.yml
@@ -32,7 +32,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+pull-request+rest-compatibility.yml
@@ -32,7 +32,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/.ci/matrix-runtime-javas-fips.yml
+++ b/.ci/matrix-runtime-javas-fips.yml
@@ -1,5 +1,5 @@
 # This file is used as part of a matrix build in Jenkins where the
 # values below are included as an axis of the matrix.
 
-ES_RUNTIME_JAVA:
+RUNTIME_JAVA_HOME:
   - openjdk17

--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -5,7 +5,7 @@
 # which Elasticsearch will be tested.  Valid Java versions are 'java'
 # or 'openjdk' followed by the major release number.
 
-ES_RUNTIME_JAVA:
+RUNTIME_JAVA_HOME:
   - graalvm-ce17
   - openjdk17
   - openjdk18

--- a/.ci/scripts/packaging-test.ps1
+++ b/.ci/scripts/packaging-test.ps1
@@ -9,7 +9,6 @@ If (-NOT ([Security.Principal.WindowsPrincipal] [Security.Principal.WindowsIdent
 
 $AppProps = ConvertFrom-StringData (Get-Content .ci/java-versions.properties -raw)
 $env:ES_BUILD_JAVA=$AppProps.ES_BUILD_JAVA
-$env:ES_RUNTIME_JAVA=$AppProps.ES_RUNTIME_JAVA
 $env:JAVA_TOOL_OPTIONS=''
 
 $ErrorActionPreference="Stop"

--- a/.ci/scripts/packaging-test.ps1
+++ b/.ci/scripts/packaging-test.ps1
@@ -23,7 +23,6 @@ Copy-Item .ci/init.gradle -Destination $gradleInit
 [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
 $env:PATH="C:\Users\jenkins\.java\$env:ES_BUILD_JAVA\bin\;$env:PATH"
 $env:JAVA_HOME=$null
-$env:SYSTEM_JAVA_HOME="C:\Users\jenkins\.java\$env:ES_RUNTIME_JAVA"
 Remove-Item -Recurse -Force \tmp -ErrorAction Ignore
 New-Item -ItemType directory -Path \tmp
 

--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -23,7 +23,6 @@ sudo useradd vagrant
 set -e
 
 . .ci/java-versions.properties
-RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
 BUILD_JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
 
 rm -Rfv $HOME/.gradle/init.d/ && mkdir -p $HOME/.gradle/init.d
@@ -57,7 +56,6 @@ fi
 sudo bash -c 'cat > /etc/sudoers.d/elasticsearch_vars'  << SUDOERS_VARS
     Defaults   env_keep += "ES_JAVA_HOME"
     Defaults   env_keep += "JAVA_HOME"
-    Defaults   env_keep += "SYSTEM_JAVA_HOME"
 SUDOERS_VARS
 sudo chmod 0440 /etc/sudoers.d/elasticsearch_vars
 
@@ -74,9 +72,7 @@ git config --global --add safe.directory $WORKSPACE
 # be explicit about Gradle home dir so we use the same even with sudo
 sudo -E env \
   PATH=$BUILD_JAVA_HOME/bin:`sudo bash -c 'echo -n $PATH'` \
-  RUNTIME_JAVA_HOME=`readlink -f -n $RUNTIME_JAVA_HOME` \
   --unset=ES_JAVA_HOME \
   --unset=JAVA_HOME \
-  SYSTEM_JAVA_HOME=`readlink -f -n $RUNTIME_JAVA_HOME` \
   ./gradlew -g $HOME/.gradle --scan --parallel --continue $@
 

--- a/.ci/templates.t/generic-gradle-unix.yml
+++ b/.ci/templates.t/generic-gradle-unix.yml
@@ -9,7 +9,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/templates.t/matrix-gradle-unix.yml
+++ b/.ci/templates.t/matrix-gradle-unix.yml
@@ -24,7 +24,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16
       - shell: |

--- a/.ci/templates.t/pull-request-gradle-unix.yml
+++ b/.ci/templates.t/pull-request-gradle-unix.yml
@@ -27,7 +27,6 @@
           properties-file: '.ci/java-versions.properties'
           properties-content: |
             JAVA_HOME=$HOME/.java/$ES_BUILD_JAVA
-            RUNTIME_JAVA_HOME=$HOME/.java/$ES_RUNTIME_JAVA
             JAVA8_HOME=$HOME/.java/java8
             JAVA11_HOME=$HOME/.java/java11
             JAVA16_HOME=$HOME/.java/openjdk16

--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -10,6 +10,8 @@ import org.elasticsearch.gradle.Architecture
 import org.elasticsearch.gradle.OS
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
+import org.elasticsearch.gradle.internal.precommit.ThirdPartyAuditPrecommitPlugin
+import org.elasticsearch.gradle.internal.precommit.ThirdPartyAuditTask
 import org.elasticsearch.gradle.internal.test.rest.RestTestBasePlugin
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
 
@@ -51,6 +53,14 @@ configure(allprojects) {
         if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
           dependsOn(project.jdks.provisioned_runtime)
           nonInputProperties.systemProperty("tests.runtime.java", "${-> project.jdks.provisioned_runtime.javaHomePath}")
+        }
+      }
+    }
+
+    project.plugins.withType(ThirdPartyAuditPrecommitPlugin) {
+      project.getTasks().withType(ThirdPartyAuditTask.class).configureEach {
+        if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
+          javaHome.set(providers.provider(() -> "${project.jdks.provisioned_runtime.javaHomePath}"))
         }
       }
     }

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditPrecommitPlugin.java
@@ -17,6 +17,7 @@ import org.gradle.api.Task;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.tasks.TaskProvider;
 
+import java.io.File;
 import java.nio.file.Path;
 
 public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
@@ -61,7 +62,7 @@ public class ThirdPartyAuditPrecommitPlugin extends PrecommitPlugin {
             }));
             t.dependsOn(resourcesTask);
             if (BuildParams.getIsRuntimeJavaHomeSet()) {
-                t.setJavaHome(BuildParams.getRuntimeJavaHome().getPath());
+                t.getJavaHome().set(project.provider(BuildParams::getRuntimeJavaHome).map(File::getPath));
             }
             t.getTargetCompatibility().set(project.provider(BuildParams::getRuntimeJavaVersion));
             t.setSignatureFile(resourcesDir.resolve("forbidden/third-party-audit.txt").toFile());

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/precommit/ThirdPartyAuditTask.java
@@ -79,7 +79,7 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
 
     private File signatureFile;
 
-    private String javaHome;
+    private Property<String> javaHome;
 
     private final Property<JavaVersion> targetCompatibility;
 
@@ -106,6 +106,7 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
         this.fileSystemOperations = fileSystemOperations;
         this.projectLayout = projectLayout;
         this.targetCompatibility = objectFactory.property(JavaVersion.class);
+        this.javaHome = objectFactory.property(String.class);
     }
 
     @Input
@@ -127,14 +128,9 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
         this.signatureFile = signatureFile;
     }
 
-    @Input
-    @Optional
-    public String getJavaHome() {
+    @Internal
+    public Property<String> getJavaHome() {
         return javaHome;
-    }
-
-    public void setJavaHome(String javaHome) {
-        this.javaHome = javaHome;
     }
 
     @Internal
@@ -335,8 +331,8 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
     private String runForbiddenAPIsCli() throws IOException {
         ByteArrayOutputStream errorOut = new ByteArrayOutputStream();
         ExecResult result = execOperations.javaexec(spec -> {
-            if (javaHome != null) {
-                spec.setExecutable(javaHome + "/bin/java");
+            if (javaHome.isPresent()) {
+                spec.setExecutable(javaHome.get() + "/bin/java");
             }
             spec.classpath(getForbiddenAPIsClasspath(), classpath);
             spec.jvmArgs("-Xmx1g");
@@ -368,8 +364,8 @@ public abstract class ThirdPartyAuditTask extends DefaultTask {
             spec.getMainClass().set(JDK_JAR_HELL_MAIN_CLASS);
             spec.args(getJarExpandDir());
             spec.setIgnoreExitValue(true);
-            if (javaHome != null) {
-                spec.setExecutable(javaHome + "/bin/java");
+            if (javaHome.isPresent()) {
+                spec.setExecutable(javaHome.get() + "/bin/java");
             }
             spec.setStandardOutput(standardOut);
         });


### PR DESCRIPTION
This removes all instances of `RUNTIME_JAVA_HOME` in CI with the exception of our Java compatibility matrix tests. In practice this means that all jobs will use the provisioned bundled JDK for test execution, which is both more accurate (this is the JDK that is included in Elasticsearch) and less prone to issues with differences between CI agent images.

The one case of where the provisioned JDK wasn't being used for "runtime" usage was for our third party audit tests. This has been fixed so that when `RUNTIME_JAVA_HOME` is unset, the third party audit task will used the bundled JDK.

Closes https://github.com/elastic/elasticsearch/issues/40531