### PR TITLE
Cache RoutingTable Building in XContent

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -83,7 +83,7 @@ public class ClusterRerouteResponseTests extends ESTestCase {
 
     public void testToXContentWithDeprecatedClusterState() {
         var clusterState = createClusterState();
-        assertXContent(createClusterRerouteResponse(clusterState), ToXContent.EMPTY_PARAMS, 32, Strings.format("""
+        assertXContent(createClusterRerouteResponse(clusterState), ToXContent.EMPTY_PARAMS, 31, Strings.format("""
             {
               "acknowledged": true,
               "state": {
@@ -188,7 +188,7 @@ public class ClusterRerouteResponseTests extends ESTestCase {
         assertXContent(
             createClusterRerouteResponse(createClusterState()),
             new ToXContent.MapParams(Map.of("metric", "metadata", "settings_filter", "index.number*,index.version.created")),
-            19,
+            20,
             """
                 {
                   "acknowledged" : true,


### PR DESCRIPTION
We are using cerebro to monitor cluster state and RoutingTable. it will use `GET /_cluster/state/master_node,routing_table,blocks`  api to get the cluster state at ES Version 7.10.

When there is a large(over 100K Shards) RoutingTable, it will take to much time to build XContent at `ClusterState:toXContent()` shows as following:
![img_v2_e680210c-9373-4f63-b3ae-d7a6ec9aba3g](https://user-images.githubusercontent.com/12760367/222330023-11cd99a2-44ce-4151-9a7f-514d23bdf73c.jpg)

i think the time cost in the following code: because it needs iterator all shards

https://github.com/elastic/elasticsearch/blob/53719cf247a270b06bd366e6e690dc9423377361/server/src/main/java/org/elasticsearch/cluster/ClusterState.java#L600-L614

![img_v2_f41acad7-9d37-4139-b571-25a5719a052g](https://user-images.githubusercontent.com/12760367/222330076-8b184b38-4e65-4e85-adca-810679940546.jpg)

I have been checked latest code, there are `chunked optimize` and `IndexRoutingTable using Array instead of IntMap`, but the iterator is inevitable

when the cluster is long term running, the cluster routingTable is less changed, there is no need to calculate build it every time. we can cache this output as same as `JoinValidationService#serializeClusterState` does

issues #94263 