### PR TITLE
Fix BytesTransportResponse.writeTo NPE

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportActionProxy.java
@@ -110,7 +110,7 @@ public final class TransportActionProxy {
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeBytes(bytes.array(), bytes.arrayOffset(), bytes.length());
+            bytes.writeTo(out);
         }
 
         @Override


### PR DESCRIPTION
We can't assume that we always have an array backed buffer here. `writeTo()` writes to the output without allocation in all cases and is as efficient as the existing method for array backed buffers.

closes #94269
