### PR TITLE
[Profiling] Adjust handling of last data slice

### DIFF
--- a/docs/changelog/94283.yaml
+++ b/docs/changelog/94283.yaml
@@ -1,0 +1,5 @@
+pr: 94283
+summary: "[Profiling] Adjust handling of last data slice"
+area: Search
+type: bug
+issues: []

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -191,11 +191,9 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         }
         List<List<T>> slicedList = new ArrayList<>();
         int batchSize = c.size() / slices;
-        if (c.size() % slices != 0) {
-            batchSize += 1;
-        }
         for (int slice = 0; slice < slices; slice++) {
-            List<T> ids = c.subList(slice * batchSize, Math.min((slice + 1) * batchSize, c.size()));
+            int upperIndex = (slice + 1 < slices) ? (slice + 1) * batchSize : c.size();
+            List<T> ids = c.subList(slice * batchSize, upperIndex);
             slicedList.add(ids);
         }
         return Collections.unmodifiableList(slicedList);

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/TransportGetProfilingActionTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/TransportGetProfilingActionTests.java
@@ -39,8 +39,16 @@ public class TransportGetProfilingActionTests extends ESTestCase {
         List<String> input = List.of("a", "b", "c", "d", "e", "f", "g", "h", "i", "j");
         List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
         assertEquals(slices, sliced.size());
-        assertEquals(List.of("a", "b", "c", "d"), sliced.get(0));
-        assertEquals(List.of("e", "f", "g", "h"), sliced.get(1));
-        assertEquals(List.of("i", "j"), sliced.get(2));
+        assertEquals(List.of("a", "b", "c"), sliced.get(0));
+        assertEquals(List.of("d", "e", "f"), sliced.get(1));
+        assertEquals(List.of("g", "h", "i", "j"), sliced.get(2));
+    }
+
+    public void testRandomLengthListGreaterThanSliceCount() {
+        int slices = randomIntBetween(1, 16);
+        // To ensure that we can actually slice the list
+        List<String> input = randomList(slices, 20000, () -> "s");
+        List<List<String>> sliced = TransportGetProfilingAction.sliced(input, slices);
+        assertEquals(slices, sliced.size());
     }
 }


### PR DESCRIPTION
The profiling plugin slices data internally in order to execute queries in parallel. However, in some cases the slicing logic did not calculate the boundaries of the last slice properly which led to error responses for clients. With this commit we now space slices evenly and put the remainder of items into the last slice.