### PR TITLE
[7.17] Fix packaging test reliance on SYSTEM_JAVA_HOME (#94293)

### DIFF
--- a/.ci/scripts/packaging-test.ps1
+++ b/.ci/scripts/packaging-test.ps1
@@ -22,6 +22,7 @@ Copy-Item .ci/init.gradle -Destination $gradleInit
 [Environment]::SetEnvironmentVariable("JAVA_HOME", $null, "Machine")
 $env:PATH="C:\Users\jenkins\.java\$env:ES_BUILD_JAVA\bin\;$env:PATH"
 $env:JAVA_HOME=$null
+$env:SYSTEM_JAVA_HOME="C:\Users\jenkins\.java\$env:ES_BUILD_JAVA"
 Remove-Item -Recurse -Force \tmp -ErrorAction Ignore
 New-Item -ItemType directory -Path \tmp
 

--- a/.ci/scripts/packaging-test.sh
+++ b/.ci/scripts/packaging-test.sh
@@ -56,6 +56,7 @@ fi
 sudo bash -c 'cat > /etc/sudoers.d/elasticsearch_vars'  << SUDOERS_VARS
     Defaults   env_keep += "ES_JAVA_HOME"
     Defaults   env_keep += "JAVA_HOME"
+    Defaults   env_keep += "SYSTEM_JAVA_HOME"
 SUDOERS_VARS
 sudo chmod 0440 /etc/sudoers.d/elasticsearch_vars
 
@@ -74,5 +75,6 @@ sudo -E env \
   PATH=$BUILD_JAVA_HOME/bin:`sudo bash -c 'echo -n $PATH'` \
   --unset=ES_JAVA_HOME \
   --unset=JAVA_HOME \
+  SYSTEM_JAVA_HOME=`readlink -f -n $BUILD_JAVA_HOME` \
   ./gradlew -g $HOME/.gradle --scan --parallel --continue $@
 


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Fix packaging test reliance on SYSTEM_JAVA_HOME (#94293)