### PR TITLE
Mute one more disruption test for jdk 20+

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -46,6 +46,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
      * Test that cluster recovers from a long GC on master that causes other nodes to elect a new one
      */
     public void testMasterNodeGCs() throws Exception {
+        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
         List<String> nodes = startCluster(3);
 
         String oldMasterNode = internalCluster().getMasterName();


### PR DESCRIPTION
In #94207 we missed one disruption test still mimicking GC.