### PR TITLE
Remove unused client methods

### DIFF
--- a/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
+++ b/modules/transport-netty4/src/internalClusterTest/java/org/elasticsearch/transport/netty4/ESLoggingHandlerIT.java
@@ -11,7 +11,6 @@ package org.elasticsearch.transport.netty4;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.elasticsearch.ESNetty4IntegTestCase;
-import org.elasticsearch.action.admin.cluster.node.hotthreads.NodesHotThreadsRequest;
 import org.elasticsearch.common.logging.Loggers;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.MockLogAppender;
@@ -85,7 +84,7 @@ public class ESLoggingHandlerIT extends ESNetty4IntegTestCase {
         appender.addExpectation(writeExpectation);
         appender.addExpectation(flushExpectation);
         appender.addExpectation(readExpectation);
-        client().admin().cluster().nodesHotThreads(new NodesHotThreadsRequest()).actionGet();
+        client().admin().cluster().prepareNodesHotThreads().get();
         appender.assertAllExpectationsMatched();
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
@@ -13,7 +13,6 @@ import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.ingest.DeletePipelineRequest;
-import org.elasticsearch.action.ingest.GetPipelineRequest;
 import org.elasticsearch.action.ingest.GetPipelineResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.search.SearchResponse;
@@ -71,8 +70,8 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         final GetPipelineResponse response = client().admin()
             .cluster()
-            .getPipeline(new GetPipelineRequest("default_pipeline", "final_pipeline", "request_pipeline"))
-            .actionGet();
+            .prepareGetPipeline("default_pipeline", "final_pipeline", "request_pipeline")
+            .get();
         for (final PipelineConfiguration pipeline : response.pipelines()) {
             client().admin().cluster().deletePipeline(new DeletePipelineRequest(pipeline.getId())).actionGet();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.ingest.DeletePipelineRequest;
-import org.elasticsearch.action.ingest.GetPipelineRequest;
 import org.elasticsearch.action.ingest.GetPipelineResponse;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.action.ingest.SimulateDocumentBaseResult;
@@ -226,8 +225,7 @@ public class IngestClientIT extends ESIntegTestCase {
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, XContentType.JSON);
         client().admin().cluster().putPipeline(putPipelineRequest).get();
 
-        GetPipelineRequest getPipelineRequest = new GetPipelineRequest("_id");
-        GetPipelineResponse getResponse = client().admin().cluster().getPipeline(getPipelineRequest).get();
+        GetPipelineResponse getResponse = client().admin().cluster().prepareGetPipeline("_id").get();
         assertThat(getResponse.isFound(), is(true));
         assertThat(getResponse.pipelines().size(), equalTo(1));
         assertThat(getResponse.pipelines().get(0).getId(), equalTo("_id"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
@@ -48,7 +48,7 @@ public class StoredScriptsIT extends ESIntegTestCase {
         assertNotNull(script);
         assertEquals("1", script);
 
-        assertAcked(client().admin().cluster().prepareDeleteStoredScript().setId("foobar"));
+        assertAcked(client().admin().cluster().prepareDeleteStoredScript("foobar"));
         StoredScriptSource source = client().admin().cluster().prepareGetStoredScript("foobar").get().getSource();
         assertNull(source);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStatusApisIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotIndexShar
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotIndexShardStatus;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStats;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotStatus;
-import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.status.SnapshotsStatusResponse;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -90,9 +89,10 @@ public class SnapshotStatusApisIT extends AbstractSnapshotIntegTestCase {
         assertThat(snapshotInfo.state(), equalTo(SnapshotState.SUCCESS));
         assertThat(snapshotInfo.version(), equalTo(Version.CURRENT));
 
-        final List<SnapshotStatus> snapshotStatus = clusterAdmin().snapshotsStatus(
-            new SnapshotsStatusRequest("test-repo", new String[] { "test-snap" })
-        ).get().getSnapshots();
+        final List<SnapshotStatus> snapshotStatus = clusterAdmin().prepareSnapshotStatus("test-repo")
+            .setSnapshots("test-snap")
+            .get()
+            .getSnapshots();
         assertThat(snapshotStatus.size(), equalTo(1));
         final SnapshotStatus snStatus = snapshotStatus.get(0);
         assertEquals(snStatus.getStats().getStartTime(), snapshotInfo.startTime());

--- a/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/ClusterAdminClient.java
@@ -36,7 +36,6 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest;
-import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageResponse;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryRequest;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryRequestBuilder;
@@ -217,14 +216,6 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     NodesInfoRequestBuilder prepareNodesInfo(String... nodesIds);
 
     /**
-     * Cluster wide aggregated stats.
-     *
-     * @param request The cluster stats request
-     * @return The result future
-     */
-    ActionFuture<ClusterStatsResponse> clusterStats(ClusterStatsRequest request);
-
-    /**
      * Cluster wide aggregated stats
      *
      * @param request  The cluster stats request
@@ -260,31 +251,10 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      *
      * @param request
      *            The nodes usage request
-     * @return The result future
-     */
-    ActionFuture<NodesUsageResponse> nodesUsage(NodesUsageRequest request);
-
-    /**
-     * Nodes usage of the cluster.
-     *
-     * @param request
-     *            The nodes usage request
      * @param listener
      *            A listener to be notified with a result
      */
     void nodesUsage(NodesUsageRequest request, ActionListener<NodesUsageResponse> listener);
-
-    /**
-     * Nodes usage of the cluster.
-     */
-    NodesUsageRequestBuilder prepareNodesUsage(String... nodesIds);
-
-    /**
-     * Returns top N hot-threads samples per node. The hot-threads are only
-     * sampled for the node ids specified in the request.
-     *
-     */
-    ActionFuture<NodesHotThreadsResponse> nodesHotThreads(NodesHotThreadsRequest request);
 
     /**
      * Returns top N hot-threads samples per node. The hot-threads are only sampled
@@ -369,27 +339,12 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     /**
      * Returns list of shards the given search would be executed on.
      */
-    ActionFuture<ClusterSearchShardsResponse> searchShards(ClusterSearchShardsRequest request);
-
-    /**
-     * Returns list of shards the given search would be executed on.
-     */
     void searchShards(ClusterSearchShardsRequest request, ActionListener<ClusterSearchShardsResponse> listener);
 
     /**
      * Returns list of shards the given search would be executed on.
      */
-    ClusterSearchShardsRequestBuilder prepareSearchShards();
-
-    /**
-     * Returns list of shards the given search would be executed on.
-     */
     ClusterSearchShardsRequestBuilder prepareSearchShards(String... indices);
-
-    /**
-     * Registers a snapshot repository.
-     */
-    ActionFuture<AcknowledgedResponse> putRepository(PutRepositoryRequest request);
 
     /**
      * Registers a snapshot repository.
@@ -404,22 +359,12 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     /**
      * Unregisters a repository.
      */
-    ActionFuture<AcknowledgedResponse> deleteRepository(DeleteRepositoryRequest request);
-
-    /**
-     * Unregisters a repository.
-     */
     void deleteRepository(DeleteRepositoryRequest request, ActionListener<AcknowledgedResponse> listener);
 
     /**
      * Unregisters a repository.
      */
     DeleteRepositoryRequestBuilder prepareDeleteRepository(String name);
-
-    /**
-     * Gets repositories.
-     */
-    ActionFuture<GetRepositoriesResponse> getRepositories(GetRepositoriesRequest request);
 
     /**
      * Gets repositories.
@@ -439,17 +384,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     /**
      * Cleans up repository.
      */
-    ActionFuture<CleanupRepositoryResponse> cleanupRepository(CleanupRepositoryRequest repository);
-
-    /**
-     * Cleans up repository.
-     */
     void cleanupRepository(CleanupRepositoryRequest repository, ActionListener<CleanupRepositoryResponse> listener);
-
-    /**
-     * Verifies a repository.
-     */
-    ActionFuture<VerifyRepositoryResponse> verifyRepository(VerifyRepositoryRequest request);
 
     /**
      * Verifies a repository.
@@ -484,17 +419,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     /**
      * Clones a snapshot.
      */
-    ActionFuture<AcknowledgedResponse> cloneSnapshot(CloneSnapshotRequest request);
-
-    /**
-     * Clones a snapshot.
-     */
     void cloneSnapshot(CloneSnapshotRequest request, ActionListener<AcknowledgedResponse> listener);
-
-    /**
-     * Get snapshots.
-     */
-    ActionFuture<GetSnapshotsResponse> getSnapshots(GetSnapshotsRequest request);
 
     /**
      * Get snapshots.
@@ -505,11 +430,6 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Get snapshots.
      */
     GetSnapshotsRequestBuilder prepareGetSnapshots(String... repository);
-
-    /**
-     * Delete snapshot.
-     */
-    ActionFuture<AcknowledgedResponse> deleteSnapshot(DeleteSnapshotRequest request);
 
     /**
      * Delete snapshot.
@@ -546,18 +466,7 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Returns a list of the pending cluster tasks, that are scheduled to be executed. This includes operations
      * that update the cluster state (for example, a create index operation)
      */
-    ActionFuture<PendingClusterTasksResponse> pendingClusterTasks(PendingClusterTasksRequest request);
-
-    /**
-     * Returns a list of the pending cluster tasks, that are scheduled to be executed. This includes operations
-     * that update the cluster state (for example, a create index operation)
-     */
     PendingClusterTasksRequestBuilder preparePendingClusterTasks();
-
-    /**
-     * Get snapshot status.
-     */
-    ActionFuture<SnapshotsStatusResponse> snapshotsStatus(SnapshotsStatusRequest request);
 
     /**
      * Get snapshot status.
@@ -602,22 +511,12 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     /**
      * Deletes a stored ingest pipeline
      */
-    DeletePipelineRequestBuilder prepareDeletePipeline();
-
-    /**
-     * Deletes a stored ingest pipeline
-     */
     DeletePipelineRequestBuilder prepareDeletePipeline(String id);
 
     /**
      * Returns a stored ingest pipeline
      */
     void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener);
-
-    /**
-     * Returns a stored ingest pipeline
-     */
-    ActionFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request);
 
     /**
      * Returns a stored ingest pipeline
@@ -667,32 +566,12 @@ public interface ClusterAdminClient extends ElasticsearchClient {
     /**
      * Delete a script from the cluster state
      */
-    ActionFuture<AcknowledgedResponse> deleteStoredScript(DeleteStoredScriptRequest request);
-
-    /**
-     * Delete a script from the cluster state
-     */
-    DeleteStoredScriptRequestBuilder prepareDeleteStoredScript();
-
-    /**
-     * Delete a script from the cluster state
-     */
     DeleteStoredScriptRequestBuilder prepareDeleteStoredScript(String id);
 
     /**
      * Store a script in the cluster state
      */
     void putStoredScript(PutStoredScriptRequest request, ActionListener<AcknowledgedResponse> listener);
-
-    /**
-     * Store a script in the cluster state
-     */
-    ActionFuture<AcknowledgedResponse> putStoredScript(PutStoredScriptRequest request);
-
-    /**
-     * Get a script from the cluster state
-     */
-    GetStoredScriptRequestBuilder prepareGetStoredScript();
 
     /**
      * Get a script from the cluster state
@@ -703,11 +582,6 @@ public interface ClusterAdminClient extends ElasticsearchClient {
      * Get a script from the cluster state
      */
     void getStoredScript(GetStoredScriptRequest request, ActionListener<GetStoredScriptResponse> listener);
-
-    /**
-     * Get a script from the cluster state
-     */
-    ActionFuture<GetStoredScriptResponse> getStoredScript(GetStoredScriptRequest request);
 
     /**
      * List dangling indices on all nodes.

--- a/server/src/main/java/org/elasticsearch/client/internal/IndicesAdminClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/IndicesAdminClient.java
@@ -545,11 +545,6 @@ public interface IndicesAdminClient extends ElasticsearchClient {
     PutIndexTemplateRequestBuilder preparePutTemplate(String name);
 
     /**
-     * Deletes index template.
-     */
-    ActionFuture<AcknowledgedResponse> deleteTemplate(DeleteIndexTemplateRequest request);
-
-    /**
      * Deletes an index template.
      */
     void deleteTemplate(DeleteIndexTemplateRequest request, ActionListener<AcknowledgedResponse> listener);
@@ -560,11 +555,6 @@ public interface IndicesAdminClient extends ElasticsearchClient {
      * @param name The name of the template.
      */
     DeleteIndexTemplateRequestBuilder prepareDeleteTemplate(String name);
-
-    /**
-     * Gets index template.
-     */
-    ActionFuture<GetIndexTemplatesResponse> getTemplates(GetIndexTemplatesRequest request);
 
     /**
      * Gets an index template.
@@ -621,11 +611,6 @@ public interface IndicesAdminClient extends ElasticsearchClient {
      * Resize an index using an explicit request allowing to specify the settings, mappings and aliases of the target index of the index.
      */
     ResizeRequestBuilder prepareResizeIndex(String sourceIndex, String targetIndex);
-
-    /**
-     * Resize an index using an explicit request allowing to specify the settings, mappings and aliases of the target index of the index.
-     */
-    ActionFuture<ResizeResponse> resizeIndex(ResizeRequest request);
 
     /**
      * Shrinks an index using an explicit request allowing to specify the settings, mappings and aliases of the target index of the index.

--- a/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
+++ b/server/src/main/java/org/elasticsearch/client/internal/support/AbstractClient.java
@@ -51,7 +51,6 @@ import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksRequestBu
 import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
 import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageAction;
 import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequest;
-import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageRequestBuilder;
 import org.elasticsearch.action.admin.cluster.node.usage.NodesUsageResponse;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryAction;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryRequest;
@@ -780,23 +779,8 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<NodesUsageResponse> nodesUsage(final NodesUsageRequest request) {
-            return execute(NodesUsageAction.INSTANCE, request);
-        }
-
-        @Override
         public void nodesUsage(final NodesUsageRequest request, final ActionListener<NodesUsageResponse> listener) {
             execute(NodesUsageAction.INSTANCE, request, listener);
-        }
-
-        @Override
-        public NodesUsageRequestBuilder prepareNodesUsage(String... nodesIds) {
-            return new NodesUsageRequestBuilder(this, NodesUsageAction.INSTANCE).setNodesIds(nodesIds);
-        }
-
-        @Override
-        public ActionFuture<ClusterStatsResponse> clusterStats(ClusterStatsRequest request) {
-            return execute(ClusterStatsAction.INSTANCE, request);
         }
 
         @Override
@@ -807,11 +791,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public ClusterStatsRequestBuilder prepareClusterStats() {
             return new ClusterStatsRequestBuilder(this, ClusterStatsAction.INSTANCE);
-        }
-
-        @Override
-        public ActionFuture<NodesHotThreadsResponse> nodesHotThreads(NodesHotThreadsRequest request) {
-            return execute(NodesHotThreadsAction.INSTANCE, request);
         }
 
         @Override
@@ -875,18 +854,8 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<ClusterSearchShardsResponse> searchShards(final ClusterSearchShardsRequest request) {
-            return execute(ClusterSearchShardsAction.INSTANCE, request);
-        }
-
-        @Override
         public void searchShards(final ClusterSearchShardsRequest request, final ActionListener<ClusterSearchShardsResponse> listener) {
             execute(ClusterSearchShardsAction.INSTANCE, request, listener);
-        }
-
-        @Override
-        public ClusterSearchShardsRequestBuilder prepareSearchShards() {
-            return new ClusterSearchShardsRequestBuilder(this, ClusterSearchShardsAction.INSTANCE);
         }
 
         @Override
@@ -900,18 +869,8 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<PendingClusterTasksResponse> pendingClusterTasks(PendingClusterTasksRequest request) {
-            return execute(PendingClusterTasksAction.INSTANCE, request);
-        }
-
-        @Override
         public void pendingClusterTasks(PendingClusterTasksRequest request, ActionListener<PendingClusterTasksResponse> listener) {
             execute(PendingClusterTasksAction.INSTANCE, request, listener);
-        }
-
-        @Override
-        public ActionFuture<AcknowledgedResponse> putRepository(PutRepositoryRequest request) {
-            return execute(PutRepositoryAction.INSTANCE, request);
         }
 
         @Override
@@ -945,18 +904,8 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<AcknowledgedResponse> cloneSnapshot(CloneSnapshotRequest request) {
-            return execute(CloneSnapshotAction.INSTANCE, request);
-        }
-
-        @Override
         public void cloneSnapshot(CloneSnapshotRequest request, ActionListener<AcknowledgedResponse> listener) {
             execute(CloneSnapshotAction.INSTANCE, request, listener);
-        }
-
-        @Override
-        public ActionFuture<GetSnapshotsResponse> getSnapshots(GetSnapshotsRequest request) {
-            return execute(GetSnapshotsAction.INSTANCE, request);
         }
 
         @Override
@@ -970,11 +919,6 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<AcknowledgedResponse> deleteSnapshot(DeleteSnapshotRequest request) {
-            return execute(DeleteSnapshotAction.INSTANCE, request);
-        }
-
-        @Override
         public void deleteSnapshot(DeleteSnapshotRequest request, ActionListener<AcknowledgedResponse> listener) {
             execute(DeleteSnapshotAction.INSTANCE, request, listener);
         }
@@ -982,11 +926,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public DeleteSnapshotRequestBuilder prepareDeleteSnapshot(String repository, String... names) {
             return new DeleteSnapshotRequestBuilder(this, DeleteSnapshotAction.INSTANCE, repository, names);
-        }
-
-        @Override
-        public ActionFuture<AcknowledgedResponse> deleteRepository(DeleteRepositoryRequest request) {
-            return execute(DeleteRepositoryAction.INSTANCE, request);
         }
 
         @Override
@@ -1000,11 +939,6 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<VerifyRepositoryResponse> verifyRepository(VerifyRepositoryRequest request) {
-            return execute(VerifyRepositoryAction.INSTANCE, request);
-        }
-
-        @Override
         public void verifyRepository(VerifyRepositoryRequest request, ActionListener<VerifyRepositoryResponse> listener) {
             execute(VerifyRepositoryAction.INSTANCE, request, listener);
         }
@@ -1012,11 +946,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public VerifyRepositoryRequestBuilder prepareVerifyRepository(String name) {
             return new VerifyRepositoryRequestBuilder(this, VerifyRepositoryAction.INSTANCE, name);
-        }
-
-        @Override
-        public ActionFuture<GetRepositoriesResponse> getRepositories(GetRepositoriesRequest request) {
-            return execute(GetRepositoriesAction.INSTANCE, request);
         }
 
         @Override
@@ -1032,11 +961,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public CleanupRepositoryRequestBuilder prepareCleanupRepository(String repository) {
             return new CleanupRepositoryRequestBuilder(this, CleanupRepositoryAction.INSTANCE, repository);
-        }
-
-        @Override
-        public ActionFuture<CleanupRepositoryResponse> cleanupRepository(CleanupRepositoryRequest request) {
-            return execute(CleanupRepositoryAction.INSTANCE, request);
         }
 
         @Override
@@ -1057,11 +981,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public RestoreSnapshotRequestBuilder prepareRestoreSnapshot(String repository, String snapshot) {
             return new RestoreSnapshotRequestBuilder(this, RestoreSnapshotAction.INSTANCE, repository, snapshot);
-        }
-
-        @Override
-        public ActionFuture<SnapshotsStatusResponse> snapshotsStatus(SnapshotsStatusRequest request) {
-            return execute(SnapshotsStatusAction.INSTANCE, request);
         }
 
         @Override
@@ -1105,11 +1024,6 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public DeletePipelineRequestBuilder prepareDeletePipeline() {
-            return new DeletePipelineRequestBuilder(this, DeletePipelineAction.INSTANCE);
-        }
-
-        @Override
         public DeletePipelineRequestBuilder prepareDeletePipeline(String id) {
             return new DeletePipelineRequestBuilder(this, DeletePipelineAction.INSTANCE, id);
         }
@@ -1117,11 +1031,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public void getPipeline(GetPipelineRequest request, ActionListener<GetPipelineResponse> listener) {
             execute(GetPipelineAction.INSTANCE, request, listener);
-        }
-
-        @Override
-        public ActionFuture<GetPipelineResponse> getPipeline(GetPipelineRequest request) {
-            return execute(GetPipelineAction.INSTANCE, request);
         }
 
         @Override
@@ -1160,11 +1069,6 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<GetStoredScriptResponse> getStoredScript(final GetStoredScriptRequest request) {
-            return execute(GetStoredScriptAction.INSTANCE, request);
-        }
-
-        @Override
         public void getStoredScript(final GetStoredScriptRequest request, final ActionListener<GetStoredScriptResponse> listener) {
             execute(GetStoredScriptAction.INSTANCE, request, listener);
         }
@@ -1200,13 +1104,8 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public GetStoredScriptRequestBuilder prepareGetStoredScript() {
-            return new GetStoredScriptRequestBuilder(this, GetStoredScriptAction.INSTANCE);
-        }
-
-        @Override
         public GetStoredScriptRequestBuilder prepareGetStoredScript(String id) {
-            return prepareGetStoredScript().setId(id);
+            return new GetStoredScriptRequestBuilder(this, GetStoredScriptAction.INSTANCE).setId(id);
         }
 
         @Override
@@ -1221,28 +1120,13 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<AcknowledgedResponse> putStoredScript(final PutStoredScriptRequest request) {
-            return execute(PutStoredScriptAction.INSTANCE, request);
-        }
-
-        @Override
         public void deleteStoredScript(DeleteStoredScriptRequest request, ActionListener<AcknowledgedResponse> listener) {
             execute(DeleteStoredScriptAction.INSTANCE, request, listener);
         }
 
         @Override
-        public ActionFuture<AcknowledgedResponse> deleteStoredScript(DeleteStoredScriptRequest request) {
-            return execute(DeleteStoredScriptAction.INSTANCE, request);
-        }
-
-        @Override
-        public DeleteStoredScriptRequestBuilder prepareDeleteStoredScript() {
-            return new DeleteStoredScriptRequestBuilder(client, DeleteStoredScriptAction.INSTANCE);
-        }
-
-        @Override
         public DeleteStoredScriptRequestBuilder prepareDeleteStoredScript(String id) {
-            return prepareDeleteStoredScript().setId(id);
+            return new DeleteStoredScriptRequestBuilder(client, DeleteStoredScriptAction.INSTANCE).setId(id);
         }
     }
 
@@ -1612,11 +1496,6 @@ public abstract class AbstractClient implements Client {
         }
 
         @Override
-        public ActionFuture<GetIndexTemplatesResponse> getTemplates(final GetIndexTemplatesRequest request) {
-            return execute(GetIndexTemplatesAction.INSTANCE, request);
-        }
-
-        @Override
         public void getTemplates(final GetIndexTemplatesRequest request, final ActionListener<GetIndexTemplatesResponse> listener) {
             execute(GetIndexTemplatesAction.INSTANCE, request, listener);
         }
@@ -1624,11 +1503,6 @@ public abstract class AbstractClient implements Client {
         @Override
         public GetIndexTemplatesRequestBuilder prepareGetTemplates(String... names) {
             return new GetIndexTemplatesRequestBuilder(this, GetIndexTemplatesAction.INSTANCE, names);
-        }
-
-        @Override
-        public ActionFuture<AcknowledgedResponse> deleteTemplate(final DeleteIndexTemplateRequest request) {
-            return execute(DeleteIndexTemplateAction.INSTANCE, request);
         }
 
         @Override
@@ -1665,11 +1539,6 @@ public abstract class AbstractClient implements Client {
         public ResizeRequestBuilder prepareResizeIndex(String sourceIndex, String targetIndex) {
             return new ResizeRequestBuilder(this, ResizeAction.INSTANCE).setSourceIndex(sourceIndex)
                 .setTargetIndex(new CreateIndexRequest(targetIndex));
-        }
-
-        @Override
-        public ActionFuture<ResizeResponse> resizeIndex(ResizeRequest request) {
-            return execute(ResizeAction.INSTANCE, request);
         }
 
         @Override

--- a/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/AbstractThirdPartyRepositoryTestCase.java
@@ -10,7 +10,6 @@ package org.elasticsearch.repositories;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.admin.cluster.repositories.cleanup.CleanupRepositoryResponse;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotResponse;
-import org.elasticsearch.action.admin.cluster.snapshots.delete.DeleteSnapshotRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.blobstore.BlobPath;
@@ -188,7 +187,7 @@ public abstract class AbstractThirdPartyRepositoryTestCase extends ESSingleNodeT
         createDanglingIndex(repo, genericExec);
 
         logger.info("--> deleting a snapshot to trigger repository cleanup");
-        client().admin().cluster().deleteSnapshot(new DeleteSnapshotRequest("test-repo", snapshotName)).actionGet();
+        client().admin().cluster().prepareDeleteSnapshot("test-repo", snapshotName).get();
 
         BlobStoreTestUtil.assertConsistency(repo);
 

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -12,7 +12,6 @@ import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.template.delete.DeleteIndexTemplateRequest;
 import org.elasticsearch.action.delete.DeleteResponse;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
@@ -75,7 +74,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
     @After
     public void deleteTemplateAndIndex() {
         client().admin().indices().delete(new DeleteIndexRequest(SamlServiceProviderIndex.INDEX_NAME + "*")).actionGet();
-        client().admin().indices().deleteTemplate(new DeleteIndexTemplateRequest(SamlServiceProviderIndex.TEMPLATE_NAME)).actionGet();
+        client().admin().indices().prepareDeleteTemplate(SamlServiceProviderIndex.TEMPLATE_NAME).get();
         serviceProviderIndex.close();
     }
 


### PR DESCRIPTION
We don't have to support the transport client API anymore. -> remove all the unused APIs as well as a few that only had a single usage in tests and replace those with another version -> streamlines tests a little more + save 300LoC
