### PR TITLE
Use 2 nodes in YAML test cluster

### DIFF
--- a/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
+++ b/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
@@ -30,6 +30,7 @@ public class ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         .module("mapper-extras")
         .feature(FeatureFlag.TIME_SERIES_MODE)
         .feature(FeatureFlag.DLM_ENABLED)
+        .nodes(2)
         .build();
 
     public ClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
@@ -42,6 +42,7 @@ public class CoreWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteTest
         .setting("xpack.security.autoconfiguration.enabled", "false")
         .user(USER, PASS)
         .feature(FeatureFlag.TIME_SERIES_MODE)
+        .nodes(2)
         .build();
 
     public CoreWithSecurityClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
We have some YAML tests that would require at least one 
replica (search shard) to run with Stateless and since they 
wait for green, they explicitly set replicas to 0 (see e.g. 
[realtime_refresh](https://github.com/elastic/elasticsearch/blob/main/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml)). Using 2 nodes 
by default makes sure we could run those tests w/o any 
changes. IMO, they are pretty important/essential tests.

Relates https://github.com/elastic/elasticsearch/pull/94303