### PR TITLE
Remove replicas settings in indices.sort YAML tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -7,7 +7,6 @@
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
             index.sort.field: rank
           mappings:
             properties:


### PR DESCRIPTION
These YAML tests should work with any number of replicas.