### PR TITLE
Behavioral analytcis ingest pipeline

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -6,29 +6,53 @@
  */
 package org.elasticsearch.xpack.application.analytics;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ingest.PutPipelineAction;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
+import org.elasticsearch.xpack.core.ingest.PipelineConfigurationTemplate;
 import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
 import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
 import org.elasticsearch.xpack.core.template.LifecyclePolicyConfig;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.core.Strings.format;
 import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
 
 public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
+    private static final Logger logger = LogManager.getLogger(AnalyticsTemplateRegistry.class);
     public static final String ROOT_RESOURCE_PATH = "/org/elasticsearch/xpack/entsearch/analytics/";
 
     // This number must be incremented when we make changes to built-in templates.
@@ -95,6 +119,18 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
         )
     );
 
+    // Ingest pipeline configuration.
+    protected final ConcurrentMap<String, AtomicBoolean> pipelineCreationsInProgress = new ConcurrentHashMap<>();
+
+    public static final String EVENT_DATA_STREAM_PIPELINE_NAME = "behavioral_analytics-events-final_pipeline";
+    private static final List<PipelineConfigurationTemplate> INGEST_PIPELINES = Collections.singletonList(
+        new PipelineConfigurationTemplate(
+            EVENT_DATA_STREAM_PIPELINE_NAME,
+            ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_PIPELINE_NAME + ".json",
+            Map.of(TEMPLATE_VERSION_VARIABLE, String.valueOf(REGISTRY_VERSION))
+        )
+    );
+
     public AnalyticsTemplateRegistry(
         ClusterService clusterService,
         ThreadPool threadPool,
@@ -102,6 +138,19 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
         NamedXContentRegistry xContentRegistry
     ) {
         super(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        super.clusterChanged(event);
+
+        DiscoveryNode masterNode = event.state().getNodes().getMasterNode();
+        DiscoveryNode localNode = event.state().getNodes().getLocalNode();
+        boolean localNodeVersionAfterMaster = localNode.getVersion().after(masterNode.getVersion());
+
+        if (event.localNodeMaster() || localNodeVersionAfterMaster) {
+            addIngestPipelineIfMissing(event.state());
+        }
     }
 
     @Override
@@ -124,6 +173,10 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
         return COMPOSABLE_INDEX_TEMPLATES;
     }
 
+    protected List<PipelineConfigurationTemplate> getIngestPipelineConfigs() {
+        return INGEST_PIPELINES;
+    }
+
     @Override
     protected boolean requiresMasterNode() {
         // We are using the composable index template and component APIs,
@@ -133,5 +186,127 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
         // are only installed via elected master node then the APIs are always
         // there and the ActionNotFoundTransportException errors are then prevented.
         return true;
+    }
+
+    private void addIngestPipelineIfMissing(ClusterState state) {
+        for (PipelineConfigurationTemplate pipelineConfigurationTemplate : getIngestPipelineConfigs()) {
+            final AtomicBoolean creationCheck = pipelineCreationsInProgress.computeIfAbsent(
+                pipelineConfigurationTemplate.id(),
+                key -> new AtomicBoolean(false)
+            );
+            try {
+                if (creationCheck.compareAndSet(false, true)) {
+                    if (ingestPipelineExists(state, pipelineConfigurationTemplate.id())) {
+                        IngestMetadata ingestMetadata = state.metadata().custom(IngestMetadata.TYPE);
+                        PipelineConfiguration existingPipeline = ingestMetadata.getPipelines().get(pipelineConfigurationTemplate.id());
+                        PipelineConfiguration newPipeline = pipelineConfigurationTemplate.loadPipelineConfiguration();
+
+                        if (Objects.isNull(existingPipeline.getVersion()) || existingPipeline.getVersion() < newPipeline.getVersion()) {
+                            logger.info(
+                                "upgrading ingest pipeline [{}] for [{}] from version [{}] to version [{}]",
+                                pipelineConfigurationTemplate.id(),
+                                getOrigin(),
+                                existingPipeline.getVersion(),
+                                newPipeline.getVersion()
+                            );
+                            putIngestPipeline(pipelineConfigurationTemplate, creationCheck);
+                        } else {
+                            logger.debug(
+                                "not adding ingest pipeline [{}] for [{}], because it already exists",
+                                pipelineConfigurationTemplate.id(),
+                                getOrigin()
+                            );
+                            creationCheck.set(false);
+                        }
+                    } else {
+                        logger.debug(
+                            "adding ingest pipeline [{}] for [{}], because it doesn't exist",
+                            pipelineConfigurationTemplate.id(),
+                            getOrigin()
+                        );
+                        putIngestPipeline(pipelineConfigurationTemplate, creationCheck);
+                    }
+                }
+            } catch (IOException e) {
+                creationCheck.set(false);
+                logger.error(
+                    Strings.format(
+                        "not adding ingest pipeline [{}] for [{}], because of an error when reading the config",
+                        pipelineConfigurationTemplate.id(),
+                        getOrigin()
+                    ),
+                    e
+                );
+            }
+        }
+    }
+
+    private static boolean ingestPipelineExists(ClusterState state, String pipelineId) {
+        Optional<IngestMetadata> maybeMeta = Optional.ofNullable(state.metadata().custom(IngestMetadata.TYPE));
+        return maybeMeta.isPresent() && maybeMeta.get().getPipelines().containsKey(pipelineId);
+    }
+
+    private void putIngestPipeline(final PipelineConfigurationTemplate pipelineConfiguration, final AtomicBoolean creationCheck) {
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            try {
+                PutPipelineRequest request = new PutPipelineRequest(
+                    pipelineConfiguration.id(),
+                    pipelineConfiguration.parsedSource(),
+                    pipelineConfiguration.xContentType()
+                );
+
+                request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+
+                executeAsyncWithOrigin(
+                    client.threadPool().getThreadContext(),
+                    getOrigin(),
+                    request,
+                    new ActionListener<AcknowledgedResponse>() {
+                        @Override
+                        public void onResponse(AcknowledgedResponse response) {
+                            creationCheck.set(false);
+                            if (response.isAcknowledged() == false) {
+                                logger.error(
+                                    "error adding ingest pipeline [{}] for [{}], request was not acknowledged",
+                                    pipelineConfiguration.id(),
+                                    getOrigin()
+                                );
+                            } else {
+                                logger.info("adding ingest pipeline {}", pipelineConfiguration.id());
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            creationCheck.set(false);
+                            onPutPipelineFailure(pipelineConfiguration.id(), e);
+                        }
+                    },
+                    (req, listener) -> client.execute(PutPipelineAction.INSTANCE, req, listener)
+                );
+
+            } catch (IOException e) {
+                creationCheck.set(false);
+                logger.error(
+                    Strings.format(
+                        "not adding ingest pipeline [{}] for [{}], because of an error when reading the config",
+                        pipelineConfiguration.id(),
+                        getOrigin()
+                    ),
+                    e
+                );
+            }
+        });
+    }
+
+    /**
+     * Called when creation of an ingest pipeline fails.
+     *
+     * @param pipelineId the pipeline that failed to be created.
+     * @param e The exception that caused the failure.
+     */
+    protected void onPutPipelineFailure(String pipelineId, Exception e) {
+        logger.error(() -> format("error adding ingest pipeline template [%s] for [%s]", pipelineId, getOrigin()), e);
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.gateway.GatewayService;
 import org.elasticsearch.ingest.IngestMetadata;
 import org.elasticsearch.ingest.PipelineConfiguration;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -144,7 +145,21 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
     public void clusterChanged(ClusterChangedEvent event) {
         super.clusterChanged(event);
 
+        ClusterState state = event.state();
+        if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            return;
+        }
+
+        // no master node, exit immediately
         DiscoveryNode masterNode = event.state().getNodes().getMasterNode();
+        if (masterNode == null) {
+            return;
+        }
+
+        if (requiresMasterNode() && state.nodes().isLocalNodeElectedMaster() == false) {
+            return;
+        }
+
         DiscoveryNode localNode = event.state().getNodes().getLocalNode();
         boolean localNodeVersionAfterMaster = localNode.getVersion().after(masterNode.getVersion());
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/core/ingest/PipelineConfigurationTemplate.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/core/ingest/PipelineConfigurationTemplate.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.ingest;
+
+import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.compress.NotXContentException;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Streams;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+/**
+ * A utility class used for ingest pipeline management.
+ */
+public class PipelineConfigurationTemplate {
+
+    private final String id;
+
+    private final String resource;
+
+    private final Map<String, String> variables;
+
+    private final XContentType xContentType;
+
+    public PipelineConfigurationTemplate(String id, String resource, Map<String, String> variables, XContentType xContentType) {
+        this.id = id;
+        this.resource = resource;
+        this.variables = variables;
+        this.xContentType = xContentType;
+    }
+
+    public PipelineConfigurationTemplate(String id, String resource, Map<String, String> variables) {
+        this(id, resource, variables, XContentType.JSON);
+    }
+
+    public String id() {
+        return id;
+    }
+
+    public BytesReference source() throws IOException {
+        return load(resource);
+    }
+
+    public XContentType xContentType() {
+        return xContentType;
+    }
+
+    public BytesReference parsedSource() throws IOException {
+        BytesReference parsedTemplate = replaceVariables(source(), variables);
+        validate(parsedTemplate);
+
+        return parsedTemplate;
+    }
+
+    public PipelineConfiguration loadPipelineConfiguration() throws IOException {
+        return new PipelineConfiguration(id(), parsedSource(), xContentType());
+    }
+
+    /**
+     * Loads a resource from the classpath and returns it as a {@link BytesReference}
+     */
+    private static BytesReference load(String name) throws IOException {
+        try (InputStream is = PipelineConfigurationTemplate.class.getResourceAsStream(name)) {
+            try (ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+                Streams.copy(is, out);
+                return new BytesArray(out.toByteArray());
+            }
+        }
+    }
+
+    private static BytesReference replaceVariables(BytesReference input, Map<String, String> variables) {
+        String template = input.utf8ToString();
+        for (Map.Entry<String, String> variable : variables.entrySet()) {
+            template = replaceVariable(template, variable.getKey(), variable.getValue());
+        }
+        return new BytesArray(template);
+    }
+
+    /**
+     * Replaces all occurrences of given variable with the value
+     */
+    public static String replaceVariable(String input, String variable, String value) {
+        return Pattern.compile("${" + variable + "}", Pattern.LITERAL).matcher(input).replaceAll(value);
+    }
+
+    /**
+     * Parses and validates that the source is not empty.
+     */
+    private static void validate(BytesReference source) {
+        if (source == null) {
+            throw new ElasticsearchParseException("pipeline configuration must not be null");
+        }
+        try {
+            XContentHelper.convertToMap(source, false, XContentType.JSON).v2();
+        } catch (NotXContentException e) {
+            throw new ElasticsearchParseException("pipeline configuration must not be empty");
+        } catch (Exception e) {
+            throw new ElasticsearchParseException("invalid pipeline configuration", e);
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/ent-search/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
@@ -1,0 +1,40 @@
+{
+  "description": "Built ingest pipeline applied by as default final pipeline to behavioral analytics event data streams.",
+  "processors": [
+    {
+      "user_agent": {
+        "field": "event.user_agent",
+        "ignore_missing": true
+      }
+    },
+    {
+      "uri_parts": {
+        "field": "event.page_url",
+        "if": "ctx.event.page_url != null",
+        "target_field": "url",
+        "keep_original": false,
+        "remove_if_successful": true
+      }
+    },
+    {
+      "remove": {
+        "field": [
+          "agent.ephemeral_id",
+          "agent.id",
+          "agent.name",
+          "agent.type",
+          "agent.version",
+          "host.name",
+          "input.type",
+          "log.file.path",
+          "log.offset"
+        ],
+        "ignore_missing": true
+      }
+    }
+  ],
+  "_meta": {
+    "managed": true
+  },
+  "version": ${xpack.entsearch.analytics.template.version}
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.indices.template.put.PutComponentTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
+import org.elasticsearch.action.ingest.PutPipelineAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
@@ -160,6 +161,9 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
             } else if (action instanceof PutComposableIndexTemplateAction) {
                 // Ignore this, it's verified in another test
                 return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutPipelineAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
             } else {
                 fail("client called with unexpected request: " + request.toString());
                 return null;
@@ -182,6 +186,9 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
 
         client.setVerifier((action, request, listener) -> {
             if (action instanceof PutComponentTemplateAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutPipelineAction) {
                 // Ignore this, it's verified in another test
                 return AcknowledgedResponse.TRUE;
             } else if (action instanceof PutLifecycleAction) {
@@ -208,6 +215,9 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
 
         client.setVerifier((action, request, listener) -> {
             if (action instanceof PutComponentTemplateAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutPipelineAction) {
                 // Ignore this, it's verified in another test
                 return AcknowledgedResponse.TRUE;
             } else if (action instanceof PutLifecycleAction) {
@@ -292,6 +302,9 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
                 // Ignore this, it's verified in another test
                 return AcknowledgedResponse.TRUE;
             } else if (action instanceof PutComposableIndexTemplateAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutPipelineAction) {
                 // Ignore this, it's verified in another test
                 return AcknowledgedResponse.TRUE;
             } else {
@@ -379,6 +392,9 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
         } else if (action instanceof PutLifecycleAction) {
             // Ignore this, it's verified in another test
             return AcknowledgedResponse.TRUE;
+        } else if (action instanceof PutPipelineAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
         } else if (action instanceof PutComposableIndexTemplateAction) {
             calledTimes.incrementAndGet();
             assertThat(action, instanceOf(PutComposableIndexTemplateAction.class));
@@ -414,6 +430,9 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
             // Ignore this, it's verified in another test
             return AcknowledgedResponse.TRUE;
         } else if (action instanceof PutComposableIndexTemplateAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
+        } else if (action instanceof PutPipelineAction) {
             // Ignore this, it's verified in another test
             return AcknowledgedResponse.TRUE;
         } else {


### PR DESCRIPTION
### Closes https://github.com/elastic/enterprise-search-team/issues/4083

### PR Description:

This PR add support of adding ingest pipeline through the `AnalyticsTemplateRegistry` and set a `final_pipeline` for analytics data streams

### STILL A WIP:
- [X] Supporting ingest pipeline into the index registry
- [X] Add tests case to the index registry
- [X] Add the default ingest pipeline for analytics data streams
- [ ] Set the pipeline as final pipeline in analytics data streams template 