### PR TITLE
[Profiling] Map stack frames more efficiently

### DIFF
--- a/docs/changelog/94327.yaml
+++ b/docs/changelog/94327.yaml
@@ -1,0 +1,5 @@
+pr: 94327
+summary: "[Profiling] Map stack frames more efficiently"
+area: Search
+type: enhancement
+issues: []

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectPath.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ObjectPath.java
@@ -27,13 +27,22 @@ public final class ObjectPath {
      */
     @SuppressWarnings("unchecked")
     public static <T> T eval(String path, Object object) {
-        return (T) evalContext(path, object);
-    }
-
-    private static Object evalContext(String path, Object ctx) {
         final String[] parts;
         if (path == null || path.isEmpty()) parts = EMPTY_ARRAY;
         else parts = path.split("\\.");
+        return (T) evalContext(parts, object);
+    }
+
+    /**
+     * Return the value within a given object at the specified path, or
+     * {@code null} if the path does not exist
+     */
+    @SuppressWarnings("unchecked")
+    public static <T> T eval(String[] path, Object object) {
+        return (T) evalContext(path, object);
+    }
+
+    private static Object evalContext(String[] parts, Object ctx) {
         for (String part : parts) {
             if (ctx == null) {
                 return null;

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectPathTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ObjectPathTests.java
@@ -24,8 +24,8 @@ public class ObjectPathTests extends ESTestCase {
     public void testEval() {
         Map<String, Object> map = singletonMap("key", "value");
 
-        assertThat(ObjectPath.eval("key", map), is((Object) "value"));
-        assertThat(ObjectPath.eval("key1", map), nullValue());
+        assertThat(randomEval(new String[] { "key" }, map), is((Object) "value"));
+        assertThat(randomEval(new String[] { "key1" }, map), nullValue());
     }
 
     public void testEvalList() {
@@ -33,7 +33,7 @@ public class ObjectPathTests extends ESTestCase {
         Map<String, Object> map = singletonMap("key", list);
 
         int index = randomInt(3);
-        assertThat(ObjectPath.eval("key." + index, map), is(list.get(index)));
+        assertThat(randomEval(new String[] { "key", String.valueOf(index) }, map), is(list.get(index)));
     }
 
     public void testEvalArray() {
@@ -41,13 +41,13 @@ public class ObjectPathTests extends ESTestCase {
         Map<String, Object> map = singletonMap("key", array);
 
         int index = randomInt(3);
-        assertThat(((Number) ObjectPath.eval("key." + index, map)).intValue(), is(array[index]));
+        assertThat(((Number) randomEval(new String[] { "key", String.valueOf(index) }, map)).intValue(), is(array[index]));
     }
 
     public void testEvalMap() {
         Map<String, Object> map = singletonMap("a", singletonMap("b", "val"));
 
-        assertThat(ObjectPath.eval("a.b", map), is((Object) "val"));
+        assertThat(randomEval(new String[] { "a", "b" }, map), is((Object) "val"));
     }
 
     public void testEvalMixed() {
@@ -65,10 +65,18 @@ public class ObjectPathTests extends ESTestCase {
         listB1.add(mapB11);
         mapB11.put("c", "val");
 
-        assertThat(ObjectPath.eval("", map), is((Object) map));
-        assertThat(ObjectPath.eval("a.b.0.0.c", map), is((Object) "val"));
-        assertThat(ObjectPath.eval("a.b.0.0.c.d", map), nullValue());
-        assertThat(ObjectPath.eval("a.b.0.0.d", map), nullValue());
-        assertThat(ObjectPath.eval("a.b.c", map), nullValue());
+        assertThat(randomEval(new String[0], map), is((Object) map));
+        assertThat(randomEval(new String[] { "a", "b", "0", "0", "c" }, map), is((Object) "val"));
+        assertThat(randomEval(new String[] { "a", "b", "0", "0", "c", "d" }, map), nullValue());
+        assertThat(randomEval(new String[] { "a", "b", "0", "0", "d" }, map), nullValue());
+        assertThat(randomEval(new String[] { "a", "b", "c" }, map), nullValue());
+    }
+
+    private <T> T randomEval(String[] path, Object object) {
+        if (randomBoolean()) {
+            return ObjectPath.eval(String.join(".", path), object);
+        } else {
+            return ObjectPath.eval(path, object);
+        }
     }
 }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
@@ -18,6 +18,11 @@ import java.util.Map;
 import java.util.Objects;
 
 final class StackFrame implements ToXContentObject {
+    private static final String[] PATH_FILE_NAME = new String[] { "Stackframe", "file", "name" };
+    private static final String[] PATH_FUNCTION_NAME = new String[] { "Stackframe", "function", "name" };
+    private static final String[] PATH_FUNCTION_OFFSET = new String[] { "Stackframe", "function", "offset" };
+    private static final String[] PATH_LINE_NUMBER = new String[] { "Stackframe", "line", "number" };
+    private static final String[] PATH_SOURCE_TYPE = new String[] { "Stackframe", "source", "type" };
     List<String> fileName;
     List<String> functionName;
     List<Integer> functionOffset;
@@ -50,11 +55,11 @@ final class StackFrame implements ToXContentObject {
         if (source.containsKey("Stackframe")) {
             // synthetic source
             return new StackFrame(
-                ObjectPath.eval("Stackframe.file.name", source),
-                ObjectPath.eval("Stackframe.function.name", source),
-                ObjectPath.eval("Stackframe.function.offset", source),
-                ObjectPath.eval("Stackframe.line.number", source),
-                ObjectPath.eval("Stackframe.source.type", source)
+                ObjectPath.eval(PATH_FILE_NAME, source),
+                ObjectPath.eval(PATH_FUNCTION_NAME, source),
+                ObjectPath.eval(PATH_FUNCTION_OFFSET, source),
+                ObjectPath.eval(PATH_LINE_NUMBER, source),
+                ObjectPath.eval(PATH_SOURCE_TYPE, source)
             );
         } else {
             // regular source


### PR DESCRIPTION
The mapping code for stack frames uses the utility method `ObjectPath#eval` to read nested properties. Callers need to pass a dot-separated path which is then split internally via a regex. This is quite slow: in a typical deployment we saw overheads of 50ms just for mapping stack frames (total response time is ~ 1 second).

With this commit we pass the property path as an array to avoid this overhead. In a microbenchmark the new implementation was 23 times faster than the current one.