### PR TITLE
[8.7] Remove replicas settings in field-caps YAML tests (#94292)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/field_caps/40_time_series.yml
@@ -10,8 +10,6 @@ setup:
         body:
           settings:
             index:
-              number_of_replicas: 0
-              number_of_shards: 2
               mode: time_series
               routing_path: [ metricset, k8s.pod.uid ]
               time_series:
@@ -62,8 +60,6 @@ setup:
         body:
           settings:
             index:
-              number_of_replicas: 0
-              number_of_shards: 2
               mode: time_series
               routing_path: [ k8s.pod.uid ]
               time_series:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/05_dimension_and_metric_in_non_tsdb_index.yml
@@ -187,9 +187,6 @@ no _tsid in standard indices:
       indices.create:
         index: test
         body:
-          settings:
-            index:
-              number_of_shards: 2
           mappings:
             properties:
               "@timestamp":

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/110_field_caps.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/110_field_caps.yml
@@ -9,8 +9,6 @@ setup:
         body:
           settings:
             index:
-              number_of_replicas: 0
-              number_of_shards: 2
               mode: time_series
               routing_path: [ metricset, k8s.pod.uid ]
               time_series:
@@ -51,10 +49,6 @@ setup:
       indices.create:
         index: test_non_time_series
         body:
-          settings:
-            index:
-              number_of_replicas: 0
-              number_of_shards: 2
           mappings:
             properties:
               "@timestamp":


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Remove replicas settings in field-caps YAML tests (#94292)