### PR TITLE
[8.7] Remove replicas settings in indices.sort YAML tests (#94308)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -7,7 +7,6 @@
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
             index.sort.field: rank
           mappings:
             properties:


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Remove replicas settings in indices.sort YAML tests (#94308)