### PR TITLE
Add a check that cluster_info is serialized as an object

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponseTests.java
@@ -296,6 +296,12 @@ public class DesiredBalanceResponseTests extends AbstractWireSerializingTestCase
                 assertEquals(jsonDesired.get("ignored"), desiredShards.desired().ignored());
             }
         }
+
+        Map<String, Object> clusterInfo = (Map<String, Object>) json.get("cluster_info");
+        assertThat(
+            clusterInfo.keySet(),
+            containsInAnyOrder("nodes", "shard_paths", "shard_sizes", "shard_data_set_sizes", "reserved_sizes")
+        );
     }
 
     public void testChunking() {


### PR DESCRIPTION
Verify that the whole object get serialized, not only the field name.

Follow up for #94272