### PR TITLE
[8.7] Remove replicas settings in search YAML tests (#94307)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -9,11 +9,17 @@
             number_of_shards: 1
             number_of_replicas: 0
             index.sort.field: rank
+            # ensure no relocation as tests rely on segments.
+            routing.rebalance.enable: "none"
           mappings:
             properties:
               rank:
                 type:     integer
-
+  - do:
+      cluster.health:
+        index: test
+        # ensure that all shards are ready before indexing/refresh as tests rely on segments.
+        wait_for_no_initializing_shards: true
   - do:
       index:
         index: test

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/115_multiple_field_collapsing.yml
@@ -7,7 +7,6 @@
           body:
             settings:
               number_of_shards: 1
-              number_of_replicas: 1
             mappings:
               properties:
                 country: {"type": "keyword"}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/120_batch_reduce_size.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/120_batch_reduce_size.yml
@@ -5,7 +5,6 @@ setup:
           body:
             settings:
               number_of_shards: 5
-              number_of_replicas: 0
             mappings:
               properties:
                 str:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/260_parameter_validation.yml
@@ -4,8 +4,6 @@ setup:
       indices.create:
         index: index1
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               foo:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
@@ -15,8 +15,13 @@
                 type: date
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
-
+            # ensure no relocation as we will verify segments.
+            routing.rebalance.enable: "none"
+  - do:
+      cluster.health:
+        index: test_index1
+        # ensure that all shards are ready before indexing/refresh as we will verify segments.
+        wait_for_no_initializing_shards: true
   # 1st segment
   - do:
       index:
@@ -54,8 +59,13 @@
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
-
+            # make sure no relocation as we will verify segments.
+            routing.rebalance.enable: "none"
+  - do:
+      cluster.health:
+        index: test_index2
+        # ensure that all shards are ready before indexing/refresh as we will verify segments.
+        wait_for_no_initializing_shards: true
   # 1st segment
   - do:
       index:
@@ -114,8 +124,13 @@
                 type: date
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
-
+            # make sure no relocation as we will verify segments.
+            routing.rebalance.enable: "none"
+  - do:
+      cluster.health:
+        index: test_index3
+        # ensure that all shards are ready before indexing/refresh as we will verify segments.
+        wait_for_no_initializing_shards: true
   # 1st segment missing @timestamp field
   - do:
       index:


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Remove replicas settings in search YAML tests (#94307)