### PR TITLE
[8.7] Remove replicas settings in indices.stats YAML tests (#94309)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/13_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/13_fields.yml
@@ -11,7 +11,6 @@ setup:
                 # to be relocated or being initialized between the test
                 # set up and the test execution
                 index.number_of_shards: 3
-                index.number_of_replicas: 0
               mappings:
                   properties:
                       bar:


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Remove replicas settings in indices.stats YAML tests (#94309)