### PR TITLE
fix testPerformActionAttrsAllNodesValid

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
 import org.elasticsearch.common.transport.TransportAddress;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.shard.ShardId;
@@ -35,6 +36,7 @@ import org.mockito.Mockito;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -112,10 +114,10 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
 
     public void testPerformActionAttrsAllNodesValid() throws Exception {
         final int numNodes = randomIntBetween(1, 20);
-        String[][] validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10));
+        var validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10));
         Settings.Builder indexSettings = settings(Version.CURRENT);
-        for (String[] attr : validAttrs) {
-            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr[0], attr[1]);
+        for (var attr : validAttrs) {
+            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr.getKey(), attr.getValue());
         }
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
             .settings(indexSettings)
@@ -130,11 +132,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             String nodeId = "node_id_" + i;
             String nodeName = "node_" + i;
             int nodePort = 9300 + i;
-            String[] nodeAttr = randomFrom(validAttrs);
+            var nodeAttr = randomFrom(validAttrs);
             Settings nodeSettings = Settings.builder()
                 .put(validNodeSettings)
                 .put(Node.NODE_NAME_SETTING.getKey(), nodeName)
-                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr[0], nodeAttr[1])
+                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr.getKey(), nodeAttr.getValue())
                 .build();
             nodes.add(DiscoveryNode.createLocal(nodeSettings, new TransportAddress(TransportAddress.META_ADDRESS, nodePort), nodeId));
             validNodeIds.add(nodeId);
@@ -253,10 +255,10 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
 
     public void testPerformActionAttrsRequestFails() {
         final int numNodes = randomIntBetween(1, 20);
-        String[][] validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10));
+        var validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10));
         Settings.Builder indexSettings = settings(Version.CURRENT);
-        for (String[] attr : validAttrs) {
-            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr[0], attr[1]);
+        for (var attr : validAttrs) {
+            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr.getKey(), attr.getValue());
         }
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
             .settings(indexSettings)
@@ -271,11 +273,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             String nodeId = "node_id_" + i;
             String nodeName = "node_" + i;
             int nodePort = 9300 + i;
-            String[] nodeAttr = randomFrom(validAttrs);
+            var nodeAttr = randomFrom(validAttrs);
             Settings nodeSettings = Settings.builder()
                 .put(validNodeSettings)
                 .put(Node.NODE_NAME_SETTING.getKey(), nodeName)
-                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr[0], nodeAttr[1])
+                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr.getKey(), nodeAttr.getValue())
                 .build();
             nodes.add(DiscoveryNode.createLocal(nodeSettings, new TransportAddress(TransportAddress.META_ADDRESS, nodePort), nodeId));
             validNodeIds.add(nodeId);
@@ -323,10 +325,10 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
 
     public void testPerformActionAttrsNoShard() {
         final int numNodes = randomIntBetween(1, 20);
-        String[][] validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10), "na_");
+        var validAttrs = generateRandomValidAttributes(randomIntBetween(1, 10), "na_");
         Settings.Builder indexSettings = settings(Version.CURRENT);
-        for (String[] attr : validAttrs) {
-            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr[0], attr[1]);
+        for (var attr : validAttrs) {
+            indexSettings.put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + attr.getKey(), attr.getValue());
         }
         IndexMetadata indexMetadata = IndexMetadata.builder(randomAlphaOfLength(10))
             .settings(indexSettings)
@@ -340,11 +342,11 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
             String nodeId = "node_id_" + i;
             String nodeName = "node_" + i;
             int nodePort = 9300 + i;
-            String[] nodeAttr = randomFrom(validAttrs);
+            var nodeAttr = randomFrom(validAttrs);
             Settings nodeSettings = Settings.builder()
                 .put(validNodeSettings)
                 .put(Node.NODE_NAME_SETTING.getKey(), nodeName)
-                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr[0], nodeAttr[1])
+                .put(Node.NODE_ATTRIBUTES.getKey() + nodeAttr.getKey(), nodeAttr.getValue())
                 .build();
             nodes.add(DiscoveryNode.createLocal(nodeSettings, new TransportAddress(TransportAddress.META_ADDRESS, nodePort), nodeId));
         }
@@ -573,19 +575,20 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         assertNodeSelected(indexMetadata, indexMetadata.getIndex(), oldNodeIds, discoveryNodes, indexRoutingTable.build());
     }
 
-    private String[][] generateRandomValidAttributes(int numAttrs) {
+    private Collection<Map.Entry<String, String>> generateRandomValidAttributes(int numAttrs) {
         return generateRandomValidAttributes(numAttrs, "");
     }
 
-    private String[][] generateRandomValidAttributes(int numAttrs, String prefix) {
-        Set<String> reservedNames = new HashSet<>(DiscoveryNodeRole.roleNames());
-        String[][] validAttrs = new String[numAttrs][2];
+    private Collection<Map.Entry<String, String>> generateRandomValidAttributes(int numAttrs, String prefix) {
+        Set<String> reservedNames = DiscoveryNodeRole.roleNames();
+        var validAttrs = Maps.<String, String>newMapWithExpectedSize(numAttrs);
         for (int i = 0; i < numAttrs; i++) {
-            validAttrs[i] = new String[] {
-                prefix + randomValueOtherThanMany(attr -> reservedNames.contains(prefix + attr), () -> randomAlphaOfLengthBetween(1, 20)),
-                randomAlphaOfLengthBetween(1, 20) };
+            validAttrs.put(
+                randomValueOtherThanMany(attr -> reservedNames.contains(attr) || validAttrs.containsKey(attr), () -> prefix + randomAlphaOfLengthBetween(1, 20)),
+                randomAlphaOfLengthBetween(1, 20)
+            );
         }
-        return validAttrs;
+        return validAttrs.entrySet();
     }
 
     private void assertNodeSelected(IndexMetadata indexMetadata, Index index, Set<String> validNodeIds, DiscoveryNodes.Builder nodes)

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/SetSingleNodeAllocateStepTests.java
@@ -584,7 +584,10 @@ public class SetSingleNodeAllocateStepTests extends AbstractStepTestCase<SetSing
         var validAttrs = Maps.<String, String>newMapWithExpectedSize(numAttrs);
         for (int i = 0; i < numAttrs; i++) {
             validAttrs.put(
-                randomValueOtherThanMany(attr -> reservedNames.contains(attr) || validAttrs.containsKey(attr), () -> prefix + randomAlphaOfLengthBetween(1, 20)),
+                randomValueOtherThanMany(
+                    attr -> reservedNames.contains(attr) || validAttrs.containsKey(attr),
+                    () -> prefix + randomAlphaOfLengthBetween(1, 20)
+                ),
                 randomAlphaOfLengthBetween(1, 20)
             );
         }


### PR DESCRIPTION
This test could fail if attributes with the same key are generated and are selected for the shrink operation.

![image](https://user-images.githubusercontent.com/1331856/223354914-15963951-7366-49d4-9aa5-dd3899b7acc3.png)

Closes: #94323