### PR TITLE
feat: speed up read DiscoveryNode from network by skip

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodeResponse.java
@@ -34,11 +34,11 @@ public abstract class BaseNodeResponse extends TransportResponse {
      */
     protected BaseNodeResponse(StreamInput in, @Nullable DiscoveryNode node) throws IOException {
         super(in);
-        final DiscoveryNode remoteNode = new DiscoveryNode(in);
         if (node == null) {
-            this.node = remoteNode;
+            this.node = new DiscoveryNode(in);
         } else {
-            assert remoteNode.equals(node) : remoteNode + " vs " + node;
+            assert node.getStreamSize() != 0 : "the stream size of node is zero";
+            in.skip(node.getStreamSize());
             this.node = node;
         }
     }

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -152,6 +152,8 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
     private final Set<String> roleNames;
     private final String externalId;
 
+    private final int streamSize;
+
     /**
      * Creates a new {@link DiscoveryNode}
      * <p>
@@ -363,6 +365,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
         this.roles = Collections.unmodifiableSortedSet(sortedRoles);
         this.roleNames = Set.of(roleNames);
         this.externalId = Objects.requireNonNullElse(externalId, this.nodeName);
+        this.streamSize = 0;
     }
 
     /** Creates a DiscoveryNode representing the local node. */
@@ -393,6 +396,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      * @throws IOException if there is an error while reading from the stream
      */
     public DiscoveryNode(StreamInput in) throws IOException {
+        final int available = in.available();
         this.nodeName = readStringLiteral.read(in);
         this.nodeId = readStringLiteral.read(in);
         this.ephemeralId = readStringLiteral.read(in);
@@ -428,6 +432,7 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
             this.externalId = nodeName;
         }
         this.roleNames = Set.of(roleNames);
+        this.streamSize = available - in.available();
     }
 
     /**
@@ -472,6 +477,13 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      */
     public String getId() {
         return nodeId;
+    }
+
+    /**
+     * the node's size in network
+     */
+    public int getStreamSize() {
+        return this.streamSize;
     }
 
     /**


### PR DESCRIPTION
Skip the whole DiscoveryNode to get some speed up. In my es version with 40w shards, we get about 4.7% speedup.
related to #94352