### PR TITLE
[8.6] Mute FrozenExistenceDeciderIT-testZeroToOne (#94353)

### DIFF
--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
@@ -74,6 +74,7 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
         return List.of(LocalStateAutoscalingAndSearchableSnapshotsAndIndexLifecycle.class);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/89082")
     public void testZeroToOne() throws Exception {
         internalCluster().startMasterOnlyNode();
         setupRepoAndPolicy();


### PR DESCRIPTION
Backports the following commits to 8.6:
 - Mute FrozenExistenceDeciderIT-testZeroToOne (#94353)