### PR TITLE
[DOCS] Add Logback config to java REST client 

### DIFF
--- a/docs/java-rest/low-level/usage.asciidoc
+++ b/docs/java-rest/low-level/usage.asciidoc
@@ -420,3 +420,37 @@ still yields the same response as it did. Enable trace logging for the `tracer`
 package to have such log lines printed out. Do note that this type of logging is
 expensive and should not be enabled at all times in production environments,
 but rather temporarily used only when needed.
+
+==== Logback
+===== Trace Logs
+In order to enable trace logs for logback, we have to use https://www.slf4j.org/legacy.html#jclOverSLF4J[jcl-over-slf4j bridging module].
+
+1. Add the following to your Gradle setting:
+[source,groovy]
+dependencies {
+    implementation('org.slf4j:slf4j-api:1.8.0-beta2')
+    implementation('ch.qos.logback:logback-classic:1.3.0-alpha4')
+    implementation('org.slf4j:jcl-over-slf4j:1.8.0-beta2')
+}
+
+2. Exclude `commons-logging.jar`:
+[source,groovy]
+dependencies {
+    configurations.all {
+        exclude group: "commons-logging", module: "commons-logging"
+    }
+}
+
+3. Add a tracer logger in Logback configuration:
+[source,xml]
+<logger name="tracer" level="TRACE" additivity="false">
+    <appender-ref ref="your_appender_block_name" />
+</logger>
+
+===== RestClient Debug Logs
+To enable debug logs for `RestClient` class, add the following to your Logback configuration:
+[source,xml]
+<logger name="org.elasticsearch.client.RestClient" level="DEBUG" additivity="false">
+    <appender-ref ref="your_appender_block_name" />
+</logger>
+


### PR DESCRIPTION
I have added a short guide on how to enable trace logs and debug logs of Java REST client for `Logback`
