### PR TITLE
Mute test for issue 94239

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -539,8 +539,8 @@ source include/exclude:
 ---
 Unsupported metric type position:
   - skip:
-      version: " - 8.0.99, 8.8.0 - "
-      reason: index.mode and routing_path introduced in 8.1.0 and time series metric position introduced in 8.8.0
+      version: "all"
+      reason: AwaitsFix https://github.com/elastic/elasticsearch/issues/94239, index.mode and routing_path introduced in 8.1.0 and time series metric position introduced in 8.8.0
 
   - do:
       catch: '/unknown parameter \[time_series_metric\] on mapper \[location\] of type \[geo_point\]/'

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/20_mapping.yml
@@ -539,7 +539,7 @@ source include/exclude:
 ---
 Unsupported metric type position:
   - skip:
-      version: "all"
+      version: "all, - 8.0.99, 8.8.0 -"
       reason: AwaitsFix https://github.com/elastic/elasticsearch/issues/94239, index.mode and routing_path introduced in 8.1.0 and time series metric position introduced in 8.8.0
 
   - do:

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/SkipSection.java
@@ -174,12 +174,12 @@ public class SkipSection {
         if (rawRanges == null) {
             return Collections.singletonList(new VersionRange(null, null));
         }
-        if (rawRanges.trim().equals("all")) {
-            return Collections.singletonList(new VersionRange(VersionUtils.getFirstVersion(), Version.CURRENT));
-        }
         String[] ranges = rawRanges.split(",");
         List<VersionRange> versionRanges = new ArrayList<>();
         for (String rawRange : ranges) {
+            if (rawRange.trim().equals("all")) {
+                return Collections.singletonList(new VersionRange(VersionUtils.getFirstVersion(), Version.CURRENT));
+            }
             String[] skipVersions = rawRange.split("-", -1);
             if (skipVersions.length > 2) {
                 throw new IllegalArgumentException("version range malformed: " + rawRanges);


### PR DESCRIPTION
I also enhance slightly the logic for parsing `skip.version: all`, so we don't have to delete all the previous version info, which is usually a very important part of the test.