### PR TITLE
Remove only use of TransportVersionUtils.compatibleFutureVersion

### DIFF
--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
@@ -51,13 +51,13 @@ import java.util.Optional;
 import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_GATEWAY;
 import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_SNAPSHOT;
 import static org.elasticsearch.persistent.PersistentTasksExecutor.NO_NODE_FOUND;
-import static org.elasticsearch.test.TransportVersionUtils.compatibleFutureVersion;
 import static org.elasticsearch.test.TransportVersionUtils.getFirstVersion;
+import static org.elasticsearch.test.TransportVersionUtils.getNextVersion;
 import static org.elasticsearch.test.TransportVersionUtils.getPreviousVersion;
 import static org.elasticsearch.test.TransportVersionUtils.randomVersionBetween;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.contains;
 
 public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffableSerializationTestCase<Custom> {
 
@@ -276,7 +276,7 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
             TestPersistentTasksExecutor.NAME,
             new TestParams(
                 null,
-                randomVersionBetween(random(), compatibleFutureVersion(streamVersion), TransportVersion.CURRENT),
+                randomVersionBetween(random(), getNextVersion(streamVersion), TransportVersion.CURRENT),
                 randomBoolean() ? Optional.empty() : Optional.of("test")
             ),
             randomAssignment()
@@ -292,7 +292,7 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
             new NamedWriteableAwareStreamInput(input, getNamedWriteableRegistry())
         );
 
-        assertThat(read.taskMap().keySet(), equalTo(Collections.singleton("test_compatible_version")));
+        assertThat(read.taskMap().keySet(), contains("test_compatible_version"));
     }
 
     public void testDisassociateDeadNodes_givenNoPersistentTasks() {

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
@@ -55,9 +55,9 @@ import static org.elasticsearch.test.TransportVersionUtils.getFirstVersion;
 import static org.elasticsearch.test.TransportVersionUtils.getNextVersion;
 import static org.elasticsearch.test.TransportVersionUtils.getPreviousVersion;
 import static org.elasticsearch.test.TransportVersionUtils.randomVersionBetween;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.hamcrest.Matchers.contains;
 
 public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffableSerializationTestCase<Custom> {
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TransportVersionUtils.java
@@ -121,17 +121,4 @@ public class TransportVersionUtils {
     public static TransportVersion randomPreviousCompatibleVersion(Random random, TransportVersion version) {
         return randomVersionBetween(random, minimumCompatibilityVersion(version), getPreviousVersion(version));
     }
-
-    private static final int MINIMUM_COMPAT_INDEX = Collections.binarySearch(ALL_VERSIONS, TransportVersion.MINIMUM_COMPATIBLE);
-
-    /** returns the first compatible future version */
-    public static TransportVersion compatibleFutureVersion(TransportVersion version) {
-        int versionIdx = Collections.binarySearch(ALL_VERSIONS, version);
-        if (versionIdx < 0) {
-            versionIdx = -(versionIdx + 1);
-        } else {
-            versionIdx++;
-        }
-        return ALL_VERSIONS.get(Math.max(versionIdx, MINIMUM_COMPAT_INDEX));
-    }
 }


### PR DESCRIPTION
Following on from https://github.com/elastic/elasticsearch/pull/94025#discussion_r1126708448, refactor the only use of TransportVersion.randomCompatibleVersion

This test is just checking that a task with a version greater than the specified minVersion is not serialized.