### PR TITLE
[8.7][DOCS] Adds ML-related items to 8.7 release highlights

### DIFF
--- a/docs/changelog/92213.yaml
+++ b/docs/changelog/92213.yaml
@@ -1,5 +1,11 @@
 pr: 92213
 summary: Make native inference generally available
 area: Machine Learning
-type: enhancement
+type: feature
 issues: []
+highlight:
+  title: Make natural language processing GA
+  body: From 8.7, NLP model management, model allocation, and support for 
+    inference against third party models are generally available. (The new 
+    `text_embedding` extension to `knn` search is still in technical preview.)
+  notable: true

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -150,11 +150,22 @@ image::images/spatial/geogrid_h3_children.png[Kibana map with three H3 layers: c
 {es-pull}93370[#93370]
 
 [discrete]
+[[make_nlp_ga]]
+=== Make natural language processing GA
+From 8.7, NLP model management, model allocation, and support for inference 
+against third party models are generally available. (The new `text_embedding` 
+extension to `knn` search is still in technical preview.)
+
+{es-pull}92213[#92213]
+
+
+[discrete]
 [[make_frequent_item_sets_aggregation_ga]]
 === Make `frequent_item_sets` aggregation GA
 The `frequent_item_sets` aggregation has been moved from technical preview to general availability.
 
 {es-pull}93421[#93421]
+
 
 [discrete]
 [[release_time_series_rate_on_counter_fields_aggegations_as_tech_preview]]


### PR DESCRIPTION
## Overview

This PR adds an ML-related release highlight item to the 8.7 "What's new" page. It also modifies the yml file of the respective PR this way the changes will be published on the page even if the highlights are re-generated.

### Preview

[What's new in 8.7](https://elasticsearch_94368.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/8.7/release-highlights.html#make_nlp_ga)