### PR TITLE
Dry up RecoveryRequest serialization code

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -630,7 +630,7 @@ public class PeerRecoveryTargetService implements IndexEventListener {
     class RestoreFileFromSnapshotTransportRequestHandler implements TransportRequestHandler<RecoverySnapshotFileRequest> {
         @Override
         public void messageReceived(final RecoverySnapshotFileRequest request, TransportChannel channel, Task task) {
-            try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.getRecoveryId(), request.getShardId())) {
+            try (RecoveryRef recoveryRef = onGoingRecoveries.getRecoverySafe(request.recoveryId(), request.shardId())) {
                 final RecoveryTarget recoveryTarget = recoveryRef.target();
                 final ActionListener<Void> listener = createOrFinishListener(recoveryRef, channel, request);
                 if (listener == null) {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryCleanFilesRequest.java
@@ -16,9 +16,6 @@ import org.elasticsearch.index.store.Store;
 import java.io.IOException;
 
 public class RecoveryCleanFilesRequest extends RecoveryTransportRequest {
-
-    private final long recoveryId;
-    private final ShardId shardId;
     private final Store.MetadataSnapshot snapshotFiles;
     private final int totalTranslogOps;
     private final long globalCheckpoint;
@@ -31,9 +28,7 @@ public class RecoveryCleanFilesRequest extends RecoveryTransportRequest {
         int totalTranslogOps,
         long globalCheckpoint
     ) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.snapshotFiles = snapshotFiles;
         this.totalTranslogOps = totalTranslogOps;
         this.globalCheckpoint = globalCheckpoint;
@@ -41,8 +36,6 @@ public class RecoveryCleanFilesRequest extends RecoveryTransportRequest {
 
     RecoveryCleanFilesRequest(StreamInput in) throws IOException {
         super(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
         snapshotFiles = Store.MetadataSnapshot.readFrom(in);
         totalTranslogOps = in.readVInt();
         globalCheckpoint = in.readZLong();
@@ -51,8 +44,6 @@ public class RecoveryCleanFilesRequest extends RecoveryTransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
         snapshotFiles.writeTo(out);
         out.writeVInt(totalTranslogOps);
         out.writeZLong(globalCheckpoint);
@@ -60,14 +51,6 @@ public class RecoveryCleanFilesRequest extends RecoveryTransportRequest {
 
     public Store.MetadataSnapshot sourceMetaSnapshot() {
         return snapshotFiles;
-    }
-
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
     }
 
     public int totalTranslogOps() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFileChunkRequest.java
@@ -19,8 +19,6 @@ import java.io.IOException;
 
 public final class RecoveryFileChunkRequest extends RecoveryTransportRequest implements RefCounted {
     private final boolean lastChunk;
-    private final long recoveryId;
-    private final ShardId shardId;
     private final long position;
     private final ReleasableBytesReference content;
     private final StoreFileMetadata metadata;
@@ -30,8 +28,6 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
 
     public RecoveryFileChunkRequest(StreamInput in) throws IOException {
         super(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
         final String name = in.readString();
         position = in.readVLong();
         final long length = in.readVLong();
@@ -55,23 +51,13 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
         int totalTranslogOps,
         long sourceThrottleTimeInNanos
     ) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.metadata = metadata;
         this.position = position;
         this.content = content.retain();
         this.lastChunk = lastChunk;
         this.totalTranslogOps = totalTranslogOps;
         this.sourceThrottleTimeInNanos = sourceThrottleTimeInNanos;
-    }
-
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
     }
 
     public String name() {
@@ -101,8 +87,6 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
         out.writeString(metadata.name());
         out.writeVLong(position);
         out.writeVLong(metadata.length());
@@ -116,7 +100,7 @@ public final class RecoveryFileChunkRequest extends RecoveryTransportRequest imp
 
     @Override
     public String toString() {
-        return shardId + ": name='" + name() + '\'' + ", position=" + position + ", length=" + length();
+        return shardId() + ": name='" + name() + '\'' + ", position=" + position + ", length=" + length();
     }
 
     public StoreFileMetadata metadata() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFilesInfoRequest.java
@@ -18,9 +18,6 @@ import java.util.List;
 
 public class RecoveryFilesInfoRequest extends RecoveryTransportRequest {
 
-    private final long recoveryId;
-    private final ShardId shardId;
-
     List<String> phase1FileNames;
     List<Long> phase1FileSizes;
     List<String> phase1ExistingFileNames;
@@ -30,8 +27,6 @@ public class RecoveryFilesInfoRequest extends RecoveryTransportRequest {
 
     public RecoveryFilesInfoRequest(StreamInput in) throws IOException {
         super(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
         int size = in.readVInt();
         phase1FileNames = new ArrayList<>(size);
         for (int i = 0; i < size; i++) {
@@ -68,9 +63,7 @@ public class RecoveryFilesInfoRequest extends RecoveryTransportRequest {
         List<Long> phase1ExistingFileSizes,
         int totalTranslogOps
     ) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.phase1FileNames = phase1FileNames;
         this.phase1FileSizes = phase1FileSizes;
         this.phase1ExistingFileNames = phase1ExistingFileNames;
@@ -78,19 +71,9 @@ public class RecoveryFilesInfoRequest extends RecoveryTransportRequest {
         this.totalTranslogOps = totalTranslogOps;
     }
 
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
-    }
-
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
 
         out.writeStringCollection(phase1FileNames);
         out.writeCollection(phase1FileSizes, StreamOutput::writeVLong);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryFinalizeRecoveryRequest.java
@@ -15,16 +15,11 @@ import org.elasticsearch.index.shard.ShardId;
 import java.io.IOException;
 
 final class RecoveryFinalizeRecoveryRequest extends RecoveryTransportRequest {
-
-    private final long recoveryId;
-    private final ShardId shardId;
     private final long globalCheckpoint;
     private final long trimAboveSeqNo;
 
     RecoveryFinalizeRecoveryRequest(StreamInput in) throws IOException {
         super(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
         globalCheckpoint = in.readZLong();
         trimAboveSeqNo = in.readZLong();
     }
@@ -36,19 +31,9 @@ final class RecoveryFinalizeRecoveryRequest extends RecoveryTransportRequest {
         final long globalCheckpoint,
         final long trimAboveSeqNo
     ) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.globalCheckpoint = globalCheckpoint;
         this.trimAboveSeqNo = trimAboveSeqNo;
-    }
-
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
     }
 
     public long globalCheckpoint() {
@@ -62,8 +47,6 @@ final class RecoveryFinalizeRecoveryRequest extends RecoveryTransportRequest {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
         out.writeZLong(globalCheckpoint);
         out.writeZLong(trimAboveSeqNo);
     }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryPrepareForTranslogOperationsRequest.java
@@ -15,31 +15,16 @@ import org.elasticsearch.index.shard.ShardId;
 import java.io.IOException;
 
 class RecoveryPrepareForTranslogOperationsRequest extends RecoveryTransportRequest {
-
-    private final long recoveryId;
-    private final ShardId shardId;
     private final int totalTranslogOps;
 
     RecoveryPrepareForTranslogOperationsRequest(long recoveryId, long requestSeqNo, ShardId shardId, int totalTranslogOps) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.totalTranslogOps = totalTranslogOps;
     }
 
     RecoveryPrepareForTranslogOperationsRequest(StreamInput in) throws IOException {
         super(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
         totalTranslogOps = in.readVInt();
-    }
-
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
     }
 
     public int totalTranslogOps() {
@@ -49,8 +34,6 @@ class RecoveryPrepareForTranslogOperationsRequest extends RecoveryTransportReque
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
         out.writeVInt(totalTranslogOps);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySnapshotFileRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySnapshotFileRequest.java
@@ -17,8 +17,6 @@ import org.elasticsearch.repositories.IndexId;
 import java.io.IOException;
 
 public class RecoverySnapshotFileRequest extends RecoveryTransportRequest {
-    private final long recoveryId;
-    private final ShardId shardId;
     private final String repository;
     private final IndexId indexId;
     private final BlobStoreIndexShardSnapshot.FileInfo fileInfo;
@@ -31,9 +29,7 @@ public class RecoverySnapshotFileRequest extends RecoveryTransportRequest {
         IndexId indexId,
         BlobStoreIndexShardSnapshot.FileInfo fileInfo
     ) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.repository = repository;
         this.indexId = indexId;
         this.fileInfo = fileInfo;
@@ -41,8 +37,6 @@ public class RecoverySnapshotFileRequest extends RecoveryTransportRequest {
 
     public RecoverySnapshotFileRequest(StreamInput in) throws IOException {
         super(in);
-        this.recoveryId = in.readLong();
-        this.shardId = new ShardId(in);
         this.repository = in.readString();
         this.indexId = new IndexId(in);
         this.fileInfo = new BlobStoreIndexShardSnapshot.FileInfo(in);
@@ -53,19 +47,9 @@ public class RecoverySnapshotFileRequest extends RecoveryTransportRequest {
         assert out.getTransportVersion().onOrAfter(RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_TRANSPORT_VERSION)
             : "Unexpected serialization version " + out.getTransportVersion();
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
         out.writeString(repository);
         indexId.writeTo(out);
         fileInfo.writeTo(out);
-    }
-
-    public long getRecoveryId() {
-        return recoveryId;
-    }
-
-    public ShardId getShardId() {
-        return shardId;
     }
 
     public String getRepository() {

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTranslogOperationsRequest.java
@@ -20,8 +20,6 @@ import java.util.List;
 
 public class RecoveryTranslogOperationsRequest extends RecoveryTransportRequest implements RawIndexingDataTransportRequest {
 
-    private final long recoveryId;
-    private final ShardId shardId;
     private final List<Translog.Operation> operations;
     private final int totalTranslogOps;
     private final long maxSeenAutoIdTimestampOnPrimary;
@@ -40,23 +38,13 @@ public class RecoveryTranslogOperationsRequest extends RecoveryTransportRequest 
         final RetentionLeases retentionLeases,
         final long mappingVersionOnPrimary
     ) {
-        super(requestSeqNo);
-        this.recoveryId = recoveryId;
-        this.shardId = shardId;
+        super(requestSeqNo, recoveryId, shardId);
         this.operations = operations;
         this.totalTranslogOps = totalTranslogOps;
         this.maxSeenAutoIdTimestampOnPrimary = maxSeenAutoIdTimestampOnPrimary;
         this.maxSeqNoOfUpdatesOrDeletesOnPrimary = maxSeqNoOfUpdatesOrDeletesOnPrimary;
         this.retentionLeases = retentionLeases;
         this.mappingVersionOnPrimary = mappingVersionOnPrimary;
-    }
-
-    public long recoveryId() {
-        return this.recoveryId;
-    }
-
-    public ShardId shardId() {
-        return shardId;
     }
 
     public List<Translog.Operation> operations() {
@@ -90,8 +78,6 @@ public class RecoveryTranslogOperationsRequest extends RecoveryTransportRequest 
 
     RecoveryTranslogOperationsRequest(StreamInput in) throws IOException {
         super(in);
-        recoveryId = in.readLong();
-        shardId = new ShardId(in);
         operations = Translog.readOperations(in, "recovery");
         totalTranslogOps = in.readVInt();
         maxSeenAutoIdTimestampOnPrimary = in.readZLong();
@@ -103,8 +89,6 @@ public class RecoveryTranslogOperationsRequest extends RecoveryTransportRequest 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeLong(recoveryId);
-        shardId.writeTo(out);
         Translog.writeOperations(out, operations);
         out.writeVInt(totalTranslogOps);
         out.writeZLong(maxSeenAutoIdTimestampOnPrimary);

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTransportRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoveryTransportRequest.java
@@ -10,6 +10,7 @@ package org.elasticsearch.indices.recovery;
 
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.transport.TransportRequest;
 
 import java.io.IOException;
@@ -18,22 +19,40 @@ public abstract class RecoveryTransportRequest extends TransportRequest {
 
     private final long requestSeqNo;
 
+    private final long recoveryId;
+
+    private final ShardId shardId;
+
     RecoveryTransportRequest(StreamInput in) throws IOException {
         super(in);
         requestSeqNo = in.readLong();
+        recoveryId = in.readLong();
+        shardId = new ShardId(in);
     }
 
-    RecoveryTransportRequest(long requestSeqNo) {
+    RecoveryTransportRequest(long requestSeqNo, long recoveryId, ShardId shardId) {
         this.requestSeqNo = requestSeqNo;
+        this.recoveryId = recoveryId;
+        this.shardId = shardId;
     }
 
     public long requestSeqNo() {
         return requestSeqNo;
     }
 
+    public final long recoveryId() {
+        return this.recoveryId;
+    }
+
+    public final ShardId shardId() {
+        return shardId;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeLong(requestSeqNo);
+        out.writeLong(recoveryId);
+        shardId.writeTo(out);
     }
 }

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -951,7 +951,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                 assertPeerRecoveryUsedSnapshots(indexRecoveredFromSnapshot1, sourceNode, targetNode);
 
                 for (RecoverySnapshotFileRequest recoverySnapshotFileRequest : recoverySnapshotFileRequests) {
-                    String indexName = recoverySnapshotFileRequest.getShardId().getIndexName();
+                    String indexName = recoverySnapshotFileRequest.shardId().getIndexName();
                     assertThat(indexName, is(equalTo(indexRecoveredFromSnapshot1)));
                 }
 


### PR DESCRIPTION
We have both the recovery id and the shard id as shared fields and they are serialized the same way over the wire for all implementations. -> we can reflect that in code
