### PR TITLE
Refactor file settings watcher to allow reuse of file watching logic

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestFileSettingsIT.java
@@ -120,15 +120,15 @@ public class IngestFileSettingsIT extends ESIntegTestCase {
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
         assertTrue(fileSettingsService.watching());
 
-        Files.deleteIfExists(fileSettingsService.operatorSettingsFile());
+        Files.deleteIfExists(fileSettingsService.watchedFile());
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         logger.info("--> writing JSON config to node {} with path {}", node, tempFilePath);
         logger.info(Strings.format(json, version));
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -235,11 +235,11 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
         logger.info("--> New file settings: [{}]", Strings.format(json, version));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/ComponentTemplatesFileSettingsIT.java
@@ -365,11 +365,11 @@ public class ComponentTemplatesFileSettingsIT extends ESIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/FileSettingsServiceIT.java
@@ -111,11 +111,11 @@ public class FileSettingsServiceIT extends ESIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
         logger.info("--> New file settings: [{}]", Strings.format(json, version));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/RepositoriesFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/RepositoriesFileSettingsIT.java
@@ -102,11 +102,11 @@ public class RepositoriesFileSettingsIT extends ESIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnapshotsAndFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/reservedstate/service/SnapshotsAndFileSettingsIT.java
@@ -86,7 +86,7 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
@@ -94,7 +94,7 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
         do {
             try {
                 // this can fail on Windows because of timing
-                Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+                Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
                 return;
             } catch (IOException e) {
                 logger.info("--> retrying writing a settings file [" + retryCount + "]");
@@ -170,7 +170,7 @@ public class SnapshotsAndFileSettingsIT extends AbstractSnapshotIntegTestCase {
         );
 
         logger.info("--> deleting operator file, no file based settings");
-        Files.delete(fs.operatorSettingsFile());
+        Files.delete(fs.watchedFile());
 
         logger.info("--> restore global state from the snapshot");
         clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap").setRestoreGlobalState(true).setWaitForCompletion(true).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/threadpool/SimpleThreadPoolIT.java
@@ -83,7 +83,7 @@ public class SimpleThreadPoolIT extends ESIntegTestCase {
                 || threadName.contains("Keep-Alive-Timer")
                 || threadName.contains("readiness-service")
                 || threadName.contains("JVMCI-native") // GraalVM Compiler Thread
-                || threadName.contains("file-settings-watcher")
+                || threadName.contains("file-watcher[") // AbstractFileWatchingService
                 || threadName.contains("FileSystemWatch")) { // FileSystemWatchService(Linux/Windows), FileSystemWatcher(BSD/AIX)
                 continue;
             }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1396,7 +1396,7 @@ public class Node implements Closeable {
         fileSettingsService.start();
         // if we are using the readiness service, listen for the file settings being applied
         if (ReadinessService.enabled(environment)) {
-            fileSettingsService.addFileSettingsChangedListener(injector.getInstance(ReadinessService.class));
+            fileSettingsService.addFileChangedListener(injector.getInstance(ReadinessService.class));
         }
 
         clusterService.addStateApplier(transportService.getTaskManager());

--- a/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
+++ b/server/src/main/java/org/elasticsearch/readiness/ReadinessService.java
@@ -20,7 +20,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.transport.BoundTransportAddress;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.env.Environment;
-import org.elasticsearch.reservedstate.service.FileSettingsChangedListener;
+import org.elasticsearch.reservedstate.service.FileChangedListener;
 import org.elasticsearch.shutdown.PluginShutdownService;
 import org.elasticsearch.transport.BindTransportException;
 
@@ -37,7 +37,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
 
-public class ReadinessService extends AbstractLifecycleComponent implements ClusterStateListener, FileSettingsChangedListener {
+public class ReadinessService extends AbstractLifecycleComponent implements ClusterStateListener, FileChangedListener {
     private static final Logger logger = LogManager.getLogger(ReadinessService.class);
 
     private final Environment environment;
@@ -263,7 +263,7 @@ public class ReadinessService extends AbstractLifecycleComponent implements Clus
     }
 
     @Override
-    public void settingsChanged() {
+    public void watchedFileChanged() {
         fileSettingsApplied = true;
         setReady(masterElected && (shuttingDown == false));
     }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -240,8 +240,7 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
             throw new IllegalStateException("unable to launch a new watch service", e);
         }
 
-        // TODO[wrb]: update thread name
-        watcherThread = new Thread(this::watcherThread, "elasticsearch[file-settings-watcher]");
+        watcherThread = new Thread(this::watcherThread, "elasticsearch[file-watcher[" + watchedFile + "]]");
         watcherThread.start();
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -55,7 +55,7 @@ import java.util.concurrent.ExecutionException;
  */
 public abstract class AbstractFileWatchingService extends AbstractLifecycleComponent implements ClusterStateListener {
 
-    private static final Logger logger = LogManager.getLogger(FileSettingsService.class);
+    private static final Logger logger = LogManager.getLogger(AbstractFileWatchingService.class);
     private static final int REGISTER_RETRY_COUNT = 5;
     private final ClusterService clusterService;
     private final Path watchedFileDir;

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -34,6 +34,23 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 
+/**
+ * <p>A file watching service watches for changes in a particular file on disk. There
+ * are three assumptions about the file structure:</p>
+ * <ol>
+ *     <li>The file itself may or may not exist.</li>
+ *     <li>The file's parent directory may or may not exist.</li>
+ *     <li>The directory above the file's parent directory must always exist.</li>
+ * </ol>
+ *
+ * <p>For example, if the watched file is under /usr/elastic/elasticsearch/conf/special/settings.yml,
+ * then /usr/elastic/elasticsearch/conf/ must exist, but special/ and special/settings.yml may
+ * be created, updated, or deleted during runtime.</p>
+ *
+ * <p>What this class does not do is define what should happen after the file changes.
+ * An implementation class should override {@link #processFileChanges(Path)} to define
+ * the correct behavior.</p>
+ */
 public abstract class AbstractFileWatchingService extends AbstractLifecycleComponent implements ClusterStateListener {
 
     private static final Logger logger = LogManager.getLogger(FileSettingsService.class);

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -49,7 +49,7 @@ import java.util.concurrent.ExecutionException;
  * be created, updated, or deleted during runtime.</p>
  *
  * <p>What this class does not do is define what should happen after the file changes.
- * An implementation class should override {@link #processFileChanges(Path)} to define
+ * An implementation class should override {@link #processFileChanges()} to define
  * the correct behavior.</p>
  */
 public abstract class AbstractFileWatchingService extends AbstractLifecycleComponent implements ClusterStateListener {
@@ -78,7 +78,7 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
      * Any implementation of this class must implement this method in order
      * to define what happens once the watched file changes.
      */
-    abstract PlainActionFuture<Void> processFileChanges(Path path);
+    abstract PlainActionFuture<Void> processFileChanges();
 
     /**
      * There may be an indication in cluster state that the file we are watching
@@ -363,7 +363,7 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
     // package private for testing
     void processSettingsAndNotifyListeners() throws InterruptedException {
         try {
-            processFileChanges(watchedFile()).get();
+            processFileChanges().get();
             for (var listener : eventListeners) {
                 listener.watchedFileChanged();
             }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -10,7 +10,6 @@ package org.elasticsearch.reservedstate.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
@@ -365,16 +364,14 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
     }
 
     // package private for testing
-    void processSettingsAndNotifyListeners() {
+    void processSettingsAndNotifyListeners() throws InterruptedException {
         try {
             processFileChanges();
             for (var listener : eventListeners) {
                 listener.watchedFileChanged();
             }
         } catch (IOException | ExecutionException e) {
-            logger.error(() -> "Error processing watched file: " + watchedFile(), e.getCause());
-        } catch (InterruptedException e) {
-            throw new ElasticsearchException(e);
+            logger.error(() -> "Error processing watched file: " + watchedFile(), e);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -10,7 +10,6 @@ package org.elasticsearch.reservedstate.service;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
@@ -78,7 +77,7 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
      * Any implementation of this class must implement this method in order
      * to define what happens once the watched file changes.
      */
-    abstract PlainActionFuture<Void> processFileChanges();
+    abstract void processFileChanges() throws InterruptedException, ExecutionException, IOException;
 
     /**
      * There may be an indication in cluster state that the file we are watching
@@ -363,11 +362,11 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
     // package private for testing
     void processSettingsAndNotifyListeners() throws InterruptedException {
         try {
-            processFileChanges().get();
+            processFileChanges();
             for (var listener : eventListeners) {
                 listener.watchedFileChanged();
             }
-        } catch (ExecutionException e) {
+        } catch (IOException | ExecutionException e) {
             logger.error(() -> "Error processing watched file: " + watchedFile(), e.getCause());
         }
     }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -368,7 +368,7 @@ public abstract class AbstractFileWatchingService extends AbstractLifecycleCompo
                 listener.watchedFileChanged();
             }
         } catch (ExecutionException e) {
-            logger.error("Error processing watched file: {}", watchedFile(), e.getCause());
+            logger.error(() -> "Error processing watched file: " + watchedFile(), e.getCause());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/AbstractFileWatchingService.java
@@ -1,0 +1,345 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.reservedstate.service;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.component.AbstractLifecycleComponent;
+import org.elasticsearch.env.Environment;
+
+import java.io.IOException;
+import java.nio.file.ClosedWatchServiceException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardWatchEventKinds;
+import java.nio.file.WatchKey;
+import java.nio.file.WatchService;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+
+public abstract class AbstractFileWatchingService extends AbstractLifecycleComponent implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(FileSettingsService.class);
+    protected static final int REGISTER_RETRY_COUNT = 5;
+    protected final ClusterService clusterService;
+    protected final ReservedClusterStateService stateService;
+    protected final Path watchedFileDir;
+    protected final Path watchedFile;
+    protected final List<FileSettingsChangedListener> eventListeners;
+    protected WatchService watchService; // null;
+    protected Thread watcherThread;
+    protected FileSettingsService.FileUpdateState fileUpdateState;
+    protected WatchKey settingsDirWatchKey;
+    protected WatchKey configDirWatchKey;
+    protected volatile boolean active = false;
+
+    public AbstractFileWatchingService(
+        ClusterService clusterService,
+        ReservedClusterStateService stateService,
+        Environment environment,
+        String watchedDirName,
+        String watchedFileName
+    ) {
+        this.clusterService = clusterService;
+        this.stateService = stateService;
+        this.watchedFileDir = environment.configFile().toAbsolutePath().resolve(watchedDirName);
+        this.watchedFile = watchedFileDir.resolve(watchedFileName);
+        this.eventListeners = new CopyOnWriteArrayList<>();
+    }
+
+    // platform independent way to tell if a file changed
+    // we compare the file modified timestamp, the absolute path (symlinks), and file id on the system
+    boolean watchedFileChanged(Path path) throws IOException {
+        if (Files.exists(path) == false) {
+            return false;
+        }
+
+        FileSettingsService.FileUpdateState previousUpdateState = fileUpdateState;
+
+        BasicFileAttributes attr = Files.readAttributes(path, BasicFileAttributes.class);
+        fileUpdateState = new FileSettingsService.FileUpdateState(
+            attr.lastModifiedTime().toMillis(),
+            path.toRealPath().toString(),
+            attr.fileKey()
+        );
+
+        return (previousUpdateState == null || previousUpdateState.equals(fileUpdateState) == false);
+    }
+
+    public Path watchedFileDir() {
+        return this.watchedFileDir;
+    }
+
+    public Path watchedFile() {
+        return this.watchedFile;
+    }
+
+    @Override
+    protected void doStart() {
+        // We start the file watcher when we know we are master from a cluster state change notification.
+        // We need the additional active flag, since cluster state can change after we've shutdown the service
+        // causing the watcher to start again.
+        this.active = Files.exists(watchedFileDir().getParent());
+        if (active == false) {
+            // we don't have a config directory, we can't possibly launch the file settings service
+            return;
+        }
+        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
+            clusterService.addListener(this);
+        }
+    }
+
+    // TODO[wrb]: update logging
+    @Override
+    protected void doStop() {
+        this.active = false;
+        logger.debug("Stopping file settings service");
+        stopWatcher();
+    }
+
+    @Override
+    protected void doClose() {}
+
+    public boolean watching() {
+        return watcherThread != null;
+    }
+
+    // TODO[wrb]: update logging
+    synchronized void stopWatcher() {
+        if (watching()) {
+            logger.debug("stopping watcher ...");
+            // make sure watch service is closed whatever
+            // this will also close any outstanding keys
+            try (var ws = watchService) {
+                watcherThread.interrupt();
+                watcherThread.join();
+
+                // make sure any keys are closed - if watchService.close() throws, it may not close the keys first
+                if (configDirWatchKey != null) {
+                    configDirWatchKey.cancel();
+                }
+                if (settingsDirWatchKey != null) {
+                    settingsDirWatchKey.cancel();
+                }
+            } catch (IOException e) {
+                logger.warn("encountered exception while closing watch service", e);
+            } catch (InterruptedException interruptedException) {
+                logger.info("interrupted while closing the watch service", interruptedException);
+            } finally {
+                watcherThread = null;
+                settingsDirWatchKey = null;
+                configDirWatchKey = null;
+                watchService = null;
+                logger.info("watcher service stopped");
+            }
+        } else {
+            logger.trace("file settings service already stopped");
+        }
+    }
+
+    protected boolean currentNodeMaster(ClusterState clusterState) {
+        return clusterState.nodes().getLocalNodeId().equals(clusterState.nodes().getMasterNodeId());
+    }
+
+    // package private for testing
+    long retryDelayMillis(int failedCount) {
+        assert failedCount < 31; // don't let the count overflow
+        return 100 * (1 << failedCount) + Randomness.get().nextInt(10); // add a bit of jitter to avoid two processes in lockstep
+    }
+
+    // package private for testing
+    WatchKey enableDirectoryWatcher(WatchKey previousKey, Path settingsDir) throws IOException, InterruptedException {
+        if (previousKey != null) {
+            previousKey.cancel();
+        }
+        int retryCount = 0;
+
+        do {
+            try {
+                return settingsDir.register(
+                    watchService,
+                    StandardWatchEventKinds.ENTRY_MODIFY,
+                    StandardWatchEventKinds.ENTRY_CREATE,
+                    StandardWatchEventKinds.ENTRY_DELETE
+                );
+            } catch (IOException e) {
+                if (retryCount == REGISTER_RETRY_COUNT - 1) {
+                    throw e;
+                }
+                Thread.sleep(retryDelayMillis(retryCount));
+                retryCount++;
+            }
+        } while (true);
+    }
+
+    // TODO[wrb]: rename
+    public void addFileSettingsChangedListener(FileSettingsChangedListener listener) {
+        eventListeners.add(listener);
+    }
+
+    // TODO[wrb]: update logging
+    // package private for testing
+    void processSettingsAndNotifyListeners() throws InterruptedException {
+        try {
+            processFileSettings(watchedFile()).get();
+            for (var listener : eventListeners) {
+                listener.settingsChanged();
+            }
+        } catch (ExecutionException e) {
+            logger.error("Error processing operator settings json file", e.getCause());
+        }
+    }
+
+    protected void watcherThread() {
+        try {
+            logger.info("file settings service up and running [tid={}]", Thread.currentThread().getId());
+
+            Path path = watchedFile();
+
+            if (Files.exists(path)) {
+                logger.debug("found initial operator settings file [{}], applying...", path);
+                processSettingsAndNotifyListeners();
+            } else {
+                // Notify everyone we don't have any initial file settings
+                for (var listener : eventListeners) {
+                    listener.settingsChanged();
+                }
+            }
+
+            WatchKey key;
+            while ((key = watchService.take()) != null) {
+                /*
+                 * Reading and interpreting watch service events can vary from platform to platform. E.g:
+                 * MacOS symlink delete and set (rm -rf operator && ln -s <path to>/file_settings/ operator):
+                 *     ENTRY_MODIFY:operator
+                 *     ENTRY_CREATE:settings.json
+                 *     ENTRY_MODIFY:settings.json
+                 * Linux in Docker symlink delete and set (rm -rf operator && ln -s <path to>/file_settings/ operator):
+                 *     ENTRY_CREATE:operator
+                 * Windows
+                 *     ENTRY_CREATE:operator
+                 *     ENTRY_MODIFY:operator
+                 * After we get an indication that something has changed, we check the timestamp, file id,
+                 * real path of our desired file. We don't actually care what changed, we just re-check ourselves.
+                 */
+                Path settingsPath = watchedFileDir();
+                if (Files.exists(settingsPath)) {
+                    try {
+                        if (logger.isDebugEnabled()) {
+                            key.pollEvents().forEach(e -> logger.debug("{}:{}", e.kind().toString(), e.context().toString()));
+                        } else {
+                            key.pollEvents();
+                        }
+                        key.reset();
+
+                        // We re-register the settings directory watch key, because we don't know
+                        // if the file name maps to the same native file system file id. Symlinks
+                        // are one potential cause of inconsistency here, since their handling by
+                        // the WatchService is platform dependent.
+                        settingsDirWatchKey = enableDirectoryWatcher(settingsDirWatchKey, settingsPath);
+
+                        if (watchedFileChanged(path)) {
+                            processSettingsAndNotifyListeners();
+                        }
+                    } catch (IOException e) {
+                        logger.warn("encountered I/O error while watching file settings", e);
+                    }
+                } else {
+                    key.pollEvents();
+                    key.reset();
+                }
+            }
+        } catch (ClosedWatchServiceException | InterruptedException expected) {
+            logger.info("shutting down watcher thread");
+        } catch (Exception e) {
+            logger.error("shutting down watcher thread with exception", e);
+        }
+    }
+
+    // TODO[wrb]: to superclass
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        ClusterState clusterState = event.state();
+        startIfMaster(clusterState);
+    }
+
+    // TODO[wrb]: to superclass
+    private void startIfMaster(ClusterState clusterState) {
+        if (currentNodeMaster(clusterState)) {
+            startWatcher(clusterState);
+        } else {
+            stopWatcher();
+        }
+    }
+
+    protected abstract void refreshExistingFileStateIfNeeded(ClusterState clusterState);
+
+    // TODO[wrb]: update logging
+    synchronized void startWatcher(ClusterState clusterState) {
+        if (watching() || active == false) {
+            refreshExistingFileStateIfNeeded(clusterState);
+
+            return;
+        }
+
+        logger.info("starting file settings watcher ...");
+
+        /*
+         * We essentially watch for two things:
+         *  - the creation of the operator directory (if it doesn't exist), symlink changes to the operator directory
+         *  - any changes to files inside the operator directory if it exists, filtering for settings.json
+         */
+        try {
+            Path settingsDirPath = watchedFileDir();
+            this.watchService = settingsDirPath.getParent().getFileSystem().newWatchService();
+            if (Files.exists(settingsDirPath)) {
+                settingsDirWatchKey = enableDirectoryWatcher(settingsDirWatchKey, settingsDirPath);
+            } else {
+                logger.debug("operator settings directory [{}] not found, will watch for its creation...", settingsDirPath);
+            }
+            // We watch the config directory always, even if initially we had an operator directory
+            // it can be deleted and created later. The config directory never goes away, we only
+            // register it once for watching.
+            configDirWatchKey = enableDirectoryWatcher(configDirWatchKey, settingsDirPath.getParent());
+        } catch (Exception e) {
+            if (watchService != null) {
+                try {
+                    // this will also close any keys
+                    this.watchService.close();
+                } catch (Exception ce) {
+                    e.addSuppressed(ce);
+                } finally {
+                    this.watchService = null;
+                }
+            }
+
+            throw new IllegalStateException("unable to launch a new watch service", e);
+        }
+
+        watcherThread = new Thread(this::watcherThread, "elasticsearch[file-settings-watcher]");
+        watcherThread.start();
+    }
+
+    abstract PlainActionFuture<Void> processFileSettings(Path path);
+
+    /**
+     * Holds information about the last known state of the file we watched. We use this
+     * class to determine if a file has been changed.
+     */
+    record FileUpdateState(long timestamp, String path, Object fileKey) {}
+}

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileChangedListener.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileChangedListener.java
@@ -9,11 +9,10 @@
 package org.elasticsearch.reservedstate.service;
 
 /**
- * Listener interface for the file settings service. Listeners will get
- * notified when the settings have been updated, or if there are no settings
+ * Listener interface for the file watching service. Listeners will get
+ * notified when the watched file has been updated, or if there is no file
  * on initial start.
  */
-// TODO[wrb]: rename for any watched file?
-public interface FileSettingsChangedListener {
-    void settingsChanged();
+public interface FileChangedListener {
+    void watchedFileChanged();
 }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsChangedListener.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsChangedListener.java
@@ -13,6 +13,7 @@ package org.elasticsearch.reservedstate.service;
  * notified when the settings have been updated, or if there are no settings
  * on initial start.
  */
+// TODO[wrb]: rename for any watched file?
 public interface FileSettingsChangedListener {
     void settingsChanged();
 }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -52,7 +52,7 @@ public class FileSettingsService extends AbstractFileWatchingService {
      * @param environment we need the environment to pull the location of the config and operator directories
      */
     public FileSettingsService(ClusterService clusterService, ReservedClusterStateService stateService, Environment environment) {
-        super(clusterService, environment, OPERATOR_DIRECTORY, SETTINGS_FILE_NAME);
+        super(clusterService, environment.configFile().toAbsolutePath().resolve(OPERATOR_DIRECTORY).resolve(SETTINGS_FILE_NAME));
         this.stateService = stateService;
     }
 

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -11,31 +11,19 @@ package org.elasticsearch.reservedstate.service;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
-import org.elasticsearch.common.Randomness;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
-import java.nio.file.ClosedWatchServiceException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.nio.file.attribute.BasicFileAttributes;
 import java.nio.file.attribute.FileTime;
 import java.time.Instant;
-import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.ExecutionException;
 
 import static org.elasticsearch.xcontent.XContentType.JSON;
 
@@ -50,39 +38,13 @@ import static org.elasticsearch.xcontent.XContentType.JSON;
  * the service as a listener to cluster state changes, so that we can enable the file watcher thread when this
  * node becomes a master node.
  */
-public class FileSettingsService extends AbstractFileWatchingService implements ClusterStateListener {
-    // TODO[wrb]: getLogger in superclass?
+public class FileSettingsService extends AbstractFileWatchingService {
+
     private static final Logger logger = LogManager.getLogger(FileSettingsService.class);
 
     public static final String SETTINGS_FILE_NAME = "settings.json";
     public static final String NAMESPACE = "file_settings";
-    // TODO[wrb]: to superclass
-    private static final int REGISTER_RETRY_COUNT = 5;
-
-    // TODO[wrb]: to superclass
-    private final ClusterService clusterService;
-    // TODO[wrb]: to superclass
-    private final ReservedClusterStateService stateService;
-    private final Path operatorSettingsDir;
-
-    // TODO[wrb]: to superclass
-    private WatchService watchService; // null;
-    // TODO[wrb]: to superclass
-    private Thread watcherThread;
-    // TODO[wrb]: to superclass
-    private FileUpdateState fileUpdateState;
-    // TODO[wrb]: to superclass
-    private WatchKey settingsDirWatchKey;
-    // TODO[wrb]: to superclass
-    // TODO[wrb]: to superclass
-    private WatchKey configDirWatchKey;
-
-    // TODO[wrb]: to superclass
-    private volatile boolean active = false;
-
     public static final String OPERATOR_DIRECTORY = "operator";
-
-    private final List<FileSettingsChangedListener> eventListeners;
 
     /**
      * Constructs the {@link FileSettingsService}
@@ -93,85 +55,7 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
      */
     // TODO[wrb]: constructor to superclass
     public FileSettingsService(ClusterService clusterService, ReservedClusterStateService stateService, Environment environment) {
-        this.clusterService = clusterService;
-        this.stateService = stateService;
-        this.operatorSettingsDir = environment.configFile().toAbsolutePath().resolve(OPERATOR_DIRECTORY);
-        this.eventListeners = new CopyOnWriteArrayList<>();
-    }
-
-    // TODO[wrb]: rename, to superclass
-    public Path operatorSettingsDir() {
-        return operatorSettingsDir;
-    }
-
-    // TODO[wrb]: rename, to superclass
-    public Path operatorSettingsFile() {
-        return operatorSettingsDir.resolve(SETTINGS_FILE_NAME);
-    }
-
-    // TODO[wrb]: to superclass
-    // platform independent way to tell if a file changed
-    // we compare the file modified timestamp, the absolute path (symlinks), and file id on the system
-    boolean watchedFileChanged(Path path) throws IOException {
-        if (Files.exists(path) == false) {
-            return false;
-        }
-
-        FileUpdateState previousUpdateState = fileUpdateState;
-
-        BasicFileAttributes attr = Files.readAttributes(path, BasicFileAttributes.class);
-        fileUpdateState = new FileUpdateState(attr.lastModifiedTime().toMillis(), path.toRealPath().toString(), attr.fileKey());
-
-        return (previousUpdateState == null || previousUpdateState.equals(fileUpdateState) == false);
-    }
-
-    // TODO[wrb]: to superclass
-    @Override
-    protected void doStart() {
-        // We start the file watcher when we know we are master from a cluster state change notification.
-        // We need the additional active flag, since cluster state can change after we've shutdown the service
-        // causing the watcher to start again.
-        this.active = Files.exists(operatorSettingsDir().getParent());
-        if (active == false) {
-            // we don't have a config directory, we can't possibly launch the file settings service
-            return;
-        }
-        if (DiscoveryNode.isMasterNode(clusterService.getSettings())) {
-            clusterService.addListener(this);
-        }
-    }
-
-    // TODO[wrb]: to superclass
-    @Override
-    protected void doStop() {
-        this.active = false;
-        logger.debug("Stopping file settings service");
-        stopWatcher();
-    }
-
-    // TODO[wrb]: to superclass
-    @Override
-    protected void doClose() {}
-
-    // TODO[wrb]: to superclass
-    private boolean currentNodeMaster(ClusterState clusterState) {
-        return clusterState.nodes().getLocalNodeId().equals(clusterState.nodes().getMasterNodeId());
-    }
-
-    // TODO[wrb]: to superclass
-    @Override
-    public void clusterChanged(ClusterChangedEvent event) {
-        ClusterState clusterState = event.state();
-        startIfMaster(clusterState);
-    }
-
-    // TODO[wrb]: to superclass
-    private void startIfMaster(ClusterState clusterState) {
-        if (currentNodeMaster(clusterState)) {
-            startWatcher(clusterState);
-        } else {
-            stopWatcher();
-        }
+        super(clusterService, stateService, environment, OPERATOR_DIRECTORY, SETTINGS_FILE_NAME);
     }
 
     /**
@@ -195,7 +79,7 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
         // since we don't know the current operator configuration, e.g. file settings could be disabled
         // on the target cluster. If file settings exist and the cluster state has lost it's reserved
         // state for the "file_settings" namespace, we touch our file settings file to cause it to re-process the file.
-        if (watching() && Files.exists(operatorSettingsFile())) {
+        if (watching() && Files.exists(watchedFile())) {
             if (fileSettingsMetadata != null) {
                 ReservedStateMetadata withResetVersion = new ReservedStateMetadata.Builder(fileSettingsMetadata).version(0L).build();
                 mdBuilder.put(withResetVersion);
@@ -205,7 +89,6 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
         }
     }
 
-    // TODO[wrb]: to superclass
     /**
      * 'Touches' the settings file so the file watcher will re-processes it.
      * <p>
@@ -216,14 +99,15 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
      * For snapshot restores we first must restore the snapshot and then force a refresh, since the cluster state
      * metadata version must be reset to 0 and saved in the cluster state.
      */
-    private void refreshExistingFileStateIfNeeded(ClusterState clusterState) {
+    @Override
+    protected void refreshExistingFileStateIfNeeded(ClusterState clusterState) {
         if (watching()) {
             ReservedStateMetadata fileSettingsMetadata = clusterState.metadata().reservedStateMetadata().get(NAMESPACE);
             // We check if the version was reset to 0, and force an update if a file exists. This can happen in situations
             // like snapshot restores.
-            if (fileSettingsMetadata != null && fileSettingsMetadata.version() == 0L && Files.exists(operatorSettingsFile())) {
+            if (fileSettingsMetadata != null && fileSettingsMetadata.version() == 0L && Files.exists(watchedFile())) {
                 try {
-                    Files.setLastModifiedTime(operatorSettingsFile(), FileTime.from(Instant.now()));
+                    Files.setLastModifiedTime(watchedFile(), FileTime.from(Instant.now()));
                 } catch (IOException e) {
                     logger.warn("encountered I/O error trying to update file settings timestamp", e);
                 }
@@ -231,203 +115,7 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
         }
     }
 
-    // TODO[wrb]: to superclass
-    public boolean watching() {
-        return watcherThread != null;
-    }
-
-    // TODO[wrb]: to superclass, update logging
-    synchronized void startWatcher(ClusterState clusterState) {
-        if (watching() || active == false) {
-            refreshExistingFileStateIfNeeded(clusterState);
-
-            return;
-        }
-
-        logger.info("starting file settings watcher ...");
-
-        /*
-         * We essentially watch for two things:
-         *  - the creation of the operator directory (if it doesn't exist), symlink changes to the operator directory
-         *  - any changes to files inside the operator directory if it exists, filtering for settings.json
-         */
-        try {
-            Path settingsDirPath = operatorSettingsDir();
-            this.watchService = settingsDirPath.getParent().getFileSystem().newWatchService();
-            if (Files.exists(settingsDirPath)) {
-                settingsDirWatchKey = enableSettingsWatcher(settingsDirWatchKey, settingsDirPath);
-            } else {
-                logger.debug("operator settings directory [{}] not found, will watch for its creation...", settingsDirPath);
-            }
-            // We watch the config directory always, even if initially we had an operator directory
-            // it can be deleted and created later. The config directory never goes away, we only
-            // register it once for watching.
-            configDirWatchKey = enableSettingsWatcher(configDirWatchKey, settingsDirPath.getParent());
-        } catch (Exception e) {
-            if (watchService != null) {
-                try {
-                    // this will also close any keys
-                    this.watchService.close();
-                } catch (Exception ce) {
-                    e.addSuppressed(ce);
-                } finally {
-                    this.watchService = null;
-                }
-            }
-
-            throw new IllegalStateException("unable to launch a new watch service", e);
-        }
-
-        watcherThread = new Thread(this::watcherThread, "elasticsearch[file-settings-watcher]");
-        watcherThread.start();
-    }
-
-    // TODO[wrb]: how much to refactor? Or can it just go to superclass?
-    private void watcherThread() {
-        try {
-            logger.info("file settings service up and running [tid={}]", Thread.currentThread().getId());
-
-            Path path = operatorSettingsFile();
-
-            if (Files.exists(path)) {
-                logger.debug("found initial operator settings file [{}], applying...", path);
-                processSettingsAndNotifyListeners();
-            } else {
-                // Notify everyone we don't have any initial file settings
-                for (var listener : eventListeners) {
-                    listener.settingsChanged();
-                }
-            }
-
-            WatchKey key;
-            while ((key = watchService.take()) != null) {
-                /*
-                 * Reading and interpreting watch service events can vary from platform to platform. E.g:
-                 * MacOS symlink delete and set (rm -rf operator && ln -s <path to>/file_settings/ operator):
-                 *     ENTRY_MODIFY:operator
-                 *     ENTRY_CREATE:settings.json
-                 *     ENTRY_MODIFY:settings.json
-                 * Linux in Docker symlink delete and set (rm -rf operator && ln -s <path to>/file_settings/ operator):
-                 *     ENTRY_CREATE:operator
-                 * Windows
-                 *     ENTRY_CREATE:operator
-                 *     ENTRY_MODIFY:operator
-                 * After we get an indication that something has changed, we check the timestamp, file id,
-                 * real path of our desired file. We don't actually care what changed, we just re-check ourselves.
-                 */
-                Path settingsPath = operatorSettingsDir();
-                if (Files.exists(settingsPath)) {
-                    try {
-                        if (logger.isDebugEnabled()) {
-                            key.pollEvents().forEach(e -> logger.debug("{}:{}", e.kind().toString(), e.context().toString()));
-                        } else {
-                            key.pollEvents();
-                        }
-                        key.reset();
-
-                        // We re-register the settings directory watch key, because we don't know
-                        // if the file name maps to the same native file system file id. Symlinks
-                        // are one potential cause of inconsistency here, since their handling by
-                        // the WatchService is platform dependent.
-                        settingsDirWatchKey = enableSettingsWatcher(settingsDirWatchKey, settingsPath);
-
-                        if (watchedFileChanged(path)) {
-                            processSettingsAndNotifyListeners();
-                        }
-                    } catch (IOException e) {
-                        logger.warn("encountered I/O error while watching file settings", e);
-                    }
-                } else {
-                    key.pollEvents();
-                    key.reset();
-                }
-            }
-        } catch (ClosedWatchServiceException | InterruptedException expected) {
-            logger.info("shutting down watcher thread");
-        } catch (Exception e) {
-            logger.error("shutting down watcher thread with exception", e);
-        }
-    }
-
-    // TODO[wrb]: to superclass, update logging
-    // package private for testing
-    void processSettingsAndNotifyListeners() throws InterruptedException {
-        try {
-            processFileSettings(operatorSettingsFile()).get();
-            for (var listener : eventListeners) {
-                listener.settingsChanged();
-            }
-        } catch (ExecutionException e) {
-            logger.error("Error processing operator settings json file", e.getCause());
-        }
-    }
-
-    // TODO[wrb]: to superclass, update logging
-    synchronized void stopWatcher() {
-        if (watching()) {
-            logger.debug("stopping watcher ...");
-            // make sure watch service is closed whatever
-            // this will also close any outstanding keys
-            try (var ws = watchService) {
-                watcherThread.interrupt();
-                watcherThread.join();
-
-                // make sure any keys are closed - if watchService.close() throws, it may not close the keys first
-                if (configDirWatchKey != null) {
-                    configDirWatchKey.cancel();
-                }
-                if (settingsDirWatchKey != null) {
-                    settingsDirWatchKey.cancel();
-                }
-            } catch (IOException e) {
-                logger.warn("encountered exception while closing watch service", e);
-            } catch (InterruptedException interruptedException) {
-                logger.info("interrupted while closing the watch service", interruptedException);
-            } finally {
-                watcherThread = null;
-                settingsDirWatchKey = null;
-                configDirWatchKey = null;
-                watchService = null;
-                logger.info("watcher service stopped");
-            }
-        } else {
-            logger.trace("file settings service already stopped");
-        }
-    }
-
-    // TODO[wrb]: to superclass
-    // package private for testing
-    long retryDelayMillis(int failedCount) {
-        assert failedCount < 31; // don't let the count overflow
-        return 100 * (1 << failedCount) + Randomness.get().nextInt(10); // add a bit of jitter to avoid two processes in lockstep
-    }
-
-    // TODO[wrb]: to superclass, rename
-    // package private for testing
-    WatchKey enableSettingsWatcher(WatchKey previousKey, Path settingsDir) throws IOException, InterruptedException {
-        if (previousKey != null) {
-            previousKey.cancel();
-        }
-        int retryCount = 0;
-
-        do {
-            try {
-                return settingsDir.register(
-                    watchService,
-                    StandardWatchEventKinds.ENTRY_MODIFY,
-                    StandardWatchEventKinds.ENTRY_CREATE,
-                    StandardWatchEventKinds.ENTRY_DELETE
-                );
-            } catch (IOException e) {
-                if (retryCount == REGISTER_RETRY_COUNT - 1) {
-                    throw e;
-                }
-                Thread.sleep(retryDelayMillis(retryCount));
-                retryCount++;
-            }
-        } while (true);
-    }
-
+    @Override
     PlainActionFuture<Void> processFileSettings(Path path) {
         PlainActionFuture<Void> completion = PlainActionFuture.newFuture();
         logger.info("processing path [{}] for [{}]", path, NAMESPACE);
@@ -452,15 +140,4 @@ public class FileSettingsService extends AbstractFileWatchingService implements 
         }
     }
 
-    /**
-     * Holds information about the last known state of the file we watched. We use this
-     * class to determine if a file has been changed.
-     */
-    // TODO[wrb]: to superclass
-    record FileUpdateState(long timestamp, String path, Object fileKey) {}
-
-    // TODO[wrb]: rename and move?
-    public void addFileSettingsChangedListener(FileSettingsChangedListener listener) {
-        eventListeners.add(listener);
-    }
 }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -102,6 +102,13 @@ public class FileSettingsService extends AbstractFileWatchingService {
         return fileSettingsMetadata != null && fileSettingsMetadata.version() == 0L;
     }
 
+    /**
+     * Read settings and pass them to {@link ReservedClusterStateService} for application
+     *
+     * @throws IOException if there is an error reading the file itself
+     * @throws ExecutionException if there is an issue while applying the changes from the file
+     * @throws InterruptedException if the file processing is interrupted by another thread.
+     */
     @Override
     void processFileChanges() throws ExecutionException, InterruptedException, IOException {
         PlainActionFuture<Void> completion = PlainActionFuture.newFuture();

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -42,6 +42,7 @@ public class FileSettingsService extends AbstractFileWatchingService {
     public static final String SETTINGS_FILE_NAME = "settings.json";
     public static final String NAMESPACE = "file_settings";
     public static final String OPERATOR_DIRECTORY = "operator";
+    private final ReservedClusterStateService stateService;
 
     /**
      * Constructs the {@link FileSettingsService}
@@ -51,7 +52,8 @@ public class FileSettingsService extends AbstractFileWatchingService {
      * @param environment we need the environment to pull the location of the config and operator directories
      */
     public FileSettingsService(ClusterService clusterService, ReservedClusterStateService stateService, Environment environment) {
-        super(clusterService, stateService, environment, OPERATOR_DIRECTORY, SETTINGS_FILE_NAME);
+        super(clusterService, environment, OPERATOR_DIRECTORY, SETTINGS_FILE_NAME);
+        this.stateService = stateService;
     }
 
     /**
@@ -123,5 +125,4 @@ public class FileSettingsService extends AbstractFileWatchingService {
             completion.onResponse(null);
         }
     }
-
 }

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -20,7 +20,6 @@ import org.elasticsearch.xcontent.XContentParserConfiguration;
 
 import java.io.BufferedInputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 
 import static org.elasticsearch.xcontent.XContentType.JSON;
 
@@ -102,11 +101,11 @@ public class FileSettingsService extends AbstractFileWatchingService {
     }
 
     @Override
-    PlainActionFuture<Void> processFileChanges(Path path) {
+    PlainActionFuture<Void> processFileChanges() {
         PlainActionFuture<Void> completion = PlainActionFuture.newFuture();
-        logger.info("processing path [{}] for [{}]", path, NAMESPACE);
+        logger.info("processing path [{}] for [{}]", watchedFile(), NAMESPACE);
         try (
-            var fis = Files.newInputStream(path);
+            var fis = Files.newInputStream(watchedFile());
             var bis = new BufferedInputStream(fis);
             var parser = JSON.xContent().createParser(XContentParserConfiguration.EMPTY, bis)
         ) {

--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -53,7 +53,6 @@ public class FileSettingsService extends AbstractFileWatchingService {
      * @param stateService an instance of the immutable cluster state controller, so we can perform the cluster state changes
      * @param environment we need the environment to pull the location of the config and operator directories
      */
-    // TODO[wrb]: constructor to superclass
     public FileSettingsService(ClusterService clusterService, ReservedClusterStateService stateService, Environment environment) {
         super(clusterService, stateService, environment, OPERATOR_DIRECTORY, SETTINGS_FILE_NAME);
     }

--- a/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/readiness/ReadinessServiceTests.java
@@ -239,7 +239,7 @@ public class ReadinessServiceTests extends ESTestCase implements ReadinessClient
             .build();
         ClusterChangedEvent event = new ClusterChangedEvent("test", newState, previousState);
         readinessService.clusterChanged(event);
-        readinessService.settingsChanged();
+        readinessService.watchedFileChanged();
 
         // sending a cluster state with active master should bring up the service
         assertTrue(readinessService.ready());

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -124,11 +124,11 @@ public class FileSettingsServiceTests extends ESTestCase {
     }
 
     public void testOperatorDirName() {
-        Path operatorPath = fileSettingsService.operatorSettingsDir();
+        Path operatorPath = fileSettingsService.watchedFileDir();
         assertTrue(operatorPath.startsWith(env.configFile()));
         assertTrue(operatorPath.endsWith("operator"));
 
-        Path operatorSettingsFile = fileSettingsService.operatorSettingsFile();
+        Path operatorSettingsFile = fileSettingsService.watchedFile();
         assertTrue(operatorSettingsFile.startsWith(operatorPath));
         assertTrue(operatorSettingsFile.endsWith("settings.json"));
     }
@@ -178,9 +178,9 @@ public class FileSettingsServiceTests extends ESTestCase {
         service.startWatcher(clusterService.state());
         assertTrue(service.watching());
 
-        Files.createDirectories(service.operatorSettingsDir());
+        Files.createDirectories(service.watchedFileDir());
 
-        writeTestFile(service.operatorSettingsFile(), "{}");
+        writeTestFile(service.watchedFile(), "{}");
 
         // we need to wait a bit, on MacOS it may take up to 10 seconds for the Java watcher service to notice the file,
         // on Linux is instantaneous. Windows is instantaneous too.
@@ -216,9 +216,9 @@ public class FileSettingsServiceTests extends ESTestCase {
             return null;
         }).when(service).processSettingsAndNotifyListeners();
 
-        Files.createDirectories(service.operatorSettingsDir());
+        Files.createDirectories(service.watchedFileDir());
         // contents of the JSON don't matter, we just need a file to exist
-        writeTestFile(service.operatorSettingsFile(), "{}");
+        writeTestFile(service.watchedFile(), "{}");
 
         service.start();
         service.startWatcher(clusterService.state());
@@ -257,9 +257,9 @@ public class FileSettingsServiceTests extends ESTestCase {
             return null;
         }).when(service).processSettingsAndNotifyListeners();
 
-        Files.createDirectories(service.operatorSettingsDir());
+        Files.createDirectories(service.watchedFileDir());
         // contents of the JSON don't matter, we just need a file to exist
-        writeTestFile(service.operatorSettingsFile(), "{}");
+        writeTestFile(service.watchedFile(), "{}");
 
         service.start();
         service.startWatcher(clusterService.state());
@@ -302,10 +302,10 @@ public class FileSettingsServiceTests extends ESTestCase {
         service.startWatcher(clusterService.state());
         assertTrue(service.watching());
 
-        Files.createDirectories(service.operatorSettingsDir());
+        Files.createDirectories(service.watchedFileDir());
 
         // Make some fake settings file to cause the file settings service to process it
-        writeTestFile(service.operatorSettingsFile(), "{}");
+        writeTestFile(service.watchedFile(), "{}");
 
         // we need to wait a bit, on MacOS it may take up to 10 seconds for the Java watcher service to notice the file,
         // on Linux is instantaneous. Windows is instantaneous too.
@@ -347,10 +347,10 @@ public class FileSettingsServiceTests extends ESTestCase {
         service.startWatcher(clusterService.state());
         assertTrue(service.watching());
 
-        Files.createDirectories(service.operatorSettingsDir());
+        Files.createDirectories(service.watchedFileDir());
 
         // Make some fake settings file to cause the file settings service to process it
-        writeTestFile(service.operatorSettingsFile(), "{}");
+        writeTestFile(service.watchedFile(), "{}");
 
         // we need to wait a bit, on MacOS it may take up to 10 seconds for the Java watcher service to notice the file,
         // on Linux is instantaneous. Windows is instantaneous too.
@@ -368,9 +368,9 @@ public class FileSettingsServiceTests extends ESTestCase {
         var service = spy(fileSettingsService);
         doAnswer(i -> 0L).when(service).retryDelayMillis(anyInt());
 
-        Files.createDirectories(service.operatorSettingsDir());
+        Files.createDirectories(service.watchedFileDir());
 
-        var mockedPath = spy(service.operatorSettingsDir());
+        var mockedPath = spy(service.watchedFileDir());
         var prevWatchKey = mock(WatchKey.class);
         var newWatchKey = mock(WatchKey.class);
 
@@ -384,7 +384,7 @@ public class FileSettingsServiceTests extends ESTestCase {
                 eq(StandardWatchEventKinds.ENTRY_DELETE)
             );
 
-        var result = service.enableSettingsWatcher(prevWatchKey, mockedPath);
+        var result = service.enableDirectoryWatcher(prevWatchKey, mockedPath);
         assertThat(result, sameInstance(newWatchKey));
         assertTrue(result != prevWatchKey);
 

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -172,7 +172,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         doAnswer((Answer<CompletableFuture<Void>>) invocation -> {
             processFileLatch.countDown();
             return CompletableFuture.completedFuture(null);
-        }).when(service).processFileChanges(any());
+        }).when(service).processFileChanges();
 
         service.start();
         service.startWatcher(clusterService.state());
@@ -187,7 +187,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         processFileLatch.await(30, TimeUnit.SECONDS);
 
         verify(service, Mockito.atLeast(1)).processSettingsAndNotifyListeners();
-        verify(service, Mockito.atLeast(1)).processFileChanges(any());
+        verify(service, Mockito.atLeast(1)).processFileChanges();
 
         service.stop();
         assertFalse(service.watching());
@@ -226,7 +226,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         // wait until the watcher thread has started, and it has discovered the file
         assertTrue(latch.await(20, TimeUnit.SECONDS));
 
-        verify(service, times(1)).processFileChanges(any());
+        verify(service, times(1)).processFileChanges();
         // assert we never notified any listeners of successful application of file based settings
         assertFalse(settingsChanged.get());
 
@@ -267,7 +267,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         // wait until the watcher thread has started, and it has discovered the file
         assertTrue(latch.await(20, TimeUnit.SECONDS));
 
-        verify(service, times(1)).processFileChanges(any());
+        verify(service, times(1)).processFileChanges();
         // assert we notified the listeners the file settings have changed, they were successfully applied
         assertTrue(settingsChanged.get());
 

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -172,7 +172,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         doAnswer((Answer<CompletableFuture<Void>>) invocation -> {
             processFileLatch.countDown();
             return CompletableFuture.completedFuture(null);
-        }).when(service).processFileSettings(any());
+        }).when(service).processFileChanges(any());
 
         service.start();
         service.startWatcher(clusterService.state());
@@ -187,7 +187,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         processFileLatch.await(30, TimeUnit.SECONDS);
 
         verify(service, Mockito.atLeast(1)).processSettingsAndNotifyListeners();
-        verify(service, Mockito.atLeast(1)).processFileSettings(any());
+        verify(service, Mockito.atLeast(1)).processFileChanges(any());
 
         service.stop();
         assertFalse(service.watching());
@@ -208,7 +208,7 @@ public class FileSettingsServiceTests extends ESTestCase {
 
         final FileSettingsService service = spy(new FileSettingsService(clusterService, stateService, env));
 
-        service.addFileSettingsChangedListener(() -> settingsChanged.set(true));
+        service.addFileChangedListener(() -> settingsChanged.set(true));
 
         doAnswer((Answer<Void>) invocation -> {
             invocation.callRealMethod();
@@ -226,7 +226,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         // wait until the watcher thread has started, and it has discovered the file
         assertTrue(latch.await(20, TimeUnit.SECONDS));
 
-        verify(service, times(1)).processFileSettings(any());
+        verify(service, times(1)).processFileChanges(any());
         // assert we never notified any listeners of successful application of file based settings
         assertFalse(settingsChanged.get());
 
@@ -249,7 +249,7 @@ public class FileSettingsServiceTests extends ESTestCase {
 
         final FileSettingsService service = spy(new FileSettingsService(clusterService, stateService, env));
 
-        service.addFileSettingsChangedListener(() -> settingsChanged.set(true));
+        service.addFileChangedListener(() -> settingsChanged.set(true));
 
         doAnswer((Answer<Void>) invocation -> {
             invocation.callRealMethod();
@@ -267,7 +267,7 @@ public class FileSettingsServiceTests extends ESTestCase {
         // wait until the watcher thread has started, and it has discovered the file
         assertTrue(latch.await(20, TimeUnit.SECONDS));
 
-        verify(service, times(1)).processFileSettings(any());
+        verify(service, times(1)).processFileChanges(any());
         // assert we notified the listeners the file settings have changed, they were successfully applied
         assertTrue(settingsChanged.get());
 

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -47,7 +47,6 @@ import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -169,9 +168,9 @@ public class FileSettingsServiceTests extends ESTestCase {
         FileSettingsService service = spy(fileSettingsService);
         CountDownLatch processFileLatch = new CountDownLatch(1);
 
-        doAnswer((Answer<CompletableFuture<Void>>) invocation -> {
+        doAnswer((Answer<Void>) invocation -> {
             processFileLatch.countDown();
-            return CompletableFuture.completedFuture(null);
+            return null;
         }).when(service).processFileChanges();
 
         service.start();

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingFileSettingsIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/AutoscalingFileSettingsIT.java
@@ -97,14 +97,14 @@ public class AutoscalingFileSettingsIT extends AutoscalingIntegTestCase {
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
         assertTrue(fileSettingsService.watching());
 
-        Files.deleteIfExists(fileSettingsService.operatorSettingsFile());
+        Files.deleteIfExists(fileSettingsService.watchedFile());
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         logger.info("--> writing JSON config to node {} with path {}", node, tempFilePath);
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node) {

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMFileSettingsIT.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMFileSettingsIT.java
@@ -165,11 +165,11 @@ public class SLMFileSettingsIT extends AbstractSnapshotIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -146,15 +146,15 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
         assertTrue(fileSettingsService.watching());
 
-        Files.deleteIfExists(fileSettingsService.operatorSettingsFile());
+        Files.deleteIfExists(fileSettingsService.watchedFile());
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         logger.info("--> writing JSON config to node {} with path {}", node, tempFilePath);
         logger.info(Strings.format(json, version));
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node, String expectedKey) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsRestartIT.java
@@ -76,15 +76,15 @@ public class FileSettingsRoleMappingsRestartIT extends SecurityIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.deleteIfExists(fileSettingsService.operatorSettingsFile());
+        Files.deleteIfExists(fileSettingsService.watchedFile());
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         logger.info("--> writing JSON config to node {} with path {}", node, tempFilePath);
         logger.info(Strings.format(json, version));
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListener(String node, String expectedKey) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsStartupIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/FileSettingsRoleMappingsStartupIT.java
@@ -77,15 +77,15 @@ public class FileSettingsRoleMappingsStartupIT extends SecurityIntegTestCase {
 
         FileSettingsService fileSettingsService = internalCluster().getInstance(FileSettingsService.class, node);
 
-        Files.deleteIfExists(fileSettingsService.operatorSettingsFile());
+        Files.deleteIfExists(fileSettingsService.watchedFile());
 
-        Files.createDirectories(fileSettingsService.operatorSettingsDir());
+        Files.createDirectories(fileSettingsService.watchedFileDir());
         Path tempFilePath = createTempFile();
 
         logger.info("--> writing JSON config to node {} with path {}", node, tempFilePath);
         logger.info(Strings.format(json, version));
         Files.write(tempFilePath, Strings.format(json, version).getBytes(StandardCharsets.UTF_8));
-        Files.move(tempFilePath, fileSettingsService.operatorSettingsFile(), StandardCopyOption.ATOMIC_MOVE);
+        Files.move(tempFilePath, fileSettingsService.watchedFile(), StandardCopyOption.ATOMIC_MOVE);
     }
 
     private Tuple<CountDownLatch, AtomicLong> setupClusterStateListenerForError(String node) {


### PR DESCRIPTION
File-based settings should potentially support use cases besides operator settings. We plan to create an extension point that would allow alternate implementations. As a step towards that extension, we factor out the file-watching logic into its own abstract class. An alternate implementation simply needs to specify its own method for processing the changed file.

Supersedes #93616 (which used delegation rather than inheritance and got convoluted)