### PR TITLE
Avoid duplicate application of RoutingTable diff

### DIFF
--- a/docs/changelog/94379.yaml
+++ b/docs/changelog/94379.yaml
@@ -1,0 +1,5 @@
+pr: 94379
+summary: "Avoid duplicate application of RoutingTable diff"
+area: Allocation
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/RoutingTable.java
@@ -398,7 +398,7 @@ public class RoutingTable implements Iterable<IndexRoutingTable>, Diffable<Routi
             if (part.version == version && updatedRouting == part.indicesRouting) {
                 return part;
             }
-            return new RoutingTable(version, indicesRouting.apply(part.indicesRouting));
+            return new RoutingTable(version, updatedRouting);
         }
 
         @Override


### PR DESCRIPTION
When I run a test case, I found this part calculate is duplicated. Am I right ? 