### PR TITLE
Add named privilege for RCS cross cluster access

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -209,7 +209,7 @@ public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
               "name": "remote_access_key",
               "role_descriptors": {
                 "role": {
-                  "cluster": ["cluster:internal/remote_cluster/handshake", "cluster:internal/remote_cluster/nodes"],
+                  "cluster": ["cross_cluster_access"],
                   "index": [
                     {
                       "names": ["*"],

--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -30,6 +30,15 @@ restResources {
   }
 }
 
+// TODO: Remove the following when RCS feature is released
+// The get-builtin-privileges doc test does not include the new cluster privilege for RCS
+// So we disable the test if the build is a snapshot where unreleased feature is enabled by default
+tasks.named("yamlRestTest").configure {
+  if (BuildParams.isSnapshotBuild()) {
+    systemProperty 'tests.rest.blacklist', '*/get-builtin-privileges/*'
+  }
+}
+
 testClusters.matching { it.name == "yamlRestTest" }.configureEach {
   extraConfigFile 'op-jwks.json', project(':x-pack:test:idp-fixture').file("oidc/op-jwks.json")
   extraConfigFile 'idp-docs-metadata.xml', project(':x-pack:test:idp-fixture').file("idp/shibboleth-idp/metadata/idp-docs-metadata.xml")

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -65,6 +65,8 @@ if (BuildParams.isSnapshotBuild() == false) {
   // Since there is no infrastructure in place (anytime soon) to generate licenses using the production
   // private key, these tests are blacklisted in non-snapshot test runs
   restTestBlacklist.addAll(['xpack/15_basic/*', 'license/20_put_license/*', 'license/30_enterprise_license/*'])
+
+  // TODO: Remove the following when RCS feature is released
   // cross_cluster_access privilege is only available when untrusted_remote_cluster_feature_flag_registered is enabled
   // which requires snapshot build
   restTestBlacklist.add('privileges/11_builtin/Test get builtin privileges')

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -65,6 +65,9 @@ if (BuildParams.isSnapshotBuild() == false) {
   // Since there is no infrastructure in place (anytime soon) to generate licenses using the production
   // private key, these tests are blacklisted in non-snapshot test runs
   restTestBlacklist.addAll(['xpack/15_basic/*', 'license/20_put_license/*', 'license/30_enterprise_license/*'])
+  // cross_cluster_access privilege is only available when untrusted_remote_cluster_feature_flag_registered is enabled
+  // which requires snapshot build
+  restTestBlacklist.add('privileges/11_builtin/Test get builtin privileges')
 }
 
 tasks.named("yamlRestTest").configure {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.transport.RemoteClusterService;
+import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.GetStatusAction;
@@ -54,13 +55,13 @@ import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.stream.Stream;
 
 /**
  * Translates cluster privilege names into concrete implementations
@@ -144,8 +145,10 @@ public class ClusterPrivilegeResolver {
         GetStatusAction.NAME
     );
     private static final Set<String> READ_SLM_PATTERN = Set.of(GetSnapshotLifecycleAction.NAME, GetStatusAction.NAME);
-    private static final Set<String> CROSS_CLUSTER_ACCESS_PATTERN =
-        Set.of(RemoteClusterService.REMOTE_CLUSTER_HANDSHAKE_ACTION_NAME, RemoteClusterNodesAction.NAME);
+    private static final Set<String> CROSS_CLUSTER_ACCESS_PATTERN = Set.of(
+        RemoteClusterService.REMOTE_CLUSTER_HANDSHAKE_ACTION_NAME,
+        RemoteClusterNodesAction.NAME
+    );
     private static final Set<String> MANAGE_ENRICH_AUTOMATON = Set.of("cluster:admin/xpack/enrich/*");
 
     public static final NamedClusterPrivilege NONE = new ActionClusterPrivilege("none", Set.of(), Set.of());
@@ -253,11 +256,13 @@ public class ClusterPrivilegeResolver {
 
     public static final NamedClusterPrivilege CANCEL_TASK = new ActionClusterPrivilege("cancel_task", Set.of(CancelTasksAction.NAME + "*"));
 
-    public static final NamedClusterPrivilege CROSS_CLUSTER_ACCESS =
-        new ActionClusterPrivilege("cross_cluster_access", CROSS_CLUSTER_ACCESS_PATTERN);
+    public static final NamedClusterPrivilege CROSS_CLUSTER_ACCESS = new ActionClusterPrivilege(
+        "cross_cluster_access",
+        CROSS_CLUSTER_ACCESS_PATTERN
+    );
 
     private static final Map<String, NamedClusterPrivilege> VALUES = sortByAccessLevel(
-        List.of(
+        Stream.of(
             NONE,
             ALL,
             MONITOR,
@@ -301,8 +306,8 @@ public class ClusterPrivilegeResolver {
             MANAGE_ENRICH,
             MANAGE_LOGSTASH_PIPELINES,
             CANCEL_TASK,
-            CROSS_CLUSTER_ACCESS
-        )
+            TcpTransport.isUntrustedRemoteClusterEnabled() ? CROSS_CLUSTER_ACCESS : null
+        ).filter(Objects::nonNull).toList()
     );
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.core.security.authz.privilege;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksAction;
+import org.elasticsearch.action.admin.cluster.remote.RemoteClusterNodesAction;
 import org.elasticsearch.action.admin.cluster.repositories.get.GetRepositoriesAction;
 import org.elasticsearch.action.admin.cluster.snapshots.create.CreateSnapshotAction;
 import org.elasticsearch.action.admin.cluster.snapshots.get.GetSnapshotsAction;
@@ -22,6 +23,7 @@ import org.elasticsearch.action.ingest.GetPipelineAction;
 import org.elasticsearch.action.ingest.SimulatePipelineAction;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.util.Maps;
+import org.elasticsearch.transport.RemoteClusterService;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.ilm.action.GetLifecycleAction;
 import org.elasticsearch.xpack.core.ilm.action.GetStatusAction;
@@ -142,6 +144,8 @@ public class ClusterPrivilegeResolver {
         GetStatusAction.NAME
     );
     private static final Set<String> READ_SLM_PATTERN = Set.of(GetSnapshotLifecycleAction.NAME, GetStatusAction.NAME);
+    private static final Set<String> CROSS_CLUSTER_ACCESS_PATTERN =
+        Set.of(RemoteClusterService.REMOTE_CLUSTER_HANDSHAKE_ACTION_NAME, RemoteClusterNodesAction.NAME);
     private static final Set<String> MANAGE_ENRICH_AUTOMATON = Set.of("cluster:admin/xpack/enrich/*");
 
     public static final NamedClusterPrivilege NONE = new ActionClusterPrivilege("none", Set.of(), Set.of());
@@ -249,6 +253,9 @@ public class ClusterPrivilegeResolver {
 
     public static final NamedClusterPrivilege CANCEL_TASK = new ActionClusterPrivilege("cancel_task", Set.of(CancelTasksAction.NAME + "*"));
 
+    public static final NamedClusterPrivilege CROSS_CLUSTER_ACCESS =
+        new ActionClusterPrivilege("cross_cluster_access", CROSS_CLUSTER_ACCESS_PATTERN);
+
     private static final Map<String, NamedClusterPrivilege> VALUES = sortByAccessLevel(
         List.of(
             NONE,
@@ -293,7 +300,8 @@ public class ClusterPrivilegeResolver {
             MANAGE_OWN_API_KEY,
             MANAGE_ENRICH,
             MANAGE_LOGSTASH_PIPELINES,
-            CANCEL_TASK
+            CANCEL_TASK,
+            CROSS_CLUSTER_ACCESS
         )
     );
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/PrivilegeTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.action.admin.indices.template.get.GetIndexTemplatesActi
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateAction;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
@@ -96,7 +97,7 @@ public class PrivilegeTests extends ESTestCase {
         }
     }
 
-    public void testCluster() throws Exception {
+    public void testCluster() {
         ClusterPrivilege allClusterPrivilege = ClusterPrivilegeResolver.resolve("all");
         assertThat(allClusterPrivilege, is(ClusterPrivilegeResolver.ALL));
         verifyClusterActionAllowed(allClusterPrivilege, "cluster:admin/xpack/security/*");
@@ -106,15 +107,6 @@ public class PrivilegeTests extends ESTestCase {
         verifyClusterActionAllowed(monitorClusterPrivilege, "cluster:monitor/*");
         verifyClusterActionDenied(monitorClusterPrivilege, "cluster:admin/xpack/security/*");
 
-        ClusterPrivilege crossClusterAccessClusterPrivilege = ClusterPrivilegeResolver.resolve("cross_cluster_access");
-        assertThat(crossClusterAccessClusterPrivilege, is(ClusterPrivilegeResolver.CROSS_CLUSTER_ACCESS));
-        verifyClusterActionAllowed(
-            crossClusterAccessClusterPrivilege,
-            "cluster:internal/remote_cluster/handshake",
-            "cluster:internal/remote_cluster/nodes"
-        );
-        verifyClusterActionDenied(crossClusterAccessClusterPrivilege, "internal:transport/handshake", "cluster:admin/xpack/security/*");
-
         ClusterPrivilege noneClusterPrivilege = ClusterPrivilegeResolver.resolve("none");
         assertThat(noneClusterPrivilege, is(ClusterPrivilegeResolver.NONE));
         verifyClusterActionDenied(noneClusterPrivilege, "cluster:admin/xpack/security/*");
@@ -122,20 +114,31 @@ public class PrivilegeTests extends ESTestCase {
         verifyClusterActionDenied(noneClusterPrivilege, "*");
 
         ClusterPermission monitorClusterPermission = monitorClusterPrivilege.buildPermission(ClusterPermission.builder()).build();
-        ClusterPermission crossClusterAccessClusterPermission = crossClusterAccessClusterPrivilege.buildPermission(
-            ClusterPermission.builder()
-        ).build();
         ClusterPermission allClusterPermission = allClusterPrivilege.buildPermission(ClusterPermission.builder()).build();
 
         // all implies monitor
         assertTrue(allClusterPermission.implies(monitorClusterPermission));
-        assertTrue(allClusterPermission.implies(crossClusterAccessClusterPermission));
 
         ClusterPermission.Builder builder = ClusterPermission.builder();
         builder = allClusterPrivilege.buildPermission(builder);
         builder = noneClusterPrivilege.buildPermission(builder);
         ClusterPermission combinedPermission = builder.build();
         assertTrue(combinedPermission.implies(monitorClusterPermission));
+
+        if (TcpTransport.isUntrustedRemoteClusterEnabled()) {
+            ClusterPrivilege crossClusterAccessClusterPrivilege = ClusterPrivilegeResolver.resolve("cross_cluster_access");
+            assertThat(crossClusterAccessClusterPrivilege, is(ClusterPrivilegeResolver.CROSS_CLUSTER_ACCESS));
+            verifyClusterActionAllowed(
+                crossClusterAccessClusterPrivilege,
+                "cluster:internal/remote_cluster/handshake",
+                "cluster:internal/remote_cluster/nodes"
+            );
+            verifyClusterActionDenied(crossClusterAccessClusterPrivilege, "internal:transport/handshake", "cluster:admin/xpack/security/*");
+            ClusterPermission crossClusterAccessClusterPermission = crossClusterAccessClusterPrivilege.buildPermission(
+                ClusterPermission.builder()
+            ).build();
+            assertTrue(allClusterPermission.implies(crossClusterAccessClusterPermission));
+        }
     }
 
     public void testClusterTemplateActions() throws Exception {

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -141,7 +141,7 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
               "name": "remote_access_key",
               "role_descriptors": {
                 "role": {
-                  "cluster": ["cluster:internal/remote_cluster/handshake", "cluster:internal/remote_cluster/nodes"],
+                  "cluster": ["cross_cluster_access"],
                   "index": %s
                 }
               }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RemoteAccessAuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/RemoteAccessAuthenticationService.java
@@ -41,7 +41,7 @@ public class RemoteAccessAuthenticationService {
 
     public static final RoleDescriptor CROSS_CLUSTER_INTERNAL_ROLE = new RoleDescriptor(
         "_cross_cluster_internal",
-        new String[] { "cluster:internal/remote_cluster/handshake", "cluster:internal/remote_cluster/nodes" },
+        new String[] { "cross_cluster_access" },
         null,
         null,
         null,

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/privileges/11_builtin.yml
@@ -15,5 +15,5 @@ setup:
   # This is fragile - it needs to be updated every time we add a new cluster/index privilege
   # I would much prefer we could just check that specific entries are in the array, but we don't have
   # an assertion for that
-  - length: { "cluster" : 43 }
+  - length: { "cluster" : 44 }
   - length: { "index" : 19 }


### PR DESCRIPTION
This PR adds a new named privilege to encapsulate system actions required for cross cluster access.
