### PR TITLE
Revert to 1 node cluster for YAML tests and avoid wait for green

### DIFF
--- a/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
+++ b/rest-api-spec/src/yamlRestTest/java/org/elasticsearch/test/rest/ClientYamlTestSuiteIT.java
@@ -30,7 +30,6 @@ public class ClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         .module("mapper-extras")
         .feature(FeatureFlag.TIME_SERIES_MODE)
         .feature(FeatureFlag.DLM_ENABLED)
-        .nodes(2)
         .build();
 
     public ClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
@@ -9,11 +9,6 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/create/40_routing.yml
@@ -9,7 +9,7 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
@@ -10,11 +10,6 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/40_routing.yml
@@ -10,7 +10,7 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
@@ -9,11 +9,6 @@
          settings:
            index:
              refresh_interval: -1
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/exists/60_realtime_refresh.yml
@@ -9,7 +9,7 @@
          settings:
            index:
              refresh_interval: -1
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -594,8 +594,6 @@ _doc_count:
       indices.create:
         index: test
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             _source:
               mode: synthetic

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/100_synthetic_source.yml
@@ -595,7 +595,7 @@ _doc_count:
         index: test
         body:
           settings:
-            number_of_replicas: 1
+            number_of_replicas: 0
           mappings:
             _source:
               mode: synthetic

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
@@ -11,11 +11,6 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/40_routing.yml
@@ -11,7 +11,7 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
@@ -10,11 +10,6 @@
           settings:
             index:
               refresh_interval: -1
-              number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get/60_realtime_refresh.yml
@@ -10,7 +10,7 @@
           settings:
             index:
               refresh_interval: -1
-              number_of_replicas: 1
+              number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
@@ -12,11 +12,6 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/40_routing.yml
@@ -12,7 +12,7 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
@@ -9,11 +9,6 @@
           body:
               settings:
                   refresh_interval: -1
-                  number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/get_source/60_realtime_refresh.yml
@@ -9,7 +9,7 @@
           body:
               settings:
                   refresh_interval: -1
-                  number_of_replicas: 1
+                  number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
@@ -10,11 +10,6 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/index/40_routing.yml
@@ -10,7 +10,7 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.clone/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.clone/10_basic.yml
@@ -49,17 +49,10 @@ setup:
       indices.clone:
         index: "source"
         target: "target"
-        wait_for_active_shards: 1
         master_timeout: 10s
         body:
           settings:
-            index.number_of_replicas: 0
             index.number_of_shards: 2
-
-  - do:
-      cluster.health:
-        wait_for_status: green
-
   - do:
       get:
         index: target

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.clone/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.clone/10_basic.yml
@@ -53,7 +53,7 @@ setup:
         master_timeout: 10s
         body:
           settings:
-            index.number_of_replicas: 1
+            index.number_of_replicas: 0
             index.number_of_shards: 2
 
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
@@ -11,11 +11,6 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 0
-
- - do:
-      cluster.health:
-          wait_for_status: green
 
  - do:
       update:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/update/40_routing.yml
@@ -11,7 +11,7 @@
            index:
              number_of_shards: 5
              number_of_routing_shards: 5
-             number_of_replicas: 1
+             number_of_replicas: 0
 
  - do:
       cluster.health:

--- a/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
+++ b/x-pack/qa/core-rest-tests-with-security/src/yamlRestTest/java/org/elasticsearch/xpack/security/CoreWithSecurityClientYamlTestSuiteIT.java
@@ -42,7 +42,6 @@ public class CoreWithSecurityClientYamlTestSuiteIT extends ESClientYamlSuiteTest
         .setting("xpack.security.autoconfiguration.enabled", "false")
         .user(USER, PASS)
         .feature(FeatureFlag.TIME_SERIES_MODE)
-        .nodes(2)
         .build();
 
     public CoreWithSecurityClientYamlTestSuiteIT(@Name("yaml") ClientYamlTestCandidate testCandidate) {


### PR DESCRIPTION
I have reviewed the tests that motivated the use of a two node cluster for the YAML tests. It seems there is no reason anymore to use `wait_for_status: green` and `number_of_replicas: 0` since the [default values](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html#index-wait-for-active-shards) make sure the write will succeed. There are many newer YAML tests where an index creation is followed by an index operation, w/o waiting for green. With this PR, I'm reverting the changes in https://github.com/elastic/elasticsearch/pull/94304, and instead modify the tests.