### PR TITLE
Add tests checking final_pipelines in YAML tests

### DIFF
--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
@@ -1,4 +1,31 @@
 ---
+setup:
+  - do:
+      indices.put_template:
+        name: add_final_pipeline
+        body:
+          index_patterns: foo
+          settings:
+            final_pipeline: "final_pipeline"
+
+  - do:
+      ingest.put_pipeline:
+        id: "final_pipeline"
+        body:  >
+          {
+            "processors": [
+              {
+                "append" : {
+                  "field" : "accumulator",
+                  "value" : [
+                    "non-repeated-value"
+                  ]
+                }
+              }
+            ]
+          }
+
+---
 teardown:
 - do:
     ingest.delete_pipeline:
@@ -9,6 +36,10 @@ teardown:
     indices.delete:
       index: foo
 
+- do:
+    ingest.delete_pipeline:
+      id: final_pipeline
+      ignore: 404
 ---
 "Test Change Target Index with Explicit Pipeline":
 
@@ -50,6 +81,11 @@ teardown:
       index: foo
       id: "1"
 - match: { _source.a: true }
+# The next is commented out because there's a bug where the final_pipeline is executed twice under certain circumstances
+# (See issue https://github.com/elastic/elasticsearch/issues/83653).
+# TODO: Uncomment after the issue is fixed, and remove the repeated value test of the current behavior
+#- match: { _source.accumulator: [ "non-repeated-value" ] }
+- match: { _source.accumulator: [ "non-repeated-value", "non-repeated-value" ] }
 
 # only the foo index
 - do:
@@ -108,6 +144,11 @@ teardown:
       index: foo
       id: "1"
 - match: { _source.a: true }
+# The next is commented out because there's a bug where the final_pipeline is executed twice under certain circumstances
+# (See issue https://github.com/elastic/elasticsearch/issues/83653).
+# TODO: Uncomment after the issue is fixed, and remove the repeated value test of the current behavior
+#- match: { _source.accumulator: [ "non-repeated-value" ] }
+- match: { _source.accumulator: [ "non-repeated-value", "non-repeated-value" ] }
 
 # only the foo index
 - do:

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/230_change_target_index.yml
@@ -1,12 +1,18 @@
 ---
 setup:
+  - skip:
+      features: [ "allowed_warnings" ]
+
   - do:
-      indices.put_template:
+      allowed_warnings:
+        - "index template [add_final_pipeline] has index patterns [foo] matching patterns from existing older templates [global] with patterns (global => [*]); this template [add_final_pipeline] will take precedence during new index creation"
+      indices.put_index_template:
         name: add_final_pipeline
         body:
-          index_patterns: foo
-          settings:
-            final_pipeline: "final_pipeline"
+          index_patterns: [ "foo" ]
+          template:
+            settings:
+              final_pipeline: "final_pipeline"
 
   - do:
       ingest.put_pipeline:


### PR DESCRIPTION
Relates to #83653

Add a commented test that ensures that final_pipeline is executed only once. Since we're touching on that part of the code, with @joegallo we want to be sure that we have some safety net here.

Replay of #94281 which was reverted in #94372