### PR TITLE
[ML] Use token strings rather than IDs in text expansion

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -33,7 +33,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -362,7 +361,14 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field("inference_results", inferenceResults.stream().map(InferenceResults::asMap).collect(Collectors.toList()));
+            builder.startArray("inference_results");
+            for (var inference : inferenceResults) {
+                // inference results implement ToXContentFragment
+                builder.startObject();
+                inference.toXContent(builder, params);
+                builder.endObject();
+            }
+            builder.endArray();
             builder.endObject();
             return builder;
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
@@ -11,7 +11,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.ToXContentFragment;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -24,28 +24,26 @@ public class TextExpansionResults extends NlpInferenceResults {
 
     public static final String NAME = "text_expansion_result";
 
-    public record WeightedToken(int token, float weight) implements Writeable, ToXContentObject {
+    public record WeightedToken(String token, float weight) implements Writeable, ToXContentFragment {
 
         public WeightedToken(StreamInput in) throws IOException {
-            this(in.readVInt(), in.readFloat());
+            this(in.readString(), in.readFloat());
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
-            out.writeVInt(token);
+            out.writeString(token);
             out.writeFloat(weight);
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-            builder.startObject();
-            builder.field(Integer.toString(token), weight);
-            builder.endObject();
+            builder.field(token, weight);
             return builder;
         }
 
         public Map<String, Object> asMap() {
-            return Map.of(Integer.toString(token), weight);
+            return Map.of(token, weight);
         }
 
         @Override
@@ -90,11 +88,11 @@ public class TextExpansionResults extends NlpInferenceResults {
 
     @Override
     void doXContentBody(XContentBuilder builder, Params params) throws IOException {
-        builder.startArray(resultsField);
+        builder.startObject(resultsField);
         for (var weightedToken : weightedTokens) {
             weightedToken.toXContent(builder, params);
         }
-        builder.endArray();
+        builder.endObject();
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResults.java
@@ -117,6 +117,6 @@ public class TextExpansionResults extends NlpInferenceResults {
 
     @Override
     void addMapFields(Map<String, Object> map) {
-        map.put(resultsField, weightedTokens.stream().map(WeightedToken::asMap).collect(Collectors.toList()));
+        map.put(resultsField, weightedTokens.stream().collect(Collectors.toMap(WeightedToken::token, WeightedToken::weight)));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionResponseTests.java
@@ -26,6 +26,8 @@ import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResu
 import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResultsTests;
 import org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResultsTests;
+import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResultsTests;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResultsTests;
 
@@ -44,7 +46,8 @@ public class InferModelActionResponseTests extends AbstractWireSerializingTestCa
             PyTorchPassThroughResults.NAME,
             FillMaskResults.NAME,
             WarningInferenceResults.NAME,
-            QuestionAnsweringInferenceResults.NAME
+            QuestionAnsweringInferenceResults.NAME,
+            TextExpansionResults.NAME
         );
         return new Response(
             Stream.generate(() -> randomInferenceResult(resultType)).limit(randomIntBetween(0, 10)).collect(Collectors.toList()),
@@ -59,27 +62,18 @@ public class InferModelActionResponseTests extends AbstractWireSerializingTestCa
     }
 
     private static InferenceResults randomInferenceResult(String resultType) {
-        switch (resultType) {
-            case ClassificationInferenceResults.NAME:
-                return ClassificationInferenceResultsTests.createRandomResults();
-            case RegressionInferenceResults.NAME:
-                return RegressionInferenceResultsTests.createRandomResults();
-            case NerResults.NAME:
-                return NerResultsTests.createRandomResults();
-            case TextEmbeddingResults.NAME:
-                return TextEmbeddingResultsTests.createRandomResults();
-            case PyTorchPassThroughResults.NAME:
-                return PyTorchPassThroughResultsTests.createRandomResults();
-            case FillMaskResults.NAME:
-                return FillMaskResultsTests.createRandomResults();
-            case WarningInferenceResults.NAME:
-                return WarningInferenceResultsTests.createRandomResults();
-            case QuestionAnsweringInferenceResults.NAME:
-                return QuestionAnsweringInferenceResultsTests.createRandomResults();
-            default:
-                fail("unexpected result type [" + resultType + "]");
-                return null;
-        }
+        return switch (resultType) {
+            case ClassificationInferenceResults.NAME -> ClassificationInferenceResultsTests.createRandomResults();
+            case RegressionInferenceResults.NAME -> RegressionInferenceResultsTests.createRandomResults();
+            case NerResults.NAME -> NerResultsTests.createRandomResults();
+            case TextEmbeddingResults.NAME -> TextEmbeddingResultsTests.createRandomResults();
+            case PyTorchPassThroughResults.NAME -> PyTorchPassThroughResultsTests.createRandomResults();
+            case FillMaskResults.NAME -> FillMaskResultsTests.createRandomResults();
+            case WarningInferenceResults.NAME -> WarningInferenceResultsTests.createRandomResults();
+            case QuestionAnsweringInferenceResults.NAME -> QuestionAnsweringInferenceResultsTests.createRandomResults();
+            case TextExpansionResults.NAME -> TextExpansionResultsTests.createRandomResults();
+            default -> throw new AssertionError("unexpected result type [" + resultType + "]");
+        };
     }
 
     @Override

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
@@ -25,7 +25,7 @@ public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpa
         int numTokens = randomIntBetween(0, 20);
         List<TextExpansionResults.WeightedToken> tokenList = new ArrayList<>();
         for (int i = 0; i < numTokens; i++) {
-            tokenList.add(new TextExpansionResults.WeightedToken(i, (float) randomDoubleBetween(0.0, 5.0, false)));
+            tokenList.add(new TextExpansionResults.WeightedToken(Integer.toString(i), (float) randomDoubleBetween(0.0, 5.0, false)));
         }
         return new TextExpansionResults(randomAlphaOfLength(4), tokenList, randomBoolean());
     }
@@ -45,11 +45,7 @@ public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpa
         var originalTokens = createdInstance.getWeightedTokens();
         assertEquals(originalTokens.size(), ingestedTokens.size());
         for (int i = 0; i < createdInstance.getWeightedTokens().size(); i++) {
-            assertEquals(
-                originalTokens.get(i).weight(),
-                (float) ingestedTokens.get(i).get(Integer.toString(originalTokens.get(i).token())),
-                0.0001
-            );
+            assertEquals(originalTokens.get(i).weight(), (float) ingestedTokens.get(i).get(originalTokens.get(i).token()), 0.0001);
         }
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.ingest.IngestDocument;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpansionResults> {
     public static TextExpansionResults createRandomResults() {
@@ -42,14 +43,15 @@ public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpa
     @Override
     @SuppressWarnings("unchecked")
     void assertFieldValues(TextExpansionResults createdInstance, IngestDocument document, String resultsField) {
-        var ingestedTokens = (List<Map<String, Object>>) document.getFieldValue(
+        var ingestedTokens = (Map<String, Object>) document.getFieldValue(
             resultsField + '.' + createdInstance.getResultsField(),
-            List.class
+            Map.class
         );
-        var originalTokens = createdInstance.getWeightedTokens();
-        assertEquals(originalTokens.size(), ingestedTokens.size());
-        for (int i = 0; i < createdInstance.getWeightedTokens().size(); i++) {
-            assertEquals(originalTokens.get(i).weight(), (float) ingestedTokens.get(i).get(originalTokens.get(i).token()), 0.0001);
-        }
+        var tokenMap = createdInstance.getWeightedTokens()
+            .stream()
+            .collect(Collectors.toMap(TextExpansionResults.WeightedToken::token, TextExpansionResults.WeightedToken::weight));
+        assertEquals(tokenMap.size(), ingestedTokens.size());
+
+        assertEquals(tokenMap, ingestedTokens);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/results/TextExpansionResultsTests.java
@@ -15,6 +15,15 @@ import java.util.List;
 import java.util.Map;
 
 public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpansionResults> {
+    public static TextExpansionResults createRandomResults() {
+        int numTokens = randomIntBetween(0, 20);
+        List<TextExpansionResults.WeightedToken> tokenList = new ArrayList<>();
+        for (int i = 0; i < numTokens; i++) {
+            tokenList.add(new TextExpansionResults.WeightedToken(Integer.toString(i), (float) randomDoubleBetween(0.0, 5.0, false)));
+        }
+        return new TextExpansionResults(randomAlphaOfLength(4), tokenList, randomBoolean());
+    }
+
     @Override
     protected Writeable.Reader<TextExpansionResults> instanceReader() {
         return TextExpansionResults::new;
@@ -22,12 +31,7 @@ public class TextExpansionResultsTests extends InferenceResultsTestCase<TextExpa
 
     @Override
     protected TextExpansionResults createTestInstance() {
-        int numTokens = randomIntBetween(0, 20);
-        List<TextExpansionResults.WeightedToken> tokenList = new ArrayList<>();
-        for (int i = 0; i < numTokens; i++) {
-            tokenList.add(new TextExpansionResults.WeightedToken(Integer.toString(i), (float) randomDoubleBetween(0.0, 5.0, false)));
-        }
-        return new TextExpansionResults(randomAlphaOfLength(4), tokenList, randomBoolean());
+        return createRandomResults();
     }
 
     @Override

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -57,7 +57,7 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
         Request loggingSettings = new Request("PUT", "_cluster/settings");
         loggingSettings.setJsonEntity("""
             {"persistent" : {
-                    "logger.org.elasticsearch.xpack.ml.inference.assignment" : "TRACE",
+                    "logger.org.elasticsearch.xpack.ml.inference.assignment" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.inference.deployment" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.inference.pytorch" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.process.logging" : "DEBUG"

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TextExpansionQueryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TextExpansionQueryIT.java
@@ -128,14 +128,14 @@ public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
             "washing machine smells"
         );
 
-        List<List<Map<String, Float>>> tokenWeights = new ArrayList<>();
+        List<Map<String, Float>> tokenWeights = new ArrayList<>();
         // Generate the rank feature weights via the inference API
         // then index them for search
         for (var input : inputs) {
             Response inference = infer(input, modelId);
             List<Map<String, Object>> responseMap = (List<Map<String, Object>>) entityAsMap(inference).get("inference_results");
             Map<String, Object> inferenceResult = responseMap.get(0);
-            var idWeights = (List<Map<String, Float>>) inferenceResult.get("predicted_value");
+            var idWeights = (Map<String, Float>) inferenceResult.get("predicted_value");
             tokenWeights.add(idWeights);
         }
 
@@ -146,13 +146,57 @@ public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
         // Test text expansion search against the indexed rank features
         for (int i = 0; i < 5; i++) {
             int randomInput = randomIntBetween(0, inputs.size() - 1);
-            var textExpansionSearchResponse = textExpansionSearch(indexName, inputs.get(randomInput), modelId, "tokens");
+            var textExpansionSearchResponse = textExpansionSearch(indexName, inputs.get(randomInput), modelId, "ml.tokens");
             assertOkWithErrorMessage(textExpansionSearchResponse);
 
             Map<String, Object> responseMap = responseAsMap(textExpansionSearchResponse);
             List<Map<String, Object>> hits = (List<Map<String, Object>>) MapHelper.dig("hits.hits", responseMap);
             Map<String, Object> topHit = hits.get(0);
-            String sourceText = (String) MapHelper.dig("_source.source_text", topHit);
+            String sourceText = (String) MapHelper.dig("_source.text_field", topHit);
+            assertEquals(inputs.get(randomInput), sourceText);
+        }
+    }
+
+    public void testWithPipelineIngest() throws IOException {
+        String modelId = "text-expansion-pipeline-test";
+        String indexName = modelId + "-index";
+
+        createTextExpansionModel(modelId);
+        putModelDefinition(modelId, BASE_64_ENCODED_MODEL, RAW_MODEL_SIZE);
+        putVocabulary(
+            List.of("these", "are", "my", "words", "the", "washing", "machine", "is", "leaking", "octopus", "comforter", "smells"),
+            modelId
+        );
+        startDeployment(modelId);
+
+        // All tokens have a weight of 1.0.
+        // By using unique combinations of words the top doc returned
+        // by the search should be the same as the query text
+        List<String> inputs = List.of(
+            "my words comforter",
+            "the machine is leaking",
+            "these are my words",
+            "the octopus comforter smells",
+            "the octopus comforter is leaking",
+            "washing machine smells"
+        );
+
+        // index tokens
+        createRankFeaturesIndex(indexName);
+        var pipelineId = putPipeline(modelId);
+        bulkIndexThroughPipeline(inputs, indexName, pipelineId);
+
+        // Test text expansion search against the indexed rank features
+        for (int i = 0; i < 5; i++) {
+            int randomInput = randomIntBetween(0, inputs.size() - 1);
+            var textExpansionSearchResponse = textExpansionSearch(indexName, inputs.get(randomInput), modelId, "ml.tokens");
+            assertOkWithErrorMessage(textExpansionSearchResponse);
+
+            Map<String, Object> responseMap = responseAsMap(textExpansionSearchResponse);
+            @SuppressWarnings("unchecked")
+            List<Map<String, Object>> hits = (List<Map<String, Object>>) MapHelper.dig("hits.hits", responseMap);
+            Map<String, Object> topHit = hits.get(0);
+            String sourceText = (String) MapHelper.dig("_source.text_field", topHit);
             assertEquals(inputs.get(randomInput), sourceText);
         }
     }
@@ -160,8 +204,7 @@ public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
     public void testSearchWithMissingModel() throws IOException {
         String modelId = "missing-model";
         String indexName = modelId + "-index";
-
-        var e = expectThrows(ResponseException.class, () -> textExpansionSearch(indexName, "the machine is leaking", modelId, "tokens"));
+        var e = expectThrows(ResponseException.class, () -> textExpansionSearch(indexName, "the machine is leaking", modelId, "ml.tokens"));
         assertThat(e.getMessage(), containsString("Could not find trained model [missing-model]"));
     }
 
@@ -208,10 +251,10 @@ public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
             {
               "mappings": {
                 "properties": {
-                  "source_text": {
+                  "text_field": {
                     "type": "text"
                   },
-                  "tokens": {
+                  "ml.tokens": {
                     "type": "rank_features"
                   }
                 }
@@ -221,22 +264,20 @@ public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
         assertOkWithErrorMessage(response);
     }
 
-    private void bulkIndexDocs(List<String> sourceText, List<List<Map<String, Float>>> tokenWeights, String indexName) throws IOException {
+    private void bulkIndexDocs(List<String> sourceText, List<Map<String, Float>> tokenWeights, String indexName) throws IOException {
         String createAction = "{\"create\": {\"_index\": \"" + indexName + "\"}}\n";
 
         StringBuilder bulkBuilder = new StringBuilder();
 
         for (int i = 0; i < sourceText.size(); i++) {
             bulkBuilder.append(createAction);
-            bulkBuilder.append("{\"source_text\": \"").append(sourceText.get(i)).append("\", \"tokens\":[");
+            bulkBuilder.append("{\"text_field\": \"").append(sourceText.get(i)).append("\", \"ml.tokens\":{");
 
-            for (int j = 0; j < tokenWeights.get(i).size() - 1; j++) {
-                var entry = tokenWeights.get(i).get(j).entrySet().iterator().next();
+            for (var entry : tokenWeights.get(i).entrySet()) {
                 writeToken(entry, bulkBuilder).append(',');
             }
-            var entry = tokenWeights.get(i).get(tokenWeights.get(i).size() - 1).entrySet().iterator().next();
-            writeToken(entry, bulkBuilder);
-            bulkBuilder.append("]}\n");
+            bulkBuilder.deleteCharAt(bulkBuilder.length() - 1); // delete the trailing ','
+            bulkBuilder.append("}}\n");
         }
 
         Request bulkRequest = new Request("POST", "/_bulk");
@@ -246,7 +287,51 @@ public class TextExpansionQueryIT extends PyTorchModelRestTestCase {
         assertOkWithErrorMessage(bulkResponse);
     }
 
+    private void bulkIndexThroughPipeline(List<String> sourceText, String indexName, String pipelineId) throws IOException {
+        String createAction = "{\"create\": {\"_index\": \"" + indexName + "\"}}\n";
+
+        StringBuilder bulkBuilder = new StringBuilder();
+
+        for (int i = 0; i < sourceText.size(); i++) {
+            bulkBuilder.append(createAction);
+            bulkBuilder.append("{\"text_field\": \"").append(sourceText.get(i)).append("\"}\n");
+        }
+
+        Request bulkRequest = new Request("POST", "/_bulk");
+        bulkRequest.setJsonEntity(bulkBuilder.toString());
+        bulkRequest.addParameter("refresh", "true");
+        bulkRequest.addParameter("pipeline", pipelineId);
+        var bulkResponse = client().performRequest(bulkRequest);
+        assertOkWithErrorMessage(bulkResponse);
+    }
+
     private StringBuilder writeToken(Map.Entry<String, Float> entry, StringBuilder builder) {
-        return builder.append("{\"").append(entry.getKey()).append("\":").append(entry.getValue()).append("}");
+        return builder.append("\"").append(entry.getKey()).append("\":").append(entry.getValue());
+    }
+
+    private String putPipeline(String modelId) throws IOException {
+        String def = Strings.format("""
+            {
+              "processors": [
+                {
+                  "inference": {
+                    "model_id": "%s",
+                    "field_map": {
+                      "text_field": "input"
+                    },
+                    "target_field": "ml",
+                    "inference_config": {
+                      "text_expansion": {
+                        "results_field": "tokens"
+                      }
+                    }
+                  }
+                }
+              ]
+            }""", modelId);
+        Request request = new Request("PUT", "_ingest/pipeline/" + modelId + "-pipeline");
+        request.setJsonEntity(def);
+        assertOkWithErrorMessage(client().performRequest(request));
+        return modelId + "-pipeline";
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractControlMessagePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractControlMessagePyTorchAction.java
@@ -24,7 +24,7 @@ import static org.elasticsearch.core.Strings.format;
 
 abstract class AbstractControlMessagePyTorchAction<T> extends AbstractPyTorchAction<T> {
 
-    private static final Logger logger = LogManager.getLogger(InferencePyTorchAction.class);
+    private static final Logger logger = LogManager.getLogger(AbstractControlMessagePyTorchAction.class);
 
     enum ControlMessageTypes {
         AllocationThreads,

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -91,7 +91,6 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             NlpTask.Request request = processor.getRequestBuilder(nlpConfig)
                 .buildRequest(text, requestIdStr, nlpConfig.getTokenization().getTruncate(), nlpConfig.getTokenization().getSpan());
             logger.debug(() -> format("handling request [%s]", requestIdStr));
-            logger.trace(() -> "Inference Request " + request.processInput().utf8ToString());
             if (request.tokenization().anyTruncated()) {
                 logger.debug("[{}] [{}] input truncated", getModelId(), getRequestId());
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessor.java
@@ -15,7 +15,9 @@ import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig.DEFAULT_RESULTS_FIELD;
@@ -23,10 +25,22 @@ import static org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceCo
 public class TextExpansionProcessor extends NlpTask.Processor {
 
     private final NlpTask.RequestBuilder requestBuilder;
+    private Map<Integer, String> replacementVocab;
 
     public TextExpansionProcessor(NlpTokenizer tokenizer) {
         super(tokenizer);
         this.requestBuilder = tokenizer.requestBuilder();
+        replacementVocab = buildSanitizedVocabMap(tokenizer.getVocabulary());
+    }
+
+    static Map<Integer, String> buildSanitizedVocabMap(List<String> inputVocab) {
+        Map<Integer, String> sanitized = new HashMap<>();
+        for (int i = 0; i < inputVocab.size(); i++) {
+            if (inputVocab.get(i).contains(".")) {
+                sanitized.put(i, inputVocab.get(i).replaceAll("\\.", "__"));
+            }
+        }
+        return sanitized;
     }
 
     @Override
@@ -39,15 +53,20 @@ public class TextExpansionProcessor extends NlpTask.Processor {
 
     @Override
     public NlpTask.ResultProcessor getResultProcessor(NlpConfig config) {
-        return (tokenization, pyTorchResult) -> processResult(tokenization, pyTorchResult, config.getResultsField());
+        return (tokenization, pyTorchResult) -> processResult(tokenization, pyTorchResult, replacementVocab, config.getResultsField());
     }
 
-    static InferenceResults processResult(TokenizationResult tokenization, PyTorchInferenceResult pyTorchResult, String resultsField) {
+    static InferenceResults processResult(
+        TokenizationResult tokenization,
+        PyTorchInferenceResult pyTorchResult,
+        Map<Integer, String> replacementVocab,
+        String resultsField
+    ) {
         List<TextExpansionResults.WeightedToken> weightedTokens;
         if (pyTorchResult.getInferenceResult()[0].length == 1) {
-            weightedTokens = sparseVectorToTokenWeights(pyTorchResult.getInferenceResult()[0][0], tokenization);
+            weightedTokens = sparseVectorToTokenWeights(pyTorchResult.getInferenceResult()[0][0], tokenization, replacementVocab);
         } else {
-            weightedTokens = multipleSparseVectorsToTokenWeights(pyTorchResult.getInferenceResult()[0], tokenization);
+            weightedTokens = multipleSparseVectorsToTokenWeights(pyTorchResult.getInferenceResult()[0], tokenization, replacementVocab);
         }
 
         weightedTokens.sort((t1, t2) -> Float.compare(t2.weight(), t1.weight()));
@@ -61,7 +80,8 @@ public class TextExpansionProcessor extends NlpTask.Processor {
 
     static List<TextExpansionResults.WeightedToken> multipleSparseVectorsToTokenWeights(
         double[][] vector,
-        TokenizationResult tokenization
+        TokenizationResult tokenization,
+        Map<Integer, String> replacementVocab
     ) {
         // reduce to a single 1d array choosing the max value
         // in each column and placing that in the first row
@@ -72,17 +92,31 @@ public class TextExpansionProcessor extends NlpTask.Processor {
                 }
             }
         }
-        return sparseVectorToTokenWeights(vector[0], tokenization);
+        return sparseVectorToTokenWeights(vector[0], tokenization, replacementVocab);
     }
 
-    static List<TextExpansionResults.WeightedToken> sparseVectorToTokenWeights(double[] vector, TokenizationResult tokenization) {
+    static List<TextExpansionResults.WeightedToken> sparseVectorToTokenWeights(
+        double[] vector,
+        TokenizationResult tokenization,
+        Map<Integer, String> replacementVocab
+    ) {
         // Anything with a score > 0.0 is retained.
         List<TextExpansionResults.WeightedToken> weightedTokens = new ArrayList<>();
         for (int i = 0; i < vector.length; i++) {
             if (vector[i] > 0.0) {
-                weightedTokens.add(new TextExpansionResults.WeightedToken(tokenization.getFromVocab(i), (float) vector[i]));
+                weightedTokens.add(
+                    new TextExpansionResults.WeightedToken(tokenForId(i, tokenization, replacementVocab), (float) vector[i])
+                );
             }
         }
         return weightedTokens;
+    }
+
+    static String tokenForId(int id, TokenizationResult tokenization, Map<Integer, String> replacementVocab) {
+        String token = replacementVocab.get(id);
+        if (token == null) {
+            token = tokenization.getFromVocab(id);
+        }
+        return token;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/BertTokenizer.java
@@ -45,15 +45,15 @@ public class BertTokenizer extends NlpTokenizer {
 
     private final WordPieceAnalyzer wordPieceAnalyzer;
     protected final List<String> originalVocab;
-    // TODO Not sure this needs to be a sorted map
-    private final SortedMap<String, Integer> vocab;
     protected final boolean withSpecialTokens;
     private final int maxSequenceLength;
-    protected final int sepTokenId;
+    private final int sepTokenId;
     private final int clsTokenId;
     private final String padToken;
-    protected final int padTokenId;
+    private final int padTokenId;
     private final String maskToken;
+    private final OptionalInt maskTokenId;
+
     private final String unknownToken;
 
     protected BertTokenizer(
@@ -107,7 +107,6 @@ public class BertTokenizer extends NlpTokenizer {
             unknownToken
         );
         this.originalVocab = originalVocab;
-        this.vocab = vocab;
         this.withSpecialTokens = withSpecialTokens;
         this.maxSequenceLength = maxSequenceLength;
         if (vocab.containsKey(unknownToken) == false) {
@@ -131,6 +130,8 @@ public class BertTokenizer extends NlpTokenizer {
         }
         this.padToken = padToken;
         this.maskToken = maskToken;
+        this.maskTokenId = vocab.containsKey(maskToken) ? OptionalInt.of(vocab.get(maskToken)) : OptionalInt.empty();
+
         this.unknownToken = unknownToken;
     }
 
@@ -164,22 +165,12 @@ public class BertTokenizer extends NlpTokenizer {
 
     @Override
     public OptionalInt getPadTokenId() {
-        Integer pad = vocab.get(this.padToken);
-        if (pad != null) {
-            return OptionalInt.of(pad);
-        } else {
-            return OptionalInt.empty();
-        }
+        return OptionalInt.of(padTokenId);
     }
 
     @Override
     public OptionalInt getMaskTokenId() {
-        Integer pad = vocab.get(this.maskToken);
-        if (pad != null) {
-            return OptionalInt.of(pad);
-        } else {
-            return OptionalInt.empty();
-        }
+        return maskTokenId;
     }
 
     @Override
@@ -188,8 +179,13 @@ public class BertTokenizer extends NlpTokenizer {
     }
 
     @Override
+    public List<String> getVocabulary() {
+        return originalVocab;
+    }
+
+    @Override
     public TokenizationResult buildTokenizationResult(List<TokenizationResult.Tokens> tokenizations) {
-        return new BertTokenizationResult(originalVocab, tokenizations, vocab.get(this.padToken));
+        return new BertTokenizationResult(originalVocab, tokenizations, padTokenId);
     }
 
     TokenizationResult.TokensBuilder createTokensBuilder(int clsTokenId, int sepTokenId, boolean withSpecialTokens) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/NlpTokenizer.java
@@ -374,6 +374,8 @@ public abstract class NlpTokenizer implements Releasable {
 
     public abstract String getMaskToken();
 
+    public abstract List<String> getVocabulary();
+
     public int getSpan() {
         return -1;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/RobertaTokenizer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/nlp/tokenizers/RobertaTokenizer.java
@@ -159,6 +159,11 @@ public class RobertaTokenizer extends NlpTokenizer {
     }
 
     @Override
+    public List<String> getVocabulary() {
+        return originalVocab;
+    }
+
+    @Override
     TokenizationResult.TokensBuilder createTokensBuilder(int clsTokenId, int sepTokenId, boolean withSpecialTokens) {
         return new RobertaTokenizationResult.RobertaTokensBuilder(withSpecialTokens, clsTokenId, sepTokenId);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -168,7 +168,7 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
     ) throws IOException {
         var boolQuery = QueryBuilders.boolQuery();
         for (var weightedToken : textExpansionResults.getWeightedTokens()) {
-            boolQuery.should(QueryBuilders.termQuery(fieldName, Integer.toString(weightedToken.token())).boost(weightedToken.weight()));
+            boolQuery.should(QueryBuilders.termQuery(fieldName, weightedToken.token()).boost(weightedToken.weight()));
         }
         boolQuery.minimumShouldMatch(1);
         return boolQuery;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
@@ -9,11 +9,16 @@ package org.elasticsearch.xpack.ml.inference.nlp;
 
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.ml.inference.results.TextExpansionResults;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.BertTokenization;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextExpansionConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.Tokenization;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizationResult;
+import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.BertTokenizer;
 import org.elasticsearch.xpack.ml.inference.nlp.tokenizers.TokenizationResult;
 import org.elasticsearch.xpack.ml.inference.pytorch.results.PyTorchInferenceResult;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
@@ -25,7 +30,12 @@ public class TextExpansionProcessorTests extends ESTestCase {
 
         TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("a", "b", "c", "d", "e", "f", "g"), List.of(), 0);
 
-        var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, new PyTorchInferenceResult(pytorchResult), "foo");
+        var inferenceResult = TextExpansionProcessor.processResult(
+            tokenizationResult,
+            new PyTorchInferenceResult(pytorchResult),
+            Map.of(),
+            "foo"
+        );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
         assertEquals(results.getResultsField(), "foo");
@@ -42,7 +52,12 @@ public class TextExpansionProcessorTests extends ESTestCase {
 
         TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("a", "b", "c", "d", "e", "f", "g"), List.of(), 0);
 
-        var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, new PyTorchInferenceResult(pytorchResult), "foo");
+        var inferenceResult = TextExpansionProcessor.processResult(
+            tokenizationResult,
+            new PyTorchInferenceResult(pytorchResult),
+            Map.of(),
+            "foo"
+        );
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
         var results = (TextExpansionResults) inferenceResult;
         assertEquals(results.getResultsField(), "foo");
@@ -54,5 +69,57 @@ public class TextExpansionProcessorTests extends ESTestCase {
         assertEquals(new TextExpansionResults.WeightedToken("b", 2.0f), weightedTokens.get(2));
         assertEquals(new TextExpansionResults.WeightedToken("a", 1.0f), weightedTokens.get(3));
         assertEquals(new TextExpansionResults.WeightedToken("g", 0.1f), weightedTokens.get(4));
+    }
+
+    public void testSanitiseVocab() {
+        double[][][] pytorchResult = new double[][][] { { { 1.0, 2.0, 3.0, 4.0, 5.0, 6.0 } } };
+
+        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("aaa", "bbb", "ccc", ".", "eee.", "fff"), List.of(), 0);
+
+        var inferenceResult = TextExpansionProcessor.processResult(
+            tokenizationResult,
+            new PyTorchInferenceResult(pytorchResult),
+            Map.of(4, "XXX", 3, "YYY"),
+            "foo"
+        );
+        assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
+        var results = (TextExpansionResults) inferenceResult;
+        assertEquals(results.getResultsField(), "foo");
+
+        var weightedTokens = results.getWeightedTokens();
+        assertThat(weightedTokens, hasSize(6));
+        assertEquals(new TextExpansionResults.WeightedToken("fff", 6.0f), weightedTokens.get(0));
+        assertEquals(new TextExpansionResults.WeightedToken("XXX", 5.0f), weightedTokens.get(1));
+        assertEquals(new TextExpansionResults.WeightedToken("YYY", 4.0f), weightedTokens.get(2));
+        assertEquals(new TextExpansionResults.WeightedToken("ccc", 3.0f), weightedTokens.get(3));
+        assertEquals(new TextExpansionResults.WeightedToken("bbb", 2.0f), weightedTokens.get(4));
+        assertEquals(new TextExpansionResults.WeightedToken("aaa", 1.0f), weightedTokens.get(5));
+    }
+
+    public void testBuildSanitizedVocabMap() {
+        var replacementMap = TextExpansionProcessor.buildSanitizedVocabMap(List.of("aa", "bb", "cc", ".d.", ".", "JJ"));
+        assertThat(replacementMap.entrySet(), hasSize(2));
+        assertEquals(replacementMap.get(3), "__d__");
+        assertEquals(replacementMap.get(4), "__");
+    }
+
+    public void testSanitizeOutputTokens() {
+        var vocab = List.of("aa", "bb", "cc", ".", "##.", BertTokenizer.UNKNOWN_TOKEN, BertTokenizer.PAD_TOKEN);
+        var processor = new TextExpansionProcessor(
+            BertTokenizer.builder(vocab, new BertTokenization(null, false, null, Tokenization.Truncate.NONE, -1)).build()
+        );
+        var resultProcessor = processor.getResultProcessor(new TextExpansionConfig(null, null, null));
+
+        var pytorchResult = new PyTorchInferenceResult(new double[][][] { { { 1.0, 2.0, 3.0, 4.0, 5.0 } } });
+        TokenizationResult tokenizationResult = new BertTokenizationResult(vocab, List.of(), 0);
+
+        TextExpansionResults results = (TextExpansionResults) resultProcessor.processResult(tokenizationResult, pytorchResult);
+        var weightedTokens = results.getWeightedTokens();
+        assertThat(weightedTokens, hasSize(5));
+        assertEquals(new TextExpansionResults.WeightedToken("##__", 5.0f), weightedTokens.get(0));
+        assertEquals(new TextExpansionResults.WeightedToken("__", 4.0f), weightedTokens.get(1));
+        assertEquals(new TextExpansionResults.WeightedToken("cc", 3.0f), weightedTokens.get(2));
+        assertEquals(new TextExpansionResults.WeightedToken("bb", 2.0f), weightedTokens.get(3));
+        assertEquals(new TextExpansionResults.WeightedToken("aa", 1.0f), weightedTokens.get(4));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/nlp/TextExpansionProcessorTests.java
@@ -23,7 +23,7 @@ public class TextExpansionProcessorTests extends ESTestCase {
     public void testProcessResult() {
         double[][][] pytorchResult = new double[][][] { { { 0.0, 1.0, 0.0, 3.0, 4.0, 0.0, 0.0 } } };
 
-        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of(), List.of(), 0);
+        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("a", "b", "c", "d", "e", "f", "g"), List.of(), 0);
 
         var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, new PyTorchInferenceResult(pytorchResult), "foo");
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
@@ -32,15 +32,15 @@ public class TextExpansionProcessorTests extends ESTestCase {
 
         var weightedTokens = results.getWeightedTokens();
         assertThat(weightedTokens, hasSize(3));
-        assertEquals(new TextExpansionResults.WeightedToken(1, 1.0f), weightedTokens.get(0));
-        assertEquals(new TextExpansionResults.WeightedToken(3, 3.0f), weightedTokens.get(1));
-        assertEquals(new TextExpansionResults.WeightedToken(4, 4.0f), weightedTokens.get(2));
+        assertEquals(new TextExpansionResults.WeightedToken("e", 4.0f), weightedTokens.get(0));
+        assertEquals(new TextExpansionResults.WeightedToken("d", 3.0f), weightedTokens.get(1));
+        assertEquals(new TextExpansionResults.WeightedToken("b", 1.0f), weightedTokens.get(2));
     }
 
     public void testProcessResultMultipleVectors() {
         double[][][] pytorchResult = new double[][][] { { { 0.0, 1.0, 0.0, 1.0, 4.0, 0.0, 0.0 }, { 1.0, 2.0, 0.0, 3.0, 4.0, 0.0, 0.1 } } };
 
-        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of(), List.of(), 0);
+        TokenizationResult tokenizationResult = new BertTokenizationResult(List.of("a", "b", "c", "d", "e", "f", "g"), List.of(), 0);
 
         var inferenceResult = TextExpansionProcessor.processResult(tokenizationResult, new PyTorchInferenceResult(pytorchResult), "foo");
         assertThat(inferenceResult, instanceOf(TextExpansionResults.class));
@@ -49,10 +49,10 @@ public class TextExpansionProcessorTests extends ESTestCase {
 
         var weightedTokens = results.getWeightedTokens();
         assertThat(weightedTokens, hasSize(5));
-        assertEquals(new TextExpansionResults.WeightedToken(0, 1.0f), weightedTokens.get(0));
-        assertEquals(new TextExpansionResults.WeightedToken(1, 2.0f), weightedTokens.get(1));
-        assertEquals(new TextExpansionResults.WeightedToken(3, 3.0f), weightedTokens.get(2));
-        assertEquals(new TextExpansionResults.WeightedToken(4, 4.0f), weightedTokens.get(3));
-        assertEquals(new TextExpansionResults.WeightedToken(6, 0.1f), weightedTokens.get(4));
+        assertEquals(new TextExpansionResults.WeightedToken("e", 4.0f), weightedTokens.get(0));
+        assertEquals(new TextExpansionResults.WeightedToken("d", 3.0f), weightedTokens.get(1));
+        assertEquals(new TextExpansionResults.WeightedToken("b", 2.0f), weightedTokens.get(2));
+        assertEquals(new TextExpansionResults.WeightedToken("a", 1.0f), weightedTokens.get(3));
+        assertEquals(new TextExpansionResults.WeightedToken("g", 0.1f), weightedTokens.get(4));
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -86,7 +86,7 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
         // asserts that 2 rewritten queries are the same
         var tokens = new ArrayList<TextExpansionResults.WeightedToken>();
         for (int i = 0; i < NUM_TOKENS; i++) {
-            tokens.add(new TextExpansionResults.WeightedToken(i, (i + 1) * 1.0f));
+            tokens.add(new TextExpansionResults.WeightedToken(Integer.toString(i), (i + 1) * 1.0f));
         }
 
         var response = InferModelAction.Response.builder()

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -15,7 +15,7 @@ setup:
             properties:
               source_text:
                 type: keyword
-              tokens:
+              ml.tokens:
                 type: rank_features
 
   - do:
@@ -78,17 +78,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "tokens":[{"my":1.0},{"words":1.0},{"comforter":1.0}]}
+          {"source_text": "my words comforter", "ml.tokens":{"my":1.0, "words":1.0,"comforter":1.0}}
           {"index": {}}
-          {"source_text": "the machine is leaking", "tokens":[{"the":1.0},{"machine":1.0},{"is":1.0},{"leaking":1.0}]}
+          {"source_text": "the machine is leaking", "ml.tokens":{"the":1.0,"machine":1.0,"is":1.0,"leaking":1.0}}
           {"index": {}}
-          {"source_text": "these are my words", "tokens":[{"these":1.0},{"are":1.0},{"my":1.0},{"words":1.0}]}
+          {"source_text": "these are my words", "ml.tokens":{"these":1.0,"are":1.0,"my":1.0,"words":1.0}}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "tokens":[{"the":1.0},{"octopus":1.0},{"comforter":1.0},{"smells":1.0}]}
+          {"source_text": "the octopus comforter smells", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"smells":1.0}}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "tokens":[{"the":1.0},{"octopus":1.0},{"comforter":1.0},{"is":1.0},{"leaking":1.0}]}
+          {"source_text": "the octopus comforter is leaking", "ml.tokens":{"the":1.0,"octopus":1.0,"comforter":1.0,"is":1.0,"leaking":1.0}}
           {"index": {}}
-          {"source_text": "washing machine smells", "tokens":[{"washing":1.0},{"machine":1.0},{"smells":1.0}]}
+          {"source_text": "washing machine smells", "ml.tokens":{"washing":1.0,"machine":1.0,"smells":1.0}}
 
   - do:
       headers:
@@ -106,7 +106,7 @@ setup:
         body:
           query:
             text_expansion:
-              tokens:
+              ml.tokens:
                 model_id: text_expansion_model
                 model_text: "octopus comforter smells"
   - match: { hits.total.value: 4 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/text_expansion_search.yml
@@ -78,17 +78,17 @@ setup:
         refresh: true
         body: |
           {"index": {}}
-          {"source_text": "my words comforter", "tokens":[{"4":1.0},{"5":1.0},{"12":1.0}]}
+          {"source_text": "my words comforter", "tokens":[{"my":1.0},{"words":1.0},{"comforter":1.0}]}
           {"index": {}}
-          {"source_text": "the machine is leaking", "tokens":[{"6":1.0},{"8":1.0},{"9":1.0},{"10":1.0}]}
+          {"source_text": "the machine is leaking", "tokens":[{"the":1.0},{"machine":1.0},{"is":1.0},{"leaking":1.0}]}
           {"index": {}}
-          {"source_text": "these are my words", "tokens":[{"2":1.0},{"3":1.0},{"4":1.0},{"5":1.0}]}
+          {"source_text": "these are my words", "tokens":[{"these":1.0},{"are":1.0},{"my":1.0},{"words":1.0}]}
           {"index": {}}
-          {"source_text": "the octopus comforter smells", "tokens":[{"6":1.0},{"11":1.0},{"12":1.0},{"13":1.0}]}
+          {"source_text": "the octopus comforter smells", "tokens":[{"the":1.0},{"octopus":1.0},{"comforter":1.0},{"smells":1.0}]}
           {"index": {}}
-          {"source_text": "the octopus comforter is leaking", "tokens":[{"6":1.0},{"9":1.0},{"10":1.0},{"11":1.0},{"12":1.0}]}
+          {"source_text": "the octopus comforter is leaking", "tokens":[{"the":1.0},{"octopus":1.0},{"comforter":1.0},{"is":1.0},{"leaking":1.0}]}
           {"index": {}}
-          {"source_text": "washing machine smells", "tokens":[{"7":1.0},{"8":1.0},{"13":1.0}]}
+          {"source_text": "washing machine smells", "tokens":[{"washing":1.0},{"machine":1.0},{"smells":1.0}]}
 
   - do:
       headers:


### PR DESCRIPTION
Results from the text expansion model now use the token string from the input vocabulary rather than the Id.
Additionally token weight pairs are now sorted by weight and returned in a single document rather than an array of docs. This format is more commonly used for rank features fields.

Because rank_features fields cannot contain a `.` character if the token string contains a `.` it is replace with double underscore `__`.  

```
POST _ml/trained_models/text_expansion_model/_infer
{
  "docs": [{"text_field": "pirate ship"}]
}
```

Returns

```
{
  "inference_results": [
    {
      "predicted_value": {
        "pirate": 3.1480324,
        "ship": 2.7033217,
        "pirates": 2.4298668,
        "ships": 1.9557489,
        "treasure": 0.9711017,
        "shipping": 0.75666434,
        "piracy": 0.7324756,
        "boat": 0.71240854,
        "criminal": 0.6781369,
        "gun": 0.5793185,
        "ruin": 0.48752055,
        "toy": 0.44296992,
        "captain": 0.43938705,
        "slave": 0.42513028,
        "party": 0.41519326,
        "discovery": 0.39670518,
        "fake": 0.39445245,
        "submarine": 0.37701997,
        "character": 0.30090195,
        "villain": 0.29887193,
        "castle": 0.28499693,
        "spy": 0.26810843,
        "prison": 0.25391698,
        "quest": 0.24493802,
        "smuggling": 0.23474619,
        "stolen": 0.21570966,
        "jones": 0.21412925,
        "ghost": 0.18707192,
        "devil": 0.18014455,
        "savage": 0.16921283,
        "hero": 0.15776168,
        "smug": 0.14755286,
        "glory": 0.13371459,
        "were": 0.12701046,
        "humor": 0.115971535,
        "henry": 0.1135293,
        "was": 0.104702994,
        "haunted": 0.09767436,
        "who": 0.052228667,
        "alien": 0.029981242,
        "cannon": 0.028697899,
        "slavery": 0.012567138,
        "doll": 0.011823103,
        "destroyed": 0.006246211,
        "dangerous": 0.0058630155,
        "jack": 0.0041660196
      }
    }
  ]
}
```