### PR TITLE
[DLM] Clear the result deduplicator on master failover

### DIFF
--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleService.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleService.java
@@ -125,6 +125,8 @@ public class DataLifecycleService implements ClusterStateListener, Closeable, Sc
             } else {
                 // we were the master, and now we aren't
                 cancelJob();
+                // clear the deduplicator on master failover so we could re-send the requests in case we're re-elected
+                transportActionsDeduplicator.clear();
             }
         }
     }


### PR DESCRIPTION
The result deduplicator makes sure we only send a particular request once during "our tenure" as a master node (DLM runs on the master node).

When there's a master failover DLM will potentially run on a new master node however, the previous master node might be re-elected in which case we'd like the result deduplicator to be empty and not contain requests that were send in the previous term.

Relates to https://github.com/elastic/elasticsearch/issues/93596