### PR TITLE
Instantiate a SearchApplicationIndexService for each action

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.IndexScopedSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
-import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.SystemIndexDescriptor;
@@ -152,16 +151,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             return Collections.emptyList();
         }
 
-        // Search Application related components
-        // TODO Don't implement this as a component, instantiate it when needed
-        final SearchApplicationIndexService searchAppIndexService = new SearchApplicationIndexService(
-            client,
-            clusterService,
-            namedWriteableRegistry,
-            // TODO We need to use use a real BigArrays which recycles pages here
-            BigArrays.NON_RECYCLING_INSTANCE
-        );
-
         // Behavioral analytics components
         final AnalyticsTemplateRegistry analyticsTemplateRegistry = new AnalyticsTemplateRegistry(
             clusterService,
@@ -176,7 +165,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             indexNameExpressionResolver
         );
 
-        return Arrays.asList(searchAppIndexService, analyticsTemplateRegistry, analyticsCollectionService);
+        return Arrays.asList(analyticsTemplateRegistry, analyticsCollectionService);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationTransportAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationTransportAction.java
@@ -12,10 +12,15 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 public abstract class SearchApplicationTransportAction<Request extends ActionRequest, Response extends ActionResponse> extends
@@ -23,15 +28,23 @@ public abstract class SearchApplicationTransportAction<Request extends ActionReq
 
     protected final XPackLicenseState licenseState;
 
+    protected final SearchApplicationIndexService systemIndexService;
+
     public SearchApplicationTransportAction(
         String actionName,
         TransportService transportService,
         ActionFilters actionFilters,
         Writeable.Reader<Request> request,
+        Client client,
+        ClusterService clusterService,
+        NamedWriteableRegistry namedWriteableRegistry,
+        BigArrays bigArrays,
         XPackLicenseState licenseState
     ) {
         super(actionName, transportService, actionFilters, request);
         this.licenseState = licenseState;
+        this.systemIndexService = new SearchApplicationIndexService(client, clusterService, namedWriteableRegistry, bigArrays);
+
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportDeleteSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportDeleteSearchApplicationAction.java
@@ -10,22 +10,26 @@ package org.elasticsearch.xpack.application.search.action;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 
 public class TransportDeleteSearchApplicationAction extends SearchApplicationTransportAction<
     DeleteSearchApplicationAction.Request,
     AcknowledgedResponse> {
 
-    private final SearchApplicationIndexService indexService;
-
     @Inject
     public TransportDeleteSearchApplicationAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        SearchApplicationIndexService indexService,
+        Client client,
+        ClusterService clusterService,
+        NamedWriteableRegistry namedWriteableRegistry,
+        BigArrays bigArrays,
         XPackLicenseState licenseState
     ) {
         super(
@@ -33,14 +37,17 @@ public class TransportDeleteSearchApplicationAction extends SearchApplicationTra
             transportService,
             actionFilters,
             DeleteSearchApplicationAction.Request::new,
+            client,
+            clusterService,
+            namedWriteableRegistry,
+            bigArrays,
             licenseState
         );
-        this.indexService = indexService;
     }
 
     @Override
     protected void doExecute(DeleteSearchApplicationAction.Request request, ActionListener<AcknowledgedResponse> listener) {
         String name = request.getName();
-        indexService.deleteSearchApplicationAndAlias(name, listener.map(v -> AcknowledgedResponse.TRUE));
+        systemIndexService.deleteSearchApplicationAndAlias(name, listener.map(v -> AcknowledgedResponse.TRUE));
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationAction.java
@@ -9,31 +9,44 @@ package org.elasticsearch.xpack.application.search.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 
 public class TransportGetSearchApplicationAction extends SearchApplicationTransportAction<
     GetSearchApplicationAction.Request,
     GetSearchApplicationAction.Response> {
 
-    private final SearchApplicationIndexService indexService;
-
     @Inject
     public TransportGetSearchApplicationAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        SearchApplicationIndexService indexService,
+        Client client,
+        ClusterService clusterService,
+        NamedWriteableRegistry namedWriteableRegistry,
+        BigArrays bigArrays,
         XPackLicenseState licenseState
     ) {
-        super(GetSearchApplicationAction.NAME, transportService, actionFilters, GetSearchApplicationAction.Request::new, licenseState);
-        this.indexService = indexService;
+        super(
+            GetSearchApplicationAction.NAME,
+            transportService,
+            actionFilters,
+            GetSearchApplicationAction.Request::new,
+            client,
+            clusterService,
+            namedWriteableRegistry,
+            bigArrays,
+            licenseState
+        );
     }
 
     @Override
     protected void doExecute(GetSearchApplicationAction.Request request, ActionListener<GetSearchApplicationAction.Response> listener) {
-        indexService.getSearchApplication(request.getName(), listener.map(GetSearchApplicationAction.Response::new));
+        systemIndexService.getSearchApplication(request.getName(), listener.map(GetSearchApplicationAction.Response::new));
     }
 
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportListSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportListSearchApplicationAction.java
@@ -9,33 +9,46 @@ package org.elasticsearch.xpack.application.search.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.core.action.util.PageParams;
 
 public class TransportListSearchApplicationAction extends SearchApplicationTransportAction<
     ListSearchApplicationAction.Request,
     ListSearchApplicationAction.Response> {
 
-    private final SearchApplicationIndexService indexService;
-
     @Inject
     public TransportListSearchApplicationAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        SearchApplicationIndexService indexService,
+        Client client,
+        ClusterService clusterService,
+        NamedWriteableRegistry namedWriteableRegistry,
+        BigArrays bigArrays,
         XPackLicenseState licenseState
     ) {
-        super(ListSearchApplicationAction.NAME, transportService, actionFilters, ListSearchApplicationAction.Request::new, licenseState);
-        this.indexService = indexService;
+        super(
+            ListSearchApplicationAction.NAME,
+            transportService,
+            actionFilters,
+            ListSearchApplicationAction.Request::new,
+            client,
+            clusterService,
+            namedWriteableRegistry,
+            bigArrays,
+            licenseState
+        );
     }
 
     @Override
     protected void doExecute(ListSearchApplicationAction.Request request, ActionListener<ListSearchApplicationAction.Response> listener) {
         final PageParams pageParams = request.pageParams();
-        indexService.listSearchApplication(
+        systemIndexService.listSearchApplication(
             request.query(),
             pageParams.getFrom(),
             pageParams.getSize(),

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportPutSearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportPutSearchApplicationAction.java
@@ -9,33 +9,46 @@ package org.elasticsearch.xpack.application.search.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.search.SearchApplication;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 
 public class TransportPutSearchApplicationAction extends SearchApplicationTransportAction<
     PutSearchApplicationAction.Request,
     PutSearchApplicationAction.Response> {
 
-    private final SearchApplicationIndexService indexService;
-
     @Inject
     public TransportPutSearchApplicationAction(
         TransportService transportService,
         ActionFilters actionFilters,
-        SearchApplicationIndexService indexService,
+        Client client,
+        ClusterService clusterService,
+        NamedWriteableRegistry namedWriteableRegistry,
+        BigArrays bigArrays,
         XPackLicenseState licenseState
     ) {
-        super(PutSearchApplicationAction.NAME, transportService, actionFilters, PutSearchApplicationAction.Request::new, licenseState);
-        this.indexService = indexService;
+        super(
+            PutSearchApplicationAction.NAME,
+            transportService,
+            actionFilters,
+            PutSearchApplicationAction.Request::new,
+            client,
+            clusterService,
+            namedWriteableRegistry,
+            bigArrays,
+            licenseState
+        );
     }
 
     @Override
     protected void doExecute(PutSearchApplicationAction.Request request, ActionListener<PutSearchApplicationAction.Response> listener) {
         SearchApplication app = request.getSearchApplication();
         boolean create = request.create();
-        indexService.putSearchApplication(app, create, listener.map(r -> new PutSearchApplicationAction.Response(r.getResult())));
+        systemIndexService.putSearchApplication(app, create, listener.map(r -> new PutSearchApplicationAction.Response(r.getResult())));
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportDeleteSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportDeleteSearchApplicationActionTests.java
@@ -11,11 +11,14 @@ import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,7 +41,10 @@ public class TransportDeleteSearchApplicationActionTests extends ESTestCase {
         TransportDeleteSearchApplicationAction transportAction = new TransportDeleteSearchApplicationAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
-            mock(SearchApplicationIndexService.class),
+            mock(Client.class),
+            mock(ClusterService.class),
+            mock(NamedWriteableRegistry.class),
+            mock(BigArrays.class),
             licenseState
         );
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportGetSearchApplicationActionTests.java
@@ -10,11 +10,14 @@ package org.elasticsearch.xpack.application.search.action;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -37,7 +40,10 @@ public class TransportGetSearchApplicationActionTests extends ESTestCase {
         TransportGetSearchApplicationAction transportAction = new TransportGetSearchApplicationAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
-            mock(SearchApplicationIndexService.class),
+            mock(Client.class),
+            mock(ClusterService.class),
+            mock(NamedWriteableRegistry.class),
+            mock(BigArrays.class),
             licenseState
         );
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportListSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportListSearchApplicationActionTests.java
@@ -10,11 +10,14 @@ package org.elasticsearch.xpack.application.search.action;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.SearchApplicationTestUtils;
 import org.elasticsearch.xpack.application.utils.LicenseUtils;
 import org.elasticsearch.xpack.core.action.util.PageParams;
@@ -39,7 +42,10 @@ public class TransportListSearchApplicationActionTests extends ESTestCase {
         TransportListSearchApplicationAction transportAction = new TransportListSearchApplicationAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
-            mock(SearchApplicationIndexService.class),
+            mock(Client.class),
+            mock(ClusterService.class),
+            mock(NamedWriteableRegistry.class),
+            mock(BigArrays.class),
             licenseState
         );
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportPutSearchApplicationActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/TransportPutSearchApplicationActionTests.java
@@ -10,12 +10,15 @@ package org.elasticsearch.xpack.application.search.action;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.license.MockLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.search.SearchApplication;
-import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 import java.util.concurrent.atomic.AtomicReference;
@@ -38,7 +41,10 @@ public class TransportPutSearchApplicationActionTests extends ESTestCase {
         TransportPutSearchApplicationAction transportAction = new TransportPutSearchApplicationAction(
             mock(TransportService.class),
             mock(ActionFilters.class),
-            mock(SearchApplicationIndexService.class),
+            mock(Client.class),
+            mock(ClusterService.class),
+            mock(NamedWriteableRegistry.class),
+            mock(BigArrays.class),
             licenseState
         );
 


### PR DESCRIPTION
The service is a light client that can be instantiated for each action and doesn't require to be a component.