### PR TITLE
[monitoring] add missing beat memory aliases

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
@@ -1652,6 +1652,26 @@
                             "id": {
                               "type": "alias",
                               "path": "beat.stats.cgroup.memory.id"
+                            },
+                            "mem": {
+                              "properties": {
+                                "usage": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "alias",
+                                      "path": "beat.stats.cgroup.memory.mem.usage.bytes"
+                                    }
+                                  }
+                                },
+                                "limit": {
+                                  "properties": {
+                                    "bytes": {
+                                      "type": "alias",
+                                      "path": "beat.stats.cgroup.memory.mem.limit.bytes"
+                                    }
+                                  }
+                                }
+                              }
                             }
                           }
                         }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 6;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 7;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
## Summary

Add cgroup memory aliases used by Stack Monitoring. Without the aliases `Memory Utilization` and `Memory Limit` are not rendered.

With the fix applied:
![Screenshot 2023-03-08 at 15 45 27](https://user-images.githubusercontent.com/5239883/223744019-27ff5e11-c16b-452b-8484-250cacb9d135.png)