### PR TITLE
Add index.auto_expand_replicas monitoring to monitoring -mb templates

### DIFF
--- a/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-beats-mb.json
@@ -2245,6 +2245,7 @@
       }
     },
     "settings": {
+      "index.auto_expand_replicas": "0-1",
       "index.mapping.total_fields.limit": 2000,
       "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }

--- a/x-pack/plugin/core/src/main/resources/monitoring-ent-search-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-ent-search-mb.json
@@ -715,6 +715,7 @@
       }
     },
     "settings": {
+      "index.auto_expand_replicas": "0-1",
       "index.mapping.total_fields.limit": 2000,
       "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }

--- a/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-es-mb.json
@@ -3212,6 +3212,7 @@
       }
     },
     "settings": {
+      "index.auto_expand_replicas": "0-1",
       "index.mapping.total_fields.limit": 2000,
       "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
@@ -520,6 +520,7 @@
       }
     },
     "settings": {
+      "index.auto_expand_replicas": "0-1",
       "index.mapping.total_fields.limit": 2000,
       "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }

--- a/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-logstash-mb.json
@@ -563,6 +563,7 @@
       }
     },
     "settings": {
+      "index.auto_expand_replicas": "0-1",
       "index.mapping.total_fields.limit": 2000,
       "index.lifecycle.name": "${xpack.stack.monitoring.policy.name}"
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 6;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 7;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
## Summary

Closes https://github.com/elastic/kibana/issues/130885

This PR adds the `index.auto_expand_replicas` settings back to `-mb` index templates, to prevent ILM policy errors when moving them to the warm and delete phases.

**Hot phase**
<img width="903" alt="image" src="https://user-images.githubusercontent.com/2767137/223774516-4b848ca7-03ef-4261-8fa8-c563acbcc4d0.png">

**Warm phase**
<img width="899" alt="image" src="https://user-images.githubusercontent.com/2767137/223774439-e61a852a-4a86-4e96-828e-f9970a4054ba.png">

**Delete phase**
<img width="895" alt="image" src="https://user-images.githubusercontent.com/2767137/223777002-e44b0feb-c992-40ef-a997-701dd1c1b3a4.png">

