### PR TITLE
Do not include frozen indices in PIT by default (#94377)

### DIFF
--- a/docs/changelog/94377.yaml
+++ b/docs/changelog/94377.yaml
@@ -1,0 +1,5 @@
+pr: 94377
+summary: Do not include frozen indices in PIT by default
+area: Search
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/OpenPointInTimeRequest.java
@@ -35,7 +35,7 @@ public final class OpenPointInTimeRequest extends ActionRequest implements Indic
     @Nullable
     private String preference;
 
-    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = IndicesOptions.strictExpandOpenAndForbidClosed();
+    public static final IndicesOptions DEFAULT_INDICES_OPTIONS = SearchRequest.DEFAULT_INDICES_OPTIONS;
 
     public OpenPointInTimeRequest(String... indices) {
         this.indices = Objects.requireNonNull(indices, "[index] is not specified");

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -331,9 +331,9 @@ public class FrozenIndexIT extends ESIntegTestCase {
         assertAcked(client().execute(FreezeIndexAction.INSTANCE, new FreezeRequest("test-index")).actionGet());
         // include the frozen indices
         {
-            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").keepAlive(
-                TimeValue.timeValueMinutes(2)
-            );
+            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").indicesOptions(
+                IndicesOptions.strictExpandOpenAndForbidClosed()
+            ).keepAlive(TimeValue.timeValueMinutes(2));
             final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
             try {
                 SearchResponse resp = client().prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();
@@ -345,9 +345,9 @@ public class FrozenIndexIT extends ESIntegTestCase {
         }
         // exclude the frozen indices
         {
-            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").indicesOptions(
-                IndicesOptions.strictExpandOpenAndForbidClosedIgnoreThrottled()
-            ).keepAlive(TimeValue.timeValueMinutes(2));
+            final OpenPointInTimeRequest openPointInTimeRequest = new OpenPointInTimeRequest("test-*").keepAlive(
+                TimeValue.timeValueMinutes(2)
+            );
             final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
             try {
                 SearchResponse resp = client().prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pitId)).get();


### PR DESCRIPTION
Backport of #94377 to 8.7

By default, PIT (Point in Time) requests should not include frozen indices because they are deprecated. The IndicesOption of PIT requests should have the same default behavior as search requests. This pull request proposes changing the default IndicesOption to exclude frozen indices as the current behavior is considered a bug. If we consider excluding frozen indices is a breaking change, an alternative solution would be to allow users to exclude frozen indices in PIT requests by using `include_throttled=false` without emitting deprecation warnings.