### PR TITLE
[Behavioral Analytics] Introduce EventEmitterService

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsEvent.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.common.logging.ESLogMessage;
+import org.elasticsearch.core.Nullable;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public abstract class AnalyticsEvent {
+    private String collectionName;
+    private String eventSource;
+    private String userUUID;
+    private String sessionUUID;
+    private List<Map<String, Object>> fields;
+
+    public AnalyticsEvent(
+        String collectionName,
+        String eventSource,
+        List<Map<String, Object>> fields,
+        @Nullable String userUUID,
+        @Nullable String sessionUUID
+    ) {
+        this.collectionName = collectionName;
+        this.eventSource = eventSource;
+        this.fields = fields;
+        this.userUUID = userUUID;
+        this.sessionUUID = sessionUUID;
+    }
+
+    /**
+     * Convert the event to the ECS compatible format.
+     * @param event Base of the event.
+     *
+     * @return The converted event as a map.
+     */
+    public ESLogMessage toESLogMessage(Map<String, Object> event) {
+        event = buildEvent(event);
+        event = buildLabels(event);
+
+        return new ESLogMessage().withFields(event);
+    }
+
+    /**
+     * Returns the name of the event.
+     *
+     * @return The name of the event.
+     */
+    public abstract String eventAction();
+
+    /**
+     * Returns the name of the collection to which the event should be sent.
+     *
+     * @return The name of the collection to which the event should be sent.
+     */
+    public String getCollectionName() {
+        return this.collectionName;
+    }
+
+    private Map<String, Object> buildEvent(Map<String, Object> event) {
+        event.put("event.name", eventAction());
+        event.put("event.source", eventSource);
+
+        return buildEventSpecificEvent(event);
+    }
+
+    private Map<String, Object> buildLabels(Map<String, Object> event) {
+        if (userUUID != null) {
+            event.put("labels.user_uuid", userUUID);
+        }
+        if (sessionUUID != null) {
+            event.put("labels.session_uuid", sessionUUID);
+        }
+        List<Map<String, Object>> fieldLabels = new ArrayList<>();
+        {
+            for (Map<String, Object> field : fields) {
+                Map<String, Object> fieldLabel = new HashMap<>();
+                fieldLabel.put("name", field.get("name"));
+                fieldLabel.put("type", field.get("type"));
+                fieldLabel.put("value", field.get("value"));
+
+                fieldLabels.add(fieldLabel);
+            }
+            event.put("labels.fields", fieldLabels);
+        }
+
+        return buildEventSpecificLabels(event);
+    }
+
+    protected abstract Map<String, Object> buildEventSpecificEvent(Map<String, Object> event);
+
+    protected abstract Map<String, Object> buildEventSpecificLabels(Map<String, Object> event);
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/EventEmitterService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/EventEmitterService.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.logging.ESLogMessage;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EventEmitterService {
+    private static final Logger logger = LogManager.getLogger(EventEmitterService.class);
+    private static final Marker AUDIT_MARKER = MarkerManager.getMarker("org.elasticsearch.xpack.application.analytics");
+    private final AnalyticsCollectionResolver analyticsCollectionResolver;
+    private final ClusterState clusterState;
+
+    public EventEmitterService(AnalyticsCollectionResolver analyticsCollectionResolver, ClusterState clusterState) {
+        this.analyticsCollectionResolver = analyticsCollectionResolver;
+        this.clusterState = clusterState;
+    }
+
+    /**
+     * Emits an {@link AnalyticsEvent} to the appropriate collection.
+     *
+     * @param event The {@link AnalyticsEvent} to emit.
+     * @param listener The {@link ActionListener} to notify when the event has been emitted.
+     */
+    public void emitEvent(final AnalyticsEvent event, final ActionListener<Void> listener) {
+        final String collectionName = getAnalyticsEventCollectionName(event);
+        final AnalyticsCollection collection;
+
+        try {
+            collection = analyticsCollectionResolver.collection(clusterState, collectionName);
+        } catch (ResourceNotFoundException e) {
+            listener.onFailure(e);
+            return;
+        }
+
+        logger.info(AUDIT_MARKER, prepareFormattedEvent(collection, event));
+
+        listener.onResponse(null);
+    }
+
+    private static ESLogMessage prepareFormattedEvent(AnalyticsCollection collection, AnalyticsEvent event) {
+        Map<String, Object> json = new HashMap<>();
+
+        json.put("event.dataset", collection.getEventDataStream());
+        json.put("@timestamp", getTimestamp());
+
+        return event.toESLogMessage(json);
+    }
+
+    private static String getAnalyticsEventCollectionName(final AnalyticsEvent event) {
+        return event.getCollectionName();
+    }
+
+    private static String getTimestamp() {
+        ZonedDateTime currentTime = ZonedDateTime.now();
+
+        return currentTime.format(DateTimeFormatter.ISO_INSTANT);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/InteractionAnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/InteractionAnalyticsEvent.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.core.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+public class InteractionAnalyticsEvent extends AnalyticsEvent {
+    private static final String ACTION = "interaction";
+
+    private final String interaction;
+
+    public InteractionAnalyticsEvent(
+        String collectionName,
+        String interaction,
+        String eventSource,
+        List<Map<String, Object>> fields,
+        @Nullable String userUUID,
+        @Nullable String sessionUUID
+    ) {
+        super(collectionName, eventSource, fields, userUUID, sessionUUID);
+
+        this.interaction = interaction;
+    }
+
+    @Override
+    protected Map<String, Object> buildEventSpecificEvent(final Map<String, Object> event) {
+        event.put("event.interaction", interaction);
+
+        return event;
+    }
+
+    @Override
+    protected Map<String, Object> buildEventSpecificLabels(final Map<String, Object> event) {
+        return event;
+    }
+
+    @Override
+    public String eventAction() {
+        return ACTION;
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/PageViewAnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/PageViewAnalyticsEvent.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.core.Nullable;
+
+import java.util.List;
+import java.util.Map;
+
+public class PageViewAnalyticsEvent extends AnalyticsEvent {
+    private static final String ACTION = "pageView";
+
+    private final String url;
+    private final String referrer;
+
+    public PageViewAnalyticsEvent(
+        String collectionName,
+        String url,
+        String referrer,
+        String eventSource,
+        List<Map<String, Object>> fields,
+        @Nullable String userUUID,
+        @Nullable String sessionUUID
+    ) {
+        super(collectionName, eventSource, fields, userUUID, sessionUUID);
+
+        this.url = url;
+        this.referrer = referrer;
+    }
+
+    @Override
+    protected Map<String, Object> buildEventSpecificEvent(final Map<String, Object> event) {
+        event.put("event.url", url);
+        event.put("event.referrer", referrer);
+
+        return event;
+    }
+
+    @Override
+    protected Map<String, Object> buildEventSpecificLabels(final Map<String, Object> event) {
+        return event;
+    }
+
+    @Override
+    public String eventAction() {
+        return ACTION;
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/SearchAnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/SearchAnalyticsEvent.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import java.util.List;
+import java.util.Map;
+
+public class SearchAnalyticsEvent extends AnalyticsEvent {
+    private static final String ACTION = "search";
+
+    private final String engineName;
+
+    private final String[] items;
+
+    public SearchAnalyticsEvent(
+        String collectionName,
+        String engineName,
+        String eventSource,
+        List<Map<String, Object>> fields,
+        String[] items,
+        String userUUID,
+        String sessionUUID
+    ) {
+        super(collectionName, eventSource, fields, userUUID, sessionUUID);
+
+        this.engineName = engineName;
+        this.items = items;
+    }
+
+    @Override
+    protected Map<String, Object> buildEventSpecificLabels(final Map<String, Object> event) {
+        event.put("labels.engineName", engineName);
+        event.put("labels.items", items);
+
+        return event;
+    }
+
+    @Override
+    protected Map<String, Object> buildEventSpecificEvent(final Map<String, Object> event) {
+        return event;
+    }
+
+    @Override
+    public String eventAction() {
+        return ACTION;
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/EventEmitterServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/EventEmitterServiceTests.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.common.logging.ESLogMessage;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashMap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class EventEmitterServiceTests extends ESTestCase {
+    private String collectionName = randomIdentifier();
+    private AnalyticsCollectionResolver collectionResolver = mock(AnalyticsCollectionResolver.class);
+    private ClusterState state = createClusterState();
+    private AnalyticsEvent analyticsEvent = mock(AnalyticsEvent.class);
+    private ActionListener<Void> actionListener = ActionListener.wrap(response -> {}, (Exception e) -> {});
+    private static final Marker AUDIT_MARKER = MarkerManager.getMarker("org.elasticsearch.xpack.application.analytics");
+
+    public void testMissingCollectionOnEmitEvent() {
+        when(collectionResolver.collection(any(), any())).thenThrow(new ResourceNotFoundException(collectionName));
+        EventEmitterService eventEmitterService = new EventEmitterService(collectionResolver, state);
+        eventEmitterService.emitEvent(analyticsEvent, actionListener);
+
+        verify(analyticsEvent, never()).toESLogMessage(expectedEvent());
+    }
+
+    public void testWriteCorrectEventToLogOnEmitEvent() {
+        final AnalyticsCollection analyticsCollection = mock(AnalyticsCollection.class);
+        when(analyticsCollection.getEventDataStream()).thenReturn("data-stream");
+
+        when(collectionResolver.collection(any(), any())).thenReturn(analyticsCollection);
+        final EventEmitterService eventEmitterService = new EventEmitterService(collectionResolver, state);
+
+        final ESLogMessage esLogMessage = mock(ESLogMessage.class);
+        when(analyticsEvent.toESLogMessage(any())).thenReturn(esLogMessage);
+
+        eventEmitterService.emitEvent(analyticsEvent, actionListener);
+
+        verify(analyticsEvent).toESLogMessage(expectedEvent());
+    }
+
+    private ClusterState createClusterState() {
+        ClusterState state = mock(ClusterState.class);
+
+        Metadata.Builder metaDataBuilder = Metadata.builder();
+
+        when(state.metadata()).thenReturn(metaDataBuilder.build());
+
+        return state;
+    }
+
+    private HashMap<String, Object> expectedEvent() {
+        return new HashMap<String, Object>() {
+            {
+                put("event.dataset", "data-stream");
+                put("@timestamp", any());
+            }
+        };
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/InteractionAnalyticsEventTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/InteractionAnalyticsEventTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.common.logging.ESLogMessage;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class InteractionAnalyticsEventTests extends ESTestCase {
+    private InteractionAnalyticsEvent interactionAnalyticsEvent;
+
+    @Before
+    public void initializeInteractionAnalyticsEvent() {
+
+        interactionAnalyticsEvent = new InteractionAnalyticsEvent(
+            "test-collection",
+            "test-interaction-type",
+            "test-event-source",
+            Arrays.asList(Map.of("name", "test-name", "value", "test-value", "type", "test-type")),
+            "test-user-uuid",
+            "test-session-uuid"
+        );
+    }
+
+    public void testFormattedEventHasRequiredFields() {
+        ESLogMessage eventESLogMessage = interactionAnalyticsEvent.toESLogMessage(new HashMap<>());
+
+        assertEquals(eventESLogMessage.get("event.name"), "interaction");
+        assertEquals(eventESLogMessage.get("event.interaction"), "test-interaction-type");
+        assertEquals(eventESLogMessage.get("event.source"), "test-event-source");
+        assertEquals(eventESLogMessage.get("labels.user_uuid"), "test-user-uuid");
+        assertEquals(eventESLogMessage.get("labels.session_uuid"), "test-session-uuid");
+        assertEquals(eventESLogMessage.get("labels.fields"), "[{name=test-name, type=test-type, value=test-value}]");
+    }
+
+    public void testCollectionName() {
+        assertEquals(interactionAnalyticsEvent.getCollectionName(), "test-collection");
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/PageViewAnalyticsEventTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/PageViewAnalyticsEventTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.common.logging.ESLogMessage;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class PageViewAnalyticsEventTests extends ESTestCase {
+    private PageViewAnalyticsEvent pageViewAnalyticsEvent;
+
+    @Before
+    public void initializePageViewAnalyticsEvent() {
+        pageViewAnalyticsEvent = new PageViewAnalyticsEvent(
+            "test-collection",
+            "https://test-url.com",
+            "https://test-referrer.com",
+            "test-event-source",
+            Arrays.asList(Map.of("name", "test-name", "value", "test-value", "type", "test-type")),
+            "test-user-uuid",
+            "test-session-uuid"
+        );
+    }
+
+    public void testFormattedEventHasRequiredFields() {
+        ESLogMessage eventESLogMessage = pageViewAnalyticsEvent.toESLogMessage(new HashMap<>());
+
+        assertEquals(eventESLogMessage.get("event.name"), "pageView");
+        assertEquals(eventESLogMessage.get("event.source"), "test-event-source");
+        assertEquals(eventESLogMessage.get("event.url"), "https://test-url.com");
+        assertEquals(eventESLogMessage.get("event.referrer"), "https://test-referrer.com");
+        assertEquals(eventESLogMessage.get("labels.fields"), "[{name=test-name, type=test-type, value=test-value}]");
+        assertEquals(eventESLogMessage.get("labels.user_uuid"), "test-user-uuid");
+        assertEquals(eventESLogMessage.get("labels.session_uuid"), "test-session-uuid");
+    }
+
+    public void testCollectionName() {
+        assertEquals(pageViewAnalyticsEvent.getCollectionName(), "test-collection");
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/SearchAnalyticsEventTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/SearchAnalyticsEventTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.common.logging.ESLogMessage;
+import org.elasticsearch.test.ESTestCase;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+public class SearchAnalyticsEventTests extends ESTestCase {
+    private SearchAnalyticsEvent searchEvent;
+
+    @Before
+    public void initializeSearchAnalyticsEvent() {
+        searchEvent = new SearchAnalyticsEvent(
+            "test-collection",
+            "test-engine",
+            "test-event-source",
+            Arrays.asList(Map.of("name", "test-name", "value", "test-value", "type", "test-type")),
+            new String[] { "test-item" },
+            "test-user-uuid",
+            "test-session-uuid"
+        );
+    }
+
+    public void testFormattedEventHasRequiredFields() {
+        ESLogMessage eventESLogMessage = searchEvent.toESLogMessage(new HashMap<>());
+        assertEquals(eventESLogMessage.get("event.name"), "search");
+        assertEquals(eventESLogMessage.get("event.source"), "test-event-source");
+        assertEquals(eventESLogMessage.get("labels.engineName"), "test-engine");
+        assertEquals(eventESLogMessage.get("labels.user_uuid"), "test-user-uuid");
+        assertEquals(eventESLogMessage.get("labels.session_uuid"), "test-session-uuid");
+        assertEquals(eventESLogMessage.get("labels.fields"), "[{name=test-name, type=test-type, value=test-value}]");
+    }
+
+    public void testCollectionName() {
+        assertEquals(searchEvent.getCollectionName(), "test-collection");
+    }
+}


### PR DESCRIPTION
### Description
In order to start writing Analytics events to the log file, it's required to introduce 3 different events
1. `SearchAnalyticsEvent` class that is responsible for creating a `Search` event
2. `PageViewAnalyticsEvent` class that is responsible for creating the `PageView` event
3. `InteractionEvent` class that is responsible for creating the `Interaction` event
All these events have a `toESLogMessage` method that forms a proper ECS-compatible `ESLogMessage` from all class fields.

In addition to that, it's required to introduce `EventEmitterService` that's responsible for enriching the event and writing it to the log file.

This PR is dedicated to introducing all these entities and later use them in Rest API for `behavioral_analytics`