### PR TITLE
Search-Troubleshoot | Most Recent Record

### DIFF
--- a/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
+++ b/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
@@ -228,8 +228,8 @@ field may have a different name.
 [[troubleshooting-searches-latest-data]]
 === Check the latest value
 
-For time-series data, confirm there's non-filtered data within the attempted 
-time range. For example, if trying to query the lastest data for field 
+For time-series data, confirm there is non-filtered data within the attempted 
+time range. For example, if you are trying to query the lastest data for field 
 `@timestamp` then you can run the following to see if the max `@timestamp` 
 falls within the attempted range:
 
@@ -237,7 +237,7 @@ falls within the attempted range:
 ----
 GET my-index-000001/_search?sort=@timestamp:desc&size=1
 ----
-
+//TEST[continued]
 
 [discrete]
 [[troubleshooting-searches-validate-explain-profile]]

--- a/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
+++ b/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
@@ -225,6 +225,21 @@ If the field does not return any values, check the data ingestion process. The
 field may have a different name.
 
 [discrete]
+[[troubleshooting-searches-latest-data]]
+=== Check the latest value
+
+For time-series data, confirm there's non-filtered data within the attempted 
+time range. For example, if trying to query the lastest data for field 
+`@timestamp` then you can run the following to see if the max `@timestamp` 
+falls within the attempted range:
+
+[source,console]
+----
+GET my-index-000001/_search?sort=@timestamp:desc&size=1
+----
+
+
+[discrete]
 [[troubleshooting-searches-validate-explain-profile]]
 === Validate, explain, and profile queries
 

--- a/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
+++ b/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
@@ -231,10 +231,10 @@ field may have a different name.
 [[troubleshooting-searches-latest-data]]
 === Check the latest value
 
-For time-series data, confirm there is non-filtered data within the attempted 
-time range. For example, if you are trying to query the lastest data for field 
-`@timestamp` then you can run the following to see if the max `@timestamp` 
-falls within the attempted range:
+For time-series data, confirm there is non-filtered data within the attempted
+time range. For example, if you are trying to query the latest data for the
+`@timestamp` field, run the following to see if the max `@timestamp` falls
+within the attempted range:
 
 [source,console]
 ----

--- a/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
+++ b/docs/reference/troubleshooting/troubleshooting-searches.asciidoc
@@ -65,6 +65,9 @@ PUT my-index-000001
 {
   "mappings": {
     "properties": {
+      "@timestamp": {
+        "type": "date"
+      },
       "my-field": {
         "type": "keyword"
       },


### PR DESCRIPTION
👋🏼  howdy, team! May we add a section to [this page](https://www.elastic.co/guide/en/elasticsearch/reference/master/troubleshooting-searches.html#troubleshooting-check-field-values) to query for the latest record on an index (pattern)? This will be helpful to decide between Kibana Discover filter and Elasticsearch ingest lag problems.