### PR TITLE
Remove all blocking on Listenable*Future

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchScrollRequest;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.aggregations.bucket.adjacency.AdjacencyMatrixAggregationBuilder;
 import org.elasticsearch.aggregations.bucket.adjacency.ParsedAdjacencyMatrix;
 import org.elasticsearch.aggregations.bucket.histogram.AutoDateHistogramAggregationBuilder;
@@ -843,7 +844,9 @@ public class RestHighLevelClient implements Closeable {
 
         Optional<String> versionValidation;
         try {
-            versionValidation = getVersionValidationFuture().get();
+            final var future = new PlainActionFuture<Optional<String>>();
+            getVersionValidationFuture().addListener(future);
+            versionValidation = future.get();
         } catch (InterruptedException | ExecutionException e) {
             // Unlikely to happen
             throw new ElasticsearchException(e);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskStorageRetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskStorageRetryIT.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.action.admin.cluster.node.tasks;
 
 import org.elasticsearch.action.admin.cluster.node.tasks.get.GetTaskResponse;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.Plugin;
@@ -59,7 +59,7 @@ public class TaskStorageRetryIT extends ESSingleNodeTestCase {
         });
         barrier.await();
         Task task;
-        ListenableActionFuture<TestTaskPlugin.NodesResponse> future = new ListenableActionFuture<>();
+        PlainActionFuture<TestTaskPlugin.NodesResponse> future = new PlainActionFuture<>();
         try {
             logger.info("start a task that will store its results");
             TestTaskPlugin.NodesRequest req = new TestTaskPlugin.NodesRequest("foo");

--- a/server/src/internalClusterTest/java/org/elasticsearch/timeseries/support/TimeSeriesMetricsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/timeseries/support/TimeSeriesMetricsIT.java
@@ -11,7 +11,7 @@ package org.elasticsearch.timeseries.support;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.IndicesOptions;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.time.DateFormatter;
@@ -485,9 +485,9 @@ public class TimeSeriesMetricsIT extends ESIntegTestCase {
         int bucketBatchSize,
         int docBatchSize,
         TimeValue staleness,
-        BiConsumer<ListenableActionFuture<R>, TimeSeriesMetrics> handle
+        BiConsumer<PlainActionFuture<R>, TimeSeriesMetrics> handle
     ) {
-        ListenableActionFuture<R> result = new ListenableActionFuture<>();
+        PlainActionFuture<R> result = new PlainActionFuture<>();
         new TimeSeriesMetricsService(client(), bucketBatchSize, docBatchSize, staleness).newMetrics(
             new String[] { "tsdb" },
             IndicesOptions.STRICT_EXPAND_OPEN,

--- a/server/src/test/java/org/elasticsearch/rest/action/RestCancellableNodeClientTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/RestCancellableNodeClientTests.java
@@ -17,7 +17,7 @@ import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksReque
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
-import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.http.HttpChannel;
@@ -74,7 +74,7 @@ public class RestCancellableNodeClientTests extends ESTestCase {
                 TestHttpChannel channel = new TestHttpChannel();
                 totalSearches += numTasks;
                 for (int j = 0; j < numTasks; j++) {
-                    ListenableActionFuture<SearchResponse> actionFuture = new ListenableActionFuture<>();
+                    PlainActionFuture<SearchResponse> actionFuture = new PlainActionFuture<>();
                     RestCancellableNodeClient client = new RestCancellableNodeClient(testClient, channel);
                     threadPool.generic().submit(() -> client.execute(SearchAction.INSTANCE, new SearchRequest(), actionFuture));
                     futures.add(actionFuture);


### PR DESCRIPTION
There are almost no places where we block a thread to wait on the result of a `ListenableFuture` or `ListenableActionFuture`, and the few places that do so can trivially use a `PlainActionFuture` instead. This commit removes all blocking on `ListenableFuture` or `ListenableActionFuture`.

Relates #94386