### PR TITLE
Upgrade Commons IO used by Security CLI

### DIFF
--- a/docs/changelog/94414.yaml
+++ b/docs/changelog/94414.yaml
@@ -1,0 +1,5 @@
+pr: 94414
+summary: Upgrade Commons IO used by Security CLI
+area: Security
+type: upgrade
+issues: []

--- a/x-pack/plugin/security/cli/build.gradle
+++ b/x-pack/plugin/security/cli/build.gradle
@@ -1,4 +1,5 @@
 import de.thetaphi.forbiddenapis.gradle.CheckForbiddenApis
+
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.build'
@@ -10,7 +11,7 @@ dependencies {
   compileOnly project(path: xpackModule('core'))
   api "org.bouncycastle:bcpkix-jdk15on:${versions.bouncycastle}"
   api "org.bouncycastle:bcprov-jdk15on:${versions.bouncycastle}"
-  api "commons-io:commons-io:2.5"
+  api "commons-io:commons-io:2.11.0"
   testImplementation("com.google.jimfs:jimfs:${versions.jimfs}") {
     // this is provided by the runtime classpath, from the security project
     exclude group: "com.google.guava", module: "guava"


### PR DESCRIPTION
This commit upgrades the version of Commons IO used by the Security CLI from 2.5 to 2.11.0.