### PR TITLE
Refactor `ShardLimitValidator` returning more info

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -261,7 +261,7 @@ public class ShardLimitValidator {
         return "this action would add ["
             + result.totalShardsToAdd
             + "] shards, but this cluster currently has ["
-            + result.currentUsedShardsByGroup.get()
+            + result.currentUsedShards.get()
             + "]/["
             + result.maxShardsInCluster
             + "] maximum "
@@ -275,7 +275,7 @@ public class ShardLimitValidator {
      */
     public record Result(
         boolean canAddShards,
-        Optional<Long> currentUsedShardsByGroup,
+        Optional<Long> currentUsedShards,
         int totalShardsToAdd,
         int maxShardsInCluster,
         String group

--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.Index;
 
-import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
@@ -103,10 +102,10 @@ public class ShardLimitValidator {
         final int shardsToCreate = numberOfShards * (1 + numberOfReplicas);
         final boolean frozen = FROZEN_GROUP.equals(INDEX_SETTING_SHARD_LIMIT_GROUP.get(settings));
 
-        final Optional<String> shardLimit = checkShardLimit(frozen == false ? shardsToCreate : 0, frozen ? shardsToCreate : 0, state);
-        if (shardLimit.isPresent()) {
+        final var result = checkShardLimitOnBothGroups(frozen == false ? shardsToCreate : 0, frozen ? shardsToCreate : 0, state);
+        if (result.canAddShards == false) {
             final ValidationException e = new ValidationException();
-            e.addValidationError(shardLimit.get());
+            e.addValidationError(errorMessageFrom(result));
             throw e;
         }
     }
@@ -134,10 +133,10 @@ public class ShardLimitValidator {
             }
         }
 
-        Optional<String> error = checkShardLimit(normal, frozen, currentState);
-        if (error.isPresent()) {
+        var result = checkShardLimitOnBothGroups(normal, frozen, currentState);
+        if (result.canAddShards == false) {
             ValidationException ex = new ValidationException();
-            ex.addValidationError(error.get());
+            ex.addValidationError(errorMessageFrom(result));
             throw ex;
         }
     }
@@ -155,10 +154,10 @@ public class ShardLimitValidator {
             }
         }
 
-        Optional<String> error = checkShardLimit(normal, frozen, currentState);
-        if (error.isPresent()) {
+        var result = checkShardLimitOnBothGroups(normal, frozen, currentState);
+        if (result.canAddShards == false) {
             ValidationException ex = new ValidationException();
-            ex.addValidationError(error.get());
+            ex.addValidationError(errorMessageFrom(result));
             throw ex;
         }
     }
@@ -172,53 +171,60 @@ public class ShardLimitValidator {
     }
 
     /**
-     * Checks to see if an operation can be performed without taking the cluster over the cluster-wide shard limit.
-     * Returns an error message if appropriate, or an empty {@link Optional} otherwise.
+     * Checks to see if an operation can be performed without taking the cluster over the cluster-wide shard limit. It follows the
+     * next rules:
+     *   - Check limits for _normal_ nodes
+     *   - If there's no room -> return the Result for _normal_ nodes (fail-fast)
+     *   - otherwise -> returns the Result of checking the limits for _frozen_ nodes
      *
-     * @param newShards         The number of normal shards to be added by this operation
-     * @param newFrozenShards   The number of frozen shards to be added by this operation
-     * @param state             The current cluster state
-     * @return If present, an error message to be given as the reason for failing
-     * an operation. If empty, a sign that the operation is valid.
+     * @param newShards       The number of normal shards to be added by this operation
+     * @param newFrozenShards The number of frozen shards to be added by this operation
+     * @param state           The current cluster state
      */
-    private Optional<String> checkShardLimit(int newShards, int newFrozenShards, ClusterState state) {
+    private Result checkShardLimitOnBothGroups(int newShards, int newFrozenShards, ClusterState state) {
         // we verify the two limits independently. This also means that if they have mixed frozen and other data-roles nodes, such a mixed
         // node can have both 1000 normal and 3000 frozen shards. This is the trade-off to keep the simplicity of the counts. We advocate
         // against such mixed nodes for production use anyway.
         int frozenNodeCount = nodeCount(state, ShardLimitValidator::hasFrozen);
         int normalNodeCount = nodeCount(state, ShardLimitValidator::hasNonFrozen);
-        return checkShardLimit(newShards, state, getShardLimitPerNode(), normalNodeCount, NORMAL_GROUP).or(
-            () -> checkShardLimit(newFrozenShards, state, shardLimitPerNodeFrozen.get(), frozenNodeCount, "frozen")
-        );
+
+        var result = checkShardLimit(newShards, state, getShardLimitPerNode(), normalNodeCount, NORMAL_GROUP);
+        // fail-fast: in case there's no room on the `normal` nodes, just return the result of that check.
+        if (result.canAddShards() == false) {
+            return result;
+        }
+        return checkShardLimit(newFrozenShards, state, shardLimitPerNodeFrozen.get(), frozenNodeCount, FROZEN_GROUP);
     }
 
     /**
-     * This method decides whether there is enough room in the cluster to add the given number of shards with the given number of replicas
-     * without exceeding the "cluster.max_shards_per_node" setting if the shards are going on normal nodes. This check does not guarantee
-     * that the number of shards can be added, just that there is theoretically room to add them without exceeding the shards per node
-     * configuration.
+     * This method checks whether there is enough room in the cluster to add the given number of shards with the given number of replicas
+     * without exceeding the "cluster.max_shards_per_node" setting for _normal_ nodes. This check does not guarantee that the number of
+     * shards can be added, just that there is theoretically room to add them without exceeding the shards per node configuration.
      * @param numberOfNewShards The number of primary shards that we want to be able to add to the cluster
      * @param replicas          The number of replicas of the primary shards that we want to be able to add to the cluster
      * @param state             The cluster state, used to get cluster settings and to get the number of open shards already in the cluster
-     * @return True if there is room to add the requested number of shards to the cluster, and false if there is not
      */
-    public static boolean canAddShardsToCluster(int numberOfNewShards, int replicas, ClusterState state) {
-        var clusterSettings = state.getMetadata().settings();
-        var maxShardsPerNode = SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(clusterSettings);
-        var nodeCount = nodeCount(state, ShardLimitValidator::hasNonFrozen);
-        var errorMessage = checkShardLimit(numberOfNewShards * (1 + replicas), state, maxShardsPerNode, nodeCount, NORMAL_GROUP);
-        return errorMessage.isEmpty();
+    public static Result checkShardLimitForNormalNode(int numberOfNewShards, int replicas, ClusterState state) {
+        final int maxShardsPerNode = SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(state.getMetadata().settings());
+        return checkShardLimit(
+            numberOfNewShards * (1 + replicas),
+            state,
+            maxShardsPerNode,
+            nodeCount(state, ShardLimitValidator::hasNonFrozen),
+            NORMAL_GROUP
+        );
     }
 
     // package-private for testing
-    static Optional<String> checkShardLimit(int newShards, ClusterState state, int maxShardsPerNode, int nodeCount, String group) {
+    static Result checkShardLimit(int newShards, ClusterState state, int maxShardsPerNode, int nodeCount, String group) {
+        int maxShardsInCluster = maxShardsPerNode * nodeCount;
+        int currentOpenShards = state.getMetadata().getTotalOpenIndexShards();
+
         // Only enforce the shard limit if we have at least one data node, so that we don't block
         // index creation during cluster setup
         if (nodeCount == 0 || newShards <= 0) {
-            return Optional.empty();
+            return new Result(true, -1, newShards, maxShardsInCluster, group);
         }
-        int maxShardsInCluster = maxShardsPerNode * nodeCount;
-        int currentOpenShards = state.getMetadata().getTotalOpenIndexShards();
 
         if ((currentOpenShards + newShards) > maxShardsInCluster) {
             Predicate<IndexMetadata> indexMetadataPredicate = imd -> imd.getState().equals(IndexMetadata.State.OPEN)
@@ -230,20 +236,12 @@ public class ShardLimitValidator {
                 .filter(indexMetadataPredicate)
                 .mapToInt(IndexMetadata::getTotalNumberOfShards)
                 .sum();
+
             if ((currentFilteredShards + newShards) > maxShardsInCluster) {
-                String errorMessage = "this action would add ["
-                    + newShards
-                    + "] shards, but this cluster currently has ["
-                    + currentFilteredShards
-                    + "]/["
-                    + maxShardsInCluster
-                    + "] maximum "
-                    + group
-                    + " shards open";
-                return Optional.of(errorMessage);
+                return new Result(false, currentFilteredShards, newShards, maxShardsInCluster, group);
             }
         }
-        return Optional.empty();
+        return new Result(true, 0, newShards, maxShardsInCluster, group);
     }
 
     private static int nodeCount(ClusterState state, Predicate<DiscoveryNode> nodePredicate) {
@@ -258,4 +256,21 @@ public class ShardLimitValidator {
         return node.getRoles().stream().anyMatch(r -> r.canContainData() && r != DiscoveryNodeRole.DATA_FROZEN_NODE_ROLE);
     }
 
+    static String errorMessageFrom(Result result) {
+        return "this action would add ["
+            + result.totalShardsToAdd
+            + "] shards, but this cluster currently has ["
+            + result.currentFilteredShards
+            + "]/["
+            + result.maxShardsInCluster
+            + "] maximum "
+            + result.group
+            + " shards open";
+    }
+
+    /**
+     * A Result object containing enough information to be used by external callers about the state of the cluster from the shard limits
+     * perspective.
+     */
+    public record Result(boolean canAddShards, long currentFilteredShards, int totalShardsToAdd, int maxShardsInCluster, String group) {}
 }

--- a/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
+++ b/server/src/main/java/org/elasticsearch/indices/ShardLimitValidator.java
@@ -205,7 +205,7 @@ public class ShardLimitValidator {
      * @param replicas          The number of replicas of the primary shards that we want to be able to add to the cluster
      * @param state             The cluster state, used to get cluster settings and to get the number of open shards already in the cluster
      */
-    public static Result checkShardLimitForNormalNode(int numberOfNewShards, int replicas, ClusterState state) {
+    public static Result checkShardLimitForNormalNodes(int numberOfNewShards, int replicas, ClusterState state) {
         final int maxShardsPerNode = SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(state.getMetadata().settings());
         return checkShardLimit(
             numberOfNewShards * (1 + replicas),

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -78,10 +78,8 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
         assertEquals(shardLimitsResult.maxShardsInCluster(), maxShards);
         assertEquals(shardLimitsResult.totalShardsToAdd(), totalShards);
-        shardLimitsResult.currentUsedShardsByGroup().ifPresentOrElse(
-                v -> assertEquals(currentOpenShards, v.intValue()),
-                () -> fail("currentUsedShard should be defined")
-        );
+        shardLimitsResult.currentUsedShardsByGroup()
+            .ifPresentOrElse(v -> assertEquals(currentOpenShards, v.intValue()), () -> fail("currentUsedShard should be defined"));
         assertEquals(shardLimitsResult.group(), "normal");
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -78,7 +78,10 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
         assertEquals(shardLimitsResult.maxShardsInCluster(), maxShards);
         assertEquals(shardLimitsResult.totalShardsToAdd(), totalShards);
-        assertEquals(shardLimitsResult.currentFilteredShards(), currentOpenShards);
+        shardLimitsResult.currentUsedShardsByGroup().ifPresentOrElse(
+                v -> assertEquals(currentOpenShards, v.intValue()),
+                () -> fail("currentUsedShard should be defined")
+        );
         assertEquals(shardLimitsResult.group(), "normal");
     }
 
@@ -108,7 +111,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         assertTrue(shardLimitsResult.canAddShards());
         assertEquals(shardLimitsResult.maxShardsInCluster(), maxShardsInCluster);
         assertEquals(shardLimitsResult.totalShardsToAdd(), shardsToAdd);
-        assertEquals(shardLimitsResult.currentFilteredShards(), 0);
+        assertFalse(shardLimitsResult.currentUsedShardsByGroup().isPresent());
         assertEquals(shardLimitsResult.group(), "normal");
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -78,7 +78,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
         assertEquals(shardLimitsResult.maxShardsInCluster(), maxShards);
         assertEquals(shardLimitsResult.totalShardsToAdd(), totalShards);
-        shardLimitsResult.currentUsedShardsByGroup()
+        shardLimitsResult.currentUsedShards()
             .ifPresentOrElse(v -> assertEquals(currentOpenShards, v.intValue()), () -> fail("currentUsedShard should be defined"));
         assertEquals(shardLimitsResult.group(), "normal");
     }
@@ -109,7 +109,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         assertTrue(shardLimitsResult.canAddShards());
         assertEquals(shardLimitsResult.maxShardsInCluster(), maxShardsInCluster);
         assertEquals(shardLimitsResult.totalShardsToAdd(), shardsToAdd);
-        assertFalse(shardLimitsResult.currentUsedShardsByGroup().isPresent());
+        assertFalse(shardLimitsResult.currentUsedShards().isPresent());
         assertEquals(shardLimitsResult.group(), "normal");
     }
 

--- a/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/ShardLimitValidatorTests.java
@@ -27,7 +27,6 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 
 import static org.elasticsearch.cluster.metadata.MetadataIndexStateServiceTests.addClosedIndex;
@@ -52,7 +51,7 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
 
         int shardsToAdd = counts.getFailingIndexShards() * (1 + counts.getFailingIndexReplicas());
-        Optional<String> errorMessage = ShardLimitValidator.checkShardLimit(
+        var shardLimitsResult = ShardLimitValidator.checkShardLimit(
             shardsToAdd,
             state,
             counts.getShardsPerNode(),
@@ -61,22 +60,26 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
 
         int totalShards = counts.getFailingIndexShards() * (1 + counts.getFailingIndexReplicas());
-        int currentShards = counts.getFirstIndexShards() * (1 + counts.getFirstIndexReplicas());
+        int currentOpenShards = counts.getFirstIndexShards() * (1 + counts.getFirstIndexReplicas());
         int maxShards = counts.getShardsPerNode() * nodesInCluster;
-        assertTrue(errorMessage.isPresent());
+
+        assertFalse(shardLimitsResult.canAddShards());
         assertEquals(
             "this action would add ["
                 + totalShards
                 + "] shards, but this cluster currently has ["
-                + currentShards
+                + currentOpenShards
                 + "]/["
                 + maxShards
                 + "] maximum "
                 + NORMAL_GROUP
                 + " shards open",
-            errorMessage.get()
+            ShardLimitValidator.errorMessageFrom(shardLimitsResult)
         );
-        assertFalse(ShardLimitValidator.canAddShardsToCluster(counts.getFailingIndexShards(), counts.getFailingIndexReplicas(), state));
+        assertEquals(shardLimitsResult.maxShardsInCluster(), maxShards);
+        assertEquals(shardLimitsResult.totalShardsToAdd(), totalShards);
+        assertEquals(shardLimitsResult.currentFilteredShards(), currentOpenShards);
+        assertEquals(shardLimitsResult.group(), "normal");
     }
 
     public void testUnderShardLimit() {
@@ -92,8 +95,9 @@ public class ShardLimitValidatorTests extends ESTestCase {
         );
 
         int existingShards = counts.getFirstIndexShards() * (1 + counts.getFirstIndexReplicas());
-        int shardsToAdd = randomIntBetween(1, (counts.getShardsPerNode() * nodesInCluster) - existingShards);
-        Optional<String> errorMessage = ShardLimitValidator.checkShardLimit(
+        int maxShardsInCluster = counts.getShardsPerNode() * nodesInCluster;
+        int shardsToAdd = randomIntBetween(1, maxShardsInCluster - existingShards);
+        var shardLimitsResult = ShardLimitValidator.checkShardLimit(
             shardsToAdd,
             state,
             counts.getShardsPerNode(),
@@ -101,8 +105,11 @@ public class ShardLimitValidatorTests extends ESTestCase {
             NORMAL_GROUP
         );
 
-        assertFalse(errorMessage.isPresent());
-        assertTrue(ShardLimitValidator.canAddShardsToCluster(shardsToAdd, 0, state));
+        assertTrue(shardLimitsResult.canAddShards());
+        assertEquals(shardLimitsResult.maxShardsInCluster(), maxShardsInCluster);
+        assertEquals(shardLimitsResult.totalShardsToAdd(), shardsToAdd);
+        assertEquals(shardLimitsResult.currentFilteredShards(), 0);
+        assertEquals(shardLimitsResult.group(), "normal");
     }
 
     public void testValidateShardLimitOpenIndices() {

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -24,7 +24,7 @@ public class ClusterDeprecationChecks {
         // Make sure we have room to add a small non-frozen index if needed
         final int shardsInFutureNewSmallIndex = 5;
         final int replicasForFutureIndex = 1;
-        ShardLimitValidator.Result shardLimitsResult = ShardLimitValidator.checkShardLimitForNormalNode(
+        ShardLimitValidator.Result shardLimitsResult = ShardLimitValidator.checkShardLimitForNormalNodes(
             shardsInFutureNewSmallIndex,
             replicasForFutureIndex,
             clusterState

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecks.java
@@ -24,10 +24,14 @@ public class ClusterDeprecationChecks {
         // Make sure we have room to add a small non-frozen index if needed
         final int shardsInFutureNewSmallIndex = 5;
         final int replicasForFutureIndex = 1;
-        if (ShardLimitValidator.canAddShardsToCluster(shardsInFutureNewSmallIndex, replicasForFutureIndex, clusterState)) {
+        ShardLimitValidator.Result shardLimitsResult = ShardLimitValidator.checkShardLimitForNormalNode(
+            shardsInFutureNewSmallIndex,
+            replicasForFutureIndex,
+            clusterState
+        );
+        if (shardLimitsResult.canAddShards()) {
             return null;
         } else {
-            final int totalShardsToAdd = shardsInFutureNewSmallIndex * (1 + replicasForFutureIndex);
             return new DeprecationIssue(
                 DeprecationIssue.Level.WARNING,
                 "The cluster has too many shards to be able to upgrade",
@@ -37,7 +41,7 @@ public class ClusterDeprecationChecks {
                     "Upgrading requires adding a small number of new shards. There is not enough room for %d more "
                         + "shards. Increase the cluster.max_shards_per_node setting, or remove indices "
                         + "to clear up resources.",
-                    totalShardsToAdd
+                    shardLimitsResult.totalShardsToAdd()
                 ),
                 false,
                 null


### PR DESCRIPTION
It adds a new `Result` record to be returned by the ShardLimitValidator class. This record contains enough information to be used by external callers to create error messages or any other information to notify users about the internal status of the cluster.

---
**Important:** This is part of #94079 stream of work. While working on adding the new health indicator, I noticed it'll be necessary to expose more information from the `ShardValidator` class. So, I'm splitting the work into small PRs –easier to review– that will pave the road to the introduction of the new indicator
