### PR TITLE
Placeholder REST controller to push analytics events.

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -39,12 +39,15 @@ import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.application.analytics.action.DeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.GetAnalyticsCollectionAction;
+import org.elasticsearch.xpack.application.analytics.action.PostAnalyticsEventAction;
 import org.elasticsearch.xpack.application.analytics.action.PutAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.RestDeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.RestGetAnalyticsCollectionAction;
+import org.elasticsearch.xpack.application.analytics.action.RestPostAnalyticsEventAction;
 import org.elasticsearch.xpack.application.analytics.action.RestPutAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportDeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportGetAnalyticsCollectionAction;
+import org.elasticsearch.xpack.application.analytics.action.TransportPostAnalyticsEventAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportPutAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.action.DeleteSearchApplicationAction;
@@ -98,6 +101,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             new ActionHandler<>(PutAnalyticsCollectionAction.INSTANCE, TransportPutAnalyticsCollectionAction.class),
             new ActionHandler<>(GetAnalyticsCollectionAction.INSTANCE, TransportGetAnalyticsCollectionAction.class),
             new ActionHandler<>(DeleteAnalyticsCollectionAction.INSTANCE, TransportDeleteAnalyticsCollectionAction.class),
+            new ActionHandler<>(PostAnalyticsEventAction.INSTANCE, TransportPostAnalyticsEventAction.class),
             new ActionHandler<>(DeleteSearchApplicationAction.INSTANCE, TransportDeleteSearchApplicationAction.class),
             new ActionHandler<>(GetSearchApplicationAction.INSTANCE, TransportGetSearchApplicationAction.class),
             new ActionHandler<>(ListSearchApplicationAction.INSTANCE, TransportListSearchApplicationAction.class),
@@ -126,7 +130,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             new RestDeleteSearchApplicationAction(),
             new RestPutAnalyticsCollectionAction(),
             new RestGetAnalyticsCollectionAction(),
-            new RestDeleteAnalyticsCollectionAction()
+            new RestDeleteAnalyticsCollectionAction(),
+            new RestPostAnalyticsEventAction()
         );
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.ToXContentObject;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventAction.Response> {
+
+    public static final PostAnalyticsEventAction INSTANCE = new PostAnalyticsEventAction();
+
+    public static final String NAME = "cluster:admin/xpack/application/analytics/post_event";
+
+    private PostAnalyticsEventAction() {
+        super(NAME, Response::new);
+    }
+
+    public static class Request extends ActionRequest {
+
+        private final String collectionName;
+
+        public Request(String collectionName) {
+            this.collectionName = collectionName;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.collectionName = in.readString();
+        }
+
+        public String collectionName() {
+            return collectionName;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(collectionName);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request that = (Request) o;
+            return Objects.equals(collectionName, that.collectionName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(collectionName);
+        }
+    }
+
+    public static class Response extends ActionResponse implements ToXContentObject {
+
+        public static Response ACCEPTED = new Response(true);
+
+        private static final ParseField RESULT_FIELD = new ParseField("accepted");
+
+        private final boolean accepted;
+
+        public Response(boolean accepted) {
+            this.accepted = accepted;
+        }
+
+        public Response(StreamInput in) throws IOException {
+            this.accepted = in.readBoolean();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            out.writeBoolean(accepted);
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Response that = (Response) o;
+            return accepted == that.accepted;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(accepted);
+        }
+
+        @Override
+        public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+            return builder.startObject().field(RESULT_FIELD.getPreferredName(), accepted).endObject();
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.application.EnterpriseSearch;
+
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+public class RestPostAnalyticsEventAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "analytics_post_event_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/" + EnterpriseSearch.BEHAVIORAL_ANALYTICS_API_ENDPOINT + "/{collection_name}/event"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        PostAnalyticsEventAction.Request request = new PostAnalyticsEventAction.Request(restRequest.param("collection_name"));
+
+        return channel -> client.execute(PostAnalyticsEventAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPostAnalyticsEventAction.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportPostAnalyticsEventAction extends HandledTransportAction<
+    PostAnalyticsEventAction.Request,
+    PostAnalyticsEventAction.Response> {
+
+    @Inject
+    public TransportPostAnalyticsEventAction(TransportService transportService, ActionFilters actionFilters) {
+        super(PostAnalyticsEventAction.NAME, transportService, actionFilters, PostAnalyticsEventAction.Request::new);
+    }
+
+    @Override
+    protected void doExecute(
+        Task task,
+        PostAnalyticsEventAction.Request request,
+        ActionListener<PostAnalyticsEventAction.Response> listener
+    ) {
+        listener.onResponse(PostAnalyticsEventAction.Response.ACCEPTED);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventRequestSerializingTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class PostAnalyticsEventRequestSerializingTests extends AbstractWireSerializingTestCase<PostAnalyticsEventAction.Request> {
+
+    @Override
+    protected Writeable.Reader<PostAnalyticsEventAction.Request> instanceReader() {
+        return PostAnalyticsEventAction.Request::new;
+    }
+
+    @Override
+    protected PostAnalyticsEventAction.Request createTestInstance() {
+        return new PostAnalyticsEventAction.Request(randomIdentifier());
+    }
+
+    @Override
+    protected PostAnalyticsEventAction.Request mutateInstance(PostAnalyticsEventAction.Request instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventResponseSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventResponseSerializingTests.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class PostAnalyticsEventResponseSerializingTests extends AbstractWireSerializingTestCase<PostAnalyticsEventAction.Response> {
+
+    @Override
+    protected Writeable.Reader<PostAnalyticsEventAction.Response> instanceReader() {
+        return PostAnalyticsEventAction.Response::new;
+    }
+
+    @Override
+    protected PostAnalyticsEventAction.Response createTestInstance() {
+        return new PostAnalyticsEventAction.Response(randomBoolean());
+    }
+
+    @Override
+    protected PostAnalyticsEventAction.Response mutateInstance(PostAnalyticsEventAction.Response instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+}

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -97,6 +97,7 @@ public class Constants {
         "cluster:admin/xpack/application/analytics/delete",
         "cluster:admin/xpack/application/analytics/get",
         "cluster:admin/xpack/application/analytics/put",
+        "cluster:admin/xpack/application/analytics/post_event",
         "cluster:admin/xpack/application/search_application/delete",
         "cluster:admin/xpack/application/search_application/get",
         "cluster:admin/xpack/application/search_application/list",


### PR DESCRIPTION
Create the transport and REST action to be used to push analytics events.
Currently it is a no-op implementation that just return always OK.

@tutelaris will be able to plug the event emitter service here.