### PR TITLE
Require the manage index privilege on the underlying indices of a SearchApplication

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/roles.yml
+++ b/x-pack/plugin/ent-search/qa/rest/roles.yml
@@ -4,5 +4,23 @@ entsearch:
     - manage_behavioral_analytics
     - monitor
   indices:
-    - names: [ "*" ]
+    - names: [
+        # indices
+        "test-index",
+        "test-index1",
+        "test-index2",
+        "test-index3",
+        "test-index4",
+        "test-index-does-not-exist",
+        # Search Applications (needed to create aliases)
+        "test-search-application",
+        "test-search-application-1",
+        "test-search-application-2",
+        "another-test-search-application",
+        "test-updated-search-application",
+        "test-error-search-application",
+        "test-re-creating-search-application",
+        "test-search-application-to-delete",
+        "test-nonexistent-search-application",
+      ]
       privileges: [ "manage" ]

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -92,7 +92,7 @@ teardown:
       search_application.put:
         name: test-error-search-application
         body:
-          indices: [ "test-index1", "index-does-not-exist" ]
+          indices: [ "test-index1", "test-index-does-not-exist" ]
 
 ---
 "Create Search Application - Resource already exists":
@@ -115,3 +115,14 @@ teardown:
 
   - match: { error.type: "version_conflict_engine_exception" }
 
+---
+"Create Search Application - Insufficient privilege":
+  - do:
+      catch: forbidden
+      search_application.put:
+        name: another-search-application
+        create: true
+        body:
+          indices: [ "another-index" ]
+
+  - match: { error.type: "security_exception" }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -19,7 +19,7 @@ setup:
 
   - do:
       search_application.put:
-        name: my-test-search-application
+        name: test-search-application
         body:
           indices: [ "test-index1", "test-index2"]
           analytics_collection_name: "test-analytics"
@@ -28,19 +28,19 @@ setup:
 teardown:
   - do:
       search_application.delete:
-        name: my-test-search-application
+        name: test-search-application
         ignore: 404
 
 ---
 "Get Search Application":
   - do:
       search_application.get:
-        name: my-test-search-application
+        name: test-search-application
 
-  - match: { name: "my-test-search-application" }
+  - match: { name: "test-search-application" }
   - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
-  - match: { search_alias: "my-test-search-application" }
+  - match: { search_alias: "test-search-application" }
   - gte: { updated_at_millis: 0 }
 
 ---


### PR DESCRIPTION
This change ensures that we use the current user to create the alias for a SearchApplication. This is required since we rely on the user to have the index manage privilege on the underlying indices as well as the Search Application name (that we use as the alias name).