### PR TITLE
Update http.max_content_length description

### DIFF
--- a/docs/reference/modules/http.asciidoc
+++ b/docs/reference/modules/http.asciidoc
@@ -43,8 +43,9 @@ Configure this setting only if you need the publish port to be different from
 
 `http.max_content_length`::
 (<<static-cluster-setting,Static>>, <<byte-units,byte value>>)
-Maximum size of an HTTP request body, compressed if applicable. Defaults to `100mb`. Configuring this
-setting to greater than `100mb` can cause cluster instability and is not
+Maximum size of an HTTP request body. If the body is compressed, the limit applies
+to the HTTP request body size before compression. Defaults to `100mb`. Configuring 
+this setting to greater than `100mb` can cause cluster instability and is not
 recommended. If you hit this limit when sending a request to the <<docs-bulk>>
 API, configure your client to send fewer documents in each bulk request. If you
 wish to index individual documents that exceed `100mb`, pre-process them into


### PR DESCRIPTION
Fixes the [http.max_content_length setting](https://www.elastic.co/guide/en/elasticsearch/reference/8.6/modules-network.html#http-settings) description, as discussed [here](https://github.com/elastic/elasticsearch/pull/94408#issuecomment-1462223324).