### PR TITLE
Added ref links to TSDS and downsampling highlights

### DIFF
--- a/docs/changelog/91519.yaml
+++ b/docs/changelog/91519.yaml
@@ -6,7 +6,7 @@ issues: []
 highlight:
   title: Time series (TSDS) GA
   body: |-
-    Time Series Data Stream (TSDS) is a feature for optimizing Elasticsearch indices for time series data.
+    <<tsds,Time Series Data Stream (TSDS)>> is a feature for optimizing Elasticsearch indices for time series data.
     This involves sorting the indices to achieve better compression and using synthetic_source to reduce index size.
     As a result, TSDS indices are significantly smaller than non-time_series indices that contain the same data.
     TSDS is particularly useful for managing time series data with high volume.

--- a/docs/changelog/91519.yaml
+++ b/docs/changelog/91519.yaml
@@ -7,7 +7,7 @@ highlight:
   title: Time series (TSDS) GA
   body: |-
     <<tsds,Time Series Data Stream (TSDS)>> is a feature for optimizing Elasticsearch indices for time series data.
-    This involves sorting the indices to achieve better compression and using synthetic_source to reduce index size.
+    This involves sorting the indices to achieve better compression and using synthetic _source to reduce index size.
     As a result, TSDS indices are significantly smaller than non-time_series indices that contain the same data.
     TSDS is particularly useful for managing time series data with high volume.
   notable: true

--- a/docs/changelog/92913.yaml
+++ b/docs/changelog/92913.yaml
@@ -6,7 +6,7 @@ issues: []
 highlight:
   title: Downsampling GA
   body: |-
-    Downsampling is a feature that reduces the number of stored documents in Elasticsearch time series indices,
+    <<downsampling,Downsampling>> is a feature that reduces the number of stored documents in Elasticsearch time series indices,
     resulting in smaller indices and improved query latency. This optimization is achieved by pre-aggregating
     time series indices, using the time_series index schema to identify the time series.
     Downsampling is configured as an action in ILM, making it a useful tool for managing large volumes of

--- a/docs/changelog/92913.yaml
+++ b/docs/changelog/92913.yaml
@@ -6,9 +6,10 @@ issues: []
 highlight:
   title: Downsampling GA
   body: |-
-    <<downsampling,Downsampling>> is a feature that reduces the number of stored documents in Elasticsearch time series indices,
-    resulting in smaller indices and improved query latency. This optimization is achieved by pre-aggregating
-    time series indices, using the time_series index schema to identify the time series.
+    <<downsampling,Downsampling>> is a feature that reduces the number of stored documents in Elasticsearch
+    time series indices, resulting in smaller indices and improved query latency.
+    This optimization is achieved by pre-aggregating time series indices,
+    using the time_series index schema to identify the time series.
     Downsampling is configured as an action in ILM, making it a useful tool for managing large volumes of
     time series data in Elasticsearch.
   notable: true

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -25,7 +25,7 @@ Other versions:
 [discrete]
 [[time_series_tsds_ga]]
 === Time series (TSDS) GA
-Time Series Data Stream (TSDS) is a feature for optimizing Elasticsearch indices for time series data.
+<<tsds,Time Series Data Stream (TSDS)>> is a feature for optimizing Elasticsearch indices for time series data.
 This involves sorting the indices to achieve better compression and using synthetic_source to reduce index size.
 As a result, TSDS indices are significantly smaller than non-time_series indices that contain the same data.
 TSDS is particularly useful for managing time series data with high volume.
@@ -35,7 +35,7 @@ TSDS is particularly useful for managing time series data with high volume.
 [discrete]
 [[downsampling_ga]]
 === Downsampling GA
-Downsampling is a feature that reduces the number of stored documents in Elasticsearch time series indices,
+<<downsampling,Downsampling>> is a feature that reduces the number of stored documents in Elasticsearch time series indices,
 resulting in smaller indices and improved query latency. This optimization is achieved by pre-aggregating
 time series indices, using the time_series index schema to identify the time series.
 Downsampling is configured as an action in ILM, making it a useful tool for managing large volumes of

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -26,7 +26,7 @@ Other versions:
 [[time_series_tsds_ga]]
 === Time series (TSDS) GA
 <<tsds,Time Series Data Stream (TSDS)>> is a feature for optimizing Elasticsearch indices for time series data.
-This involves sorting the indices to achieve better compression and using synthetic_source to reduce index size.
+This involves sorting the indices to achieve better compression and using synthetic _source to reduce index size.
 As a result, TSDS indices are significantly smaller than non-time_series indices that contain the same data.
 TSDS is particularly useful for managing time series data with high volume.
 
@@ -35,9 +35,10 @@ TSDS is particularly useful for managing time series data with high volume.
 [discrete]
 [[downsampling_ga]]
 === Downsampling GA
-<<downsampling,Downsampling>> is a feature that reduces the number of stored documents in Elasticsearch time series indices,
-resulting in smaller indices and improved query latency. This optimization is achieved by pre-aggregating
-time series indices, using the time_series index schema to identify the time series.
+<<downsampling,Downsampling>> is a feature that reduces the number of stored documents in Elasticsearch
+time series indices, resulting in smaller indices and improved query latency.
+This optimization is achieved by pre-aggregating time series indices,
+using the time_series index schema to identify the time series.
 Downsampling is configured as an action in ILM, making it a useful tool for managing large volumes of
 time series data in Elasticsearch.
 


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/94419 we added two new release highlights. Since merging that, we discovered the opportunity to add links from the highlights to the relevant reference documentation. This PR adds those links.