### PR TITLE
Log HTTP response trace when sending is complete

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -158,7 +158,7 @@ public class FakeRestRequest extends RestRequest {
 
         @Override
         public void sendResponse(HttpResponse response, ActionListener<Void> listener) {
-
+            listener.onResponse(null);
         }
 
         @Override


### PR DESCRIPTION
HttpTracer logs a message when an HTTP response is sent to a HttpChannel but that does not mean the response sending process is completed.

This pull request changes the HttpTracer so that the message is now logged when the sending is complete.