### PR TITLE
Remove search alias from Get and List Search Applications responses

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -40,7 +40,6 @@ teardown:
   - match: { name: "my-test-search-application" }
   - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
-  - match: { search_alias: "my-test-search-application" }
   - gte: { updated_at_millis: 0 }
 
 ---

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -64,19 +64,16 @@ teardown:
 
   # Alphabetical order for results
   - match: { results.0.name: "another-test-search-application" }
-  - match: { results.0.search_alias: "another-test-search-application" }
   - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
   - match: { results.0.updated_at_millis: null }
 
   - match: { results.1.name: "test-search-application-1" }
-  - match: { results.1.search_alias: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
   - match: { results.1.updated_at_millis: null }
 
   - match: { results.2.name: "test-search-application-2" }
-  - match: { results.2.search_alias: "test-search-application-2" }
   - match: { results.2.indices: [ "test-index2" ] }
   - match: { results.2.analytics_collection_name: "test-analytics2" }
   - match: { results.2.updated_at_millis: null }
@@ -90,13 +87,11 @@ teardown:
   - match: { count: 3 }
 
   - match: { results.0.name: "test-search-application-1" }
-  - match: { results.0.search_alias: "test-search-application-1" }
   - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
   - match: { results.0.updated_at_millis: null }
 
   - match: { results.1.name: "test-search-application-2" }
-  - match: { results.1.search_alias: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
   - match: { results.1.updated_at_millis: null }
@@ -110,13 +105,11 @@ teardown:
   - match: { count: 3 }
 
   - match: { results.0.name: "another-test-search-application" }
-  - match: { results.0.search_alias: "another-test-search-application" }
   - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
   - match: { results.0.updated_at_millis: null }
 
   - match: { results.1.name: "test-search-application-1" }
-  - match: { results.1.search_alias: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
   - match: { results.1.updated_at_millis: null }
@@ -131,13 +124,11 @@ teardown:
   - match: { count: 2 }
 
   - match: { results.0.name: "test-search-application-1" }
-  - match: { results.0.search_alias: "test-search-application-1" }
   - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
   - match: { results.0.updated_at_millis: null }
 
   - match: { results.1.name: "test-search-application-2" }
-  - match: { results.1.search_alias: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
   - match: { results.1.updated_at_millis: null }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -44,7 +44,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
     private final String[] indices;
     private long updatedAtMillis = System.currentTimeMillis();
     private final String analyticsCollectionName;
-    private final String searchAlias;
 
     /**
      * Public constructor.
@@ -59,7 +58,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         Arrays.sort(indices);
 
         this.analyticsCollectionName = analyticsCollectionName;
-        this.searchAlias = getSearchAliasName(name);
     }
 
     public SearchApplication(StreamInput in) throws IOException {
@@ -67,12 +65,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         this.indices = in.readStringArray();
         this.analyticsCollectionName = in.readOptionalString();
         this.updatedAtMillis = in.readLong();
-
-        this.searchAlias = getSearchAliasName(this.name);
-    }
-
-    public static String getSearchAliasName(String resourceName) {
-        return resourceName;
     }
 
     @Override
@@ -112,7 +104,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
     public static final ParseField INDICES_FIELD = new ParseField("indices");
     public static final ParseField ANALYTICS_COLLECTION_NAME_FIELD = new ParseField("analytics_collection_name");
     public static final ParseField UPDATED_AT_MILLIS_FIELD = new ParseField("updated_at_millis");
-    public static final ParseField SEARCH_ALIAS_NAME_FIELD = new ParseField("search_alias");
     public static final ParseField BINARY_CONTENT_FIELD = new ParseField("binary_content");
 
     static {
@@ -120,7 +111,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         PARSER.declareStringArray(constructorArg(), INDICES_FIELD);
         PARSER.declareStringOrNull(optionalConstructorArg(), ANALYTICS_COLLECTION_NAME_FIELD);
         PARSER.declareLong(optionalConstructorArg(), UPDATED_AT_MILLIS_FIELD);
-        PARSER.declareString(optionalConstructorArg(), SEARCH_ALIAS_NAME_FIELD);
     }
 
     /**
@@ -165,7 +155,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         if (analyticsCollectionName != null) {
             builder.field(ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), analyticsCollectionName);
         }
-        builder.field(SEARCH_ALIAS_NAME_FIELD.getPreferredName(), searchAlias);
         builder.field(UPDATED_AT_MILLIS_FIELD.getPreferredName(), updatedAtMillis);
         builder.endObject();
         return builder;
@@ -206,10 +195,6 @@ public class SearchApplication implements Writeable, ToXContentObject {
         this.updatedAtMillis = updatedAtMillis;
     }
 
-    public String searchAlias() {
-        return searchAlias;
-    }
-
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -218,13 +203,12 @@ public class SearchApplication implements Writeable, ToXContentObject {
         return name.equals(app.name)
             && Arrays.equals(indices, app.indices)
             && Objects.equals(analyticsCollectionName, app.analyticsCollectionName)
-            && updatedAtMillis == app.updatedAtMillis()
-            && Objects.equals(searchAlias, app.searchAlias());
+            && updatedAtMillis == app.updatedAtMillis();
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(name, analyticsCollectionName, updatedAtMillis, searchAlias);
+        int result = Objects.hash(name, analyticsCollectionName, updatedAtMillis);
         result = 31 * result + Arrays.hashCode(indices);
         return result;
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -198,7 +198,7 @@ public class SearchApplicationIndexService {
     }
 
     private static String getSearchAliasName(SearchApplication app) {
-        return app.searchAlias();
+        return app.name();
     }
 
     /**
@@ -339,7 +339,7 @@ public class SearchApplicationIndexService {
      *
      */
     public void deleteSearchApplicationAndAlias(String resourceName, ActionListener<DeleteResponse> listener) {
-        removeAlias(SearchApplication.getSearchAliasName(resourceName), new ActionListener<AcknowledgedResponse>() {
+        removeAlias(resourceName, new ActionListener<>() {
             @Override
             public void onResponse(AcknowledgedResponse acknowledgedResponse) {
                 deleteSearchApplication(resourceName, listener);
@@ -407,7 +407,6 @@ public class SearchApplicationIndexService {
         return new SearchApplicationListItem(
             resourceName,
             documentFields.get(SearchApplication.INDICES_FIELD.getPreferredName()).getValues().toArray(String[]::new),
-            SearchApplication.getSearchAliasName(resourceName),
             documentFields.get(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName()).getValue()
         );
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationListItem.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationListItem.java
@@ -27,24 +27,20 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
 
     public static final ParseField NAME_FIELD = new ParseField("name");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
-    public static final ParseField SEARCH_ALIAS_NAME_FIELD = new ParseField("search_alias");
     public static final ParseField ANALYTICS_COLLECTION_NAME_FIELD = new ParseField("analytics_collection_name");
     private final String name;
     private final String[] indices;
-    private final String searchAlias;
     private final String analyticsCollectionName;
 
-    public SearchApplicationListItem(String name, String[] indices, String searchAlias, @Nullable String analyticsCollectionName) {
+    public SearchApplicationListItem(String name, String[] indices, @Nullable String analyticsCollectionName) {
         this.name = name;
         this.indices = indices;
-        this.searchAlias = searchAlias;
         this.analyticsCollectionName = analyticsCollectionName;
     }
 
     public SearchApplicationListItem(StreamInput in) throws IOException {
         this.name = in.readString();
         this.indices = in.readStringArray();
-        this.searchAlias = in.readString();
         this.analyticsCollectionName = in.readOptionalString();
     }
 
@@ -53,7 +49,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         builder.startObject();
         builder.field(NAME_FIELD.getPreferredName(), name);
         builder.field(INDICES_FIELD.getPreferredName(), indices);
-        builder.field(SEARCH_ALIAS_NAME_FIELD.getPreferredName(), searchAlias);
         if (analyticsCollectionName != null) {
             builder.field(ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), analyticsCollectionName);
         }
@@ -65,7 +60,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(name);
         out.writeStringArray(indices);
-        out.writeString(searchAlias);
         out.writeOptionalString(analyticsCollectionName);
     }
 
@@ -75,10 +69,6 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
 
     public String[] indices() {
         return indices;
-    }
-
-    public String searchAlias() {
-        return searchAlias;
     }
 
     public String analyticsCollectionName() {
@@ -92,13 +82,12 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         SearchApplicationListItem item = (SearchApplicationListItem) o;
         return name.equals(item.name)
             && Arrays.equals(indices, item.indices)
-            && Objects.equals(searchAlias, item.searchAlias)
             && Objects.equals(analyticsCollectionName, item.analyticsCollectionName);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(name, searchAlias, analyticsCollectionName);
+        int result = Objects.hash(name, analyticsCollectionName);
         result = 31 * result + Arrays.hashCode(indices);
         return result;
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
@@ -198,7 +198,7 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         DeleteResponse resp = awaitDeleteSearchApplication("my_search_app_4");
         assertThat(resp.status(), equalTo(RestStatus.OK));
         expectThrows(ResourceNotFoundException.class, () -> awaitGetSearchApplication("my_search_app_4"));
-        GetAliasesResponse response = searchAppService.getAlias(SearchApplication.getSearchAliasName("my_search_app_4"));
+        GetAliasesResponse response = searchAppService.getAlias("my_search_app_4");
         assertTrue(response.getAliases().isEmpty());
 
         {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationActionResponseSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationActionResponseSerializingTests.java
@@ -24,7 +24,7 @@ public class ListSearchApplicationActionResponseSerializingTests extends Abstrac
     private static ListSearchApplicationAction.Response randomSearchApplicationListItem() {
         return new ListSearchApplicationAction.Response(randomList(10, () -> {
             SearchApplication app = SearchApplicationTestUtils.randomSearchApplication();
-            return new SearchApplicationListItem(app.name(), app.indices(), app.searchAlias(), app.analyticsCollectionName());
+            return new SearchApplicationListItem(app.name(), app.indices(), app.analyticsCollectionName());
         }), randomLongBetween(0, 1000));
     }
 


### PR DESCRIPTION
Since the Search Application alias is always the same as the Search Application name, we don't need to return it as a different field in API responses.