### PR TITLE
[8.7] Check jdk20 assumption after starting cluster (#94413)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -46,8 +46,9 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
      * Test that cluster recovers from a long GC on master that causes other nodes to elect a new one
      */
     public void testMasterNodeGCs() throws Exception {
-        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
         List<String> nodes = startCluster(3);
+        // NOTE: this assume must happen after starting the cluster, so that cleanup will have something to cleanup.
+        assumeFalse("jdk20 removed thread suspend/resume", Runtime.version().feature() >= 20);
 
         String oldMasterNode = internalCluster().getMasterName();
         // a very long GC, but it's OK as we remove the disruption when it has had an effect


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Check jdk20 assumption after starting cluster (#94413)