### PR TITLE
Correct Guava version used for OWASP Java HTML Sanitizer

### DIFF
--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -30,7 +30,7 @@ dependencies {
 
   // watcher deps
   api 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.2'
-  runtimeOnly 'com.google.guava:guava:27.1-jre' // needed by watcher for the html sanitizer
+  runtimeOnly 'com.google.guava:guava:30.1-jre' // needed by watcher for the html sanitizer
   runtimeOnly 'com.google.guava:failureaccess:1.0.1'
   api 'com.sun.mail:jakarta.mail:1.6.4'
   api 'com.sun.activation:jakarta.activation:1.2.1'


### PR DESCRIPTION
The OWASP Java HTML Sanitizer has a dependency on Guava, specifically on version 30.1. However, prior to this PR, we have been using 27.1. While this does not seem to have caused any issues, we should still correct the problem.
