### PR TITLE
Change TokenMetadata to use the minimum compatible transport version

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/FailedNodeRoutingTests.java
@@ -229,7 +229,7 @@ public class FailedNodeRoutingTests extends ESAllocationTestCase {
             buildNewFakeTransportAddress(),
             Collections.emptyMap(),
             roles,
-            VersionUtils.randomIndexCompatibleVersion(random())
+            VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
         );
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/TokenMetadata.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.core.security.authc;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.AbstractNamedDiffable;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NamedDiff;
@@ -94,7 +93,7 @@ public final class TokenMetadata extends AbstractNamedDiffable<ClusterState.Cust
 
     @Override
     public TransportVersion getMinimalSupportedVersion() {
-        return Version.CURRENT.minimumIndexCompatibilityVersion().transportVersion;
+        return TransportVersion.MINIMUM_COMPATIBLE;
     }
 
     @Override

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/cluster/ClusterStatsMonitoringDocTests.java
@@ -311,7 +311,7 @@ public class ClusterStatsMonitoringDocTests extends BaseMonitoringDocTestCase<Cl
         final List<XPackFeatureSet.Usage> usageList = singletonList(new MonitoringFeatureSetUsage(false, null));
 
         final NodeInfo mockNodeInfo = mock(NodeInfo.class);
-        Version mockNodeVersion = Version.CURRENT.minimumIndexCompatibilityVersion();
+        Version mockNodeVersion = Version.CURRENT.minimumCompatibilityVersion();
         when(mockNodeInfo.getVersion()).thenReturn(mockNodeVersion);
         when(mockNodeInfo.getNode()).thenReturn(discoveryNode);
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndexRecoveryMonitoringDocTests.java
@@ -101,7 +101,7 @@ public class IndexRecoveryMonitoringDocTests extends BaseMonitoringDocTestCase<I
             new TransportAddress(TransportAddress.META_ADDRESS, 9301),
             singletonMap("attr", "value_1"),
             singleton(DiscoveryNodeRole.DATA_ROLE),
-            Version.CURRENT.minimumIndexCompatibilityVersion()
+            Version.CURRENT.minimumCompatibilityVersion()
         );
 
         final ShardId shardId = new ShardId("_index_a", "_uuid_a", 0);


### PR DESCRIPTION
This change to use index compatibility was done in #41517, it should really be node compatibility.

Also fix up a few other instances where index compatibility was used instead of node compatibility in the same commit