### PR TITLE
test-fix: ShardLimits should use values >= 1

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
@@ -53,7 +53,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
                 ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
                 String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
                 ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
-                var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(0, 1000), randomIntBetween(1001, 2000));
+                var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(1, 1000), randomIntBetween(1001, 2000));
                 String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString(), customShardLimits);
                 watermarkByNode.put(nodeName, customWatermark);
                 maxHeadroomByNode.put(nodeName, customMaxHeadroom);
@@ -95,7 +95,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
             String initialWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
             ByteSizeValue initialMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
             HealthMetadata.ShardLimits initialShardLimits = new HealthMetadata.ShardLimits(
-                randomIntBetween(0, 1000),
+                randomIntBetween(1, 1000),
                 randomIntBetween(1001, 2000)
             );
             for (int i = 0; i < numberOfNodes; i++) {


### PR DESCRIPTION
tests were creating random values within an unaccepted interval (0-..), so this change ensures that the value is always greater than or equal to 1

> Failing execution passes:

```
 ./gradlew ':server:internalClusterTest' --tests "org.elasticsearch.health.HealthMetadataServiceIT.testEachMasterPublishesTheirThresholds" -Dtests.seed=8F8ACBE5210B39A4 -Dtests.locale=hu-HU -Dtests.timezone=UTC
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 8.0.2
  OS Info               : Mac OS X 13.2.1 (aarch64)
  JDK Version           : 17.0.5+8-LTS (BellSoft Liberica)
  JAVA_HOME             : /Users/palcantar/.sdkman/candidates/java/17.0.5-librca
  Random Testing Seed   : 8F8ACBE5210B39A4
  In FIPS 140 mode      : false
=======================================

> Task :server:compileInternalClusterTestJava
Note: Some input files use or override a deprecated API.
Note: Recompile with -Xlint:deprecation for details.

> Task :server:internalClusterTest
WARNING: A terminally deprecated method in java.lang.System has been called
WARNING: System::setSecurityManager has been called by org.gradle.api.internal.tasks.testing.worker.TestWorker (file:/Users/palcantar/.gradle/wrapper/dists/gradle-8.0.2-all/25ipb77ce0ypy3f9xdton1ae6/gradle-8.0.2/lib/plugins/gradle-testing-base-8.0.2.jar)
WARNING: Please consider reporting this to the maintainers of org.gradle.api.internal.tasks.testing.worker.TestWorker
WARNING: System::setSecurityManager will be removed in a future release

BUILD SUCCESSFUL in 32s
62 actionable tasks: 3 executed, 4 from cache, 55 up-to-date

Publishing build scan...
https://gradle-enterprise.elastic.co/s/oqwrotamipqus
```

Closes #94451