### PR TITLE
Added more debugging for investigating 'tsdb/25_id_generation/delete over _bulk' test failure

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/tsdb/25_id_generation.yml
@@ -338,6 +338,20 @@ delete over _bulk:
       version: " - 8.1.99"
       reason: ids generation changed in 8.2
 
+  # mget call added to investigate test failure: https://github.com/elastic/elasticsearch/issues/93852
+  # (should be removed when test issue is resolved)
+  - do:
+      mget:
+        index: test
+        body:
+          ids: [ cn4exTOUtxytuLkQAAABeRnR_mY, cZZNs4NdV58ePSPIAAABeRnSA5M ]
+  - match: { docs.0._index: "test" }
+  - match: { docs.0._id: "cn4exTOUtxytuLkQAAABeRnR_mY" }
+  - match: { docs.0.found: true }
+  - match: { docs.1._index: "test" }
+  - match: { docs.1._id: "cZZNs4NdV58ePSPIAAABeRnSA5M" }
+  - match: { docs.1.found: true }
+
   - do:
       bulk:
         index:   test

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -96,6 +96,7 @@ final class PerThreadIDVersionAndSeqNoLookup {
         this.loadedTimestampRange = loadTimestampRange;
         if (loadTimestampRange) {
             PointValues tsPointValues = reader.getPointValues(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD);
+            assert tsPointValues != null : "no timestamp field for reader:" + reader + " and parent:" + reader.getContext().parent.reader();
             minTimestamp = LongPoint.decodeDimension(tsPointValues.getMinPackedValue(), 0);
             maxTimestamp = LongPoint.decodeDimension(tsPointValues.getMaxPackedValue(), 0);
         } else {


### PR DESCRIPTION
Added mget call to verify the documents being deleted actually got indexed. And added an assertion to PerThreadIDVersionAndSeqNoLookup to get more information about the reader if there is no timestamp point values field.

Relates to #93852