### PR TITLE
Introduce ClusterCoordinationPlugin

### DIFF
--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -152,6 +152,7 @@ import org.elasticsearch.persistent.PersistentTasksService;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.AnalysisPlugin;
 import org.elasticsearch.plugins.CircuitBreakerPlugin;
+import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.EnginePlugin;
@@ -899,6 +900,7 @@ public class Node implements Closeable {
                 clusterService.getClusterApplierService(),
                 clusterService.getClusterSettings(),
                 pluginsService.filterPlugins(DiscoveryPlugin.class),
+                pluginsService.filterPlugins(ClusterCoordinationPlugin.class),
                 clusterModule.getAllocationService(),
                 environment.configFile(),
                 gatewayMetaState,

--- a/server/src/main/java/org/elasticsearch/plugins/ClusterCoordinationPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/ClusterCoordinationPlugin.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.coordination.ElectionStrategy;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+public interface ClusterCoordinationPlugin {
+
+    /**
+     * Returns a consumer that validate the initial join cluster state. The validator, unless <code>null</code> is called exactly once per
+     * join attempt but might be called multiple times during the lifetime of a node. Validators are expected to throw a
+     * {@link IllegalStateException} if the node and the cluster-state are incompatible.
+     */
+    default BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
+        return null;
+    }
+
+    /**
+     * Allows plugging in election strategies (see {@link ElectionStrategy}) that define a customized notion of an election quorum.
+     */
+    default Map<String, ElectionStrategy> getElectionStrategies() {
+        return Collections.emptyMap();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/DiscoveryPlugin.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.plugins;
 
-import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.coordination.ElectionStrategy;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.discovery.SeedHostsProvider;
@@ -18,7 +15,6 @@ import org.elasticsearch.transport.TransportService;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.BiConsumer;
 import java.util.function.Supplier;
 
 /**
@@ -68,24 +64,6 @@ public interface DiscoveryPlugin {
         TransportService transportService,
         NetworkService networkService
     ) {
-        return Collections.emptyMap();
-    }
-
-    /**
-     * Returns a consumer that validate the initial join cluster state. The validator, unless <code>null</code> is called exactly once per
-     * join attempt but might be called multiple times during the lifetime of a node. Validators are expected to throw a
-     * {@link IllegalStateException} if the node and the cluster-state are incompatible.
-     */
-    @Deprecated
-    default BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
-        return null;
-    }
-
-    /**
-     * Allows plugging in election strategies (see {@link ElectionStrategy}) that define a customized notion of an election quorum.
-     */
-    @Deprecated
-    default Map<String, ElectionStrategy> getElectionStrategies() {
         return Collections.emptyMap();
     }
 }

--- a/server/src/test/java/org/elasticsearch/discovery/DiscoveryModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/DiscoveryModuleTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.gateway.GatewayMetaState;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
+import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.transport.MockTransportService;
@@ -31,7 +32,6 @@ import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -84,7 +84,11 @@ public class DiscoveryModuleTests extends ESTestCase {
         IOUtils.close(transportService);
     }
 
-    private DiscoveryModule newModule(Settings settings, List<DiscoveryPlugin> plugins) {
+    private DiscoveryModule newModule(
+        Settings settings,
+        List<DiscoveryPlugin> discoveryPlugins,
+        List<ClusterCoordinationPlugin> clusterCoordinationPlugins
+    ) {
         return new DiscoveryModule(
             settings,
             transportService,
@@ -94,7 +98,8 @@ public class DiscoveryModuleTests extends ESTestCase {
             masterService,
             clusterApplier,
             clusterSettings,
-            plugins,
+            discoveryPlugins,
+            clusterCoordinationPlugins,
             null,
             createTempDir().toAbsolutePath(),
             gatewayMetaState,
@@ -105,13 +110,13 @@ public class DiscoveryModuleTests extends ESTestCase {
     }
 
     public void testDefaults() {
-        newModule(Settings.EMPTY, Collections.emptyList());
+        newModule(Settings.EMPTY, List.of(), List.of());
         // just checking it doesn't throw
     }
 
     public void testUnknownDiscovery() {
         Settings settings = Settings.builder().put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), "dne").build();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newModule(settings, Collections.emptyList()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newModule(settings, List.of(), List.of()));
         assertEquals("Unknown discovery type [dne]", e.getMessage());
     }
 
@@ -122,13 +127,13 @@ public class DiscoveryModuleTests extends ESTestCase {
             created.set(true);
             return hostsResolver -> Collections.emptyList();
         });
-        newModule(settings, Collections.singletonList(plugin));
+        newModule(settings, List.of(plugin), List.of());
         assertTrue(created.get());
     }
 
     public void testUnknownSeedsProvider() {
         Settings settings = Settings.builder().put(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "dne").build();
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newModule(settings, Collections.emptyList()));
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newModule(settings, List.of(), List.of()));
         assertEquals("Unknown seed providers [dne]", e.getMessage());
     }
 
@@ -137,14 +142,17 @@ public class DiscoveryModuleTests extends ESTestCase {
         DummyHostsProviderPlugin plugin2 = () -> Collections.singletonMap("dup", () -> null);
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> newModule(Settings.EMPTY, Arrays.asList(plugin1, plugin2))
+            () -> newModule(Settings.EMPTY, List.of(plugin1, plugin2), List.of())
         );
         assertEquals("Cannot register seed provider [dup] twice", e.getMessage());
     }
 
     public void testSettingsSeedsProvider() {
         DummyHostsProviderPlugin plugin = () -> Collections.singletonMap("settings", () -> null);
-        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> newModule(Settings.EMPTY, Arrays.asList(plugin)));
+        IllegalArgumentException e = expectThrows(
+            IllegalArgumentException.class,
+            () -> newModule(Settings.EMPTY, List.of(plugin), List.of())
+        );
         assertEquals("Cannot register seed provider [settings] twice", e.getMessage());
     }
 
@@ -167,7 +175,7 @@ public class DiscoveryModuleTests extends ESTestCase {
         Settings settings = Settings.builder()
             .putList(DiscoveryModule.DISCOVERY_SEED_PROVIDERS_SETTING.getKey(), "provider1", "provider3")
             .build();
-        newModule(settings, Arrays.asList(plugin1, plugin2, plugin3));
+        newModule(settings, List.of(plugin1, plugin2, plugin3), List.of());
         assertTrue(created1.get());
         assertFalse(created2.get());
         assertTrue(created3.get());
@@ -178,14 +186,15 @@ public class DiscoveryModuleTests extends ESTestCase {
             "custom",
             () -> { throw new AssertionError("created hosts provider which was not selected"); }
         );
-        newModule(Settings.EMPTY, Collections.singletonList(plugin));
+        newModule(Settings.EMPTY, List.of(plugin), List.of());
     }
 
     public void testJoinValidator() {
         BiConsumer<DiscoveryNode, ClusterState> consumer = (a, b) -> {};
         DiscoveryModule module = newModule(
             Settings.builder().put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.MULTI_NODE_DISCOVERY_TYPE).build(),
-            Collections.singletonList(new DiscoveryPlugin() {
+            List.of(),
+            List.of(new ClusterCoordinationPlugin() {
                 @Override
                 public BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
                     return consumer;
@@ -203,7 +212,8 @@ public class DiscoveryModuleTests extends ESTestCase {
             Settings.builder()
                 .put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.LEGACY_MULTI_NODE_DISCOVERY_TYPE)
                 .build(),
-            Collections.emptyList()
+            List.of(),
+            List.of()
         );
         assertCriticalWarnings(
             "Support for setting [discovery.type] to [zen] is deprecated and will be removed in a future version. Set this setting to "

--- a/server/src/test/java/org/elasticsearch/plugins/PluginIntrospectorTests.java
+++ b/server/src/test/java/org/elasticsearch/plugins/PluginIntrospectorTests.java
@@ -9,14 +9,14 @@
 package org.elasticsearch.plugins;
 
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
+import org.elasticsearch.cluster.routing.allocation.allocator.ShardsAllocator;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
 
@@ -388,12 +387,13 @@ public class PluginIntrospectorTests extends ESTestCase {
     }
 
     public void testDeprecatedMethod() {
-        class JoinValidatorPlugin extends Plugin implements DiscoveryPlugin {
+        class TestClusterPlugin extends Plugin implements ClusterPlugin {
+            @SuppressWarnings("removal")
             @Override
-            public BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
-                return null;
+            public Map<String, Supplier<ShardsAllocator>> getShardsAllocators(Settings settings, ClusterSettings clusterSettings) {
+                return Map.of();
             }
         }
-        assertThat(pluginIntrospector.deprecatedMethods(JoinValidatorPlugin.class), hasEntry("getJoinValidator", "DiscoveryPlugin"));
+        assertThat(pluginIntrospector.deprecatedMethods(TestClusterPlugin.class), hasEntry("getShardsAllocators", "ClusterPlugin"));
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -63,6 +63,7 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.persistent.PersistentTasksExecutor;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.AnalysisPlugin;
+import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
 import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.EnginePlugin;
@@ -126,6 +127,7 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
         NetworkPlugin,
         ClusterPlugin,
         DiscoveryPlugin,
+        ClusterCoordinationPlugin,
         MapperPlugin,
         AnalysisPlugin,
         PersistentTaskPlugin,
@@ -481,7 +483,7 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
     @Override
     public Map<String, ElectionStrategy> getElectionStrategies() {
         Map<String, ElectionStrategy> electionStrategies = new HashMap<>();
-        filterPlugins(DiscoveryPlugin.class).stream().forEach(p -> electionStrategies.putAll(p.getElectionStrategies()));
+        filterPlugins(ClusterCoordinationPlugin.class).stream().forEach(p -> electionStrategies.putAll(p.getElectionStrategies()));
         return electionStrategies;
     }
 
@@ -525,7 +527,7 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
     @Override
     public BiConsumer<DiscoveryNode, ClusterState> getJoinValidator() {
         // There can be only one.
-        List<BiConsumer<DiscoveryNode, ClusterState>> items = filterPlugins(DiscoveryPlugin.class).stream()
+        List<BiConsumer<DiscoveryNode, ClusterState>> items = filterPlugins(ClusterCoordinationPlugin.class).stream()
             .map(p -> p.getJoinValidator())
             .collect(Collectors.toList());
         if (items.size() > 1) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -59,8 +59,8 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.LicensedFeature;
 import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.ClusterPlugin;
-import org.elasticsearch.plugins.DiscoveryPlugin;
 import org.elasticsearch.plugins.ExtensiblePlugin;
 import org.elasticsearch.plugins.IngestPlugin;
 import org.elasticsearch.plugins.MapperPlugin;
@@ -381,7 +381,7 @@ public class Security extends Plugin
         IngestPlugin,
         NetworkPlugin,
         ClusterPlugin,
-        DiscoveryPlugin,
+        ClusterCoordinationPlugin,
         MapperPlugin,
         ExtensiblePlugin,
         SearchPlugin,

--- a/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePlugin.java
+++ b/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/votingonly/VotingOnlyNodePlugin.java
@@ -30,7 +30,7 @@ import org.elasticsearch.discovery.DiscoveryModule;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.ActionPlugin;
-import org.elasticsearch.plugins.DiscoveryPlugin;
+import org.elasticsearch.plugins.ClusterCoordinationPlugin;
 import org.elasticsearch.plugins.NetworkPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesService;
@@ -58,7 +58,7 @@ import java.util.Map;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 
-public class VotingOnlyNodePlugin extends Plugin implements DiscoveryPlugin, NetworkPlugin, ActionPlugin {
+public class VotingOnlyNodePlugin extends Plugin implements ClusterCoordinationPlugin, NetworkPlugin, ActionPlugin {
 
     private static final String VOTING_ONLY_ELECTION_STRATEGY = "supports_voting_only";
 


### PR DESCRIPTION
Today `DiscoveryPlugin` allows to modify the behaviour of discovery (which is a reasonable thing for third-party plugins to do) and also certain aspects of cluster coordination (which is not).

This commit introduces `ClusterCoordinationPlugin` to segregate the internal-only customization of cluster coordination from the pluggable customizations of discovery.