### PR TITLE
[7.17] Add checks for exception loops through suppressed exceptions (#93944)

### DIFF
--- a/docs/changelog/93944.yaml
+++ b/docs/changelog/93944.yaml
@@ -1,0 +1,6 @@
+pr: 93944
+summary: Add checks for exception loops through suppressed exceptions only
+area: Infra/Core
+type: bug
+issues:
+ - 93943

--- a/server/src/main/java/org/elasticsearch/ElasticsearchStatusException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchStatusException.java
@@ -45,8 +45,8 @@ public class ElasticsearchStatusException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         RestStatus.writeTo(out, status);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
+++ b/server/src/main/java/org/elasticsearch/action/FailedNodeException.java
@@ -34,8 +34,8 @@ public class FailedNodeException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(nodeId);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/RoutingMissingException.java
+++ b/server/src/main/java/org/elasticsearch/action/RoutingMissingException.java
@@ -52,8 +52,8 @@ public class RoutingMissingException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeString(type);
         out.writeString(id);
     }

--- a/server/src/main/java/org/elasticsearch/action/TimestampParsingException.java
+++ b/server/src/main/java/org/elasticsearch/action/TimestampParsingException.java
@@ -38,8 +38,8 @@ public class TimestampParsingException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(timestamp);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchPhaseExecutionException.java
@@ -43,8 +43,8 @@ public class SearchPhaseExecutionException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(phaseName);
         out.writeArray(shardFailures);
     }

--- a/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlockException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/block/ClusterBlockException.java
@@ -41,8 +41,8 @@ public class ClusterBlockException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         if (blocks != null) {
             out.writeCollection(blocks);
         } else {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IllegalShardRoutingStateException.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IllegalShardRoutingStateException.java
@@ -35,8 +35,8 @@ public class IllegalShardRoutingStateException extends RoutingException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         shard.writeTo(out);
     }
 

--- a/server/src/main/java/org/elasticsearch/common/ParsingException.java
+++ b/server/src/main/java/org/elasticsearch/common/ParsingException.java
@@ -93,8 +93,8 @@ public class ParsingException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeInt(lineNumber);
         out.writeInt(columnNumber);
     }

--- a/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
+++ b/server/src/main/java/org/elasticsearch/common/breaker/CircuitBreakingException.java
@@ -48,8 +48,8 @@ public class CircuitBreakingException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeLong(byteLimit);
         out.writeLong(bytesWanted);
         if (out.getVersion().onOrAfter(Version.V_7_0_0)) {

--- a/server/src/main/java/org/elasticsearch/common/io/stream/NotSerializableExceptionWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/NotSerializableExceptionWrapper.java
@@ -52,8 +52,8 @@ public final class NotSerializableExceptionWrapper extends ElasticsearchExceptio
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeString(name);
         RestStatus.writeTo(out, status);
     }

--- a/server/src/main/java/org/elasticsearch/index/engine/RecoveryEngineException.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/RecoveryEngineException.java
@@ -29,8 +29,8 @@ public class RecoveryEngineException extends EngineException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeInt(phase);
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
+++ b/server/src/main/java/org/elasticsearch/index/query/QueryShardException.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.query;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.rest.RestStatus;
 
@@ -45,10 +44,5 @@ public class QueryShardException extends ElasticsearchException {
     @Override
     public RestStatus status() {
         return RestStatus.BAD_REQUEST;
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
     }
 }

--- a/server/src/main/java/org/elasticsearch/index/shard/IllegalIndexShardStateException.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IllegalIndexShardStateException.java
@@ -39,8 +39,8 @@ public class IllegalIndexShardStateException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeByte(currentState.id());
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/IndexTemplateMissingException.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndexTemplateMissingException.java
@@ -33,8 +33,8 @@ public class IndexTemplateMissingException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(name);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/InvalidIndexTemplateException.java
+++ b/server/src/main/java/org/elasticsearch/indices/InvalidIndexTemplateException.java
@@ -33,8 +33,8 @@ public class InvalidIndexTemplateException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(name);
     }
 

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverFilesRecoveryException.java
@@ -47,8 +47,8 @@ public class RecoverFilesRecoveryException extends ElasticsearchException implem
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeInt(numberOfFiles);
         totalFilesSize.writeTo(out);
     }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryException.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryException.java
@@ -44,8 +44,8 @@ public class RepositoryException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(repository);
     }
 }

--- a/server/src/main/java/org/elasticsearch/script/ScriptException.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptException.java
@@ -86,8 +86,8 @@ public class ScriptException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeStringArray(scriptStack.toArray(new String[0]));
         out.writeString(script);
         out.writeString(lang);

--- a/server/src/main/java/org/elasticsearch/search/SearchContextMissingException.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchContextMissingException.java
@@ -40,8 +40,8 @@ public class SearchContextMissingException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         contextId.writeTo(out);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/SearchException.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchException.java
@@ -38,8 +38,8 @@ public class SearchException extends ElasticsearchException implements Elasticse
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         if (shardTarget == null) {
             out.writeBoolean(false);
         } else {

--- a/server/src/main/java/org/elasticsearch/search/SearchParseException.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchParseException.java
@@ -48,8 +48,8 @@ public class SearchParseException extends SearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeInt(lineNumber);
         out.writeInt(columnNumber);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -64,8 +64,8 @@ public class MultiBucketConsumerService {
         }
 
         @Override
-        public void writeTo(StreamOutput out) throws IOException {
-            super.writeTo(out);
+        protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+            super.writeTo(out, nestedExceptionsWriter);
             out.writeInt(maxBuckets);
         }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotException.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotException.java
@@ -63,8 +63,8 @@ public class SnapshotException extends ElasticsearchException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(repositoryName);
         out.writeOptionalString(snapshotName);
     }

--- a/server/src/main/java/org/elasticsearch/transport/ActionNotFoundTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ActionNotFoundTransportException.java
@@ -33,8 +33,8 @@ public class ActionNotFoundTransportException extends TransportException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalString(action);
     }
 

--- a/server/src/main/java/org/elasticsearch/transport/ActionTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ActionTransportException.java
@@ -44,8 +44,8 @@ public class ActionTransportException extends TransportException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalWriteable(address);
         out.writeOptionalString(action);
     }

--- a/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectTransportException.java
@@ -41,8 +41,8 @@ public class ConnectTransportException extends ActionTransportException {
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeOptionalWriteable(node);
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.common.io.stream;
 
-import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -48,7 +47,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
 
 /**
  * Tests for {@link StreamOutput}.
@@ -929,30 +927,5 @@ public class BytesStreamsTests extends ESTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
         out.writeZLong(timeValue.duration());
         assertEqualityAfterSerialize(timeValue, 1 + out.bytes().length());
-    }
-
-    public void testWriteCircularReferenceException() throws IOException {
-        IOException rootEx = new IOException("disk broken");
-        AlreadyClosedException ace = new AlreadyClosedException("closed", rootEx);
-        rootEx.addSuppressed(ace); // circular reference
-
-        BytesStreamOutput testOut = new BytesStreamOutput();
-        AssertionError error = expectThrows(AssertionError.class, () -> testOut.writeException(rootEx));
-        assertThat(error.getMessage(), containsString("too many nested exceptions"));
-        assertThat(error.getCause(), equalTo(rootEx));
-
-        BytesStreamOutput prodOut = new BytesStreamOutput() {
-            @Override
-            boolean failOnTooManyNestedExceptions(Throwable throwable) {
-                assertThat(throwable, sameInstance(rootEx));
-                return true;
-            }
-        };
-        prodOut.writeException(rootEx);
-        StreamInput in = prodOut.bytes().streamInput();
-        Exception newEx = in.readException();
-        assertThat(newEx, instanceOf(IOException.class));
-        assertThat(newEx.getMessage(), equalTo("disk broken"));
-        assertArrayEquals(newEx.getStackTrace(), rootEx.getStackTrace());
     }
 }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportException.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportException.java
@@ -53,7 +53,7 @@ public class ExportException extends ElasticsearchException implements Iterable<
     }
 
     @Override
-    public void writeTo(StreamOutput out) throws IOException {
+    protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
         super.writeTo(out);
         out.writeVInt(exceptions.size());
         for (ExportException e : exceptions) {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportException.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/ExportException.java
@@ -54,7 +54,7 @@ public class ExportException extends ElasticsearchException implements Iterable<
 
     @Override
     protected void writeTo(StreamOutput out, Writer<Throwable> nestedExceptionsWriter) throws IOException {
-        super.writeTo(out);
+        super.writeTo(out, nestedExceptionsWriter);
         out.writeVInt(exceptions.size());
         for (ExportException e : exceptions) {
             e.writeTo(out);


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Add checks for exception loops through suppressed exceptions (#93944)](https://github.com/elastic/elasticsearch/pull/93944)

<!--- Backport version: 8.9.7 -->