### PR TITLE
[7.17] Log HTTP response trace when sending is complete

### DIFF
--- a/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
+++ b/server/src/main/java/org/elasticsearch/http/DefaultRestChannel.java
@@ -131,16 +131,24 @@ public class DefaultRestChannel extends AbstractRestChannel implements RestChann
             addCookies(httpResponse);
 
             ActionListener<Void> listener = ActionListener.wrap(() -> Releasables.close(toClose));
-            try (ThreadContext.StoredContext existing = threadContext.stashContext()) {
+            if (tracerLog != null) {
+                final String finalContentLength = contentLength;
+                final String finalOpaque = opaque;
+                listener = ActionListener.runAfter(
+                    listener,
+                    () -> tracerLog.traceResponse(restResponse, httpChannel, finalContentLength, finalOpaque, request.getRequestId(), true)
+                );
+            }
+            try (ThreadContext.StoredContext ignored = threadContext.stashContext()) {
                 httpChannel.sendResponse(httpResponse, listener);
             }
             success = true;
         } finally {
             if (success == false) {
                 Releasables.close(toClose);
-            }
-            if (tracerLog != null) {
-                tracerLog.traceResponse(restResponse, httpChannel, contentLength, opaque, request.getRequestId(), success);
+                if (tracerLog != null) {
+                    tracerLog.traceResponse(restResponse, httpChannel, contentLength, opaque, request.getRequestId(), false);
+                }
             }
         }
     }

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/FakeRestRequest.java
@@ -149,7 +149,7 @@ public class FakeRestRequest extends RestRequest {
 
         @Override
         public void sendResponse(HttpResponse response, ActionListener<Void> listener) {
-
+            listener.onResponse(null);
         }
 
         @Override


### PR DESCRIPTION
HttpTracer logs a message when an HTTP response is sent to a HttpChannel but that does not mean the response sending process is completed.

This pull request changes the HttpTracer so that the message is now logged when the sending is complete.

Backport of #94436