### PR TITLE
[8.7] Mute 380_sort_segments (#94473)

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
@@ -49,7 +49,7 @@
 ---
 "Test that index segments are NOT sorted on timestamp field when @timestamp field is dynamically added":
   - skip:
-      version: " - 7.99.99"
+      version: " - " # Tracked at https://github.com/elastic/elasticsearch/issues/94357
       reason: "sorting segments was added in 7.16"
       features: allowed_warnings
 
@@ -110,7 +110,7 @@
 ---
 "Test if segments are missing @timestamp field we don't get errors":
   - skip:
-      version: " - 7.99.99"
+      version: " - " # Tracked at https://github.com/elastic/elasticsearch/issues/94357
       reason: "sorting segments was added in 7.16"
       features: allowed_warnings
 


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Mute 380_sort_segments (#94473)