### PR TITLE
Fix metadata _size when it comes to stored fields extraction

### DIFF
--- a/docs/changelog/94483.yaml
+++ b/docs/changelog/94483.yaml
@@ -1,0 +1,6 @@
+pr: 94483
+summary: Fix metadata `_size` when it comes to stored fields extraction
+area: Search
+type: bug
+issues:
+ - 94468

--- a/plugins/mapper-size/src/internalClusterTest/java/org/elasticsearch/index/mapper/size/SizeMappingIT.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/elasticsearch/index/mapper/size/SizeMappingIT.java
@@ -116,5 +116,37 @@ public class SizeMappingIT extends ESIntegTestCase {
         // this should not work when requesting fields via wildcard expression
         searchResponse = client().prepareSearch("test").addFetchField("*").get();
         assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+
+        // This should STILL work
+        searchResponse = client().prepareSearch("test").addStoredField("*").get();
+        assertNotNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+    }
+
+    public void testWildCardWithFieldsWhenDisabled() throws Exception {
+        assertAcked(prepareCreate("test").setMapping("_size", "enabled=false"));
+        final String source = "{\"f\":\"" + randomAlphaOfLengthBetween(1, 100) + "\"}";
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource(source, XContentType.JSON));
+        SearchResponse searchResponse = client().prepareSearch("test").addFetchField("_size").get();
+        assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+
+        searchResponse = client().prepareSearch("test").addFetchField("*").get();
+        assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+
+        searchResponse = client().prepareSearch("test").addStoredField("*").get();
+        assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+    }
+
+    public void testWildCardWithFieldsWhenNotProvided() throws Exception {
+        assertAcked(prepareCreate("test"));
+        final String source = "{\"f\":\"" + randomAlphaOfLengthBetween(1, 100) + "\"}";
+        indexRandom(true, client().prepareIndex("test").setId("1").setSource(source, XContentType.JSON));
+        SearchResponse searchResponse = client().prepareSearch("test").addFetchField("_size").get();
+        assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+
+        searchResponse = client().prepareSearch("test").addFetchField("*").get();
+        assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
+
+        searchResponse = client().prepareSearch("test").addStoredField("*").get();
+        assertNull(searchResponse.getHits().getHits()[0].getFields().get("_size"));
     }
 }

--- a/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
+++ b/plugins/mapper-size/src/main/java/org/elasticsearch/index/mapper/size/SizeFieldMapper.java
@@ -20,6 +20,7 @@ import org.elasticsearch.index.mapper.SourceLoader;
 import org.elasticsearch.index.mapper.ValueFetcher;
 import org.elasticsearch.index.query.SearchExecutionContext;
 
+import java.util.Collections;
 import java.util.List;
 
 public class SizeFieldMapper extends MetadataFieldMapper {
@@ -50,7 +51,7 @@ public class SizeFieldMapper extends MetadataFieldMapper {
 
     private static class SizeFieldType extends NumberFieldType {
         SizeFieldType() {
-            super(NAME, NumberType.INTEGER);
+            super(NAME, NumberType.INTEGER, true, true, true, false, null, Collections.emptyMap(), null, false, null, null);
         }
 
         @Override


### PR DESCRIPTION
Corrects weird regression introduced in: https://github.com/elastic/elasticsearch/pull/91269

Previous to that change, getting `_size` worked when using `storedFields`. However, that change now detects if a field type declares itself as `stored`. Even though `_size` is stored, it didn't declare itself as such. 

This change fixes that.

closes https://github.com/elastic/elasticsearch/issues/94468