### PR TITLE
[7.17] Correct Guava version used for OWASP Java HTML Sanitizer (#94442)

### DIFF
--- a/x-pack/plugin/watcher/build.gradle
+++ b/x-pack/plugin/watcher/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
   // watcher deps
   api 'com.googlecode.owasp-java-html-sanitizer:owasp-java-html-sanitizer:20211018.2'
-  runtimeOnly 'com.google.guava:guava:27.1-jre' // needed by watcher for the html sanitizer
+  runtimeOnly 'com.google.guava:guava:30.1-jre' // needed by watcher for the html sanitizer
   runtimeOnly 'com.google.guava:failureaccess:1.0.1'
   api 'com.sun.mail:jakarta.mail:1.6.4'
   api 'com.sun.activation:jakarta.activation:1.2.1'


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Correct Guava version used for OWASP Java HTML Sanitizer (#94442)](https://github.com/elastic/elasticsearch/pull/94442)

<!--- Backport version: 7.3.0 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)