### PR TITLE
[Test] Increase timeout for RcsCcsCommonYamlTestSuiteIT

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -55,7 +55,7 @@ import static org.elasticsearch.test.rest.yaml.CcsCommonYamlTestSuiteIT.rewrite;
  * using the client running against the "write" cluster.
  *
  */
-@TimeoutSuite(millis = 15 * TimeUnits.MINUTE) // to account for slow as hell VMs
+@TimeoutSuite(millis = 20 * TimeUnits.MINUTE) // to account for slow as hell VMs
 public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static final Logger logger = LogManager.getLogger(RcsCcsCommonYamlTestSuiteIT.class);


### PR DESCRIPTION
The test suite has been recently expanded to including more YAML tests, PIT and msearh (#93720), EQL (#94265) and SQL (#94416). The original 15 min timeout needs to be bumped a bit to accomodate the new tests. This PR increases it for additional 5 minutes.

PS: It is possible that the corresponding CcsCommonYamlTestSuite also needs to similar increase in timeout. This PR does not touch it because we haven't observed similar timeout for it so far and also tests with existing CCS model and security disabled run a bit faster. So it may not be an issue yet.

Resolves: #94491
