### PR TITLE
Introduce more leniency to date formats that mistakenly use week-based years instead of years of era.

### DIFF
--- a/docs/changelog/94499.yaml
+++ b/docs/changelog/94499.yaml
@@ -1,0 +1,6 @@
+pr: 94499
+summary: Introduce more leniency to date formats that mistakenly use week-based years
+  instead of years of era
+area: Infra/Core
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
+++ b/server/src/main/java/org/elasticsearch/common/time/DateFormatters.java
@@ -2219,10 +2219,18 @@ public class DateFormatters {
                 .with(weekFields.weekOfWeekBasedYear(), accessor.get(weekFields.weekOfWeekBasedYear()))
                 .with(TemporalAdjusters.previousOrSame(weekFields.getFirstDayOfWeek()));
         } else {
-            return LocalDate.ofEpochDay(0)
+            LocalDate localDate = LocalDate.ofEpochDay(0)
                 .with(weekFields.weekBasedYear(), accessor.get(weekFields.weekBasedYear()))
                 .with(TemporalAdjusters.previousOrSame(weekFields.getFirstDayOfWeek()));
-
+            // Note: we would often end here in case of a user mistakenly using YYYY (week-based year) instead of yyyy (year of era). So
+            // we're doing a best effort to also look at month-of-year and day-of-month.
+            if (accessor.isSupported(ChronoField.MONTH_OF_YEAR)) {
+                localDate = localDate.with(MONTH_OF_YEAR, accessor.get(MONTH_OF_YEAR));
+            }
+            if (accessor.isSupported(DAY_OF_MONTH)) {
+                localDate = localDate.with(DAY_OF_MONTH, accessor.get(DAY_OF_MONTH));
+            }
+            return localDate;
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
+++ b/server/src/test/java/org/elasticsearch/common/time/JavaDateMathParserTests.java
@@ -97,6 +97,13 @@ public class JavaDateMathParserTests extends ESTestCase {
         assertDateMathEquals(formatter.toDateMathParser(), "2022W02", "2022-01-10T23:59:59.999Z", 0, true, ZoneOffset.UTC);
     }
 
+    public void testWeekBasedDateLeniency() {
+        // Many users mistakenly use YYYY when they actually meant yyyy. Since date formats can't be changed on existing indices, we're
+        // doing a best effort to make these bad formats work.
+        DateFormatter formatter = DateFormatter.forPattern("YYYY-MM-dd");
+        assertDateMathEquals(formatter.toDateMathParser(), "2022-03-04", "2022-03-04T23:59:59.999Z", 0, true, ZoneOffset.UTC);
+    }
+
     public void testDayOfYear() {
         DateFormatter formatter = DateFormatter.forPattern("yyyy-DDD'T'HH:mm:ss.SSS");
         assertDateMathEquals(formatter.toDateMathParser(), "2022-104T14:08:30.293", "2022-04-14T14:08:30.293", 0, true, ZoneOffset.UTC);


### PR DESCRIPTION
It's frequent for users to mistakenly configure a week-based year instead of a year of era in their date formats. These error are challenging to address since date formats can't be changed on existing indices. So this change proposes to add some leniency to formats that use a week-based year so that the month-of-year and day-of-month fields no longer get ignored when parsing range queries.