### PR TITLE
Only clear request cache when request=true in clear cache API

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -1174,7 +1174,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
     /**
      * Clears the caches for the given shard id if the shard is still allocated on this node
      */
-    public boolean clearCaches(boolean queryCache, boolean fieldDataCache, String... fields) {
+    public boolean clearCaches(boolean queryCache, boolean fieldDataCache, boolean requestCache, String... fields) {
         boolean clearedAtLeastOne = false;
         if (queryCache) {
             clearedAtLeastOne = true;
@@ -1190,7 +1190,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
                 }
             }
         }
-        if (clearedAtLeastOne == false) {
+        if (clearedAtLeastOne == false && requestCache == false) {
             if (fields.length == 0) {
                 indexCache.clear("api");
                 indexFieldData.clear();

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -1704,7 +1704,7 @@ public class IndicesService extends AbstractLifecycleComponent
         final IndexService service = indexService(shardId.getIndex());
         if (service != null) {
             IndexShard shard = service.getShardOrNull(shardId.id());
-            final boolean clearedAtLeastOne = service.clearCaches(queryCache, fieldDataCache, fields);
+            final boolean clearedAtLeastOne = service.clearCaches(queryCache, fieldDataCache, requestCache, fields);
             if ((requestCache || (clearedAtLeastOne == false && fields.length == 0)) && shard != null) {
                 indicesRequestCache.clear(new IndexShardCacheEntity(shard));
             }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/AbstractStringFieldDataTestCase.java
@@ -632,7 +632,7 @@ public abstract class AbstractStringFieldDataTestCase extends AbstractFieldDataI
         refreshReader();
         assertThat(ifd.loadGlobal(topLevelReader), not(sameInstance(globalOrdinals)));
 
-        indexService.clearCaches(false, true);
+        indexService.clearCaches(false, true, false);
         assertThat(indicesFieldDataCache.getCache().weight(), equalTo(0L));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fielddata/FilterFieldDataTests.java
@@ -51,7 +51,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         final MapperBuilderContext builderContext = MapperBuilderContext.root(false);
 
         {
-            indexService.clearCaches(false, true);
+            indexService.clearCaches(false, true, false);
             MappedFieldType ft = new TextFieldMapper.Builder("high_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(0, random.nextBoolean() ? 100 : 0.5d, 0)
                 .build(builderContext)
@@ -66,7 +66,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
             }
         }
         {
-            indexService.clearCaches(false, true);
+            indexService.clearCaches(false, true, false);
             MappedFieldType ft = new TextFieldMapper.Builder("high_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, 201, 100)
                 .build(builderContext)
@@ -81,7 +81,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         }
 
         {
-            indexService.clearCaches(false, true);// test # docs with value
+            indexService.clearCaches(false, true, false);// test # docs with value
             MappedFieldType ft = new TextFieldMapper.Builder("med_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, Integer.MAX_VALUE, 101)
                 .build(builderContext)
@@ -97,7 +97,7 @@ public class FilterFieldDataTests extends AbstractFieldDataTestCase {
         }
 
         {
-            indexService.clearCaches(false, true);
+            indexService.clearCaches(false, true, false);
             MappedFieldType ft = new TextFieldMapper.Builder("med_freq", createDefaultIndexAnalyzers()).fielddata(true)
                 .fielddataFrequencyFilter(random.nextBoolean() ? 101 : 101d / 200.0d, Integer.MAX_VALUE, 101)
                 .build(builderContext)


### PR DESCRIPTION
The Clear cache API 

````
POST /my-index-000001/_cache/clear?request=true 
````

must clears the request cache only, but it will also clear query cache and fielddata, In a production environment, it will cause a significant decrease of query performance.

this change will only clear request cache when  `request=true `, If there are no  objections for this change, I will add more tests.
