### PR TITLE
[ML] Add _meta field to data frame analytics config

### DIFF
--- a/docs/changelog/94529.yaml
+++ b/docs/changelog/94529.yaml
@@ -1,0 +1,5 @@
+pr: 94529
+summary: Add `_meta` field to data frame analytics config
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
+++ b/docs/reference/ml/anomaly-detection/apis/close-job.asciidoc
@@ -41,7 +41,7 @@ Depending upon the size of the job, it could take several minutes to close and
 the equivalent time to re-open.
 
 After it is closed, the job has a minimal overhead on the cluster except for
-maintaining its meta data. Therefore it is a best practice to close jobs that
+maintaining its metadata. Therefore it is a best practice to close jobs that
 are no longer required to process data.
 
 When a {dfeed} that has a specified end date stops, it automatically closes

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -253,6 +253,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
 (Optional, integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 
+`_meta`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=meta]
+
 `num_top_classes`::::
 (Optional, integer)
 Defines the number of categories for which the predicted probabilities are

--- a/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/put-dfanalytics.asciidoc
@@ -253,10 +253,6 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=dfas-max-optimization-rounds]
 (Optional, integer)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=max-trees]
 
-`_meta`::::
-(Optional, object)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=meta]
-
 `num_top_classes`::::
 (Optional, integer)
 Defines the number of categories for which the predicted probabilities are
@@ -510,6 +506,10 @@ The default value is `1`. Using more threads may decrease the time
 necessary to complete the analysis at the cost of using more CPU.
 Note that the process may use additional threads for operational
 functionality other than the analysis itself.
+
+`_meta`::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=meta]
 
 `model_memory_limit`::
 (Optional, string)

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -72,7 +72,7 @@ necessary to complete the analysis at the cost of using more CPU.
 Note that the process may use additional threads for operational
 functionality other than the analysis itself.
 
-`_meta`::::
+`_meta`::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=meta]
 

--- a/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
+++ b/docs/reference/ml/df-analytics/apis/update-dfanalytics.asciidoc
@@ -72,6 +72,10 @@ necessary to complete the analysis at the cost of using more CPU.
 Note that the process may use additional threads for operational
 functionality other than the analysis itself.
 
+`_meta`::::
+(Optional, object)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=meta]
+
 `model_memory_limit`::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-memory-limit-dfa]

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -405,7 +405,7 @@ The value that is compared against the `applies_to` field using the `operator`.
 end::custom-rules-conditions-value[]
 
 tag::custom-settings[]
-Advanced configuration option. Contains custom meta data about the job. For
+Advanced configuration option. Contains custom metadata about the job. For
 example, it can contain custom URL information as shown in
 {ml-docs}/ml-configuring-url.html[Adding custom URLs to {ml} results].
 end::custom-settings[]
@@ -1312,7 +1312,7 @@ By default, this value is calculated during hyperparameter optimization.
 end::max-trees-trained-models[]
 
 tag::meta[]
-Advanced configuration option. Contains custom meta data about the job. For
+Advanced configuration option. Contains custom metadata about the job. For
 example, it can contain custom URL information.
 end::meta[]
 

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1311,6 +1311,11 @@ The maximum number of decision trees in the forest. The maximum value is 2000.
 By default, this value is calculated during hyperparameter optimization.
 end::max-trees-trained-models[]
 
+tag::meta[]
+Advanced configuration option. Contains custom meta data about the job. For
+example, it can contain custom URL information.
+end::meta[]
+
 tag::method[]
 The method that {oldetection} uses. Available methods are `lof`, `ldof`,
 `distance_kth_nn`, `distance_knn`, and `ensemble`. The default value is

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -247,6 +247,10 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         return maxNumThreads;
     }
 
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         final boolean forInternalStorage = params.paramAsBoolean(ToXContentParams.FOR_INTERNAL_STORAGE, false);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -67,6 +68,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     public static final ParseField VERSION = new ParseField("version");
     public static final ParseField ALLOW_LAZY_START = new ParseField("allow_lazy_start");
     public static final ParseField MAX_NUM_THREADS = new ParseField("max_num_threads");
+    public static final ParseField META = new ParseField("_meta");
 
     public static final ObjectParser<Builder, Void> STRICT_PARSER = createParser(false);
     public static final ObjectParser<Builder, Void> LENIENT_PARSER = createParser(true);
@@ -94,6 +96,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         );
         parser.declareBoolean(Builder::setAllowLazyStart, ALLOW_LAZY_START);
         parser.declareInt(Builder::setMaxNumThreads, MAX_NUM_THREADS);
+        parser.declareObject(Builder::setMeta, (p, c) -> p.mapOrdered(), META);
         if (ignoreUnknownFields) {
             // Headers are not parsed by the strict (config) parser, so headers supplied in the _body_ of a REST request will be rejected.
             // (For config, headers are explicitly transferred from the auth headers by code in the put data frame actions.)
@@ -139,6 +142,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
     private final Version version;
     private final boolean allowLazyStart;
     private final int maxNumThreads;
+    private final Map<String, Object> meta;
 
     private DataFrameAnalyticsConfig(
         String id,
@@ -152,7 +156,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         Instant createTime,
         Version version,
         boolean allowLazyStart,
-        Integer maxNumThreads
+        Integer maxNumThreads,
+        Map<String, Object> meta
     ) {
         this.id = ExceptionsHelper.requireNonNull(id, ID);
         this.description = description;
@@ -170,6 +175,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             throw ExceptionsHelper.badRequestException("[{}] must be a positive integer", MAX_NUM_THREADS.getPreferredName());
         }
         this.maxNumThreads = maxNumThreads == null ? 1 : maxNumThreads;
+        this.meta = meta == null ? null : Collections.unmodifiableMap(meta);
     }
 
     public DataFrameAnalyticsConfig(StreamInput in) throws IOException {
@@ -185,6 +191,12 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.version = in.readBoolean() ? Version.readVersion(in) : null;
         this.allowLazyStart = in.readBoolean();
         this.maxNumThreads = in.readVInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            Map<String, Object> readMeta = in.readMap();
+            this.meta = readMeta == null ? null : Collections.unmodifiableMap(readMeta);
+        } else {
+            this.meta = null;
+        }
     }
 
     public String getId() {
@@ -277,6 +289,9 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         builder.field(MODEL_MEMORY_LIMIT.getPreferredName(), getModelMemoryLimit().getStringRep());
         builder.field(ALLOW_LAZY_START.getPreferredName(), allowLazyStart);
         builder.field(MAX_NUM_THREADS.getPreferredName(), maxNumThreads);
+        if (meta != null) {
+            builder.field(META.getPreferredName(), meta);
+        }
         builder.endObject();
         return builder;
     }
@@ -300,6 +315,9 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         }
         out.writeBoolean(allowLazyStart);
         out.writeVInt(maxNumThreads);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            out.writeGenericMap(meta);
+        }
     }
 
     @Override
@@ -319,7 +337,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             && Objects.equals(createTime, other.createTime)
             && Objects.equals(version, other.version)
             && Objects.equals(allowLazyStart, other.allowLazyStart)
-            && maxNumThreads == other.maxNumThreads;
+            && maxNumThreads == other.maxNumThreads
+            && Objects.equals(meta, other.meta);
     }
 
     @Override
@@ -336,7 +355,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             createTime,
             version,
             allowLazyStart,
-            maxNumThreads
+            maxNumThreads,
+            meta
         );
     }
 
@@ -373,6 +393,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         private Version version;
         private boolean allowLazyStart;
         private Integer maxNumThreads;
+        private Map<String, Object> meta;
 
         public Builder() {}
 
@@ -396,6 +417,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             this.version = config.version;
             this.allowLazyStart = config.allowLazyStart;
             this.maxNumThreads = config.maxNumThreads;
+            this.meta = config.meta;
         }
 
         public String getId() {
@@ -463,6 +485,11 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
             return this;
         }
 
+        public Builder setMeta(Map<String, Object> meta) {
+            this.meta = meta;
+            return this;
+        }
+
         /**
          * Builds {@link DataFrameAnalyticsConfig} object.
          */
@@ -480,7 +507,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
                 createTime,
                 version,
                 allowLazyStart,
-                maxNumThreads
+                maxNumThreads,
+                meta
             );
         }
 
@@ -502,7 +530,8 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
                 createTime,
                 version,
                 allowLazyStart,
-                maxNumThreads
+                maxNumThreads,
+                meta
             );
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
@@ -123,6 +123,10 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         return maxNumThreads;
     }
 
+    public Map<String, Object> getMeta() {
+        return meta;
+    }
+
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
@@ -169,6 +173,9 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         }
         if (maxNumThreads != null) {
             builder.setMaxNumThreads(maxNumThreads);
+        }
+        if (meta != null) {
+            builder.setMeta(meta);
         }
         return builder;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdate.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.dataframe;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -17,6 +18,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
@@ -41,6 +44,7 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         );
         PARSER.declareBoolean(Builder::setAllowLazyStart, DataFrameAnalyticsConfig.ALLOW_LAZY_START);
         PARSER.declareInt(Builder::setMaxNumThreads, DataFrameAnalyticsConfig.MAX_NUM_THREADS);
+        PARSER.declareObject(Builder::setMeta, (p, c) -> p.mapOrdered(), DataFrameAnalyticsConfig.META);
     }
 
     private final String id;
@@ -48,13 +52,15 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
     private final ByteSizeValue modelMemoryLimit;
     private final Boolean allowLazyStart;
     private final Integer maxNumThreads;
+    private final Map<String, Object> meta;
 
     private DataFrameAnalyticsConfigUpdate(
         String id,
         @Nullable String description,
         @Nullable ByteSizeValue modelMemoryLimit,
         @Nullable Boolean allowLazyStart,
-        @Nullable Integer maxNumThreads
+        @Nullable Integer maxNumThreads,
+        @Nullable Map<String, Object> meta
     ) {
         this.id = id;
         this.description = description;
@@ -68,6 +74,7 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
             );
         }
         this.maxNumThreads = maxNumThreads;
+        this.meta = meta == null ? null : Collections.unmodifiableMap(meta);
     }
 
     public DataFrameAnalyticsConfigUpdate(StreamInput in) throws IOException {
@@ -76,6 +83,12 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::readFrom);
         this.allowLazyStart = in.readOptionalBoolean();
         this.maxNumThreads = in.readOptionalVInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            Map<String, Object> readMeta = in.readMap();
+            this.meta = readMeta == null ? null : Collections.unmodifiableMap(readMeta);
+        } else {
+            this.meta = null;
+        }
     }
 
     @Override
@@ -85,6 +98,9 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         out.writeOptionalWriteable(modelMemoryLimit);
         out.writeOptionalBoolean(allowLazyStart);
         out.writeOptionalVInt(maxNumThreads);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            out.writeGenericMap(meta);
+        }
     }
 
     public String getId() {
@@ -122,6 +138,9 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         }
         if (maxNumThreads != null) {
             builder.field(DataFrameAnalyticsConfig.MAX_NUM_THREADS.getPreferredName(), maxNumThreads);
+        }
+        if (meta != null) {
+            builder.field(DataFrameAnalyticsConfig.META.getPreferredName(), meta);
         }
         builder.endObject();
         return builder;
@@ -210,6 +229,7 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
         private ByteSizeValue modelMemoryLimit;
         private Boolean allowLazyStart;
         private Integer maxNumThreads;
+        private Map<String, Object> meta;
 
         public Builder(String id) {
             this.id = id;
@@ -244,8 +264,13 @@ public class DataFrameAnalyticsConfigUpdate implements Writeable, ToXContentObje
             return this;
         }
 
+        public Builder setMeta(Map<String, Object> meta) {
+            this.meta = meta;
+            return this;
+        }
+
         public DataFrameAnalyticsConfigUpdate build() {
-            return new DataFrameAnalyticsConfigUpdate(id, description, modelMemoryLimit, allowLazyStart, maxNumThreads);
+            return new DataFrameAnalyticsConfigUpdate(id, description, modelMemoryLimit, allowLazyStart, maxNumThreads, meta);
         }
     }
 }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/core/ml/config_index_mappings.json
@@ -413,6 +413,10 @@
       "max_num_threads" : {
         "type" : "integer"
       },
+      "_meta" : {
+        "type" : "object",
+        "enabled" : false
+      },
       "model_memory_limit": {
         "type" : "keyword"
       },

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchModule;
@@ -115,6 +116,9 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
         if (instance.getAnalysis() instanceof Classification) {
             builder.setAnalysis(ClassificationTests.mutateForVersion((Classification) instance.getAnalysis(), version));
         }
+        if (version.before(TransportVersion.V_8_8_0)) {
+            builder.setMeta(null);
+        }
         return builder.build();
     }
 
@@ -178,6 +182,9 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
         }
         if (randomBoolean()) {
             builder.setMaxNumThreads(randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            builder.setMeta(randomMeta());
         }
         return builder;
     }
@@ -464,5 +471,19 @@ public class DataFrameAnalyticsConfigTests extends AbstractBWCSerializationTestC
             XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry()),
             json.streamInput()
         );
+    }
+
+    public static Map<String, Object> randomMeta() {
+        return rarely() ? null : randomMap(0, 10, () -> {
+            String key = randomAlphaOfLengthBetween(1, 10);
+            Object value = switch (randomIntBetween(0, 3)) {
+                case 0 -> null;
+                case 1 -> randomLong();
+                case 2 -> randomAlphaOfLengthBetween(1, 10);
+                case 3 -> randomMap(0, 3, () -> Tuple.tuple(randomAlphaOfLengthBetween(1, 10), randomAlphaOfLengthBetween(1, 10)));
+                default -> throw new AssertionError("Error in test code");
+            };
+            return Tuple.tuple(key, value);
+        });
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdateTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import java.io.IOException;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests.randomMeta;
 import static org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests.randomValidId;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
@@ -58,6 +59,9 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
         }
         if (randomBoolean()) {
             builder.setMaxNumThreads(randomIntBetween(1, 20));
+        }
+        if (randomBoolean()) {
+            builder.setMeta(randomMeta());
         }
         return builder.build();
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfigUpdateTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.test.AbstractXContentSerializingTestCase;
 import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Objects;
 
 import static org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfigTests.randomMeta;
@@ -73,6 +74,24 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
         assertThat(
             update.mergeWithConfig(config).build(),
             is(equalTo(new DataFrameAnalyticsConfig.Builder(config).setDescription("new description").build()))
+        );
+    }
+
+    public void testMergeWithConfig_UpdatedMeta() {
+        String id = randomValidId();
+        Map<String, Object> oldMeta = randomMeta();
+        Map<String, Object> newMeta;
+        // There's a limitation that you cannot completely remove a _meta field in an update.
+        // The best you can do is set it to an empty object. The test needs to reflect this limitation.
+        // (custom_settings on anomaly detection jobs have the same limitation.)
+        do {
+            newMeta = randomMeta();
+        } while (newMeta == null);
+        DataFrameAnalyticsConfig config = DataFrameAnalyticsConfigTests.createRandomBuilder(id).setMeta(oldMeta).build();
+        DataFrameAnalyticsConfigUpdate update = new DataFrameAnalyticsConfigUpdate.Builder(id).setMeta(newMeta).build();
+        assertThat(
+            update.mergeWithConfig(config).build(),
+            is(equalTo(new DataFrameAnalyticsConfig.Builder(config).setMeta(newMeta).build()))
         );
     }
 
@@ -256,6 +275,7 @@ public class DataFrameAnalyticsConfigUpdateTests extends AbstractXContentSeriali
         return (update.getDescription() == null || Objects.equals(config.getDescription(), update.getDescription()))
             && (update.getModelMemoryLimit() == null || Objects.equals(config.getModelMemoryLimit(), update.getModelMemoryLimit()))
             && (update.isAllowLazyStart() == null || Objects.equals(config.isAllowLazyStart(), update.isAllowLazyStart()))
-            && (update.getMaxNumThreads() == null || Objects.equals(config.getMaxNumThreads(), update.getMaxNumThreads()));
+            && (update.getMaxNumThreads() == null || Objects.equals(config.getMaxNumThreads(), update.getMaxNumThreads()))
+            && (update.getMeta() == null || Objects.equals(config.getMeta(), update.getMeta()));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPostDataFrameAnalyticsUpdateAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPostDataFrameAnalyticsUpdateAction.java
@@ -13,12 +13,14 @@ import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.action.UpdateDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
+import static org.elasticsearch.xpack.ml.rest.dataframe.RestPutDataFrameAnalyticsAction.MAX_REQUEST_SIZE;
 
 public class RestPostDataFrameAnalyticsUpdateAction extends BaseRestHandler {
 
@@ -34,6 +36,14 @@ public class RestPostDataFrameAnalyticsUpdateAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        if (restRequest.contentLength() > MAX_REQUEST_SIZE.getBytes()) {
+            throw ExceptionsHelper.badRequestException(
+                "Request is too large: was [{}b], expected at most [{}]",
+                restRequest.contentLength(),
+                MAX_REQUEST_SIZE
+            );
+        }
+
         String id = restRequest.param(DataFrameAnalyticsConfig.ID.getPreferredName());
         XContentParser parser = restRequest.contentParser();
         UpdateDataFrameAnalyticsAction.Request updateRequest = UpdateDataFrameAnalyticsAction.Request.parseRequest(id, parser);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPutDataFrameAnalyticsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/dataframe/RestPutDataFrameAnalyticsAction.java
@@ -7,12 +7,14 @@
 package org.elasticsearch.xpack.ml.rest.dataframe;
 
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.action.PutDataFrameAnalyticsAction;
 import org.elasticsearch.xpack.core.ml.dataframe.DataFrameAnalyticsConfig;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,6 +23,15 @@ import static org.elasticsearch.rest.RestRequest.Method.PUT;
 import static org.elasticsearch.xpack.ml.MachineLearning.BASE_PATH;
 
 public class RestPutDataFrameAnalyticsAction extends BaseRestHandler {
+
+    /**
+     * Maximum allowed size of the REST request.
+     * <p>
+     * It is set so that the user is not able to provide DataFrameAnalyticsConfig._meta map of arbitrary
+     * size. Such configs could be a problem upon fetch so it's better to prevent them on put and update
+     * actions.
+     */
+    static final ByteSizeValue MAX_REQUEST_SIZE = ByteSizeValue.ofMb(5);
 
     @Override
     public List<Route> routes() {
@@ -34,6 +45,14 @@ public class RestPutDataFrameAnalyticsAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        if (restRequest.contentLength() > MAX_REQUEST_SIZE.getBytes()) {
+            throw ExceptionsHelper.badRequestException(
+                "Request is too large: was [{}b], expected at most [{}]",
+                restRequest.contentLength(),
+                MAX_REQUEST_SIZE
+            );
+        }
+
         String id = restRequest.param(DataFrameAnalyticsConfig.ID.getPreferredName());
         XContentParser parser = restRequest.contentParser();
         PutDataFrameAnalyticsAction.Request putRequest = PutDataFrameAnalyticsAction.Request.parseRequest(id, parser);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/data_frame_analytics_crud.yml
@@ -48,7 +48,8 @@ setup:
               "index": "index-dest"
             },
             "analysis": {"outlier_detection":{}},
-            "analyzed_fields": [ "obj1.*", "obj2.*" ]
+            "analyzed_fields": [ "obj1.*", "obj2.*" ],
+            "_meta" : {"my_custom_tag":"custom", "version":7}
           }
   - match: { id: "simple-outlier-detection-with-query" }
   - match: { source.index: ["index-source"] }
@@ -62,6 +63,8 @@ setup:
     }
   }}
   - match: { analyzed_fields: {"includes" : ["obj1.*", "obj2.*" ], "excludes": [] } }
+  - match: { _meta.my_custom_tag: "custom" }
+  - match: { _meta.version: 7 }
   - is_true: create_time
   - is_true: version
   - is_true: authorization.roles


### PR DESCRIPTION
This PR adds a new field, `_meta`, to the data frame analytics configuration.

The `_meta` field stores an arbitrary key-value map. Keys are strings. Values are arbitrary objects
(possibly also maps).

The `_meta` field can be updated using the data frame analytics `_update` endpoint.