### PR TITLE
Rebuild routing allocation from desired balance info

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/IndexMetadata.java
@@ -74,6 +74,7 @@ import java.util.Objects;
 import java.util.OptionalDouble;
 import java.util.OptionalLong;
 import java.util.Set;
+import java.util.function.Consumer;
 import java.util.function.Function;
 
 import static org.elasticsearch.cluster.metadata.Metadata.CONTEXT_MODE_PARAM;
@@ -1849,6 +1850,13 @@ public class IndexMetadata implements Diffable<IndexMetadata>, ToXContentFragmen
 
         public Builder settings(Settings settings) {
             this.settings = settings;
+            return this;
+        }
+
+        public Builder applySettingUpdate(Consumer<Settings.Builder> updater) {
+            var settingsBuilder = Settings.builder().put(this.settings);
+            updater.accept(settingsBuilder);
+            this.settings = settingsBuilder.build();
             return this;
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceSimulationTests.java
@@ -8,40 +8,271 @@
 
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterModule;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.DiskUsage;
 import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.routing.IndexRoutingTable;
+import org.elasticsearch.cluster.routing.RoutingNodes;
+import org.elasticsearch.cluster.routing.RoutingNodesHelper;
+import org.elasticsearch.cluster.routing.RoutingTable;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.elasticsearch.cluster.routing.TestShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.cluster.routing.allocation.WriteLoadForecaster;
+import org.elasticsearch.cluster.routing.allocation.decider.ClusterRebalanceAllocationDecider;
+import org.elasticsearch.cluster.routing.allocation.decider.ConcurrentRebalanceAllocationDecider;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.index.Index;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.cluster.ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING;
+import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
 
 public class DesiredBalanceSimulationTests extends ESAllocationTestCase {
 
-    public void testDesiredBalanceFromDesiredBalanceOutput() {
+    public void testDesiredBalanceFromDesiredBalanceOutput() throws IOException {
 
-        var allocator = createDesiredBalanceShardsAllocator(Settings.EMPTY);
+        var data = parse();
 
-        var allocation = new RoutingAllocation(
-            randomAllocationDeciders(Settings.EMPTY, ClusterSettings.createBuiltInClusterSettings()),
-            parseMinimizedClusterState(),
-            parseClusterInfo(),
-            SnapshotShardSizeInfo.EMPTY,
-            0L
-        );
+        logger.info("Initial stats {}", stats(data));
 
-        allocator.allocate(allocation, ActionListener.noop());
+        Settings settings = Settings.builder()
+//            .put(
+//                ClusterModule.SHARDS_ALLOCATOR_TYPE_SETTING.getKey(),
+//                ClusterModule.DESIRED_BALANCE_ALLOCATOR
+//            )
+            .put(
+                ClusterRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ALLOW_REBALANCE_SETTING.getKey(),
+                ClusterRebalanceAllocationDecider.ClusterRebalanceType.INDICES_PRIMARIES_ACTIVE
+            )
+            .put(
+                ConcurrentRebalanceAllocationDecider.CLUSTER_ROUTING_ALLOCATION_CLUSTER_CONCURRENT_REBALANCE_SETTING.getKey(),
+                50
+            )
+            .build();
 
-        logger.info("Result routing nodes {}", allocation.routingNodes());
+//        var allocator = createShardsAllocator(settings);
+//        var allocation = new RoutingAllocation(
+//            randomAllocationDeciders(settings, ClusterSettings.createBuiltInClusterSettings(settings)),
+//            data.clusterState.mutableRoutingNodes(),
+//            data.clusterState,
+//            data.clusterInfo,
+//            SnapshotShardSizeInfo.EMPTY,
+//            0L
+//        );
+//        allocator.allocate(allocation, ActionListener.noop());
+//
+//        logger.info("Same: {}, initializing: {}",
+//            data.clusterState.getRoutingNodes().equals(allocation.routingNodes()),
+//            RoutingNodesHelper.shardsWithState(allocation.routingNodes(), INITIALIZING).size()
+//        );
+
+        var service = createAllocationService(settings, () -> data.clusterInfo);
+        var newClusterState = applyStartedShardsUntilNoChange(data.clusterState, service);
+
+        logger.info("Updated stats {}", stats(newClusterState, data.clusterInfo));
     }
 
-    private static ClusterInfo parseClusterInfo() {
-        return ClusterInfo.EMPTY;
+    private record Data(ClusterState clusterState, ClusterInfo clusterInfo) {}
+
+    private Data parse() throws IOException {
+
+        var metadataBuilder = Metadata.builder();
+        var routingTableBuilder = RoutingTable.builder();
+        var discoveryNodesBuilder = DiscoveryNodes.builder();
+
+        final Map<String, DiskUsage> leastAvailableSpaceUsage = new HashMap<>();
+        final Map<String, DiskUsage> mostAvailableSpaceUsage = new HashMap<>();
+        final Map<String, Long> shardSizes = new HashMap<>();
+
+        try (
+            var parser = createParser(
+                JsonXContent.jsonXContent,
+                DesiredBalanceSimulationTests.class.getResourceAsStream("allocated_index.json")
+            )
+        ) {
+            var data = parser.map();
+            var clusterInfo = (Map<String, Object>) data.get("cluster_info");
+            var nodes = (Map<String, Object>) clusterInfo.get("nodes");
+
+            for (var nodeEntry : nodes.entrySet()) {
+                var nodeId = nodeEntry.getKey();
+                var nodeNode = (Map<String, Object>) nodeEntry.getValue();
+
+                var nodeName = (String) nodeNode.get("node_name");
+                var leastAvailable = (Map<String, Object>) nodeNode.get("least_available");
+                var mostAvailable = (Map<String, Object>) nodeNode.get("most_available");
+
+                leastAvailableSpaceUsage.put(
+                    nodeId,
+                    new DiskUsage(
+                        nodeId,
+                        nodeName,
+                        (String) leastAvailable.get("path"),
+                        (long) leastAvailable.get("total_bytes"),
+                        (long) leastAvailable.get("free_bytes")
+                    )
+                );
+
+                mostAvailableSpaceUsage.put(
+                    nodeId,
+                    new DiskUsage(
+                        nodeId,
+                        nodeName,
+                        (String) mostAvailable.get("path"),
+                        (long) mostAvailable.get("total_bytes"),
+                        (long) mostAvailable.get("free_bytes")
+                    )
+                );
+            }
+
+            for (var shardEntry : ((Map<String, Number>) clusterInfo.get("shard_sizes")).entrySet()) {
+                String shardId = shardEntry.getKey();
+                shardId = shardId.substring(0, shardId.length() - "_bytes".length());
+                shardSizes.put(shardId, shardEntry.getValue().longValue());
+            }
+        }
+
+        var writeLoadForecast = new HashMap<String, Double>();
+        var shardSizeForecast = new HashMap<String, Long>();
+        try (
+            var parser = createParser(JsonXContent.jsonXContent, DesiredBalanceSimulationTests.class.getResourceAsStream("routing.json"))
+        ) {
+            var data = parser.map();
+            var metadata = (Map<String, Object>) data.get("metadata");
+            var indices = (Map<String, Object>) metadata.get("indices");
+
+            for (var indexEntry : indices.entrySet()) {
+                var indexName = indexEntry.getKey();
+                var indexNode = (Map<String, Object>) indexEntry.getValue();
+
+                if (indexNode.containsKey("write_load_forecast")) {
+                    writeLoadForecast.put(indexName, ((Number) indexNode.get("write_load_forecast")).doubleValue());
+                }
+                if (indexNode.containsKey("shard_size_forecast")) {
+                    shardSizeForecast.put(indexName, ((Number) indexNode.get("shard_size_forecast")).longValue());
+                }
+            }
+        }
+
+        try (
+            var parser = createParser(
+                JsonXContent.jsonXContent,
+                DesiredBalanceSimulationTests.class.getResourceAsStream("desired_balance.json")
+            )
+        ) {
+            var data = parser.map();
+            var routingTable = (Map<String, Object>) data.get("routing_table");
+
+            for (var indexEntry : routingTable.entrySet()) {
+                var index = new Index(indexEntry.getKey(), ClusterState.UNKNOWN_UUID);
+                var indexNode = (Map<String, Object>) indexEntry.getValue();
+
+                var indexRoutingTableBuilder = IndexRoutingTable.builder(index);
+                int primaries = indexNode.size();
+                int replicas = 0;
+                Double forecastWriteLoad = null;
+                Long forecastShardSizeInBytes = null;
+
+                var indexMetadataBuilder = IndexMetadata.builder(index.getName())
+                    .settings(Settings.builder().put("index.version.created", Version.CURRENT).build());
+
+                for (var shardEntry : indexNode.entrySet()) {
+                    var shardId = new ShardId(index, Integer.parseInt(shardEntry.getKey()));
+                    var shardNode = (Map<String, Object>) shardEntry.getValue();
+
+                    var shardCopies = (List<Map<String, Object>>) shardNode.get("current");
+                    var desiredNode = (Map<String, Object>) shardNode.get("desired");
+
+                    replicas = shardCopies.size() - 1;
+                    if (shardNode.containsKey("forecast_write_load")) {
+                        forecastWriteLoad = (Double) shardNode.get("forecast_write_load");
+                    }
+                    if (shardNode.containsKey("forecast_shard_size_in_bytes")) {
+                        forecastShardSizeInBytes = (Long) shardNode.get("forecast_shard_size_in_bytes");
+                    }
+
+                    var inSyncIds = new HashSet<String>();
+                    for (Map<String, Object> shardCopy : shardCopies) {
+
+                        String node = (String) shardCopy.get("node");
+                        if (discoveryNodesBuilder.get(node) == null) {
+                            discoveryNodesBuilder.add(newNode(node, node, MASTER_DATA_ROLES));
+                        }
+                        String relocatingNode = (String) shardCopy.get("relocating_node");
+                        if (relocatingNode != null && discoveryNodesBuilder.get(relocatingNode) == null) {
+                            discoveryNodesBuilder.add(newNode(relocatingNode, relocatingNode, MASTER_DATA_ROLES));
+                        }
+
+                        ShardRouting shardRouting = TestShardRouting.newShardRouting(
+                            shardId,
+                            node,
+                            relocatingNode,
+                            (boolean) shardCopy.get("primary"),
+                            ShardRoutingState.valueOf((String) shardCopy.get("state"))
+                        );
+                        indexRoutingTableBuilder.addShard(
+                            shardRouting
+                        );
+                        inSyncIds.add(shardRouting.allocationId().getId());
+                    }
+                    indexMetadataBuilder.putInSyncAllocationIds(shardId.id(), inSyncIds);
+                }
+
+                indexMetadataBuilder
+                    .numberOfShards(primaries)
+                    .numberOfReplicas(replicas);
+                if (forecastWriteLoad != null) {
+                    indexMetadataBuilder.indexWriteLoadForecast(forecastWriteLoad);
+                } else if (writeLoadForecast.containsKey(index.getName())) {
+                    indexMetadataBuilder.indexWriteLoadForecast(writeLoadForecast.get(index.getName()));
+                }
+                if (forecastShardSizeInBytes != null) {
+                    indexMetadataBuilder.shardSizeInBytesForecast(forecastShardSizeInBytes);
+                } else if (shardSizeForecast.containsKey(index.getName())) {
+                    indexMetadataBuilder.shardSizeInBytesForecast(shardSizeForecast.get(index.getName()));
+                }
+
+                metadataBuilder.put(indexMetadataBuilder.build(), false);
+                routingTableBuilder.add(indexRoutingTableBuilder);
+            }
+
+            var clusterState = ClusterState.builder(ClusterName.DEFAULT)
+                .metadata(metadataBuilder)
+                .routingTable(routingTableBuilder)
+                .nodes(discoveryNodesBuilder)
+                .build();
+
+            return new Data(
+                clusterState,
+                new ClusterInfo(leastAvailableSpaceUsage, mostAvailableSpaceUsage, shardSizes, Map.of(), Map.of(), Map.of())
+            );
+        }
     }
 
-    private static ClusterState parseMinimizedClusterState() {
-        return ClusterState.builder(ClusterName.DEFAULT).build();
+    private ClusterBalanceStats stats(Data data) {
+        return stats(data.clusterState, data.clusterInfo);
+    }
+
+    private ClusterBalanceStats stats(ClusterState clusterState, ClusterInfo clusterInfo) {
+        return ClusterBalanceStats.createFrom(clusterState, clusterInfo, WriteLoadForecaster.DEFAULT);
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceSimulationTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceSimulationTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.routing.allocation.allocator;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.cluster.ClusterInfo;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ESAllocationTestCase;
+import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
+
+public class DesiredBalanceSimulationTests extends ESAllocationTestCase {
+
+    public void testDesiredBalanceFromDesiredBalanceOutput() {
+
+        var allocator = createDesiredBalanceShardsAllocator(Settings.EMPTY);
+
+        var allocation = new RoutingAllocation(
+            randomAllocationDeciders(Settings.EMPTY, ClusterSettings.createBuiltInClusterSettings()),
+            parseMinimizedClusterState(),
+            parseClusterInfo(),
+            SnapshotShardSizeInfo.EMPTY,
+            0L
+        );
+
+        allocator.allocate(allocation, ActionListener.noop());
+
+        logger.info("Result routing nodes {}", allocation.routingNodes());
+    }
+
+    private static ClusterInfo parseClusterInfo() {
+        return ClusterInfo.EMPTY;
+    }
+
+    private static ClusterState parseMinimizedClusterState() {
+        return ClusterState.builder(ClusterName.DEFAULT).build();
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -150,7 +150,7 @@ public abstract class ESAllocationTestCase extends ESTestCase {
             : randomFrom(BALANCED_ALLOCATOR, DESIRED_BALANCE_ALLOCATOR);
     }
 
-    private static DesiredBalanceShardsAllocator createDesiredBalanceShardsAllocator(Settings settings) {
+    protected static DesiredBalanceShardsAllocator createDesiredBalanceShardsAllocator(Settings settings) {
         var queue = new DeterministicTaskQueue();
         return new DesiredBalanceShardsAllocator(
             createBuiltInClusterSettings(settings),

--- a/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/ESAllocationTestCase.java
@@ -150,7 +150,7 @@ public abstract class ESAllocationTestCase extends ESTestCase {
             : randomFrom(BALANCED_ALLOCATOR, DESIRED_BALANCE_ALLOCATOR);
     }
 
-    protected static DesiredBalanceShardsAllocator createDesiredBalanceShardsAllocator(Settings settings) {
+    private static DesiredBalanceShardsAllocator createDesiredBalanceShardsAllocator(Settings settings) {
         var queue = new DeterministicTaskQueue();
         return new DesiredBalanceShardsAllocator(
             createBuiltInClusterSettings(settings),


### PR DESCRIPTION
(DO NOT MERGE)
This allows to rebuild routing allocation from the `GET /_internal/desired-balance` output to troubleshoot unbalanced clusters