### PR TITLE
Simplify FieldLookup

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -138,7 +138,8 @@ public class SearchFieldsIT extends ESIntegTestCase {
         static Object fieldsScript(Map<String, Object> vars, String fieldName) {
             Map<?, ?> fields = (Map<?, ?>) vars.get("_fields");
             FieldLookup fieldLookup = (FieldLookup) fields.get(fieldName);
-            return fieldLookup.getValue();
+            List<Object> values = fieldLookup.getValues();
+            return values.isEmpty() ? null : values.get(0);
         }
 
         static Object sourceScript(Map<String, Object> vars, String path) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fields/SearchFieldsIT.java
@@ -138,8 +138,7 @@ public class SearchFieldsIT extends ESIntegTestCase {
         static Object fieldsScript(Map<String, Object> vars, String fieldName) {
             Map<?, ?> fields = (Map<?, ?>) vars.get("_fields");
             FieldLookup fieldLookup = (FieldLookup) fields.get(fieldName);
-            List<Object> values = fieldLookup.getValues();
-            return values.isEmpty() ? null : values.get(0);
+            return fieldLookup.getValue();
         }
 
         static Object sourceScript(Map<String, Object> vars, String path) {

--- a/server/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
@@ -11,22 +11,11 @@ import org.elasticsearch.index.mapper.MappedFieldType;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 public class FieldLookup {
 
-    // we can cached fieldType completely per name, since its on an index/shard level (the lookup, and it does not change within the scope
-    // of a search request)
     private final MappedFieldType fieldType;
-
-    private Map<String, List<Object>> fields;
-
-    private Object value;
-
-    private boolean valueLoaded = false;
-
     private List<Object> values = new ArrayList<>();
-
     private boolean valuesLoaded = false;
 
     FieldLookup(MappedFieldType fieldType) {
@@ -37,51 +26,25 @@ public class FieldLookup {
         return fieldType;
     }
 
-    public Map<String, List<Object>> fields() {
-        return fields;
-    }
-
     /**
      * Sets the post processed values.
      */
-    public void fields(Map<String, List<Object>> fields) {
-        this.fields = fields;
+    public void setValues(List<Object> values) {
+        this.values.clear();
+        this.values.addAll(values);
+        this.valuesLoaded = true;
+    }
+
+    public boolean isLoaded() {
+        return valuesLoaded;
     }
 
     public void clear() {
-        value = null;
-        valueLoaded = false;
         values.clear();
         valuesLoaded = false;
-        fields = null;
-    }
-
-    public boolean isEmpty() {
-        if (valueLoaded) {
-            return value == null;
-        }
-        if (valuesLoaded) {
-            return values.isEmpty();
-        }
-        return getValue() == null;
-    }
-
-    public Object getValue() {
-        if (valueLoaded) {
-            return value;
-        }
-        valueLoaded = true;
-        value = null;
-        List<Object> values = fields.get(fieldType.name());
-        return values != null ? value = values.get(0) : null;
     }
 
     public List<Object> getValues() {
-        if (valuesLoaded) {
-            return values;
-        }
-        valuesLoaded = true;
-        values.clear();
-        return values = fields().get(fieldType.name());
+        return values;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
@@ -15,7 +15,7 @@ import java.util.List;
 public class FieldLookup {
 
     private final MappedFieldType fieldType;
-    private List<Object> values = new ArrayList<>();
+    private final List<Object> values = new ArrayList<>();
     private boolean valuesLoaded = false;
 
     FieldLookup(MappedFieldType fieldType) {
@@ -30,7 +30,7 @@ public class FieldLookup {
      * Sets the post processed values.
      */
     public void setValues(List<Object> values) {
-        this.values.clear();
+        assert valuesLoaded == false : "Call clear() before calling setValues()";
         this.values.addAll(values);
         this.valuesLoaded = true;
     }
@@ -46,5 +46,9 @@ public class FieldLookup {
 
     public List<Object> getValues() {
         return values;
+    }
+
+    public Object getValue() {
+        return values.get(0);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/FieldLookup.java
@@ -44,11 +44,21 @@ public class FieldLookup {
         valuesLoaded = false;
     }
 
+    // exposed by painless
     public List<Object> getValues() {
+        assert valuesLoaded;
         return values;
     }
 
+    // exposed by painless
     public Object getValue() {
-        return values.get(0);
+        assert valuesLoaded;
+        return values.isEmpty() ? null : values.get(0);
+    }
+
+    // exposed by painless
+    public boolean isEmpty() {
+        assert valuesLoaded;
+        return values.isEmpty();
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookup.java
+++ b/server/src/main/java/org/elasticsearch/search/lookup/LeafStoredFieldsLookup.java
@@ -22,8 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
-import static java.util.Collections.singletonMap;
-
 @SuppressWarnings({ "unchecked", "rawtypes" })
 public class LeafStoredFieldsLookup implements Map<Object, FieldLookup> {
 
@@ -133,11 +131,11 @@ public class LeafStoredFieldsLookup implements Map<Object, FieldLookup> {
             data = new FieldLookup(fieldType);
             cachedFieldData.put(name, data);
         }
-        if (data.fields() == null) {
+        if (data.isLoaded() == false) {
             List<Object> values = new ArrayList<>(2);
             SingleFieldsVisitor visitor = new SingleFieldsVisitor(data.fieldType(), values);
             storedFields.document(docId, visitor);
-            data.fields(singletonMap(data.fieldType().name(), values));
+            data.setValues(values);
         }
         return data;
     }


### PR DESCRIPTION
FieldLookup is used to cache values loaded from stored fields for scripts
or value fetchers.  It still has leftover code from when it needed to support
multiple data types, and has different paths for single or multiple values,
all of which are now unnecessary.  This PR removes all the extra indirection
in favour of a simple object cache.