### PR TITLE
[7.17] Allow ILM step transition to the phase terminal step (#91754)

### DIFF
--- a/docs/changelog/91754.yaml
+++ b/docs/changelog/91754.yaml
@@ -1,0 +1,5 @@
+pr: 91754
+summary: Allow ILM step transition to the phase terminal step
+area: ILM+SLM
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStep.java
@@ -21,6 +21,10 @@ public class PhaseCompleteStep extends Step {
         return new PhaseCompleteStep(new StepKey(phase, NAME, NAME), null);
     }
 
+    public static StepKey stepKey(String phase) {
+        return new StepKey(phase, NAME, NAME);
+    }
+
     @Override
     public boolean isRetryable() {
         // this is marker step so it doesn't make sense to be retryable

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/PhaseCompleteStepTests.java
@@ -8,6 +8,8 @@ package org.elasticsearch.xpack.core.ilm;
 
 import org.elasticsearch.xpack.core.ilm.Step.StepKey;
 
+import static org.hamcrest.Matchers.is;
+
 public class PhaseCompleteStepTests extends AbstractStepTestCase<PhaseCompleteStep> {
 
     @Override
@@ -34,5 +36,10 @@ public class PhaseCompleteStepTests extends AbstractStepTestCase<PhaseCompleteSt
     @Override
     public PhaseCompleteStep copyInstance(PhaseCompleteStep instance) {
         return new PhaseCompleteStep(instance.getKey(), instance.getNextStepKey());
+    }
+
+    public void testPhaseCompeteStepKey() {
+        String phaseName = randomAlphaOfLength(30);
+        assertThat(PhaseCompleteStep.stepKey(phaseName), is(new StepKey(phaseName, PhaseCompleteStep.NAME, PhaseCompleteStep.NAME)));
     }
 }

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransition.java
@@ -33,6 +33,7 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
 import org.elasticsearch.xpack.core.ilm.Phase;
+import org.elasticsearch.xpack.core.ilm.PhaseCompleteStep;
 import org.elasticsearch.xpack.core.ilm.PhaseExecutionInfo;
 import org.elasticsearch.xpack.core.ilm.RolloverAction;
 import org.elasticsearch.xpack.core.ilm.Step;
@@ -100,7 +101,9 @@ public final class IndexLifecycleTransition {
 
         // Always allow moving to the terminal step or to a step that's present in the cached phase, even if it doesn't exist in the policy
         if (isNewStepCached == false
-            && (stepRegistry.stepExists(indexPolicySetting, newStepKey) == false && newStepKey.equals(TerminalPolicyStep.KEY) == false)) {
+            && (stepRegistry.stepExists(indexPolicySetting, newStepKey) == false
+                && newStepKey.equals(TerminalPolicyStep.KEY) == false
+                && newStepKey.equals(PhaseCompleteStep.stepKey(lifecycleState.getPhase())) == false)) {
             throw new IllegalArgumentException(
                 "step ["
                     + newStepKey

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/IndexLifecycleTransitionTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.core.ilm.AbstractStepTestCase;
+import org.elasticsearch.xpack.core.ilm.DataTierMigrationRoutedStep;
 import org.elasticsearch.xpack.core.ilm.ErrorStep;
 import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecycleAction;
@@ -33,6 +34,7 @@ import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
 import org.elasticsearch.xpack.core.ilm.LifecyclePolicyTests;
 import org.elasticsearch.xpack.core.ilm.LifecycleSettings;
+import org.elasticsearch.xpack.core.ilm.MigrateAction;
 import org.elasticsearch.xpack.core.ilm.MockAction;
 import org.elasticsearch.xpack.core.ilm.MockStep;
 import org.elasticsearch.xpack.core.ilm.OperationMode;
@@ -606,16 +608,6 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
 
         IndexMetadata meta = buildIndexMetadata("my-policy", executionState);
 
-        Map<String, LifecycleAction> actions = new HashMap<>();
-        actions.put(SetPriorityAction.NAME, new SetPriorityAction(100));
-        Phase hotPhase = new Phase("hot", TimeValue.ZERO, actions);
-        Map<String, Phase> phases = Collections.singletonMap("hot", hotPhase);
-        LifecyclePolicy policyWithoutRollover = new LifecyclePolicy("my-policy", phases);
-        LifecyclePolicyMetadata policyMetadata = new LifecyclePolicyMetadata(policyWithoutRollover, Collections.emptyMap(), 2L, 2L);
-
-        ClusterState existingState = ClusterState.builder(ClusterState.EMPTY_STATE)
-            .metadata(Metadata.builder(Metadata.EMPTY_METADATA).put(meta, false).build())
-            .build();
         try (Client client = new NoOpClient(getTestName())) {
             Step.StepKey currentStepKey = new Step.StepKey("hot", RolloverAction.NAME, WaitForRolloverReadyStep.NAME);
             Step.StepKey nextStepKey = new Step.StepKey("hot", RolloverAction.NAME, RolloverStep.NAME);
@@ -626,6 +618,62 @@ public class IndexLifecycleTransitionTests extends ESTestCase {
                     currentStepKey,
                     nextStepKey,
                     createOneStepPolicyStepRegistry("my-policy", currentStep)
+                );
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+                fail("validateTransition should not throw exception on valid transitions");
+            }
+        }
+    }
+
+    public void testValidateTransitionToCachedStepWhenMissingPhaseFromPolicy() {
+        // we'll test the case when the warm phase was deleted and the next step is the phase complete one
+
+        LifecycleExecutionState.Builder executionState = LifecycleExecutionState.builder()
+            .setPhase("warm")
+            .setAction("migrate")
+            .setStep("check-migration")
+            .setPhaseDefinition(
+                "\n"
+                    + "{\n"
+                    + "  policy : my-policy,\n"
+                    + "  phase_definition : {\n"
+                    + "    min_age 20m,\n"
+                    + "    actions : {\n"
+                    + "      set_priority : {\n"
+                    + "        priority : 150\n"
+                    + "      }\n"
+                    + "    }\n"
+                    + "  },\n"
+                    + "  version : 1,\n"
+                    + "  modified_date_in_millis : 1578521007076\n"
+                    + "}"
+            );
+
+        IndexMetadata meta = buildIndexMetadata("my-policy", executionState);
+
+        try (Client client = new NoOpClient(getTestName())) {
+            Step.StepKey currentStepKey = new Step.StepKey("warm", MigrateAction.NAME, DataTierMigrationRoutedStep.NAME);
+            Step.StepKey nextStepKey = new Step.StepKey("warm", PhaseCompleteStep.NAME, PhaseCompleteStep.NAME);
+
+            Step.StepKey waitForRolloverStepKey = new Step.StepKey("hot", RolloverAction.NAME, WaitForRolloverReadyStep.NAME);
+            Step.StepKey rolloverStepKey = new Step.StepKey("hot", RolloverAction.NAME, RolloverStep.NAME);
+            Step waitForRolloverReadyStep = new WaitForRolloverReadyStep(
+                waitForRolloverStepKey,
+                rolloverStepKey,
+                client,
+                null,
+                null,
+                null,
+                1L
+            );
+
+            try {
+                IndexLifecycleTransition.validateTransition(
+                    meta,
+                    currentStepKey,
+                    nextStepKey,
+                    createOneStepPolicyStepRegistry("my-policy", waitForRolloverReadyStep)
                 );
             } catch (Exception e) {
                 logger.error(e.getMessage(), e);


### PR DESCRIPTION
ILM tries to honour the cached phase however, some steps are implicit (e.g. injected actions or the terminal policy/phase step) Currently ILM would throw an exception if the currently cached phase was removed:
```
step [{"phase":"warm","action":"complete","name":"complete"}] for index [index] with policy [my-policy] does not exist
```

This fixes this scenario allowing ILM to transition to the phase complete step even if the phase has been removed from the actual policy.

(cherry picked from commit 39625567e0fb5acf8d8d5f7a30bd17e4b7e2fab3)
Signed-off-by: Andrei Dan <andrei.dan@elastic.co>

Backport of #91754 