### PR TITLE
Add null check for sort fields over collapse fields

### DIFF
--- a/docs/changelog/94546.yaml
+++ b/docs/changelog/94546.yaml
@@ -1,0 +1,6 @@
+pr: 94546
+summary: Add null check for sort fields over collapse fields
+area: Search
+type: bug
+issues:
+ - 94407

--- a/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/searchafter/SearchAfterBuilder.java
@@ -101,7 +101,7 @@ public class SearchAfterBuilder implements ToXContentObject, Writeable {
             );
         }
 
-        if (collapseField != null && (sortFields.length > 1 || sortFields[0].getField().equals(collapseField) == false)) {
+        if (collapseField != null && (sortFields.length > 1 || Objects.equals(sortFields[0].getField(), collapseField) == false)) {
             throw new IllegalArgumentException(
                 "Cannot use [collapse] in conjunction with ["
                     + SEARCH_AFTER.getPreferredName()


### PR DESCRIPTION
When building a FieldDoc for use in search_after, we check that if there is 
a collapse field specified it is the same as the search field for the top-level
sort.  However, some sorts (eg SCORE or DOC) don't have a search field,
and this can cause a null pointer exception to be thrown.  This commit makes
sure that the case where the search field is null is handled correctly.

Fixes #94407 