### PR TITLE
[Transform] Catch deprecations as `Exception` rather than `IOException`

### DIFF
--- a/docs/changelog/94553.yaml
+++ b/docs/changelog/94553.yaml
@@ -1,0 +1,5 @@
+pr: 94553
+summary: Catch deprecations as `Exception` rather than `IOException`
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
@@ -147,7 +147,7 @@ public class QueryConfig implements SimpleDiffable<QueryConfig>, Writeable, ToXC
 
         try {
             queryFromXContent(source, namedXContentRegistry, deprecationLogger);
-        } catch (IOException e) {
+        } catch (Exception e) {
             onDeprecation.accept(
                 new DeprecationIssue(
                     Level.CRITICAL,


### PR DESCRIPTION
This PR changes the exception type (from `IOException` to `Exception`) caught when calling `QueryConfig.checkForDeprecations` method.
The goal is to catch the deprecation exceptions with type other than `IOException` so that they are reported properly to the user.