### PR TITLE
Add new XContent type for streaming SMILE documents

### DIFF
--- a/docs/changelog/94556.yaml
+++ b/docs/changelog/94556.yaml
@@ -1,0 +1,5 @@
+pr: 94556
+summary: Add new XContent type for streaming SMILE documents
+area: Infra/Core
+type: enhancement
+issues: []

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentProviderImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/XContentProviderImpl.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xcontent.provider.cbor.CborXContentImpl;
 import org.elasticsearch.xcontent.provider.json.JsonStringEncoderImpl;
 import org.elasticsearch.xcontent.provider.json.JsonXContentImpl;
 import org.elasticsearch.xcontent.provider.smile.SmileXContentImpl;
+import org.elasticsearch.xcontent.provider.streamsmile.StreamSmileXContentImpl;
 import org.elasticsearch.xcontent.provider.yaml.YamlXContentImpl;
 import org.elasticsearch.xcontent.spi.XContentProvider;
 
@@ -66,6 +67,21 @@ public class XContentProviderImpl implements XContentProvider {
             @Override
             public XContent XContent() {
                 return SmileXContentImpl.smileXContent();
+            }
+        };
+    }
+
+    @Override
+    public FormatProvider getStreamSmileXContent() {
+        return new FormatProvider() {
+            @Override
+            public XContentBuilder getContentBuilder() throws IOException {
+                return StreamSmileXContentImpl.getContentBuilder();
+            }
+
+            @Override
+            public XContent XContent() {
+                return StreamSmileXContentImpl.streamSmileXContent();
             }
         };
     }

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/streamsmile/StreamSmileXContentGenerator.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/streamsmile/StreamSmileXContentGenerator.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xcontent.provider.streamsmile;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.provider.json.JsonXContentGenerator;
+
+import java.io.OutputStream;
+import java.util.Set;
+
+public class StreamSmileXContentGenerator extends JsonXContentGenerator {
+
+    public StreamSmileXContentGenerator(JsonGenerator jsonGenerator, OutputStream os, Set<String> includes, Set<String> excludes) {
+        super(jsonGenerator, os, includes, excludes);
+    }
+
+    @Override
+    public XContentType contentType() {
+        return XContentType.STREAM_SMILE;
+    }
+
+    @Override
+    public void usePrintLineFeedAtEnd() {
+        // nothing here
+    }
+
+    @Override
+    protected boolean supportsRawWrites() {
+        return false;
+    }
+}

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/streamsmile/StreamSmileXContentParser.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/streamsmile/StreamSmileXContentParser.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xcontent.provider.streamsmile;
+
+import com.fasterxml.jackson.core.JsonParser;
+
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xcontent.provider.json.JsonXContentParser;
+
+public class StreamSmileXContentParser extends JsonXContentParser {
+
+    public StreamSmileXContentParser(XContentParserConfiguration config, JsonParser parser) {
+        super(config, parser);
+    }
+
+    @Override
+    public XContentType contentType() {
+        return XContentType.STREAM_SMILE;
+    }
+
+    @Override
+    public void allowDuplicateKeys(boolean allowDuplicateKeys) {
+        throw new UnsupportedOperationException("Allowing duplicate keys after the parser has been created is not possible for Smile");
+    }
+}

--- a/libs/x-content/impl/src/test/java/org/elasticsearch/xcontent/internal/SmileTests.java
+++ b/libs/x-content/impl/src/test/java/org/elasticsearch/xcontent/internal/SmileTests.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xcontent.internal;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.io.stream.BytesStreamOutput;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+
+public class SmileTests extends ESTestCase {
+
+    public void testSmileBinaryContent() throws IOException {
+        {
+            BytesStreamOutput bos = new BytesStreamOutput();
+            XContentBuilder builder = XContentFactory.smileBuilder(bos).startObject().endObject();
+            builder.close();
+            BytesReference ref = bos.bytes();
+            assertTrue(XContentType.SMILE.xContent().detectContent(ref.array(), ref.arrayOffset(), ref.length()));
+            assertFalse(XContentType.STREAM_SMILE.xContent().detectContent(ref.array(), ref.arrayOffset(), ref.length()));
+        }
+        {
+            BytesStreamOutput bos = new BytesStreamOutput();
+            XContentBuilder builder = XContentFactory.streamSmileBuilder(bos).startObject().endObject();
+            builder.close();
+            BytesReference ref = bos.bytes();
+            assertTrue(XContentType.STREAM_SMILE.xContent().detectContent(ref.array(), ref.arrayOffset(), ref.length()));
+            assertFalse(XContentType.SMILE.xContent().detectContent(ref.array(), ref.arrayOffset(), ref.length()));
+        }
+    }
+}

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentFactory.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentFactory.java
@@ -11,6 +11,7 @@ package org.elasticsearch.xcontent;
 import org.elasticsearch.xcontent.cbor.CborXContent;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xcontent.smile.SmileXContent;
+import org.elasticsearch.xcontent.streamsmile.StreamSmileXContent;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
 
 import java.io.IOException;
@@ -55,6 +56,20 @@ public class XContentFactory {
     }
 
     /**
+     * Returns a content builder using STREAM_SMILE format ({@link org.elasticsearch.xcontent.XContentType#STREAM_SMILE}.
+     */
+    public static XContentBuilder streamSmileBuilder() throws IOException {
+        return contentBuilder(XContentType.STREAM_SMILE);
+    }
+
+    /**
+     * Constructs a new STREAM_SMILE builder that will output the result into the provided output stream.
+     */
+    public static XContentBuilder streamSmileBuilder(OutputStream os) throws IOException {
+        return new XContentBuilder(StreamSmileXContent.streamSmileXContent, os);
+    }
+
+    /**
      * Returns a content builder using YAML format ({@link org.elasticsearch.xcontent.XContentType#YAML}.
      */
     public static XContentBuilder yamlBuilder() throws IOException {
@@ -95,6 +110,8 @@ public class XContentFactory {
             return yamlBuilder(outputStream);
         } else if (canonical == XContentType.CBOR) {
             return cborBuilder(outputStream);
+        } else if (canonical == XContentType.STREAM_SMILE) {
+            return streamSmileBuilder(outputStream);
         }
         throw new IllegalArgumentException("No matching content type for " + type);
     }
@@ -113,6 +130,8 @@ public class XContentFactory {
             return YamlXContent.contentBuilder();
         } else if (canonical == XContentType.CBOR) {
             return CborXContent.contentBuilder();
+        } else if (canonical == XContentType.STREAM_SMILE) {
+            return StreamSmileXContent.contentBuilder();
         }
         throw new IllegalArgumentException("No matching content type for " + type);
     }
@@ -150,6 +169,10 @@ public class XContentFactory {
         }
         if (YamlXContent.yamlXContent.detectContent(content)) {
             return XContentType.YAML;
+        }
+        // Should we throw a failure here? Smile idea is to use it in bytes....
+        if (StreamSmileXContent.streamSmileXContent.detectContent(content)) {
+            return XContentType.STREAM_SMILE;
         }
         // CBOR is not supported
 
@@ -294,6 +317,9 @@ public class XContentFactory {
         }
         if (CborXContent.cborXContent.detectContent(bytes, offset, length)) {
             return XContentType.CBOR;
+        }
+        if (StreamSmileXContent.streamSmileXContent.detectContent(bytes, offset, length)) {
+            return XContentType.STREAM_SMILE;
         }
 
         // fallback for JSON

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/XContentType.java
@@ -11,6 +11,7 @@ package org.elasticsearch.xcontent;
 import org.elasticsearch.xcontent.cbor.CborXContent;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xcontent.smile.SmileXContent;
+import org.elasticsearch.xcontent.streamsmile.StreamSmileXContent;
 import org.elasticsearch.xcontent.yaml.YamlXContent;
 
 import java.util.Map;
@@ -239,6 +240,38 @@ public enum XContentType implements MediaType {
         @Override
         public XContentType canonical() {
             return CBOR;
+        }
+    },
+    /**
+     * jackson based smile binary format that escapes the byte `0xFF` so documents can be safely streamed using
+     * that byte as separator.
+     */
+    STREAM_SMILE(8) {
+        @Override
+        public String mediaTypeWithoutParameters() {
+            return VENDOR_APPLICATION_PREFIX + "stream_smile";
+        }
+
+        @Override
+        public String queryParameter() {
+            return "stream_smile";
+        }
+
+        @Override
+        public XContent xContent() {
+            return StreamSmileXContent.streamSmileXContent;
+        }
+
+        @Override
+        public Set<HeaderValue> headerValues() {
+            return Set.of(
+                new HeaderValue(VENDOR_APPLICATION_PREFIX + "stream_smile", Map.of(COMPATIBLE_WITH_PARAMETER_NAME, VERSION_PATTERN))
+            );
+        }
+
+        @Override
+        public XContentType canonical() {
+            return STREAM_SMILE;
         }
     };
 

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/spi/XContentProvider.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/spi/XContentProvider.java
@@ -55,6 +55,11 @@ public interface XContentProvider {
     FormatProvider getSmileXContent();
 
     /**
+     * Returns the STREAM_SMILE format provider.
+     */
+    FormatProvider getStreamSmileXContent();
+
+    /**
      * Returns the YAML format provider.
      */
     FormatProvider getYamlXContent();

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/streamsmile/StreamSmileXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/streamsmile/StreamSmileXContent.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.xcontent.streamsmile;
+
+import org.elasticsearch.xcontent.XContent;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.spi.XContentProvider;
+
+import java.io.IOException;
+
+/**
+ * Smile based XContent that escapes the stream separator so it can be safely
+ * used for streaming smile documents.
+ */
+public final class StreamSmileXContent {
+
+    private static final XContentProvider.FormatProvider provider = XContentProvider.provider().getStreamSmileXContent();
+
+    private StreamSmileXContent() {}
+
+    /**
+     * Returns an {@link XContentBuilder} for building Smile XContent that is safe for streaming documents.
+     */
+    public static XContentBuilder contentBuilder() throws IOException {
+        return provider.getContentBuilder();
+    }
+
+    /**
+     * A Smile based XContent that can be used safely for streaming documents.
+     */
+    public static final XContent streamSmileXContent = provider.XContent();
+
+}

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/xcontent/XContentSourceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/xcontent/XContentSourceTests.java
@@ -15,11 +15,28 @@ import org.elasticsearch.xpack.core.watcher.support.xcontent.XContentSource;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.elasticsearch.xcontent.XContentFactory.smileBuilder;
+import static org.elasticsearch.xcontent.XContentFactory.streamSmileBuilder;
 import static org.elasticsearch.xcontent.XContentFactory.yamlBuilder;
 
 public class XContentSourceTests extends ESTestCase {
-    public void testToXContent() throws Exception {
-        XContentBuilder builder = randomBoolean() ? jsonBuilder() : randomBoolean() ? yamlBuilder() : smileBuilder();
+
+    public void testJson() throws Exception {
+        testToXContent(jsonBuilder());
+    }
+
+    public void testYaml() throws Exception {
+        testToXContent(yamlBuilder());
+    }
+
+    public void testSmile() throws Exception {
+        testToXContent(smileBuilder());
+    }
+
+    public void testStreamSmile() throws Exception {
+        testToXContent(streamSmileBuilder());
+    }
+
+    private void testToXContent(XContentBuilder builder) throws Exception {
         BytesReference bytes = randomBoolean()
             ? BytesReference.bytes(builder.startObject().field("key", "value").endObject())
             : BytesReference.bytes(


### PR DESCRIPTION
The SMILE content type offered by XContent is not suitable for streaming documents because the setting `ENCODE_BINARY_AS_7BIT` is set to false, so we are not escaping the stream separator. This makes sense as we use smile for some perfromance sensitive operations and setting the flag to true carries a big overhead.

In this PR we propose to add a new content type called STREAM_SMILE (could not find a better name) which works very similar to the current SMILE type but it sets the  `ENCODE_BINARY_AS_7BIT`  flag to true, making the format suitable for streaming documents. That will enable using SMILE for bulk requests for example.

I set the PR to draft as it deserves a discussion. @DaveCTurner 