### PR TITLE
Fix named queries in the query rescorer

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesIT.java
@@ -11,11 +11,14 @@ package org.elasticsearch.search.fetch.subphase;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.query.MatchPhraseQueryBuilder;
 import org.elasticsearch.index.query.MatchQueryBuilder;
 import org.elasticsearch.index.query.QueryBuilder;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.index.query.TermQueryBuilder;
 import org.elasticsearch.search.SearchHit;
+import org.elasticsearch.search.rescore.QueryRescorerBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -332,11 +335,37 @@ public class MatchedQueriesIT extends ESIntegTestCase {
         BytesReference matchBytes = XContentHelper.toXContent(matchQueryBuilder, XContentType.JSON, false);
         TermQueryBuilder termQueryBuilder = termQuery("content", "amet").queryName("abc");
         BytesReference termBytes = XContentHelper.toXContent(termQueryBuilder, XContentType.JSON, false);
-        QueryBuilder[] queries = new QueryBuilder[] { wrapperQuery(matchBytes), constantScoreQuery(wrapperQuery(termBytes)) };
+        QueryBuilder[] queries = new QueryBuilder[]{wrapperQuery(matchBytes), constantScoreQuery(wrapperQuery(termBytes))};
         for (QueryBuilder query : queries) {
             SearchResponse searchResponse = client().prepareSearch().setQuery(query).get();
             assertHitCount(searchResponse, 1L);
             assertThat(searchResponse.getHits().getAt(0).getMatchedQueries()[0], equalTo("abc"));
         }
+    }
+
+    public void testMatchedWithRescoreQuery() throws Exception {
+        createIndex("test");
+        ensureGreen();
+
+        client().prepareIndex("test").setId("1").setSource("content", "hello world").get();
+        client().prepareIndex("test").setId("2").setSource("content", "hello you").get();
+        refresh();
+
+        SearchResponse searchResponse = client().prepareSearch()
+            .setQuery(new MatchAllQueryBuilder().queryName("all"))
+            .setRescorer(
+                new QueryRescorerBuilder(
+                    new MatchPhraseQueryBuilder("content", "hello you")
+                        .boost(10)
+                        .queryName("rescore_phrase")
+                )
+            )
+            .get();
+        assertHitCount(searchResponse, 2L);
+        assertThat(searchResponse.getHits().getAt(0).getMatchedQueries().length, equalTo(2));
+        assertThat(searchResponse.getHits().getAt(0).getMatchedQueries(), equalTo(new String[]{"all", "rescore_phrase"}));
+
+        assertThat(searchResponse.getHits().getAt(1).getMatchedQueries().length, equalTo(1));
+        assertThat(searchResponse.getHits().getAt(1).getMatchedQueries(), equalTo(new String[]{"all"}));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesIT.java
@@ -335,7 +335,7 @@ public class MatchedQueriesIT extends ESIntegTestCase {
         BytesReference matchBytes = XContentHelper.toXContent(matchQueryBuilder, XContentType.JSON, false);
         TermQueryBuilder termQueryBuilder = termQuery("content", "amet").queryName("abc");
         BytesReference termBytes = XContentHelper.toXContent(termQueryBuilder, XContentType.JSON, false);
-        QueryBuilder[] queries = new QueryBuilder[]{wrapperQuery(matchBytes), constantScoreQuery(wrapperQuery(termBytes))};
+        QueryBuilder[] queries = new QueryBuilder[] { wrapperQuery(matchBytes), constantScoreQuery(wrapperQuery(termBytes)) };
         for (QueryBuilder query : queries) {
             SearchResponse searchResponse = client().prepareSearch().setQuery(query).get();
             assertHitCount(searchResponse, 1L);
@@ -354,18 +354,14 @@ public class MatchedQueriesIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(new MatchAllQueryBuilder().queryName("all"))
             .setRescorer(
-                new QueryRescorerBuilder(
-                    new MatchPhraseQueryBuilder("content", "hello you")
-                        .boost(10)
-                        .queryName("rescore_phrase")
-                )
+                new QueryRescorerBuilder(new MatchPhraseQueryBuilder("content", "hello you").boost(10).queryName("rescore_phrase"))
             )
             .get();
         assertHitCount(searchResponse, 2L);
         assertThat(searchResponse.getHits().getAt(0).getMatchedQueries().length, equalTo(2));
-        assertThat(searchResponse.getHits().getAt(0).getMatchedQueries(), equalTo(new String[]{"all", "rescore_phrase"}));
+        assertThat(searchResponse.getHits().getAt(0).getMatchedQueries(), equalTo(new String[] { "all", "rescore_phrase" }));
 
         assertThat(searchResponse.getHits().getAt(1).getMatchedQueries().length, equalTo(1));
-        assertThat(searchResponse.getHits().getAt(1).getMatchedQueries(), equalTo(new String[]{"all"}));
+        assertThat(searchResponse.getHits().getAt(1).getMatchedQueries(), equalTo(new String[] { "all" }));
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermStatistics;
 import org.apache.lucene.search.TopScoreDocCollector;
+import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.SearchContext;
@@ -122,11 +123,11 @@ public class DfsPhase {
                 maybeStop.accept(DfsTimingType.CREATE_WEIGHT);
             }
             for (RescoreContext rescoreContext : context.rescore()) {
-                for (Query query : rescoreContext.getQueries()) {
+                for (ParsedQuery parsedQuery : rescoreContext.getParsedQueries()) {
                     final Query rewritten;
                     try {
                         maybeStart.accept(DfsTimingType.REWRITE);
-                        rewritten = searcher.rewrite(query);
+                        rewritten = searcher.rewrite(parsedQuery.query());
                     } finally {
                         maybeStop.accept(DfsTimingType.REWRITE);
                     }

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/MatchedQueriesPhase.java
@@ -14,10 +14,12 @@ import org.apache.lucene.search.ScorerSupplier;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.util.Bits;
 import org.elasticsearch.common.lucene.Lucene;
+import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
 import org.elasticsearch.search.fetch.StoredFieldsSpec;
+import org.elasticsearch.search.rescore.RescoreContext;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -34,6 +36,11 @@ public final class MatchedQueriesPhase implements FetchSubPhase {
         }
         if (context.parsedPostFilter() != null) {
             namedQueries.putAll(context.parsedPostFilter().namedFilters());
+        }
+        for (RescoreContext rescoreContext : context.rescore()) {
+            for (ParsedQuery parsedQuery : rescoreContext.getParsedQueries()) {
+                namedQueries.putAll(parsedQuery.namedFilters());
+            }
         }
         if (namedQueries.isEmpty()) {
             return null;

--- a/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorer.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorer.java
@@ -10,9 +10,9 @@ package org.elasticsearch.search.rescore;
 
 import org.apache.lucene.search.Explanation;
 import org.apache.lucene.search.IndexSearcher;
-import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.TopDocs;
+import org.elasticsearch.index.query.ParsedQuery;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -37,7 +37,7 @@ public final class QueryRescorer implements Rescorer {
 
         final QueryRescoreContext rescore = (QueryRescoreContext) rescoreContext;
 
-        org.apache.lucene.search.Rescorer rescorer = new org.apache.lucene.search.QueryRescorer(rescore.query()) {
+        org.apache.lucene.search.Rescorer rescorer = new org.apache.lucene.search.QueryRescorer(rescore.parsedQuery().query()) {
 
             @Override
             protected float combine(float firstPassScore, boolean secondPassMatches, float secondPassScore) {
@@ -90,7 +90,7 @@ public final class QueryRescorer implements Rescorer {
             prim = Explanation.noMatch("First pass did not match", sourceExplanation);
         }
         if (rescoreContext.isRescored(topLevelDocId)) {
-            Explanation rescoreExplain = searcher.explain(rescore.query(), topLevelDocId);
+            Explanation rescoreExplain = searcher.explain(rescore.parsedQuery().query(), topLevelDocId);
             // NOTE: we don't use Lucene's Rescorer.explain because we want to insert our own description with which ScoreMode was used.
             // Maybe we should add QueryRescorer.explainCombine to Lucene?
             if (rescoreExplain != null && rescoreExplain.isMatch()) {
@@ -152,7 +152,7 @@ public final class QueryRescorer implements Rescorer {
     }
 
     public static class QueryRescoreContext extends RescoreContext {
-        private Query query;
+        private ParsedQuery query;
         private float queryWeight = 1.0f;
         private float rescoreQueryWeight = 1.0f;
         private QueryRescoreMode scoreMode;
@@ -162,16 +162,16 @@ public final class QueryRescorer implements Rescorer {
             this.scoreMode = QueryRescoreMode.Total;
         }
 
-        public void setQuery(Query query) {
+        public void setQuery(ParsedQuery query) {
             this.query = query;
         }
 
         @Override
-        public List<Query> getQueries() {
+        public List<ParsedQuery> getParsedQueries() {
             return Collections.singletonList(query);
         }
 
-        public Query query() {
+        public ParsedQuery parsedQuery() {
             return query;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/QueryRescorerBuilder.java
@@ -168,7 +168,7 @@ public class QueryRescorerBuilder extends RescorerBuilder<QueryRescorerBuilder> 
     public QueryRescoreContext innerBuildContext(int windowSize, SearchExecutionContext context) throws IOException {
         QueryRescoreContext queryRescoreContext = new QueryRescoreContext(windowSize);
         // query is rewritten at this point already
-        queryRescoreContext.setQuery(queryBuilder.toQuery(context));
+        queryRescoreContext.setQuery(context.toQuery(queryBuilder));
         queryRescoreContext.setQueryWeight(this.queryWeight);
         queryRescoreContext.setRescoreQueryWeight(this.rescoreQueryWeight);
         queryRescoreContext.setScoreMode(this.scoreMode);

--- a/server/src/main/java/org/elasticsearch/search/rescore/RescoreContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/RescoreContext.java
@@ -8,7 +8,7 @@
 
 package org.elasticsearch.search.rescore;
 
-import org.apache.lucene.search.Query;
+import org.elasticsearch.index.query.ParsedQuery;
 
 import java.util.Collections;
 import java.util.List;
@@ -62,7 +62,7 @@ public class RescoreContext {
     /**
      * Returns queries associated with the rescorer
      */
-    public List<Query> getQueries() {
+    public List<ParsedQuery> getParsedQueries() {
         return Collections.emptyList();
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
+++ b/server/src/test/java/org/elasticsearch/search/rescore/QueryRescorerBuilderTests.java
@@ -167,7 +167,7 @@ public class QueryRescorerBuilderTests extends ESTestCase {
                 : rescoreBuilder.windowSize().intValue();
             assertEquals(expectedWindowSize, rescoreContext.getWindowSize());
             Query expectedQuery = Rewriteable.rewrite(rescoreBuilder.getRescoreQuery(), mockContext).toQuery(mockContext);
-            assertEquals(expectedQuery, rescoreContext.query());
+            assertEquals(expectedQuery, rescoreContext.parsedQuery().query());
             assertEquals(rescoreBuilder.getQueryWeight(), rescoreContext.queryWeight(), Float.MIN_VALUE);
             assertEquals(rescoreBuilder.getRescoreQueryWeight(), rescoreContext.rescoreQueryWeight(), Float.MIN_VALUE);
             assertEquals(rescoreBuilder.getScoreMode(), rescoreContext.scoreMode());


### PR DESCRIPTION
This change fixes the handling of named queries when they appear in the query rescorer.

Closes #65563