### PR TITLE
[7.17] [Transform] Catch deprecations as `Exception` rather than `IOException` (#94553)

### DIFF
--- a/docs/changelog/94553.yaml
+++ b/docs/changelog/94553.yaml
@@ -1,0 +1,5 @@
+pr: 94553
+summary: Catch deprecations as `Exception` rather than `IOException`
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/QueryConfig.java
@@ -147,7 +147,7 @@ public class QueryConfig extends AbstractDiffable<QueryConfig> implements Writea
 
         try {
             queryFromXContent(source, namedXContentRegistry, deprecationLogger);
-        } catch (IOException e) {
+        } catch (Exception e) {
             onDeprecation.accept(
                 new DeprecationIssue(
                     Level.CRITICAL,


### PR DESCRIPTION
Backports the following commits to 7.17:
 - [Transform] Catch deprecations as `Exception` rather than `IOException` (#94553)