### PR TITLE
[Test] Randomly enable RemoteClusterServer when security is enabled

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -113,7 +113,8 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
         final boolean transportSSLEnabled = randomBoolean();
         settings.put("xpack.security.transport.ssl.enabled", transportSSLEnabled);
 
-        final boolean remoteClusterPortEnabled = randomBoolean();
+        // Remote cluster server requires security to be enabled
+        final boolean remoteClusterPortEnabled = explicitlyDisabled ? false : randomBoolean();
         settings.put("remote_cluster_server.enabled", remoteClusterPortEnabled);
         final boolean remoteClusterSslEnabled = randomBoolean();
         settings.put("xpack.security.remote_cluster_server.ssl.enabled", remoteClusterSslEnabled);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityInfoTransportActionTests.java
@@ -97,7 +97,6 @@ public class SecurityInfoTransportActionTests extends ESTestCase {
     }
 
     @SuppressWarnings("rawtypes")
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94568")
     public void testUsage() throws Exception {
         final boolean explicitlyDisabled = randomBoolean();
         final boolean enabled = explicitlyDisabled == false;


### PR DESCRIPTION
The RCS remote cluster server feature requires security to be enabled since #94425. This PR ensures this requirement is met in the test.

Resolves: #94568

