### PR TITLE
Build index qualified name in cross cluster vector tile search

### DIFF
--- a/docs/changelog/94574.yaml
+++ b/docs/changelog/94574.yaml
@@ -1,0 +1,6 @@
+pr: 94574
+summary: Build index qualified name in cross cluster vector tile search
+area: Geo
+type: bug
+issues:
+ - 94557

--- a/x-pack/plugin/vector-tile/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/vectortile/VectorTileCCSIT.java
+++ b/x-pack/plugin/vector-tile/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/vectortile/VectorTileCCSIT.java
@@ -69,17 +69,29 @@ public class VectorTileCCSIT extends ESRestTestCase {
         try (RestClient local = buildLocalClusterClient(); RestClient remote = buildRemoteClusterClient()) {
             final int localGeometries = createIndex(local, "test");
             final int remoteGeometries = createIndex(remote, "test");
-            // check call in each cluster
-            final Request mvtRequest = new Request(HttpPost.METHOD_NAME, "test/_mvt/location/0/0/0");
-            final VectorTile.Tile localTile = execute(local, mvtRequest);
-            assertThat(getLayer(localTile, "hits").getFeaturesCount(), Matchers.equalTo(localGeometries));
-            final VectorTile.Tile remoteTile = execute(remote, mvtRequest);
-            assertThat(getLayer(remoteTile, "hits").getFeaturesCount(), Matchers.equalTo(remoteGeometries));
-            // call to both clusters
-            final Request mvtCCSRequest = new Request(HttpPost.METHOD_NAME, "/test,other:test/_mvt/location/0/0/0");
-            final VectorTile.Tile ccsTile = execute(local, mvtCCSRequest);
-            assertThat(getLayer(ccsTile, "hits").getFeaturesCount(), Matchers.equalTo(localGeometries + remoteGeometries));
+            // check with no params
+            assertLocalAndRemote(local, remote, localGeometries, remoteGeometries, "");
+            // check with labels
+            assertLocalAndRemote(local, remote, 2 * localGeometries, 2 * remoteGeometries, "?with_labels=true");
         }
+    }
+
+    private void assertLocalAndRemote(RestClient local, RestClient remote, int localGeometries, int remoteGeometries, String param)
+        throws IOException {
+        // check call in each cluster
+        final Request mvtRequest = new Request(HttpPost.METHOD_NAME, "test/_mvt/location/0/0/0" + param);
+        final VectorTile.Tile localTile = execute(local, mvtRequest);
+        assertThat(getLayer(localTile, "hits").getFeaturesCount(), Matchers.equalTo(localGeometries));
+        assertEquals(localGeometries, countFeaturesWithTag(getLayer(localTile, "hits"), "_index", "test"));
+        final VectorTile.Tile remoteTile = execute(remote, mvtRequest);
+        assertThat(getLayer(remoteTile, "hits").getFeaturesCount(), Matchers.equalTo(remoteGeometries));
+        assertEquals(remoteGeometries, countFeaturesWithTag(getLayer(remoteTile, "hits"), "_index", "test"));
+        // call to both clusters
+        final Request mvtCCSRequest = new Request(HttpPost.METHOD_NAME, "/test,other:test/_mvt/location/0/0/0" + param);
+        final VectorTile.Tile ccsTile = execute(local, mvtCCSRequest);
+        assertThat(getLayer(ccsTile, "hits").getFeaturesCount(), Matchers.equalTo(localGeometries + remoteGeometries));
+        assertEquals(localGeometries, countFeaturesWithTag(getLayer(ccsTile, "hits"), "_index", "test"));
+        assertEquals(remoteGeometries, countFeaturesWithTag(getLayer(ccsTile, "hits"), "_index", "other:test"));
     }
 
     private VectorTile.Tile.Layer getLayer(VectorTile.Tile tile, String layerName) {
@@ -116,5 +128,28 @@ public class VectorTileCCSIT extends ESRestTestCase {
             getProtocol()
         );
         return buildClient(restAdminSettings(), new HttpHost[] { httpHost });
+    }
+
+    private int countFeaturesWithTag(VectorTile.Tile.Layer layer, String tag, String value) {
+        int count = 0;
+        for (int i = 0; i < layer.getFeaturesCount(); i++) {
+            VectorTile.Tile.Feature feature = layer.getFeatures(i);
+            if (hasLabel(layer, feature, tag, value)) {
+                count++;
+            }
+        }
+        return count;
+    }
+
+    private boolean hasLabel(VectorTile.Tile.Layer layer, VectorTile.Tile.Feature feature, String tag, String value) {
+        for (int i = 0; i < feature.getTagsCount(); i += 2) {
+            String thisTag = layer.getKeys(feature.getTags(i));
+            if (tag.equals(thisTag)) {
+                VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
+                return value.equals(thisValue.getStringValue());
+
+            }
+        }
+        return false;
     }
 }

--- a/x-pack/plugin/vector-tile/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/vectortile/VectorTileCCSIT.java
+++ b/x-pack/plugin/vector-tile/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/vectortile/VectorTileCCSIT.java
@@ -147,7 +147,6 @@ public class VectorTileCCSIT extends ESRestTestCase {
             if (tag.equals(thisTag)) {
                 VectorTile.Tile.Value thisValue = layer.getValues(feature.getTags(i + 1));
                 return value.equals(thisValue.getStringValue());
-
             }
         }
         return false;

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.transport.RemoteClusterAware.buildRemoteIndexName;
 
 /**
  * Main class handling a call to the _mvt API.
@@ -294,7 +295,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                 featureBuilder.clear();
                 featureBuilder.mergeFrom((byte[]) feature);
                 VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, ID_TAG, searchHit.getId());
-                VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, searchHit.getIndex());
+                VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, buildQualifiedIndex(searchHit));
                 addHitsFields(featureBuilder, layerProps, requestField, fields);
                 hitsLayerBuilder.addFeatures(featureBuilder);
             }
@@ -308,7 +309,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                         featureBuilder.clear();
                         featureBuilder.mergeFrom(labelPosFeature);
                         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, ID_TAG, searchHit.getId());
-                        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, searchHit.getIndex());
+                        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, buildQualifiedIndex(searchHit));
                         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, LABEL_POSITION_FIELD_NAME, true);
                         addHitsFields(featureBuilder, layerProps, requestField, fields);
                         hitsLayerBuilder.addFeatures(featureBuilder);
@@ -331,6 +332,10 @@ public class RestVectorTileAction extends BaseRestHandler {
                 VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, field, fields.get(field).getValue());
             }
         }
+    }
+
+    private static String buildQualifiedIndex(SearchHit hit) {
+        return buildRemoteIndexName(hit.getClusterAlias(), hit.getIndex());
     }
 
     private static VectorTile.Tile.Layer.Builder buildAggsLayer(


### PR DESCRIPTION
We are recurrently using `SearchHit#getIndex` to populate the index tag on vector tiles. This is not enough for CCS where we need to build the qualified name by using the method `RemoteClusterAware#buildRemoteIndexName`. This change just do that, it changes the way we populate the index tag to take into account if the search hit comes from a remote cluster. 

fixes https://github.com/elastic/elasticsearch/issues/94557