### PR TITLE
[8.7] Build index qualified name in cross cluster vector tile search (#94574)

### DIFF
--- a/docs/changelog/94574.yaml
+++ b/docs/changelog/94574.yaml
@@ -1,0 +1,6 @@
+pr: 94574
+summary: Build index qualified name in cross cluster vector tile search
+area: Geo
+type: bug
+issues:
+ - 94557

--- a/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
+++ b/x-pack/plugin/vector-tile/src/main/java/org/elasticsearch/xpack/vectortile/rest/RestVectorTileAction.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.transport.RemoteClusterAware.buildRemoteIndexName;
 
 /**
  * Main class handling a call to the _mvt API.
@@ -294,7 +295,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                 featureBuilder.clear();
                 featureBuilder.mergeFrom((byte[]) feature);
                 VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, ID_TAG, searchHit.getId());
-                VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, searchHit.getIndex());
+                VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, buildQualifiedIndex(searchHit));
                 addHitsFields(featureBuilder, layerProps, requestField, fields);
                 hitsLayerBuilder.addFeatures(featureBuilder);
             }
@@ -308,7 +309,7 @@ public class RestVectorTileAction extends BaseRestHandler {
                         featureBuilder.clear();
                         featureBuilder.mergeFrom(labelPosFeature);
                         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, ID_TAG, searchHit.getId());
-                        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, searchHit.getIndex());
+                        VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, INDEX_TAG, buildQualifiedIndex(searchHit));
                         VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, LABEL_POSITION_FIELD_NAME, true);
                         addHitsFields(featureBuilder, layerProps, requestField, fields);
                         hitsLayerBuilder.addFeatures(featureBuilder);
@@ -331,6 +332,10 @@ public class RestVectorTileAction extends BaseRestHandler {
                 VectorTileUtils.addPropertyToFeature(featureBuilder, layerProps, field, fields.get(field).getValue());
             }
         }
+    }
+
+    private static String buildQualifiedIndex(SearchHit hit) {
+        return buildRemoteIndexName(hit.getClusterAlias(), hit.getIndex());
     }
 
     private static VectorTile.Tile.Layer.Builder buildAggsLayer(


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Build index qualified name in cross cluster vector tile search (#94574)