### PR TITLE
Add license checks to behavioral analytics actions.

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionAction.java
@@ -17,15 +17,19 @@ import org.elasticsearch.cluster.block.ClusterBlockLevel;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
+import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransportMasterNodeAction<
     DeleteAnalyticsCollectionAction.Request> {
 
     private final AnalyticsCollectionService analyticsCollectionService;
+
+    private final XPackLicenseState licenseState;
 
     @Inject
     public TransportDeleteAnalyticsCollectionAction(
@@ -34,7 +38,8 @@ public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransp
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        AnalyticsCollectionService analyticsCollectionService
+        AnalyticsCollectionService analyticsCollectionService,
+        XPackLicenseState licenseState
     ) {
         super(
             DeleteAnalyticsCollectionAction.NAME,
@@ -47,6 +52,7 @@ public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransp
             ThreadPool.Names.SAME
         );
         this.analyticsCollectionService = analyticsCollectionService;
+        this.licenseState = licenseState;
     }
 
     @Override
@@ -61,6 +67,10 @@ public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransp
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        analyticsCollectionService.deleteAnalyticsCollection(state, request, listener.map(v -> AcknowledgedResponse.TRUE));
+        LicenseUtils.runIfSupportedLicence(
+            licenseState,
+            () -> analyticsCollectionService.deleteAnalyticsCollection(state, request, listener),
+            listener::onFailure
+        );
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionAction.java
@@ -67,7 +67,7 @@ public class TransportDeleteAnalyticsCollectionAction extends AcknowledgedTransp
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        LicenseUtils.runIfSupportedLicence(
+        LicenseUtils.runIfSupportedLicense(
             licenseState,
             () -> analyticsCollectionService.deleteAnalyticsCollection(state, request, listener),
             listener::onFailure

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionAction.java
@@ -62,7 +62,7 @@ public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeRe
         ClusterState state,
         ActionListener<GetAnalyticsCollectionAction.Response> listener
     ) {
-        LicenseUtils.runIfSupportedLicence(
+        LicenseUtils.runIfSupportedLicense(
             licenseState,
             () -> analyticsCollectionService.getAnalyticsCollection(state, request, listener),
             listener::onFailure

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionAction.java
@@ -15,16 +15,20 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
+import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeReadAction<
     GetAnalyticsCollectionAction.Request,
     GetAnalyticsCollectionAction.Response> {
 
     private final AnalyticsCollectionService analyticsCollectionService;
+
+    private final XPackLicenseState licenseState;
 
     @Inject
     public TransportGetAnalyticsCollectionAction(
@@ -33,7 +37,8 @@ public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeRe
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        AnalyticsCollectionService analyticsCollectionService
+        AnalyticsCollectionService analyticsCollectionService,
+        XPackLicenseState licenseState
     ) {
         super(
             GetAnalyticsCollectionAction.NAME,
@@ -47,6 +52,7 @@ public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeRe
             ThreadPool.Names.SAME
         );
         this.analyticsCollectionService = analyticsCollectionService;
+        this.licenseState = licenseState;
     }
 
     @Override
@@ -56,7 +62,11 @@ public class TransportGetAnalyticsCollectionAction extends TransportMasterNodeRe
         ClusterState state,
         ActionListener<GetAnalyticsCollectionAction.Response> listener
     ) {
-        analyticsCollectionService.getAnalyticsCollection(state, request, listener);
+        LicenseUtils.runIfSupportedLicence(
+            licenseState,
+            () -> analyticsCollectionService.getAnalyticsCollection(state, request, listener),
+            listener::onFailure
+        );
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
@@ -67,7 +67,7 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
         ClusterState state,
         ActionListener<PutAnalyticsCollectionAction.Response> listener
     ) {
-        LicenseUtils.runIfSupportedLicence(
+        LicenseUtils.runIfSupportedLicense(
             licenseState,
             () -> analyticsCollectionService.putAnalyticsCollection(state, request, listener),
             listener::onFailure

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionAction.java
@@ -15,16 +15,20 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
+import org.elasticsearch.xpack.application.utils.LicenseUtils;
 
 public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAction<
     PutAnalyticsCollectionAction.Request,
     PutAnalyticsCollectionAction.Response> {
 
     private final AnalyticsCollectionService analyticsCollectionService;
+
+    private final XPackLicenseState licenseState;
 
     @Inject
     public TransportPutAnalyticsCollectionAction(
@@ -33,7 +37,8 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
         ThreadPool threadPool,
         ActionFilters actionFilters,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        AnalyticsCollectionService analyticsCollectionService
+        AnalyticsCollectionService analyticsCollectionService,
+        XPackLicenseState licenseState
     ) {
         super(
             PutAnalyticsCollectionAction.NAME,
@@ -47,6 +52,7 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
             ThreadPool.Names.SAME
         );
         this.analyticsCollectionService = analyticsCollectionService;
+        this.licenseState = licenseState;
     }
 
     @Override
@@ -61,7 +67,11 @@ public class TransportPutAnalyticsCollectionAction extends TransportMasterNodeAc
         ClusterState state,
         ActionListener<PutAnalyticsCollectionAction.Response> listener
     ) {
-        analyticsCollectionService.putAnalyticsCollection(state, request, listener);
+        LicenseUtils.runIfSupportedLicence(
+            licenseState,
+            () -> analyticsCollectionService.putAnalyticsCollection(state, request, listener),
+            listener::onFailure
+        );
     }
 
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationTransportAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationTransportAction.java
@@ -49,11 +49,7 @@ public abstract class SearchApplicationTransportAction<Request extends ActionReq
 
     @Override
     public final void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        if (LicenseUtils.supportedLicense(licenseState)) {
-            doExecute(request, listener);
-        } else {
-            listener.onFailure(LicenseUtils.newComplianceException(licenseState));
-        }
+        LicenseUtils.runIfSupportedLicence(licenseState, () -> doExecute(request, listener), listener::onFailure);
     }
 
     protected abstract void doExecute(Request request, ActionListener<Response> listener);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationTransportAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationTransportAction.java
@@ -49,7 +49,7 @@ public abstract class SearchApplicationTransportAction<Request extends ActionReq
 
     @Override
     public final void doExecute(Task task, final Request request, ActionListener<Response> listener) {
-        LicenseUtils.runIfSupportedLicence(licenseState, () -> doExecute(request, listener), listener::onFailure);
+        LicenseUtils.runIfSupportedLicense(licenseState, () -> doExecute(request, listener), listener::onFailure);
     }
 
     protected abstract void doExecute(Request request, ActionListener<Response> listener);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
@@ -39,7 +39,7 @@ public final class LicenseUtils {
         return e;
     }
 
-    public static void runIfSupportedLicence(XPackLicenseState licenseState, Runnable onSuccess, Consumer<Exception> onFailure) {
+    public static void runIfSupportedLicense(XPackLicenseState licenseState, Runnable onSuccess, Consumer<Exception> onFailure) {
         if (supportedLicense(licenseState)) {
             onSuccess.run();
         } else {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/LicenseUtils.java
@@ -14,6 +14,8 @@ import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.core.XPackField;
 
+import java.util.function.Consumer;
+
 public final class LicenseUtils {
     public static final LicensedFeature.Momentary LICENSED_ENT_SEARCH_FEATURE = LicensedFeature.momentary(
         null,
@@ -35,5 +37,13 @@ public final class LicenseUtils {
             licenseStatus
         );
         return e;
+    }
+
+    public static void runIfSupportedLicence(XPackLicenseState licenseState, Runnable onSuccess, Consumer<Exception> onFailure) {
+        if (supportedLicense(licenseState)) {
+            onSuccess.run();
+        } else {
+            onFailure.accept(newComplianceException(licenseState));
+        }
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionActionTests.java
@@ -42,7 +42,7 @@ public class TransportDeleteAnalyticsCollectionActionTests extends ESTestCase {
         AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
 
         TransportDeleteAnalyticsCollectionAction transportAction = createTransportAction(
-            mockLicenceState(true),
+            mockLicenseState(true),
             analyticsCollectionService
         );
         DeleteAnalyticsCollectionAction.Request request = mock(DeleteAnalyticsCollectionAction.Request.class);
@@ -60,7 +60,7 @@ public class TransportDeleteAnalyticsCollectionActionTests extends ESTestCase {
         AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
 
         TransportDeleteAnalyticsCollectionAction transportAction = createTransportAction(
-            mockLicenceState(false),
+            mockLicenseState(false),
             analyticsCollectionService
         );
         DeleteAnalyticsCollectionAction.Request request = mock(DeleteAnalyticsCollectionAction.Request.class);
@@ -83,7 +83,7 @@ public class TransportDeleteAnalyticsCollectionActionTests extends ESTestCase {
         verify(analyticsCollectionService, never()).deleteAnalyticsCollection(any(), any(), any());
     }
 
-    private MockLicenseState mockLicenceState(boolean supported) {
+    private MockLicenseState mockLicenseState(boolean supported) {
         MockLicenseState licenseState = mock(MockLicenseState.class);
 
         when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportDeleteAnalyticsCollectionActionTests.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
+import org.elasticsearch.xpack.application.utils.LicenseUtils;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportDeleteAnalyticsCollectionActionTests extends ESTestCase {
+    @SuppressWarnings("unchecked")
+    public void testWithSupportedLicense() {
+        AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
+
+        TransportDeleteAnalyticsCollectionAction transportAction = createTransportAction(
+            mockLicenceState(true),
+            analyticsCollectionService
+        );
+        DeleteAnalyticsCollectionAction.Request request = mock(DeleteAnalyticsCollectionAction.Request.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+
+        ActionListener<AcknowledgedResponse> listener = mock(ActionListener.class);
+
+        transportAction.masterOperation(mock(Task.class), request, clusterState, listener);
+        verify(analyticsCollectionService, times(1)).deleteAnalyticsCollection(clusterState, request, listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    public void testWithUnsupportedLicense() {
+        AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
+
+        TransportDeleteAnalyticsCollectionAction transportAction = createTransportAction(
+            mockLicenceState(false),
+            analyticsCollectionService
+        );
+        DeleteAnalyticsCollectionAction.Request request = mock(DeleteAnalyticsCollectionAction.Request.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        final AtomicReference<AcknowledgedResponse> responseRef = new AtomicReference<>();
+        ActionListener<AcknowledgedResponse> listener = ActionListener.wrap(r -> responseRef.set(r), e -> throwableRef.set(e));
+
+        transportAction.masterOperation(mock(Task.class), request, clusterState, listener);
+
+        assertThat(responseRef.get(), is(nullValue()));
+        assertThat(throwableRef.get(), instanceOf(ElasticsearchSecurityException.class));
+        assertThat(
+            throwableRef.get().getMessage(),
+            containsString("Search Applications and behavioral analytics require an active trial, platinum or enterprise license.")
+        );
+
+        verify(analyticsCollectionService, never()).deleteAnalyticsCollection(any(), any(), any());
+    }
+
+    private MockLicenseState mockLicenceState(boolean supported) {
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+
+        when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);
+        when(licenseState.isActive()).thenReturn(supported);
+        when(licenseState.statusDescription()).thenReturn("invalid license");
+
+        return licenseState;
+    }
+
+    private TransportDeleteAnalyticsCollectionAction createTransportAction(
+        XPackLicenseState licenseState,
+        AnalyticsCollectionService analyticsCollectionService
+    ) {
+        return new TransportDeleteAnalyticsCollectionAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            mock(IndexNameExpressionResolver.class),
+            analyticsCollectionService,
+            licenseState
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionActionTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
+import org.elasticsearch.xpack.application.utils.LicenseUtils;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportGetAnalyticsCollectionActionTests extends ESTestCase {
+    @SuppressWarnings("unchecked")
+    public void testWithSupportedLicense() {
+        AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
+
+        TransportGetAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(true), analyticsCollectionService);
+        GetAnalyticsCollectionAction.Request request = mock(GetAnalyticsCollectionAction.Request.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+
+        ActionListener<GetAnalyticsCollectionAction.Response> listener = mock(ActionListener.class);
+
+        transportAction.masterOperation(mock(Task.class), request, clusterState, listener);
+        verify(analyticsCollectionService, times(1)).getAnalyticsCollection(clusterState, request, listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    public void testWithUnsupportedLicense() {
+        AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
+
+        TransportGetAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(false), analyticsCollectionService);
+        GetAnalyticsCollectionAction.Request request = mock(GetAnalyticsCollectionAction.Request.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        final AtomicReference<GetAnalyticsCollectionAction.Response> responseRef = new AtomicReference<>();
+        ActionListener<GetAnalyticsCollectionAction.Response> listener = ActionListener.wrap(
+            r -> responseRef.set(r),
+            e -> throwableRef.set(e)
+        );
+
+        transportAction.masterOperation(mock(Task.class), request, clusterState, listener);
+
+        assertThat(responseRef.get(), is(nullValue()));
+        assertThat(throwableRef.get(), instanceOf(ElasticsearchSecurityException.class));
+        assertThat(
+            throwableRef.get().getMessage(),
+            containsString("Search Applications and behavioral analytics require an active trial, platinum or enterprise license.")
+        );
+
+        verify(analyticsCollectionService, never()).getAnalyticsCollection(any(), any(), any());
+    }
+
+    private MockLicenseState mockLicenceState(boolean supported) {
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+
+        when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);
+        when(licenseState.isActive()).thenReturn(supported);
+        when(licenseState.statusDescription()).thenReturn("invalid license");
+
+        return licenseState;
+    }
+
+    private TransportGetAnalyticsCollectionAction createTransportAction(
+        XPackLicenseState licenseState,
+        AnalyticsCollectionService analyticsCollectionService
+    ) {
+        return new TransportGetAnalyticsCollectionAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            mock(IndexNameExpressionResolver.class),
+            analyticsCollectionService,
+            licenseState
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionActionTests.java
@@ -79,7 +79,7 @@ public class TransportGetAnalyticsCollectionActionTests extends ESTestCase {
         verify(analyticsCollectionService, never()).getAnalyticsCollection(any(), any(), any());
     }
 
-    private MockLicenseState mockLicenceState(boolean supported) {
+    private MockLicenseState mockLicenseState(boolean supported) {
         MockLicenseState licenseState = mock(MockLicenseState.class);
 
         when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportGetAnalyticsCollectionActionTests.java
@@ -40,7 +40,7 @@ public class TransportGetAnalyticsCollectionActionTests extends ESTestCase {
     public void testWithSupportedLicense() {
         AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
 
-        TransportGetAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(true), analyticsCollectionService);
+        TransportGetAnalyticsCollectionAction transportAction = createTransportAction(mockLicenseState(true), analyticsCollectionService);
         GetAnalyticsCollectionAction.Request request = mock(GetAnalyticsCollectionAction.Request.class);
 
         ClusterState clusterState = mock(ClusterState.class);
@@ -55,7 +55,7 @@ public class TransportGetAnalyticsCollectionActionTests extends ESTestCase {
     public void testWithUnsupportedLicense() {
         AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
 
-        TransportGetAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(false), analyticsCollectionService);
+        TransportGetAnalyticsCollectionAction transportAction = createTransportAction(mockLicenseState(false), analyticsCollectionService);
         GetAnalyticsCollectionAction.Request request = mock(GetAnalyticsCollectionAction.Request.class);
 
         ClusterState clusterState = mock(ClusterState.class);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionActionTests.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.action;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.license.MockLicenseState;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.application.analytics.AnalyticsCollectionService;
+import org.elasticsearch.xpack.application.utils.LicenseUtils;
+
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransportPutAnalyticsCollectionActionTests extends ESTestCase {
+    @SuppressWarnings("unchecked")
+    public void testWithSupportedLicense() {
+        AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
+
+        TransportPutAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(true), analyticsCollectionService);
+        PutAnalyticsCollectionAction.Request request = mock(PutAnalyticsCollectionAction.Request.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+
+        ActionListener<PutAnalyticsCollectionAction.Response> listener = mock(ActionListener.class);
+
+        transportAction.masterOperation(mock(Task.class), request, clusterState, listener);
+        verify(analyticsCollectionService, times(1)).putAnalyticsCollection(clusterState, request, listener);
+        verify(listener, never()).onFailure(any());
+    }
+
+    public void testWithUnsupportedLicense() {
+        AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
+
+        TransportPutAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(false), analyticsCollectionService);
+        PutAnalyticsCollectionAction.Request request = mock(PutAnalyticsCollectionAction.Request.class);
+
+        ClusterState clusterState = mock(ClusterState.class);
+
+        final AtomicReference<Throwable> throwableRef = new AtomicReference<>();
+        final AtomicReference<PutAnalyticsCollectionAction.Response> responseRef = new AtomicReference<>();
+        ActionListener<PutAnalyticsCollectionAction.Response> listener = ActionListener.wrap(
+            r -> responseRef.set(r),
+            e -> throwableRef.set(e)
+        );
+
+        transportAction.masterOperation(mock(Task.class), request, clusterState, listener);
+
+        assertThat(responseRef.get(), is(nullValue()));
+        assertThat(throwableRef.get(), instanceOf(ElasticsearchSecurityException.class));
+        assertThat(
+            throwableRef.get().getMessage(),
+            containsString("Search Applications and behavioral analytics require an active trial, platinum or enterprise license.")
+        );
+
+        verify(analyticsCollectionService, never()).putAnalyticsCollection(any(), any(), any());
+    }
+
+    private MockLicenseState mockLicenceState(boolean supported) {
+        MockLicenseState licenseState = mock(MockLicenseState.class);
+
+        when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);
+        when(licenseState.isActive()).thenReturn(supported);
+        when(licenseState.statusDescription()).thenReturn("invalid license");
+
+        return licenseState;
+    }
+
+    private TransportPutAnalyticsCollectionAction createTransportAction(
+        XPackLicenseState licenseState,
+        AnalyticsCollectionService analyticsCollectionService
+    ) {
+        return new TransportPutAnalyticsCollectionAction(
+            mock(TransportService.class),
+            mock(ClusterService.class),
+            mock(ThreadPool.class),
+            mock(ActionFilters.class),
+            mock(IndexNameExpressionResolver.class),
+            analyticsCollectionService,
+            licenseState
+        );
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionActionTests.java
@@ -40,7 +40,7 @@ public class TransportPutAnalyticsCollectionActionTests extends ESTestCase {
     public void testWithSupportedLicense() {
         AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
 
-        TransportPutAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(true), analyticsCollectionService);
+        TransportPutAnalyticsCollectionAction transportAction = createTransportAction(mockLicenseState(true), analyticsCollectionService);
         PutAnalyticsCollectionAction.Request request = mock(PutAnalyticsCollectionAction.Request.class);
 
         ClusterState clusterState = mock(ClusterState.class);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionActionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/TransportPutAnalyticsCollectionActionTests.java
@@ -55,7 +55,7 @@ public class TransportPutAnalyticsCollectionActionTests extends ESTestCase {
     public void testWithUnsupportedLicense() {
         AnalyticsCollectionService analyticsCollectionService = mock(AnalyticsCollectionService.class);
 
-        TransportPutAnalyticsCollectionAction transportAction = createTransportAction(mockLicenceState(false), analyticsCollectionService);
+        TransportPutAnalyticsCollectionAction transportAction = createTransportAction(mockLicenseState(false), analyticsCollectionService);
         PutAnalyticsCollectionAction.Request request = mock(PutAnalyticsCollectionAction.Request.class);
 
         ClusterState clusterState = mock(ClusterState.class);
@@ -79,7 +79,7 @@ public class TransportPutAnalyticsCollectionActionTests extends ESTestCase {
         verify(analyticsCollectionService, never()).putAnalyticsCollection(any(), any(), any());
     }
 
-    private MockLicenseState mockLicenceState(boolean supported) {
+    private MockLicenseState mockLicenseState(boolean supported) {
         MockLicenseState licenseState = mock(MockLicenseState.class);
 
         when(licenseState.isAllowed(LicenseUtils.LICENSED_ENT_SEARCH_FEATURE)).thenReturn(supported);


### PR DESCRIPTION
## Work done:

- Added some license check on behavioral analytics controllers.

## Examples

```
curl -XPUT -u "elastic-admin:elastic-password" "localhost:9200/_application/analytics/foo?pretty"
```

> ```
> {
>   "error" : {
>     "root_cause" : [
>       {
>         "type" : "security_exception",
>         "reason" : "Current license is non-compliant for search application and behavioral analytics. Current license is active basic license. Search Applications and behavioral analytics require an active trial, platinum or enterprise license."
>       }
>     ],
>     "type" : "security_exception",
>     "reason" : "Current license is non-compliant for search application and behavioral analytics. Current license is active basic license. Search Applications and behavioral analytics require an active trial, platinum or enterprise license."
>   },
>   "status" : 403
> }
> ```


```
curl -XPOST -u "elastic-admin:elastic-password" "localhost:9200/_license/start_trial?acknowledge=true"

curl -XPUT -u "elastic-admin:elastic-password" "localhost:9200/_application/analytics/foo?pretty"
```

> ```
> {
>   "acknowledged" : true,
>   "name" : "foo"
> }
> ```