### PR TITLE
Mute MultiVersionRepositoryAccessIT tests

### DIFF
--- a/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
+++ b/qa/repository-multi-version/src/test/java/org/elasticsearch/upgrades/MultiVersionRepositoryAccessIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.upgrades;
 
+import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.repositories.put.PutRepositoryRequest;
@@ -45,6 +46,7 @@ import static org.hamcrest.Matchers.is;
  * </ul>
  */
 @SuppressWarnings("removal")
+@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94459")
 public class MultiVersionRepositoryAccessIT extends ESRestTestCase {
 
     private enum TestStep {


### PR DESCRIPTION
`MultiVersionRepositoryAccessIT` tests are failing often and causing BWC CI to fail.

Relates to: https://github.com/elastic/elasticsearch/issues/94459