### PR TITLE
Asyncify `ElectionStrategy#beforeCommit`

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ElectionStrategy.java
@@ -105,5 +105,7 @@ public abstract class ElectionStrategy {
             && lastCommittedConfiguration.equals(lastAcceptedConfiguration) == false;
     }
 
-    public void beforeCommit(long term, long version) {}
+    public void beforeCommit(long term, long version, ActionListener<Void> listener) {
+        listener.onResponse(null);
+    }
 }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Publication.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.ClusterStatePublisher.AckListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.transport.TransportException;
 import org.elasticsearch.transport.TransportResponse;
@@ -37,7 +38,7 @@ public abstract class Publication {
     private final LongSupplier currentTimeSupplier;
     private final long startTime;
 
-    private Optional<ApplyCommitRequest> applyCommitRequest; // set when state is committed
+    private Optional<ListenableFuture<ApplyCommitRequest>> applyCommitRequest; // set when state is committed
     private boolean isCompleted; // set when publication is completed
     private boolean cancelled; // set when publication is cancelled
 
@@ -122,7 +123,7 @@ public abstract class Publication {
     }
 
     // For assertions only: verify that this invariant holds
-    private boolean publicationCompletedIffAllTargetsInactiveOrCancelled() {
+    boolean publicationCompletedIffAllTargetsInactiveOrCancelled() {
         if (cancelled == false) {
             for (final PublicationTarget target : publicationTargets) {
                 if (target.isActive()) {
@@ -173,7 +174,10 @@ public abstract class Publication {
 
     protected abstract boolean isPublishQuorum(CoordinationState.VoteCollection votes);
 
-    protected abstract Optional<ApplyCommitRequest> handlePublishResponse(DiscoveryNode sourceNode, PublishResponse publishResponse);
+    protected abstract Optional<ListenableFuture<ApplyCommitRequest>> handlePublishResponse(
+        DiscoveryNode sourceNode,
+        PublishResponse publishResponse
+    );
 
     protected abstract void onJoin(Join join);
 
@@ -190,6 +194,8 @@ public abstract class Publication {
         ApplyCommitRequest applyCommit,
         ActionListener<TransportResponse.Empty> responseActionListener
     );
+
+    protected abstract <T> ActionListener<T> wrapListener(ActionListener<T> listener);
 
     @Override
     public String toString() {
@@ -280,7 +286,19 @@ public abstract class Publication {
             assert state == PublicationTargetState.WAITING_FOR_QUORUM : state + " -> " + PublicationTargetState.SENT_APPLY_COMMIT;
             state = PublicationTargetState.SENT_APPLY_COMMIT;
             assert applyCommitRequest.isPresent();
-            Publication.this.sendApplyCommit(discoveryNode, applyCommitRequest.get(), new ApplyCommitResponseHandler());
+            applyCommitRequest.get().addListener(wrapListener(new ActionListener<>() {
+                @Override
+                public void onResponse(ApplyCommitRequest applyCommitRequest) {
+                    Publication.this.sendApplyCommit(discoveryNode, applyCommitRequest, new ApplyCommitResponseHandler());
+                    assert publicationCompletedIffAllTargetsInactiveOrCancelled();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    setFailed(e);
+                    onPossibleCommitFailure();
+                }
+            }));
             assert publicationCompletedIffAllTargetsInactiveOrCancelled();
         }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -515,11 +515,13 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         }
 
         @Override
-        public void beforeCommit(long term, long version) {
+        public void beforeCommit(long term, long version, ActionListener<Void> listener) {
             // TODO: add a test to ensure that this gets called
             final var currentTermOwner = register.getTermOwner();
             if (currentTermOwner.term() > term) {
-                throw new CoordinationStateRejectedException("Term " + term + " already claimed by another node");
+                listener.onFailure(new CoordinationStateRejectedException("Term " + term + " already claimed by another node"));
+            } else {
+                listener.onResponse(null);
             }
         }
     }


### PR DESCRIPTION
Adjusts `ElectionStrategy#beforeCommit` to accept a listener, because the stateless implementation will need to call into some async code.