### PR TITLE
[DOCS] Fix figure references

### DIFF
--- a/docs/reference/search/search-your-data/near-real-time.asciidoc
+++ b/docs/reference/search/search-your-data/near-real-time.asciidoc
@@ -1,10 +1,12 @@
+:xrefstyle: short
+
 [[near-real-time]]
 == Near real-time search
 The overview of <<documents-indices,documents and indices>> indicates that when a document is stored in {es}, it is indexed and fully searchable in _near real-time_--within 1 second. What defines near real-time search?
 
 Lucene, the Java libraries on which {es} is based, introduced the concept of per-segment search. A _segment_ is similar to an inverted index, but the word _index_ in Lucene means "a collection of segments plus a commit point". After a commit, a new segment is added to the commit point and the buffer is cleared.
 
-Sitting between {es} and the disk is the filesystem cache. Documents in the in-memory indexing buffer (<<img-pre-refresh,Figure 1>>) are written to a new segment (<<img-post-refresh,Figure 2>>). The new segment is written to the filesystem cache first (which is cheap) and only later is it flushed to disk (which is expensive). However, after a file is in the cache, it can be opened and read just like any other file.
+Sitting between {es} and the disk is the filesystem cache. Documents in the in-memory indexing buffer (<<img-pre-refresh>>) are written to a new segment (<<img-post-refresh>>). The new segment is written to the filesystem cache first (which is cheap) and only later is it flushed to disk (which is expensive). However, after a file is in the cache, it can be opened and read just like any other file.
 
 [[img-pre-refresh]]
 .A Lucene index with new documents in the in-memory buffer


### PR DESCRIPTION
Fixes the incorrect references to the figures on [this page](https://www.elastic.co/guide/en/elasticsearch/reference/current/near-real-time.html).

Closes #94342