### PR TITLE
Add updated timestamp to list search apps response

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -74,12 +74,12 @@ teardown:
   - match: { results.1.name: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
-  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
+  - match: { results.1.updated_at_millis: $updatedAtMillis1 }
 
   - match: { results.2.name: "test-search-application-2" }
   - match: { results.2.indices: [ "test-index2" ] }
   - match: { results.2.analytics_collection_name: "test-analytics2" }
-  - match: { results.0.updated_at_millis: $updatedAtMillis2 }
+  - match: { results.2.updated_at_millis: $updatedAtMillis2 }
 
 ---
 "Pagination - From":
@@ -99,7 +99,7 @@ teardown:
   - match: { results.1.name: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
-  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
+  - match: { results.1.updated_at_millis: $updatedAtMillis1 }
 
 ---
 "Pagination - Size":
@@ -119,7 +119,7 @@ teardown:
   - match: { results.1.name: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
-  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
+  - match: { results.1.updated_at_millis: $updatedAtMillis1 }
 
 
 ---
@@ -140,7 +140,7 @@ teardown:
   - match: { results.1.name: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
-  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
+  - match: { results.1.updated_at_millis: $updatedAtMillis1 }
 
 ---
 "Empty query results":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -70,16 +70,19 @@ teardown:
   - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
+  - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
+  - gte: { results.1.updated_at_millis: 0 }
 
   - match: { results.2.name: "test-search-application-2" }
   - match: { results.2.indices: [ "test-index2" ] }
   - match: { results.2.analytics_collection_name: "test-analytics2" }
   - match: { results.2.updated_at_millis: $updatedAtMillis2 }
+  - gte: { results.2.updated_at_millis: 0 }
 
 ---
 "Pagination - From":
@@ -95,11 +98,13 @@ teardown:
   - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
+  - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
+  - gte: { results.1.updated_at_millis: 0 }
 
 ---
 "Pagination - Size":
@@ -115,11 +120,13 @@ teardown:
   - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
+  - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
+  - gte: { results.1.updated_at_millis: 0 }
 
 
 ---
@@ -136,11 +143,13 @@ teardown:
   - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
   - match: { results.0.updated_at_millis: $updatedAtMillis0 }
+  - gte: { results.0.updated_at_millis: 0 }
 
   - match: { results.1.name: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
   - match: { results.1.updated_at_millis: $updatedAtMillis1 }
+  - gte: { results.1.updated_at_millis: 0 }
 
 ---
 "Empty query results":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -59,6 +59,9 @@ teardown:
 "List Search Applications":
   - do:
       search_application.list: { }
+  - set: { results.0.updated_at_millis: updatedAtMillis0 }
+  - set: { results.1.updated_at_millis: updatedAtMillis1 }
+  - set: { results.2.updated_at_millis: updatedAtMillis2 }
 
   - match: { count: 3 }
 
@@ -66,53 +69,57 @@ teardown:
   - match: { results.0.name: "another-test-search-application" }
   - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
-  - match: { results.0.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis0 }
 
   - match: { results.1.name: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
-  - match: { results.1.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
 
   - match: { results.2.name: "test-search-application-2" }
   - match: { results.2.indices: [ "test-index2" ] }
   - match: { results.2.analytics_collection_name: "test-analytics2" }
-  - match: { results.2.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis2 }
 
 ---
 "Pagination - From":
   - do:
       search_application.list:
         from: 1
+  - set: { results.0.updated_at_millis: updatedAtMillis0 }
+  - set: { results.1.updated_at_millis: updatedAtMillis1 }
 
   - match: { count: 3 }
 
   - match: { results.0.name: "test-search-application-1" }
   - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
-  - match: { results.0.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis0 }
 
   - match: { results.1.name: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
-  - match: { results.1.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
 
 ---
 "Pagination - Size":
   - do:
       search_application.list:
         size: 2
+  - set: { results.0.updated_at_millis: updatedAtMillis0 }
+  - set: { results.1.updated_at_millis: updatedAtMillis1 }
 
   - match: { count: 3 }
 
   - match: { results.0.name: "another-test-search-application" }
   - match: { results.0.indices: [ "test-index1", "test-index2" ] }
   - match: { results.0.analytics_collection_name: "test-another-analytics" }
-  - match: { results.0.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis0 }
 
   - match: { results.1.name: "test-search-application-1" }
   - match: { results.1.indices: [ "test-index1" ] }
   - match: { results.1.analytics_collection_name: "test-analytics1" }
-  - match: { results.1.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
 
 
 ---
@@ -120,18 +127,21 @@ teardown:
   - do:
       search_application.list:
         q: "test-search-application-*"
+  - set: { results.0.updated_at_millis: updatedAtMillis0 }
+  - set: { results.0.updated_at_millis: updatedAtMillis1 }
 
   - match: { count: 2 }
 
   - match: { results.0.name: "test-search-application-1" }
   - match: { results.0.indices: [ "test-index1" ] }
   - match: { results.0.analytics_collection_name: "test-analytics1" }
-  - match: { results.0.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis0 }
 
   - match: { results.1.name: "test-search-application-2" }
   - match: { results.1.indices: [ "test-index2" ] }
   - match: { results.1.analytics_collection_name: "test-analytics2" }
-  - match: { results.1.updated_at_millis: null }
+  - match: { results.0.updated_at_millis: $updatedAtMillis1 }
+
 ---
 "Empty query results":
   - do:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/50_search_application_list.yml
@@ -128,7 +128,7 @@ teardown:
       search_application.list:
         q: "test-search-application-*"
   - set: { results.0.updated_at_millis: updatedAtMillis0 }
-  - set: { results.0.updated_at_millis: updatedAtMillis1 }
+  - set: { results.1.updated_at_millis: updatedAtMillis1 }
 
   - match: { count: 2 }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -410,7 +410,8 @@ public class SearchApplicationIndexService {
         return new SearchApplicationListItem(
             resourceName,
             documentFields.get(SearchApplication.INDICES_FIELD.getPreferredName()).getValues().toArray(String[]::new),
-            documentFields.get(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName()).getValue()
+            documentFields.get(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName()).getValue(),
+            System.currentTimeMillis()
         );
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -411,7 +411,7 @@ public class SearchApplicationIndexService {
             resourceName,
             documentFields.get(SearchApplication.INDICES_FIELD.getPreferredName()).getValues().toArray(String[]::new),
             documentFields.get(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName()).getValue(),
-            System.currentTimeMillis()
+            documentFields.get(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName()).getValue()
         );
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -374,6 +374,7 @@ public class SearchApplicationIndexService {
                 .docValueField(SearchApplication.NAME_FIELD.getPreferredName())
                 .docValueField(SearchApplication.INDICES_FIELD.getPreferredName())
                 .docValueField(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName())
+                .docValueField(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName())
                 .storedFields(Collections.singletonList("_none_"))
                 .sort(SearchApplication.NAME_FIELD.getPreferredName(), SortOrder.ASC);
             final SearchRequest req = new SearchRequest(SEARCH_APPLICATION_ALIAS_NAME).source(source);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -166,6 +166,10 @@ public class SearchApplicationIndexService {
                     builder.field("type", "keyword");
                     builder.endObject();
 
+                    builder.startObject(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName());
+                    builder.field("type", "long");
+                    builder.endObject();
+
                     builder.startObject(SearchApplication.BINARY_CONTENT_FIELD.getPreferredName());
                     builder.field("type", "object");
                     builder.field("enabled", "false");
@@ -275,6 +279,7 @@ public class SearchApplicationIndexService {
                     .field(SearchApplication.NAME_FIELD.getPreferredName(), app.name())
                     .field(SearchApplication.INDICES_FIELD.getPreferredName(), app.indices())
                     .field(SearchApplication.ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), app.analyticsCollectionName())
+                    .field(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName(), app.updatedAtMillis())
                     .directFieldAsBase64(
                         SearchApplication.BINARY_CONTENT_FIELD.getPreferredName(),
                         os -> writeSearchApplicationBinaryWithVersion(app, os, clusterService.state().nodes().getMinNodeVersion())

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationListItem.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationListItem.java
@@ -28,20 +28,26 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
     public static final ParseField NAME_FIELD = new ParseField("name");
     public static final ParseField INDICES_FIELD = new ParseField("indices");
     public static final ParseField ANALYTICS_COLLECTION_NAME_FIELD = new ParseField("analytics_collection_name");
+
+    public static final ParseField UPDATED_AT_MILLIS_FIELD = new ParseField("updated_at_millis");
     private final String name;
     private final String[] indices;
     private final String analyticsCollectionName;
 
-    public SearchApplicationListItem(String name, String[] indices, @Nullable String analyticsCollectionName) {
+    private final long updatedAtMillis;
+
+    public SearchApplicationListItem(String name, String[] indices, @Nullable String analyticsCollectionName, long updatedAtMillis) {
         this.name = name;
         this.indices = indices;
         this.analyticsCollectionName = analyticsCollectionName;
+        this.updatedAtMillis = updatedAtMillis;
     }
 
     public SearchApplicationListItem(StreamInput in) throws IOException {
         this.name = in.readString();
         this.indices = in.readStringArray();
         this.analyticsCollectionName = in.readOptionalString();
+        this.updatedAtMillis = in.readLong();
     }
 
     @Override
@@ -52,6 +58,7 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         if (analyticsCollectionName != null) {
             builder.field(ANALYTICS_COLLECTION_NAME_FIELD.getPreferredName(), analyticsCollectionName);
         }
+        builder.field(UPDATED_AT_MILLIS_FIELD.getPreferredName(), updatedAtMillis);
         builder.endObject();
         return builder;
     }
@@ -61,6 +68,7 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         out.writeString(name);
         out.writeStringArray(indices);
         out.writeOptionalString(analyticsCollectionName);
+        out.writeLong(updatedAtMillis);
     }
 
     public String name() {
@@ -75,6 +83,10 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         return analyticsCollectionName;
     }
 
+    public long updatedAtMillis() {
+        return updatedAtMillis;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
@@ -82,12 +94,13 @@ public class SearchApplicationListItem implements Writeable, ToXContentObject {
         SearchApplicationListItem item = (SearchApplicationListItem) o;
         return name.equals(item.name)
             && Arrays.equals(indices, item.indices)
-            && Objects.equals(analyticsCollectionName, item.analyticsCollectionName);
+            && Objects.equals(analyticsCollectionName, item.analyticsCollectionName)
+            && updatedAtMillis == item.updatedAtMillis;
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(name, analyticsCollectionName);
+        int result = Objects.hash(name, analyticsCollectionName, updatedAtMillis);
         result = 31 * result + Arrays.hashCode(indices);
         return result;
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationActionResponseSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/action/ListSearchApplicationActionResponseSerializingTests.java
@@ -24,7 +24,7 @@ public class ListSearchApplicationActionResponseSerializingTests extends Abstrac
     private static ListSearchApplicationAction.Response randomSearchApplicationListItem() {
         return new ListSearchApplicationAction.Response(randomList(10, () -> {
             SearchApplication app = SearchApplicationTestUtils.randomSearchApplication();
-            return new SearchApplicationListItem(app.name(), app.indices(), app.analyticsCollectionName());
+            return new SearchApplicationListItem(app.name(), app.indices(), app.analyticsCollectionName(), app.updatedAtMillis());
         }), randomLongBetween(0, 1000));
     }
 


### PR DESCRIPTION
In order to support the List Search Applications page, we need to include the `updatedAtMillis` field in the response. This PR adds this field to the list search applications response. 