### PR TITLE
Refactor Retry test util to not use CompletableFuture

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/Retry.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/util/Retry.java
@@ -9,51 +9,55 @@
 package org.elasticsearch.test.cluster.util;
 
 import java.time.Duration;
-import java.util.concurrent.Callable;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.BooleanSupplier;
 
 public final class Retry {
-    private static final Executor EXECUTOR = new Executor() {
-        @Override
-        public void execute(Runnable command) {
-            new Thread(command).start();
-        }
-    };
-
     private Retry() {}
 
-    public static void retryUntilTrue(Duration timeout, Duration delay, Callable<Boolean> predicate) throws TimeoutException,
+    public static void retryUntilTrue(Duration timeout, Duration delay, BooleanSupplier predicate) throws TimeoutException,
         ExecutionException {
-        getValueWithTimeout(timeout.toMillis(), TimeUnit.MILLISECONDS, () -> {
-            while (true) {
-                Boolean call = predicate.call();
-                if (call) {
-                    return true;
+
+        long delayMs = delay.toMillis();
+        AtomicReference<Exception> exception = new AtomicReference<>();
+        Thread t = new Thread(() -> {
+            for (;;) {
+                try {
+                    boolean complete = predicate.getAsBoolean();
+                    if (complete) {
+                        return;
+                    }
+                } catch (Exception e) {
+                    exception.set(e);
+                    return;
                 }
 
-                Thread.sleep(delay.toMillis());
+                try {
+                    Thread.sleep(delayMs);
+                } catch (InterruptedException e) {
+                    return;
+                }
             }
-        });
-    }
-
-    private static <T> T getValueWithTimeout(long timeout, TimeUnit timeUnit, Callable<T> predicate) throws TimeoutException,
-        ExecutionException {
-        CompletableFuture<T> future = CompletableFuture.supplyAsync(() -> {
-            try {
-                return predicate.call();
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }, EXECUTOR);
+        }, "Retry");
+        t.start();
 
         try {
-            return future.get(timeout, timeUnit);
+            t.join(timeout.toMillis());
+            if (t.isAlive()) {
+                // it didn't complete in time
+                throw new TimeoutException();
+            }
+            if (exception.get() != null) {
+                throw new ExecutionException(exception.get());
+            }
         } catch (InterruptedException e) {
+            // this thread was interrupted while waiting for t to stop
             throw new TimeoutException();
+        } finally {
+            // stop the thread if it's still running
+            t.interrupt();
         }
     }
 }


### PR DESCRIPTION
This simplifies `Retry` test utility class to not use `CompletableFuture`, and also ensures the created thread stops in all situations