### PR TITLE
Improve task removal assertion message

### DIFF
--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -744,7 +744,7 @@ public class TaskManager implements ClusterStateApplier {
 
         void removeTask(CancellableTask task) {
             final boolean removed = pendingTasks.remove(task);
-            assert removed : "task " + task.getId() + " is not in the pending list";
+            assert removed : "task is not in the pending list: " + task;
         }
     }
 


### PR DESCRIPTION
An assertion exists to ensure if a task to be removed was actually pending removal. This commit improves the assertion message to contain the entire task string representation like action/etc, instead of just the task id.