### PR TITLE
Adding BulkProcessor2.addWithBackpressure()

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
@@ -332,13 +332,13 @@ public class BulkProcessor2 {
         boolean successfullyAdded = false;
         while (successfullyAdded == false) {
             if (shouldAbort.get()) {
-                throw new EsRejectedExecutionException("Rejecting request because shouldAbort is now true");
+                throw new EsRejectedExecutionException("Rejecting request because bulk add has been cancelled by the caller");
             }
             try {
                 add(request);
                 successfullyAdded = true;
             } catch (EsRejectedExecutionException e) {
-                logger.trace("Rollup doc rejected, and will try again");
+                logger.trace("Attempt to add request to batch rejected because too many bytes are in flight already. Will try again.");
                 /*
                  * Note: It is possible that signalAll was called between the call to add above and acquiring this lock.
                  * But in that case, either we wait 500ms, or another batch completes and another call to signalAll wakes us up.

--- a/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
+++ b/server/src/main/java/org/elasticsearch/action/bulk/BulkProcessor2.java
@@ -26,7 +26,11 @@ import org.elasticsearch.threadpool.ThreadPool;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
+import java.util.function.Supplier;
 
 /**
  * A bulk processor is a thread safe bulk processing class, allowing to easily set when to "flush" a new bulk request
@@ -206,6 +210,13 @@ public class BulkProcessor2 {
      */
     private final Object mutex = new Object();
 
+    /*
+     * This Lock and Condition are used to throttle calls to bulkProcessor.addWithBackpressure when the bulkProcessor already has too many
+     * bytes in flight and cannot accept more data until already-in-flight requests complete.
+     */
+    private final Lock backpressureLock = new ReentrantLock();
+    private final Condition backpressureNotRequiredCondition = backpressureLock.newCondition();
+
     BulkProcessor2(
         BiConsumer<BulkRequest, ActionListener<BulkResponse>> consumer,
         int maxNumberOfRetries,
@@ -277,6 +288,21 @@ public class BulkProcessor2 {
     }
 
     /**
+     * This method is similar to {@link #add(IndexRequest) add()}, except that if adding the approximate size in bytes of the request to
+     * totalBytesInFlight would exceed maxBytesInFlight then this method will block until the request can be added without exceeding
+     * maxBytesInFlight (or until shouldAbort returns false). This method should be used carefully, ideally from a single thread. This is
+     * because calling it with multiple threads would either hang up all the threads in the pool (in the case of a bounded thread pool) or
+     * effectively create an unbounded queue (in the case of an unbounded thread pool).
+     * @param request The request to add to a batch to be consumed
+     * @param shouldAbort If this returns true then this method bails out with an EsRejectedExecutionException
+     * @return this BulkProcessor2
+     * @throws EsRejectedExecutionException if shouldAbort returns true before the request has been added to a batch
+     */
+    public BulkProcessor2 addWithBackpressure(IndexRequest request, Supplier<Boolean> shouldAbort) throws EsRejectedExecutionException {
+        return addWithBackpressure((DocWriteRequest<?>) request, shouldAbort);
+    }
+
+    /**
      * Adds an {@link DeleteRequest} to the list of actions to execute.
      * @throws EsRejectedExecutionException if adding the approximate size in bytes of the request to totalBytesInFlight would exceed
      * maxBytesInFlight
@@ -292,6 +318,44 @@ public class BulkProcessor2 {
      */
     private BulkProcessor2 add(DocWriteRequest<?> request) throws EsRejectedExecutionException {
         internalAdd(request);
+        return this;
+    }
+
+    private BulkProcessor2 addWithBackpressure(DocWriteRequest<?> request, Supplier<Boolean> shouldAbort)
+        throws EsRejectedExecutionException {
+        /*
+         * We want this method to block until the bulkProcessor accepts the request. Otherwise, the subsequent calls to this method will
+         * likely continue rejecting. BulkProcessor2.add does not have the ability to exert backpressure.
+         * So we have to catch the EsRejectedExecutionException that is thrown when it already has too many bytes in flight. We then
+         * wait until some bulk has been completed, reducing the amount of data in flight and (probably) making room for this request.
+         */
+        boolean successfullyAdded = false;
+        while (successfullyAdded == false) {
+            if (shouldAbort.get()) {
+                throw new EsRejectedExecutionException("Rejecting request because shouldAbort is now true");
+            }
+            try {
+                add(request);
+                successfullyAdded = true;
+            } catch (EsRejectedExecutionException e) {
+                logger.trace("Rollup doc rejected, and will try again");
+                /*
+                 * Note: It is possible that signalAll was called between the call to add above and acquiring this lock.
+                 * But in that case, either we wait 500ms, or another batch completes and another call to signalAll wakes us up.
+                 * Either way is preferable to requiring this lock for the whole try/catch block. That is why we ignore the
+                 * result of the call to await() -- either way we are going to try calling bulkProcessor.add() again.
+                 */
+                backpressureLock.lock();
+                try {
+                    backpressureNotRequiredCondition.await(500, TimeUnit.MILLISECONDS);
+                } catch (InterruptedException ex) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException(ex);
+                } finally {
+                    backpressureLock.unlock();
+                }
+            }
+        }
         return this;
     }
 
@@ -393,19 +457,36 @@ public class BulkProcessor2 {
                 @Override
                 public void onResponse(BulkResponse response) {
                     totalBytesInFlight.addAndGet(-1 * bulkRequest.estimatedSizeInBytes());
+                    maybeNoLongerInExcessofMaxBytesInFlight();
                     listener.afterBulk(executionId, bulkRequest, response);
                 }
 
                 @Override
                 public void onFailure(Exception e) {
                     totalBytesInFlight.addAndGet(-1 * bulkRequest.estimatedSizeInBytes());
+                    maybeNoLongerInExcessofMaxBytesInFlight();
                     listener.afterBulk(executionId, bulkRequest, e);
                 }
             });
         } catch (Exception e) {
             logger.warn(() -> "Failed to execute bulk request " + executionId + ".", e);
             totalBytesInFlight.addAndGet(-1 * bulkRequest.estimatedSizeInBytes());
+            maybeNoLongerInExcessofMaxBytesInFlight();
             listener.afterBulk(executionId, bulkRequest, e);
+        }
+    }
+
+    /*
+     * This method is to be called whenever we deduct from totalBytesInFlight, signalling that it's worth retrying any requests blocked in
+     * addWithBackpressure.
+     */
+    private void maybeNoLongerInExcessofMaxBytesInFlight() {
+        // Signal in case any rejected docs were waiting for the space in bulkProcessor in addWithBackPressure
+        backpressureLock.lock();
+        try {
+            backpressureNotRequiredCondition.signalAll();
+        } finally {
+            backpressureLock.unlock();
         }
     }
 


### PR DESCRIPTION
Most clients of BulkProcessor are OK with using it asynchronously. For example [failing to load a single ILM history record](https://github.com/elastic/elasticsearch/blob/main/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/history/ILMHistoryStore.java#L187) does not impact what we do with other ILM history records. But some clients do care. For example if we are downsampling a TSDB index we want to abort if a single entry does not make it.
This PR adds a method called addWithBackpressure() to BulkProcessor2. This method is similar to the add() method that already exists, except that it blocks the calling thread until there is room to add the request.
This code is ported from code that was originally in RollupShardIndexer in #94197.