### PR TITLE
Fix third party audit task when running with Java 20

### DIFF
--- a/libs/plugin-analysis-api/build.gradle
+++ b/libs/plugin-analysis-api/build.gradle
@@ -29,13 +29,3 @@ tasks.named('forbiddenApisMain').configure {
 tasks.named("dependencyLicenses").configure {
   mapping from: /lucene-.*/, to: 'lucene'
 }
-
-tasks.named("thirdPartyAudit").configure {
-  if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20) {
-    ignoreMissingClasses(
-      // This class was removed in Java 20 but is only referenced by a class that requires preview features anyhow
-      // See: https://github.com/apache/lucene/pull/12042
-      'java.lang.foreign.MemorySession',
-    )
-  }
-}

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -239,14 +239,6 @@ tasks.named("thirdPartyAudit").configure {
             'org.zeromq.ZMQ',
     )
     ignoreMissingClasses 'javax.xml.bind.DatatypeConverter'
-
-    if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20) {
-      ignoreMissingClasses(
-        // This class was removed in Java 20 but is only referenced by a class that requires preview features anyhow
-        // See: https://github.com/apache/lucene/pull/12042
-        'java.lang.foreign.MemorySession',
-      )
-    }
 }
 
 tasks.named("dependencyLicenses").configure {


### PR DESCRIPTION
The upgrade to Lucene 9.6 snapshot broke third party audit when running against Java 20, presumably because the usage of the since removed MemorySegment API has been removed.