### PR TITLE
Remove compareAndSet in failure handling

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/CountDownActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/CountDownActionListener.java
@@ -57,15 +57,17 @@ public final class CountDownActionListener extends DelegatingActionListener<Void
 
     @Override
     public void onFailure(Exception e) {
-        if (failure.compareAndSet(null, e) == false) {
-            failure.accumulateAndGet(e, (current, update) -> {
-                // we have to avoid self-suppression!
-                if (update != current) {
-                    current.addSuppressed(update);
-                }
-                return current;
-            });
-        }
+        failure.accumulateAndGet(e, (current, update) -> {
+            if (current == null) {
+                return update;
+            }
+
+            // we have to avoid self-suppression!
+            if (update != current) {
+                current.addSuppressed(update);
+            }
+            return current;
+        });
         if (countDown()) {
             super.onFailure(failure.get());
         }

--- a/server/src/main/java/org/elasticsearch/action/support/CountDownActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/CountDownActionListener.java
@@ -57,17 +57,10 @@ public final class CountDownActionListener extends DelegatingActionListener<Void
 
     @Override
     public void onFailure(Exception e) {
-        failure.accumulateAndGet(e, (current, update) -> {
-            if (current == null) {
-                return update;
-            }
-
-            // we have to avoid self-suppression!
-            if (update != current) {
-                current.addSuppressed(update);
-            }
-            return current;
-        });
+        final var firstException = failure.compareAndExchange(null, e);
+        if (firstException != null && firstException != e) {
+            firstException.addSuppressed(e);
+        }
         if (countDown()) {
             super.onFailure(failure.get());
         }

--- a/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
@@ -60,15 +60,17 @@ public final class GroupedActionListener<T> extends DelegatingActionListener<T, 
 
     @Override
     public void onFailure(Exception e) {
-        if (failure.compareAndSet(null, e) == false) {
-            failure.accumulateAndGet(e, (current, update) -> {
-                // we have to avoid self-suppression!
-                if (update != current) {
-                    current.addSuppressed(update);
-                }
-                return current;
-            });
-        }
+        failure.accumulateAndGet(e, (current, update) -> {
+            if (current == null) {
+                return update;
+            }
+
+            // we have to avoid self-suppression!
+            if (update != current) {
+                current.addSuppressed(update);
+            }
+            return current;
+        });
         if (countDown.countDown()) {
             super.onFailure(failure.get());
         }

--- a/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
+++ b/server/src/main/java/org/elasticsearch/action/support/GroupedActionListener.java
@@ -60,17 +60,10 @@ public final class GroupedActionListener<T> extends DelegatingActionListener<T, 
 
     @Override
     public void onFailure(Exception e) {
-        failure.accumulateAndGet(e, (current, update) -> {
-            if (current == null) {
-                return update;
-            }
-
-            // we have to avoid self-suppression!
-            if (update != current) {
-                current.addSuppressed(update);
-            }
-            return current;
-        });
+        final var firstException = failure.compareAndExchange(null, e);
+        if (firstException != null && firstException != e) {
+            firstException.addSuppressed(e);
+        }
         if (countDown.countDown()) {
             super.onFailure(failure.get());
         }


### PR DESCRIPTION
As requested in https://github.com/elastic/elasticsearch/pull/92308#discussion_r1048632033 (which I'm finally getting back to, yikes!).

Instead of a `compareAndSet` followed by an `accumulateAndGet`, just use a single ~`accumulateAndGet`~ `compareAndExchange` for everything.

I'm 97.5% sure the logic of this remains correct, and I think it's simpler this way, but if somebody can point out a bug in the logic or disagrees about it being simpler, I'm happy to change or close this PR.

For a bit of the history on this, see `https://github.com/elastic/elasticsearch/pull/23969` (code highlighting to avoid a github reference being added), as well as #37649 and #53262.