### PR TITLE
[TRANSFORM] No point sorting preview docs for serialization

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/PreviewTransformAction.java
@@ -200,7 +200,7 @@ public class PreviewTransformAction extends ActionType<PreviewTransformAction.Re
         public void writeTo(StreamOutput out) throws IOException {
             out.writeInt(docs.size());
             for (Map<String, Object> doc : docs) {
-                out.writeMapWithConsistentOrder(doc);
+                out.writeGenericMap(doc);
             }
             generatedDestIndexSettings.writeTo(out);
         }


### PR DESCRIPTION
Currently we serialize the transform preview docs in sorted order. However, when we read them at the other end we deserialize into a hash map, which loses the ordering. Therefore sorting when serializing is pointless.

The serverless integration tests are tripping an assertion in writeMapWithConsistentOrder that the map being serialized is not a linked hash map. It makes no difference to the functionality if it is, so this does not affect production clusters (where assertions are disabled). But it causes integration tests to fail.