### PR TITLE
[DOCS] Add privileges on privileges.asciidoc

### DIFF
--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -135,9 +135,10 @@ All operations related to managing autoscaling policies.
 
 `manage_data_frame_transforms`::
 All operations related to managing {transforms}.
+deprecated[7.5] Use `manage_transform` instead.
 
 `manage_enrich`::
-Enable you to manage transforms (Need to be reviewed).
+All operations related to managing and executing enrich policies.
 
 `manage_watcher`::
 All watcher operations, such as putting watches, executing, activate or acknowledging.

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -131,7 +131,7 @@ Service.
 All operations related to managing {transforms}.
 
 `manage_autoscaling`::
-All deployment operations, create or update autoscaling policy API (Need to be reviewed).
+All operations related to managing autoscaling policies.
 
 `manage_data_frame_transforms`::
 Enable you to manage transforms (Need to be reviewed).

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -130,6 +130,15 @@ Service.
 `manage_transform`::
 All operations related to managing {transforms}.
 
+`manage_autoscaling`::
+All deployment operations, create or update autoscaling policy API (Need to be reviewed).
+
+`manage_data_frame_transforms`::
+Enable you to manage transforms (Need to be reviewed).
+
+`manage_enrich`::
+Enable you to manage transforms (Need to be reviewed).
+
 `manage_watcher`::
 All watcher operations, such as putting watches, executing, activate or acknowledging.
 +

--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -134,7 +134,7 @@ All operations related to managing {transforms}.
 All operations related to managing autoscaling policies.
 
 `manage_data_frame_transforms`::
-Enable you to manage transforms (Need to be reviewed).
+All operations related to managing {transforms}.
 
 `manage_enrich`::
 Enable you to manage transforms (Need to be reviewed).


### PR DESCRIPTION
Requested to update the below privileges the cluster privileges description. 
I typed descriptions per each but it probably needs to be reviewed and corrected.

Doc: https://www.elastic.co/guide/en/elasticsearch/reference/master/security-privileges.html. 


### Privileges
- manage_autoscaling
- manage_data_frame_transforms
- manage_enrich

![CleanShot 2023-03-22 at 10 37 48](https://user-images.githubusercontent.com/87506906/226769278-549269b3-af91-49aa-8653-01527d3053a5.png)

