### PR TITLE
Stop processing TransportDownsampleAction on failure

### DIFF
--- a/docs/changelog/94624.yaml
+++ b/docs/changelog/94624.yaml
@@ -1,0 +1,5 @@
+pr: 94624
+summary: Stop processing `TransportDownsampleAction` on failure
+area: Rollup
+type: bug
+issues: []

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -165,6 +165,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
                             "Rollup forbidden for index [" + sourceIndexName + "] with document level or field level security settings."
                         )
                     );
+                    return;
                 }
             }
         }


### PR DESCRIPTION
In #90593 we introduced a new failure path into `TransportDownsampleAction` but omitted the `return` after completing the listener so processing would continue (and fail further down, completing the listener again). This commit adds the missing `return`.