### PR TITLE
Improve toString() on Releasables utils

### DIFF
--- a/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
+++ b/libs/core/src/main/java/org/elasticsearch/core/Releasables.java
@@ -10,6 +10,7 @@ package org.elasticsearch.core;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicReference;
 
 /** Utility methods to work with {@link Releasable}s. */
@@ -89,12 +90,32 @@ public enum Releasables {
      *  </pre>
      */
     public static Releasable wrap(final Iterable<Releasable> releasables) {
-        return () -> close(releasables);
+        return new Releasable() {
+            @Override
+            public void close() {
+                Releasables.close(releasables);
+            }
+
+            @Override
+            public String toString() {
+                return "wrapped[" + releasables + "]";
+            }
+        };
     }
 
     /** @see #wrap(Iterable) */
     public static Releasable wrap(final Releasable... releasables) {
-        return () -> close(releasables);
+        return new Releasable() {
+            @Override
+            public void close() {
+                Releasables.close(releasables);
+            }
+
+            @Override
+            public String toString() {
+                return "wrapped" + Arrays.toString(releasables);
+            }
+        };
     }
 
     /**


### PR DESCRIPTION
Today both `Releasables#wrap` implementations return a lambda which does not render well in logs or exception messages. This commit improves that. It also adds tests for these methods and moves the test suite to the correct module.