### PR TITLE
[8.7] Stop processing TransportDownsampleAction on failure (#94624)

### DIFF
--- a/docs/changelog/94624.yaml
+++ b/docs/changelog/94624.yaml
@@ -1,0 +1,5 @@
+pr: 94624
+summary: Stop processing `TransportDownsampleAction` on failure
+area: Rollup
+type: bug
+issues: []

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -163,6 +163,7 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
                             "Rollup forbidden for index [" + sourceIndexName + "] with document level or field level security settings."
                         )
                     );
+                    return;
                 }
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Stop processing TransportDownsampleAction on failure (#94624)