### PR TITLE
Enable dlm flag on non-snapshot builds tests

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -136,9 +136,11 @@ sourceSets.main.compiledBy(generateModulesList, generatePluginsList)
 if (BuildParams.isSnapshotBuild() == false) {
     tasks.named("test").configure {
         systemProperty 'es.index_mode_feature_flag_registered', 'true'
+        systemProperty 'es.dlm_feature_flag_enabled', 'true'
     }
     tasks.named("internalClusterTest").configure {
         systemProperty 'es.index_mode_feature_flag_registered', 'true'
+        systemProperty 'es.dlm_feature_flag_enabled', 'true'
     }
 }
 


### PR DESCRIPTION
Enable the DLM feature flag for server tests.

Fixes: https://github.com/elastic/elasticsearch/issues/94579