### PR TITLE
Refactor DataLifecycleService and DataLifecycleErrorStore

### DIFF
--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleErrorStore.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleErrorStore.java
@@ -11,6 +11,7 @@ package org.elasticsearch.dlm;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.core.Nullable;
 
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -58,4 +59,10 @@ public class DataLifecycleErrorStore {
         return indexNameToError.get(indexName);
     }
 
+    /**
+     * Return an immutable view (a snapshot) of the tracked indices at the moment this method is called.
+     */
+    public List<String> getAllIndices() {
+        return List.copyOf(indexNameToError.keySet());
+    }
 }

--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleErrorStore.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleErrorStore.java
@@ -23,38 +23,39 @@ import static org.elasticsearch.xcontent.ToXContent.EMPTY_PARAMS;
  */
 public class DataLifecycleErrorStore {
 
-    private final ConcurrentMap<String, String> targetToError = new ConcurrentHashMap<>();
+    private final ConcurrentMap<String, String> indexNameToError = new ConcurrentHashMap<>();
 
     /**
-     * Records a string representation of the provided exception for the provided target.
-     * If an error was already recorded for the provided target this will override that error.
+     * Records a string representation of the provided exception for the provided index.
+     * If an error was already recorded for the provided index this will override that error.
      */
-    public void recordError(String target, Exception e) {
-        targetToError.put(target, org.elasticsearch.common.Strings.toString(((builder, params) -> {
+    public void recordError(String indexName, Exception e) {
+        indexNameToError.put(indexName, org.elasticsearch.common.Strings.toString(((builder, params) -> {
             ElasticsearchException.generateThrowableXContent(builder, EMPTY_PARAMS, e);
             return builder;
         })));
     }
 
     /**
-     * Clears the recorded error for the provided target (if any exists)
+     * Clears the recorded error for the provided index (if any exists)
      */
-    public void clearRecordedError(String target) {
-        targetToError.remove(target);
+    public void clearRecordedError(String indexName) {
+        indexNameToError.remove(indexName);
     }
 
     /**
      * Clears all the errors recorded in the store.
      */
     public void clearStore() {
-        targetToError.clear();
+        indexNameToError.clear();
     }
 
     /**
-     * Retrieves the recorderd error for the provided target.
+     * Retrieves the recorderd error for the provided index.
      */
     @Nullable
-    public String getError(String target) {
-        return targetToError.get(target);
+    public String getError(String indexName) {
+        return indexNameToError.get(indexName);
     }
+
 }

--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleService.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleService.java
@@ -210,9 +210,12 @@ public class DataLifecycleService implements ClusterStateListener, Closeable, Sc
      */
     private void clearErrorStoreForUnmanagedIndices(DataStream dataStream) {
         Metadata metadata = clusterService.state().metadata();
-        for (Index index : dataStream.getIndices()) {
-            if (dataStream.isIndexManagedByDLM(index, metadata::index) == false) {
-                errorStore.clearRecordedError(index.getName());
+        for (String indexName : errorStore.getAllIndices()) {
+            IndexMetadata indexMeta = metadata.index(indexName);
+            if (indexMeta == null) {
+                errorStore.clearRecordedError(indexName);
+            } else if (dataStream.isIndexManagedByDLM(indexMeta.getIndex(), metadata::index) == false) {
+                errorStore.clearRecordedError(indexName);
             }
         }
     }

--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleService.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/DataLifecycleService.java
@@ -134,13 +134,6 @@ public class DataLifecycleService implements ClusterStateListener, Closeable, Sc
                 errorStore.clearStore();
             }
         }
-        if (event.localNodeMaster()) {
-            // only execute if we're the master
-            List<Index> indicesDeleted = event.indicesDeleted();
-            for (Index deleted : indicesDeleted) {
-                errorStore.clearRecordedError(deleted.getName());
-            }
-        }
     }
 
     @Override

--- a/modules/dlm/src/test/java/org/elasticsearch/dlm/DataLifecycleErrorStoreTests.java
+++ b/modules/dlm/src/test/java/org/elasticsearch/dlm/DataLifecycleErrorStoreTests.java
@@ -11,6 +11,10 @@ package org.elasticsearch.dlm;
 import org.elasticsearch.test.ESTestCase;
 import org.junit.Before;
 
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -27,11 +31,41 @@ public class DataLifecycleErrorStoreTests extends ESTestCase {
     public void testRecordAndRetrieveError() {
         errorStore.recordError("test", new NullPointerException("testing"));
         assertThat(errorStore.getError("test"), is(notNullValue()));
+        assertThat(errorStore.getAllIndices().size(), is(1));
+        assertThat(errorStore.getAllIndices().get(0), is("test"));
     }
 
     public void testRetrieveAfterClear() {
         errorStore.recordError("test", new NullPointerException("testing"));
         errorStore.clearStore();
         assertThat(errorStore.getError("test"), is(nullValue()));
+    }
+
+    public void testGetAllIndicesIsASnapshotViewOfTheStore() {
+        Stream.iterate(0, i -> i + 1).limit(5).forEach(i -> errorStore.recordError("test" + i, new NullPointerException("testing")));
+        List<String> initialAllIndices = errorStore.getAllIndices();
+        assertThat(initialAllIndices.size(), is(5));
+        assertThat(
+            initialAllIndices,
+            containsInAnyOrder(Stream.iterate(0, i -> i + 1).limit(5).map(i -> "test" + i).toArray(String[]::new))
+        );
+
+        // let's add some more items to the store and clear a couple of the initial ones
+        Stream.iterate(5, i -> i + 1).limit(5).forEach(i -> errorStore.recordError("test" + i, new NullPointerException("testing")));
+        errorStore.clearRecordedError("test0");
+        errorStore.clearRecordedError("test1");
+        // the initial list should remain unchanged
+        assertThat(initialAllIndices.size(), is(5));
+        assertThat(
+            initialAllIndices,
+            containsInAnyOrder(Stream.iterate(0, i -> i + 1).limit(5).map(i -> "test" + i).toArray(String[]::new))
+        );
+
+        // calling getAllIndices again should reflect the latest state
+        assertThat(errorStore.getAllIndices().size(), is(8));
+        assertThat(
+            errorStore.getAllIndices(),
+            containsInAnyOrder(Stream.iterate(2, i -> i + 1).limit(8).map(i -> "test" + i).toArray(String[]::new))
+        );
     }
 }

--- a/modules/dlm/src/test/java/org/elasticsearch/dlm/DataLifecycleServiceTests.java
+++ b/modules/dlm/src/test/java/org/elasticsearch/dlm/DataLifecycleServiceTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.admin.indices.rollover.MaxAgeCondition;
 import org.elasticsearch.action.admin.indices.rollover.RolloverInfo;
 import org.elasticsearch.action.admin.indices.rollover.RolloverRequest;
-import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataLifecycle;
@@ -36,7 +35,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.index.Index;
-import org.elasticsearch.test.ClusterServiceUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
 import org.elasticsearch.threadpool.TestThreadPool;
@@ -58,6 +56,8 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.newInstance;
+import static org.elasticsearch.test.ClusterServiceUtils.createClusterService;
+import static org.elasticsearch.test.ClusterServiceUtils.setState;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -70,6 +70,7 @@ public class DataLifecycleServiceTests extends ESTestCase {
     private DataLifecycleService dataLifecycleService;
     private List<TransportRequest> clientSeenRequests;
     private NoOpClient client;
+    private ClusterService clusterService;
 
     @Before
     public void setupServices() {
@@ -77,7 +78,7 @@ public class DataLifecycleServiceTests extends ESTestCase {
         Set<Setting<?>> builtInClusterSettings = new HashSet<>(ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         builtInClusterSettings.add(DataLifecycleService.DLM_POLL_INTERVAL_SETTING);
         ClusterSettings clusterSettings = new ClusterSettings(Settings.EMPTY, builtInClusterSettings);
-        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool, clusterSettings);
+        clusterService = createClusterService(threadPool, clusterSettings);
 
         now = System.currentTimeMillis();
         Clock clock = Clock.fixed(Instant.ofEpochMilli(now), ZoneId.of(randomFrom(ZoneId.getAvailableZoneIds())));
@@ -100,6 +101,7 @@ public class DataLifecycleServiceTests extends ESTestCase {
     public void cleanup() {
         clientSeenRequests.clear();
         dataLifecycleService.close();
+        clusterService.close();
         threadPool.shutdownNow();
         client.close();
     }
@@ -218,8 +220,8 @@ public class DataLifecycleServiceTests extends ESTestCase {
             builder,
             dataStreamName,
             numBackingIndices,
-            Settings.builder().put(IndexMetadata.LIFECYCLE_NAME, "ILM_policy").put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT),
-            null
+            Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT),
+            new DataLifecycle()
         );
         builder.put(dataStream);
         String nodeId = "localNode";
@@ -247,63 +249,15 @@ public class DataLifecycleServiceTests extends ESTestCase {
         }
         newStateBuilder.metadata(metaBuilder);
         ClusterState stateWithDeletedIndices = newStateBuilder.nodes(buildNodes(nodeId).masterNodeId(nodeId)).build();
-        ClusterChangedEvent event = new ClusterChangedEvent("_na_", stateWithDeletedIndices, previousState);
+        setState(clusterService, stateWithDeletedIndices);
 
-        dataLifecycleService.clusterChanged(event);
+        dataLifecycleService.run(stateWithDeletedIndices);
 
         for (Index deletedIndex : deletedIndices) {
             assertThat(dataLifecycleService.getErrorStore().getError(deletedIndex.getName()), nullValue());
         }
         // the value for the write index should still be in the error store
         assertThat(dataLifecycleService.getErrorStore().getError(dataStream.getWriteIndex().getName()), notNullValue());
-    }
-
-    public void testErrorStoreIsNotUpdatedIfWeAreNotMaster() {
-        String dataStreamName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        int numBackingIndices = 3;
-        Metadata.Builder builder = Metadata.builder();
-        DataStream dataStream = createDataStream(
-            builder,
-            dataStreamName,
-            numBackingIndices,
-            Settings.builder().put(IndexMetadata.LIFECYCLE_NAME, "ILM_policy").put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT),
-            null
-        );
-        builder.put(dataStream);
-        String localNode = "localNode";
-        String masterNodeId = "some_other_node";
-        DiscoveryNodes.Builder nodesBuilder = buildNodes(localNode).add(getNode(masterNodeId)).masterNodeId(masterNodeId);
-        ClusterState previousState = ClusterState.builder(ClusterName.DEFAULT).metadata(builder).nodes(nodesBuilder).build();
-
-        // all backing indices are in the error store
-        for (Index index : dataStream.getIndices()) {
-            dataLifecycleService.getErrorStore().recordError(index.getName(), new NullPointerException("bad"));
-        }
-        Index writeIndex = dataStream.getWriteIndex();
-        // all indices but the write index are deleted
-        List<Index> deletedIndices = dataStream.getIndices().stream().filter(index -> index.equals(writeIndex) == false).toList();
-
-        ClusterState.Builder newStateBuilder = ClusterState.builder(previousState);
-        newStateBuilder.stateUUID(UUIDs.randomBase64UUID());
-        Metadata.Builder metaBuilder = Metadata.builder(previousState.metadata());
-        for (Index index : deletedIndices) {
-            metaBuilder.remove(index.getName());
-            IndexGraveyard.Builder graveyardBuilder = IndexGraveyard.builder(metaBuilder.indexGraveyard());
-            graveyardBuilder.addTombstone(index);
-            metaBuilder.indexGraveyard(graveyardBuilder.build());
-        }
-        newStateBuilder.metadata(metaBuilder);
-        ClusterState stateWithDeletedIndices = newStateBuilder.nodes(
-            buildNodes(localNode).add(getNode(masterNodeId)).masterNodeId(masterNodeId)
-        ).build();
-        ClusterChangedEvent event = new ClusterChangedEvent("_na_", stateWithDeletedIndices, previousState);
-
-        dataLifecycleService.clusterChanged(event);
-
-        for (Index index : dataStream.getIndices()) {
-            // all the errors shoudl still be in the error store as the node where DLM runs is not the master node
-            assertThat(dataLifecycleService.getErrorStore().getError(index.getName()), notNullValue());
-        }
     }
 
     public void testErrorStoreIsClearedOnBackingIndexBecomingUnmanaged() {


### PR DESCRIPTION
This encapsulates a few changes:
- we clear the error store of unmanaged or deleted indices in a more efficient way
- the `ErrorRecordingActionListener` is now aware of the error store
- we renamed `target` to `indexName`

Relates to https://github.com/elastic/elasticsearch/issues/93596