### PR TITLE
[main] Fix backwards description in runtime fields documentation (#94608)

### DIFF
--- a/docs/reference/mapping/runtime.asciidoc
+++ b/docs/reference/mapping/runtime.asciidoc
@@ -277,7 +277,7 @@ as part of the `runtime_mappings` section, just as you would if
 
 Defining a runtime field in a search request uses the same format as defining
 a runtime field in the index mapping. Just copy the field definition from
-the `runtime_mappings` in the index mapping to the `runtime` section of the search request.
+the `runtime` in the index mapping to the `runtime_mappings` section of the search request.
 
 The following search request adds a `day_of_week` field to the
 `runtime_mappings` section. The field values will be calculated dynamically,


### PR DESCRIPTION
Backports the following commits to main:
 - Fix backwards description in runtime fields documentation (#94608)