### PR TITLE
Generate build report tarball when building in Buildkite CI

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.build-complete.gradle
@@ -10,7 +10,7 @@ import org.elasticsearch.gradle.util.GradleUtils
 
 import java.nio.file.Files
 
-String buildNumber = System.getenv('BUILD_NUMBER')
+String buildNumber = System.getenv('BUILD_NUMBER') ?: System.getenv('BUILDKITE_BUILD_NUMBER')
 String performanceTest = System.getenv('BUILD_PERFORMANCE_TEST')
 if (buildNumber && performanceTest == null && GradleUtils.isIncludedBuild(project) == false) {
   File uploadFile = file("build/${buildNumber}.tar.bz2")


### PR DESCRIPTION
We generate a tarball with various test reports, logs and diagnostics on build completion when running in CI. Adapt this script to also support Buildkite, in addition to Jenkins.