### PR TITLE
Use correct target compatibility for third party audit tasks

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -61,6 +61,7 @@ configure(allprojects) {
       project.getTasks().withType(ThirdPartyAuditTask.class).configureEach {
         if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
           javaHome.set(providers.provider(() -> "${project.jdks.provisioned_runtime.javaHomePath}"))
+          targetCompatibility.set(providers.provider(() -> JavaVersion.toVersion(project.jdks.provisioned_runtime.major)))
         }
       }
     }


### PR DESCRIPTION
When running `thirdPartyAudit` tasks using the provisioned runtime JDK (aka the bundled JDK) we were not passing the correct target compatibility version to the forbidden APIs CLI. We were using the current build (compiler) Java version instead of the runtime version. This can cause issues because we use that to determine which classes in multi-release JARs to pass to the scanner.