### PR TITLE
Don't create many Rounding.Prepared instances when checking for empty buckets in date_histogram aggregator.

### DIFF
--- a/docs/changelog/94649.yaml
+++ b/docs/changelog/94649.yaml
@@ -1,5 +1,5 @@
 pr: 94649
-summary: Stop using Rounding#nextRoundingValue(...) when creating empty buckets
+summary: Don't create many Rounding.Prepared instances when checking for empty buckets in date_histogram aggregator.
 area: Aggregations
 type: enhancement
 issues: []

--- a/docs/changelog/94649.yaml
+++ b/docs/changelog/94649.yaml
@@ -1,0 +1,5 @@
+pr: 94649
+summary: Stop using Rounding#nextRoundingValue(...) when creating empty buckets
+area: Aggregations
+type: enhancement
+issues: []

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/histogram/InternalAutoDateHistogram.java
@@ -637,11 +637,6 @@ public final class InternalAutoDateHistogram extends InternalMultiBucketAggregat
     }
 
     @Override
-    public Number nextKey(Number key) {
-        return bucketInfo.roundingInfos[bucketInfo.roundingIdx].rounding.nextRoundingValue(key.longValue());
-    }
-
-    @Override
     public InternalAggregation createAggregation(List<MultiBucketsAggregation.Bucket> buckets) {
         // convert buckets to the right type
         List<Bucket> buckets2 = new ArrayList<>(buckets.size());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/HistogramFactory.java
@@ -23,10 +23,6 @@ public interface HistogramFactory {
      *  must return the double value of the key. */
     Number getKey(MultiBucketsAggregation.Bucket bucket);
 
-    /** Given a key returned by {@link #getKey}, compute the lowest key that is
-     *  greater than it. */
-    Number nextKey(Number key);
-
     /** Create an {@link InternalAggregation} object that wraps the given buckets. */
     InternalAggregation createAggregation(List<MultiBucketsAggregation.Bucket> buckets);
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -440,7 +440,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
                     long max = bounds.getMax() + offset;
                     while (key <= max) {
                         onBucket.accept(key);
-                        key = nextKey(prepared, key).longValue();
+                        key = nextKey(prepared, key);
                     }
                 }
             } else {
@@ -449,7 +449,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
                     if (key < firstBucket.key) {
                         while (key < firstBucket.key) {
                             onBucket.accept(key);
-                            key = nextKey(prepared, key).longValue();
+                            key = nextKey(prepared, key);
                         }
                     }
                 }
@@ -462,10 +462,10 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         while (iter.hasNext()) {
             Bucket nextBucket = list.get(iter.nextIndex());
             if (lastBucket != null) {
-                long key = nextKey(prepared, lastBucket.key).longValue();
+                long key = nextKey(prepared, lastBucket.key);
                 while (key < nextBucket.key) {
                     onBucket.accept(key);
-                    key = nextKey(prepared, key).longValue();
+                    key = nextKey(prepared, key);
                 }
                 assert key == nextBucket.key : "key: " + key + ", nextBucket.key: " + nextBucket.key;
             }
@@ -474,11 +474,11 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
         // finally, adding the empty buckets *after* the actual data (based on the extended_bounds.max requested by the user)
         if (bounds != null && lastBucket != null && bounds.getMax() != null && bounds.getMax() + offset > lastBucket.key) {
-            long key = nextKey(prepared, lastBucket.key).longValue();
+            long key = nextKey(prepared, lastBucket.key);
             long max = bounds.getMax() + offset;
             while (key <= max) {
                 onBucket.accept(key);
-                key = nextKey(prepared, key).longValue();
+                key = nextKey(prepared, key);
             }
         }
     }
@@ -566,8 +566,8 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
 
     /** Given a key returned by {@link #getKey}, compute the lowest key that is
      *  greater than it. */
-    Number nextKey(Rounding.Prepared prepared, Number key) {
-        return prepared.nextRoundingValue(key.longValue() - offset) + offset;
+    long nextKey(Rounding.Prepared prepared, long key) {
+        return prepared.nextRoundingValue(key - offset) + offset;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalDateHistogram.java
@@ -163,10 +163,6 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         final InternalAggregations subAggregations;
         final LongBounds bounds;
 
-        EmptyBucketInfo(Rounding rounding, InternalAggregations subAggregations) {
-            this(rounding, subAggregations, null);
-        }
-
         EmptyBucketInfo(Rounding rounding, InternalAggregations subAggregations, LongBounds bounds) {
             this.rounding = rounding;
             this.subAggregations = subAggregations;
@@ -310,7 +306,7 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         for (InternalAggregation aggregation : aggregations) {
             InternalDateHistogram histogram = (InternalDateHistogram) aggregation;
             if (histogram.buckets.isEmpty() == false) {
-                pq.add(new IteratorAndCurrent<Bucket>(histogram.buckets.iterator()));
+                pq.add(new IteratorAndCurrent<>(histogram.buckets.iterator()));
             }
         }
 
@@ -564,16 +560,13 @@ public final class InternalDateHistogram extends InternalMultiBucketAggregation<
         return ((Bucket) bucket).key;
     }
 
-    @Override
-    public Number nextKey(Number key) {
-        return emptyBucketInfo.rounding.nextRoundingValue(key.longValue() - offset) + offset;
-    }
-
-    public Rounding.Prepared createPrepared(long min, long max) {
+    Rounding.Prepared createPrepared(long min, long max) {
         return emptyBucketInfo.rounding.prepare(min - offset, max - offset);
     }
 
-    public Number nextKey(Rounding.Prepared prepared, Number key) {
+    /** Given a key returned by {@link #getKey}, compute the lowest key that is
+     *  greater than it. */
+    Number nextKey(Rounding.Prepared prepared, Number key) {
         return prepared.nextRoundingValue(key.longValue() - offset) + offset;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalHistogram.java
@@ -520,11 +520,6 @@ public final class InternalHistogram extends InternalMultiBucketAggregation<Inte
     }
 
     @Override
-    public Number nextKey(Number key) {
-        return nextKey(key.doubleValue());
-    }
-
-    @Override
     public InternalAggregation createAggregation(List<MultiBucketsAggregation.Bucket> buckets) {
         // convert buckets to the right type
         List<Bucket> buckets2 = new ArrayList<>(buckets.size());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/InternalVariableWidthHistogram.java
@@ -315,19 +315,6 @@ public class InternalVariableWidthHistogram extends InternalMultiBucketAggregati
     }
 
     @Override
-    public Number nextKey(Number key) {
-        return nextKey(key.doubleValue());
-    }
-
-    /**
-     * This method should not be called for this specific subclass of InternalHistogram, since there should not be
-     * empty buckets when clustering.
-    =    */
-    private static double nextKey(double key) {
-        return key + 1;
-    }
-
-    @Override
     protected Bucket reduceBucket(List<Bucket> buckets, AggregationReduceContext context) {
         List<InternalAggregations> aggregations = new ArrayList<>(buckets.size());
         long docCount = 0;


### PR DESCRIPTION
This change stops using Rounding#nextRoundingValue(...) when creating empty buckets in `date_histogram` aggregator.
This method creates an `Rounding.Prepared` each time when computing the next rounding value, which happen a lot. This has a significant overhead. Also `Rounding#nextRoundingValue(...)` has been deprecated for this reason.

Instead, this change, when checking for empty buckets, the Rounding.Prepared is created once and then used many times when computing the next rounding value (`Rounding.Prepared.nextRoundingValue(...)`)

This change also removes the `nextKey(...)` method from the `HistogramFactory` interface. This method was only used in `InternalAutoDateHistogram` and I think there is no reason to leave this method in this interface and force other implementations of this interface to implement this (the other implementations aren't used).