### PR TITLE
[8.7] Use correct target compatibility for third party audit tasks (#94648)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.runtime-jdk-provision.gradle
@@ -61,6 +61,7 @@ configure(allprojects) {
       project.getTasks().withType(ThirdPartyAuditTask.class).configureEach {
         if (BuildParams.getIsRuntimeJavaHomeSet() == false) {
           javaHome.set(providers.provider(() -> "${project.jdks.provisioned_runtime.javaHomePath}"))
+          targetCompatibility.set(providers.provider(() -> JavaVersion.toVersion(project.jdks.provisioned_runtime.major)))
         }
       }
     }

--- a/libs/plugin-analysis-api/build.gradle
+++ b/libs/plugin-analysis-api/build.gradle
@@ -31,7 +31,7 @@ tasks.named("dependencyLicenses").configure {
 }
 
 tasks.named("thirdPartyAudit").configure {
-  if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20) {
+  if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20 || BuildParams.isRuntimeJavaHomeSet == false) {
     ignoreMissingClasses(
       // This class was removed in Java 20 but is only referenced by a class that requires preview features anyhow
       // See: https://github.com/apache/lucene/pull/12042

--- a/server/build.gradle
+++ b/server/build.gradle
@@ -236,7 +236,7 @@ tasks.named("thirdPartyAudit").configure {
     )
     ignoreMissingClasses 'javax.xml.bind.DatatypeConverter'
 
-    if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20) {
+    if (BuildParams.runtimeJavaVersion == JavaVersion.VERSION_20 || BuildParams.isRuntimeJavaHomeSet == false) {
       ignoreMissingClasses(
         // This class was removed in Java 20 but is only referenced by a class that requires preview features anyhow
         // See: https://github.com/apache/lucene/pull/12042


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Use correct target compatibility for third party audit tasks (#94648)