### PR TITLE
[Fleet] Remove ILM policy from fleet files indices and make them hidden

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-file-data.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-file-data.json
@@ -10,8 +10,8 @@
   },
   "template" : {
     "settings": {
-      "index.lifecycle.name": ".fleet-file-data-ilm-policy",
-      "auto_expand_replicas": "0-1"
+      "auto_expand_replicas": "0-1",
+      "hidden": true
     },
     "mappings": {
       "_doc": {

--- a/x-pack/plugin/core/src/main/resources/fleet-file-data.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-file-data.json
@@ -10,8 +10,8 @@
   },
   "template" : {
     "settings": {
-      "auto_expand_replicas": "0-1",
-      "hidden": true
+      "index.auto_expand_replicas": "0-1",
+      "index.hidden": true
     },
     "mappings": {
       "_doc": {

--- a/x-pack/plugin/core/src/main/resources/fleet-files.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-files.json
@@ -11,7 +11,7 @@
   "template": {
     "settings": {
       "index.auto_expand_replicas": "0-1",
-      "hidden": true
+      "index.hidden": true
     },
     "mappings": {
       "_doc": {

--- a/x-pack/plugin/core/src/main/resources/fleet-files.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-files.json
@@ -10,8 +10,8 @@
   },
   "template": {
     "settings": {
-      "index.lifecycle.name": ".fleet-files-ilm-policy",
-      "index.auto_expand_replicas": "0-1"
+      "index.auto_expand_replicas": "0-1",
+      "hidden": true
     },
     "mappings": {
       "_doc": {

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.fleet;
 
 import org.apache.http.util.EntityUtils;
 import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -18,7 +17,6 @@ import org.elasticsearch.test.SecuritySettingsSourceField;
 import org.elasticsearch.test.rest.ESRestTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
-import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -40,22 +40,6 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
             .build();
     }
 
-    private void expectSystemIndexWarning(Request request, String indexName) {
-        String warningMsg = "index name ["
-            + indexName
-            + "] starts with a dot '.', in the next major version, "
-            + "index names starting with a dot are reserved for hidden indices and system indices";
-
-        List<String> expectedWarnings = List.of(warningMsg);
-
-        logger.info("expecting warnings: " + expectedWarnings.toString());
-        RequestOptions consumeSystemIndicesWarningsOptions = RequestOptions.DEFAULT.toBuilder()
-            .setWarningsHandler(warnings -> expectedWarnings.equals(warnings) == false)
-            .build();
-
-        request.setOptions(consumeSystemIndicesWarningsOptions);
-    }
-
     public void testSearchWithoutIndexCreatedIsAllowed() throws Exception {
         Request request = new Request("GET", ".fleet-agents/_search");
         request.setJsonEntity("{ \"query\": { \"match_all\": {} } }");
@@ -98,7 +82,6 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
 
     public void testCreationOfFleetFiles() throws Exception {
         Request request = new Request("PUT", ".fleet-files-agent-00001");
-        expectSystemIndexWarning(request, ".fleet-files-agent-00001");
         Response response = client().performRequest(request);
         assertEquals(200, response.getStatusLine().getStatusCode());
 
@@ -111,7 +94,6 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
 
     public void testCreationOfFleetFileData() throws Exception {
         Request request = new Request("PUT", ".fleet-file-data-agent-00001");
-        expectSystemIndexWarning(request, ".fleet-file-data-agent-00001");
         Response response = client().performRequest(request);
         assertEquals(200, response.getStatusLine().getStatusCode());
 


### PR DESCRIPTION
Closes #94647 

Part of https://github.com/elastic/kibana/issues/153483.

There is a problem with the way we set up the indices that these ILM policies affect, causing the error below, it's too late to implement a full fix in 8.7.0 so for now we are removing the policy from the file upload indices.

In investgating the issue I also noticed that the index templates do not hide the indices so I have added `hidden: true` also.

<img width="878" alt="Screenshot 2023-03-22 at 17 13 41" src="https://user-images.githubusercontent.com/3315046/227037524-0e049d54-5f6f-4d9b-a552-4df0a3664614.png">


### Testing steps
To check that diagnostic upload is still working:

1. run elasticsearch locally using `gradlew run`
2. generate a sevrice token (probably a better way to do this but this is how I do it:
```
curl -XPOST -u elastic:password http://localhost:9200/_security/service/elastic/kibana/credential/token/token1
```
3. add the service token to kibana config:

```
elasticsearch.serviceAccountToken: "token"
elasticsearch.hosts: ["http://localhost:9200"]
```

4. Add an 8.7.0 fleet server and agent to fleet
5. request a diagnostic file, it should be uploaded successfully
