### PR TITLE
add support for javadoc in version >= 8.x

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -19,7 +19,7 @@ Javadoc roots used to generate links from Painless's API reference
 :lucene-core-javadoc: https://lucene.apache.org/core/{lucene_version_path}/core
 
 ifeval::["{release-state}"=="unreleased"]
-:elasticsearch-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}-SNAPSHOT
+:elasticsearch-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}-SNAPSHOT/org.elasticsearch.server
 :rest-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}-SNAPSHOT
 :rest-client-sniffer-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}-SNAPSHOT
 :mapper-extras-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/plugin/mapper-extras-client/{version}-SNAPSHOT
@@ -32,12 +32,7 @@ ifeval::["{release-state}"=="unreleased"]
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
-ifeval::[{minor-version}>=8]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}/org.elasticsearch.server
-endif::[]
-ifeval::[{minor-version}<8]
-:elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
-endif::[]
 :rest-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}
 :rest-client-sniffer-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}
 :mapper-extras-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/plugin/mapper-extras-client/{version}

--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -32,7 +32,12 @@ ifeval::["{release-state}"=="unreleased"]
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
+ifeval::[{minor-version}>=8]
+:elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}/org.elasticsearch.server
+endif::[]
+ifeval::[{minor-version}<8]
 :elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
+endif::[]
 :rest-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}
 :rest-client-sniffer-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}
 :mapper-extras-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/plugin/mapper-extras-client/{version}


### PR DESCRIPTION
A first try to fix #94666. Not sure if appropriate, was not able to build the docs for older versions.
