### PR TITLE
Add transport_version to node info json

### DIFF
--- a/docs/changelog/94669.yaml
+++ b/docs/changelog/94669.yaml
@@ -1,0 +1,5 @@
+pr: 94669
+summary: Add `transport_version` to node info json
+area: Infra/Transport API
+type: enhancement
+issues: []

--- a/docs/changelog/94669.yaml
+++ b/docs/changelog/94669.yaml
@@ -1,5 +1,5 @@
 pr: 94669
-summary: Add `transport_version` to node info json
+summary: Add `transport_version` to node info JSON
 area: Infra/Transport API
 type: enhancement
 issues: []

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -133,6 +133,9 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id]
 `version`::
 		{es} version running on this node.
 
+`transport_version`::
+		The most recent transport version that this node can communicate with.
+
 The `os` flag can be set to retrieve information that concern the operating
 system:
 
@@ -228,6 +231,7 @@ The API returns the following response:
       "host": "node-0.elastic.co",
       "ip": "192.168.17",
       "version": "{version}",
+      "transport_version": "{transport_version}",
       "build_flavor": "default",
       "build_type": "{build_type}",
       "build_hash": "587409e",
@@ -299,6 +303,7 @@ The API returns the following response:
       "host": "node-0.elastic.co",
       "ip": "192.168.17",
       "version": "{version}",
+      "transport_version": "{transport_version}",
       "build_flavor": "default",
       "build_type": "{build_type}",
       "build_hash": "587409e",

--- a/docs/reference/cluster/nodes-info.asciidoc
+++ b/docs/reference/cluster/nodes-info.asciidoc
@@ -231,7 +231,7 @@ The API returns the following response:
       "host": "node-0.elastic.co",
       "ip": "192.168.17",
       "version": "{version}",
-      "transport_version": "{transport_version}",
+      "transport_version": 100000298,
       "build_flavor": "default",
       "build_type": "{build_type}",
       "build_hash": "587409e",
@@ -270,6 +270,7 @@ The API returns the following response:
 // TESTRESPONSE[s/"transport_address": "192.168.17:9300"/"transport_address": $body.$_path/]
 // TESTRESPONSE[s/"host": "node-0.elastic.co"/"host": $body.$_path/]
 // TESTRESPONSE[s/"ip": "192.168.17"/"ip": $body.$_path/]
+// TESTRESPONSE[s/"transport_version": 100000298/"transport_version": $body.$_path/]
 // TESTRESPONSE[s/"build_hash": "587409e"/"build_hash": $body.$_path/]
 // TESTRESPONSE[s/"roles": \[[^\]]*\]/"roles": $body.$_path/]
 // TESTRESPONSE[s/"attributes": \{[^\}]*\}/"attributes": $body.$_path/]
@@ -303,7 +304,7 @@ The API returns the following response:
       "host": "node-0.elastic.co",
       "ip": "192.168.17",
       "version": "{version}",
-      "transport_version": "{transport_version}",
+      "transport_version": 100000298,
       "build_flavor": "default",
       "build_type": "{build_type}",
       "build_hash": "587409e",
@@ -366,6 +367,7 @@ The API returns the following response:
 // TESTRESPONSE[s/"transport_address": "192.168.17:9300"/"transport_address": $body.$_path/]
 // TESTRESPONSE[s/"host": "node-0.elastic.co"/"host": $body.$_path/]
 // TESTRESPONSE[s/"ip": "192.168.17"/"ip": $body.$_path/]
+// TESTRESPONSE[s/"transport_version": 100000298/"transport_version": $body.$_path/]
 // TESTRESPONSE[s/"build_hash": "587409e"/"build_hash": $body.$_path/]
 // TESTRESPONSE[s/"roles": \[[^\]]*\]/"roles": $body.$_path/]
 // TESTRESPONSE[s/"attributes": \{[^\}]*\}/"attributes": $body.$_path/]

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -267,6 +267,10 @@ public class TransportVersion implements Comparable<TransportVersion> {
         return Integer.compare(this.id, other.id);
     }
 
+    public static TransportVersion fromString(String str) {
+        return TransportVersion.fromId(Integer.parseInt(str));
+    }
+
     @Override
     public String toString() {
         return Integer.toString(id);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -63,7 +63,6 @@ public class NodeInfo extends BaseNodeResponse {
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
             transportVersion = TransportVersion.readVersion(in);
         } else {
-            assert version.before(Version.V_8_8_0);
             transportVersion = TransportVersion.fromId(version.id);
         }
         build = Build.readBuild(in);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfo.java
@@ -40,25 +40,32 @@ import static org.elasticsearch.transport.RemoteClusterPortSettings.TRANSPORT_VE
  */
 public class NodeInfo extends BaseNodeResponse {
 
-    private Version version;
-    private Build build;
+    private final Version version;
+    private final TransportVersion transportVersion;
+    private final Build build;
 
     @Nullable
-    private Settings settings;
+    private final Settings settings;
 
     /**
      * Do not expose this map to other classes. For type safety, use {@link #getInfo(Class)}
      * to retrieve items from this map and {@link #addInfoIfNonNull(Class, ReportingService.Info)}
      * to retrieve items from it.
      */
-    private Map<Class<? extends ReportingService.Info>, ReportingService.Info> infoMap = new HashMap<>();
+    private final Map<Class<? extends ReportingService.Info>, ReportingService.Info> infoMap = new HashMap<>();
 
     @Nullable
-    private ByteSizeValue totalIndexingBuffer;
+    private final ByteSizeValue totalIndexingBuffer;
 
     public NodeInfo(StreamInput in) throws IOException {
         super(in);
         version = Version.readVersion(in);
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            transportVersion = TransportVersion.readVersion(in);
+        } else {
+            assert version.before(Version.V_8_8_0);
+            transportVersion = TransportVersion.fromId(version.id);
+        }
         build = Build.readBuild(in);
         if (in.readBoolean()) {
             totalIndexingBuffer = ByteSizeValue.ofBytes(in.readLong());
@@ -67,6 +74,8 @@ public class NodeInfo extends BaseNodeResponse {
         }
         if (in.readBoolean()) {
             settings = Settings.readSettingsFromStream(in);
+        } else {
+            settings = null;
         }
         addInfoIfNonNull(OsInfo.class, in.readOptionalWriteable(OsInfo::new));
         addInfoIfNonNull(ProcessInfo.class, in.readOptionalWriteable(ProcessInfo::new));
@@ -86,6 +95,7 @@ public class NodeInfo extends BaseNodeResponse {
 
     public NodeInfo(
         Version version,
+        TransportVersion transportVersion,
         Build build,
         DiscoveryNode node,
         @Nullable Settings settings,
@@ -103,6 +113,7 @@ public class NodeInfo extends BaseNodeResponse {
     ) {
         super(node);
         this.version = version;
+        this.transportVersion = transportVersion;
         this.build = build;
         this.settings = settings;
         addInfoIfNonNull(OsInfo.class, os);
@@ -131,6 +142,13 @@ public class NodeInfo extends BaseNodeResponse {
      */
     public Version getVersion() {
         return version;
+    }
+
+    /**
+     * The most recent transport version that can be used by this node
+     */
+    public TransportVersion getTransportVersion() {
+        return transportVersion;
     }
 
     /**
@@ -180,7 +198,10 @@ public class NodeInfo extends BaseNodeResponse {
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeVInt(version.id);
+        Version.writeVersion(version, out);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            TransportVersion.writeVersion(transportVersion, out);
+        }
         Build.writeBuild(build, out);
         if (totalIndexingBuffer == null) {
             out.writeBoolean(false);

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -64,7 +64,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             builder.field("ip", nodeInfo.getNode().getHostAddress());
 
             builder.field("version", nodeInfo.getVersion());
-            builder.field("transport_version", nodeInfo.getTransportVersion());
+            builder.field("transport_version", nodeInfo.getTransportVersion().id);
             // flavor no longer exists, but we keep it here for backcompat
             builder.field("build_flavor", "default");
             builder.field("build_type", nodeInfo.getBuild().type().displayName());

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -64,6 +64,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             builder.field("ip", nodeInfo.getNode().getHostAddress());
 
             builder.field("version", nodeInfo.getVersion());
+            builder.field("transport_version", nodeInfo.getTransportVersion());
             // flavor no longer exists, but we keep it here for backcompat
             builder.field("build_flavor", "default");
             builder.field("build_type", nodeInfo.getBuild().type().displayName());

--- a/server/src/main/java/org/elasticsearch/node/NodeService.java
+++ b/server/src/main/java/org/elasticsearch/node/NodeService.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.node;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
@@ -109,6 +110,7 @@ public class NodeService implements Closeable {
     ) {
         return new NodeInfo(
             Version.CURRENT,
+            TransportVersion.CURRENT,
             Build.CURRENT,
             transportService.getLocalNode(),
             settings ? settingsFilter.filter(this.settings) : null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.admin.cluster.node.info;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.monitor.jvm.JvmInfo;
@@ -35,6 +36,7 @@ public class NodeInfoTests extends ESTestCase {
     public void testGetInfo() {
         NodeInfo nodeInfo = new NodeInfo(
             Version.CURRENT,
+            TransportVersion.CURRENT,
             Build.CURRENT,
             new DiscoveryNode("test_node", buildNewFakeTransportAddress(), emptyMap(), emptySet(), VersionUtils.randomVersion(random())),
             null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.admin.cluster.remote;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -75,6 +76,7 @@ public class RemoteClusterNodesActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Version.CURRENT,
+                    TransportVersion.CURRENT,
                     null,
                     node,
                     null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.action.admin.cluster.stats;
 
+import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests;
@@ -197,8 +200,9 @@ public class ClusterStatsNodesTests extends ESTestCase {
             settings.put(randomFrom(NetworkModule.HTTP_TYPE_KEY, NetworkModule.HTTP_TYPE_DEFAULT_KEY), httpType);
         }
         return new NodeInfo(
-            null,
-            null,
+            Version.CURRENT,
+            TransportVersion.CURRENT,
+            Build.CURRENT,
             new DiscoveryNode(nodeId, buildNewFakeTransportAddress(), null),
             settings.build(),
             null,

--- a/server/src/test/java/org/elasticsearch/action/ingest/ReservedPipelineActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/ingest/ReservedPipelineActionTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.action.ingest;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -102,6 +103,7 @@ public class ReservedPipelineActionTests extends ESTestCase {
 
         NodeInfo nodeInfo = new NodeInfo(
             Version.CURRENT,
+            TransportVersion.CURRENT,
             Build.CURRENT,
             discoveryNode,
             Settings.EMPTY,

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -31,6 +31,7 @@ import org.elasticsearch.plugins.PluginRuntimeInfo;
 import org.elasticsearch.search.aggregations.support.AggregationInfo;
 import org.elasticsearch.search.aggregations.support.AggregationUsageService;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.TransportVersionUtils;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolInfo;
@@ -229,6 +230,7 @@ public class NodeInfoStreamingTests extends ESTestCase {
         }
         return new NodeInfo(
             VersionUtils.randomVersion(random()),
+            TransportVersionUtils.randomVersion(random()),
             build,
             node,
             settings,

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestPluginsActionTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.rest.action.cat;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
@@ -62,6 +63,7 @@ public class RestPluginsActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Version.CURRENT,
+                    TransportVersion.CURRENT,
                     null,
                     node(i),
                     null,

--- a/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
+++ b/x-pack/plugin/autoscaling/src/test/java/org/elasticsearch/xpack/autoscaling/capacity/nodeinfo/AutoscalingNodesInfoServiceTests.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.autoscaling.capacity.nodeinfo;
 
 import org.elasticsearch.Build;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
@@ -449,6 +450,7 @@ public class AutoscalingNodesInfoServiceTests extends AutoscalingTestCase {
         OsInfo osInfo = new OsInfo(randomLong(), processors, Processors.of((double) processors), null, null, null, null);
         return new org.elasticsearch.action.admin.cluster.node.info.NodeInfo(
             Version.CURRENT,
+            TransportVersion.CURRENT,
             Build.CURRENT,
             node,
             null,

--- a/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
+++ b/x-pack/plugin/eql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/eql/qa/mixed_node/EqlSearchIT.java
@@ -118,10 +118,7 @@ public class EqlSearchIT extends ESRestTestCase {
         // each function has a query and query results associated to it
         Set<String> testedFunctions = new HashSet<>();
         try (
-            RestClient client = buildClient(
-                restClientSettings(),
-                newNodes.stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
-            )
+            RestClient client = buildClient(restClientSettings(), newNodes.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
         ) {
             // filter only the relevant bits of the response
             String filterPath = "filter_path=hits.events._id";
@@ -282,10 +279,7 @@ public class EqlSearchIT extends ESRestTestCase {
         final String event = randomEvent();
         Map<String, Object> expectedResponse = prepareEventsTestData(event);
         try (
-            RestClient client = buildClient(
-                restClientSettings(),
-                nodesList.stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
-            )
+            RestClient client = buildClient(restClientSettings(), nodesList.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
         ) {
             // filter only the relevant bits of the response
             String filterPath = "filter_path=hits.events._source.@timestamp,hits.events._source.event_type,hits.events._source.sequence";
@@ -299,10 +293,7 @@ public class EqlSearchIT extends ESRestTestCase {
     private void assertSequncesQueryOnNodes(List<TestNode> nodesList) throws Exception {
         Map<String, Object> expectedResponse = prepareSequencesTestData();
         try (
-            RestClient client = buildClient(
-                restClientSettings(),
-                nodesList.stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
-            )
+            RestClient client = buildClient(restClientSettings(), nodesList.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
         ) {
             String filterPath = "filter_path=hits.sequences.join_keys,hits.sequences.events._id,hits.sequences.events._source";
             String query = "sequence by `sequence` with maxspan=100ms [success where true] by correlation_success1, correlation_success2 "

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestNode.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestNode.java
@@ -10,8 +10,9 @@ package org.elasticsearch.xpack.ql;
 import org.apache.http.HttpHost;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
+import org.elasticsearch.core.Nullable;
 
-public record TestNode(String id, Version version, TransportVersion transportVersion, HttpHost publishAddress) {
+public record TestNode(String id, Version version, @Nullable TransportVersion transportVersion, HttpHost publishAddress) {
     @Override
     public String toString() {
         return "Node{" + "id='" + id + '\'' + ", version=" + version + '}';

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestNode.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestNode.java
@@ -8,32 +8,10 @@
 package org.elasticsearch.xpack.ql;
 
 import org.apache.http.HttpHost;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 
-public final class TestNode {
-
-    private final String id;
-    private final Version version;
-    private final HttpHost publishAddress;
-
-    public TestNode(String id, Version version, HttpHost publishAddress) {
-        this.id = id;
-        this.version = version;
-        this.publishAddress = publishAddress;
-    }
-
-    public String getId() {
-        return id;
-    }
-
-    public HttpHost getPublishAddress() {
-        return publishAddress;
-    }
-
-    public Version getVersion() {
-        return version;
-    }
-
+public record TestNode(String id, Version version, TransportVersion transportVersion, HttpHost publishAddress) {
     @Override
     public String toString() {
         return "Node{" + "id='" + id + '\'' + ", version=" + version + '}';

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestNodes.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestNodes.java
@@ -16,24 +16,24 @@ import java.util.stream.Collectors;
 public final class TestNodes extends HashMap<String, TestNode> {
 
     public void add(TestNode node) {
-        put(node.getId(), node);
+        put(node.id(), node);
     }
 
     public List<TestNode> getNewNodes() {
         Version bwcVersion = getBWCVersion();
-        return values().stream().filter(n -> n.getVersion().after(bwcVersion)).collect(Collectors.toList());
+        return values().stream().filter(n -> n.version().after(bwcVersion)).collect(Collectors.toList());
     }
 
     public List<TestNode> getBWCNodes() {
         Version bwcVersion = getBWCVersion();
-        return values().stream().filter(n -> n.getVersion().equals(bwcVersion)).collect(Collectors.toList());
+        return values().stream().filter(n -> n.version().equals(bwcVersion)).collect(Collectors.toList());
     }
 
     public Version getBWCVersion() {
         if (isEmpty()) {
             throw new IllegalStateException("no nodes available");
         }
-        return Version.fromId(values().stream().map(node -> node.getVersion().id).min(Integer::compareTo).get());
+        return Version.fromId(values().stream().mapToInt(node -> node.version().id).min().getAsInt());
     }
 
     @Override

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -290,11 +290,12 @@ public final class TestUtils {
         TestNodes nodes = new TestNodes();
         for (String id : nodesAsMap.keySet()) {
             Version nodeVersion = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
-            Object tvField = objectPath.evaluate("nodes." + id + ".transport_version");
+
+            Object tvField;
             TransportVersion transportVersion = null;
             if (nodeVersion.before(Version.V_8_8_0)) {
                 transportVersion = TransportVersion.fromId(nodeVersion.id);   // no transport_version field
-            } else if (tvField != null) {
+            } else if ((tvField = objectPath.evaluate("nodes." + id + ".transport_version")) != null) {
                 // this json might be from a node <8.8.0, but about a node >=8.8.0
                 // in which case the transport_version field won't exist. Just ignore it for now.
                 transportVersion = TransportVersion.fromString(tvField.toString());

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -290,10 +290,6 @@ public final class TestUtils {
         TestNodes nodes = new TestNodes();
         for (String id : nodesAsMap.keySet()) {
             Version nodeVersion = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
-            Object transportVersionField = objectPath.evaluate("nodes." + id + ".transport_version");
-            if (nodeVersion.onOrAfter(Version.V_8_8_0) && transportVersionField == null) {
-                throw new IllegalStateException(nodeVersion + " had null TV field: " + nodesAsMap.get(id));
-            }
             TransportVersion transportVersion = nodeVersion.before(Version.V_8_8_0)
                 ? TransportVersion.fromId(nodeVersion.id)   // no transport_version field
                 : TransportVersion.fromString(objectPath.evaluate("nodes." + id + ".transport_version").toString());

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -289,11 +289,15 @@ public final class TestUtils {
         Map<String, Object> nodesAsMap = objectPath.evaluate("nodes");
         TestNodes nodes = new TestNodes();
         for (String id : nodesAsMap.keySet()) {
+            Version nodeVersion = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
+            TransportVersion transportVersion = nodeVersion.before(Version.V_8_8_0)
+                ? TransportVersion.fromId(nodeVersion.id)   // no transport_version field
+                : TransportVersion.fromString(objectPath.evaluate("nodes." + id + ".transport_version").toString());
             nodes.add(
                 new TestNode(
                     id,
-                    Version.fromString(objectPath.evaluate("nodes." + id + ".version")),
-                    TransportVersion.fromString(objectPath.evaluate("nodes." + id + ".transport_version").toString()),
+                    nodeVersion,
+                    transportVersion,
                     HttpHost.create(objectPath.evaluate("nodes." + id + ".http.publish_address"))
                 )
             );

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.ql;
 
 import org.apache.http.HttpHost;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
@@ -292,6 +293,7 @@ public final class TestUtils {
                 new TestNode(
                     id,
                     Version.fromString(objectPath.evaluate("nodes." + id + ".version")),
+                    TransportVersion.fromString(objectPath.evaluate("nodes." + id + ".transport_version").toString()),
                     HttpHost.create(objectPath.evaluate("nodes." + id + ".http.publish_address"))
                 )
             );

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -290,9 +290,16 @@ public final class TestUtils {
         TestNodes nodes = new TestNodes();
         for (String id : nodesAsMap.keySet()) {
             Version nodeVersion = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
-            TransportVersion transportVersion = nodeVersion.before(Version.V_8_8_0)
-                ? TransportVersion.fromId(nodeVersion.id)   // no transport_version field
-                : TransportVersion.fromString(objectPath.evaluate("nodes." + id + ".transport_version").toString());
+            Object tvField = objectPath.evaluate("nodes." + id + ".transport_version");
+            TransportVersion transportVersion = null;
+            if (nodeVersion.before(Version.V_8_8_0)) {
+                transportVersion = TransportVersion.fromId(nodeVersion.id);   // no transport_version field
+            } else if (tvField != null) {
+                // this json might be from a node <8.8.0, but about a node >=8.8.0
+                // in which case the transport_version field won't exist. Just ignore it for now.
+                transportVersion = TransportVersion.fromString(tvField.toString());
+            }
+
             nodes.add(
                 new TestNode(
                     id,

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -290,6 +290,10 @@ public final class TestUtils {
         TestNodes nodes = new TestNodes();
         for (String id : nodesAsMap.keySet()) {
             Version nodeVersion = Version.fromString(objectPath.evaluate("nodes." + id + ".version"));
+            Object transportVersionField = objectPath.evaluate("nodes." + id + ".transport_version");
+            if (nodeVersion.onOrAfter(Version.V_8_8_0) && transportVersionField == null) {
+                throw new IllegalStateException(nodeVersion + " had null TV field: " + nodesAsMap.get(id));
+            }
             TransportVersion transportVersion = nodeVersion.before(Version.V_8_8_0)
                 ? TransportVersion.fromId(nodeVersion.id)   // no transport_version field
                 : TransportVersion.fromString(objectPath.evaluate("nodes." + id + ".transport_version").toString());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/enrollment/TransportNodeEnrollmentActionTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.action.enrollment;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -100,6 +101,7 @@ public class TransportNodeEnrollmentActionTests extends ESTestCase {
             nodeInfos.add(
                 new NodeInfo(
                     Version.CURRENT,
+                    TransportVersion.CURRENT,
                     null,
                     n,
                     null,

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGeneratorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/enrollment/InternalEnrollmentTokenGeneratorTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.security.enrollment;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
@@ -222,6 +223,7 @@ public class InternalEnrollmentTokenGeneratorTests extends ESTestCase {
                 List.of(
                     new NodeInfo(
                         Version.CURRENT,
+                        TransportVersion.CURRENT,
                         null,
                         new DiscoveryNode("node-name", "1", buildNewFakeTransportAddress(), Map.of(), Set.of(), Version.CURRENT),
                         null,
@@ -254,6 +256,7 @@ public class InternalEnrollmentTokenGeneratorTests extends ESTestCase {
                 List.of(
                     new NodeInfo(
                         Version.CURRENT,
+                        TransportVersion.CURRENT,
                         null,
                         new DiscoveryNode("node-name", "1", buildNewFakeTransportAddress(), Map.of(), Set.of(), Version.CURRENT),
                         null,

--- a/x-pack/plugin/sql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlCompatIT.java
@@ -50,11 +50,11 @@ public class SqlCompatIT extends BaseRestSqlTestCase {
             bwcVersion = nodes.getBWCVersion();
             newNodesClient = buildClient(
                 restClientSettings(),
-                nodes.getNewNodes().stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
+                nodes.getNewNodes().stream().map(TestNode::publishAddress).toArray(HttpHost[]::new)
             );
             oldNodesClient = buildClient(
                 restClientSettings(),
-                nodes.getBWCNodes().stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
+                nodes.getBWCNodes().stream().map(TestNode::publishAddress).toArray(HttpHost[]::new)
             );
         }
     }

--- a/x-pack/plugin/sql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
+++ b/x-pack/plugin/sql/qa/mixed-node/src/javaRestTest/java/org/elasticsearch/xpack/sql/qa/mixed_node/SqlSearchIT.java
@@ -57,7 +57,7 @@ public class SqlSearchIT extends ESRestTestCase {
         numDocs = randomIntBetween(numShards, 15);
         newNodes = new ArrayList<>(nodes.getNewNodes());
         bwcNodes = new ArrayList<>(nodes.getBWCNodes());
-        bwcVersion = nodes.getBWCNodes().get(0).getVersion();
+        bwcVersion = nodes.getBWCNodes().get(0).version();
 
         String mappings = readResource(SqlSearchIT.class.getResourceAsStream("/all_field_types.json"));
         createIndex(
@@ -229,10 +229,7 @@ public class SqlSearchIT extends ESRestTestCase {
 
     private void assertAllTypesWithNodes(Map<String, Object> expectedResponse, List<TestNode> nodesList) throws Exception {
         try (
-            RestClient client = buildClient(
-                restClientSettings(),
-                nodesList.stream().map(TestNode::getPublishAddress).toArray(HttpHost[]::new)
-            )
+            RestClient client = buildClient(restClientSettings(), nodesList.stream().map(TestNode::publishAddress).toArray(HttpHost[]::new))
         ) {
             @SuppressWarnings("unchecked")
             List<Map<String, Object>> columns = (List<Map<String, Object>>) expectedResponse.get("columns");


### PR DESCRIPTION
Add a transport version field to the node info JSON.

This is primarily informative, but also needed for tests in #94597