### PR TITLE
[8.6] [DOCS] Show how to reset a dynamically-adjusted log level (#94573)

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -162,6 +162,19 @@ PUT /_cluster/settings
 }
 ----
 
+To reset a logger's verbosity to its default level, set the logger setting to
+`null`:
+
+[source,console]
+----
+PUT /_cluster/settings
+{
+  "persistent": {
+    "logger.org.elasticsearch.discovery": null
+  }
+}
+----
+
 Other ways to change log levels include:
 
 1. `elasticsearch.yml`:


### PR DESCRIPTION
Backports the following commits to 8.6:
 - [DOCS] Show how to reset a dynamically-adjusted log level (#94573)