### PR TITLE
Fix race condition in NodeEnvironment.close()

### DIFF
--- a/docs/changelog/94677.yaml
+++ b/docs/changelog/94677.yaml
@@ -1,0 +1,6 @@
+pr: 94677
+summary: Fix race condition in `NodeEnvironment.close()`
+area: Infra/Core
+type: bug
+issues:
+ - 94672

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1281,8 +1281,7 @@ public final class NodeEnvironment implements Closeable {
     private void assertEnvIsLocked() {
         if (closed.get() == false && locks != null) {
             synchronized (locks) {
-                if (closed.get())
-                    return; // raced with close() - we lost
+                if (closed.get()) return; // raced with close() - we lost
                 for (Lock lock : locks) {
                     try {
                         lock.ensureValid();

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1265,12 +1265,14 @@ public final class NodeEnvironment implements Closeable {
     @Override
     public void close() {
         if (closed.compareAndSet(false, true) && locks != null) {
-            for (Lock lock : locks) {
-                try {
-                    logger.trace("releasing lock [{}]", lock);
-                    lock.close();
-                } catch (IOException e) {
-                    logger.trace(() -> "failed to release lock [" + lock + "]", e);
+            synchronized (locks) {
+                for (Lock lock : locks) {
+                    try {
+                        logger.trace("releasing lock [{}]", lock);
+                        lock.close();
+                    } catch (IOException e) {
+                        logger.trace(() -> "failed to release lock [" + lock + "]", e);
+                    }
                 }
             }
         }
@@ -1278,12 +1280,16 @@ public final class NodeEnvironment implements Closeable {
 
     private void assertEnvIsLocked() {
         if (closed.get() == false && locks != null) {
-            for (Lock lock : locks) {
-                try {
-                    lock.ensureValid();
-                } catch (IOException e) {
-                    logger.warn("lock assertion failed", e);
-                    throw new IllegalStateException("environment is not locked", e);
+            synchronized (locks) {
+                if (closed.get())
+                    return; // raced with close() - we lost
+                for (Lock lock : locks) {
+                    try {
+                        lock.ensureValid();
+                    } catch (IOException e) {
+                        logger.warn("lock assertion failed", e);
+                        throw new IllegalStateException("environment is not locked", e);
+                    }
                 }
             }
         }


### PR DESCRIPTION
This fixes #94672

Race condition between close() and assertEnvIsLocked(). Fix is to use double-checked locking.