### PR TITLE
Skip RCS test on feature flag

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/remote/RemoteClusterNodesActionTests.java
@@ -26,7 +26,9 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.RemoteClusterServerInfo;
+import org.elasticsearch.transport.TcpTransport;
 import org.elasticsearch.transport.TransportService;
+import org.junit.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -44,6 +46,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 public class RemoteClusterNodesActionTests extends ESTestCase {
+
+    @BeforeClass
+    public static void ensureFeatureFlag() {
+        assumeTrue("untrusted remote cluster feature flag must be enabled", TcpTransport.isUntrustedRemoteClusterEnabled());
+    }
 
     public void testDoExecute() {
         final ThreadPool threadPool = mock(ThreadPool.class);


### PR DESCRIPTION
The test relies on the new `remote_cluster_server` metric for the nodes API but that metric is not available without the feature flag, so the release test fails. The underlying action is `RemoteClusterNodesAction` which does not have a REST API and therefore will not be exposed to end-users, so simply skipping this test if feature flag is disabled seems acceptable.

Fixes: https://github.com/elastic/elasticsearch/issues/94681