### PR TITLE
Fix `_id` field fetch issue (#94528)

### DIFF
--- a/docs/changelog/94528.yaml
+++ b/docs/changelog/94528.yaml
@@ -1,0 +1,5 @@
+pr: 94528
+summary: Fix _id field fetch issue.
+area: Search
+type: bug
+issues: [94515]

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -2241,4 +2241,21 @@ public class SearchQueryIT extends ESIntegTestCase {
         SearchResponse response = client().prepareSearch("test").setQuery(query).get();
         assertHitCount(response, 1);
     }
+
+    public void testFetchIdFieldQuery() {
+        createIndex("test");
+        int docCount = randomIntBetween(10, 50);
+        for (int i = 0; i < docCount; i++) {
+            client().prepareIndex("test", "_doc").setSource("field", "foobarbaz").get();
+        }
+        ensureGreen();
+        refresh();
+
+        SearchResponse response = client().prepareSearch("test").addFetchField("_id").setSize(docCount).get();
+        SearchHit[] hits = response.getHits().getHits();
+        assertEquals(docCount, hits.length);
+        for (SearchHit hit : hits) {
+            assertNotNull(hit.getFields().get("_id").getValue());
+        }
+    }
 }

--- a/server/src/main/java/org/elasticsearch/index/mapper/StoredValueFetcher.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/StoredValueFetcher.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.SourceLookup;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -38,7 +39,12 @@ public final class StoredValueFetcher implements ValueFetcher {
     @Override
     public List<Object> fetchValues(SourceLookup lookup, List<Object> ignoredValues) throws IOException {
         leafSearchLookup.setDocument(lookup.docId());
-        return leafSearchLookup.fields().get(fieldname).getValues();
+        List<Object> values = leafSearchLookup.fields().get(fieldname).getValues();
+        if (values == null) {
+            return values;
+        } else {
+            return new ArrayList<>(values);
+        }
     }
 
 }


### PR DESCRIPTION
When queries through the "fields" API, the metadata _id field is not returned consistently due to frequently clearing an internal data cache. This commit fixes this by making copies of those values in the value fetcher so clearing the cache doesn't affect displaying the results in the search hits.

Closes #94515