### PR TITLE
[Backport] [8.5] [94667] add support for javadoc in version >= 8.x

### DIFF
--- a/docs/Versions.asciidoc
+++ b/docs/Versions.asciidoc
@@ -19,7 +19,7 @@ Javadoc roots used to generate links from Painless's API reference
 :lucene-core-javadoc: https://lucene.apache.org/core/{lucene_version_path}/core
 
 ifeval::["{release-state}"=="unreleased"]
-:elasticsearch-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}-SNAPSHOT
+:elasticsearch-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}-SNAPSHOT/org.elasticsearch.server
 :rest-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}-SNAPSHOT
 :rest-client-sniffer-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}-SNAPSHOT
 :mapper-extras-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/plugin/mapper-extras-client/{version}-SNAPSHOT
@@ -32,7 +32,7 @@ ifeval::["{release-state}"=="unreleased"]
 endif::[]
 
 ifeval::["{release-state}"!="unreleased"]
-:elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}
+:elasticsearch-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/elasticsearch/{version}/org.elasticsearch.server
 :rest-client-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client/{version}
 :rest-client-sniffer-javadoc: https://artifacts.elastic.co/javadoc/org/elasticsearch/client/elasticsearch-rest-client-sniffer/{version}
 :mapper-extras-client-javadoc: https://snapshots.elastic.co/javadoc/org/elasticsearch/plugin/mapper-extras-client/{version}


### PR DESCRIPTION
Manual backport of #94667 to 8.5