### PR TITLE
Improve efficiency of packer cache script

### DIFF
--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -43,6 +43,7 @@ fi
 ## Gradle is able to resolve dependencies resolved with earlier gradle versions
 ## therefore we run main _AFTER_ we run 6.8 which uses an earlier gradle version
 branches=($(cat .ci/snapshotBwcVersions | sed '1d;$d' | grep -E -o "[0-9]+\.[0-9]+"))
+branches+=("main")
 for branch in "${branches[@]}"; do
   echo "Resolving dependencies for ${branch} branch"
   rm -rf checkout/$branch

--- a/.ci/packer_cache.sh
+++ b/.ci/packer_cache.sh
@@ -4,11 +4,11 @@ SCRIPT="$0"
 
 # SCRIPT might be an arbitrarily deep series of symbolic links; loop until we
 # have the concrete path
-while [ -h "$SCRIPT" ] ; do
+while [ -h "$SCRIPT" ]; do
   ls=$(ls -ld "$SCRIPT")
   # Drop everything prior to ->
   link=$(expr "$ls" : '.*-> \(.*\)$')
-  if expr "$link" : '/.*' > /dev/null; then
+  if expr "$link" : '/.*' >/dev/null; then
     SCRIPT="$link"
   else
     SCRIPT=$(dirname "$SCRIPT")/"$link"
@@ -42,5 +42,12 @@ fi
 
 ## Gradle is able to resolve dependencies resolved with earlier gradle versions
 ## therefore we run main _AFTER_ we run 6.8 which uses an earlier gradle version
-export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
-./gradlew --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none -Drecurse.bwc=true
+branches=($(cat .ci/snapshotBwcVersions | sed '1d;$d' | grep -E -o "[0-9]+\.[0-9]+"))
+for branch in "${branches[@]}"; do
+  echo "Resolving dependencies for ${branch} branch"
+  rm -rf checkout/$branch
+  git clone --reference $(dirname "${SCRIPT}")/../.git https://github.com/elastic/elasticsearch.git --branch ${branch} --single-branch checkout/${branch}
+  export JAVA_HOME="${HOME}"/.java/${ES_BUILD_JAVA}
+  ./checkout/${branch}/gradlew --project-dir ./checkout/${branch} --parallel clean -s resolveAllDependencies -Dorg.gradle.warning.mode=none
+  rm -rf ./checkout/${branch}
+done

--- a/distribution/build.gradle
+++ b/distribution/build.gradle
@@ -604,3 +604,8 @@ artifacts.add('log4jConfig', file("${defaultOutputs}/log4j2.properties")) {
   name 'log4j2.properties'
   builtBy 'buildDefaultLog4jConfig'
 }
+
+tasks.named('resolveAllDependencies') {
+  // We don't want to build all our distribution artifacts when priming our dependency cache
+  configs = []
+}

--- a/distribution/bwc/build.gradle
+++ b/distribution/bwc/build.gradle
@@ -7,22 +7,3 @@
  */
 
 apply plugin:"elasticsearch.internal-distribution-bwc-setup"
-
-import org.elasticsearch.gradle.Version
-import org.elasticsearch.gradle.internal.info.BuildParams
-
-
-BuildParams.getBwcVersions().forPreviousUnreleased { unreleasedVersion ->
-    project(unreleasedVersion.gradleProjectPath) {
-        Version currentVersion = Version.fromString(version)
-        TaskProvider<Task> resolveAllBwcDepsTaskProvider = bwcSetup.bwcTask("resolveAllBwcDependencies", {
-            t -> t.args("resolveAllDependencies", "-Dorg.gradle.warning.mode=none")
-        }, false)
-        if (Boolean.getBoolean("recurse.bwc")) {
-            // We only want to resolve dependencies for live versions of main, without cascading this to older versions
-            tasks.named("resolveAllDependencies").configure {
-                dependsOn(resolveAllBwcDepsTaskProvider)
-            }
-        }
-    }
-}

--- a/distribution/docker/build.gradle
+++ b/distribution/docker/build.gradle
@@ -550,5 +550,6 @@ subprojects { Project subProject ->
 
 tasks.named('resolveAllDependencies') {
   // Don't try and resolve filebeat or metricbeat snapshots as they may not always be available
-  configs = configurations.matching { it.name.contains('beat') == false }
+  // Also skip building Elasticsearch distributions
+  configs = configurations.matching { it.name.contains('beat') == false && it.name.toLowerCase().contains('dockersource') == false }
 }


### PR DESCRIPTION
We've noticed a lot of issues with our packer cache script timing out. It seems a lot of this may be due to gradle dependency cache lock contention, since we are running `resolveAllDependencies` for all our BWC branches concurrently in nested builds. This PR refactors our cache script to do each branch sequentially instead. This also