### PR TITLE
Improve FixedRounding#nextRoundingValue(...) performance.

### DIFF
--- a/docs/changelog/94706.yaml
+++ b/docs/changelog/94706.yaml
@@ -1,0 +1,5 @@
+pr: 94706
+summary: Improve `FixedRounding#nextRoundingValue(...)` performance
+area: Aggregations
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/Rounding.java
+++ b/server/src/main/java/org/elasticsearch/common/Rounding.java
@@ -1089,8 +1089,7 @@ public abstract class Rounding implements Writeable {
 
             @Override
             public long nextRoundingValue(long utcMillis) {
-                // TODO this is used in date range's collect so we should optimize it too
-                return new JavaTimeRounding().nextRoundingValue(utcMillis);
+                return round(utcMillis) + interval;
             }
 
             @Override


### PR DESCRIPTION
This currently uses `JavaTimeRounding#nextRoundingValue(...)` to find the next rounding value, which functionally is correct, but is slow. Since FixedRounding only deals with fixed intervals, we should just be able to round the provided time and then add the fixed interval to it.

This is used during adding empty buckets if missing in date_histogram with a fixed interval. In case there are many buckets to overhead of using `JavaTimeRounding` is noticeable.