### PR TITLE
Expand tests for geo_grid aggregations

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/geohash_grid.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/geohash_grid.yml
@@ -1,61 +1,139 @@
 setup:
   - do:
       indices.create:
-        index: test_1
+        index: locations
         body:
           settings:
-            number_of_replicas: 0
+            number_of_shards: 3
           mappings:
             properties:
               location:
                 type: geo_point
 
----
-"Basic test":
   - do:
       bulk:
         refresh: true
-        body:
-          - index:
-              _index: test_1
-              _id:    "1"
-          - location: "52.374081,4.912350"
-          - index:
-              _index: test_1
-              _id:    "2"
-          - location: "52.369219,4.901618"
-          - index:
-              _index: test_1
-              _id:    "3"
-          - location: "52.371667,4.914722"
-          - index:
-              _index: test_1
-              _id:    "4"
-          - location: "51.222900,4.405200"
-          - index:
-              _index: test_1
-              _id:    "5"
-          - location: "48.861111,2.336389"
-          - index:
-              _index: test_1
-              _id:    "6"
-          - location: "48.860000,2.327000"
+        index: locations
+        body: |
+          {"index":{}}
+          {"location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}
+          {"index":{}}
+          {"location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}
+          {"index":{}}
+          {"location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}
+          {"index":{}}
+          {"location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}
+          {"index":{}}
+          {"location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}
+          {"index":{}}
+          {"location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}
+
+  - do:
+      indices.refresh: { }
+
+---
+"Test geohash_grid on geo_shape field with defaults":
 
   - do:
       search:
-        rest_total_hits_as_int: true
+        index: locations
+        size: 0
         body:
-          aggregations:
+          aggs:
             grid:
               geohash_grid:
                 field: location
-                precision: 3
-
-
-  - match: { hits.total: 6 }
-  - match: { aggregations.grid.buckets.0.key: u17 }
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 4 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
   - match: { aggregations.grid.buckets.0.doc_count: 3 }
-  - match: { aggregations.grid.buckets.1.key: u09 }
-  - match: { aggregations.grid.buckets.1.doc_count: 2 }
-  - match: { aggregations.grid.buckets.2.key: u15 }
+  - match: { aggregations.grid.buckets.1.key: "u155k" }
+  - match: { aggregations.grid.buckets.1.doc_count: 1 }
+  - match: { aggregations.grid.buckets.2.key: "u09tv" }
   - match: { aggregations.grid.buckets.2.doc_count: 1 }
+  - match: { aggregations.grid.buckets.3.key: "u09tu" }
+  - match: { aggregations.grid.buckets.3.doc_count: 1 }
+
+---
+"Test geohash_grid on geo_shape field with precision":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                precision: 4
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 3 }
+  - match: { aggregations.grid.buckets.0.key: "u173" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+  - match: { aggregations.grid.buckets.1.key: "u09t" }
+  - match: { aggregations.grid.buckets.1.doc_count: 2 }
+  - match: { aggregations.grid.buckets.2.key: "u155" }
+  - match: { aggregations.grid.buckets.2.doc_count: 1 }
+
+---
+"Test geohash_grid on geo_shape field with size":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                size: 1
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 1 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+
+---
+"Test geohash_grid on geo_shape field with shard_size":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                shard_size: 10
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 4 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+  - match: { aggregations.grid.buckets.1.key: "u155k" }
+  - match: { aggregations.grid.buckets.1.doc_count: 1 }
+  - match: { aggregations.grid.buckets.2.key: "u09tv" }
+  - match: { aggregations.grid.buckets.2.doc_count: 1 }
+  - match: { aggregations.grid.buckets.3.key: "u09tu" }
+  - match: { aggregations.grid.buckets.3.doc_count: 1 }
+
+---
+"Test geohash_grid on geo_shape field with bounds":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                bounds:
+                  top_left: "POINT (4.9 52.4)"
+                  bottom_right: "POINT (5.0 52.3)"
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 1 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/geotile_grid.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/geotile_grid.yml
@@ -1,62 +1,131 @@
 setup:
-
   - do:
       indices.create:
-        index: test_1
+        index: locations
         body:
           settings:
-            number_of_replicas: 0
+            number_of_shards: 3
           mappings:
             properties:
               location:
                 type: geo_point
 
----
-"Basic test":
   - do:
       bulk:
         refresh: true
-        body:
-          - index:
-              _index: test_1
-              _id:    "1"
-          - location: "52.374081,4.912350"
-          - index:
-              _index: test_1
-              _id:    "2"
-          - location: "52.369219,4.901618"
-          - index:
-              _index: test_1
-              _id:    "3"
-          - location: "52.371667,4.914722"
-          - index:
-              _index: test_1
-              _id:    "4"
-          - location: "51.222900,4.405200"
-          - index:
-              _index: test_1
-              _id:    "5"
-          - location: "48.861111,2.336389"
-          - index:
-              _index: test_1
-              _id:    "6"
-          - location: "48.860000,2.327000"
+        index: locations
+        body: |
+          {"index":{}}
+          {"location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}
+          {"index":{}}
+          {"location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}
+          {"index":{}}
+          {"location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}
+          {"index":{}}
+          {"location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}
+          {"index":{}}
+          {"location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}
+          {"index":{}}
+          {"location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}
+
+  - do:
+      indices.refresh: { }
+
+---
+"Test geotile_grid on geo_shape field with defaults":
 
   - do:
       search:
-        rest_total_hits_as_int: true
+        index: locations
+        size: 0
         body:
-          aggregations:
+          aggs:
             grid:
               geotile_grid:
                 field: location
-                precision: 8
-
-
-  - match: { hits.total: 6 }
-  - match: { aggregations.grid.buckets.0.key: "8/131/84" }
-  - match: { aggregations.grid.buckets.0.doc_count: 3 }
-  - match: { aggregations.grid.buckets.1.key: "8/129/88" }
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 2 }
+  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
+  - match: { aggregations.grid.buckets.0.doc_count: 4 }
+  - match: { aggregations.grid.buckets.1.key: "7/64/44" }
   - match: { aggregations.grid.buckets.1.doc_count: 2 }
-  - match: { aggregations.grid.buckets.2.key: "8/131/85" }
-  - match: { aggregations.grid.buckets.2.doc_count: 1 }
+
+---
+"Test geotile_grid on geo_shape field with precision":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geotile_grid:
+                precision: 5
+                field: location
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 2 }
+  - match: { aggregations.grid.buckets.0.key: "5/16/10" }
+  - match: { aggregations.grid.buckets.0.doc_count: 4 }
+  - match: { aggregations.grid.buckets.1.key: "5/16/11" }
+  - match: { aggregations.grid.buckets.1.doc_count: 2 }
+
+---
+"Test geotile_grid on geo_shape field with size":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geotile_grid:
+                field: location
+                size: 1
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 1 }
+  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
+  - match: { aggregations.grid.buckets.0.doc_count: 4 }
+
+
+---
+"Test geotile_grid on geo_shape field with shard_size":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geotile_grid:
+                field: location
+                shard_size: 10
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 2 }
+  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
+  - match: { aggregations.grid.buckets.0.doc_count: 4 }
+  - match: { aggregations.grid.buckets.1.key: "7/64/44" }
+  - match: { aggregations.grid.buckets.1.doc_count: 2 }
+
+
+---
+"Test geotile_grid on geo_shape field with bounds":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geotile_grid:
+                field: location
+                bounds:
+                  top_left: "POINT (4.9 52.4)"
+                  bottom_right: "POINT (5.0 52.3)"
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 1 }
+  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
+  - match: { aggregations.grid.buckets.0.doc_count: 4 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/40_geohash_grid.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/40_geohash_grid.yml
@@ -1,9 +1,10 @@
----
-"Test geohash_grid aggregation on geo_shape field":
+setup:
   - do:
       indices.create:
         index: locations
         body:
+          settings:
+            number_of_shards: 3
           mappings:
             properties:
               location:
@@ -12,44 +13,61 @@
   - do:
       bulk:
         refresh: true
-        body:
-          - index:
-              _index: locations
-              _id: "1"
-          - '{"location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}'
-          - index:
-              _index: locations
-              _id: "2"
-          - '{"location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}'
-          - index:
-              _index: locations
-              _id: "3"
-          - '{"location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}'
-          - index:
-              _index: locations
-              _id: "4"
-          - '{"location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}'
-          - index:
-              _index: locations
-              _id: "5"
-          - '{"location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}'
-          - index:
-              _index: locations
-              _id: "6"
-          - '{"location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}'
+        index: locations
+        body: |
+          {"index":{}}
+          {"location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}
+          {"index":{}}
+          {"location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}
+          {"index":{}}
+          {"location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}
+          {"index":{}}
+          {"location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}
+          {"index":{}}
+          {"location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}
+          {"index":{}}
+          {"location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}
+
+  - do:
+      indices.refresh: { }
+
+---
+"Test geohash_grid on geo_shape field with defaults":
 
   - do:
       search:
-        rest_total_hits_as_int: true
         index: locations
         size: 0
         body:
           aggs:
             grid:
               geohash_grid:
-                precision: 4
                 field: location
-  - match: {hits.total:      6    }
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 4 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+  - match: { aggregations.grid.buckets.1.key: "u155k" }
+  - match: { aggregations.grid.buckets.1.doc_count: 1 }
+  - match: { aggregations.grid.buckets.2.key: "u09tv" }
+  - match: { aggregations.grid.buckets.2.doc_count: 1 }
+  - match: { aggregations.grid.buckets.3.key: "u09tu" }
+  - match: { aggregations.grid.buckets.3.doc_count: 1 }
+
+---
+"Test geohash_grid on geo_shape field with precision":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                precision: 4
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 3 }
   - match: { aggregations.grid.buckets.0.key: "u173" }
   - match: { aggregations.grid.buckets.0.doc_count: 3 }
@@ -57,3 +75,65 @@
   - match: { aggregations.grid.buckets.1.doc_count: 2 }
   - match: { aggregations.grid.buckets.2.key: "u155" }
   - match: { aggregations.grid.buckets.2.doc_count: 1 }
+
+---
+"Test geohash_grid on geo_shape field with size":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                size: 1
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 1 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+
+---
+"Test geohash_grid on geo_shape field with shard_size":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                shard_size: 10
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 4 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+  - match: { aggregations.grid.buckets.1.key: "u155k" }
+  - match: { aggregations.grid.buckets.1.doc_count: 1 }
+  - match: { aggregations.grid.buckets.2.key: "u09tv" }
+  - match: { aggregations.grid.buckets.2.doc_count: 1 }
+  - match: { aggregations.grid.buckets.3.key: "u09tu" }
+  - match: { aggregations.grid.buckets.3.doc_count: 1 }
+
+---
+"Test geohash_grid on geo_shape field with bounds":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohash_grid:
+                field: location
+                bounds:
+                  top_left: "POINT (4.9 52.4)"
+                  bottom_right: "POINT (5.0 52.3)"
+  - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 1 }
+  - match: { aggregations.grid.buckets.0.key: "u173z" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/80_geohex_grid.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/80_geohex_grid.yml
@@ -13,36 +13,26 @@ setup:
   - do:
       bulk:
         refresh: true
-        body:
-          - index:
-              _index: locations
-              _id: 1
-          - '{"location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}'
-          - index:
-              _index: locations
-              _id: 2
-          - '{"location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}'
-          - index:
-              _index: locations
-              _id: 3
-          - '{"location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}'
-          - index:
-              _index: locations
-              _id: 4
-          - '{"location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}'
-          - index:
-              _index: locations
-              _id: 5
-          - '{"location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}'
-          - index:
-              _index: locations
-              _id: 6
-          - '{"location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}'
+        index: locations
+        body: |
+          {"index":{}}
+          {"location": "POINT(4.912350 52.374081)", "city": "Amsterdam", "name": "NEMO Science Museum"}
+          {"index":{}}
+          {"location": "POINT(4.901618 52.369219)", "city": "Amsterdam", "name": "Museum Het Rembrandthuis"}
+          {"index":{}}
+          {"location": "POINT(4.914722 52.371667)", "city": "Amsterdam", "name": "Nederlands Scheepvaartmuseum"}
+          {"index":{}}
+          {"location": "POINT(4.405200 51.222900)", "city": "Antwerp", "name": "Letterenhuis"}
+          {"index":{}}
+          {"location": "POINT(2.336389 48.861111)", "city": "Paris", "name": "Musée du Louvre"}
+          {"index":{}}
+          {"location": "POINT(2.327000 48.860000)", "city": "Paris", "name": "Musée dOrsay"}
+
   - do:
-      indices.refresh: {}
+      indices.refresh: { }
 
 ---
-"Test geohex_grid with defaults":
+"Test geohex_grid on geo_point field with defaults":
 
   - do:
       search:
@@ -53,7 +43,7 @@ setup:
             grid:
               geohex_grid:
                 field: location
-  - match: {hits.total.value:      6    }
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 3 }
   - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
   - match: { aggregations.grid.buckets.0.doc_count: 3 }
@@ -63,7 +53,7 @@ setup:
   - match: { aggregations.grid.buckets.2.doc_count: 1 }
 
 ---
-"Test geohex_grid with precision":
+"Test geohex_grid on geo_point field with precision":
 
   - do:
       search:
@@ -75,7 +65,7 @@ setup:
               geohex_grid:
                 field: location
                 precision: 0
-  - match: { hits.total.value:      6    }
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 2 }
   - match: { aggregations.grid.buckets.0.key: "801ffffffffffff" }
   - match: { aggregations.grid.buckets.0.doc_count: 4 }
@@ -83,7 +73,7 @@ setup:
   - match: { aggregations.grid.buckets.1.doc_count: 2 }
 
 ---
-"Test geohex_grid with size":
+"Test geohex_grid on geo_point field with size":
 
   - do:
       search:
@@ -95,13 +85,13 @@ setup:
               geohex_grid:
                 field: location
                 size: 1
-  - match: {hits.total.value:      6    }
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 1 }
   - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
   - match: { aggregations.grid.buckets.0.doc_count: 3 }
 
 ---
-"Test geohex_grid with shard size":
+"Test geohex_grid on geo_point field with shard size":
 
   - do:
       search:
@@ -113,7 +103,7 @@ setup:
               geohex_grid:
                 field: location
                 shard_size: 10
-  - match: {hits.total.value:      6    }
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 3 }
   - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
   - match: { aggregations.grid.buckets.0.doc_count: 3 }
@@ -123,7 +113,7 @@ setup:
   - match: { aggregations.grid.buckets.2.doc_count: 1 }
 
 ---
-"Test geohex_grid with bounds":
+"Test geohex_grid on geo_point field with bounds":
 
   - do:
       search:
@@ -137,7 +127,7 @@ setup:
                 bounds:
                   top_left: "POINT (4.9 52.4)"
                   bottom_right: "POINT (5.0 52.3)"
-  - match: {hits.total.value:      6    }
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 1 }
   - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
   - match: { aggregations.grid.buckets.0.doc_count: 3 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/80_geohex_grid_geo_shape.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/80_geohex_grid_geo_shape.yml
@@ -32,7 +32,7 @@ setup:
       indices.refresh: { }
 
 ---
-"Test geotile_grid on geo_shape field with defaults":
+"Test geohex_grid on geo_shape field with defaults":
 
   - do:
       search:
@@ -41,17 +41,39 @@ setup:
         body:
           aggs:
             grid:
-              geotile_grid:
+              geohex_grid:
                 field: location
   - match: { hits.total.value: 6 }
+  - length: { aggregations.grid.buckets: 3 }
+  - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+  - match: { aggregations.grid.buckets.1.key: "851fb467fffffff" }
+  - match: { aggregations.grid.buckets.1.doc_count: 2 }
+  - match: { aggregations.grid.buckets.2.key: "851fa4c7fffffff" }
+  - match: { aggregations.grid.buckets.2.doc_count: 1 }
+
+---
+"Test geohex_grid on geo_shape field with precision":
+
+  - do:
+      search:
+        index: locations
+        size: 0
+        body:
+          aggs:
+            grid:
+              geohex_grid:
+                field: location
+                precision: 0
+  - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 2 }
-  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
+  - match: { aggregations.grid.buckets.0.key: "801ffffffffffff" }
   - match: { aggregations.grid.buckets.0.doc_count: 4 }
-  - match: { aggregations.grid.buckets.1.key: "7/64/44" }
+  - match: { aggregations.grid.buckets.1.key: "8019fffffffffff" }
   - match: { aggregations.grid.buckets.1.doc_count: 2 }
 
 ---
-"Test geotile_grid on geo_shape field with precision":
+"Test geohex_grid on geo_shape field with size":
 
   - do:
       search:
@@ -60,37 +82,16 @@ setup:
         body:
           aggs:
             grid:
-              geotile_grid:
-                precision: 5
-                field: location
-  - match: { hits.total.value: 6 }
-  - length: { aggregations.grid.buckets: 2 }
-  - match: { aggregations.grid.buckets.0.key: "5/16/10" }
-  - match: { aggregations.grid.buckets.0.doc_count: 4 }
-  - match: { aggregations.grid.buckets.1.key: "5/16/11" }
-  - match: { aggregations.grid.buckets.1.doc_count: 2 }
-
----
-"Test geotile_grid on geo_shape field with size":
-
-  - do:
-      search:
-        index: locations
-        size: 0
-        body:
-          aggs:
-            grid:
-              geotile_grid:
+              geohex_grid:
                 field: location
                 size: 1
   - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 1 }
-  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
-  - match: { aggregations.grid.buckets.0.doc_count: 4 }
-
+  - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
 
 ---
-"Test geotile_grid on geo_shape field with shard_size":
+"Test geohex_grid on geo_shape field with shard size":
 
   - do:
       search:
@@ -99,19 +100,20 @@ setup:
         body:
           aggs:
             grid:
-              geotile_grid:
+              geohex_grid:
                 field: location
                 shard_size: 10
   - match: { hits.total.value: 6 }
-  - length: { aggregations.grid.buckets: 2 }
-  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
-  - match: { aggregations.grid.buckets.0.doc_count: 4 }
-  - match: { aggregations.grid.buckets.1.key: "7/64/44" }
+  - length: { aggregations.grid.buckets: 3 }
+  - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }
+  - match: { aggregations.grid.buckets.1.key: "851fb467fffffff" }
   - match: { aggregations.grid.buckets.1.doc_count: 2 }
-
+  - match: { aggregations.grid.buckets.2.key: "851fa4c7fffffff" }
+  - match: { aggregations.grid.buckets.2.doc_count: 1 }
 
 ---
-"Test geotile_grid on geo_shape field with bounds":
+"Test geohex_grid on geo_shape field with bounds":
 
   - do:
       search:
@@ -120,12 +122,12 @@ setup:
         body:
           aggs:
             grid:
-              geotile_grid:
+              geohex_grid:
                 field: location
                 bounds:
                   top_left: "POINT (4.9 52.4)"
                   bottom_right: "POINT (5.0 52.3)"
   - match: { hits.total.value: 6 }
   - length: { aggregations.grid.buckets: 1 }
-  - match: { aggregations.grid.buckets.0.key: "7/65/42" }
-  - match: { aggregations.grid.buckets.0.doc_count: 4 }
+  - match: { aggregations.grid.buckets.0.key: "85196953fffffff" }
+  - match: { aggregations.grid.buckets.0.doc_count: 3 }


### PR DESCRIPTION
Test for geohex are doubled to support both geo_point and geo_shape, while geotile and geohash are expanded to cover same range as geohex, covering the various options supported like:

* defaults
* precision
* size
* shard_size
* bounds

Before this PR, the test coverage was:

| aggregation  | geo_point  | geo_shape |
| -------------| ------------- | ------------- |
| geohash  | 1 | 1 |
| geotile  | 1 | 1 |
| geohex  | 5 | 0 |

With the PR we now have:

| aggregation  | geo_point  | geo_shape |
| -------------| ------------- | ------------- |
| geohash  | 5 | 5 |
| geotile  | 5 | 5 |
| geohex  | 5 | 5 |

Note that the tests are in two locations:

* modules/aggregations for geo_point and geohash/geotile combinations
* x-pack/plugin for geo_shape and for geo_point/geohex

| aggregation  | geo_point  | geo_shape |
| -------------| ------------- | ------------- |
| geohash  | aggregations | xpack |
| geotile  | aggregations | xpack |
| geohex  | xpack | xpack |

For testing these two locations, different commands are used:

For `modules/aggregations`, eg. test geotile_grid over geo_point:

```
./gradlew ':modules:aggregations:yamlRestTest' --tests \
  "org.elasticsearch.aggregations.AggregationsClientYamlTestSuiteIT.test {yaml=aggregations/geotile_grid/*}"
```

For `x-pack/plugin`, eg. test geohash_grid over geo_shape:

```
./gradlew ':x-pack:plugin:yamlRestTest' --tests \
  "org.elasticsearch.xpack.test.rest.XPackRestIT.test {p0=spatial/40_geohash_grid/*}" 
```
