### PR TITLE
Modularize blob cache and searchable snapshots

### DIFF
--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/module-info.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/module-info.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 module org.elasticsearch.blobcache.preallocate {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/module-info.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/module-info.java
@@ -1,0 +1,8 @@
+module org.elasticsearch.blobcache.preallocate {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.server;
+    requires org.apache.logging.log4j;
+    requires com.sun.jna;
+
+    exports org.elasticsearch.blobcache.preallocate to org.elasticsearch.blobcache;
+}

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/LinuxPreallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/LinuxPreallocator.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.blobcache.preallocate;
 
 import com.sun.jna.Native;

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/LinuxPreallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/LinuxPreallocator.java
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.searchablesnapshots.preallocate;
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.blobcache.preallocate;
 
 import com.sun.jna.Native;
 import com.sun.jna.Platform;

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/MacOsPreallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/MacOsPreallocator.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.blobcache.preallocate;
 
 import com.sun.jna.Native;

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/MacOsPreallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/MacOsPreallocator.java
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.searchablesnapshots.preallocate;
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.blobcache.preallocate;
 
 import com.sun.jna.Native;
 import com.sun.jna.NativeLong;

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/NoNativePreallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/NoNativePreallocator.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.blobcache.preallocate;
 
 final class NoNativePreallocator implements Preallocator {

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/NoNativePreallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/NoNativePreallocator.java
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.searchablesnapshots.preallocate;
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.blobcache.preallocate;
 
 final class NoNativePreallocator implements Preallocator {
 

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocate.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocate.java
@@ -5,11 +5,18 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.searchablesnapshots.preallocate;
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.blobcache.preallocate;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.lucene.util.Constants;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.core.SuppressForbidden;
 
@@ -26,10 +33,18 @@ public class Preallocate {
 
     private static final Logger logger = LogManager.getLogger(Preallocate.class);
 
+    private static final boolean IS_LINUX;
+    private static final boolean IS_MACOS;
+    static {
+        String osName = System.getProperty("os.name");
+        IS_LINUX = osName.startsWith("Linux");
+        IS_MACOS = osName.startsWith("Mac OS X");
+    }
+
     public static void preallocate(final Path cacheFile, final long fileSize) throws IOException {
-        if (Constants.LINUX) {
+        if (IS_LINUX) {
             preallocate(cacheFile, fileSize, new LinuxPreallocator());
-        } else if (Constants.MAC_OS_X) {
+        } else if (IS_MACOS) {
             preallocate(cacheFile, fileSize, new MacOsPreallocator());
         } else {
             preallocate(cacheFile, fileSize, new NoNativePreallocator());

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocate.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocate.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.blobcache.preallocate;
 
 import org.apache.logging.log4j.LogManager;

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocator.java
@@ -5,14 +5,6 @@
  * 2.0.
  */
 
-/*
- * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
- * or more contributor license agreements. Licensed under the Elastic License
- * 2.0 and the Server Side Public License, v 1; you may not use this file except
- * in compliance with, at your election, the Elastic License 2.0 or the Server
- * Side Public License, v 1.
- */
-
 package org.elasticsearch.blobcache.preallocate;
 
 /**

--- a/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocator.java
+++ b/x-pack/plugin/blob-cache/preallocate/src/main/java/org/elasticsearch/blobcache/preallocate/Preallocator.java
@@ -5,7 +5,15 @@
  * 2.0.
  */
 
-package org.elasticsearch.xpack.searchablesnapshots.preallocate;
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.blobcache.preallocate;
 
 /**
  * Represents platform native methods for pre-allocating files.

--- a/x-pack/plugin/blob-cache/src/main/java/module-info.java
+++ b/x-pack/plugin/blob-cache/src/main/java/module-info.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 module org.elasticsearch.blobcache {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;

--- a/x-pack/plugin/blob-cache/src/main/java/module-info.java
+++ b/x-pack/plugin/blob-cache/src/main/java/module-info.java
@@ -1,0 +1,12 @@
+module org.elasticsearch.blobcache {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.blobcache.preallocate;
+
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.core;
+
+    exports org.elasticsearch.blobcache;
+    exports org.elasticsearch.blobcache.common;
+    exports org.elasticsearch.blobcache.shared;
+}

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.blobcache.BlobCacheUtils;
 import org.elasticsearch.blobcache.common.ByteBufferReference;
+import org.elasticsearch.blobcache.preallocate.Preallocate;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.AbstractRefCounted;
@@ -18,7 +19,6 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.blobcache.preallocate.Preallocate;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -18,7 +18,7 @@ import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
-import org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate;
+import org.elasticsearch.blobcache.preallocate.Preallocate;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -1,0 +1,7 @@
+module org.elasticsearch.searchablesnapshots {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.server;
+
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.core;
+}

--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -1,8 +1,12 @@
 module org.elasticsearch.searchablesnapshots {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;
+    requires org.elasticsearch.xcore;
+    requires org.elasticsearch.xcontent;
+
     requires org.elasticsearch.blobcache;
 
     requires org.apache.logging.log4j;
     requires org.apache.lucene.core;
+    requires org.apache.lucene.analysis.common;
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -18,5 +18,5 @@ module org.elasticsearch.searchablesnapshots {
     requires org.apache.lucene.analysis.common;
 
     exports org.elasticsearch.xpack.searchablesnapshots.action.cache to org.elasticsearch.server;
-    exports  org.elasticsearch.xpack.searchablesnapshots.action to org.elasticsearch.server;
+    exports org.elasticsearch.xpack.searchablesnapshots.action to org.elasticsearch.server;
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -16,4 +16,7 @@ module org.elasticsearch.searchablesnapshots {
     requires org.apache.logging.log4j;
     requires org.apache.lucene.core;
     requires org.apache.lucene.analysis.common;
+
+    exports org.elasticsearch.xpack.searchablesnapshots.action.cache to org.elasticsearch.server;
+    exports  org.elasticsearch.xpack.searchablesnapshots.action to org.elasticsearch.server;
 }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -1,3 +1,10 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
 module org.elasticsearch.searchablesnapshots {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/module-info.java
@@ -1,6 +1,7 @@
 module org.elasticsearch.searchablesnapshots {
     requires org.elasticsearch.base;
     requires org.elasticsearch.server;
+    requires org.elasticsearch.blobcache;
 
     requires org.apache.logging.log4j;
     requires org.apache.lucene.core;


### PR DESCRIPTION
This commit modularize tow more xpack plugins: blob cache and searchable snapshots. It also modularizes the separate jar blob cache uses for preallocating memory using jna.

relates #78744