### PR TITLE
Fix bug deleting search application with no alias

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -357,9 +357,10 @@ public class SearchApplicationIndexService {
             @Override
             public void onFailure(Exception e) {
                 if (e instanceof AliasesNotFoundException) {
-                    listener.onFailure(new ResourceNotFoundException(resourceName));
+                    deleteSearchApplication(resourceName, listener);
+                } else {
+                    listener.onFailure(e);
                 }
-                listener.onFailure(e);
             }
         });
     }


### PR DESCRIPTION
When all indices associated with an alias are deleted, the underlying alias is also deleted.
This fixes the edge case where a user deletes all underlying indices associated with a search application before deleting the search application itself - instead of an error, we want to allow the deletion in this case. 