### PR TITLE
Change java.io opens to new preallocate module

### DIFF
--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/SystemJvmOptions.java
@@ -58,10 +58,8 @@ final class SystemJvmOptions {
             /*
              * Temporarily suppress illegal reflective access in searchable snapshots shared cache preallocation; this is temporary while we
              * explore alternatives. See org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate.
-             *
-             * TODO: either modularlize Elasticsearch so that we can limit the opening of this module, or find an alternative
              */
-            "--add-opens=java.base/java.io=ALL-UNNAMED",
+            "--add-opens=java.base/java.io=org.elasticsearch.blobcache.preallocate",
             maybeOverrideDockerCgroup()
         ).stream().filter(e -> e.isEmpty() == false).collect(Collectors.toList());
     }


### PR DESCRIPTION
With the modularization of preallocate, the opens command line can be changed to only open to this module instead of all unnamed.

