### PR TITLE
SeekStatsService.registerIndex() needs to be idempotent

### DIFF
--- a/test/external-modules/seek-tracking-directory/src/internalClusterTest/java/org/elasticsearch/test/seektracker/SeekTrackerPluginIT.java
+++ b/test/external-modules/seek-tracking-directory/src/internalClusterTest/java/org/elasticsearch/test/seektracker/SeekTrackerPluginIT.java
@@ -36,7 +36,6 @@ public class SeekTrackerPluginIT extends ESIntegTestCase {
             .build();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94727")
     public void testSeekTrackerPlugin() throws InterruptedException {
 
         assertAcked(client().admin().indices().prepareCreate("index"));

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/IndexSeekTracker.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/IndexSeekTracker.java
@@ -17,7 +17,12 @@ import java.util.concurrent.atomic.LongAdder;
 
 public class IndexSeekTracker {
 
+    private final String index;
     private final Map<String, Map<String, LongAdder>> seeks = new HashMap<>();
+
+    public IndexSeekTracker(String index) {
+        this.index = index;
+    }
 
     public void track(String shard) {
         seeks.computeIfAbsent(shard, k -> new ConcurrentHashMap<>());   // increment can be called by multiple threads
@@ -39,4 +44,8 @@ public class IndexSeekTracker {
         return new ShardSeekStats(shard, seeksPerFile);
     }
 
+    @Override
+    public String toString() {
+        return "seeks for " + index + ": " + seeks;
+    }
 }

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekStatsService.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/SeekStatsService.java
@@ -16,9 +16,7 @@ public class SeekStatsService {
     private final Map<String, IndexSeekTracker> seeks = new HashMap<>();
 
     public IndexSeekTracker registerIndex(String index) {
-        IndexSeekTracker tracker = new IndexSeekTracker();
-        seeks.put(index, tracker);
-        return tracker;
+        return seeks.computeIfAbsent(index, IndexSeekTracker::new);
     }
 
     public Map<String, IndexSeekTracker> getSeekStats() {


### PR DESCRIPTION
`SeekTrackerPlugin.onModule()` can be called multiple times if extra 
validation is enabled, so we need to ensure that we always return the
same IndexSeekTracker for a given index from registerIndex().