### PR TITLE
Introduce setup and tear down

### DIFF
--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -69,6 +69,7 @@ PUT _ilm/policy/my_policy
 }
 --------------------------------------------------
 // TESTSETUP
+
 [source,console]
 --------------------------------------------------
 DELETE _ilm/policy/my_policy
@@ -80,8 +81,6 @@ DELETE _ilm/policy/my_policy
 --------------------------------------------------
 GET _ilm/policy/my_policy
 --------------------------------------------------
-// TEST[continued]
-
 
 If the request succeeds, the body of the response contains the policy definition:
 

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -43,8 +43,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=timeoutparms]
 
 The following example retrieves `my_policy`:
 
-//////////////////////////
-
+////
 [source,console]
 --------------------------------------------------
 PUT _ilm/policy/my_policy
@@ -69,8 +68,13 @@ PUT _ilm/policy/my_policy
   }
 }
 --------------------------------------------------
-
-//////////////////////////
+// TESTSETUP
+[source,console]
+--------------------------------------------------
+DELETE _ilm/policy/my_policy
+--------------------------------------------------
+// TEARDOWN
+////
 
 [source,console]
 --------------------------------------------------
@@ -115,7 +119,6 @@ If the request succeeds, the body of the response contains the policy definition
   }
 }
 --------------------------------------------------
-// TEST[skip:https://github.com/elastic/elasticsearch/issues/89623]
 // TESTRESPONSE[s/"modified_date": 82392349/"modified_date": $body.my_policy.modified_date/]
 
 <1> The policy version is incremented whenever the policy is updated


### PR DESCRIPTION
The test in the docs fails because the version of the policy is greater than `1`. I believe this is happening because the policy is not cleared at a different test. 

In this PR we will go through the tests that are using `PUT _ilm/policy/my_policy` and add a tear down.

Fixes #89623
