### PR TITLE
[7.17] Check no unassigned shards even if the node already left (#94722)

### DIFF
--- a/docs/changelog/94722.yaml
+++ b/docs/changelog/94722.yaml
@@ -1,0 +1,5 @@
+pr: 94722
+summary: Check no unassigned shards even if the node already left
+area: Infra/Core
+type: bug
+issues: []

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -558,7 +558,11 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
 
         createIndex(
             "index",
-            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build()
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("index.routing.allocation.include._name", nodeA)
+                .build()
         );
 
         ensureYellow("index");

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -12,7 +12,6 @@ import org.elasticsearch.Build;
 import org.elasticsearch.action.admin.cluster.allocation.ClusterAllocationExplainResponse;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
-import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.indices.settings.put.UpdateSettingsRequestBuilder;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -559,7 +558,7 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
 
         createIndex(
             "index",
-            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build()
+            Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0).build()
         );
 
         ensureYellow("index");
@@ -569,21 +568,9 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
         final String nodeBId = getNodeId(nodeB);
         ensureGreen("index");
 
-        client().admin()
-            .cluster()
-            .updateSettings(
-                new ClusterUpdateSettingsRequest().persistentSettings(Settings.builder().put("cluster.routing.allocation.enable", "none"))
-            );
-
-        assertThat(client().admin().indices().prepareFlush("index").get().getSuccessfulShards(), equalTo(2));
-        assertThat(client().admin().indices().prepareRefresh("index").get().getSuccessfulShards(), equalTo(2));
-
-        internalCluster().restartNode(nodeA);
-        internalCluster().restartNode(nodeB);
-
-        assertThat(client().admin().cluster().prepareHealth("index").get().getUnassignedShards(), equalTo(1));
-
         putNodeShutdown(nodeAId, SingleNodeShutdownMetadata.Type.REMOVE, null);
+
+        internalCluster().stopNode(nodeA);
 
         assertBusy(() -> assertNodeShutdownStatus(nodeAId, STALLED));
     }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/TransportGetShutdownStatusAction.java
@@ -188,12 +188,6 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
             );
         }
 
-        // The node is in `DiscoveryNodes`, but not `RoutingNodes` - so there are no shards assigned to it. We're done.
-        if (currentState.getRoutingNodes().node(nodeId) == null) {
-            // We don't know about that node
-            return new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.COMPLETE, 0);
-        }
-
         final RoutingAllocation allocation = new RoutingAllocation(
             allocationDeciders,
             currentState.getRoutingNodes(),
@@ -234,6 +228,12 @@ public class TransportGetShutdownStatusAction extends TransportMasterNodeAction<
                 ).getFormattedMessage(),
                 decision
             );
+        }
+
+        // The node is in `DiscoveryNodes`, but not `RoutingNodes` - so there are no shards assigned to it. We're done.
+        if (currentState.getRoutingNodes().node(nodeId) == null) {
+            // We don't know about that node
+            return new ShutdownShardMigrationStatus(SingleNodeShutdownMetadata.Status.COMPLETE, 0);
         }
 
         // Check if there are any shards currently on this node, and if there are any relocating shards


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Check no unassigned shards even if the node already left (#94722 )