### PR TITLE
[DOCS] clarify v7 file realm configuration

### DIFF
--- a/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
@@ -1,3 +1,14 @@
+To use the `file` or `native` realms when any other realms are configured and
+enabled, you need to explicitly configure them in the `elasticsearch.yml` file.
+
+If no other realms are configured and enabled, you don't need to explicitly
+configure a `file` realm. The `file` and `native` realms are added to the realm
+chain by default then.  Unless configured otherwise, the `file` realm is added
+first, followed by the `native` realm.
+
+IMPORTANT: While it is possible to define multiple instances of some other
+realms, you can define only _one_ `file` realm per node.
+
 All the data about the users for the `file` realm is stored in two files on each 
 node in the cluster: `users` and `users_roles`. Both files are located in 
 `ES_PATH_CONF` and are read on startup.
@@ -13,9 +24,6 @@ A safer approach would be to apply the change on one of the nodes and have the
 files distributed or copied to all other nodes in the cluster (either manually 
 or using a configuration management system such as Puppet or Chef).
 ==============================
-
-The `file` realm is added to the realm chain by default. You don't need to
-explicitly configure a `file` realm.
 
 . (Optional) Add a realm configuration to `elasticsearch.yml` under the
 `xpack.security.authc.realms.file` namespace. At a minimum, you must set 

--- a/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/configuring-file-realm.asciidoc
@@ -2,8 +2,8 @@ To use the `file` or `native` realms when any other realms are configured and
 enabled, you need to explicitly configure them in the `elasticsearch.yml` file.
 
 If no other realms are configured and enabled, you don't need to explicitly
-configure a `file` realm. The `file` and `native` realms are added to the realm
-chain by default then.  Unless configured otherwise, the `file` realm is added
+configure a `file` or `native` realm and they are added to the realm
+chain by default.  Unless configured otherwise, the `file` realm is added
 first, followed by the `native` realm.
 
 IMPORTANT: While it is possible to define multiple instances of some other

--- a/x-pack/docs/en/security/authentication/file-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/file-realm.asciidoc
@@ -19,11 +19,6 @@ In this type of scenario, the `file` realm is a convenient way out - you can
 define a new `admin` user in the `file` realm and use it to log in and reset the
 credentials of all other users.
 
-IMPORTANT: When you configure realms in `elasticsearch.yml`, only the realms you
-specify are used for authentication. To use the `file` realm you must explicitly
-include it in the realm chain. While it is possible to define multiple instances
-of some other realms, you can define only _one_ file realm per node.
-
 To define users, the {security-features} provide the
 {ref}/users-command.html[users] command-line tool. This tool enables you to add
 and remove users, assign user roles, and manage user passwords.


### PR DESCRIPTION
Clarify the default behavior of the file realm in v7.x.

Related to https://github.com/elastic/elasticsearch/issues/94658