### PR TITLE
Refactor _cluster/stats .nodes.fs deduplication

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodes.java
@@ -62,10 +62,10 @@ public class ClusterStatsNodes implements ToXContentFragment {
 
     ClusterStatsNodes(List<ClusterStatsNodeResponse> nodeResponses) {
         this.versions = new HashSet<>();
-        this.fs = new FsInfo.Path();
         this.plugins = new HashSet<>();
 
-        Set<InetAddress> seenAddresses = Sets.newHashSetWithExpectedSize(nodeResponses.size());
+        ClusterFsStatsDeduplicator deduplicator = new ClusterFsStatsDeduplicator(nodeResponses.size());
+
         List<NodeInfo> nodeInfos = new ArrayList<>(nodeResponses.size());
         List<NodeStats> nodeStats = new ArrayList<>(nodeResponses.size());
         for (ClusterStatsNodeResponse nodeResponse : nodeResponses) {
@@ -74,16 +74,12 @@ public class ClusterStatsNodes implements ToXContentFragment {
             this.versions.add(nodeResponse.nodeInfo().getVersion());
             this.plugins.addAll(nodeResponse.nodeInfo().getInfo(PluginsAndModules.class).getPluginInfos());
 
-            // now do the stats that should be deduped by hardware (implemented by ip deduping)
             TransportAddress publishAddress = nodeResponse.nodeInfo().getInfo(TransportInfo.class).address().publishAddress();
             final InetAddress inetAddress = publishAddress.address().getAddress();
-            if (seenAddresses.add(inetAddress) == false) {
-                continue;
-            }
-            if (nodeResponse.nodeStats().getFs() != null) {
-                this.fs.add(nodeResponse.nodeStats().getFs().getTotal());
-            }
+            deduplicator.add(inetAddress, nodeResponse.nodeStats().getFs());
         }
+        this.fs = deduplicator.getTotal();
+
         this.counts = new Counts(nodeInfos);
         this.os = new OsStats(nodeInfos, nodeStats);
         this.process = new ProcessStats(nodeStats);
@@ -845,6 +841,31 @@ public class ClusterStatsNodes implements ToXContentFragment {
             return indexingPressureStats.toXContent(builder, params);
         }
 
+    }
+
+    static class ClusterFsStatsDeduplicator {
+
+        private final Set<InetAddress> seenAddresses;
+        private final FsInfo.Path total = new FsInfo.Path();
+
+        ClusterFsStatsDeduplicator(int expectedSize) {
+            seenAddresses = Sets.newHashSetWithExpectedSize(expectedSize);
+        }
+
+        public void add(InetAddress inetAddress, FsInfo fsInfo) {
+            if (seenAddresses.add(inetAddress) == false) {
+                return;
+            }
+            if (fsInfo != null) {
+                total.add(fsInfo.getTotal());
+            }
+        }
+
+        public FsInfo.Path getTotal() {
+            FsInfo.Path result = new FsInfo.Path();
+            result.add(total);
+            return result;
+        }
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -22,16 +22,12 @@ import org.elasticsearch.index.stats.IndexingPressureStats;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singletonList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -42,14 +38,14 @@ public class ClusterStatsNodesTests extends ESTestCase {
      * of the cluster stats xcontent output.
      */
     public void testNetworkTypesToXContent() throws Exception {
-        ClusterStatsNodes.NetworkTypes stats = new ClusterStatsNodes.NetworkTypes(emptyList());
+        ClusterStatsNodes.NetworkTypes stats = new ClusterStatsNodes.NetworkTypes(List.of());
         assertEquals("{\"transport_types\":{},\"http_types\":{}}", toXContent(stats, XContentType.JSON, randomBoolean()).utf8ToString());
 
-        List<NodeInfo> nodeInfos = singletonList(createNodeInfo("node_0", null, null));
+        List<NodeInfo> nodeInfos = List.of(createNodeInfo("node_0", null, null));
         stats = new ClusterStatsNodes.NetworkTypes(nodeInfos);
         assertEquals("{\"transport_types\":{},\"http_types\":{}}", toXContent(stats, XContentType.JSON, randomBoolean()).utf8ToString());
 
-        nodeInfos = Arrays.asList(
+        nodeInfos = List.of(
             createNodeInfo("node_1", "", ""),
             createNodeInfo("node_2", "custom", "custom"),
             createNodeInfo("node_3", null, "custom")
@@ -85,7 +81,7 @@ public class ClusterStatsNodesTests extends ESTestCase {
             });
         });
 
-        ClusterStatsNodes.IngestStats stats = new ClusterStatsNodes.IngestStats(Collections.singletonList(nodeStats));
+        ClusterStatsNodes.IngestStats stats = new ClusterStatsNodes.IngestStats(List.of(nodeStats));
         assertThat(stats.pipelineCount, equalTo(nodeStats.getIngestStats().getProcessorStats().size()));
         StringBuilder processorStatsString = new StringBuilder("{");
         Iterator<Map.Entry<String, long[]>> iter = processorStats.entrySet().iterator();
@@ -110,7 +106,7 @@ public class ClusterStatsNodesTests extends ESTestCase {
     }
 
     public void testIndexPressureStats() throws Exception {
-        List<NodeStats> nodeStats = Arrays.asList(
+        List<NodeStats> nodeStats = List.of(
             randomValueOtherThanMany(n -> n.getIndexingPressureStats() == null, NodeStatsTests::createNodeStats),
             randomValueOtherThanMany(n -> n.getIndexingPressureStats() == null, NodeStatsTests::createNodeStats)
         );

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -216,9 +216,13 @@ public class ClusterStatsNodesTests extends ESTestCase {
             FsInfo.Path total = deduplicator.getTotal();
 
             // since it's the same device, they don't sum, we just see the one
-            assertThat(total.getTotal().getBytes(), equalTo(3L));
-            assertThat(total.getFree().getBytes(), equalTo(2L));
-            assertThat(total.getAvailable().getBytes(), equalTo(1L));
+            // assertThat(total.getTotal().getBytes(), equalTo(3L));
+            // assertThat(total.getFree().getBytes(), equalTo(2L));
+            // assertThat(total.getAvailable().getBytes(), equalTo(1L));
+            // BUG 0: even though it's the same device, we're summing, bleh
+            assertThat(total.getTotal().getBytes(), equalTo(6L));
+            assertThat(total.getFree().getBytes(), equalTo(4L));
+            assertThat(total.getAvailable().getBytes(), equalTo(2L));
         }
 
         {
@@ -251,9 +255,13 @@ public class ClusterStatsNodesTests extends ESTestCase {
 
             // wait a second, this is the super-special case -- you can't actually have two nodes doing this unless something
             // very interesting is happening, so they sum (i.e. we assume the operator is doing smart things)
-            assertThat(total.getTotal().getBytes(), equalTo(6L));
-            assertThat(total.getFree().getBytes(), equalTo(4L));
-            assertThat(total.getAvailable().getBytes(), equalTo(2L));
+            // assertThat(total.getTotal().getBytes(), equalTo(6L));
+            // assertThat(total.getFree().getBytes(), equalTo(4L));
+            // assertThat(total.getAvailable().getBytes(), equalTo(2L));
+            // BUG 1: we don't sum in this super-special case, we just dedup by ip address
+            assertThat(total.getTotal().getBytes(), equalTo(3L));
+            assertThat(total.getFree().getBytes(), equalTo(2L));
+            assertThat(total.getAvailable().getBytes(), equalTo(1L));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -15,13 +15,16 @@ import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.stats.IndexingPressureStats;
+import org.elasticsearch.monitor.fs.FsInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 
+import java.net.InetAddress;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -185,6 +188,77 @@ public class ClusterStatsNodesTests extends ESTestCase {
                     + "}}"
             )
         );
+    }
+
+    public void testClusterFsStatsDeduplicator() {
+        {
+            // single node, multiple data paths, different devices
+            InetAddress address1 = InetAddresses.forString("192.168.0.1");
+            FsInfo.Path path1 = new FsInfo.Path("/a", "/dev/sda", 3, 2, 1);
+            FsInfo.Path path2 = new FsInfo.Path("/b", "/dev/sdb", 3, 2, 1);
+            ClusterStatsNodes.ClusterFsStatsDeduplicator deduplicator = new ClusterStatsNodes.ClusterFsStatsDeduplicator(1);
+            deduplicator.add(address1, newFsInfo(path1, path2));
+            FsInfo.Path total = deduplicator.getTotal();
+
+            // since they're different devices, they sum
+            assertThat(total.getTotal().getBytes(), equalTo(6L));
+            assertThat(total.getFree().getBytes(), equalTo(4L));
+            assertThat(total.getAvailable().getBytes(), equalTo(2L));
+        }
+
+        {
+            // single node, multiple data paths, same device
+            InetAddress address1 = InetAddresses.forString("192.168.0.1");
+            FsInfo.Path path1 = new FsInfo.Path("/data/a", "/dev/sda", 3, 2, 1);
+            FsInfo.Path path2 = new FsInfo.Path("/data/b", "/dev/sda", 3, 2, 1);
+            ClusterStatsNodes.ClusterFsStatsDeduplicator deduplicator = new ClusterStatsNodes.ClusterFsStatsDeduplicator(1);
+            deduplicator.add(address1, newFsInfo(path1, path2));
+            FsInfo.Path total = deduplicator.getTotal();
+
+            // since it's the same device, they don't sum, we just see the one
+            assertThat(total.getTotal().getBytes(), equalTo(3L));
+            assertThat(total.getFree().getBytes(), equalTo(2L));
+            assertThat(total.getAvailable().getBytes(), equalTo(1L));
+        }
+
+        {
+            // two nodes, different ip addresses, same data paths, same device
+            InetAddress address1 = InetAddresses.forString("192.168.0.1");
+            FsInfo.Path path1 = new FsInfo.Path("/data/a", "/dev/sda", 3, 2, 1);
+            InetAddress address2 = InetAddresses.forString("192.168.0.2");
+            FsInfo.Path path2 = new FsInfo.Path("/data/b", "/dev/sda", 3, 2, 1);
+            ClusterStatsNodes.ClusterFsStatsDeduplicator deduplicator = new ClusterStatsNodes.ClusterFsStatsDeduplicator(1);
+            deduplicator.add(address1, newFsInfo(path1));
+            deduplicator.add(address2, newFsInfo(path2));
+            FsInfo.Path total = deduplicator.getTotal();
+
+            // it's the same device, yeah, but on entirely different machines, so they sum
+            assertThat(total.getTotal().getBytes(), equalTo(6L));
+            assertThat(total.getFree().getBytes(), equalTo(4L));
+            assertThat(total.getAvailable().getBytes(), equalTo(2L));
+        }
+
+        {
+            // two nodes, same ip addresses, same data paths, same device
+            InetAddress address1 = InetAddresses.forString("192.168.0.1");
+            FsInfo.Path path1 = new FsInfo.Path("/app/data", "/app (/dev/mapper/lxc-data)", 3, 2, 1);
+            InetAddress address2 = InetAddresses.forString("192.168.0.1");
+            FsInfo.Path path2 = new FsInfo.Path("/app/data", "/app (/dev/mapper/lxc-data)", 3, 2, 1);
+            ClusterStatsNodes.ClusterFsStatsDeduplicator deduplicator = new ClusterStatsNodes.ClusterFsStatsDeduplicator(1);
+            deduplicator.add(address1, newFsInfo(path1));
+            deduplicator.add(address2, newFsInfo(path2));
+            FsInfo.Path total = deduplicator.getTotal();
+
+            // wait a second, this is the super-special case -- you can't actually have two nodes doing this unless something
+            // very interesting is happening, so they sum (i.e. we assume the operator is doing smart things)
+            assertThat(total.getTotal().getBytes(), equalTo(6L));
+            assertThat(total.getFree().getBytes(), equalTo(4L));
+            assertThat(total.getAvailable().getBytes(), equalTo(2L));
+        }
+    }
+
+    private static FsInfo newFsInfo(FsInfo.Path... paths) {
+        return new FsInfo(-1, null, paths);
     }
 
     private static NodeInfo createNodeInfo(String nodeId, String transportType, String httpType) {


### PR DESCRIPTION
Related to #94744 and to #24472

Refactors the `ClusterStatsNodes` fs deduplication logic in order to make it easier to test, then adds four test scenarios (two of which currently pass, the two that fail are bugs that should be fixed -- I'll be fixing them in other PRs).

In the response from `GET _cluster/stats`, this section:

```
{
  [...]
  "nodes": {
    [...]
    "fs": {
      "total_in_bytes": 821412495360,
      "free_in_bytes": 820742066176,
      "available_in_bytes": 820742066176
    },
    [...]
  }
  [...]
}
```

is currently governed by some logic that de-duplicates by ip address, this PR twiddles the code of that logic around a little bit without actually **changing** the logic.