### PR TITLE
Fix flaky testNodeShutdownWithUnassignedShards

### DIFF
--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -414,7 +414,15 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
         final String nodeA = internalCluster().startNode();
         final String nodeAId = getNodeId(nodeA);
 
-        createIndex("index", 1, 0);
+        createIndex(
+            "index",
+            Settings.builder()
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+                .put("index.routing.allocation.include._name", nodeA)
+                .build()
+        );
+
 
         ensureYellow("index");
 

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -423,7 +423,6 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
                 .build()
         );
 
-
         ensureYellow("index");
 
         // Start a second node, so the replica will be on nodeB


### PR DESCRIPTION
This test can occasionally fail if the index is moved to nodeB (as a result of a rebalance after starting second node) and do not need to be migrated in response to the putNodeShutdown request.
