### PR TITLE
[8.7] Migrate MockHttpServer to Apache HttpServer (#94205)

### DIFF
--- a/modules/repository-gcs/build.gradle
+++ b/modules/repository-gcs/build.gradle
@@ -57,6 +57,9 @@ dependencies {
   api 'io.opencensus:opencensus-contrib-http-util:0.31.1'
   api 'com.google.apis:google-api-services-storage:v1-rev20220705-2.0.0'
 
+  testImplementation "org.apache.httpcomponents:httpclient:${versions.httpclient}"
+  testImplementation "org.apache.httpcomponents:httpcore:${versions.httpcore}"
+
   testImplementation project(':test:fixtures:gcs-fixture')
 }
 

--- a/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GcsProxyIntegrationTests.java
+++ b/modules/repository-gcs/src/internalClusterTest/java/org/elasticsearch/repositories/gcs/GcsProxyIntegrationTests.java
@@ -13,7 +13,6 @@ import fixture.gcs.TestUtils;
 
 import com.sun.net.httpserver.HttpServer;
 
-import org.apache.lucene.tests.util.LuceneTestCase;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.SuppressForbidden;
@@ -41,7 +40,6 @@ import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.BU
 import static org.elasticsearch.repositories.gcs.GoogleCloudStorageRepository.CLIENT_NAME;
 
 @SuppressForbidden(reason = "We start an HTTP proxy server to test proxy support for GCS")
-@LuceneTestCase.AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/93811")
 public class GcsProxyIntegrationTests extends ESBlobStoreRepositoryIntegTestCase {
 
     private static HttpServer upstreamServer;

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageClientSettingsTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageClientSettingsTests.java
@@ -10,6 +10,11 @@ package org.elasticsearch.repositories.gcs;
 import com.google.api.services.storage.StorageScopes;
 import com.google.auth.oauth2.ServiceAccountCredentials;
 
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.protocol.HttpContext;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
@@ -18,9 +23,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
@@ -169,12 +171,10 @@ public class GoogleCloudStorageClientSettingsTests extends ESTestCase {
             ).getBytes(StandardCharsets.UTF_8)
         );
         var settings = Settings.builder().setSecureSettings(secureSettings).build();
-        var proxyServer = new MockHttpProxyServer((is, os) -> {
-            try (
-                var reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-                var writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)
-            ) {
-                assertEquals("POST http://oauth2.googleapis.com/oauth2/token HTTP/1.1", reader.readLine());
+        var proxyServer = new MockHttpProxyServer() {
+            @Override
+            public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
+                assertEquals("POST http://oauth2.googleapis.com/oauth2/token HTTP/1.1", request.getRequestLine().toString());
                 String body = """
                     {
                         "access_token": "proxy_access_token",
@@ -182,13 +182,9 @@ public class GoogleCloudStorageClientSettingsTests extends ESTestCase {
                         "expires_in": 3600
                     }
                     """;
-                writer.write(Strings.format("""
-                    HTTP/1.1 200 OK\r
-                    Content-Length: %s\r
-                    \r
-                    %s""", body.length(), body));
+                response.setEntity(new StringEntity(body, ContentType.TEXT_PLAIN));
             }
-        }).await();
+        };
         try (proxyServer) {
             var proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(InetAddress.getLoopbackAddress(), proxyServer.getPort()));
             ServiceAccountCredentials credentials = loadCredential(settings, clientName, proxy);

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/GoogleCloudStorageServiceTests.java
@@ -11,24 +11,24 @@ package org.elasticsearch.repositories.gcs;
 import com.google.cloud.http.HttpTransportOptions;
 import com.google.cloud.storage.Storage;
 
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.apache.http.protocol.HttpContext;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.core.Strings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.hamcrest.Matchers;
 
-import java.io.BufferedReader;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Proxy;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyPair;
 import java.security.KeyPairGenerator;
 import java.util.Base64;
@@ -190,19 +190,16 @@ public class GoogleCloudStorageServiceTests extends ESTestCase {
 
     public void testGetDefaultProjectIdViaProxy() throws Exception {
         String proxyProjectId = randomAlphaOfLength(16);
-        var proxyServer = new MockHttpProxyServer((is, os) -> {
-            try (
-                var reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8));
-                var writer = new OutputStreamWriter(os, StandardCharsets.UTF_8)
-            ) {
-                assertEquals("GET http://metadata.google.internal/computeMetadata/v1/project/project-id HTTP/1.1", reader.readLine());
-                writer.write(Strings.format("""
-                    HTTP/1.1 200 OK\r
-                    Content-Length: %s\r
-                    \r
-                    %s""", proxyProjectId.length(), proxyProjectId));
+        var proxyServer = new MockHttpProxyServer() {
+            @Override
+            public void handle(HttpRequest request, HttpResponse response, HttpContext context) {
+                assertEquals(
+                    "GET http://metadata.google.internal/computeMetadata/v1/project/project-id HTTP/1.1",
+                    request.getRequestLine().toString()
+                );
+                response.setEntity(new StringEntity(proxyProjectId, ContentType.TEXT_PLAIN));
             }
-        }).await();
+        };
         try (proxyServer) {
             var proxy = new Proxy(Proxy.Type.HTTP, new InetSocketAddress(InetAddress.getLoopbackAddress(), proxyServer.getPort()));
             assertEquals(proxyProjectId, SocketAccess.doPrivilegedIOException(() -> GoogleCloudStorageService.getDefaultProjectId(proxy)));

--- a/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockHttpProxyServer.java
+++ b/modules/repository-gcs/src/test/java/org/elasticsearch/repositories/gcs/MockHttpProxyServer.java
@@ -7,91 +7,51 @@
  */
 package org.elasticsearch.repositories.gcs;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
+import org.apache.http.HttpException;
+import org.apache.http.HttpRequest;
+import org.apache.http.HttpResponse;
+import org.apache.http.impl.bootstrap.HttpServer;
+import org.apache.http.impl.bootstrap.ServerBootstrap;
+import org.apache.http.protocol.HttpContext;
 import org.elasticsearch.common.network.NetworkAddress;
-import org.elasticsearch.mocksocket.MockServerSocket;
 
-import java.io.BufferedInputStream;
-import java.io.BufferedOutputStream;
 import java.io.Closeable;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.net.Socket;
-import java.net.SocketException;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
+import java.net.InetAddress;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A mock HTTP Proxy server for testing of support of HTTP proxies in various SDKs
  */
-class MockHttpProxyServer implements Closeable {
+abstract class MockHttpProxyServer implements Closeable {
 
-    private static final Logger log = LogManager.getLogger(MockHttpProxyServer.class);
+    private final HttpServer httpServer;
 
-    private final MockServerSocket serverSocket;
-    private final Thread serverThread;
-    private final CountDownLatch latch;
-    private final ExecutorService executorService = Executors.newCachedThreadPool();
-
-    MockHttpProxyServer(SocketRequestHandler handler) throws IOException {
-        // Emulate a proxy HTTP server with plain sockets because MockHttpServer doesn't work as a proxy
-        serverSocket = new MockServerSocket(0);
-        latch = new CountDownLatch(1);
-        serverThread = new Thread(() -> {
-            latch.countDown();
-            while (Thread.currentThread().isInterrupted() == false) {
-                Socket socket;
-                try {
-                    socket = serverSocket.accept();
-                } catch (SocketException e) {
-                    // Server socket is closed
-                    break;
-                } catch (IOException e) {
-                    log.error("Unable to accept socket request", e);
-                    break;
-                }
-                executorService.submit(() -> {
-                    try (
-                        socket;
-                        var is = new BufferedInputStream(socket.getInputStream());
-                        var os = new BufferedOutputStream(socket.getOutputStream())
-                    ) {
-                        // Don't handle keep-alive connections to keep things simple
-                        handler.handle(is, os);
-                    } catch (IOException e) {
-                        log.error("Unable to handle socket request", e);
-                    }
-                });
-            }
-        });
-        serverThread.start();
+    MockHttpProxyServer() {
+        httpServer = ServerBootstrap.bootstrap()
+            .setLocalAddress(InetAddress.getLoopbackAddress())
+            .setListenerPort(0)
+            .registerHandler("*", this::handle)
+            .create();
+        try {
+            httpServer.start();
+        } catch (IOException e) {
+            throw new RuntimeException("Unable to start HTTP proxy server", e);
+        }
     }
 
-    MockHttpProxyServer await() throws InterruptedException {
-        latch.await();
-        return this;
-    }
+    public abstract void handle(HttpRequest request, HttpResponse response, HttpContext context) throws HttpException, IOException;
 
     int getPort() {
-        return serverSocket.getLocalPort();
+        return httpServer.getLocalPort();
     }
 
     String getHost() {
-        return NetworkAddress.format(serverSocket.getInetAddress());
+        return NetworkAddress.format(httpServer.getInetAddress());
     }
 
     @Override
     public void close() throws IOException {
-        executorService.shutdown();
-        serverThread.interrupt();
-        serverSocket.close();
-    }
-
-    @FunctionalInterface
-    interface SocketRequestHandler {
-        void handle(InputStream is, OutputStream os) throws IOException;
+        httpServer.shutdown(10, TimeUnit.SECONDS);
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Migrate MockHttpServer to Apache HttpServer (#94205)