### PR TITLE
Read current term before claiming

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -458,7 +458,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         @Override
         public void onNewElection(DiscoveryNode localNode, long proposedTerm, ActionListener<Void> listener) {
             ActionListener.completeWith(listener, () -> {
-                maxTermSeen = Math.max(maxTermSeen, proposedTerm);
+                maxTermSeen = Math.max(maxTermSeen, Math.max(proposedTerm, register.readCurrentTerm()));
                 register.claimTerm(proposedTerm);
                 lastWonTerm = proposedTerm;
                 return null;


### PR DESCRIPTION
If our attempt to claim a term fails, we must record the term we saw in order for subsequent attempts to have a chance of succeeding.

Closes #94788