### PR TITLE
Cross-reference disclaimer

### DIFF
--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -10,6 +10,11 @@ for use in a <<restart-upgrade,full cluster restart>>, and freshly-started nodes
 that are joining a running cluster obtain this information from the cluster's
 elected master.
 
+IMPORTANT: After the cluster forms successfully for the first time, remove the
+`cluster.initial_master_nodes` setting from each node's configuration. Do not
+use this setting when restarting a cluster or adding a new node to an existing
+cluster.
+
 The initial set of master-eligible nodes is defined in the
 <<initial_master_nodes,`cluster.initial_master_nodes` setting>>. This should be
 set to a list containing one of the following items for each master-eligible


### PR DESCRIPTION
👋🏼 howdy, team! Can we cross pollinate the [important banner](https://www.elastic.co/guide/en/elasticsearch/reference/master/important-settings.html#initial_master_nodes) from the `cluster.initial_master_nodes` setting page to the related [bootstrap doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/modules-discovery-bootstrap-cluster.html#bootstrap-cluster-name) to avoid user's misunderstanding the latter's "This is only required the first time a cluster starts up" as saying they don't need to comment-out these settings?