### PR TITLE
Ignore states from later terms in getLatestStoredState

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationState.java
@@ -572,7 +572,7 @@ public class CoordinationState {
             }
         }
 
-        default void getLatestStoredState(ActionListener<ClusterState> listener) {
+        default void getLatestStoredState(long term, ActionListener<ClusterState> listener) {
             listener.onResponse(null);
         }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1380,8 +1380,8 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         }
     }
 
-    private void getLatestStoredStateAfterWinningAnElection(ActionListener<ClusterState> listener) {
-        persistedStateSupplier.get().getLatestStoredState(listener.delegateResponse((delegate, e) -> {
+    private void getLatestStoredStateAfterWinningAnElection(ActionListener<ClusterState> listener, long joiningTerm) {
+        persistedStateSupplier.get().getLatestStoredState(joiningTerm, listener.delegateResponse((delegate, e) -> {
             synchronized (mutex) {
                 // TODO: add test coverage for this branch
                 becomeCandidate("failed fetching latest stored state");

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -515,11 +515,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
             );
         }
 
-        private PersistentClusterState getLatestClusterState() {
-            return getClusterStateForTerm(register.readCurrentTerm());
-        }
-
-        private PersistentClusterState getClusterStateForTerm(long termGoal) {
+        PersistentClusterState getClusterStateForTerm(long termGoal) {
             for (long term = termGoal; term > 0; term--) {
                 var persistedState = clusterStateByTerm.get(term);
                 if (persistedState != null) {
@@ -613,9 +609,9 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         }
 
         @Override
-        public void getLatestStoredState(ActionListener<ClusterState> listener) {
+        public void getLatestStoredState(long term, ActionListener<ClusterState> listener) {
             ActionListener.completeWith(listener, () -> {
-                var latestClusterState = sharedStore.getLatestClusterState();
+                var latestClusterState = sharedStore.getClusterStateForTerm(term - 1);
                 if (latestClusterState == null) {
                     return null;
                 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -82,7 +82,7 @@ public class JoinHelperTests extends ESTestCase {
             new JoinReasonService(() -> 0L),
             new NoneCircuitBreakerService(),
             Function.identity(),
-            (listener) -> listener.onResponse(null)
+            (listener, term) -> listener.onResponse(null)
         );
         transportService.start();
 
@@ -246,7 +246,7 @@ public class JoinHelperTests extends ESTestCase {
             new JoinReasonService(() -> 0L),
             new NoneCircuitBreakerService(),
             Function.identity(),
-            (listener) -> listener.onResponse(null)
+            (listener, term) -> listener.onResponse(null)
         );
         transportService.start();
 


### PR DESCRIPTION
We know the term in use for the election when refreshing our local state, so we can avoid re-reading the current term before searching for fresher states.