### PR TITLE
Test validation of fragment IDs in reference docs

### DIFF
--- a/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
+++ b/server/src/main/resources/org/elasticsearch/common/reference-docs-links.json
@@ -6,5 +6,5 @@
   "SHARD_LOCK_TROUBLESHOOTING": "cluster-fault-detection.html#_diagnosing_shardlockobtainfailedexception_failures",
   "CONCURRENT_REPOSITORY_WRITERS": "add-repository.html",
   "ARCHIVE_INDICES": "archive-indices.html",
-  "HTTP_TRACER": "modules-network.html#http-rest-request-tracer"
+  "HTTP_TRACER": "modules-network.html#http-rest-request-tracer-not-a-valid-fragment"
 }


### PR DESCRIPTION
Not to be merged, just to see whether CI fails on this.