### PR TITLE
Adjust some yaml tests to use the default number of replicas

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/matrix_stats.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/matrix_stats.yml
@@ -3,8 +3,6 @@ setup:
       indices.create:
         index: test1
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               value1:
@@ -18,8 +16,6 @@ setup:
       indices.create:
         index: test2
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               value1:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/nested_top_metrics_sort.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/nested_top_metrics_sort.yml
@@ -6,8 +6,6 @@ setup:
       indices.create:
         index: test
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               timestamp:
@@ -25,8 +23,6 @@ setup:
       indices.create:
         index: test_order_by_top_metrics
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               name:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/reset_tracking_rate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/reset_tracking_rate.yml
@@ -65,7 +65,7 @@ setup:
                 type: date
   - do:
       cluster.health:
-        wait_for_status: green
+        wait_for_status: yellow
 
   - do:
       bulk:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/reset_tracking_rate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/reset_tracking_rate.yml
@@ -8,7 +8,6 @@ setup:
         index: tsdb-01
         body:
           settings:
-            number_of_replicas: 0
             mode: time_series
             routing_path: [key]
             time_series:
@@ -29,7 +28,6 @@ setup:
         index: tsdb-02
         body:
           settings:
-            number_of_replicas: 0
             mode: time_series
             routing_path: [key]
             time_series:
@@ -50,7 +48,6 @@ setup:
         index: tsdb-03
         body:
           settings:
-            number_of_replicas: 0
             mode: time_series
             routing_path: [key]
             time_series:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/authenticate/10_field_level_security.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/authenticate/10_field_level_security.yml
@@ -93,7 +93,6 @@ teardown:
           settings:
             index:
               number_of_shards: 1
-              number_of_replicas: 0
 
   - do:
       bulk:

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/wildcard/10_wildcard_basic.yml
@@ -8,8 +8,6 @@ setup:
       indices.create:
         index: test-index
         body:
-          settings:
-            number_of_replicas: 0
           mappings:
             properties:
               my_wildcard:


### PR DESCRIPTION
In stateless an index with no replicas is unsearchable. Some yaml tests that currently specify zero replicas can be made cross-compatible between stateful and stateless simply by not specifying the number of replicas for the indices they create.