### PR TITLE
Stand down as leader on heartbeat failure

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
 import org.elasticsearch.action.support.ChannelActionListener;
 import org.elasticsearch.action.support.ListenableActionFuture;
+import org.elasticsearch.action.support.ThreadedActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -875,9 +876,10 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         assert mode == Mode.CANDIDATE : "expected candidate but was " + mode;
         assert getLocalNode().isMasterNode() : getLocalNode() + " became a leader but is not master-eligible";
 
+        final var leaderTerm = getCurrentTerm();
         logger.debug(
             "handleJoinRequest: coordinator becoming LEADER in term {} (was {}, lastKnownLeader was [{}])",
-            getCurrentTerm(),
+            leaderTerm,
             mode,
             lastKnownLeader
         );
@@ -891,10 +893,31 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
         clusterFormationFailureHelper.stop();
         closePrevotingAndElectionScheduler();
         preVoteCollector.update(getPreVoteResponse(), getLocalNode());
-        leaderHeartbeatService.start(getLocalNode(), getCurrentTerm());
+        leaderHeartbeatService.start(
+            getLocalNode(),
+            leaderTerm,
+            new ThreadedActionListener<>(transportService.getThreadPool().executor(Names.CLUSTER_COORDINATION), new ActionListener<>() {
+                @Override
+                public void onResponse(Long newTerm) {
+                    assert newTerm != null && newTerm > leaderTerm : newTerm + " vs " + leaderTerm;
+                    updateMaxTermSeen(newTerm);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    // TODO tests for heartbeat failures
+                    logger.debug(() -> Strings.format("heartbeat failure in term [%s]", leaderTerm), e);
+                    synchronized (mutex) {
+                        if (getCurrentTerm() == leaderTerm) {
+                            becomeCandidate("leaderHeartbeatService");
+                        }
+                    }
+                }
+            })
+        );
 
         assert leaderChecker.leader() == null : leaderChecker.leader();
-        followersChecker.updateFastResponseState(getCurrentTerm(), mode);
+        followersChecker.updateFastResponseState(leaderTerm, mode);
 
         updateSingleNodeClusterChecker();
     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderHeartbeatService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderHeartbeatService.java
@@ -8,22 +8,23 @@
 
 package org.elasticsearch.cluster.coordination;
 
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 
 public interface LeaderHeartbeatService {
     LeaderHeartbeatService NO_OP = new LeaderHeartbeatService() {
         @Override
-        public void start(DiscoveryNode currentLeader, long term) {
-
-        }
+        public void start(DiscoveryNode currentLeader, long term, ActionListener<Long> completionListener) {}
 
         @Override
-        public void stop() {
-
-        }
+        public void stop() {}
     };
 
-    void start(DiscoveryNode currentLeader, long term);
+    /**
+     * Start a heartbeat process for the given term. The listener is notified when the heartbeat process completes, which may happen if
+     * it fails to write a heartbeat, or a newer term is discovered.
+     */
+    void start(DiscoveryNode currentLeader, long term, ActionListener<Long> completionListener);
 
     void stop();
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.coordination;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
@@ -23,7 +24,6 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.gateway.ClusterStateUpdaters;
 import org.elasticsearch.test.junit.annotations.TestLogging;
-import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.HashMap;
@@ -227,9 +227,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         private final TimeValue maxTimeSinceLastHeartbeat;
         private final AtomicRegister register;
 
-        private DiscoveryNode currentLeader;
-        private long currentTerm;
-        private Scheduler.Cancellable heartbeatTask;
+        private volatile HeartbeatTask heartbeatTask;
 
         StoreHeartbeatService(
             SharedStore sharedStore,
@@ -246,33 +244,15 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         }
 
         @Override
-        public void start(DiscoveryNode currentLeader, long term) {
-            this.currentLeader = currentLeader;
-            this.currentTerm = term;
-
-            sendHeartBeatToStore();
-            this.heartbeatTask = threadPool.scheduleWithFixedDelay(
-                this::sendHeartBeatToStore,
-                heartbeatFrequency,
-                ThreadPool.Names.GENERIC
-            );
-        }
-
-        private void sendHeartBeatToStore() {
-            if (register.readCurrentTerm() == currentTerm) {
-                sharedStore.writeHeartBeat(new HeartBeat(currentLeader, currentTerm, threadPool.absoluteTimeInMillis()));
-            }
-            // TODO: become candidate if the currentTerm read from the register is greater than the local term
+        public void start(DiscoveryNode currentLeader, long term, ActionListener<Long> completionListener) {
+            final var newHeartbeatTask = new HeartbeatTask(currentLeader, term, completionListener);
+            heartbeatTask = newHeartbeatTask;
+            newHeartbeatTask.run();
         }
 
         @Override
         public void stop() {
-            this.currentLeader = null;
-            this.currentTerm = 0;
-            var heartBeatTask = this.heartbeatTask;
-            if (heartBeatTask != null) {
-                heartBeatTask.cancel();
-            }
+            heartbeatTask = null;
         }
 
         private Optional<DiscoveryNode> isLeaderAlive() {
@@ -285,6 +265,36 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
                 return Optional.of(latestHeartBeat.leader());
             } else {
                 return Optional.empty();
+            }
+        }
+
+        private class HeartbeatTask extends ActionRunnable<Long> {
+            private final DiscoveryNode currentLeader;
+            private final long heartbeatTerm;
+
+            HeartbeatTask(DiscoveryNode currentLeader, long heartbeatTerm, ActionListener<Long> listener) {
+                super(listener);
+                this.currentLeader = currentLeader;
+                this.heartbeatTerm = heartbeatTerm;
+            }
+
+            @Override
+            protected void doRun() throws Exception {
+                if (heartbeatTask != HeartbeatTask.this) {
+                    // already cancelled
+                    return;
+                }
+
+                final var registerTerm = register.readCurrentTerm();
+                if (registerTerm == heartbeatTerm) {
+                    ActionListener.run(listener, l -> {
+                        sharedStore.writeHeartBeat(new HeartBeat(currentLeader, heartbeatTerm, threadPool.absoluteTimeInMillis()));
+                        threadPool.schedule(HeartbeatTask.this, heartbeatFrequency, ThreadPool.Names.GENERIC);
+                    });
+                } else {
+                    assert heartbeatTerm < registerTerm;
+                    listener.onResponse(registerTerm);
+                }
             }
         }
     }


### PR DESCRIPTION
The heartbeat process periodically checks the current term in the register. With this commit it reacts to a term mismatch or write failure by standing down as leader and restarting the discovery process.