### PR TITLE
Migrate LuceneDocument.getFields(String) to a List

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/mapper/DataStreamTimestampFieldMapperTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/mapper/DataStreamTimestampFieldMapperTests.java
@@ -79,7 +79,7 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
         }));
 
         ParsedDocument doc = docMapper.parse(source(b -> b.field("@timestamp", "2020-12-12")));
-        assertThat(doc.rootDoc().getFields("@timestamp").length, equalTo(1));
+        assertThat(doc.rootDoc().getFields("@timestamp").size(), equalTo(1));
 
         Exception e = expectThrows(MapperException.class, () -> docMapper.parse(source(b -> b.field("@timestamp1", "2020-12-12"))));
         assertThat(e.getCause().getMessage(), equalTo("data stream timestamp field [@timestamp] is missing"));

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapperTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/mapper/LegacyGeoShapeFieldMapperTests.java
@@ -639,8 +639,8 @@ public class LegacyGeoShapeFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
         assertThat(document.docs(), hasSize(1));
-        IndexableField[] fields = document.docs().get(0).getFields("field");
-        assertThat(fields.length, equalTo(2));
+        List<IndexableField> fields = document.docs().get(0).getFields("field");
+        assertThat(fields.size(), equalTo(2));
         assertFieldWarnings("tree", "strategy");
     }
 

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/MatchOnlyTextFieldMapperTests.java
@@ -124,10 +124,10 @@ public class MatchOnlyTextFieldMapperTests extends MapperTestCase {
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals("1234", fields[0].stringValue());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals("1234", fields.get(0).stringValue());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(true));
         assertTrue(fieldType.tokenized());
         assertFalse(fieldType.stored());

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapperTests.java
@@ -93,13 +93,13 @@ public class RankFeatureFieldMapperTests extends MapperTestCase {
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());
 
         ParsedDocument doc1 = mapper.parse(source(b -> b.field("field", 10)));
-        IndexableField[] fields = doc1.rootDoc().getFields("_feature");
-        assertEquals(1, fields.length);
-        assertThat(fields[0], instanceOf(FeatureField.class));
-        FeatureField featureField1 = (FeatureField) fields[0];
+        List<IndexableField> fields = doc1.rootDoc().getFields("_feature");
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(FeatureField.class));
+        FeatureField featureField1 = (FeatureField) fields.get(0);
 
         ParsedDocument doc2 = mapper.parse(source(b -> b.field("field", 12)));
-        FeatureField featureField2 = (FeatureField) doc2.rootDoc().getFields("_feature")[0];
+        FeatureField featureField2 = (FeatureField) doc2.rootDoc().getFields("_feature").get(0);
 
         int freq1 = getFrequency(featureField1.tokenStream(null, null));
         int freq2 = getFrequency(featureField2.tokenStream(null, null));
@@ -112,13 +112,13 @@ public class RankFeatureFieldMapperTests extends MapperTestCase {
         );
 
         ParsedDocument doc1 = mapper.parse(source(b -> b.field("field", 10)));
-        IndexableField[] fields = doc1.rootDoc().getFields("_feature");
-        assertEquals(1, fields.length);
-        assertThat(fields[0], instanceOf(FeatureField.class));
-        FeatureField featureField1 = (FeatureField) fields[0];
+        List<IndexableField> fields = doc1.rootDoc().getFields("_feature");
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(FeatureField.class));
+        FeatureField featureField1 = (FeatureField) fields.get(0);
 
         ParsedDocument doc2 = mapper.parse(source(b -> b.field("field", 12)));
-        FeatureField featureField2 = (FeatureField) doc2.rootDoc().getFields("_feature")[0];
+        FeatureField featureField2 = (FeatureField) doc2.rootDoc().getFields("_feature").get(0);
 
         int freq1 = getFrequency(featureField1.tokenStream(null, null));
         int freq2 = getFrequency(featureField2.tokenStream(null, null));

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeaturesFieldMapperTests.java
@@ -79,9 +79,9 @@ public class RankFeaturesFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc1 = mapper.parse(source(this::writeField));
 
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertThat(fields[0], Matchers.instanceOf(FeatureField.class));
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertThat(fields.get(0), Matchers.instanceOf(FeatureField.class));
         FeatureField featureField1 = null;
         FeatureField featureField2 = null;
         for (IndexableField field : fields) {
@@ -106,9 +106,9 @@ public class RankFeaturesFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc1 = mapper.parse(source(this::writeField));
 
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertThat(fields[0], Matchers.instanceOf(FeatureField.class));
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertThat(fields.get(0), Matchers.instanceOf(FeatureField.class));
         FeatureField featureField1 = null;
         FeatureField featureField2 = null;
         for (IndexableField field : fields) {

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapperTests.java
@@ -37,6 +37,7 @@ import java.util.List;
 
 import static java.util.Collections.singletonList;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
@@ -93,9 +94,9 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
         assertEquals(Strings.toString(mapping), mapper.mappingSource().toString());
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", 123)));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals("LongField <field:1230>", fields[0].toString());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals("LongField <field:1230>", fields.get(0).toString());
     }
 
     public void testMissingScalingFactor() {
@@ -127,9 +128,9 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
             )
         );
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField dvField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField dvField = fields.get(0);
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
         assertEquals(1230, dvField.numericValue().longValue());
     }
@@ -147,9 +148,9 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
             )
         );
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(1, pointField.fieldType().pointDimensionCount());
         assertEquals(1230, pointField.numericValue().longValue());
     }
@@ -167,10 +168,10 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
             )
         );
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertEquals("LongField <field:1230>", fields[0].toString());
-        IndexableField storedField = fields[1];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertEquals("LongField <field:1230>", fields.get(0).toString());
+        IndexableField storedField = fields.get(1);
         assertTrue(storedField.fieldType().stored());
         assertEquals(1230, storedField.numericValue().longValue());
     }
@@ -184,9 +185,9 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals("LongField <field:1230>", fields[0].toString());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals("LongField <field:1230>", fields.get(0).toString());
 
         DocumentMapper mapper2 = createDocumentMapper(
             fieldMapping(b -> b.field("type", "scaled_float").field("scaling_factor", 10.0).field("coerce", false))
@@ -226,7 +227,7 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
                 XContentType.JSON
             )
         );
-        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+        assertThat(doc.rootDoc().getFields("field"), empty());
 
         mapper = createDocumentMapper(
             fieldMapping(b -> b.field("type", "scaled_float").field("scaling_factor", 10.0).field("null_value", 2.5))
@@ -238,9 +239,9 @@ public class ScaledFloatFieldMapperTests extends MapperTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals("LongField <field:25>", fields[0].toString());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals("LongField <field:25>", fields.get(0).toString());
     }
 
     /**

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/SearchAsYouTypeFieldMapperTests.java
@@ -58,7 +58,6 @@ import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -159,9 +158,9 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "new york city")));
         for (String field : new String[] { "field", "field._index_prefix", "field._2gram", "field._3gram" }) {
-            IndexableField[] fields = doc.rootDoc().getFields(field);
-            assertEquals(1, fields.length);
-            assertEquals("new york city", fields[0].stringValue());
+            List<IndexableField> fields = doc.rootDoc().getFields(field);
+            assertEquals(1, fields.size());
+            assertEquals("new york city", fields.get(0).stringValue());
         }
     }
 
@@ -299,9 +298,9 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", "new york city")));
         for (String field : fields) {
-            IndexableField[] indexFields = doc.rootDoc().getFields(field);
-            assertEquals(1, indexFields.length);
-            assertEquals("new york city", indexFields[0].stringValue());
+            List<IndexableField> indexFields = doc.rootDoc().getFields(field);
+            assertEquals(1, indexFields.size());
+            assertEquals("new york city", indexFields.get(0).stringValue());
         }
     }
 
@@ -667,12 +666,12 @@ public class SearchAsYouTypeFieldMapperTests extends MapperTestCase {
             }
         }));
 
-        IndexableField[] rootFields = parsedDocument.rootDoc().getFields("field");
-        IndexableField[] prefixFields = parsedDocument.rootDoc().getFields("field._index_prefix");
-        IndexableField[] shingle2Fields = parsedDocument.rootDoc().getFields("field._2gram");
-        IndexableField[] shingle3Fields = parsedDocument.rootDoc().getFields("field._3gram");
-        for (IndexableField[] fields : new IndexableField[][] { rootFields, prefixFields, shingle2Fields, shingle3Fields }) {
-            Set<String> expectedValues = Arrays.stream(fields).map(IndexableField::stringValue).collect(Collectors.toSet());
+        List<IndexableField> rootFields = parsedDocument.rootDoc().getFields("field");
+        List<IndexableField> prefixFields = parsedDocument.rootDoc().getFields("field._index_prefix");
+        List<IndexableField> shingle2Fields = parsedDocument.rootDoc().getFields("field._2gram");
+        List<IndexableField> shingle3Fields = parsedDocument.rootDoc().getFields("field._3gram");
+        for (List<IndexableField> fields : List.of(rootFields, prefixFields, shingle2Fields, shingle3Fields)) {
+            Set<String> expectedValues = fields.stream().map(IndexableField::stringValue).collect(Collectors.toSet());
             assertThat(values, equalTo(expectedValues));
         }
     }

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorFieldMapperTests.java
@@ -112,6 +112,7 @@ import static org.elasticsearch.percolator.PercolatorFieldMapper.EXTRACTION_PART
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 
 //TODO migrate tests that don't require a node to a unit test that subclasses MapperTestCase
@@ -222,13 +223,13 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         PercolatorFieldMapper.PercolatorFieldType percolatorFieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
         assertThat(document.getField(percolatorFieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_COMPLETE));
-        List<IndexableField> fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.queryTermsField.name())));
+        List<IndexableField> fields = new ArrayList<>(document.getFields(percolatorFieldType.queryTermsField.name()));
         fields.sort(Comparator.comparing(IndexableField::binaryValue));
         assertThat(fields.size(), equalTo(2));
         assertThat(fields.get(0).binaryValue().utf8ToString(), equalTo("field\u0000term1"));
         assertThat(fields.get(1).binaryValue().utf8ToString(), equalTo("field\u0000term2"));
 
-        fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.minimumShouldMatchField.name())));
+        fields = new ArrayList<>(document.getFields(percolatorFieldType.minimumShouldMatchField.name()));
         assertThat(fields.size(), equalTo(1));
         assertThat(fields.get(0).numericValue(), equalTo(1L));
 
@@ -242,13 +243,13 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         document = documentParserContext.doc();
 
         assertThat(document.getField(percolatorFieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_COMPLETE));
-        fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.queryTermsField.name())));
+        fields = new ArrayList<>(document.getFields(percolatorFieldType.queryTermsField.name()));
         fields.sort(Comparator.comparing(IndexableField::binaryValue));
         assertThat(fields.size(), equalTo(2));
         assertThat(fields.get(0).binaryValue().utf8ToString(), equalTo("field\u0000term1"));
         assertThat(fields.get(1).binaryValue().utf8ToString(), equalTo("field\u0000term2"));
 
-        fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.minimumShouldMatchField.name())));
+        fields = new ArrayList<>(document.getFields(percolatorFieldType.minimumShouldMatchField.name()));
         assertThat(fields.size(), equalTo(1));
         assertThat(fields.get(0).numericValue(), equalTo(2L));
     }
@@ -270,7 +271,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
 
         PercolatorFieldMapper.PercolatorFieldType percolatorFieldType = (PercolatorFieldMapper.PercolatorFieldType) fieldMapper.fieldType();
         assertThat(document.getField(percolatorFieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
-        List<IndexableField> fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.rangeField.name())));
+        List<IndexableField> fields = new ArrayList<>(document.getFields(percolatorFieldType.rangeField.name()));
         fields.sort(Comparator.comparing(IndexableField::binaryValue));
         assertThat(fields.size(), equalTo(2));
         assertThat(IntPoint.decodeDimension(fields.get(0).binaryValue().bytes, 12), equalTo(10));
@@ -278,7 +279,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(IntPoint.decodeDimension(fields.get(1).binaryValue().bytes, 12), equalTo(15));
         assertThat(IntPoint.decodeDimension(fields.get(1).binaryValue().bytes, 28), equalTo(20));
 
-        fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.minimumShouldMatchField.name())));
+        fields = new ArrayList<>(document.getFields(percolatorFieldType.minimumShouldMatchField.name()));
         assertThat(fields.size(), equalTo(1));
         assertThat(fields.get(0).numericValue(), equalTo(1L));
 
@@ -293,7 +294,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         document = documentParserContext.doc();
 
         assertThat(document.getField(percolatorFieldType.extractionResultField.name()).stringValue(), equalTo(EXTRACTION_PARTIAL));
-        fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.rangeField.name())));
+        fields = new ArrayList<>(document.getFields(percolatorFieldType.rangeField.name()));
         fields.sort(Comparator.comparing(IndexableField::binaryValue));
         assertThat(fields.size(), equalTo(2));
         assertThat(IntPoint.decodeDimension(fields.get(0).binaryValue().bytes, 12), equalTo(10));
@@ -301,7 +302,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(LongPoint.decodeDimension(fields.get(1).binaryValue().bytes, 8), equalTo(15L));
         assertThat(LongPoint.decodeDimension(fields.get(1).binaryValue().bytes, 24), equalTo(20L));
 
-        fields = new ArrayList<>(Arrays.asList(document.getFields(percolatorFieldType.minimumShouldMatchField.name())));
+        fields = new ArrayList<>(document.getFields(percolatorFieldType.minimumShouldMatchField.name()));
         assertThat(fields.size(), equalTo(1));
         assertThat(fields.get(0).numericValue(), equalTo(2L));
     }
@@ -482,12 +483,12 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 )
             );
 
-        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name())[0].binaryValue().utf8ToString(), equalTo("field\0value"));
-        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name())[0].stringValue(), equalTo(EXTRACTION_COMPLETE));
-        BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
+        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()), hasSize(1));
+        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()).get(0).binaryValue().utf8ToString(), equalTo("field\0value"));
+        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()), hasSize(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()), hasSize(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).get(0).stringValue(), equalTo(EXTRACTION_COMPLETE));
+        BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name()).get(0).binaryValue();
         assertQueryBuilder(qbSource, queryBuilder);
 
         // add an query for which we don't extract terms from
@@ -500,11 +501,11 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON
                 )
             );
-        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name())[0].stringValue(), equalTo(EXTRACTION_FAILED));
-        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()).length, equalTo(0));
-        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(1));
-        qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()), hasSize(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).get(0).stringValue(), equalTo(EXTRACTION_FAILED));
+        assertThat(doc.rootDoc().getFields(fieldType.queryTermsField.name()), hasSize(0));
+        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()), hasSize(1));
+        qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name()).get(0).binaryValue();
         assertQueryBuilder(qbSource, queryBuilder);
 
         queryBuilder = rangeQuery("date_field").from("now");
@@ -516,8 +517,8 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON
                 )
             );
-        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).length, equalTo(1));
-        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name())[0].stringValue(), equalTo(EXTRACTION_FAILED));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()), hasSize(1));
+        assertThat(doc.rootDoc().getFields(fieldType.extractionResultField.name()).get(0).stringValue(), equalTo(EXTRACTION_FAILED));
     }
 
     public void testStoringQueries() throws Exception {
@@ -543,7 +544,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                         XContentType.JSON
                     )
                 );
-            BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
+            BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name()).get(0).binaryValue();
             assertQueryBuilder(qbSource, query);
         }
     }
@@ -560,7 +561,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON
                 )
             );
-        BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
+        BytesRef qbSource = doc.rootDoc().getFields(fieldType.queryBuilderField.name()).get(0).binaryValue();
         SearchExecutionContext searchExecutionContext = indexService.newSearchExecutionContext(
             randomInt(20),
             0,
@@ -598,7 +599,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
             .parse(
                 new SourceToParse("1", BytesReference.bytes(XContentFactory.jsonBuilder().startObject().endObject()), XContentType.JSON)
             );
-        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()).length, equalTo(0));
+        assertThat(doc.rootDoc().getFields(fieldType.queryBuilderField.name()), hasSize(0));
 
         try {
             mapperService.documentMapper()
@@ -879,7 +880,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON
                 )
             );
-        BytesRef querySource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
+        BytesRef querySource = doc.rootDoc().getFields(fieldType.queryBuilderField.name()).get(0).binaryValue();
         try (InputStream in = new ByteArrayInputStream(querySource.bytes, querySource.offset, querySource.length)) {
             try (StreamInput input = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(in), writableRegistry())) {
                 // Query builder's content is stored via BinaryFieldMapper, which has a custom encoding
@@ -925,7 +926,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                     XContentType.JSON
                 )
             );
-        querySource = doc.rootDoc().getFields(fieldType.queryBuilderField.name())[0].binaryValue();
+        querySource = doc.rootDoc().getFields(fieldType.queryBuilderField.name()).get(0).binaryValue();
         try (InputStream in = new ByteArrayInputStream(querySource.bytes, querySource.offset, querySource.length)) {
             try (StreamInput input = new NamedWriteableAwareStreamInput(new InputStreamStreamInput(in), writableRegistry())) {
                 input.readVInt();
@@ -1011,15 +1012,14 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 )
             );
 
-        List<String> values = Arrays.stream(doc.rootDoc().getFields(fieldType.queryTermsField.name()))
-            .map(f -> f.binaryValue().utf8ToString())
+        List<String> values = (doc.rootDoc().getFields(fieldType.queryTermsField.name()).stream()).map(f -> f.binaryValue().utf8ToString())
             .sorted()
             .collect(Collectors.toList());
         assertThat(values.size(), equalTo(3));
         assertThat(values.get(0), equalTo("field\0value1"));
         assertThat(values.get(1), equalTo("field\0value2"));
         assertThat(values.get(2), equalTo("field\0value3"));
-        int msm = doc.rootDoc().getFields(fieldType.minimumShouldMatchField.name())[0].numericValue().intValue();
+        int msm = doc.rootDoc().getFields(fieldType.minimumShouldMatchField.name()).get(0).numericValue().intValue();
         assertThat(msm, equalTo(3));
 
         qb = boolQuery().must(boolQuery().must(termQuery("field", "value1")).must(termQuery("field", "value2")))
@@ -1035,7 +1035,9 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 )
             );
 
-        values = Arrays.stream(doc.rootDoc().getFields(fieldType.queryTermsField.name()))
+        values = doc.rootDoc()
+            .getFields(fieldType.queryTermsField.name())
+            .stream()
             .map(f -> f.binaryValue().utf8ToString())
             .sorted()
             .collect(Collectors.toList());
@@ -1045,7 +1047,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(values.get(2), equalTo("field\0value3"));
         assertThat(values.get(3), equalTo("field\0value4"));
         assertThat(values.get(4), equalTo("field\0value5"));
-        msm = doc.rootDoc().getFields(fieldType.minimumShouldMatchField.name())[0].numericValue().intValue();
+        msm = doc.rootDoc().getFields(fieldType.minimumShouldMatchField.name()).get(0).numericValue().intValue();
         assertThat(msm, equalTo(4));
 
         qb = boolQuery().minimumShouldMatch(3)
@@ -1062,7 +1064,9 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
                 )
             );
 
-        values = Arrays.stream(doc.rootDoc().getFields(fieldType.queryTermsField.name()))
+        values = doc.rootDoc()
+            .getFields(fieldType.queryTermsField.name())
+            .stream()
             .map(f -> f.binaryValue().utf8ToString())
             .sorted()
             .collect(Collectors.toList());
@@ -1072,7 +1076,7 @@ public class PercolatorFieldMapperTests extends ESSingleNodeTestCase {
         assertThat(values.get(2), equalTo("field\0value3"));
         assertThat(values.get(3), equalTo("field\0value4"));
         assertThat(values.get(4), equalTo("field\0value5"));
-        msm = doc.rootDoc().getFields(fieldType.minimumShouldMatchField.name())[0].numericValue().intValue();
+        msm = doc.rootDoc().getFields(fieldType.minimumShouldMatchField.name()).get(0).numericValue().intValue();
         assertThat(msm, equalTo(1));
     }
 

--- a/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapperTests.java
+++ b/plugins/analysis-icu/src/test/java/org/elasticsearch/plugin/analysis/icu/ICUCollationKeywordFieldMapperTests.java
@@ -37,6 +37,7 @@ import java.util.Collection;
 import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
@@ -75,15 +76,15 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
 
         Collator collator = Collator.getInstance(ULocale.ROOT);
         RawCollationKey key = collator.getRawCollationKey("1234", null);
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
-        assertEquals(expected, fields[0].binaryValue());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        assertEquals(expected, fields.get(0).binaryValue());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(true));
         assertFalse(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -94,8 +95,8 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         assertThat(fieldType.storeTermVectorPayloads(), equalTo(false));
         assertEquals(DocValuesType.NONE, fieldType.docValuesType());
 
-        assertEquals(expected, fields[1].binaryValue());
-        fieldType = fields[1].fieldType();
+        assertEquals(expected, fields.get(1).binaryValue());
+        fieldType = fields.get(1).fieldType();
         assertThat(fieldType.indexOptions(), equalTo(IndexOptions.NONE));
         assertEquals(DocValuesType.SORTED_SET, fieldType.docValuesType());
     }
@@ -103,15 +104,15 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
     public void testNullValue() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
-        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+        assertThat(doc.rootDoc().getFields("field"), empty());
 
         mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("null_value", "1234")));
         doc = mapper.parse(
             new SourceToParse("1", BytesReference.bytes(XContentFactory.jsonBuilder().startObject().endObject()), XContentType.JSON)
         );
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertThat(fields, empty());
 
         doc = mapper.parse(source(b -> b.nullField("field")));
         Collator collator = Collator.getInstance(ULocale.ROOT);
@@ -119,48 +120,48 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
         fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertEquals(expected, fields[0].binaryValue());
+        assertEquals(2, fields.size());
+        assertEquals(expected, fields.get(0).binaryValue());
     }
 
     public void testEnableStore() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("store", true)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertTrue(fields[0].fieldType().stored());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertTrue(fields.get(0).fieldType().stored());
     }
 
     public void testDisableIndex() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("index", false)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals(IndexOptions.NONE, fields[0].fieldType().indexOptions());
-        assertEquals(DocValuesType.SORTED_SET, fields[0].fieldType().docValuesType());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals(IndexOptions.NONE, fields.get(0).fieldType().indexOptions());
+        assertEquals(DocValuesType.SORTED_SET, fields.get(0).fieldType().docValuesType());
     }
 
     public void testDisableDocValues() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("doc_values", false)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals(DocValuesType.NONE, fields[0].fieldType().docValuesType());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
     }
 
     public void testMultipleValues() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", List.of("1234", "5678"))));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(4, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(4, fields.size());
 
         Collator collator = Collator.getInstance(ULocale.ROOT);
         RawCollationKey key = collator.getRawCollationKey("1234", null);
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
-        assertEquals(expected, fields[0].binaryValue());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        assertEquals(expected, fields.get(0).binaryValue());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(true));
         assertFalse(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -171,8 +172,8 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         assertThat(fieldType.storeTermVectorPayloads(), equalTo(false));
         assertEquals(DocValuesType.NONE, fieldType.docValuesType());
 
-        assertEquals(expected, fields[1].binaryValue());
-        fieldType = fields[1].fieldType();
+        assertEquals(expected, fields.get(1).binaryValue());
+        fieldType = fields.get(1).fieldType();
         assertThat(fieldType.indexOptions(), equalTo(IndexOptions.NONE));
         assertEquals(DocValuesType.SORTED_SET, fieldType.docValuesType());
 
@@ -180,8 +181,8 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         key = collator.getRawCollationKey("5678", null);
         expected = new BytesRef(key.bytes, 0, key.size);
 
-        assertEquals(expected, fields[2].binaryValue());
-        fieldType = fields[2].fieldType();
+        assertEquals(expected, fields.get(2).binaryValue());
+        fieldType = fields.get(2).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(true));
         assertFalse(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -192,8 +193,8 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         assertThat(fieldType.storeTermVectorPayloads(), equalTo(false));
         assertEquals(DocValuesType.NONE, fieldType.docValuesType());
 
-        assertEquals(expected, fields[3].binaryValue());
-        fieldType = fields[3].fieldType();
+        assertEquals(expected, fields.get(3).binaryValue());
+        fieldType = fields.get(3).fieldType();
         assertThat(fieldType.indexOptions(), equalTo(IndexOptions.NONE));
         assertEquals(DocValuesType.SORTED_SET, fieldType.docValuesType());
     }
@@ -201,9 +202,9 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
     public void testIndexOptions() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("index_options", "freqs")));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertEquals(IndexOptions.DOCS_AND_FREQS, fields[0].fieldType().indexOptions());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertEquals(IndexOptions.DOCS_AND_FREQS, fields.get(0).fieldType().indexOptions());
 
         for (String indexOptions : Arrays.asList("positions", "offsets")) {
             Exception e = expectThrows(
@@ -220,9 +221,9 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
     public void testEnableNorms() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("norms", true)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertFalse(fields[0].fieldType().omitNorms());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertFalse(fields.get(0).fieldType().omitNorms());
     }
 
     public void testCollator() throws IOException {
@@ -235,11 +236,11 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         RawCollationKey key = collator.getRawCollationKey("ı will use turkish casıng", null); // should collate to same value
         BytesRef expected = new BytesRef(key.bytes, 0, key.size);
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
 
-        assertEquals(expected, fields[0].binaryValue());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        assertEquals(expected, fields.get(0).binaryValue());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(true));
         assertFalse(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -250,8 +251,8 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
         assertThat(fieldType.storeTermVectorPayloads(), equalTo(false));
         assertEquals(DocValuesType.NONE, fieldType.docValuesType());
 
-        assertEquals(expected, fields[1].binaryValue());
-        fieldType = fields[1].fieldType();
+        assertEquals(expected, fields.get(1).binaryValue());
+        fieldType = fields.get(1).fieldType();
         assertThat(fieldType.indexOptions(), equalTo(IndexOptions.NONE));
         assertEquals(DocValuesType.SORTED_SET, fieldType.docValuesType());
     }
@@ -271,25 +272,25 @@ public class ICUCollationKeywordFieldMapperTests extends MapperTestCase {
     public void testIgnoreAbove() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", FIELD_TYPE).field("ignore_above", 5)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "elk")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
         fields = doc.rootDoc().getFields("_ignored");
-        assertEquals(0, fields.length);
+        assertThat(fields, empty());
 
         doc = mapper.parse(source(b -> b.field("field", "elasticsearch")));
         fields = doc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        assertThat(fields, empty());
         fields = doc.rootDoc().getFields("_ignored");
-        assertEquals(1, fields.length);
-        assertEquals("field", fields[0].stringValue());
+        assertEquals(1, fields.size());
+        assertEquals("field", fields.get(0).stringValue());
     }
 
     public void testUpdateIgnoreAbove() throws IOException {
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         merge(mapperService, fieldMapping(b -> b.field("type", FIELD_TYPE).field("ignore_above", 5)));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", "elasticsearch")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertThat(fields, empty());
     }
 
     @Override

--- a/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
+++ b/plugins/mapper-annotated-text/src/test/java/org/elasticsearch/index/mapper/annotatedtext/AnnotatedTextFieldMapperTests.java
@@ -51,6 +51,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -157,10 +158,10 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
         String annotatedText = "He paid [Stormy Daniels](Stephanie+Clifford&Payee) hush money";
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", annotatedText)));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
 
-        assertEquals(annotatedText, fields[0].stringValue());
+        assertEquals(annotatedText, fields.get(0).stringValue());
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
 
@@ -196,10 +197,10 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
         String annotatedText = "foo [bar](MissingEndBracket baz";
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", annotatedText)));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
 
-        assertEquals(annotatedText, fields[0].stringValue());
+        assertEquals(annotatedText, fields.get(0).stringValue());
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
             LeafReader leaf = reader.leaves().get(0).reader();
@@ -254,11 +255,11 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
 
-        assertEquals("1234", fields[0].stringValue());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        assertEquals("1234", fields.get(0).stringValue());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(false));
         assertTrue(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -279,9 +280,9 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertTrue(fields[0].fieldType().stored());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertTrue(fields.get(0).fieldType().stored());
     }
 
     public void testDisableNorms() throws IOException {
@@ -293,9 +294,9 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertTrue(fields[0].fieldType().omitNorms());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertTrue(fields.get(0).fieldType().omitNorms());
     }
 
     public void testIndexOptions() throws IOException {
@@ -311,9 +312,9 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
                 b.field("index_options", option);
             }));
             ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-            IndexableField[] fields = doc.rootDoc().getFields("field");
-            assertEquals(1, fields.length);
-            assertEquals(supportedOptions.get(option), fields[0].fieldType().indexOptions());
+            List<IndexableField> fields = doc.rootDoc().getFields("field");
+            assertEquals(1, fields.size());
+            assertEquals(supportedOptions.get(option), fields.get(0).fieldType().indexOptions());
         }
     }
 
@@ -323,11 +324,11 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.array("field", "a", "b")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
 
-        assertEquals("a", fields[0].stringValue());
-        assertEquals("b", fields[1].stringValue());
+        assertEquals("a", fields.get(0).stringValue());
+        assertEquals("b", fields.get(1).stringValue());
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
             LeafReader leaf = reader.leaves().get(0).reader();
@@ -349,10 +350,10 @@ public class AnnotatedTextFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.array("field", "a", "b")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertEquals("a", fields[0].stringValue());
-        assertEquals("b", fields[1].stringValue());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertEquals("a", fields.get(0).stringValue());
+        assertEquals("b", fields.get(1).stringValue());
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
             LeafReader leaf = reader.leaves().get(0).reader();

--- a/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapperTests.java
+++ b/plugins/mapper-murmur3/src/test/java/org/elasticsearch/index/mapper/murmur3/Murmur3FieldMapperTests.java
@@ -21,9 +21,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+
+import static org.hamcrest.Matchers.hasSize;
 
 public class Murmur3FieldMapperTests extends MapperTestCase {
 
@@ -50,10 +51,10 @@ public class Murmur3FieldMapperTests extends MapperTestCase {
     public void testDefaults() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.field("field", "value")));
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
         assertNotNull(fields);
-        assertEquals(Arrays.toString(fields), 1, fields.length);
-        IndexableField field = fields[0];
+        assertThat(fields, hasSize(1));
+        IndexableField field = fields.get(0);
         assertEquals(IndexOptions.NONE, field.fieldType().indexOptions());
         assertEquals(DocValuesType.SORTED_NUMERIC, field.fieldType().docValuesType());
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/LuceneDocument.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/LuceneDocument.java
@@ -111,14 +111,14 @@ public class LuceneDocument implements Iterable<IndexableField> {
         return keyedFields == null ? null : keyedFields.get(key);
     }
 
-    public IndexableField[] getFields(String name) {
+    public List<IndexableField> getFields(String name) {
         List<IndexableField> f = new ArrayList<>();
         for (IndexableField field : fields) {
             if (field.name().equals(name)) {
                 f.add(field);
             }
         }
-        return f.toArray(new IndexableField[f.size()]);
+        return f;
     }
 
     public IndexableField getField(String name) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/TsidExtractingIdFieldMapper.java
@@ -26,6 +26,7 @@ import org.elasticsearch.index.query.SearchExecutionContext;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 /**
@@ -99,13 +100,13 @@ public class TsidExtractingIdFieldMapper extends IdFieldMapper {
     private static final long SEED = 0;
 
     public static void createField(DocumentParserContext context, IndexRouting.ExtractFromSource.Builder routingBuilder, BytesRef tsid) {
-        IndexableField[] timestampFields = context.rootDoc().getFields(DataStreamTimestampFieldMapper.DEFAULT_PATH);
-        if (timestampFields.length == 0) {
+        List<IndexableField> timestampFields = context.rootDoc().getFields(DataStreamTimestampFieldMapper.DEFAULT_PATH);
+        if (timestampFields.isEmpty()) {
             throw new IllegalArgumentException(
                 "data stream timestamp field [" + DataStreamTimestampFieldMapper.DEFAULT_PATH + "] is missing"
             );
         }
-        long timestamp = timestampFields[0].numericValue().longValue();
+        long timestamp = timestampFields.get(0).numericValue().longValue();
         byte[] suffix = new byte[16];
         String id = createId(context.getDynamicMappers().isEmpty(), routingBuilder, tsid, timestamp, suffix);
         /*

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -326,8 +326,9 @@ public class TermVectorsService {
             } else {
                 seenFields.add(field.name());
             }
-            String[] values = getValues(doc.getFields(field.name()));
-            documentFields.add(new DocumentField(field.name(), Arrays.asList((Object[]) values)));
+            @SuppressWarnings("unchecked")
+            List<Object> values = (List)getValues(doc.getFields(field.name()));
+            documentFields.add(new DocumentField(field.name(), values));
         }
         return generateTermVectors(
             indexShard,
@@ -346,7 +347,7 @@ public class TermVectorsService {
      * @param fields The <code>IndexableField</code> to get the values from
      * @return a <code>String[]</code> of field values
      */
-    public static String[] getValues(IndexableField[] fields) {
+    public static List<String> getValues(List<IndexableField> fields) {
         List<String> result = new ArrayList<>();
         for (IndexableField field : fields) {
             if (field.fieldType().indexOptions() != IndexOptions.NONE) {
@@ -357,7 +358,7 @@ public class TermVectorsService {
                 }
             }
         }
-        return result.toArray(new String[0]);
+        return result;
     }
 
     private static Fields mergeFields(Fields fields1, Fields fields2) throws IOException {

--- a/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
+++ b/server/src/main/java/org/elasticsearch/index/termvectors/TermVectorsService.java
@@ -46,7 +46,6 @@ import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -327,7 +326,7 @@ public class TermVectorsService {
                 seenFields.add(field.name());
             }
             @SuppressWarnings("unchecked")
-            List<Object> values = (List)getValues(doc.getFields(field.name()));
+            List<Object> values = (List) getValues(doc.getFields(field.name()));
             documentFields.add(new DocumentField(field.name(), values));
         }
         return generateTermVectors(

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/CategoryContextMapping.java
@@ -126,8 +126,8 @@ public class CategoryContextMapping extends ContextMapping<CategoryQueryContext>
     public Set<String> parseContext(LuceneDocument document) {
         Set<String> values = null;
         if (fieldName != null) {
-            IndexableField[] fields = document.getFields(fieldName);
-            values = Sets.newHashSetWithExpectedSize(fields.length);
+            List<IndexableField> fields = document.getFields(fieldName);
+            values = Sets.newHashSetWithExpectedSize(fields.size());
             // TODO we should be checking mapped field types, not lucene field types
             for (IndexableField field : fields) {
                 if (field instanceof SortedDocValuesField || field instanceof SortedSetDocValuesField || field instanceof StoredField) {

--- a/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/completion/context/GeoContextMapping.java
@@ -176,7 +176,7 @@ public class GeoContextMapping extends ContextMapping<GeoQueryContext> {
         final Set<String> geohashes = new HashSet<>();
 
         if (fieldName != null) {
-            IndexableField[] fields = document.getFields(fieldName);
+            List<IndexableField> fields = document.getFields(fieldName);
             GeoPoint spare = new GeoPoint();
             for (IndexableField field : fields) {
                 if (field instanceof StringField) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BinaryFieldMapperTests.java
@@ -23,6 +23,7 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Base64;
 
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.instanceOf;
 
 public class BinaryFieldMapperTests extends MapperTestCase {
@@ -93,7 +94,7 @@ public class BinaryFieldMapperTests extends MapperTestCase {
 
         byte[] value = new byte[100];
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.field("field", value)));
-        assertEquals(0, doc.rootDoc().getFields("field").length);
+        assertThat(doc.rootDoc().getFields("field"), empty());
     }
 
     public void testStoredValue() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanFieldMapperTests.java
@@ -170,16 +170,16 @@ public class BooleanFieldMapperTests extends MapperTestCase {
         }));
 
         LuceneDocument doc = parsedDoc.rootDoc();
-        IndexableField[] fields = doc.getFields("bool1");
-        assertEquals(2, fields.length);
-        assertEquals(DocValuesType.NONE, fields[0].fieldType().docValuesType());
-        assertEquals(DocValuesType.SORTED_NUMERIC, fields[1].fieldType().docValuesType());
+        List<IndexableField> fields = doc.getFields("bool1");
+        assertEquals(2, fields.size());
+        assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
+        assertEquals(DocValuesType.SORTED_NUMERIC, fields.get(1).fieldType().docValuesType());
         fields = doc.getFields("bool2");
-        assertEquals(1, fields.length);
-        assertEquals(DocValuesType.SORTED_NUMERIC, fields[0].fieldType().docValuesType());
+        assertEquals(1, fields.size());
+        assertEquals(DocValuesType.SORTED_NUMERIC, fields.get(0).fieldType().docValuesType());
         fields = doc.getFields("bool3");
-        assertEquals(DocValuesType.NONE, fields[0].fieldType().docValuesType());
-        assertEquals(DocValuesType.SORTED_NUMERIC, fields[1].fieldType().docValuesType());
+        assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
+        assertEquals(DocValuesType.SORTED_NUMERIC, fields.get(1).fieldType().docValuesType());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/BooleanScriptMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.BooleanFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -71,23 +72,23 @@ public class BooleanScriptMapperTests extends MapperScriptTestCase<BooleanFieldS
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(4, fields.length);
-        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[46]>", fields[0].toString());
-        assertEquals("docValuesType=SORTED_NUMERIC<field:0>", fields[1].toString());
-        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[54]>", fields[2].toString());
-        assertEquals("docValuesType=SORTED_NUMERIC<field:1>", fields[3].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(4, fields.size());
+        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[46]>", fields.get(0).toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:0>", fields.get(1).toString());
+        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[54]>", fields.get(2).toString());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:1>", fields.get(3).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[54]>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[54]>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("docValuesType=SORTED_NUMERIC<field:1>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:1>", fields.get(0).toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -59,8 +59,6 @@ import java.util.Set;
 import java.util.function.Function;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
-import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -436,14 +434,8 @@ public class CompletionFieldMapperTests extends MapperTestCase {
 
         LuceneDocument indexableFields = parsedDocument.rootDoc();
         assertThat(indexableFields.getFields("field"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
-        assertThat(
-            indexableFields.getFields("field.subcompletion1"),
-            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
-        );
-        assertThat(
-            indexableFields.getFields("field.subcompletion2"),
-            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
-        );
+        assertThat(indexableFields.getFields("field.subcompletion1"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
+        assertThat(indexableFields.getFields("field.subcompletion2"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
         assertThat(indexableFields.getFields("field.analyzed1"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
         assertThat(indexableFields.getFields("field.analyzed2"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
     }
@@ -476,14 +468,8 @@ public class CompletionFieldMapperTests extends MapperTestCase {
 
         LuceneDocument indexableFields = parsedDocument.rootDoc();
         assertThat(indexableFields.getFields("field"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
-        assertThat(
-            indexableFields.getFields("field.subcompletion1"),
-            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
-        );
-        assertThat(
-            indexableFields.getFields("field.subcompletion2"),
-            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
-        );
+        assertThat(indexableFields.getFields("field.subcompletion1"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
+        assertThat(indexableFields.getFields("field.subcompletion2"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
         assertThat(indexableFields.getFields("field.analyzed1"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
         assertThat(indexableFields.getFields("field.analyzed2"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
         // unable to assert about weight, covered in a REST test
@@ -530,10 +516,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         }));
 
         List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(
-            fields,
-            containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3"))
-        );
+        assertThat(fields, containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3")));
     }
 
     public void testParsingWithGeoFieldAlias() throws Exception {
@@ -588,10 +571,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         }));
 
         List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(
-            fields,
-            containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3"))
-        );
+        assertThat(fields, containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3")));
     }
 
     public void testParsingMixed() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CompletionFieldMapperTests.java
@@ -61,8 +61,10 @@ import java.util.function.Function;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 
@@ -234,7 +236,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         Mapper fieldMapper = defaultMapper.mappers().getMapper("field");
 
         ParsedDocument parsedDocument = defaultMapper.parse(source(b -> b.field("field", "suggestion")));
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertFieldsOfType(fields);
     }
 
@@ -277,11 +279,11 @@ public class CompletionFieldMapperTests extends MapperTestCase {
 
         assertThat(
             indexableFields.getFields("field"),
-            arrayContainingInAnyOrder(keywordField("key1"), keywordField("key2"), keywordField("key3"))
+            containsInAnyOrder(keywordField("key1"), keywordField("key2"), keywordField("key3"))
         );
         assertThat(
             indexableFields.getFields("field.subsuggest"),
-            arrayContainingInAnyOrder(contextSuggestField("key1"), contextSuggestField("key2"), contextSuggestField("key3"))
+            containsInAnyOrder(contextSuggestField("key1"), contextSuggestField("key2"), contextSuggestField("key3"))
         );
     }
 
@@ -331,15 +333,15 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             LuceneDocument indexableFields = parsedDocument.rootDoc();
             assertThat(
                 indexableFields.getFields("field"),
-                arrayContainingInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
+                containsInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
             );
             assertThat(
                 indexableFields.getFields("field.subsuggest"),
-                arrayContainingInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
+                containsInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
             );
             // check that the indexable fields produce tokenstreams without throwing an exception
             // if this breaks it is likely a problem with setting contexts
-            try (TokenStream ts = indexableFields.getFields("field.subsuggest")[0].tokenStream(Lucene.WHITESPACE_ANALYZER, null)) {
+            try (TokenStream ts = indexableFields.getFields("field.subsuggest").get(0).tokenStream(Lucene.WHITESPACE_ANALYZER, null)) {
                 ts.reset();
                 while (ts.incrementToken()) {
                 }
@@ -357,11 +359,11 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             LuceneDocument indexableFields = parsedDocument.rootDoc();
             assertThat(
                 indexableFields.getFields("field"),
-                arrayContainingInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
+                containsInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
             );
             assertThat(
                 indexableFields.getFields("field.subsuggest"),
-                arrayContainingInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
+                containsInAnyOrder(contextSuggestField("timmy"), contextSuggestField("starbucks"))
             );
             // unable to assert about context, covered in a REST test
         }
@@ -381,8 +383,8 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         ParsedDocument parsedDocument = defaultMapper.parse(source(b -> b.field("field", "drm3btev3e86")));
 
         LuceneDocument indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("field"), arrayWithSize(2));
-        assertThat(indexableFields.getFields("field.analyzed"), arrayContainingInAnyOrder(suggestField("drm3btev3e86")));
+        assertThat(indexableFields.getFields("field"), hasSize(2));
+        assertThat(indexableFields.getFields("field.analyzed"), containsInAnyOrder(suggestField("drm3btev3e86")));
         // unable to assert about geofield content, covered in a REST test
     }
 
@@ -406,11 +408,11 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         ParsedDocument parsedDocument = defaultMapper.parse(source(b -> b.field("field", "suggestion")));
 
         LuceneDocument indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("field"), arrayContainingInAnyOrder(suggestField("suggestion")));
-        assertThat(indexableFields.getFields("field.subsuggest1"), arrayContainingInAnyOrder(suggestField("suggestion")));
-        assertThat(indexableFields.getFields("field.subsuggest2"), arrayContainingInAnyOrder(suggestField("suggestion")));
-        assertThat(indexableFields.getFields("field.analyzed1"), arrayContainingInAnyOrder(keywordField("suggestion")));
-        assertThat(indexableFields.getFields("field.analyzed2"), arrayContainingInAnyOrder(keywordField("suggestion")));
+        assertThat(indexableFields.getFields("field"), containsInAnyOrder(suggestField("suggestion")));
+        assertThat(indexableFields.getFields("field.subsuggest1"), containsInAnyOrder(suggestField("suggestion")));
+        assertThat(indexableFields.getFields("field.subsuggest2"), containsInAnyOrder(suggestField("suggestion")));
+        assertThat(indexableFields.getFields("field.analyzed1"), containsInAnyOrder(keywordField("suggestion")));
+        assertThat(indexableFields.getFields("field.analyzed2"), containsInAnyOrder(keywordField("suggestion")));
     }
 
     public void testCompletionTypeWithSubfieldsAndArrayInsert() throws Exception {
@@ -433,17 +435,17 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         ParsedDocument parsedDocument = defaultMapper.parse(source(b -> b.array("field", "New York", "NY")));
 
         LuceneDocument indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("field"), arrayContainingInAnyOrder(suggestField("New York"), suggestField("NY")));
+        assertThat(indexableFields.getFields("field"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
         assertThat(
             indexableFields.getFields("field.subcompletion1"),
-            arrayContainingInAnyOrder(suggestField("New York"), suggestField("NY"))
+            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
         );
         assertThat(
             indexableFields.getFields("field.subcompletion2"),
-            arrayContainingInAnyOrder(suggestField("New York"), suggestField("NY"))
+            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
         );
-        assertThat(indexableFields.getFields("field.analyzed1"), arrayContainingInAnyOrder(keywordField("New York"), keywordField("NY")));
-        assertThat(indexableFields.getFields("field.analyzed2"), arrayContainingInAnyOrder(keywordField("New York"), keywordField("NY")));
+        assertThat(indexableFields.getFields("field.analyzed1"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
+        assertThat(indexableFields.getFields("field.analyzed2"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
     }
 
     public void testCompletionTypeWithSubfieldsAndObjectInsert() throws Exception {
@@ -473,17 +475,17 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         }));
 
         LuceneDocument indexableFields = parsedDocument.rootDoc();
-        assertThat(indexableFields.getFields("field"), arrayContainingInAnyOrder(suggestField("New York"), suggestField("NY")));
+        assertThat(indexableFields.getFields("field"), containsInAnyOrder(suggestField("New York"), suggestField("NY")));
         assertThat(
             indexableFields.getFields("field.subcompletion1"),
-            arrayContainingInAnyOrder(suggestField("New York"), suggestField("NY"))
+            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
         );
         assertThat(
             indexableFields.getFields("field.subcompletion2"),
-            arrayContainingInAnyOrder(suggestField("New York"), suggestField("NY"))
+            containsInAnyOrder(suggestField("New York"), suggestField("NY"))
         );
-        assertThat(indexableFields.getFields("field.analyzed1"), arrayContainingInAnyOrder(keywordField("New York"), keywordField("NY")));
-        assertThat(indexableFields.getFields("field.analyzed2"), arrayContainingInAnyOrder(keywordField("New York"), keywordField("NY")));
+        assertThat(indexableFields.getFields("field.analyzed1"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
+        assertThat(indexableFields.getFields("field.analyzed2"), containsInAnyOrder(keywordField("New York"), keywordField("NY")));
         // unable to assert about weight, covered in a REST test
     }
 
@@ -493,8 +495,8 @@ public class CompletionFieldMapperTests extends MapperTestCase {
 
         ParsedDocument parsedDocument = defaultMapper.parse(source(b -> b.array("field", "suggestion1", "suggestion2")));
 
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, arrayContainingInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2")));
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        assertThat(fields, containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2")));
     }
 
     public void testParsingWithWeight() throws Exception {
@@ -510,8 +512,8 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
 
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
-        assertThat(fields, arrayContainingInAnyOrder(suggestField("suggestion")));
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        assertThat(fields, containsInAnyOrder(suggestField("suggestion")));
     }
 
     public void testParsingMultiValueWithWeight() throws Exception {
@@ -527,10 +529,10 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
 
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertThat(
             fields,
-            arrayContainingInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3"))
+            containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3"))
         );
     }
 
@@ -567,7 +569,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
 
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertFieldsOfType(fields);
     }
 
@@ -585,10 +587,10 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
 
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertThat(
             fields,
-            arrayContainingInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3"))
+            containsInAnyOrder(suggestField("suggestion1"), suggestField("suggestion2"), suggestField("suggestion3"))
         );
     }
 
@@ -621,10 +623,10 @@ public class CompletionFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
 
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertThat(
             fields,
-            arrayContainingInAnyOrder(
+            containsInAnyOrder(
                 suggestField("suggestion1"),
                 suggestField("suggestion2"),
                 suggestField("suggestion3"),
@@ -740,7 +742,7 @@ public class CompletionFieldMapperTests extends MapperTestCase {
         assertThat(prefixQuery, instanceOf(RegexCompletionQuery.class));
     }
 
-    private static void assertFieldsOfType(IndexableField[] fields) {
+    private static void assertFieldsOfType(List<IndexableField> fields) {
         int actualFieldCount = 0;
         for (IndexableField field : fields) {
             if (field instanceof SuggestField) {

--- a/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/CopyToMapperTests.java
@@ -79,26 +79,26 @@ public class CopyToMapperTests extends MapperServiceTestCase {
             b.field("int_to_str_test", 42);
         }));
         LuceneDocument doc = parsedDoc.rootDoc();
-        assertThat(doc.getFields("copy_test").length, equalTo(2));
-        assertThat(doc.getFields("copy_test")[0].stringValue(), equalTo("foo"));
-        assertThat(doc.getFields("copy_test")[1].stringValue(), equalTo("bar"));
+        assertThat(doc.getFields("copy_test").size(), equalTo(2));
+        assertThat(doc.getFields("copy_test").get(0).stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("copy_test").get(1).stringValue(), equalTo("bar"));
 
-        assertThat(doc.getFields("another_field").length, equalTo(2));
-        assertThat(doc.getFields("another_field")[0].stringValue(), equalTo("foo"));
-        assertThat(doc.getFields("another_field")[1].stringValue(), equalTo("42"));
+        assertThat(doc.getFields("another_field").size(), equalTo(2));
+        assertThat(doc.getFields("another_field").get(0).stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("another_field").get(1).stringValue(), equalTo("42"));
 
-        assertThat(doc.getFields("cyclic_test").length, equalTo(2));
-        assertThat(doc.getFields("cyclic_test")[0].stringValue(), equalTo("foo"));
-        assertThat(doc.getFields("cyclic_test")[1].stringValue(), equalTo("bar"));
+        assertThat(doc.getFields("cyclic_test").size(), equalTo(2));
+        assertThat(doc.getFields("cyclic_test").get(0).stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("cyclic_test").get(1).stringValue(), equalTo("bar"));
 
-        assertThat(doc.getFields("int_to_str_test").length, equalTo(1));
-        assertThat(doc.getFields("int_to_str_test")[0].fieldType().docValuesType(), equalTo(DocValuesType.NONE));
-        assertThat(doc.getFields("int_to_str_test")[0].numericValue().intValue(), equalTo(42));
+        assertThat(doc.getFields("int_to_str_test").size(), equalTo(1));
+        assertThat(doc.getFields("int_to_str_test").get(0).fieldType().docValuesType(), equalTo(DocValuesType.NONE));
+        assertThat(doc.getFields("int_to_str_test").get(0).numericValue().intValue(), equalTo(42));
 
-        assertThat(doc.getFields("new_field").length, equalTo(1));
+        assertThat(doc.getFields("new_field").size(), equalTo(1));
         // new_field has doc values
-        assertThat(doc.getFields("new_field")[0].fieldType().docValuesType(), equalTo(DocValuesType.SORTED_NUMERIC));
-        assertThat(doc.getFields("new_field")[0].numericValue().intValue(), equalTo(42));
+        assertThat(doc.getFields("new_field").get(0).fieldType().docValuesType(), equalTo(DocValuesType.SORTED_NUMERIC));
+        assertThat(doc.getFields("new_field").get(0).numericValue().intValue(), equalTo(42));
 
         assertNotNull(parsedDoc.dynamicMappingsUpdate());
 
@@ -138,11 +138,11 @@ public class CopyToMapperTests extends MapperServiceTestCase {
             b.endObject();
         })).rootDoc();
 
-        assertThat(doc.getFields("copy_test").length, equalTo(1));
-        assertThat(doc.getFields("copy_test")[0].stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("copy_test").size(), equalTo(1));
+        assertThat(doc.getFields("copy_test").get(0).stringValue(), equalTo("foo"));
 
-        assertThat(doc.getFields("very.inner.field").length, equalTo(1));
-        assertThat(doc.getFields("very.inner.field")[0].stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("very.inner.field").size(), equalTo(1));
+        assertThat(doc.getFields("very.inner.field").get(0).stringValue(), equalTo("foo"));
 
     }
 
@@ -162,14 +162,14 @@ public class CopyToMapperTests extends MapperServiceTestCase {
             b.field("new_field", "bar");
         })).rootDoc();
 
-        assertThat(doc.getFields("copy_test").length, equalTo(1));
-        assertThat(doc.getFields("copy_test")[0].stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("copy_test").size(), equalTo(1));
+        assertThat(doc.getFields("copy_test").get(0).stringValue(), equalTo("foo"));
 
-        assertThat(doc.getFields("very.inner.field").length, equalTo(1));
-        assertThat(doc.getFields("very.inner.field")[0].stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("very.inner.field").size(), equalTo(1));
+        assertThat(doc.getFields("very.inner.field").get(0).stringValue(), equalTo("foo"));
 
-        assertThat(doc.getFields("new_field").length, equalTo(1));
-        assertThat(doc.getFields("new_field")[0].stringValue(), equalTo("bar"));
+        assertThat(doc.getFields("new_field").size(), equalTo(1));
+        assertThat(doc.getFields("new_field").get(0).stringValue(), equalTo("bar"));
     }
 
     public void testCopyToDynamicInnerInnerObjectParsing() throws Exception {
@@ -198,14 +198,14 @@ public class CopyToMapperTests extends MapperServiceTestCase {
             b.field("new_field", "bar");
         })).rootDoc();
 
-        assertThat(doc.getFields("copy_test").length, equalTo(1));
-        assertThat(doc.getFields("copy_test")[0].stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("copy_test").size(), equalTo(1));
+        assertThat(doc.getFields("copy_test").get(0).stringValue(), equalTo("foo"));
 
-        assertThat(doc.getFields("very.far.inner.field").length, equalTo(1));
-        assertThat(doc.getFields("very.far.inner.field")[0].stringValue(), equalTo("foo"));
+        assertThat(doc.getFields("very.far.inner.field").size(), equalTo(1));
+        assertThat(doc.getFields("very.far.inner.field").get(0).stringValue(), equalTo("foo"));
 
-        assertThat(doc.getFields("new_field").length, equalTo(1));
-        assertThat(doc.getFields("new_field")[0].stringValue(), equalTo("bar"));
+        assertThat(doc.getFields("new_field").size(), equalTo(1));
+        assertThat(doc.getFields("new_field").get(0).stringValue(), equalTo("bar"));
     }
 
     public void testCopyToStrictDynamicInnerObjectParsing() throws Exception {
@@ -383,37 +383,37 @@ public class CopyToMapperTests extends MapperServiceTestCase {
         assertFieldValue(nested, "n1.n2.target", 3L);
         assertFieldValue(nested, "n1.target");
         assertFieldValue(nested, "target");
-        assertEquals(1, nested.getFields(NestedPathFieldMapper.NAME).length);
+        assertEquals(1, nested.getFields(NestedPathFieldMapper.NAME).size());
 
         nested = doc.docs().get(1);
         assertFieldValue(nested, "n1.n2.target", 5L);
         assertFieldValue(nested, "n1.target");
         assertFieldValue(nested, "target");
-        assertEquals(1, nested.getFields(NestedPathFieldMapper.NAME).length);
+        assertEquals(1, nested.getFields(NestedPathFieldMapper.NAME).size());
 
         nested = doc.docs().get(3);
         assertFieldValue(nested, "n1.n2.target", 7L);
         assertFieldValue(nested, "n1.target");
         assertFieldValue(nested, "target");
-        assertEquals(1, nested.getFields(NestedPathFieldMapper.NAME).length);
+        assertEquals(1, nested.getFields(NestedPathFieldMapper.NAME).size());
 
         LuceneDocument parent = doc.docs().get(2);
         assertFieldValue(parent, "target");
         assertFieldValue(parent, "n1.target", 3L, 5L);
         assertFieldValue(parent, "n1.n2.target");
-        assertEquals(1, parent.getFields(NestedPathFieldMapper.NAME).length);
+        assertEquals(1, parent.getFields(NestedPathFieldMapper.NAME).size());
 
         parent = doc.docs().get(4);
         assertFieldValue(parent, "target");
         assertFieldValue(parent, "n1.target", 7L);
         assertFieldValue(parent, "n1.n2.target");
-        assertEquals(1, parent.getFields(NestedPathFieldMapper.NAME).length);
+        assertEquals(1, parent.getFields(NestedPathFieldMapper.NAME).size());
 
         LuceneDocument root = doc.docs().get(5);
         assertFieldValue(root, "target", 3L, 5L, 7L);
         assertFieldValue(root, "n1.target");
         assertFieldValue(root, "n1.n2.target");
-        assertEquals(0, root.getFields(NestedPathFieldMapper.NAME).length);
+        assertEquals(0, root.getFields(NestedPathFieldMapper.NAME).size());
     }
 
     public void testCopyToChildNested() {
@@ -553,13 +553,10 @@ public class CopyToMapperTests extends MapperServiceTestCase {
     }
 
     private void assertFieldValue(LuceneDocument doc, String field, Number... expected) {
-        IndexableField[] values = doc.getFields(field);
-        if (values == null) {
-            values = new IndexableField[0];
-        }
-        Number[] actual = new Number[values.length];
-        for (int i = 0; i < values.length; ++i) {
-            actual[i] = values[i].numericValue();
+        List<IndexableField> values = doc.getFields(field);
+        Number[] actual = new Number[values.size()];
+        for (int i = 0; i < values.size(); ++i) {
+            actual[i] = values.get(i).numericValue();
         }
         assertArrayEquals(expected, actual);
     }
@@ -690,10 +687,10 @@ public class CopyToMapperTests extends MapperServiceTestCase {
         BytesReference json = BytesReference.bytes(jsonBuilder().startObject().nullField("keyword").endObject());
 
         LuceneDocument document = docMapper.parse(new SourceToParse("1", json, XContentType.JSON)).rootDoc();
-        assertEquals(0, document.getFields("keyword").length);
+        assertEquals(0, document.getFields("keyword").size());
 
-        IndexableField[] fields = document.getFields("keyword_copy");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = document.getFields("keyword_copy");
+        assertEquals(1, fields.size());
     }
 
     public void testCopyToGeoPoint() throws Exception {
@@ -717,11 +714,11 @@ public class CopyToMapperTests extends MapperServiceTestCase {
 
                 LuceneDocument doc = docMapper.parse(new SourceToParse("1", json, XContentType.JSON)).rootDoc();
 
-                IndexableField[] fields = doc.getFields("geopoint");
-                assertThat(fields.length, equalTo(2));
+                List<IndexableField> fields = doc.getFields("geopoint");
+                assertThat(fields.size(), equalTo(2));
 
                 fields = doc.getFields("geopoint_copy");
-                assertThat(fields.length, equalTo(2));
+                assertThat(fields.size(), equalTo(2));
             }
         }
         // check failure for object/array type representations
@@ -798,8 +795,8 @@ public class CopyToMapperTests extends MapperServiceTestCase {
             { "du" : { "bc" : [ { "bc4": { "area" : "foo" } }, { "bc4" : { "area" : "bar" } } ] } }
             """));
 
-        assertEquals(1, doc.rootDoc().getFields("_id").length);
-        assertEquals(2, doc.rootDoc().getFields("du._all").length);
+        assertEquals(1, doc.rootDoc().getFields("_id").size());
+        assertEquals(2, doc.rootDoc().getFields("du._all").size());
 
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateFieldMapperTests.java
@@ -36,6 +36,7 @@ import java.util.List;
 
 import static org.elasticsearch.index.mapper.DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -88,9 +89,9 @@ public class DateFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField field = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField field = fields.get(0);
         assertEquals(1, field.fieldType().pointIndexDimensionCount());
         assertEquals(8, field.fieldType().pointNumBytes());
         assertFalse(field.fieldType().stored());
@@ -105,9 +106,9 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField dvField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField dvField = fields.get(0);
         assertEquals(DocValuesType.SORTED_NUMERIC, dvField.fieldType().docValuesType());
     }
 
@@ -117,9 +118,9 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(1, pointField.fieldType().pointIndexDimensionCount());
     }
 
@@ -129,12 +130,12 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "2016-03-11")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        IndexableField field = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        IndexableField field = fields.get(0);
         assertEquals(1, field.fieldType().pointIndexDimensionCount());
         assertEquals(DocValuesType.SORTED_NUMERIC, field.fieldType().docValuesType());
-        IndexableField storedField = fields[1];
+        IndexableField storedField = fields.get(1);
         assertTrue(storedField.fieldType().stored());
         assertEquals(1457654400000L, storedField.numericValue().longValue());
     }
@@ -166,9 +167,9 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", 1457654400)));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField field = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField field = fields.get(0);
         assertEquals(1457654400000L, field.numericValue().longValue());
     }
 
@@ -185,14 +186,14 @@ public class DateFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
 
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
-        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+        assertThat(doc.rootDoc().getFields("field"), empty());
 
         mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "date").field("null_value", "2016-03-11")));
 
         doc = mapper.parse(source(b -> b.nullField("field")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField field = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField field = fields.get(0);
         assertEquals(1, field.fieldType().pointIndexDimensionCount());
         assertEquals(8, field.fieldType().pointNumBytes());
         assertEquals("LongField <field:1457654400000>", field.toString());
@@ -205,7 +206,7 @@ public class DateFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
 
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
-        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+        assertThat(doc.rootDoc().getFields("field"), empty());
 
         MapperService mapperService = createMapperService(
             fieldMapping(b -> b.field("type", "date_nanos").field("null_value", "2016-03-11"))
@@ -215,9 +216,9 @@ public class DateFieldMapperTests extends MapperTestCase {
         long expectedNullValue = ft.parse("2016-03-11");
 
         doc = mapperService.documentMapper().parse(source(b -> b.nullField("field")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField field = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField field = fields.get(0);
         assertEquals(1, field.fieldType().pointIndexDimensionCount());
         assertEquals(8, field.fieldType().pointNumBytes());
         assertEquals(DocValuesType.SORTED_NUMERIC, field.fieldType().docValuesType());
@@ -264,11 +265,11 @@ public class DateFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", formatter.format(randomDate))));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
 
         long millis = randomDate.withZoneSameInstant(ZoneOffset.UTC).toInstant().toEpochMilli();
-        assertEquals(millis, fields[0].numericValue().longValue());
+        assertEquals(millis, fields.get(0).numericValue().longValue());
     }
 
     public void testMergeDate() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DateScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DateScriptMapperTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.script.DateFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -73,21 +74,21 @@ public class DateScriptMapperTests extends MapperScriptTestCase<DateFieldScript.
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(2, fields.length);
-        assertEquals("LongField <field:1516729294000>", fields[0].toString());
-        assertEquals("LongField <field:1516729295000>", fields[1].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(2, fields.size());
+        assertEquals("LongField <field:1516729294000>", fields.get(0).toString());
+        assertEquals("LongField <field:1516729295000>", fields.get(1).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("LongPoint <field:1516729294000>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("LongPoint <field:1516729294000>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("docValuesType=SORTED_NUMERIC<field:1516729294000>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:1516729294000>", fields.get(0).toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DocCountFieldMapperTests.java
@@ -45,7 +45,7 @@ public class DocCountFieldMapperTests extends MetadataMapperTestCase {
 
         IndexableField field = doc.rootDoc().getField(DOC_COUNT_FIELD);
         assertEquals(DOC_COUNT_FIELD, field.stringValue());
-        assertEquals(1, doc.rootDoc().getFields(DOC_COUNT_FIELD).length);
+        assertEquals(1, doc.rootDoc().getFields(DOC_COUNT_FIELD).size());
     }
 
     public void testInvalidDocument_NegativeDocCount() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DoubleScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DoubleScriptMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.DoubleFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -71,21 +72,21 @@ public class DoubleScriptMapperTests extends MapperScriptTestCase<DoubleFieldScr
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(2, fields.length);
-        assertEquals("DoubleField <field:3.14>", fields[0].toString());
-        assertEquals("DoubleField <field:2.78>", fields[1].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(2, fields.size());
+        assertEquals("DoubleField <field:3.14>", fields.get(0).toString());
+        assertEquals("DoubleField <field:2.78>", fields.get(1).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("DoublePoint <field:3.14>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("DoublePoint <field:3.14>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("docValuesType=SORTED_NUMERIC<field:4614253070214989087>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:4614253070214989087>", fields.get(0).toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicMappingTests.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.time.Instant;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
@@ -811,12 +812,12 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.array("something.myfield", "value2", "value3");
         }));
 
-        assertThat(doc.rootDoc().getFields("myfield"), arrayWithSize(1));
+        assertThat(doc.rootDoc().getFields("myfield"), hasSize(1));
         for (IndexableField field : doc.rootDoc().getFields("myfield")) {
             assertThat(field.binaryValue(), equalTo(new BytesRef("value1")));
         }
         // dynamic is false, so `something.myfield` should be ignored entirely. It used to be merged with myfield by mistake.
-        assertThat(doc.rootDoc().getFields("something.myfield"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getFields("something.myfield"), hasSize(0));
 
         assertNull(doc.dynamicMappingsUpdate());
     }
@@ -831,8 +832,8 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.array("myarray", "array1", "array2");
         }));
 
-        assertThat(doc.rootDoc().getFields("myarray"), arrayWithSize(2));
-        assertThat(doc.rootDoc().getFields("unmapped"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getFields("myarray"), hasSize(2));
+        assertThat(doc.rootDoc().getFields("unmapped"), empty());
         assertNull(doc.dynamicMappingsUpdate());
     }
 
@@ -859,9 +860,9 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.endArray();
         }));
 
-        assertThat(doc.rootDoc().getFields("objects.subfield"), arrayWithSize(1));
-        assertThat(doc.rootDoc().getFields("objects.unmapped"), arrayWithSize(0));
-        assertThat(doc.rootDoc().getFields("unmapped.subfield"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getFields("objects.subfield"), hasSize(1));
+        assertThat(doc.rootDoc().getFields("objects.unmapped"), empty());
+        assertThat(doc.rootDoc().getFields("unmapped.subfield"), empty());
         assertNull(doc.dynamicMappingsUpdate());
     }
 
@@ -887,9 +888,9 @@ public class DynamicMappingTests extends MapperServiceTestCase {
             b.field("myfield", 2);
         }));
 
-        assertThat(doc.rootDoc().getFields("myfield"), arrayWithSize(1));
-        assertThat(doc.rootDoc().getFields("objects.subfield"), arrayWithSize(1));
-        assertThat(doc.rootDoc().getFields("objects.unmapped"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getFields("myfield"), hasSize(1));
+        assertThat(doc.rootDoc().getFields("objects.subfield"), hasSize(1));
+        assertThat(doc.rootDoc().getFields("objects.unmapped"), empty());
         assertEquals(XContentHelper.stripWhitespace("""
             {
               "_doc": {

--- a/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/DynamicTemplatesTests.java
@@ -28,9 +28,9 @@ import java.util.Map;
 
 import static org.elasticsearch.test.StreamsUtils.copyToStringFromClasspath;
 import static org.elasticsearch.test.VersionUtils.randomVersionBetween;
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.notNullValue;
 
@@ -689,8 +689,8 @@ public class DynamicTemplatesTests extends MapperServiceTestCase {
             """;
         ParsedDocument doc = mapperService.documentMapper()
             .parse(new SourceToParse("1", new BytesArray(json), XContentType.JSON, null, Map.of("foo", "geo_point")));
-        assertThat(doc.rootDoc().getFields("foo"), arrayWithSize(2));
-        assertThat(doc.rootDoc().getFields("bar"), arrayWithSize(1));
+        assertThat(doc.rootDoc().getFields("foo"), hasSize(2));
+        assertThat(doc.rootDoc().getFields("bar"), hasSize(1));
     }
 
     public void testMixTemplateMultiFieldAndMappingReuse() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -22,6 +22,8 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
 public class FieldNamesFieldMapperTests extends MetadataMapperTestCase {
 
     @Override
@@ -42,8 +44,7 @@ public class FieldNamesFieldMapperTests extends MetadataMapperTestCase {
     }
 
     private static void assertFieldNames(Set<String> expected, ParsedDocument doc) {
-        String[] got = TermVectorsService.getValues(doc.rootDoc().getFields("_field_names"));
-        assertEquals(expected, set(got));
+        assertThat(TermVectorsService.getValues(doc.rootDoc().getFields("_field_names")), containsInAnyOrder(expected));
     }
 
     public void testFieldType() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -16,11 +16,8 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Set;
-import java.util.SortedSet;
-import java.util.TreeSet;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/FieldNamesFieldMapperTests.java
@@ -39,12 +39,8 @@ public class FieldNamesFieldMapperTests extends MetadataMapperTestCase {
     @Override
     protected void registerParameters(ParameterChecker checker) throws IOException {}
 
-    private static SortedSet<String> set(String... values) {
-        return new TreeSet<>(Arrays.asList(values));
-    }
-
     private static void assertFieldNames(Set<String> expected, ParsedDocument doc) {
-        assertThat(TermVectorsService.getValues(doc.rootDoc().getFields("_field_names")), containsInAnyOrder(expected));
+        assertThat(TermVectorsService.getValues(doc.rootDoc().getFields("_field_names")), containsInAnyOrder(expected.toArray()));
     }
 
     public void testFieldType() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointFieldMapperTests.java
@@ -28,12 +28,10 @@ import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.XContentParserConfiguration;
 import org.elasticsearch.xcontent.json.JsonXContent;
-import org.hamcrest.CoreMatchers;
 import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -42,10 +40,10 @@ import java.util.TreeMap;
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.elasticsearch.test.ListMatcher.matchesList;
 import static org.elasticsearch.test.MapMatcher.assertMap;
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.both;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.hasToString;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
@@ -256,7 +254,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
         // doc values are enabled by default, but in this test we disable them; we should only have 2 points
         assertThat(doc.rootDoc().getFields("field"), notNullValue());
-        assertThat(doc.rootDoc().getFields("field").length, equalTo(4));
+        assertThat(doc.rootDoc().getFields("field"), hasSize(4));
     }
 
     public void testLatLonInOneValue() throws Exception {
@@ -291,7 +289,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
         // doc values are enabled by default, but in this test we disable them; we should only have 2 points
         assertThat(doc.rootDoc().getFields("field"), notNullValue());
-        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(4));
+        assertThat(doc.rootDoc().getFields("field"), hasSize(4));
     }
 
     public void testLonLatArray() throws Exception {
@@ -320,7 +318,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
     public void testLonLatArrayStored() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_point").field("store", true)));
         ParsedDocument doc = mapper.parse(source(b -> b.startArray("field").value(1.3).value(1.2).endArray()));
-        assertThat(doc.rootDoc().getFields("field").length, equalTo(3));
+        assertThat(doc.rootDoc().getFields("field"), hasSize(3));
     }
 
     public void testLonLatArrayArrayStored() throws Exception {
@@ -334,7 +332,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
         assertThat(doc.rootDoc().getFields("field"), notNullValue());
-        assertThat(doc.rootDoc().getFields("field").length, CoreMatchers.equalTo(4));
+        assertThat(doc.rootDoc().getFields("field"), hasSize(4));
     }
 
     /**
@@ -374,11 +372,11 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
         LuceneDocument doc = mapper.parse(source(b -> b.field("field", "POINT (2 3)"))).rootDoc();
-        assertThat(doc.getFields("field"), arrayWithSize(1));
+        assertThat(doc.getFields("field"), hasSize(1));
         assertThat(doc.getField("field"), hasToString(both(containsString("field:2.999")).and(containsString("1.999"))));
-        assertThat(doc.getFields("field.geohash"), arrayWithSize(1));
+        assertThat(doc.getFields("field.geohash"), hasSize(1));
         assertThat(doc.getField("field.geohash").binaryValue().utf8ToString(), equalTo("s093jd0k72s1"));
-        assertThat(doc.getFields("field.latlon"), arrayWithSize(1));
+        assertThat(doc.getFields("field.latlon"), hasSize(1));
         assertThat(doc.getField("field.latlon").stringValue(), equalTo("s093jd0k72s1"));
     }
 
@@ -392,9 +390,9 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
         LuceneDocument doc = mapper.parse(source(b -> b.array("field", "POINT (2 3)", "POINT (4 5)"))).rootDoc();
-        assertThat(doc.getFields("field.geohash"), arrayWithSize(2));
-        assertThat(doc.getFields("field.geohash")[0].binaryValue().utf8ToString(), equalTo("s093jd0k72s1"));
-        assertThat(doc.getFields("field.geohash")[1].binaryValue().utf8ToString(), equalTo("s0fu7n0xng81"));
+        assertThat(doc.getFields("field.geohash"), hasSize(2));
+        assertThat(doc.getFields("field.geohash").get(0).binaryValue().utf8ToString(), equalTo("s093jd0k72s1"));
+        assertThat(doc.getFields("field.geohash").get(1).binaryValue().utf8ToString(), equalTo("s0fu7n0xng81"));
     }
 
     public void testKeywordWithGeopointSubfield() throws Exception {
@@ -407,9 +405,9 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
             b.endObject();
         }));
         LuceneDocument doc = mapper.parse(source(b -> b.array("field", "s093jd0k72s1"))).rootDoc();
-        assertThat(doc.getFields("field"), arrayWithSize(1));
-        assertEquals("s093jd0k72s1", doc.getFields("field")[0].binaryValue().utf8ToString());
-        assertThat(doc.getFields("field.geopoint"), arrayWithSize(1));
+        assertThat(doc.getFields("field"), hasSize(1));
+        assertEquals("s093jd0k72s1", doc.getFields("field").get(0).binaryValue().utf8ToString());
+        assertThat(doc.getFields("field.geopoint"), hasSize(1));
         assertThat(doc.getField("field.geopoint"), hasToString(both(containsString("field.geopoint:2.999")).and(containsString("1.999"))));
     }
 
@@ -450,11 +448,11 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
         assertThat(doc.rootDoc().getField("field"), nullValue());
-        assertThat(doc.rootDoc().getFields(FieldNamesFieldMapper.NAME).length, equalTo(0));
+        assertThat(doc.rootDoc().getFields(FieldNamesFieldMapper.NAME), hasSize(0));
 
         doc = mapper.parse(source(b -> b.startArray("field").value((String) null).endArray()));
         assertThat(doc.rootDoc().getField("field"), nullValue());
-        assertThat(doc.rootDoc().getFields(FieldNamesFieldMapper.NAME).length, equalTo(0));
+        assertThat(doc.rootDoc().getFields(FieldNamesFieldMapper.NAME), hasSize(0));
 
         mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_point").field("doc_values", false)));
         fieldMapper = mapper.mappers().getMapper("field");
@@ -462,7 +460,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
         doc = mapper.parse(source(b -> b.nullField("field")));
         assertThat(doc.rootDoc().getField("field"), nullValue());
-        assertThat(doc.rootDoc().getFields(FieldNamesFieldMapper.NAME).length, equalTo(0));
+        assertThat(doc.rootDoc().getFields(FieldNamesFieldMapper.NAME), hasSize(0));
 
         mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "geo_point").field("null_value", "1,2")));
         fieldMapper = mapper.mappers().getMapper("field");
@@ -485,7 +483,7 @@ public class GeoPointFieldMapperTests extends MapperTestCase {
 
         doc = mapper.parse(source(b -> b.startArray("field").nullValue().value("3, 4").endArray()));
         assertMap(
-            Arrays.stream(doc.rootDoc().getFields("field")).map(IndexableField::binaryValue).filter(Objects::nonNull).toList(),
+            doc.rootDoc().getFields("field").stream().map(IndexableField::binaryValue).filter(Objects::nonNull).toList(),
             matchesList().item(equalTo(defaultValue)).item(equalTo(threeFour))
         );
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoPointScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoPointScriptMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.GeoPointFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -71,23 +72,23 @@ public class GeoPointScriptMapperTests extends MapperScriptTestCase<GeoPointFiel
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(4, fields.length);
-        assertEquals("LatLonPoint <field:-1.000000024214387,0.9999999403953552>", fields[0].toString());
-        assertEquals("LatLonDocValuesField <field:-1.000000024214387,0.9999999403953552>", fields[1].toString());
-        assertEquals("LatLonPoint <field:-2.000000006519258,1.9999999646097422>", fields[2].toString());
-        assertEquals("LatLonDocValuesField <field:-2.000000006519258,1.9999999646097422>", fields[3].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(4, fields.size());
+        assertEquals("LatLonPoint <field:-1.000000024214387,0.9999999403953552>", fields.get(0).toString());
+        assertEquals("LatLonDocValuesField <field:-1.000000024214387,0.9999999403953552>", fields.get(1).toString());
+        assertEquals("LatLonPoint <field:-2.000000006519258,1.9999999646097422>", fields.get(2).toString());
+        assertEquals("LatLonDocValuesField <field:-2.000000006519258,1.9999999646097422>", fields.get(3).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("LatLonPoint <field:-1.000000024214387,0.9999999403953552>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("LatLonPoint <field:-1.000000024214387,0.9999999403953552>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("LatLonDocValuesField <field:-1.000000024214387,0.9999999403953552>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("LatLonDocValuesField <field:-1.000000024214387,0.9999999403953552>", fields.get(0).toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/GeoShapeFieldMapperTests.java
@@ -187,7 +187,7 @@ public class GeoShapeFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
         assertThat(document.docs(), hasSize(1));
-        assertThat(document.docs().get(0).getFields("field").length, equalTo(2));
+        assertThat(document.docs().get(0).getFields("field"), hasSize(2));
     }
 
     public void testMultiFieldsDeprecationWarning() throws Exception {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IgnoredFieldMapperTests.java
@@ -53,10 +53,10 @@ public class IgnoredFieldMapperTests extends MetadataMapperTestCase {
             mapping(b -> b.startObject("field").field("type", "keyword").field("ignore_above", 3).endObject())
         );
         ParsedDocument document = mapper.parse(source(b -> b.field("field", "value")));
-        IndexableField[] fields = document.rootDoc().getFields(IgnoredFieldMapper.NAME);
-        assertEquals(1, fields.length);
-        assertEquals(IndexOptions.DOCS, fields[0].fieldType().indexOptions());
-        assertTrue(fields[0].fieldType().stored());
+        List<IndexableField> fields = document.rootDoc().getFields(IgnoredFieldMapper.NAME);
+        assertEquals(1, fields.size());
+        assertEquals(IndexOptions.DOCS, fields.get(0).fieldType().indexOptions());
+        assertTrue(fields.get(0).fieldType().stored());
     }
 
     public void testFetchIgnoredFieldValue() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IndexTimeScriptTests.java
@@ -36,9 +36,9 @@ public class IndexTimeScriptTests extends MapperServiceTestCase {
         }));
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("message", "this is some text")));
-        IndexableField[] lengthFields = doc.rootDoc().getFields("message_length");
-        assertEquals(1, lengthFields.length);
-        assertEquals("LongField <message_length:17>", lengthFields[0].toString());
+        List<IndexableField> lengthFields = doc.rootDoc().getFields("message_length");
+        assertEquals(1, lengthFields.size());
+        assertEquals("LongField <message_length:17>", lengthFields.get(0).toString());
     }
 
     public void testDocAccess() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpFieldMapperTests.java
@@ -31,6 +31,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 
 public class IpFieldMapperTests extends MapperTestCase {
@@ -76,14 +77,14 @@ public class IpFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "::1")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(1, pointField.fieldType().pointIndexDimensionCount());
         assertEquals(16, pointField.fieldType().pointNumBytes());
         assertFalse(pointField.fieldType().stored());
         assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), pointField.binaryValue());
-        IndexableField dvField = fields[1];
+        IndexableField dvField = fields.get(1);
         assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
         assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), dvField.binaryValue());
         assertFalse(dvField.fieldType().stored());
@@ -98,9 +99,9 @@ public class IpFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "::1")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField dvField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField dvField = fields.get(0);
         assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
     }
 
@@ -112,15 +113,15 @@ public class IpFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "::1")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(1, pointField.fieldType().pointIndexDimensionCount());
         assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), pointField.binaryValue());
 
         fields = doc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
-        assertEquals(1, fields.length);
-        assertEquals("field", fields[0].stringValue());
+        assertEquals(1, fields.size());
+        assertEquals("field", fields.get(0).stringValue());
 
         FieldMapper m = (FieldMapper) mapper.mappers().getMapper("field");
         Query existsQuery = m.fieldType().existsQuery(null);
@@ -135,13 +136,13 @@ public class IpFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "::1")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(3, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(1, pointField.fieldType().pointIndexDimensionCount());
-        IndexableField dvField = fields[1];
+        IndexableField dvField = fields.get(1);
         assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
-        IndexableField storedField = fields[2];
+        IndexableField storedField = fields.get(2);
         assertTrue(storedField.fieldType().stored());
         assertEquals(new BytesRef(InetAddressPoint.encode(InetAddress.getByName("::1"))), storedField.binaryValue());
     }
@@ -161,7 +162,7 @@ public class IpFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
 
         ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
-        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+        assertThat(doc.rootDoc().getFields("field"), empty());
 
         mapper = createDocumentMapper(fieldMapping(b -> {
             b.field("type", "ip");
@@ -170,14 +171,14 @@ public class IpFieldMapperTests extends MapperTestCase {
 
         doc = mapper.parse(source(b -> b.nullField("field")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(1, pointField.fieldType().pointIndexDimensionCount());
         assertEquals(16, pointField.fieldType().pointNumBytes());
         assertFalse(pointField.fieldType().stored());
         assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), pointField.binaryValue());
-        IndexableField dvField = fields[1];
+        IndexableField dvField = fields.get(1);
         assertEquals(DocValuesType.SORTED_SET, dvField.fieldType().docValuesType());
         assertEquals(new BytesRef(InetAddressPoint.encode(InetAddresses.forString("::1"))), dvField.binaryValue());
         assertFalse(dvField.fieldType().stored());
@@ -188,7 +189,7 @@ public class IpFieldMapperTests extends MapperTestCase {
         }));
 
         doc = mapper.parse(source(b -> b.nullField("field")));
-        assertArrayEquals(new IndexableField[0], doc.rootDoc().getFields("field"));
+        assertThat(doc.rootDoc().getFields("field"), empty());
 
         MapperParsingException e = expectThrows(
             MapperParsingException.class,

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpRangeFieldMapperTests.java
@@ -15,6 +15,7 @@ import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
@@ -68,13 +69,13 @@ public class IpRangeFieldMapperTests extends RangeFieldMapperTests {
         cases.put("192.168.0.0/17", "192.168.127.255");
         for (final Map.Entry<String, String> entry : cases.entrySet()) {
             ParsedDocument doc = mapper.parse(source(b -> b.field("field", entry.getKey())));
-            IndexableField[] fields = doc.rootDoc().getFields("field");
-            assertEquals(3, fields.length);
-            IndexableField dvField = fields[0];
+            List<IndexableField> fields = doc.rootDoc().getFields("field");
+            assertEquals(3, fields.size());
+            IndexableField dvField = fields.get(0);
             assertEquals(DocValuesType.BINARY, dvField.fieldType().docValuesType());
-            IndexableField pointField = fields[1];
+            IndexableField pointField = fields.get(1);
             assertEquals(2, pointField.fieldType().pointIndexDimensionCount());
-            IndexableField storedField = fields[2];
+            IndexableField storedField = fields.get(2);
             assertTrue(storedField.fieldType().stored());
             String strVal = InetAddresses.toAddrString(InetAddresses.forString("192.168.0.0"))
                 + " : "

--- a/server/src/test/java/org/elasticsearch/index/mapper/IpScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/IpScriptMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.IpFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -71,23 +72,23 @@ public class IpScriptMapperTests extends MapperScriptTestCase<IpFieldScript.Fact
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(4, fields.length);
-        assertEquals("InetAddressPoint <field:[0:0:0:0:0:0:0:1]>", fields[0].toString());
-        assertEquals("docValuesType=SORTED_SET<field:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]>", fields[1].toString());
-        assertEquals("InetAddressPoint <field:[0:0:0:0:0:0:0:2]>", fields[2].toString());
-        assertEquals("docValuesType=SORTED_SET<field:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2]>", fields[3].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(4, fields.size());
+        assertEquals("InetAddressPoint <field:[0:0:0:0:0:0:0:1]>", fields.get(0).toString());
+        assertEquals("docValuesType=SORTED_SET<field:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]>", fields.get(1).toString());
+        assertEquals("InetAddressPoint <field:[0:0:0:0:0:0:0:2]>", fields.get(2).toString());
+        assertEquals("docValuesType=SORTED_SET<field:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 2]>", fields.get(3).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("InetAddressPoint <field:[0:0:0:0:0:0:0:1]>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("InetAddressPoint <field:[0:0:0:0:0:0:0:1]>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("docValuesType=SORTED_SET<field:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("docValuesType=SORTED_SET<field:[0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 1]>", fields.get(0).toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordScriptMapperTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.script.StringFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -72,22 +73,22 @@ public class KeywordScriptMapperTests extends MapperScriptTestCase<StringFieldSc
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(2, fields.length);
-        assertEquals("indexed,omitNorms,indexOptions=DOCS,docValuesType=SORTED_SET<field:[76 61 6c 75 65 31]>", fields[0].toString());
-        assertEquals("indexed,omitNorms,indexOptions=DOCS,docValuesType=SORTED_SET<field:[76 61 6c 75 65 32]>", fields[1].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(2, fields.size());
+        assertEquals("indexed,omitNorms,indexOptions=DOCS,docValuesType=SORTED_SET<field:[76 61 6c 75 65 31]>", fields.get(0).toString());
+        assertEquals("indexed,omitNorms,indexOptions=DOCS,docValuesType=SORTED_SET<field:[76 61 6c 75 65 32]>", fields.get(1).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[76 61 6c 75 65]>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("indexed,omitNorms,indexOptions=DOCS<field:[76 61 6c 75 65]>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("docValuesType=SORTED_SET<field:[76 61 6c 75 65]>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("docValuesType=SORTED_SET<field:[76 61 6c 75 65]>", fields.get(0).toString());
     }
 
     @Override
@@ -115,7 +116,7 @@ public class KeywordScriptMapperTests extends MapperScriptTestCase<StringFieldSc
         }));
 
         ParsedDocument doc = mapper.parse(source(b -> {}));
-        IndexableField[] letterFields = doc.rootDoc().getFields("letters");
-        assertEquals(8, letterFields.length);
+        List<IndexableField> letterFields = doc.rootDoc().getFields("letters");
+        assertEquals(8, letterFields.size());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongFieldMapperTests.java
@@ -20,8 +20,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
 
-import static org.hamcrest.Matchers.arrayWithSize;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
 
@@ -90,16 +91,16 @@ public class LongFieldMapperTests extends WholeNumberFieldMapperTests {
         ParsedDocument doc = mapper.parse(
             source(b -> b.rawField("field", new BytesArray("9223372036854775808").streamInput(), XContentType.JSON))
         );
-        assertEquals(0, doc.rootDoc().getFields("field").length);
+        assertThat(doc.rootDoc().getFields("field"), empty());
     }
 
     public void testLongIndexingCoercesIntoRange() throws Exception {
         // the following two strings are in-range for a long after coercion
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "9223372036854775807.9")));
-        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(1));
+        assertThat(doc.rootDoc().getFields("field"), hasSize(1));
         doc = mapper.parse(source(b -> b.field("field", "-9223372036854775808.9")));
-        assertThat(doc.rootDoc().getFields("field"), arrayWithSize(1));
+        assertThat(doc.rootDoc().getFields("field"), hasSize(1));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/LongScriptMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/LongScriptMapperTests.java
@@ -13,6 +13,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.elasticsearch.script.LongFieldScript;
 import org.elasticsearch.search.lookup.SearchLookup;
 
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 
@@ -71,21 +72,21 @@ public class LongScriptMapperTests extends MapperScriptTestCase<LongFieldScript.
     }
 
     @Override
-    protected void assertMultipleValues(IndexableField[] fields) {
-        assertEquals(2, fields.length);
-        assertEquals("LongField <field:1>", fields[0].toString());
-        assertEquals("LongField <field:2>", fields[1].toString());
+    protected void assertMultipleValues(List<IndexableField> fields) {
+        assertEquals(2, fields.size());
+        assertEquals("LongField <field:1>", fields.get(0).toString());
+        assertEquals("LongField <field:2>", fields.get(1).toString());
     }
 
     @Override
-    protected void assertDocValuesDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("LongPoint <field:4>", fields[0].toString());
+    protected void assertDocValuesDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("LongPoint <field:4>", fields.get(0).toString());
     }
 
     @Override
-    protected void assertIndexDisabled(IndexableField[] fields) {
-        assertEquals(1, fields.length);
-        assertEquals("docValuesType=SORTED_NUMERIC<field:4>", fields[0].toString());
+    protected void assertIndexDisabled(List<IndexableField> fields) {
+        assertEquals(1, fields.size());
+        assertEquals("docValuesType=SORTED_NUMERIC<field:4>", fields.get(0).toString());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/MapperServiceTests.java
@@ -423,7 +423,7 @@ public class MapperServiceTests extends MapperServiceTestCase {
             }"""));
 
         assertNull(parsedDocument.dynamicMappingsUpdate());
-        IndexableField[] fields = parsedDocument.rootDoc().getFields("obj.sub.string");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields("obj.sub.string");
+        assertEquals(1, fields.size());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedObjectMapperTests.java
@@ -385,8 +385,8 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         assertThat(doc.docs().get(5).get("nested1.nested2.field2"), equalTo("5"));
         assertThat(doc.docs().get(5).get("field"), nullValue());
         assertThat(doc.docs().get(6).get("field"), equalTo("value"));
-        assertThat(doc.docs().get(6).getFields("nested1.field1").length, equalTo(2));
-        assertThat(doc.docs().get(6).getFields("nested1.nested2.field2").length, equalTo(4));
+        assertThat(doc.docs().get(6).getFields("nested1.field1"), hasSize(2));
+        assertThat(doc.docs().get(6).getFields("nested1.nested2.field2"), hasSize(4));
     }
 
     public void testMultiRootAndNested1() throws Exception {
@@ -480,7 +480,7 @@ public class NestedObjectMapperTests extends MapperServiceTestCase {
         assertThat(doc.docs().get(5).get("field"), nullValue());
         assertThat(doc.docs().get(6).get("field"), equalTo("value"));
         assertThat(doc.docs().get(6).get("nested1.field1"), nullValue());
-        assertThat(doc.docs().get(6).getFields("nested1.nested2.field2").length, equalTo(4));
+        assertThat(doc.docs().get(6).getFields("nested1.nested2.field2"), hasSize(4));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/index/mapper/NestedPathFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NestedPathFieldMapperTests.java
@@ -8,14 +8,13 @@
 
 package org.elasticsearch.index.mapper;
 
-import org.apache.lucene.index.IndexableField;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.xcontent.XContentType;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
+
+import static org.hamcrest.Matchers.empty;
 
 public class NestedPathFieldMapperTests extends MetadataMapperTestCase {
 
@@ -40,6 +39,6 @@ public class NestedPathFieldMapperTests extends MetadataMapperTestCase {
     public void testDefaults() throws IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument document = mapper.parse(new SourceToParse("id", new BytesArray("{}"), XContentType.JSON));
-        assertEquals(Collections.<IndexableField>emptyList(), Arrays.asList(document.rootDoc().getFields(NestedPathFieldMapper.NAME)));
+        assertThat(document.rootDoc().getFields(NestedPathFieldMapper.NAME), empty());
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/ProvidedIdFieldMapperTests.java
@@ -41,11 +41,11 @@ public class ProvidedIdFieldMapperTests extends MapperServiceTestCase {
     public void testDefaults() throws IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument document = mapper.parse(source(b -> {}));
-        IndexableField[] fields = document.rootDoc().getFields(IdFieldMapper.NAME);
-        assertEquals(1, fields.length);
-        assertEquals(IndexOptions.DOCS, fields[0].fieldType().indexOptions());
-        assertTrue(fields[0].fieldType().stored());
-        assertEquals(Uid.encodeId("1"), fields[0].binaryValue());
+        List<IndexableField> fields = document.rootDoc().getFields(IdFieldMapper.NAME);
+        assertEquals(1, fields.size());
+        assertEquals(IndexOptions.DOCS, fields.get(0).fieldType().indexOptions());
+        assertTrue(fields.get(0).fieldType().stored());
+        assertEquals(Uid.encodeId("1"), fields.get(0).binaryValue());
     }
 
     public void testEnableFieldData() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/RangeFieldMapperTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Collections;
+import java.util.List;
 
 import static org.elasticsearch.index.query.RangeQueryBuilder.GTE_FIELD;
 import static org.elasticsearch.index.query.RangeQueryBuilder.GT_FIELD;
@@ -91,12 +92,12 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
 
         ParsedDocument doc = mapper.parse(source(this::rangeSource));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        IndexableField dvField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        IndexableField dvField = fields.get(0);
         assertEquals(DocValuesType.BINARY, dvField.fieldType().docValuesType());
 
-        IndexableField pointField = fields[1];
+        IndexableField pointField = fields.get(1);
         assertEquals(2, pointField.fieldType().pointIndexDimensionCount());
         assertFalse(pointField.fieldType().stored());
     }
@@ -107,8 +108,8 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
             b.field("index", false);
         }));
         ParsedDocument doc = mapper.parse(source(this::rangeSource));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
     }
 
     public final void testNoDocValues() throws Exception {
@@ -118,9 +119,9 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
         }));
         ParsedDocument doc = mapper.parse(source(this::rangeSource));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        IndexableField pointField = fields.get(0);
         assertEquals(2, pointField.fieldType().pointIndexDimensionCount());
     }
 
@@ -132,13 +133,13 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
             b.field("store", true);
         }));
         ParsedDocument doc = mapper.parse(source(this::rangeSource));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(3, fields.length);
-        IndexableField dvField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(3, fields.size());
+        IndexableField dvField = fields.get(0);
         assertEquals(DocValuesType.BINARY, dvField.fieldType().docValuesType());
-        IndexableField pointField = fields[1];
+        IndexableField pointField = fields.get(1);
         assertEquals(2, pointField.fieldType().pointIndexDimensionCount());
-        IndexableField storedField = fields[2];
+        IndexableField storedField = fields.get(2);
         assertTrue(storedField.fieldType().stored());
         assertThat(storedField.stringValue(), containsString(storedValue()));
     }
@@ -183,10 +184,10 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
             source(b -> b.startObject("field").field(GT_FIELD.getPreferredName(), "2").field(LT_FIELD.getPreferredName(), "5").endObject())
         );
 
-        IndexableField[] fields1 = doc1.rootDoc().getFields("field");
-        IndexableField[] fields2 = doc2.rootDoc().getFields("field");
+        List<IndexableField> fields1 = doc1.rootDoc().getFields("field");
+        List<IndexableField> fields2 = doc2.rootDoc().getFields("field");
 
-        assertEquals(fields1[1].binaryValue(), fields2[1].binaryValue());
+        assertEquals(fields1.get(1).binaryValue(), fields2.get(1).binaryValue());
     }
 
     protected abstract Object rangeValue();
@@ -217,9 +218,9 @@ public abstract class RangeFieldMapperTests extends MapperTestCase {
     }
 
     private static String storedValue(ParsedDocument doc) {
-        assertEquals(3, doc.rootDoc().getFields("field").length);
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        IndexableField storedField = fields[2];
+        assertEquals(3, doc.rootDoc().getFields("field").size());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        IndexableField storedField = fields.get(2);
         return storedField.stringValue();
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/TextFieldMapperTests.java
@@ -226,10 +226,10 @@ public class TextFieldMapperTests extends MapperTestCase {
         assertEquals(Strings.toString(fieldMapping(this::minimalMapping)), mapper.mappingSource().toString());
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals("1234", fields[0].stringValue());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals("1234", fields.get(0).stringValue());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(false));
         assertTrue(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -260,24 +260,24 @@ public class TextFieldMapperTests extends MapperTestCase {
     public void testEnableStore() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text").field("store", true)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertTrue(fields[0].fieldType().stored());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertTrue(fields.get(0).fieldType().stored());
     }
 
     public void testDisableIndex() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text").field("index", false)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(0, fields.size());
     }
 
     public void testDisableNorms() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "text").field("norms", false)));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "1234")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertTrue(fields[0].fieldType().omitNorms());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertTrue(fields.get(0).fieldType().omitNorms());
     }
 
     public void testIndexOptions() throws IOException {
@@ -311,9 +311,9 @@ public class TextFieldMapperTests extends MapperTestCase {
         for (Map.Entry<String, IndexOptions> entry : supportedOptions.entrySet()) {
             String field = entry.getKey();
             IndexOptions options = entry.getValue();
-            IndexableField[] fields = doc.rootDoc().getFields(field);
-            assertEquals(1, fields.length);
-            assertEquals(options, fields[0].fieldType().indexOptions());
+            List<IndexableField> fields = doc.rootDoc().getFields(field);
+            assertEquals(1, fields.size());
+            assertEquals(options, fields.get(0).fieldType().indexOptions());
         }
     }
 
@@ -321,10 +321,10 @@ public class TextFieldMapperTests extends MapperTestCase {
         MapperService mapperService = createMapperService(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.array("field", new String[] { "a", "b" })));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertEquals("a", fields[0].stringValue());
-        assertEquals("b", fields[1].stringValue());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertEquals("a", fields.get(0).stringValue());
+        assertEquals("b", fields.get(1).stringValue());
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
             TermsEnum terms = getOnlyLeafReader(reader).terms("field").iterator();
@@ -365,10 +365,10 @@ public class TextFieldMapperTests extends MapperTestCase {
         );
         ParsedDocument doc = mapperService.documentMapper().parse(source(b -> b.array("field", new String[] { "a", "b" })));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
-        assertEquals("a", fields[0].stringValue());
-        assertEquals("b", fields[1].stringValue());
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
+        assertEquals("a", fields.get(0).stringValue());
+        assertEquals("b", fields.get(1).stringValue());
 
         withLuceneIndex(mapperService, iw -> iw.addDocument(doc.rootDoc()), reader -> {
             TermsEnum terms = getOnlyLeafReader(reader).terms("field").iterator();
@@ -797,10 +797,10 @@ public class TextFieldMapperTests extends MapperTestCase {
         ParsedDocument doc = mapperService.documentMapper()
             .parse(source(b -> b.array("field", "Some English text that is going to be very useful", "bad", "Prio 1")));
 
-        IndexableField[] fields = doc.rootDoc().getFields("field._index_phrase");
-        assertEquals(3, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field._index_phrase");
+        assertEquals(3, fields.size());
 
-        try (TokenStream ts = fields[0].tokenStream(mapperService.indexAnalyzer(fields[0].name(), f -> null), null)) {
+        try (TokenStream ts = fields.get(0).tokenStream(mapperService.indexAnalyzer(fields.get(0).name(), f -> null), null)) {
             CharTermAttribute termAtt = ts.addAttribute(CharTermAttribute.class);
             ts.reset();
             assertTrue(ts.incrementToken());
@@ -882,8 +882,8 @@ public class TextFieldMapperTests extends MapperTestCase {
 
             ParsedDocument doc = ms.documentMapper()
                 .parse(source(b -> b.field("field", "Some English text that is going to be very useful")));
-            IndexableField[] fields = doc.rootDoc().getFields("field._index_prefix");
-            assertEquals(1, fields.length);
+            List<IndexableField> fields = doc.rootDoc().getFields("field._index_prefix");
+            assertEquals(1, fields.size());
             withLuceneIndex(ms, iw -> iw.addDocument(doc.rootDoc()), ir -> {}); // check we can index
 
             assertAnalyzesTo(

--- a/server/src/test/java/org/elasticsearch/index/mapper/VersionFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/VersionFieldMapperTests.java
@@ -50,10 +50,10 @@ public class VersionFieldMapperTests extends MetadataMapperTestCase {
     public void testDefaults() throws IOException {
         DocumentMapper mapper = createDocumentMapper(mapping(b -> {}));
         ParsedDocument document = mapper.parse(source(b -> b.field("field", "value")));
-        IndexableField[] fields = document.rootDoc().getFields(VersionFieldMapper.NAME);
-        assertEquals(1, fields.length);
-        assertEquals(IndexOptions.NONE, fields[0].fieldType().indexOptions());
-        assertEquals(DocValuesType.NUMERIC, fields[0].fieldType().docValuesType());
+        List<IndexableField> fields = document.rootDoc().getFields(VersionFieldMapper.NAME);
+        assertEquals(1, fields.size());
+        assertEquals(IndexOptions.NONE, fields.get(0).fieldType().indexOptions());
+        assertEquals(DocValuesType.NUMERIC, fields.get(0).fieldType().docValuesType());
     }
 
     public void testFetchFieldValue() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/WholeNumberFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/WholeNumberFieldMapperTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index.mapper;
 import org.apache.lucene.index.IndexableField;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 
@@ -19,8 +20,8 @@ public abstract class WholeNumberFieldMapperTests extends NumberFieldMapperTests
     protected void testDecimalCoerce() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "7.89")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        IndexableField pointField = fields[0];
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        IndexableField pointField = fields.get(0);
         assertEquals(7, pointField.numericValue().doubleValue(), 0d);
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldMapperTests.java
@@ -30,6 +30,7 @@ import org.junit.AssumptionViolatedException;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static org.apache.lucene.tests.analysis.BaseTokenStreamTestCase.assertTokenStreamContents;
@@ -80,36 +81,36 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("key", "value").endObject()));
 
         // Check the root fields.
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
 
-        assertEquals("field", fields[0].name());
-        assertEquals(new BytesRef("value"), fields[0].binaryValue());
-        assertFalse(fields[0].fieldType().stored());
-        assertTrue(fields[0].fieldType().omitNorms());
-        assertEquals(DocValuesType.NONE, fields[0].fieldType().docValuesType());
+        assertEquals("field", fields.get(0).name());
+        assertEquals(new BytesRef("value"), fields.get(0).binaryValue());
+        assertFalse(fields.get(0).fieldType().stored());
+        assertTrue(fields.get(0).fieldType().omitNorms());
+        assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
 
-        assertEquals("field", fields[1].name());
-        assertEquals(new BytesRef("value"), fields[1].binaryValue());
-        assertEquals(DocValuesType.SORTED_SET, fields[1].fieldType().docValuesType());
+        assertEquals("field", fields.get(1).name());
+        assertEquals(new BytesRef("value"), fields.get(1).binaryValue());
+        assertEquals(DocValuesType.SORTED_SET, fields.get(1).fieldType().docValuesType());
 
         // Check the keyed fields.
-        IndexableField[] keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
-        assertEquals(2, keyedFields.length);
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(2, keyedFields.size());
 
-        assertEquals("field._keyed", keyedFields[0].name());
-        assertEquals(new BytesRef("key\0value"), keyedFields[0].binaryValue());
-        assertFalse(keyedFields[0].fieldType().stored());
-        assertTrue(keyedFields[0].fieldType().omitNorms());
-        assertEquals(DocValuesType.NONE, keyedFields[0].fieldType().docValuesType());
+        assertEquals("field._keyed", keyedFields.get(0).name());
+        assertEquals(new BytesRef("key\0value"), keyedFields.get(0).binaryValue());
+        assertFalse(keyedFields.get(0).fieldType().stored());
+        assertTrue(keyedFields.get(0).fieldType().omitNorms());
+        assertEquals(DocValuesType.NONE, keyedFields.get(0).fieldType().docValuesType());
 
-        assertEquals("field._keyed", keyedFields[1].name());
-        assertEquals(new BytesRef("key\0value"), keyedFields[1].binaryValue());
-        assertEquals(DocValuesType.SORTED_SET, keyedFields[1].fieldType().docValuesType());
+        assertEquals("field._keyed", keyedFields.get(1).name());
+        assertEquals(new BytesRef("key\0value"), keyedFields.get(1).binaryValue());
+        assertEquals(DocValuesType.SORTED_SET, keyedFields.get(1).fieldType().docValuesType());
 
         // Check that there is no 'field names' field.
-        IndexableField[] fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
-        assertEquals(0, fieldNamesFields.length);
+        List<IndexableField> fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
+        assertEquals(0, fieldNamesFields.size());
     }
 
     public void testDisableIndex() throws Exception {
@@ -120,13 +121,13 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         }));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("key", "value").endObject()));
 
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals(DocValuesType.SORTED_SET, fields[0].fieldType().docValuesType());
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals(DocValuesType.SORTED_SET, fields.get(0).fieldType().docValuesType());
 
-        IndexableField[] keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
-        assertEquals(1, keyedFields.length);
-        assertEquals(DocValuesType.SORTED_SET, keyedFields[0].fieldType().docValuesType());
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(1, keyedFields.size());
+        assertEquals(DocValuesType.SORTED_SET, keyedFields.get(0).fieldType().docValuesType());
     }
 
     public void testDisableDocValues() throws Exception {
@@ -137,17 +138,17 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         }));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("key", "value").endObject()));
 
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertEquals(DocValuesType.NONE, fields[0].fieldType().docValuesType());
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(1, fields.size());
+        assertEquals(DocValuesType.NONE, fields.get(0).fieldType().docValuesType());
 
-        IndexableField[] keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
-        assertEquals(1, keyedFields.length);
-        assertEquals(DocValuesType.NONE, keyedFields[0].fieldType().docValuesType());
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(1, keyedFields.size());
+        assertEquals(DocValuesType.NONE, keyedFields.get(0).fieldType().docValuesType());
 
-        IndexableField[] fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
-        assertEquals(1, fieldNamesFields.length);
-        assertEquals("field", fieldNamesFields[0].stringValue());
+        List<IndexableField> fieldNamesFields = parsedDoc.rootDoc().getFields(FieldNamesFieldMapper.NAME);
+        assertEquals(1, fieldNamesFields.size());
+        assertEquals("field", fieldNamesFields.get(0).stringValue());
     }
 
     public void testIndexOptions() throws IOException {
@@ -172,15 +173,15 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
     public void testNullField() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.nullField("field")));
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(0, fields.size());
     }
 
     public void testBlankFieldName() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         ParsedDocument parsedDoc = mapper.parse(source(b -> b.startObject("field").field("", "value").endObject()));
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
     }
 
     public void testDotOnlyFieldName() throws Exception {
@@ -188,8 +189,8 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         ParsedDocument parsedDoc = mapper.parse(
             source(b -> b.startObject("field").field(".", "value1").field("..", "value2").field("...", "value3").endObject())
         );
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(6, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(6, fields.size());
     }
 
     public void testMixOfOrdinaryAndFlattenedFields() throws Exception {
@@ -240,16 +241,16 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             )
         );
         assertNull(parsedDoc.dynamicMappingsUpdate());
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(6, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(6, fields.size());
         fields = parsedDoc.rootDoc().getFields("a.b");
-        assertEquals(0, fields.length);
+        assertEquals(0, fields.size());
         fields = parsedDoc.rootDoc().getFields("a.b.c");
-        assertEquals(1, fields.length);
+        assertEquals(1, fields.size());
         fields = parsedDoc.rootDoc().getFields("d");
-        assertEquals(0, fields.length);
+        assertEquals(0, fields.size());
         fields = parsedDoc.rootDoc().getFields("d.e");
-        assertEquals(1, fields.length);
+        assertEquals(1, fields.size());
     }
 
     public void testMalformedJson() throws Exception {
@@ -279,17 +280,17 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
 
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(6, fields.length);
-        assertEquals(new BytesRef("value"), fields[0].binaryValue());
-        assertEquals(new BytesRef("true"), fields[2].binaryValue());
-        assertEquals(new BytesRef("false"), fields[4].binaryValue());
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(6, fields.size());
+        assertEquals(new BytesRef("value"), fields.get(0).binaryValue());
+        assertEquals(new BytesRef("true"), fields.get(2).binaryValue());
+        assertEquals(new BytesRef("false"), fields.get(4).binaryValue());
 
-        IndexableField[] keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
-        assertEquals(6, keyedFields.length);
-        assertEquals(new BytesRef("key1\0value"), keyedFields[0].binaryValue());
-        assertEquals(new BytesRef("key2\0true"), keyedFields[2].binaryValue());
-        assertEquals(new BytesRef("key3\0false"), keyedFields[4].binaryValue());
+        List<IndexableField> keyedFields = parsedDoc.rootDoc().getFields("field._keyed");
+        assertEquals(6, keyedFields.size());
+        assertEquals(new BytesRef("key1\0value"), keyedFields.get(0).binaryValue());
+        assertEquals(new BytesRef("key2\0true"), keyedFields.get(2).binaryValue());
+        assertEquals(new BytesRef("key3\0false"), keyedFields.get(4).binaryValue());
     }
 
     public void testDepthLimit() throws IOException {
@@ -354,8 +355,8 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             }
             b.endArray();
         }));
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
 
         // Set a lower value for ignore_above and check that the field is skipped.
         DocumentMapper newMapper = createDocumentMapper(fieldMapping(b -> {
@@ -370,8 +371,8 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             }
             b.endArray();
         }));
-        IndexableField[] newFields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(0, newFields.length);
+        List<IndexableField> newFields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(0, newFields.size());
 
         // using a key bigger than ignore_above should not prevent the field from being indexed, although we store key:value pairs
         parsedDoc = newMapper.parse(source(b -> {
@@ -382,7 +383,7 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             b.endArray();
         }));
         newFields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        assertEquals(2, fields.size());
     }
 
     /**
@@ -441,18 +442,18 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
             b.startObject("other_field").nullField("key").endObject();
         }));
 
-        IndexableField[] fields = parsedDoc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        List<IndexableField> fields = parsedDoc.rootDoc().getFields("field");
+        assertEquals(0, fields.size());
 
-        IndexableField[] otherFields = parsedDoc.rootDoc().getFields("other_field");
-        assertEquals(2, otherFields.length);
-        assertEquals(new BytesRef("placeholder"), otherFields[0].binaryValue());
-        assertEquals(new BytesRef("placeholder"), otherFields[1].binaryValue());
+        List<IndexableField> otherFields = parsedDoc.rootDoc().getFields("other_field");
+        assertEquals(2, otherFields.size());
+        assertEquals(new BytesRef("placeholder"), otherFields.get(0).binaryValue());
+        assertEquals(new BytesRef("placeholder"), otherFields.get(1).binaryValue());
 
-        IndexableField[] prefixedOtherFields = parsedDoc.rootDoc().getFields("other_field._keyed");
-        assertEquals(2, prefixedOtherFields.length);
-        assertEquals(new BytesRef("key\0placeholder"), prefixedOtherFields[0].binaryValue());
-        assertEquals(new BytesRef("key\0placeholder"), prefixedOtherFields[1].binaryValue());
+        List<IndexableField> prefixedOtherFields = parsedDoc.rootDoc().getFields("other_field._keyed");
+        assertEquals(2, prefixedOtherFields.size());
+        assertEquals(new BytesRef("key\0placeholder"), prefixedOtherFields.get(0).binaryValue());
+        assertEquals(new BytesRef("key\0placeholder"), prefixedOtherFields.get(1).binaryValue());
     }
 
     public void testSplitQueriesOnWhitespace() throws IOException {
@@ -498,10 +499,10 @@ public class FlattenedFieldMapperTests extends MapperTestCase {
         }));
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("a.b.c.d", "value")));
-        IndexableField[] fields = doc.rootDoc().getFields("a.b.c");
-        assertEquals(new BytesRef("value"), fields[0].binaryValue());
-        IndexableField[] keyed = doc.rootDoc().getFields("a.b.c._keyed");
-        assertEquals(new BytesRef("d\0value"), keyed[0].binaryValue());
+        List<IndexableField> fields = doc.rootDoc().getFields("a.b.c");
+        assertEquals(new BytesRef("value"), fields.get(0).binaryValue());
+        List<IndexableField> keyed = doc.rootDoc().getFields("a.b.c._keyed");
+        assertEquals(new BytesRef("d\0value"), keyed.get(0).binaryValue());
     }
 
     public void testAggregationsDocValuesDisabled() throws IOException {

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -211,10 +211,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", validVector)));
 
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertThat(fields[0], instanceOf(BinaryDocValuesField.class));
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(BinaryDocValuesField.class));
         // assert that after decoding the indexed value is equal to expected
-        BytesRef vectorBR = fields[0].binaryValue();
+        BytesRef vectorBR = fields.get(0).binaryValue();
         float[] decodedValues = decodeDenseVector(Version.CURRENT, vectorBR);
         float decodedMagnitude = VectorEncoderDecoder.decodeMagnitude(Version.CURRENT, vectorBR);
         assertEquals(expectedMagnitude, decodedMagnitude, 0.001f);
@@ -231,10 +231,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", vector)));
 
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertThat(fields[0], instanceOf(KnnFloatVectorField.class));
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(KnnFloatVectorField.class));
 
-        KnnFloatVectorField vectorField = (KnnFloatVectorField) fields[0];
+        KnnFloatVectorField vectorField = (KnnFloatVectorField) fields.get(0);
         assertArrayEquals("Parsed vector is not equal to original.", vector, vectorField.vectorValue(), 0.001f);
         assertEquals(similarity.function, vectorField.fieldType().vectorSimilarityFunction());
     }
@@ -255,10 +255,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", vector)));
 
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertThat(fields[0], instanceOf(KnnByteVectorField.class));
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(KnnByteVectorField.class));
 
-        KnnByteVectorField vectorField = (KnnByteVectorField) fields[0];
+        KnnByteVectorField vectorField = (KnnByteVectorField) fields.get(0);
         vectorField.vectorValue();
         assertArrayEquals(
             "Parsed vector is not equal to original.",
@@ -429,10 +429,10 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         float[] validVector = { -12.1f, 100.7f, -4 };
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", validVector)));
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
-        assertEquals(1, fields.length);
-        assertThat(fields[0], instanceOf(BinaryDocValuesField.class));
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(BinaryDocValuesField.class));
         // assert that after decoding the indexed value is equal to expected
-        BytesRef vectorBR = fields[0].binaryValue();
+        BytesRef vectorBR = fields.get(0).binaryValue();
         float[] decodedValues = decodeDenseVector(indexVersion, vectorBR);
         assertArrayEquals("Decoded dense vector values is not equal to the indexed one.", validVector, decodedValues, 0.001f);
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -210,7 +210,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         float expectedMagnitude = (float) Math.sqrt(dotProduct);
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", validVector)));
 
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
         assertEquals(1, fields.length);
         assertThat(fields[0], instanceOf(BinaryDocValuesField.class));
         // assert that after decoding the indexed value is equal to expected
@@ -230,7 +230,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         float[] vector = { -0.5f, 0.5f, 0.7071f };
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", vector)));
 
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
         assertEquals(1, fields.length);
         assertThat(fields[0], instanceOf(KnnFloatVectorField.class));
 
@@ -254,7 +254,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
         byte[] vector = { (byte) -1, (byte) 1, (byte) 127 };
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", vector)));
 
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
         assertEquals(1, fields.length);
         assertThat(fields[0], instanceOf(KnnByteVectorField.class));
 
@@ -428,7 +428,7 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         float[] validVector = { -12.1f, 100.7f, -4 };
         ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", validVector)));
-        IndexableField[] fields = doc1.rootDoc().getFields("field");
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
         assertEquals(1, fields.length);
         assertThat(fields[0], instanceOf(BinaryDocValuesField.class));
         // assert that after decoding the indexed value is equal to expected

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/CategoryContextMappingTests.java
@@ -114,7 +114,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 7);
     }
 
@@ -158,7 +158,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -202,7 +202,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -246,7 +246,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -330,7 +330,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -372,7 +372,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
                 XContentType.JSON
             )
         );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -451,7 +451,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
             .endArray()
             .endObject();
         ParsedDocument parsedDocument = defaultMapper.parse(new SourceToParse("1", BytesReference.bytes(builder), XContentType.JSON));
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(fieldMapper.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -830,7 +830,7 @@ public class CategoryContextMappingTests extends MapperServiceTestCase {
         assertThat(exc.getMessage(), containsString("Failed to parse context field [category]"));
     }
 
-    static void assertContextSuggestFields(IndexableField[] fields, int expected) {
+    static void assertContextSuggestFields(List<IndexableField> fields, int expected) {
         int actualFieldCount = 0;
         for (IndexableField field : fields) {
             if (field instanceof ContextSuggestField) {

--- a/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
+++ b/server/src/test/java/org/elasticsearch/search/suggest/completion/GeoContextMappingTests.java
@@ -102,7 +102,7 @@ public class GeoContextMappingTests extends MapperServiceTestCase {
                     XContentType.JSON
                 )
             );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
         assertContextSuggestFields(fields, 7);
     }
 
@@ -148,7 +148,7 @@ public class GeoContextMappingTests extends MapperServiceTestCase {
                     XContentType.JSON
                 )
             );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -198,7 +198,7 @@ public class GeoContextMappingTests extends MapperServiceTestCase {
                     XContentType.JSON
                 )
             );
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
         assertContextSuggestFields(fields, 3);
     }
 
@@ -239,7 +239,7 @@ public class GeoContextMappingTests extends MapperServiceTestCase {
             .endObject();
         ParsedDocument parsedDocument = mapperService.documentMapper()
             .parse(new SourceToParse("1", BytesReference.bytes(builder), XContentType.JSON));
-        IndexableField[] fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
+        List<IndexableField> fields = parsedDocument.rootDoc().getFields(completionFieldType.name());
         assertContextSuggestFields(fields, 3);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperScriptTestCase.java
@@ -14,10 +14,11 @@ import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 
 import java.io.IOException;
+import java.util.List;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 
 public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTestCase {
 
@@ -136,7 +137,7 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
         }));
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("message", "this is some text")));
-        assertThat(doc.rootDoc().getFields("message_error"), arrayWithSize(0));
+        assertThat(doc.rootDoc().getFields("message_error"), hasSize(0));
         assertThat(doc.rootDoc().getField("_ignored").stringValue(), equalTo("message_error"));
     }
 
@@ -164,7 +165,7 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
         assertMultipleValues(doc.rootDoc().getFields("field"));
     }
 
-    protected abstract void assertMultipleValues(IndexableField[] fields);
+    protected abstract void assertMultipleValues(List<IndexableField> fields);
 
     public final void testDocValuesDisabled() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
@@ -176,7 +177,7 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
         assertDocValuesDisabled(doc.rootDoc().getFields("field"));
     }
 
-    protected abstract void assertDocValuesDisabled(IndexableField[] fields);
+    protected abstract void assertDocValuesDisabled(List<IndexableField> fields);
 
     public final void testIndexDisabled() throws IOException {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {
@@ -188,5 +189,5 @@ public abstract class MapperScriptTestCase<FactoryType> extends MapperServiceTes
         assertIndexDisabled(doc.rootDoc().getFields("field"));
     }
 
-    protected abstract void assertIndexDisabled(IndexableField[] fields);
+    protected abstract void assertIndexDisabled(List<IndexableField> fields);
 }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperTestCase.java
@@ -71,8 +71,10 @@ import java.util.stream.IntStream;
 
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.matchesPattern;
@@ -277,9 +279,9 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
                 b.field("field");
                 example.value.accept(b);
             }));
-            IndexableField[] fields = doc.rootDoc().getFields("field");
-            assertThat(fields, equalTo(new IndexableField[0]));
-            assertThat(TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")), equalTo(new String[] { "field" }));
+            List<IndexableField> fields = doc.rootDoc().getFields("field");
+            assertThat(fields, empty());
+            assertThat(TermVectorsService.getValues(doc.rootDoc().getFields("_ignored")), contains("field"));
         }
     }
 
@@ -318,7 +320,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     protected static void assertHasNorms(LuceneDocument doc, String field) {
-        IndexableField[] fields = doc.getFields(field);
+        List<IndexableField> fields = doc.getFields(field);
         for (IndexableField indexableField : fields) {
             IndexableFieldType indexableFieldType = indexableField.fieldType();
             if (indexableFieldType.indexOptions() != IndexOptions.NONE) {
@@ -330,7 +332,7 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
     }
 
     protected static void assertNoDocValuesField(LuceneDocument doc, String field) {
-        IndexableField[] fields = doc.getFields(field);
+        List<IndexableField> fields = doc.getFields(field);
         for (IndexableField indexableField : fields) {
             assertEquals(DocValuesType.NONE, indexableField.fieldType().docValuesType());
         }
@@ -949,8 +951,8 @@ public abstract class MapperTestCase extends MapperServiceTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(this::minimalMapping));
         if (allowsNullValues()) {
             ParsedDocument doc = mapper.parse(source(b -> b.nullField("field")));
-            assertThat(doc.docs().get(0).getFields("field").length, equalTo(0));
-            assertThat(doc.docs().get(0).getFields("_field_names").length, equalTo(0));
+            assertThat(doc.docs().get(0).getFields("field"), empty());
+            assertThat(doc.docs().get(0).getFields("_field_names"), empty());
         } else {
             expectThrows(MapperParsingException.class, () -> mapper.parse(source(b -> b.nullField("field"))));
         }

--- a/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Stack;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;

--- a/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/test/XContentTestUtilsTests.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Stack;
 import java.util.function.Predicate;
 
 import static org.elasticsearch.test.XContentTestUtils.insertRandomFields;

--- a/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperTests.java
+++ b/x-pack/plugin/mapper-version/src/test/java/org/elasticsearch/xpack/versionfield/VersionStringFieldMapperTests.java
@@ -80,11 +80,11 @@ public class VersionStringFieldMapperTests extends MapperTestCase {
             )
         );
 
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
 
-        assertEquals("1.2.3", VersionEncoder.decodeVersion(fields[0].binaryValue()).utf8ToString());
-        IndexableFieldType fieldType = fields[0].fieldType();
+        assertEquals("1.2.3", VersionEncoder.decodeVersion(fields.get(0).binaryValue()).utf8ToString());
+        IndexableFieldType fieldType = fields.get(0).fieldType();
         assertThat(fieldType.omitNorms(), equalTo(true));
         assertFalse(fieldType.tokenized());
         assertFalse(fieldType.stored());
@@ -95,8 +95,8 @@ public class VersionStringFieldMapperTests extends MapperTestCase {
         assertThat(fieldType.storeTermVectorPayloads(), equalTo(false));
         assertEquals(DocValuesType.NONE, fieldType.docValuesType());
 
-        assertEquals("1.2.3", VersionEncoder.decodeVersion(fields[1].binaryValue()).utf8ToString());
-        fieldType = fields[1].fieldType();
+        assertEquals("1.2.3", VersionEncoder.decodeVersion(fields.get(1).binaryValue()).utf8ToString());
+        fieldType = fields.get(1).fieldType();
         assertThat(fieldType.indexOptions(), equalTo(IndexOptions.NONE));
         assertEquals(DocValuesType.SORTED_SET, fieldType.docValuesType());
 

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/GeoShapeWithDocValuesFieldMapperTests.java
@@ -376,9 +376,9 @@ public class GeoShapeWithDocValuesFieldMapperTests extends GeoFieldMapperTests {
 
         ParsedDocument document = mapper.parse(sourceToParse);
         assertThat(document.docs(), hasSize(1));
-        IndexableField[] fields = document.docs().get(0).getFields(FIELD_NAME);
+        List<IndexableField> fields = document.docs().get(0).getFields(FIELD_NAME);
         // 2 BKD points, 2 stored fields and 1 doc value
-        assertThat(fields.length, equalTo(5));
+        assertThat(fields, hasSize(5));
     }
 
     public void testMultiFieldsDeprecationWarning() throws Exception {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/PointFieldMapperTests.java
@@ -27,6 +27,7 @@ import java.util.List;
 import static org.elasticsearch.geometry.utils.Geohash.stringEncode;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -103,7 +104,7 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
 
         // doc values are enabled by default, but in this test we disable them; we should only have 2 points
         assertThat(doc.rootDoc().getFields(FIELD_NAME), notNullValue());
-        assertThat(doc.rootDoc().getFields(FIELD_NAME).length, equalTo(4));
+        assertThat(doc.rootDoc().getFields(FIELD_NAME), hasSize(4));
     }
 
     public void testXYInOneValue() throws Exception {
@@ -134,7 +135,7 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
 
         // doc values are enabled by default, but in this test we disable them; we should only have 2 points
         assertThat(doc.rootDoc().getFields(FIELD_NAME), notNullValue());
-        assertThat(doc.rootDoc().getFields(FIELD_NAME).length, equalTo(4));
+        assertThat(doc.rootDoc().getFields(FIELD_NAME), hasSize(4));
     }
 
     public void testArray() throws Exception {
@@ -169,7 +170,7 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
         SourceToParse sourceToParse = source(b -> b.startArray(FIELD_NAME).value(1.3).value(1.2).endArray());
         ParsedDocument doc = mapper.parse(sourceToParse);
         assertThat(doc.rootDoc().getField(FIELD_NAME), notNullValue());
-        assertThat(doc.rootDoc().getFields(FIELD_NAME).length, equalTo(3));
+        assertThat(doc.rootDoc().getFields(FIELD_NAME), hasSize(3));
     }
 
     public void testArrayArrayStored() throws Exception {
@@ -194,7 +195,7 @@ public class PointFieldMapperTests extends CartesianFieldMapperTests {
         ParsedDocument doc = mapper.parse(sourceToParse);
 
         assertThat(doc.rootDoc().getFields(FIELD_NAME), notNullValue());
-        assertThat(doc.rootDoc().getFields(FIELD_NAME).length, equalTo(4));
+        assertThat(doc.rootDoc().getFields(FIELD_NAME), hasSize(4));
     }
 
     public void testNullValue() throws Exception {

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/mapper/ShapeFieldMapperTests.java
@@ -317,8 +317,8 @@ public class ShapeFieldMapperTests extends CartesianFieldMapperTests {
 
         ParsedDocument document = mapper.parse(sourceToParse);
         assertThat(document.docs(), hasSize(1));
-        IndexableField[] fields = document.docs().get(0).getFields("shape.type");
-        assertThat(fields.length, equalTo(2));
+        List<IndexableField> fields = document.docs().get(0).getFields("shape.type");
+        assertThat(fields.size(), equalTo(2));
     }
 
     public void testMultiFieldsDeprecationWarning() throws Exception {

--- a/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
+++ b/x-pack/plugin/wildcard/src/test/java/org/elasticsearch/xpack/wildcard/mapper/WildcardFieldMapperTests.java
@@ -194,18 +194,18 @@ public class WildcardFieldMapperTests extends MapperTestCase {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> b.field("type", "wildcard").field("ignore_above", 5)));
 
         ParsedDocument doc = mapper.parse(source(b -> b.field("field", "elk")));
-        IndexableField[] fields = doc.rootDoc().getFields("field");
-        assertEquals(2, fields.length);
+        List<IndexableField> fields = doc.rootDoc().getFields("field");
+        assertEquals(2, fields.size());
         fields = doc.rootDoc().getFields("_ignored");
-        assertEquals(0, fields.length);
+        assertEquals(0, fields.size());
 
         doc = mapper.parse(source(b -> b.field("field", "elasticsearch")));
         fields = doc.rootDoc().getFields("field");
-        assertEquals(0, fields.length);
+        assertEquals(0, fields.size());
 
         fields = doc.rootDoc().getFields("_ignored");
-        assertEquals(1, fields.length);
-        assertEquals("field", fields[0].stringValue());
+        assertEquals(1, fields.size());
+        assertEquals("field", fields.get(0).stringValue());
     }
 
     public void testBWCIndexVersion() throws IOException {


### PR DESCRIPTION
Change `LuceneDocument.getFields(String)` to a List rather than array, to save an array copy. This shows a small perf improvement in local rally runs