### PR TITLE
Fail in beforeCommit on all other terms

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -514,7 +514,10 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         public void beforeCommit(long term, long version, ActionListener<Void> listener) {
             // TODO: add a test to ensure that this gets called
             final var currentTerm = register.readCurrentTerm();
-            if (currentTerm > term) {
+            if (currentTerm == term) {
+                listener.onResponse(null);
+            } else {
+                assert term < currentTerm : term + " vs " + currentTerm;
                 listener.onFailure(
                     new CoordinationStateRejectedException(
                         Strings.format(
@@ -525,9 +528,6 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
                         )
                     )
                 );
-            } else {
-                assert currentTerm == term : currentTerm + " vs " + term;
-                listener.onResponse(null);
             }
         }
     }


### PR DESCRIPTION
Today `beforeCommit()` would succeed in production if the current term decreases. This shouldn't happen for sure, but if it does it would be safer to fail. This commit adjusts the condition so that we only proceed with the commit if the term is exactly correct.