### PR TITLE
[8.7] Revert "Cross-reference disclaimer" (#94829)

### DIFF
--- a/docs/reference/modules/discovery/bootstrapping.asciidoc
+++ b/docs/reference/modules/discovery/bootstrapping.asciidoc
@@ -10,11 +10,6 @@ for use in a <<restart-upgrade,full cluster restart>>, and freshly-started nodes
 that are joining a running cluster obtain this information from the cluster's
 elected master.
 
-IMPORTANT: After the cluster forms successfully for the first time, remove the
-`cluster.initial_master_nodes` setting from each node's configuration. Do not
-use this setting when restarting a cluster or adding a new node to an existing
-cluster.
-
 The initial set of master-eligible nodes is defined in the
 <<initial_master_nodes,`cluster.initial_master_nodes` setting>>. This should be
 set to a list containing one of the following items for each master-eligible
@@ -35,8 +30,10 @@ node:
   multiple nodes sharing a single IP address.
 
 When you start a master-eligible node, you can provide this setting on the
-command line or in the `elasticsearch.yml` file. After the cluster has formed,
-remove this setting from each node's configuration. It should not be set for
+command line or in the `elasticsearch.yml` file.
+
+IMPORTANT: After the cluster has formed, remove the `cluster.initial_master_nodes`
+setting from each node's configuration. It should not be set for
 master-ineligible nodes, master-eligible nodes joining an existing cluster, or
 when restarting one or more nodes.
 


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Revert "Cross-reference disclaimer" (#94829)