### PR TITLE
[7.17] Refactor enrich maintenance coordination logic (#90931)

### DIFF
--- a/docs/changelog/90931.yaml
+++ b/docs/changelog/90931.yaml
@@ -1,0 +1,5 @@
+pr: 90931
+summary: Refactor enrich maintenance coordination logic
+area: Ingest Node
+type: enhancement
+issues: []

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutor.java
@@ -15,11 +15,15 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.Releasable;
+import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
+import org.elasticsearch.xpack.enrich.EnrichPolicyLocks.EnrichPolicyLock;
 import org.elasticsearch.xpack.enrich.action.InternalExecutePolicyAction;
+import org.elasticsearch.xpack.enrich.action.InternalExecutePolicyAction.Request;
 
 import java.util.concurrent.Semaphore;
 import java.util.function.LongSupplier;
@@ -64,28 +68,39 @@ public class EnrichPolicyExecutor {
         ExecuteEnrichPolicyAction.Request request,
         ActionListener<ExecuteEnrichPolicyAction.Response> listener
     ) {
-        tryLockingPolicy(request.getName());
+        long nowTimestamp = nowSupplier.getAsLong();
+        String enrichIndexName = EnrichPolicy.getIndexName(request.getName(), nowTimestamp);
+        Releasable policyLock = tryLockingPolicy(request.getName(), enrichIndexName);
         try {
-            client.execute(InternalExecutePolicyAction.INSTANCE, request, ActionListener.wrap(response -> {
+            Request internalRequest = new Request(request.getName(), enrichIndexName);
+            internalRequest.setWaitForCompletion(request.isWaitForCompletion());
+            internalRequest.setParentTask(request.getParentTask());
+            client.execute(InternalExecutePolicyAction.INSTANCE, internalRequest, ActionListener.wrap(response -> {
                 if (response.getStatus() != null) {
-                    releasePolicy(request.getName());
+                    policyLock.close();
                     listener.onResponse(response);
                 } else {
-                    waitAndThenRelease(request.getName(), response);
+                    assert response.getTaskId() != null : "If the execute response does not have a status it must return a task id";
+                    awaitTaskCompletionAndThenRelease(response.getTaskId(), policyLock);
                     listener.onResponse(response);
                 }
             }, e -> {
-                releasePolicy(request.getName());
+                policyLock.close();
                 listener.onFailure(e);
             }));
         } catch (Exception e) {
             // Be sure to unlock if submission failed.
-            releasePolicy(request.getName());
+            policyLock.close();
             throw e;
         }
     }
 
-    public void runPolicyLocally(ExecuteEnrichPolicyTask task, String policyName, ActionListener<ExecuteEnrichPolicyStatus> listener) {
+    public void runPolicyLocally(
+        ExecuteEnrichPolicyTask task,
+        String policyName,
+        String enrichIndexName,
+        ActionListener<ExecuteEnrichPolicyStatus> listener
+    ) {
         try {
             EnrichPolicy policy = EnrichStore.getPolicy(policyName, clusterService.state());
             if (policy == null) {
@@ -93,7 +108,7 @@ public class EnrichPolicyExecutor {
             }
 
             task.setStatus(new ExecuteEnrichPolicyStatus(ExecuteEnrichPolicyStatus.PolicyPhases.SCHEDULED));
-            Runnable runnable = createPolicyRunner(policyName, policy, task, listener);
+            Runnable runnable = createPolicyRunner(policyName, policy, enrichIndexName, task, listener);
             threadPool.executor(ThreadPool.Names.GENERIC).execute(runnable);
         } catch (Exception e) {
             task.setStatus(new ExecuteEnrichPolicyStatus(ExecuteEnrichPolicyStatus.PolicyPhases.FAILED));
@@ -101,11 +116,11 @@ public class EnrichPolicyExecutor {
         }
     }
 
-    private void tryLockingPolicy(String policyName) {
-        policyLocks.lockPolicy(policyName);
+    private Releasable tryLockingPolicy(String policyName, String enrichIndexName) {
+        EnrichPolicyLock policyLock = policyLocks.lockPolicy(policyName, enrichIndexName);
         if (policyExecutionPermits.tryAcquire() == false) {
             // Release policy lock, and throw a different exception
-            policyLocks.releasePolicy(policyName);
+            policyLock.close();
             throw new EsRejectedExecutionException(
                 "Policy execution failed. Policy execution for ["
                     + policyName
@@ -115,26 +130,25 @@ public class EnrichPolicyExecutor {
                     + "]"
             );
         }
+        // Wrap the result so that when releasing it we also release the held execution permit.
+        return () -> {
+            try (EnrichPolicyLock ignored = policyLock) {
+                policyExecutionPermits.release();
+            }
+        };
     }
 
-    private void releasePolicy(String policyName) {
-        try {
-            policyExecutionPermits.release();
-        } finally {
-            policyLocks.releasePolicy(policyName);
-        }
-    }
-
-    private void waitAndThenRelease(String policyName, ExecuteEnrichPolicyAction.Response response) {
+    private void awaitTaskCompletionAndThenRelease(TaskId taskId, Releasable policyLock) {
         GetTaskRequest getTaskRequest = new GetTaskRequest();
-        getTaskRequest.setTaskId(response.getTaskId());
+        getTaskRequest.setTaskId(taskId);
         getTaskRequest.setWaitForCompletion(true);
-        client.admin().cluster().getTask(getTaskRequest, ActionListener.wrap(() -> releasePolicy(policyName)));
+        client.admin().cluster().getTask(getTaskRequest, ActionListener.wrap(policyLock::close));
     }
 
     private Runnable createPolicyRunner(
         String policyName,
         EnrichPolicy policy,
+        String enrichIndexName,
         ExecuteEnrichPolicyTask task,
         ActionListener<ExecuteEnrichPolicyStatus> listener
     ) {
@@ -146,7 +160,7 @@ public class EnrichPolicyExecutor {
             clusterService,
             client,
             indexNameExpressionResolver,
-            nowSupplier,
+            enrichIndexName,
             fetchSize,
             maxForceMergeAttempts
         );

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyLocks.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyLocks.java
@@ -7,12 +7,12 @@
 package org.elasticsearch.xpack.enrich;
 
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
+import org.elasticsearch.core.Releasable;
 
+import java.util.HashSet;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 
 /**
  * A coordination object that allows multiple distinct polices to be executed concurrently, but also makes sure that a single
@@ -23,28 +23,36 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 public class EnrichPolicyLocks {
 
     /**
-     * A snapshot in time detailing if any policy executions are in flight and total number of local executions that
-     * have been kicked off since the node has started
+     * An instance of a specific lock on a single policy object. Ensures that when unlocking a policy, the policy is only unlocked if this
+     * object is the owner of the held lock. Additionally, this manages the lock lifecycle for any other resources tracked by the policy
+     * coordination logic, such as a policy execution's target index.
      */
-    public static class EnrichPolicyExecutionState {
-        final boolean anyPolicyInFlight;
-        final long executions;
+    public class EnrichPolicyLock implements Releasable {
+        private final String policyName;
+        private final String enrichIndexName;
+        private final Semaphore executionLease;
 
-        EnrichPolicyExecutionState(boolean anyPolicyInFlight, long executions) {
-            this.anyPolicyInFlight = anyPolicyInFlight;
-            this.executions = executions;
+        private EnrichPolicyLock(String policyName, String enrichIndexName, Semaphore executionLease) {
+            this.policyName = policyName;
+            this.enrichIndexName = enrichIndexName;
+            this.executionLease = executionLease;
         }
 
-        public boolean isAnyPolicyInFlight() {
-            return anyPolicyInFlight;
+        /**
+         * Unlocks this policy for execution and maintenance IFF this lock represents the currently held semaphore for a policy name. If
+         * this lock was created for an execution, the target index for the policy execution is also cleared from the locked state.
+         */
+        @Override
+        public void close() {
+            if (enrichIndexName != null) {
+                boolean wasRemoved = workingIndices.remove(enrichIndexName, executionLease);
+                assert wasRemoved
+                    : "Target index [" + enrichIndexName + "] for policy [" + policyName + "] was removed prior to policy unlock";
+            }
+            boolean wasRemoved = policyLocks.remove(policyName, executionLease);
+            assert wasRemoved : "Second attempt was made to unlock policy [" + policyName + "]";
         }
     }
-
-    /**
-     * A read-write lock that allows for policies to be executed concurrently with minimal overhead, but allows for blocking
-     * policy locking operations while capturing the state of policy executions.
-     */
-    private final ReadWriteLock currentStateLock = new ReentrantReadWriteLock(true);
 
     /**
      * A mapping of policy name to a semaphore used for ensuring that a single policy can only have one execution in flight
@@ -53,73 +61,58 @@ public class EnrichPolicyLocks {
     private final ConcurrentHashMap<String, Semaphore> policyLocks = new ConcurrentHashMap<>();
 
     /**
-     * A counter that is used as a sort of policy execution sequence id / dirty bit. This is incremented every time a policy
-     * successfully acquires an execution lock.
+     * When a policy is locked for execution the new index that is created is added to this set to keep it from being accidentally
+     * cleaned up by the maintenance task.
      */
-    private final AtomicLong policyRunCounter = new AtomicLong(0L);
+    private final ConcurrentHashMap<String, Semaphore> workingIndices = new ConcurrentHashMap<>();
 
     /**
      * Locks a policy to prevent concurrent execution. If the policy is currently executing, this method will immediately
      * throw without waiting. This method only blocks if another thread is currently capturing the current policy execution state.
+     * <br/><br/>
+     * If a policy is being executed, use {@link EnrichPolicyLocks#lockPolicy(String, String)} instead in order to properly track the
+     * new enrich index that will be created.
      * @param policyName The policy name to lock for execution
      * @throws EsRejectedExecutionException if the policy is locked already or if the maximum number of concurrent policy executions
      *                                      has been reached
      */
-    public void lockPolicy(String policyName) {
-        currentStateLock.readLock().lock();
-        try {
-            Semaphore runLock = policyLocks.computeIfAbsent(policyName, (name) -> new Semaphore(1));
-            boolean acquired = runLock.tryAcquire();
-            if (acquired == false) {
-                throw new EsRejectedExecutionException(
-                    "Could not obtain lock because policy execution for [" + policyName + "] is already in progress."
-                );
-            }
-            policyRunCounter.incrementAndGet();
-        } finally {
-            currentStateLock.readLock().unlock();
-        }
+    public EnrichPolicyLock lockPolicy(String policyName) {
+        return lockPolicy(policyName, null);
     }
 
     /**
-     * Captures a snapshot of the current policy execution state. This method never blocks, instead assuming that a policy is
-     * currently starting its execution and returns an appropriate state.
-     * @return The current state of in-flight policy executions
+     * Locks a policy to prevent concurrent execution. If the policy is currently executing, this method will immediately
+     * throw without waiting. This method only blocks if another thread is currently capturing the current policy execution state.
+     * <br/><br/>
+     * If a policy needs to be locked just to ensure it is not executing, use {@link EnrichPolicyLocks#lockPolicy(String)} instead since
+     * no new enrich indices need to be maintained.
+     * @param policyName The policy name to lock for execution
+     * @param enrichIndexName If the policy is being executed, this parameter denotes the index that should be protected from maintenance
+     *                  operations.
+     * @throws EsRejectedExecutionException if the policy is locked already or if the maximum number of concurrent policy executions
+     *                                      has been reached
      */
-    public EnrichPolicyExecutionState captureExecutionState() {
-        if (currentStateLock.writeLock().tryLock()) {
-            try {
-                long revision = policyRunCounter.get();
-                long currentPolicyExecutions = policyLocks.mappingCount();
-                return new EnrichPolicyExecutionState(currentPolicyExecutions > 0L, revision);
-            } finally {
-                currentStateLock.writeLock().unlock();
-            }
+    public EnrichPolicyLock lockPolicy(String policyName, String enrichIndexName) {
+        Semaphore runLock = policyLocks.computeIfAbsent(policyName, (name) -> new Semaphore(1));
+        boolean acquired = runLock.tryAcquire();
+        if (acquired == false) {
+            throw new EsRejectedExecutionException(
+                "Could not obtain lock because policy execution for [" + policyName + "] is already in progress."
+            );
         }
-        return new EnrichPolicyExecutionState(true, policyRunCounter.get());
+        if (enrichIndexName != null) {
+            Semaphore previous = workingIndices.putIfAbsent(enrichIndexName, runLock);
+            assert previous == null : "Target index [" + enrichIndexName + "] is already claimed by an execution, or was not cleaned up.";
+        }
+        return new EnrichPolicyLock(policyName, enrichIndexName, runLock);
     }
 
-    /**
-     * Checks if the current execution state matches that of the given execution state. Used to ensure that over a period of time
-     * no changes to the policy execution state have occurred.
-     * @param previousState The previous state to check the current state against
-     * @return true if the current state matches the given previous state, false if policy executions have changed over time.
-     */
-    boolean isSameState(EnrichPolicyExecutionState previousState) {
-        EnrichPolicyExecutionState currentState = captureExecutionState();
-        return currentState.anyPolicyInFlight == previousState.anyPolicyInFlight && currentState.executions == previousState.executions;
+    public Set<String> lockedPolices() {
+        return new HashSet<>(policyLocks.keySet());
     }
 
-    /**
-     * Releases the lock for a given policy name, allowing it to be executed.
-     * @param policyName The policy to release.
-     */
-    public void releasePolicy(String policyName) {
-        currentStateLock.readLock().lock();
-        try {
-            policyLocks.remove(policyName);
-        } finally {
-            currentStateLock.readLock().unlock();
-        }
+    public Set<String> inflightPolicyIndices() {
+        return new HashSet<>(workingIndices.keySet());
     }
+
 }

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyMaintenanceService.java
@@ -11,14 +11,14 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
-import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.client.OriginSettingClient;
+import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.LocalNodeMasterListener;
 import org.elasticsearch.cluster.metadata.AliasMetadata;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -26,15 +26,15 @@ import org.elasticsearch.common.component.LifecycleListener;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.index.mapper.MapperService;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ObjectPath;
 import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 
 import java.util.Arrays;
-import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Semaphore;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
@@ -147,65 +147,55 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
     }
 
     void cleanUpEnrichIndices() {
-        final Map<String, EnrichPolicy> policies = EnrichStore.getPolicies(clusterService.state());
-        GetIndexRequest indices = new GetIndexRequest().indices(EnrichPolicy.ENRICH_INDEX_NAME_BASE + "*")
-            .indicesOptions(IndicesOptions.lenientExpand());
-        // Check that no enrich policies are being executed
-        final EnrichPolicyLocks.EnrichPolicyExecutionState executionState = enrichPolicyLocks.captureExecutionState();
-        if (executionState.isAnyPolicyInFlight() == false) {
-            client.admin().indices().getIndex(indices, new ActionListener<GetIndexResponse>() {
-                @Override
-                public void onResponse(GetIndexResponse getIndexResponse) {
-                    // Ensure that no enrich policy executions started while we were retrieving the snapshot of index data
-                    // If executions were kicked off, we can't be sure that the indices we are about to process are a
-                    // stable state of the system (they could be new indices created by a policy that hasn't been published yet).
-                    if (enrichPolicyLocks.isSameState(executionState)) {
-                        String[] removeIndices = Arrays.stream(getIndexResponse.getIndices())
-                            .filter(indexName -> shouldRemoveIndex(getIndexResponse, policies, indexName))
-                            .toArray(String[]::new);
-                        deleteIndices(removeIndices);
-                    } else {
-                        logger.debug("Skipping enrich index cleanup since enrich policy was executed while gathering indices");
-                        concludeMaintenance();
-                    }
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.error("Failed to get indices during enrich index maintenance task", e);
-                    concludeMaintenance();
-                }
-            });
-        } else {
-            concludeMaintenance();
-        }
+        // Get cluster state first because for a new index to exist there then it has to have already been added to the inflight list
+        // If the new index is in the cluster state but not in the inflight list, then that means that the index name was removed from the
+        // list inflight list because it has already been promoted or because the policy execution failed.
+        ClusterState clusterState = clusterService.state();
+        Set<String> inflightPolicyExecutionIndices = enrichPolicyLocks.inflightPolicyIndices();
+        final Map<String, EnrichPolicy> policies = EnrichStore.getPolicies(clusterState);
+        logger.debug(() -> "Working enrich indices excluded from maintenance [" + String.join(", ", inflightPolicyExecutionIndices) + "]");
+        String[] removeIndices = clusterState.metadata()
+            .indices()
+            .values()
+            .stream()
+            .filter(indexMetadata -> indexMetadata.getIndex().getName().startsWith(EnrichPolicy.ENRICH_INDEX_NAME_BASE))
+            .filter(indexMetadata -> indexUsedByPolicy(indexMetadata, policies, inflightPolicyExecutionIndices) == false)
+            .map(IndexMetadata::getIndex)
+            .map(Index::getName)
+            .toArray(String[]::new);
+        deleteIndices(removeIndices);
     }
 
-    private boolean shouldRemoveIndex(GetIndexResponse getIndexResponse, Map<String, EnrichPolicy> policies, String indexName) {
-        // Find the policy on the index
+    private boolean indexUsedByPolicy(IndexMetadata indexMetadata, Map<String, EnrichPolicy> policies, Set<String> inflightPolicyIndices) {
+        String indexName = indexMetadata.getIndex().getName();
         logger.debug("Checking if should remove enrich index [{}]", indexName);
-        ImmutableOpenMap<String, MappingMetadata> indexMapping = getIndexResponse.getMappings().get(indexName);
-        MappingMetadata mappingMetadata = indexMapping.get(MapperService.SINGLE_MAPPING_NAME);
+        // First ignore the index entirely if it is in the inflightPolicyIndices set as it is actively being worked on
+        if (inflightPolicyIndices.contains(indexName)) {
+            logger.debug("Enrich index [{}] was spared since it is reserved for an active policy execution.", indexName);
+            return true;
+        }
+        // Find the policy on the index
+        MappingMetadata mappingMetadata = indexMetadata.mapping();
         Map<String, Object> mapping = mappingMetadata.getSourceAsMap();
         String policyName = ObjectPath.eval(MAPPING_POLICY_FIELD_PATH, mapping);
         // Check if index has a corresponding policy
         if (policyName == null || policies.containsKey(policyName) == false) {
             // No corresponding policy. Index should be marked for removal.
             logger.debug("Enrich index [{}] does not correspond to any existing policy. Found policy name [{}]", indexName, policyName);
-            return true;
+            return false;
         }
         // Check if index is currently linked to an alias
         final String aliasName = EnrichPolicy.getBaseName(policyName);
-        List<AliasMetadata> aliasMetadata = getIndexResponse.aliases().get(indexName);
+        ImmutableOpenMap<String, AliasMetadata> aliasMetadata = indexMetadata.getAliases();
         if (aliasMetadata == null) {
             logger.debug("Enrich index [{}] is not marked as a live index since it has no alias information", indexName);
-            return true;
+            return false;
         }
-        boolean hasAlias = aliasMetadata.stream().anyMatch((am -> am.getAlias().equals(aliasName)));
+        boolean hasAlias = aliasMetadata.containsKey(aliasName);
         // Index is not currently published to the enrich alias. Should be marked for removal.
         if (hasAlias == false) {
             logger.debug("Enrich index [{}] is not marked as a live index since it lacks the alias [{}]", indexName, aliasName);
-            return true;
+            return false;
         }
         logger.debug(
             "Enrich index [{}] was spared since it is associated with the valid policy [{}] and references alias [{}]",
@@ -213,7 +203,7 @@ public class EnrichPolicyMaintenanceService implements LocalNodeMasterListener {
             policyName,
             aliasName
         );
-        return false;
+        return true;
     }
 
     private void deleteIndices(String[] removeIndices) {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunner.java
@@ -64,7 +64,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.LongSupplier;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ENRICH_ORIGIN;
@@ -87,7 +86,7 @@ public class EnrichPolicyRunner implements Runnable {
     private final ClusterService clusterService;
     private final Client client;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
-    private final LongSupplier nowSupplier;
+    private final String enrichIndexName;
     private final int fetchSize;
     private final int maxForceMergeAttempts;
 
@@ -99,7 +98,7 @@ public class EnrichPolicyRunner implements Runnable {
         ClusterService clusterService,
         Client client,
         IndexNameExpressionResolver indexNameExpressionResolver,
-        LongSupplier nowSupplier,
+        String enrichIndexName,
         int fetchSize,
         int maxForceMergeAttempts
     ) {
@@ -110,7 +109,7 @@ public class EnrichPolicyRunner implements Runnable {
         this.clusterService = Objects.requireNonNull(clusterService);
         this.client = wrapClient(client, policyName, task, clusterService);
         this.indexNameExpressionResolver = Objects.requireNonNull(indexNameExpressionResolver);
-        this.nowSupplier = Objects.requireNonNull(nowSupplier);
+        this.enrichIndexName = enrichIndexName;
         this.fetchSize = fetchSize;
         this.maxForceMergeAttempts = maxForceMergeAttempts;
     }
@@ -371,8 +370,6 @@ public class EnrichPolicyRunner implements Runnable {
     }
 
     private void prepareAndCreateEnrichIndex(List<Map<String, Object>> mappings) {
-        long nowTimestamp = nowSupplier.getAsLong();
-        String enrichIndexName = EnrichPolicy.getIndexName(policyName, nowTimestamp);
         Settings enrichIndexSettings = Settings.builder()
             .put("index.number_of_shards", 1)
             .put("index.number_of_replicas", 0)

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
@@ -21,20 +21,24 @@ import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Set;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskAwareRequest;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction;
 import org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyStatus;
 import org.elasticsearch.xpack.enrich.EnrichPolicyExecutor;
 import org.elasticsearch.xpack.enrich.ExecuteEnrichPolicyTask;
 
+import java.io.IOException;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction.Request;
 import static org.elasticsearch.xpack.core.enrich.action.ExecuteEnrichPolicyAction.Response;
 import static org.elasticsearch.xpack.enrich.EnrichPolicyExecutor.TASK_ACTION;
 
@@ -58,6 +62,45 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
 
     private InternalExecutePolicyAction() {
         super(NAME, Response::new);
+    }
+
+    public static class Request extends ExecuteEnrichPolicyAction.Request {
+
+        private final String enrichIndexName;
+
+        public Request(String name, String enrichIndexName) {
+            super(name);
+            this.enrichIndexName = enrichIndexName;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.enrichIndexName = in.readString();
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(enrichIndexName);
+        }
+
+        public String getEnrichIndexName() {
+            return enrichIndexName;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            if (super.equals(o) == false) return false;
+            Request request = (Request) o;
+            return Objects.equals(enrichIndexName, request.enrichIndexName);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(super.hashCode(), enrichIndexName);
+        }
     }
 
     public static class Transport extends HandledTransportAction<Request, Response> {
@@ -107,7 +150,11 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
 
                 @Override
                 public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-                    String description = "executing enrich policy [" + request.getName() + "]";
+                    String description = "executing enrich policy ["
+                            + request.getName()
+                            + "] creating new enrich index ["
+                            + request.getEnrichIndexName()
+                            + "]";
                     return new ExecuteEnrichPolicyTask(id, type, action, description, parentTaskId, headers);
                 }
             });
@@ -125,7 +172,7 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
                         }
                     });
                 }
-                policyExecutor.runPolicyLocally(task, request.getName(), ActionListener.wrap(result -> {
+                policyExecutor.runPolicyLocally(task, request.getName(), request.getEnrichIndexName(), ActionListener.wrap(result -> {
                     taskManager.unregister(task);
                     listener.onResponse(result);
                 }, e -> {

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyAction.java
@@ -151,10 +151,10 @@ public class InternalExecutePolicyAction extends ActionType<Response> {
                 @Override
                 public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
                     String description = "executing enrich policy ["
-                            + request.getName()
-                            + "] creating new enrich index ["
-                            + request.getEnrichIndexName()
-                            + "]";
+                        + request.getName()
+                        + "] creating new enrich index ["
+                        + request.getEnrichIndexName()
+                        + "]";
                     return new ExecuteEnrichPolicyTask(id, type, action, description, parentTaskId, headers);
                 }
             });

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyAction.java
@@ -32,6 +32,7 @@ import org.elasticsearch.xpack.core.enrich.EnrichPolicy;
 import org.elasticsearch.xpack.core.enrich.action.DeleteEnrichPolicyAction;
 import org.elasticsearch.xpack.enrich.AbstractEnrichProcessor;
 import org.elasticsearch.xpack.enrich.EnrichPolicyLocks;
+import org.elasticsearch.xpack.enrich.EnrichPolicyLocks.EnrichPolicyLock;
 import org.elasticsearch.xpack.enrich.EnrichStore;
 
 import java.util.ArrayList;
@@ -80,14 +81,14 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
         DeleteEnrichPolicyAction.Request request,
         ClusterState state,
         ActionListener<AcknowledgedResponse> listener
-    ) throws Exception {
+    ) {
         final String policyName = request.getName();
         final EnrichPolicy policy = EnrichStore.getPolicy(policyName, state); // ensure the policy exists first
         if (policy == null) {
             throw new ResourceNotFoundException("policy [{}] not found", policyName);
         }
 
-        enrichPolicyLocks.lockPolicy(policyName);
+        EnrichPolicyLock policyLock = enrichPolicyLocks.lockPolicy(policyName);
         try {
             final List<PipelineConfiguration> pipelines = IngestService.getPipelines(state);
             final List<String> pipelinesWithProcessors = new ArrayList<>();
@@ -113,27 +114,26 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
                 );
             }
         } catch (Exception e) {
-            enrichPolicyLocks.releasePolicy(policyName);
+            policyLock.close();
             listener.onFailure(e);
             return;
         }
 
-        final GetIndexRequest indices = new GetIndexRequest().indices(EnrichPolicy.getBaseName(policyName) + "-*")
-            .indicesOptions(IndicesOptions.lenientExpand());
+        try {
+            final GetIndexRequest indices = new GetIndexRequest().indices(EnrichPolicy.getBaseName(policyName) + "-*")
+                .indicesOptions(IndicesOptions.lenientExpand());
 
-        String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(state, indices);
+            String[] concreteIndices = indexNameExpressionResolver.concreteIndexNamesWithSystemIndexAccess(state, indices);
 
-        // the wildcard expansion could be too wide (e.g. in the case of a policy named policy-1 and another named policy-10),
-        // so we need to filter down to just the concrete indices that are actually indices for this policy
-        concreteIndices = Stream.of(concreteIndices).filter(i -> EnrichPolicy.isPolicyForIndex(policyName, i)).toArray(String[]::new);
+            // the wildcard expansion could be too wide (e.g. in the case of a policy named policy-1 and another named policy-10),
+            // so we need to filter down to just the concrete indices that are actually indices for this policy
+            concreteIndices = Stream.of(concreteIndices).filter(i -> EnrichPolicy.isPolicyForIndex(policyName, i)).toArray(String[]::new);
 
-        deleteIndicesAndPolicy(concreteIndices, policyName, ActionListener.wrap((response) -> {
-            enrichPolicyLocks.releasePolicy(policyName);
-            listener.onResponse(response);
-        }, (exc) -> {
-            enrichPolicyLocks.releasePolicy(policyName);
-            listener.onFailure(exc);
-        }));
+            deleteIndicesAndPolicy(concreteIndices, policyName, ActionListener.runBefore(listener, policyLock::close));
+        } catch (Exception e) {
+            policyLock.close();
+            listener.onFailure(e);
+        }
     }
 
     private void deleteIndicesAndPolicy(String[] indices, String name, ActionListener<AcknowledgedResponse> listener) {
@@ -158,7 +158,7 @@ public class TransportDeleteEnrichPolicyAction extends AcknowledgedTransportMast
             } else {
                 deletePolicy(name, listener);
             }
-        }, (error) -> listener.onFailure(error)));
+        }, listener::onFailure));
     }
 
     private void deletePolicy(String name, ActionListener<AcknowledgedResponse> listener) {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutorTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyExecutorTests.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.Matchers.empty;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -120,13 +122,14 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         Settings testSettings = Settings.builder().put(EnrichPlugin.ENRICH_MAX_CONCURRENT_POLICY_EXECUTIONS.getKey(), 2).build();
         CountDownLatch latch = new CountDownLatch(1);
         Client client = getClient(latch);
+        EnrichPolicyLocks locks = new EnrichPolicyLocks();
         final EnrichPolicyExecutor testExecutor = new EnrichPolicyExecutor(
             testSettings,
             null,
             client,
             testThreadPool,
             TestIndexNameExpressionResolver.newInstance(testThreadPool.getThreadContext()),
-            new EnrichPolicyLocks(),
+            locks,
             ESTestCase::randomNonNegativeLong
         );
 
@@ -171,6 +174,7 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         );
 
         // Ensure that the lock from the previous run has been cleared
+        assertThat(locks.lockedPolices(), is(empty()));
         CountDownLatch finalTaskComplete = new CountDownLatch(1);
         testExecutor.coordinatePolicyExecution(
             new ExecuteEnrichPolicyAction.Request(testPolicyBaseName + "1"),
@@ -198,7 +202,10 @@ public class EnrichPolicyExecutorTests extends ESTestCase {
         );
 
         ExecuteEnrichPolicyTask task = mock(ExecuteEnrichPolicyTask.class);
-        Exception e = expectThrows(ResourceNotFoundException.class, () -> testExecutor.runPolicyLocally(task, "my-policy", null));
+        Exception e = expectThrows(
+            ResourceNotFoundException.class,
+            () -> testExecutor.runPolicyLocally(task, "my-policy", ".enrich-my-policy-123456789", null)
+        );
         assertThat(e.getMessage(), equalTo("policy [my-policy] does not exist"));
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -143,10 +143,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -156,7 +157,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -215,10 +215,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -228,7 +229,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -303,10 +303,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -316,7 +317,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -393,10 +393,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -406,7 +407,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -496,10 +496,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -509,7 +510,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -603,10 +603,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -616,7 +617,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -708,10 +708,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -721,7 +722,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -765,10 +765,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -794,10 +795,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -853,10 +855,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "nesting.key", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -918,10 +921,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "key", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1009,10 +1013,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1022,7 +1027,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1124,10 +1128,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1137,7 +1142,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1243,10 +1247,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.RANGE_TYPE, null, singletonList(sourceIndex), "data.subnet", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1256,7 +1261,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1379,10 +1383,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         );
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1392,7 +1397,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1519,10 +1523,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         );
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1532,7 +1537,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1666,10 +1670,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         );
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1679,7 +1684,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1799,10 +1803,11 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         EnrichPolicy policy = new EnrichPolicy(EnrichPolicy.MATCH_TYPE, null, singletonList(sourceIndex), "data.field1", enrichFields);
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(policyName, policy, listener, createdEnrichIndex);
 
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
@@ -1812,7 +1817,6 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         }
 
         // Validate Index definition
-        String createdEnrichIndex = ".enrich-test1-" + createTime;
         GetIndexResponse enrichIndex = getGetIndexResponseAndCheck(createdEnrichIndex);
 
         // Validate Mapping
@@ -1945,7 +1949,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             clusterService,
             client(),
             resolver,
-            () -> createTime,
+            createdEnrichIndex,
             randomIntBetween(1, 10000),
             randomIntBetween(3, 10)
         ) {
@@ -2043,6 +2047,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName = "test1";
 
         final long createTime = randomNonNegativeLong();
+        String createdEnrichIndex = ".enrich-test1-" + createTime;
         final AtomicReference<Exception> exception = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ExecuteEnrichPolicyStatus> listener = createTestListener(latch, exception::set);
@@ -2077,7 +2082,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             }
         };
 
-        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(client, policyName, policy, listener, createTime);
+        EnrichPolicyRunner enrichPolicyRunner = createPolicyRunner(client, policyName, policy, listener, createdEnrichIndex);
         logger.info("Starting policy run");
         enrichPolicyRunner.run();
         latch.await();
@@ -2089,9 +2094,9 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName,
         EnrichPolicy policy,
         ActionListener<ExecuteEnrichPolicyStatus> listener,
-        Long createTime
+        String targetIndex
     ) {
-        return createPolicyRunner(client(), policyName, policy, listener, createTime);
+        return createPolicyRunner(client(), policyName, policy, listener, targetIndex);
     }
 
     private EnrichPolicyRunner createPolicyRunner(
@@ -2099,7 +2104,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
         String policyName,
         EnrichPolicy policy,
         ActionListener<ExecuteEnrichPolicyStatus> listener,
-        Long createTime
+        String targetIndex
     ) {
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         IndexNameExpressionResolver resolver = getInstanceFromNode(IndexNameExpressionResolver.class);
@@ -2147,7 +2152,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             clusterService,
             client,
             resolver,
-            () -> createTime,
+            targetIndex,
             randomIntBetween(1, 10000),
             randomIntBetween(1, 10)
         );

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionRequestTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionRequestTests.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.enrich.action;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.xpack.enrich.action.InternalExecutePolicyAction.Request;
+
+public class InternalExecutePolicyActionRequestTests extends AbstractWireSerializingTestCase<Request> {
+    @Override
+    protected Writeable.Reader<Request> instanceReader() {
+        return Request::new;
+    }
+
+    @Override
+    protected Request createTestInstance() {
+        Request request = new Request(randomAlphaOfLength(3), randomAlphaOfLength(5));
+        if (randomBoolean()) {
+            request.setWaitForCompletion(true);
+        }
+        return request;
+    }
+
+    @Override
+    protected Request mutateInstance(Request instance) {
+        String policyName = instance.getName();
+        String enrichIndexName = instance.getEnrichIndexName();
+        boolean waitForCompletion = instance.isWaitForCompletion();
+
+        switch (between(0, 2)) {
+            case 0 -> policyName = randomAlphaOfLength(4);
+            case 1 -> enrichIndexName = randomAlphaOfLength(6);
+            case 2 -> waitForCompletion = waitForCompletion == false;
+            default -> throw new AssertionError("Illegal randomisation branch");
+        }
+
+        Request request = new Request(policyName, enrichIndexName);
+        request.setWaitForCompletion(waitForCompletion);
+        return request;
+    }
+}

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionRequestTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionRequestTests.java
@@ -33,10 +33,17 @@ public class InternalExecutePolicyActionRequestTests extends AbstractWireSeriali
         boolean waitForCompletion = instance.isWaitForCompletion();
 
         switch (between(0, 2)) {
-            case 0 -> policyName = randomAlphaOfLength(4);
-            case 1 -> enrichIndexName = randomAlphaOfLength(6);
-            case 2 -> waitForCompletion = waitForCompletion == false;
-            default -> throw new AssertionError("Illegal randomisation branch");
+            case 0:
+                policyName = randomAlphaOfLength(4);
+                break;
+            case 1:
+                enrichIndexName = randomAlphaOfLength(6);
+                break;
+            case 2:
+                waitForCompletion = waitForCompletion == false;
+                break;
+            default:
+                throw new AssertionError("Illegal randomisation branch");
         }
 
         Request request = new Request(policyName, enrichIndexName);

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportGetEnrichPolicyActionTests.java
@@ -59,7 +59,7 @@ public class TransportGetEnrichPolicyActionTests extends AbstractEnrichTestCase 
 
         // fail if the state of this is left locked
         EnrichPolicyLocks enrichPolicyLocks = getInstanceFromNode(EnrichPolicyLocks.class);
-        assertFalse(enrichPolicyLocks.captureExecutionState().isAnyPolicyInFlight());
+        assertThat(enrichPolicyLocks.lockedPolices().size(), equalTo(0));
     }
 
     public void testListPolicies() throws InterruptedException {


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `7.17`:
 - [Refactor enrich maintenance coordination logic (#90931)](https://github.com/elastic/elasticsearch/pull/90931)

<!--- Backport version: 8.4.2 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)