### PR TITLE
Fix test codebase mapping for Preallocate

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/plugin-metadata/plugin-security.codebases
+++ b/x-pack/plugin/blob-cache/src/main/plugin-metadata/plugin-security.codebases
@@ -1,1 +1,1 @@
-preallocate: org.elasticsearch.xpack.searchablesnapshots.preallocate.Preallocate
+preallocate: org.elasticsearch.blobcache.preallocate.Preallocate


### PR DESCRIPTION
Preallocate was moved to a different package, but the codebase mapping used by tests was missed. This commit updates the mapping.

relates #94751