### PR TITLE
Share early termination code block in EarlyTerminatingCollector

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/EarlyTerminatingCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/query/EarlyTerminatingCollector.java
@@ -29,8 +29,8 @@ public class EarlyTerminatingCollector extends FilterCollector {
     }
 
     private final int maxCountHits;
+    private final boolean forceTermination;
     private int numCollected;
-    private boolean forceTermination;
     private boolean earlyTerminated;
 
     /**
@@ -59,27 +59,26 @@ public class EarlyTerminatingCollector extends FilterCollector {
     @Override
     public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
         if (numCollected >= maxCountHits) {
-            earlyTerminated = true;
-            if (forceTermination) {
-                throw new EarlyTerminationException("early termination [CountBased]");
-            } else {
-                throw new CollectionTerminatedException();
-            }
+            earlyTerminate();
         }
         return new FilterLeafCollector(super.getLeafCollector(context)) {
             @Override
             public void collect(int doc) throws IOException {
                 if (++numCollected > maxCountHits) {
-                    earlyTerminated = true;
-                    if (forceTermination) {
-                        throw new EarlyTerminationException("early termination [CountBased]");
-                    } else {
-                        throw new CollectionTerminatedException();
-                    }
+                    earlyTerminate();
                 }
                 super.collect(doc);
             }
         };
+    }
+
+    private void earlyTerminate() {
+        earlyTerminated = true;
+        if (forceTermination) {
+            throw new EarlyTerminationException("early termination [CountBased]");
+        } else {
+            throw new CollectionTerminatedException();
+        }
     }
 
     /**


### PR DESCRIPTION
This is a minor improvement to EarlyTerminatingCollector that helps readability in that there's two places where the exact same code is executed, hence code duplication can be avoided.