### PR TITLE
[ML] Mute "Test put with defer_definition_decompression with invalid definition and no memory estimate"

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/inference_crud.yml
@@ -1113,6 +1113,10 @@ setup:
 
 ---
 "Test put with defer_definition_decompression with invalid definition and no memory estimate":
+  - skip:
+       version: all
+       reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/94854"
+
   - do:
       catch: /Model \[my-regression-model\] inference config type \[classification\] does not support definition target type \[regression\]/
       ml.put_trained_model:


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/issues/94854