### PR TITLE
Use regular initial configuration in CoordinatorTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -416,14 +416,6 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         ) {
             return new AtomicRegisterPersistedState(newLocalNode, sharedStore);
         }
-
-        @Override
-        public CoordinationMetadata.VotingConfiguration getInitialConfigurationForNode(
-            DiscoveryNode localNode,
-            CoordinationMetadata.VotingConfiguration initialConfiguration
-        ) {
-            return new CoordinationMetadata.VotingConfiguration(Set.of(localNode.getId()));
-        }
     }
 
     static class SingleNodeReconfigurator extends Reconfigurator {

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -898,10 +898,6 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             );
         }
 
-        private VotingConfiguration getInitialConfigurationForNode(DiscoveryNode localNode, VotingConfiguration initialConfiguration) {
-            return coordinatorStrategy.getInitialConfigurationForNode(localNode, initialConfiguration);
-        }
-
         CoordinationState.PersistedState createFreshPersistedState(DiscoveryNode localNode) {
             return coordinatorStrategy.createFreshPersistedState(localNode, () -> disruptStorage);
         }
@@ -1418,10 +1414,19 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
             void applyInitialConfiguration() {
                 onNode(() -> {
-                    final VotingConfiguration configurationWithPlaceholders = getInitialConfigurationForNode(
-                        localNode,
-                        initialConfiguration
+                    final Set<String> nodeIdsWithPlaceholders = new HashSet<>(initialConfiguration.getNodeIds());
+                    Stream.generate(() -> BOOTSTRAP_PLACEHOLDER_PREFIX + UUIDs.randomBase64UUID(random()))
+                        .limit((Math.max(initialConfiguration.getNodeIds().size(), 2) - 1) / 2)
+                        .forEach(nodeIdsWithPlaceholders::add);
+                    final Set<String> nodeIds = new HashSet<>(
+                        randomSubsetOf(initialConfiguration.getNodeIds().size(), nodeIdsWithPlaceholders)
                     );
+                    // initial configuration should not have a place holder for local node
+                    if (initialConfiguration.getNodeIds().contains(localNode.getId()) && nodeIds.contains(localNode.getId()) == false) {
+                        nodeIds.remove(nodeIds.iterator().next());
+                        nodeIds.add(localNode.getId());
+                    }
+                    final VotingConfiguration configurationWithPlaceholders = new VotingConfiguration(nodeIds);
                     try {
                         coordinator.setInitialConfiguration(configurationWithPlaceholders);
                         logger.info("successfully set initial configuration to {}", configurationWithPlaceholders);
@@ -1479,8 +1484,6 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             NamedWriteableRegistry namedWriteableRegistry,
             BooleanSupplier disruptStorage
         );
-
-        VotingConfiguration getInitialConfigurationForNode(DiscoveryNode localNode, VotingConfiguration initialConfiguration);
     }
 
     protected interface CoordinationServices {
@@ -1559,21 +1562,6 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                 namedWriteableRegistry,
                 disruptStorage
             );
-        }
-
-        @Override
-        public VotingConfiguration getInitialConfigurationForNode(DiscoveryNode localNode, VotingConfiguration initialConfiguration) {
-            final Set<String> nodeIdsWithPlaceholders = new HashSet<>(initialConfiguration.getNodeIds());
-            Stream.generate(() -> BOOTSTRAP_PLACEHOLDER_PREFIX + UUIDs.randomBase64UUID(random()))
-                .limit((Math.max(initialConfiguration.getNodeIds().size(), 2) - 1) / 2)
-                .forEach(nodeIdsWithPlaceholders::add);
-            final Set<String> nodeIds = new HashSet<>(randomSubsetOf(initialConfiguration.getNodeIds().size(), nodeIdsWithPlaceholders));
-            // initial configuration should not have a place holder for local node
-            if (initialConfiguration.getNodeIds().contains(localNode.getId()) && nodeIds.contains(localNode.getId()) == false) {
-                nodeIds.remove(nodeIds.iterator().next());
-                nodeIds.add(localNode.getId());
-            }
-            return new VotingConfiguration(nodeIds);
         }
     }
 


### PR DESCRIPTION
After introducing #94779 it's not necessary to inject a custom initial voting configuration for the AtomicRegisterCoordinatorTests. The initial configuration will be ignored since one it's already provided in the initial cluster state.

