### PR TITLE
Destringify APM tracer interface

### DIFF
--- a/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMTracer.java
+++ b/modules/apm/src/main/java/org/elasticsearch/tracing/apm/APMTracer.java
@@ -34,6 +34,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.tracing.SpanId;
 
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -59,7 +60,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     private static final Logger logger = LogManager.getLogger(APMTracer.class);
 
     /** Holds in-flight span information. */
-    private final Map<String, Context> spans = ConcurrentCollections.newConcurrentMap();
+    private final Map<SpanId, Context> spans = ConcurrentCollections.newConcurrentMap();
 
     private volatile boolean enabled;
     private volatile APMServices services;
@@ -158,7 +159,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void startTrace(ThreadContext threadContext, String spanId, String spanName, @Nullable Map<String, Object> attributes) {
+    public void startTrace(ThreadContext threadContext, SpanId spanId, String spanName, @Nullable Map<String, Object> attributes) {
         assert threadContext != null;
         assert spanId != null;
         assert spanName != null;
@@ -273,7 +274,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
      * @return a method to close the scope when you are finished with it.
      */
     @Override
-    public Releasable withScope(String spanId) {
+    public Releasable withScope(SpanId spanId) {
         final Context context = spans.get(spanId);
         if (context != null) {
             var scope = context.makeCurrent();
@@ -330,7 +331,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void addError(String spanId, Throwable throwable) {
+    public void addError(SpanId spanId, Throwable throwable) {
         final var span = Span.fromContextOrNull(spans.get(spanId));
         if (span != null) {
             span.recordException(throwable);
@@ -338,7 +339,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void setAttribute(String spanId, String key, boolean value) {
+    public void setAttribute(SpanId spanId, String key, boolean value) {
         final var span = Span.fromContextOrNull(spans.get(spanId));
         if (span != null) {
             span.setAttribute(key, value);
@@ -346,7 +347,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void setAttribute(String spanId, String key, double value) {
+    public void setAttribute(SpanId spanId, String key, double value) {
         final var span = Span.fromContextOrNull(spans.get(spanId));
         if (span != null) {
             span.setAttribute(key, value);
@@ -354,7 +355,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void setAttribute(String spanId, String key, long value) {
+    public void setAttribute(SpanId spanId, String key, long value) {
         final var span = Span.fromContextOrNull(spans.get(spanId));
         if (span != null) {
             span.setAttribute(key, value);
@@ -362,7 +363,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void setAttribute(String spanId, String key, String value) {
+    public void setAttribute(SpanId spanId, String key, String value) {
         final var span = Span.fromContextOrNull(spans.get(spanId));
         if (span != null) {
             span.setAttribute(key, value);
@@ -370,7 +371,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void stopTrace(String spanId) {
+    public void stopTrace(SpanId spanId) {
         final var span = Span.fromContextOrNull(spans.remove(spanId));
         if (span != null) {
             logger.trace("Finishing trace [{}]", spanId);
@@ -387,7 +388,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     @Override
-    public void addEvent(String spanId, String eventName) {
+    public void addEvent(SpanId spanId, String eventName) {
         final var span = Span.fromContextOrNull(spans.get(spanId));
         if (span != null) {
             span.addEvent(eventName);
@@ -412,7 +413,7 @@ public class APMTracer extends AbstractLifecycleComponent implements org.elastic
     }
 
     // VisibleForTesting
-    Map<String, Context> getSpans() {
+    Map<SpanId, Context> getSpans() {
         return spans;
     }
 

--- a/modules/apm/src/test/java/org/elasticsearch/tracing/apm/APMTracerTests.java
+++ b/modules/apm/src/test/java/org/elasticsearch/tracing/apm/APMTracerTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.tracing.SpanId;
 
 import java.util.List;
 import java.util.stream.Stream;
@@ -28,6 +29,10 @@ import static org.hamcrest.Matchers.notNullValue;
 
 public class APMTracerTests extends ESTestCase {
 
+    private static final SpanId SPAN_ID1 = SpanId.forBareString("id1");
+    private static final SpanId SPAN_ID2 = SpanId.forBareString("id2");
+    private static final SpanId SPAN_ID3 = SpanId.forBareString("id3");
+
     /**
      * Check that the tracer doesn't create spans when tracing is disabled.
      */
@@ -35,7 +40,7 @@ public class APMTracerTests extends ESTestCase {
         Settings settings = Settings.builder().put(APM_ENABLED_SETTING.getKey(), false).build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name1", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
 
         assertThat(apmTracer.getSpans(), anEmptyMap());
     }
@@ -50,7 +55,7 @@ public class APMTracerTests extends ESTestCase {
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name1", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
 
         assertThat(apmTracer.getSpans(), anEmptyMap());
     }
@@ -62,10 +67,10 @@ public class APMTracerTests extends ESTestCase {
         Settings settings = Settings.builder().put(APM_ENABLED_SETTING.getKey(), true).build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name1", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
 
         assertThat(apmTracer.getSpans(), aMapWithSize(1));
-        assertThat(apmTracer.getSpans(), hasKey("id1"));
+        assertThat(apmTracer.getSpans(), hasKey(SPAN_ID1));
     }
 
     /**
@@ -75,8 +80,8 @@ public class APMTracerTests extends ESTestCase {
         Settings settings = Settings.builder().put(APM_ENABLED_SETTING.getKey(), true).build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name1", null);
-        apmTracer.stopTrace("id1");
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name1", null);
+        apmTracer.stopTrace(SPAN_ID1);
 
         assertThat(apmTracer.getSpans(), anEmptyMap());
     }
@@ -93,7 +98,7 @@ public class APMTracerTests extends ESTestCase {
         APMTracer apmTracer = buildTracer(settings);
 
         ThreadContext threadContext = new ThreadContext(settings);
-        apmTracer.startTrace(threadContext, "id1", "name1", null);
+        apmTracer.startTrace(threadContext, SPAN_ID1, "name1", null);
         assertThat(threadContext.getTransient(Task.APM_TRACE_CONTEXT), notNullValue());
     }
 
@@ -114,13 +119,13 @@ public class APMTracerTests extends ESTestCase {
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name-aaa", null);
-        apmTracer.startTrace(new ThreadContext(settings), "id2", "name-bbb", null);
-        apmTracer.startTrace(new ThreadContext(settings), "id3", "name-ccc", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name-aaa", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID2, "name-bbb", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID3, "name-ccc", null);
 
-        assertThat(apmTracer.getSpans(), hasKey("id1"));
-        assertThat(apmTracer.getSpans(), hasKey("id2"));
-        assertThat(apmTracer.getSpans(), not(hasKey("id3")));
+        assertThat(apmTracer.getSpans(), hasKey(SPAN_ID1));
+        assertThat(apmTracer.getSpans(), hasKey(SPAN_ID2));
+        assertThat(apmTracer.getSpans(), not(hasKey(SPAN_ID3)));
     }
 
     /**
@@ -137,7 +142,7 @@ public class APMTracerTests extends ESTestCase {
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name-aaa", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name-aaa", null);
 
         assertThat(apmTracer.getSpans(), not(hasKey("id1")));
     }
@@ -159,13 +164,13 @@ public class APMTracerTests extends ESTestCase {
             .build();
         APMTracer apmTracer = buildTracer(settings);
 
-        apmTracer.startTrace(new ThreadContext(settings), "id1", "name-aaa", null);
-        apmTracer.startTrace(new ThreadContext(settings), "id2", "name-bbb", null);
-        apmTracer.startTrace(new ThreadContext(settings), "id3", "name-ccc", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID1, "name-aaa", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID2, "name-bbb", null);
+        apmTracer.startTrace(new ThreadContext(settings), SPAN_ID3, "name-ccc", null);
 
-        assertThat(apmTracer.getSpans(), not(hasKey("id1")));
-        assertThat(apmTracer.getSpans(), not(hasKey("id2")));
-        assertThat(apmTracer.getSpans(), hasKey("id3"));
+        assertThat(apmTracer.getSpans(), not(hasKey(SPAN_ID1)));
+        assertThat(apmTracer.getSpans(), not(hasKey(SPAN_ID2)));
+        assertThat(apmTracer.getSpans(), hasKey(SPAN_ID3));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/rest/RestController.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestController.java
@@ -490,11 +490,11 @@ public class RestController implements HttpServerTransport.Dispatcher {
             case HTTP_1_1 -> attributes.put("http.flavour", "1.1");
         }
 
-        tracer.startTrace(threadContext, "rest-" + channel.request().getRequestId(), name, attributes);
+        tracer.startTrace(threadContext, channel.request(), name, attributes);
     }
 
     private void traceException(RestChannel channel, Throwable e) {
-        this.tracer.addError("rest-" + channel.request().getRequestId(), e);
+        this.tracer.addError(channel.request(), e);
     }
 
     private static void sendContentTypeErrorMessage(@Nullable List<String> contentTypeHeader, RestChannel channel) throws IOException {

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -445,7 +445,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private DfsSearchResult executeDfsPhase(ShardSearchRequest request, SearchShardTask task) throws IOException {
         ReaderContext readerContext = createOrGetReaderContext(request);
         try (
-            Releasable scope = tracer.withScope("task-" + task.getId());
+            Releasable scope = tracer.withScope(task);
             Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
             SearchContext context = createContext(readerContext, request, task, true)
         ) {
@@ -626,7 +626,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     private SearchPhaseResult executeQueryPhase(ShardSearchRequest request, SearchShardTask task) throws Exception {
         final ReaderContext readerContext = createOrGetReaderContext(request);
         try (
-            Releasable scope = tracer.withScope("task-" + task.getId());
+            Releasable scope = tracer.withScope(task);
             Releasable ignored = readerContext.markAsUsed(getKeepAlive(request));
             SearchContext context = createContext(readerContext, request, task, true)
         ) {
@@ -668,7 +668,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
 
     private QueryFetchSearchResult executeFetchPhase(ReaderContext reader, SearchContext context, long afterQueryTime) {
         try (
-            Releasable scope = tracer.withScope("task-" + context.getTask().getId());
+            Releasable scope = tracer.withScope(context.getTask());
             SearchOperationListenerExecutor executor = new SearchOperationListenerExecutor(context, true, afterQueryTime)
         ) {
             shortcutDocIdsToLoad(context);

--- a/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskManager.java
@@ -171,7 +171,7 @@ public class TaskManager implements ClusterStateApplier {
             Tracer.AttributeKeys.PARENT_TASK_ID,
             parentTask.toString()
         );
-        tracer.startTrace(threadContext, "task-" + task.getId(), task.getAction(), attributes);
+        tracer.startTrace(threadContext, task, task.getAction(), attributes);
     }
 
     public <Request extends ActionRequest, Response extends ActionResponse> Task registerAndExecute(
@@ -288,7 +288,7 @@ public class TaskManager implements ClusterStateApplier {
                 return removedTask;
             }
         } finally {
-            tracer.stopTrace("task-" + task.getId());
+            tracer.stopTrace(task);
             for (RemovedTaskListener listener : removedTaskListeners) {
                 listener.onRemoved(task);
             }

--- a/server/src/main/java/org/elasticsearch/tracing/SpanId.java
+++ b/server/src/main/java/org/elasticsearch/tracing/SpanId.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.tracing;
+
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.tasks.Task;
+
+import java.util.Objects;
+
+public class SpanId {
+    private final String rawId;
+
+    private SpanId(String rawId) {
+        this.rawId = Objects.requireNonNull(rawId);
+    }
+
+    public String getRawId() {
+        return rawId;
+    }
+
+    @Override
+    public String toString() {
+        return "SpanId[" + rawId + "]";
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SpanId spanId = (SpanId) o;
+        return rawId.equals(spanId.rawId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(rawId);
+    }
+
+    public static SpanId forTask(Task task) {
+        return new SpanId("task-" + task.getId());
+    }
+
+    public static SpanId forRestRequest(RestRequest restRequest) {
+        return new SpanId("rest-" + restRequest.getRequestId());
+    }
+
+    public static SpanId forBareString(String rawId) {
+        return new SpanId(rawId);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/http/DefaultRestChannelTests.java
@@ -423,8 +423,8 @@ public class DefaultRestChannelTests extends ESTestCase {
 
         executeRequest(Settings.EMPTY, "request-host");
 
-        verify(tracer).setAttribute(argThat(id -> id.startsWith("rest-")), eq("http.status_code"), eq(200L));
-        verify(tracer).stopTrace(argThat(id -> id.startsWith("rest-")));
+        verify(tracer).setAttribute(argThat(id -> id.getRawId().startsWith("rest-")), eq("http.status_code"), eq(200L));
+        verify(tracer).stopTrace(any(RestRequest.class));
     }
 
     public void testHandleHeadRequest() {

--- a/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestControllerTests.java
@@ -188,7 +188,7 @@ public class RestControllerTests extends ESTestCase {
         restController.dispatchRequest(fakeRequest, channel, threadContext);
         verify(tracer).startTrace(
             eq(threadContext),
-            eq("rest-" + channel.request().getRequestId()),
+            eq(channel.request()),
             eq("GET /"),
             eq(Map.of("http.method", "GET", "http.flavour", "1.1", "http.url", "/"))
         );
@@ -768,8 +768,8 @@ public class RestControllerTests extends ESTestCase {
 
         final AssertingChannel channel = new AssertingChannel(request, true, RestStatus.METHOD_NOT_ALLOWED);
         restController.dispatchRequest(request, channel, client.threadPool().getThreadContext());
-        verify(tracer).startTrace(any(), anyString(), anyString(), anyMap());
-        verify(tracer).addError(any(), any(IllegalArgumentException.class));
+        verify(tracer).startTrace(any(), any(RestRequest.class), anyString(), anyMap());
+        verify(tracer).addError(any(RestRequest.class), any(IllegalArgumentException.class));
     }
 
     public void testDispatchCompatibleHandler() {

--- a/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/tasks/TaskManagerTests.java
@@ -294,7 +294,7 @@ public class TaskManagerTests extends ESTestCase {
             }
         });
 
-        verify(mockTracer).startTrace(any(), eq("task-" + task.getId()), eq("testAction"), anyMap());
+        verify(mockTracer).startTrace(any(), eq(task), eq("testAction"), anyMap());
     }
 
     /**
@@ -317,7 +317,7 @@ public class TaskManagerTests extends ESTestCase {
 
         taskManager.unregister(task);
 
-        verify(mockTracer).stopTrace("task-" + task.getId());
+        verify(mockTracer).stopTrace(task);
     }
 
     /**
@@ -353,7 +353,7 @@ public class TaskManagerTests extends ESTestCase {
             ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
-        verify(mockTracer).startTrace(any(), eq("task-" + task.getId()), eq("actionName"), anyMap());
+        verify(mockTracer).startTrace(any(), eq(task), eq("actionName"), anyMap());
     }
 
     public void testRegisterWithEnabledDisabledTracing() {


### PR DESCRIPTION
Today the APM `Tracer` interface identifies each span by a raw string, but in practice there is structure to these strings: task-related spans have IDs like `task-NNNN` and spans that relate to REST requests have IDs like `rest-NNNN`. This convention is distributed across the codebase a little too widely, so with this commit we centralise it into a `SpanId` class, and introduce specific overrides for `Task` and `RestRequest` to avoid callers needing to construct IDs themselves.