### PR TITLE
Close task after calling sendResponse()

### DIFF
--- a/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
+++ b/server/src/main/java/org/elasticsearch/transport/TaskTransportChannel.java
@@ -39,18 +39,18 @@ public class TaskTransportChannel implements TransportChannel {
     @Override
     public void sendResponse(TransportResponse response) throws IOException {
         try {
-            onTaskFinished.close();
-        } finally {
             channel.sendResponse(response);
+        } finally {
+            onTaskFinished.close();
         }
     }
 
     @Override
     public void sendResponse(Exception exception) throws IOException {
         try {
-            onTaskFinished.close();
-        } finally {
             channel.sendResponse(exception);
+        } finally {
+            onTaskFinished.close();
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TaskTransportChannelTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TaskTransportChannelTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.transport;
+
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.core.CheckedConsumer;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class TaskTransportChannelTests extends ESTestCase {
+
+    public void testClosesTaskAfterChannelHandoff() throws IOException {
+        runCompletionOrderTest(c -> c.sendResponse(new ElasticsearchException("simulated")));
+        runCompletionOrderTest(c -> c.sendResponse(TransportResponse.Empty.INSTANCE));
+    }
+
+    private void runCompletionOrderTest(CheckedConsumer<TransportChannel, IOException> channelConsumer) throws IOException {
+        final var stage = new AtomicInteger();
+        var channel = new TaskTransportChannel(
+            1,
+            new TestTransportChannel(ActionListener.running(() -> assertTrue(stage.compareAndSet(0, 1)))),
+            () -> assertTrue(stage.compareAndSet(1, 2))
+        );
+        channelConsumer.accept(channel);
+        assertEquals(2, stage.get());
+    }
+}


### PR DESCRIPTION
Today we unregister transport tasks before calling `TransportChannel#sendResponse` in order to send back the response. Yet the serialization and transmission work is still really part of the task's work, so we should keep the task around until these parts are done too.

This commit delays the task unregistration until after `sendResponse` returns, which is simple to achieve. Delaying it until the end of transmission is a little harder and will be the subject of future work.

Relates #94845