### PR TITLE
[8.7] Add note about ENV for systemd installs (#91424)

### DIFF
--- a/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
+++ b/docs/reference/setup/sysconfig/executable-jna-tmpdir.asciidoc
@@ -34,6 +34,9 @@ instance:
 export ES_TMPDIR=/usr/share/elasticsearch/tmp
 --------------------------------------------
 
+* For installs done through RPM or DEB packages, the environment variable needs
+to be set through the <<sysconfig,system configuration file>>.
+
 * If you are using `systemd` to run {es} as a service, add the following
 line to the `[Service]` section in a <<systemd,service override file>>:
 +


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Add note about ENV for systemd installs (#91424)](https://github.com/elastic/elasticsearch/pull/91424)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)