### PR TITLE
Remove data stream actions from all cluster actions

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolver.java
@@ -50,6 +50,7 @@ import org.elasticsearch.xpack.core.security.action.user.GetUsersAction;
 import org.elasticsearch.xpack.core.security.action.user.HasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.user.ProfileHasPrivilegesAction;
 import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.support.Automatons;
 import org.elasticsearch.xpack.core.slm.action.GetSnapshotLifecycleAction;
 
 import java.util.Collection;
@@ -61,6 +62,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 /**
@@ -97,9 +99,9 @@ public class ClusterPrivilegeResolver {
     private static final Set<String> ALL_CLUSTER_PATTERN = Set.of(
         "cluster:*",
         "indices:admin/template/*",
-        "indices:admin/index_template/*",
-        "indices:admin/data_stream/*"
+        "indices:admin/index_template/*"
     );
+    private static final Predicate<String> ACTION_MATCHER = Automatons.predicate(ALL_CLUSTER_PATTERN);
     private static final Set<String> MANAGE_ML_PATTERN = Set.of("cluster:admin/xpack/ml/*", "cluster:monitor/xpack/ml/*");
     private static final Set<String> MANAGE_TRANSFORM_PATTERN = Set.of(
         "cluster:admin/data_frame/*",
@@ -343,9 +345,7 @@ public class ClusterPrivilegeResolver {
     }
 
     public static boolean isClusterAction(String actionName) {
-        return actionName.startsWith("cluster:")
-            || actionName.startsWith("indices:admin/template/")
-            || actionName.startsWith("indices:admin/index_template/");
+        return ACTION_MATCHER.test(actionName);
     }
 
     private static String actionToPattern(String text) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolverTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/privilege/ClusterPrivilegeResolverTests.java
@@ -8,6 +8,8 @@
 package org.elasticsearch.xpack.core.security.authz.privilege;
 
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.transport.TransportRequest;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationTestHelper;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -15,6 +17,10 @@ import java.util.List;
 import java.util.SortedMap;
 
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockito.Mockito.mock;
 
 public class ClusterPrivilegeResolverTests extends ESTestCase {
 
@@ -42,4 +48,22 @@ public class ClusterPrivilegeResolverTests extends ESTestCase {
         );
     }
 
+    public void testDataStreamActionsNotGrantedByAllClusterPrivilege() {
+        ClusterPrivilegeResolver.ALL.permission()
+            .privileges()
+            .forEach(
+                p -> ((ActionClusterPrivilege) p).getAllowedActionPatterns()
+                    .forEach(pattern -> assertThat(pattern, not(startsWith("indices:admin/data_stream/"))))
+            );
+
+        assertThat(
+            ClusterPrivilegeResolver.ALL.permission()
+                .check(
+                    "indices:admin/data_stream/" + randomAlphaOfLengthBetween(0, 10),
+                    mock(TransportRequest.class),
+                    AuthenticationTestHelper.builder().build()
+                ),
+            is(false)
+        );
+    }
 }


### PR DESCRIPTION
The data stream actions were added to all cluster actions as a temporary measure when developing data stream
https://github.com/elastic/elasticsearch/pull/53666/files#r395491859

However it was not removed when the data stream feature is completed. It is not causing any real bug because isClusterAction test correctly directs data stream actions through the indices authorization path. This PR removes these actions from the ALL pattern. It also refactor the isClusterAction method to enforce consistency between the method and the ALL patterns.
