### PR TITLE
Update field-caps.asciidoc to add information about `include_unmapped`

### DIFF
--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -74,8 +74,8 @@ Defaults to `open`.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `include_unmapped`::
-  (Optional, Boolean) If `true`, unmapped fields are included in the response.
-  Defaults to `false`.
+  (Optional, Boolean) If `true`, unmapped fields that are mapped in one index but not in another are included in the response. Fields that don't have any mapping are never included.
+  Defaults to `false`. 
 
 `filters`::
 (Optional, string) Comma-separated list of filters to apply to the response.


### PR DESCRIPTION
This PR adds information about the `include_unmapped` parameter of the `field_caps` API. The current description leaves the impression, that if a field is generally unmapped, it is returned when setting `include_unmapped` to true. But this is not the case.
