### PR TITLE
Stop sorting indices in get-snapshots API

### DIFF
--- a/docs/changelog/94890.yaml
+++ b/docs/changelog/94890.yaml
@@ -1,0 +1,5 @@
+pr: 94890
+summary: Stop sorting indices in get-snapshots API
+area: Snapshot/Restore
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SharedClusterSnapshotRestoreIT.java
@@ -2238,8 +2238,7 @@ public class SharedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTestCas
 
     private void verifySnapshotInfo(final GetSnapshotsResponse response, final Map<String, List<String>> indicesPerSnapshot) {
         for (SnapshotInfo snapshotInfo : response.getSnapshots()) {
-            final List<String> expected = snapshotInfo.indices();
-            assertEquals(expected, indicesPerSnapshot.get(snapshotInfo.snapshotId().getName()));
+            assertEquals(Set.copyOf(indicesPerSnapshot.get(snapshotInfo.snapshotId().getName())), Set.copyOf(snapshotInfo.indices()));
             assertEquals(SnapshotState.SUCCESS, snapshotInfo.state());
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.get;
 
-import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
@@ -509,12 +508,10 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             }
         }
         for (Snapshot snapshot : toResolve) {
-            final List<String> indices = snapshotsToIndices.getOrDefault(snapshot.getSnapshotId(), Collections.emptyList());
-            CollectionUtil.timSort(indices);
             snapshotInfos.add(
                 new SnapshotInfo(
                     snapshot,
-                    indices,
+                    snapshotsToIndices.getOrDefault(snapshot.getSnapshotId(), Collections.emptyList()),
                     Collections.emptyList(),
                     Collections.emptyList(),
                     repositoryData.getSnapshotState(snapshot.getSnapshotId())


### PR DESCRIPTION
Today the get-snapshots API sorts the index list by name for every completed snapshot that matches the requested name pattern. This is pretty time-consuming in a large cluster, and much of the work is wasted when using pagination options that will filter out the snapshot later on in the process. Moreover we only do this when `?verbose=false`, and we don't do this for ongoing snapshots. There's nothing in the docs about the index list being in sorted order either, so I think we can just skip this step and save a bunch of time.