### PR TITLE
Add utility for atomic file move

### DIFF
--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/DatabaseNodeService.java
@@ -367,7 +367,7 @@ public final class DatabaseNodeService implements GeoIpDatabaseProvider, Closeab
                 }
 
                 LOGGER.debug("moving database from [{}] to [{}]", databaseTmpFile, databaseFile);
-                Files.move(databaseTmpFile, databaseFile, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                Files.move(databaseTmpFile, databaseFile, StandardCopyOption.ATOMIC_MOVE);
                 updateDatabase(databaseName, recordedMd5, databaseFile);
                 Files.delete(databaseTmpGzFile);
             },

--- a/server/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/io/FileSystemUtils.java
@@ -17,10 +17,14 @@ import org.elasticsearch.core.SuppressForbidden;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.StreamSupport;
+
+import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
+import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 
 /**
  * Elasticsearch utils to work with {@link java.nio.file.Path}
@@ -163,6 +167,21 @@ public final class FileSystemUtils {
 
     private static Path[] toArray(DirectoryStream<Path> stream) {
         return StreamSupport.stream(stream.spliterator(), false).toArray(length -> new Path[length]);
+    }
+
+    /**
+     * Moves a file from {@code source} to {@code target} using {@link java.nio.file.StandardCopyOption#ATOMIC_MOVE} if supported and falls
+     * back to a non-atomic move with flag {@link java.nio.file.StandardCopyOption#REPLACE_EXISTING} otherwise.
+     * @param source source path
+     * @param target target path
+     * @throws IOException on failure
+     */
+    public static void moveAtomicIfSupported(Path source, Path target) throws IOException {
+        try {
+            Files.move(source, target, ATOMIC_MOVE);
+        } catch (final AtomicMoveNotSupportedException e) {
+            Files.move(source, target, REPLACE_EXISTING);
+        }
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -511,7 +511,7 @@ public class KeyStoreWrapper implements SecureSettings {
         }
 
         try {
-            Files.move(keystoreTempFile, keystoreFile, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            Files.move(keystoreTempFile, keystoreFile, StandardCopyOption.ATOMIC_MOVE);
         } catch (Exception e) {
             try {
                 Files.deleteIfExists(keystoreTempFile);

--- a/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
+++ b/server/src/main/java/org/elasticsearch/env/NodeEnvironment.java
@@ -1308,7 +1308,7 @@ public final class NodeEnvironment implements Closeable {
             try {
                 Files.deleteIfExists(src);
                 Files.createFile(src);
-                Files.move(src, target, StandardCopyOption.ATOMIC_MOVE, StandardCopyOption.REPLACE_EXISTING);
+                Files.move(src, target, StandardCopyOption.ATOMIC_MOVE);
             } catch (AtomicMoveNotSupportedException ex) {
                 throw new IllegalStateException(
                     "atomic_move is not supported by the filesystem on path ["

--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -172,7 +172,7 @@ public class FsBlobContainerTests extends ESTestCase {
         this.fileSystem = new FilterFileSystemProvider("nooverwritefs://", fileSystem) {
             @Override
             public void move(Path source, Path target, CopyOption... options) throws IOException {
-                if (Set.of(options).contains(StandardCopyOption.ATOMIC_MOVE) && Files.exists(target)) {
+                if (options.length == 1 && options[0] == StandardCopyOption.ATOMIC_MOVE && Files.exists(target)) {
                     // simulate a file system that can't do atomic move + overwrite
                     throw new IOException("no atomic overwrite moves");
                 } else {

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/test/IdentityProviderIntegTestCase.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/test/IdentityProviderIntegTestCase.java
@@ -12,6 +12,7 @@ import org.elasticsearch.analysis.common.CommonAnalysisPlugin;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.SecureString;
@@ -34,7 +35,6 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -44,8 +44,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -255,12 +253,7 @@ public abstract class IdentityProviderIntegTestCase extends ESIntegTestCase {
             try (OutputStream os = Files.newOutputStream(tempFile, CREATE, TRUNCATE_EXISTING, WRITE)) {
                 Streams.copy(content, os);
             }
-
-            try {
-                Files.move(tempFile, path, REPLACE_EXISTING, ATOMIC_MOVE);
-            } catch (final AtomicMoveNotSupportedException e) {
-                Files.move(tempFile, path, REPLACE_EXISTING);
-            }
+            FileSystemUtils.moveAtomicIfSupported(tempFile, path);
         } catch (final IOException e) {
             throw new UncheckedIOException(Strings.format("could not write file [%s]", path.toAbsolutePath()), e);
         } finally {

--- a/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
+++ b/x-pack/plugin/security/cli/src/main/java/org/elasticsearch/xpack/security/cli/AutoConfigureNode.java
@@ -584,13 +584,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             // restore keystore to revert possible keystore bootstrap
             try {
                 if (Files.exists(keystoreBackupPath)) {
-                    Files.move(
-                        keystoreBackupPath,
-                        keystorePath,
-                        StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.ATOMIC_MOVE,
-                        StandardCopyOption.COPY_ATTRIBUTES
-                    );
+                    Files.move(keystoreBackupPath, keystorePath, StandardCopyOption.ATOMIC_MOVE);
                 } else {
                     Files.deleteIfExists(keystorePath);
                 }
@@ -631,13 +625,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
             // restore keystore to revert possible keystore bootstrap
             try {
                 if (Files.exists(keystoreBackupPath)) {
-                    Files.move(
-                        keystoreBackupPath,
-                        keystorePath,
-                        StandardCopyOption.REPLACE_EXISTING,
-                        StandardCopyOption.ATOMIC_MOVE,
-                        StandardCopyOption.COPY_ATTRIBUTES
-                    );
+                    Files.move(keystoreBackupPath, keystorePath, StandardCopyOption.ATOMIC_MOVE);
                 } else {
                     Files.deleteIfExists(keystorePath);
                 }
@@ -815,7 +803,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
         } catch (Throwable t) {
             try {
                 if (Files.exists(keystoreBackupPath)) {
-                    Files.move(keystoreBackupPath, keystorePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+                    Files.move(keystoreBackupPath, keystorePath, StandardCopyOption.ATOMIC_MOVE);
                 } else {
                     // this removes a statically named file, so it is potentially dangerous
                     Files.deleteIfExists(keystorePath);
@@ -1123,12 +1111,7 @@ public class AutoConfigureNode extends EnvironmentAwareCommand {
                     view.setGroup(groupPrincipal);
                 }
             }
-            if (replace) {
-                Files.move(tmpPath, filePath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-            } else {
-                Files.move(tmpPath, filePath, StandardCopyOption.ATOMIC_MOVE);
-            }
-
+            Files.move(tmpPath, filePath, StandardCopyOption.ATOMIC_MOVE);
         } finally {
             Files.deleteIfExists(tmpPath);
         }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadDuringStartupIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadDuringStartupIntegTests.java
@@ -196,7 +196,7 @@ public class SSLReloadDuringStartupIntegTests extends SecurityIntegTestCase {
         LOGGER.trace("Created temporary file [{}]", tmp);
         Files.copy(source, tmp, StandardCopyOption.REPLACE_EXISTING);
         try {
-            Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
+            Files.move(tmp, target, StandardCopyOption.ATOMIC_MOVE);
             LOGGER.debug("Atomic move succeeded from [{}] to [{}]", tmp, target);
         } catch (AtomicMoveNotSupportedException e) {
             Files.move(tmp, target, StandardCopyOption.REPLACE_EXISTING);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLReloadIntegTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ssl;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.MockSecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.SslConfiguration;
@@ -18,10 +19,8 @@ import org.elasticsearch.xpack.core.ssl.SSLService;
 
 import java.io.IOException;
 import java.net.SocketException;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardCopyOption;
 import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 
@@ -129,11 +128,7 @@ public class SSLReloadIntegTests extends SecurityIntegTestCase {
             logger.trace("expected exception", expected);
         }
         // Copy testnode_updated.crt to the placeholder updateable.crt so that the nodes will start trusting it now
-        try {
-            Files.move(certPath, updateableCertPath, StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
-        } catch (AtomicMoveNotSupportedException e) {
-            Files.move(certPath, updateableCertPath, StandardCopyOption.REPLACE_EXISTING);
-        }
+        FileSystemUtils.moveAtomicIfSupported(certPath, updateableCertPath);
         CountDownLatch latch = new CountDownLatch(1);
         assertBusy(() -> {
             try (SSLSocket socket = (SSLSocket) sslSocketFactory.createSocket(address.getAddress(), address.getPort())) {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLTrustRestrictionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/ssl/SSLTrustRestrictionsTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ssl;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.ssl.PemUtils;
 import org.elasticsearch.common.ssl.SslConfiguration;
@@ -28,7 +29,6 @@ import org.junit.BeforeClass;
 import java.io.IOException;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.security.PrivateKey;
@@ -42,8 +42,6 @@ import javax.net.ssl.SSLException;
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static org.elasticsearch.core.Strings.format;
 import static org.hamcrest.Matchers.is;
 
@@ -149,11 +147,7 @@ public class SSLTrustRestrictionsTests extends SecurityIntegTestCase {
     private void writeRestrictions(String trustedPattern) {
         try {
             Files.write(restrictionsTmpPath, Collections.singleton("trust.subject_name: \"" + trustedPattern + "\""));
-            try {
-                Files.move(restrictionsTmpPath, restrictionsPath, REPLACE_EXISTING, ATOMIC_MOVE);
-            } catch (final AtomicMoveNotSupportedException e) {
-                Files.move(restrictionsTmpPath, restrictionsPath, REPLACE_EXISTING);
-            }
+            FileSystemUtils.moveAtomicIfSupported(restrictionsTmpPath, restrictionsPath);
         } catch (IOException e) {
             throw new ElasticsearchException("failed to write restrictions", e);
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityFiles.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/SecurityFiles.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.security.support;
 
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.env.Environment;
 
@@ -13,7 +14,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFileAttributeView;
@@ -22,8 +22,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.Function;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -62,12 +60,7 @@ public class SecurityFiles {
                     setPosixAttributesOnTempFile(path, tempFile);
                 }
             }
-
-            try {
-                Files.move(tempFile, path, REPLACE_EXISTING, ATOMIC_MOVE);
-            } catch (final AtomicMoveNotSupportedException e) {
-                Files.move(tempFile, path, REPLACE_EXISTING);
-            }
+            FileSystemUtils.moveAtomicIfSupported(tempFile, path);
         } catch (final IOException e) {
             throw new UncheckedIOException(String.format(Locale.ROOT, "could not write file [%s]", path.toAbsolutePath()), e);
         } finally {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityTestUtils.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/test/SecurityTestUtils.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.routing.RecoverySource.ExistingStoreRecoverySou
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
+import org.elasticsearch.common.io.FileSystemUtils;
 import org.elasticsearch.common.io.Streams;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.Index;
@@ -25,13 +26,10 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.io.UncheckedIOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.AtomicMoveNotSupportedException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Locale;
 
-import static java.nio.file.StandardCopyOption.ATOMIC_MOVE;
-import static java.nio.file.StandardCopyOption.REPLACE_EXISTING;
 import static java.nio.file.StandardOpenOption.CREATE;
 import static java.nio.file.StandardOpenOption.TRUNCATE_EXISTING;
 import static java.nio.file.StandardOpenOption.WRITE;
@@ -49,11 +47,7 @@ public class SecurityTestUtils {
                 Streams.copy(content, os);
             }
 
-            try {
-                Files.move(tempFile, path, REPLACE_EXISTING, ATOMIC_MOVE);
-            } catch (final AtomicMoveNotSupportedException e) {
-                Files.move(tempFile, path, REPLACE_EXISTING);
-            }
+            FileSystemUtils.moveAtomicIfSupported(tempFile, path);
         } catch (final IOException e) {
             throw new UncheckedIOException(String.format(Locale.ROOT, "could not write file [%s]", path.toAbsolutePath()), e);
         } finally {


### PR DESCRIPTION
This first of all cleans up usages of Files.move that involved flags in addition to the atomic move flag because they are redundant since Files.move ignores them.
While doing so I found a common pattern where we use atomic move and if it's unsupported fall back to moving with the replace-existing flag. I'm not 100% convinced this is actually the correct pattern in all cases where an atomic overwrite fails but I think extracting to a dry utility is a good first step here in case we ever need to fix this.

