### PR TITLE
Streamline dropping indices in get-snapshots API

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.get;
 
-import org.apache.lucene.util.CollectionUtil;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.StepListener;
@@ -190,9 +189,10 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 order
             );
             final var snapshotInfos = sortedSnapshotsInRepos.snapshotInfos();
+            assert indices || snapshotInfos.stream().allMatch(snapshotInfo -> snapshotInfo.indices().isEmpty());
             final int finalRemaining = sortedSnapshotsInRepos.remaining() + remaining.get();
             return new GetSnapshotsResponse(
-                indices ? snapshotInfos : snapshotInfos.stream().map(SnapshotInfo::withoutIndices).toList(),
+                snapshotInfos,
                 failures,
                 finalRemaining > 0
                     ? GetSnapshotsRequest.After.from(snapshotInfos.get(snapshotInfos.size() - 1), sortBy).asQueryParam()
@@ -214,6 +214,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                     sortBy,
                     after,
                     order,
+                    indices,
                     listeners.acquire((SnapshotsInRepo snapshotsInRepo) -> {
                         allSnapshotInfos.add(snapshotsInRepo.snapshotInfos());
                         remaining.addAndGet(snapshotsInRepo.remaining());
@@ -242,6 +243,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         GetSnapshotsRequest.SortBy sortBy,
         @Nullable final GetSnapshotsRequest.After after,
         SortOrder order,
+        boolean indices,
         ActionListener<SnapshotsInRepo> listener
     ) {
         final Map<String, Snapshot> allSnapshotIds = new HashMap<>();
@@ -249,7 +251,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         for (SnapshotInfo snapshotInfo : currentSnapshots(snapshotsInProgress, repo)) {
             Snapshot snapshot = snapshotInfo.snapshot();
             allSnapshotIds.put(snapshot.getSnapshotId().getName(), snapshot);
-            currentSnapshots.add(snapshotInfo);
+            currentSnapshots.add(snapshotInfo.maybeWithoutIndices(indices));
         }
 
         final StepListener<RepositoryData> repositoryDataListener = new StepListener<>();
@@ -274,6 +276,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 after,
                 order,
                 predicates,
+                indices,
                 listener
             ),
             listener::onFailure
@@ -314,6 +317,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         @Nullable final GetSnapshotsRequest.After after,
         SortOrder order,
         SnapshotPredicates predicates,
+        boolean indices,
         ActionListener<SnapshotsInRepo> listener
     ) {
         if (task.notifyIfCancelled(listener)) {
@@ -388,6 +392,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
                 after,
                 order,
                 predicates,
+                indices,
                 listener
             );
         } else {
@@ -395,7 +400,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             final SnapshotsInRepo snapshotInfos;
             if (repositoryData != null) {
                 // want non-current snapshots as well, which are found in the repository data
-                snapshotInfos = buildSimpleSnapshotInfos(toResolve, repo, repositoryData, currentSnapshots, sortBy, after, order);
+                snapshotInfos = buildSimpleSnapshotInfos(toResolve, repo, repositoryData, currentSnapshots, sortBy, after, order, indices);
             } else {
                 // only want current snapshots
                 snapshotInfos = sortSnapshots(
@@ -413,10 +418,12 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
 
     /**
      * Returns a list of snapshots from repository sorted by snapshot creation date
-     *  @param snapshotsInProgress snapshots in progress in the cluster state
+     *
+     * @param snapshotsInProgress snapshots in progress in the cluster state
      * @param repositoryName      repository name
      * @param snapshotIds         snapshots for which to fetch snapshot information
      * @param ignoreUnavailable   if true, snapshots that could not be read will only be logged with a warning,
+     * @param indices             if false, drop the list of indices from each result
      */
     private void snapshots(
         SnapshotsInProgress snapshotsInProgress,
@@ -428,6 +435,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         @Nullable GetSnapshotsRequest.After after,
         SortOrder order,
         SnapshotPredicates predicate,
+        boolean indices,
         ActionListener<SnapshotsInRepo> listener
     ) {
         if (task.notifyIfCancelled(listener)) {
@@ -445,7 +453,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             if (snapshotIdsToIterate.remove(entry.snapshot().getSnapshotId())) {
                 final SnapshotInfo snapshotInfo = SnapshotInfo.inProgress(entry);
                 if (predicate.test(snapshotInfo)) {
-                    snapshotSet.add(snapshotInfo);
+                    snapshotSet.add(snapshotInfo.maybeWithoutIndices(indices));
                 }
             }
         }
@@ -475,7 +483,7 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         repository.getSnapshotInfo(
             new GetSnapshotInfoContext(snapshotIdsToIterate, ignoreUnavailable == false, task::isCancelled, (context, snapshotInfo) -> {
                 if (predicate.test(snapshotInfo)) {
-                    snapshotInfos.add(snapshotInfo);
+                    snapshotInfos.add(snapshotInfo.maybeWithoutIndices(indices));
                 }
             }, allDoneListener)
         );
@@ -492,7 +500,8 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         final List<SnapshotInfo> currentSnapshots,
         final GetSnapshotsRequest.SortBy sortBy,
         @Nullable final GetSnapshotsRequest.After after,
-        final SortOrder order
+        final SortOrder order,
+        boolean indices
     ) {
         List<SnapshotInfo> snapshotInfos = new ArrayList<>();
         for (SnapshotInfo snapshotInfo : currentSnapshots) {
@@ -501,20 +510,20 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
             }
         }
         Map<SnapshotId, List<String>> snapshotsToIndices = new HashMap<>();
-        for (IndexId indexId : repositoryData.getIndices().values()) {
-            for (SnapshotId snapshotId : repositoryData.getSnapshots(indexId)) {
-                if (toResolve.contains(new Snapshot(repoName, snapshotId))) {
-                    snapshotsToIndices.computeIfAbsent(snapshotId, (k) -> new ArrayList<>()).add(indexId.getName());
+        if (indices) {
+            for (IndexId indexId : repositoryData.getIndices().values()) {
+                for (SnapshotId snapshotId : repositoryData.getSnapshots(indexId)) {
+                    if (toResolve.contains(new Snapshot(repoName, snapshotId))) {
+                        snapshotsToIndices.computeIfAbsent(snapshotId, (k) -> new ArrayList<>()).add(indexId.getName());
+                    }
                 }
             }
         }
         for (Snapshot snapshot : toResolve) {
-            final List<String> indices = snapshotsToIndices.getOrDefault(snapshot.getSnapshotId(), Collections.emptyList());
-            CollectionUtil.timSort(indices);
             snapshotInfos.add(
                 new SnapshotInfo(
                     snapshot,
-                    indices,
+                    snapshotsToIndices.getOrDefault(snapshot.getSnapshotId(), Collections.emptyList()),
                     Collections.emptyList(),
                     Collections.emptyList(),
                     repositoryData.getSnapshotState(snapshot.getSnapshotId())

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -469,8 +469,8 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         this.indexSnapshotDetails = Map.copyOf(indexSnapshotDetails);
     }
 
-    public SnapshotInfo withoutIndices() {
-        if (indices.isEmpty()) {
+    public SnapshotInfo maybeWithoutIndices(boolean retainIndices) {
+        if (retainIndices || indices.isEmpty()) {
             return this;
         }
         return new SnapshotInfo(


### PR DESCRIPTION
Today when calling the get-snapshots API with `?indices=false` we still do a bunch of unnecessary work to invert the index/snapshot mapping for all snapshots. This commit pushes the index-dropping logic lower down to skip this unnecessary work.