### PR TITLE
Remove TopDocsCollectorContext#shouldRescore method

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -79,9 +79,7 @@ public class QueryPhase {
         AggregationPhase.preProcess(searchContext);
         executeInternal(searchContext);
 
-        if (searchContext.rescore().isEmpty() == false) { // only if we do a regular search
-            RescorePhase.execute(searchContext);
-        }
+        RescorePhase.execute(searchContext);
         SuggestPhase.execute(searchContext);
         AggregationPhase.execute(searchContext);
 

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -91,7 +91,6 @@ public class QueryPhase {
     /**
      * In a package-private method so that it can be tested without having to
      * wire everything (mapperService, etc.)
-     * @return whether the rescoring phase should be executed
      */
     static void executeInternal(SearchContext searchContext) throws QueryPhaseExecutionException {
         final ContextIndexSearcher searcher = searchContext.searcher();

--- a/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/TopDocsCollectorContext.java
@@ -74,20 +74,6 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
         this.numHits = numHits;
     }
 
-    /**
-     * Returns the number of top docs to retrieve
-     */
-    final int numHits() {
-        return numHits;
-    }
-
-    /**
-     * Returns true if the top docs should be re-scored after initial search
-     */
-    boolean shouldRescore() {
-        return false;
-    }
-
     static class EmptyTopDocsCollectorContext extends TopDocsCollectorContext {
         private final Sort sort;
         private final Collector collector;
@@ -188,7 +174,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
         }
     }
 
-    abstract static class SimpleTopDocsCollectorContext extends TopDocsCollectorContext {
+    static class SimpleTopDocsCollectorContext extends TopDocsCollectorContext {
 
         private static TopDocsCollector<?> createCollector(
             @Nullable SortAndFormats sortAndFormats,
@@ -479,12 +465,7 @@ abstract class TopDocsCollectorContext extends QueryCollectorContext {
                 searchContext.trackScores(),
                 searchContext.trackTotalHitsUpTo(),
                 hasFilterCollector
-            ) {
-                @Override
-                boolean shouldRescore() {
-                    return rescore;
-                }
-            };
+            );
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
@@ -22,6 +22,10 @@ import java.io.IOException;
 public class RescorePhase {
 
     public static void execute(SearchContext context) {
+        if (context.size() == 0 || context.collapse() != null || context.rescore() == null || context.rescore().isEmpty()) {
+            return;
+        }
+
         TopDocs topDocs = context.queryResult().topDocs().topDocs;
         if (topDocs.scoreDocs.length == 0) {
             return;

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -116,8 +116,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         context.parsedQuery(new ParsedQuery(query));
         context.setSize(0);
         context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        final boolean rescore = QueryPhase.executeInternal(context);
-        assertFalse(rescore);
+        QueryPhase.executeInternal(context);
 
         ContextIndexSearcher countSearcher = shouldCollectCount
             ? newContextSearcher(reader)


### PR DESCRIPTION
QueryPhase#executeInternal returns a boolean that tells whether we
should rescore. That one is returned by searchWithCollector which in
turn is returned by TopDocsCollectorContext#shouldRescore which returns
false by default and the only subclass that overrides it returns whether
the search context had a rescorer configured. 

We can simplify this by pulling out the logic that we use to make the decision on whether to execute the rescore phase or not, and remove the shouldRescore method and return value that gets carried around which adds complexity.