### PR TITLE
Publish test artifact from server project

### DIFF
--- a/server/build.gradle
+++ b/server/build.gradle
@@ -11,6 +11,7 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 apply plugin: 'elasticsearch.build'
 apply plugin: 'elasticsearch.publish'
 apply plugin: 'elasticsearch.internal-cluster-test'
+apply plugin: 'elasticsearch.internal-test-artifact'
 
 publishing {
   publications {


### PR DESCRIPTION
This allows other projects to extend tests from server. This supports running some of these unit tests in different configurations.