### PR TITLE
[8.7] Closing an empty PIT should return 200 (#94708)

### DIFF
--- a/docs/changelog/94708.yaml
+++ b/docs/changelog/94708.yaml
@@ -1,0 +1,5 @@
+pr: 94708
+summary: Return 200 when closing empty PIT or scroll
+area: Search
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -22,6 +23,7 @@ import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.indices.IndicesService;
+import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.search.SearchContextMissingException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchService;
@@ -277,6 +279,14 @@ public class PointInTimeIT extends ESIntegTestCase {
         } finally {
             closePointInTime(pit);
         }
+    }
+
+    public void testAllowNoIndex() {
+        var request = new OpenPointInTimeRequest("my_index").indicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+            .keepAlive(TimeValue.timeValueMinutes(between(1, 10)));
+        String pit = client().execute(OpenPointInTimeAction.INSTANCE, request).actionGet().getPointInTimeId();
+        var closeResp = client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest(pit)).actionGet();
+        assertThat(closeResp.status(), equalTo(RestStatus.OK));
     }
 
     public void testCanMatch() throws Exception {

--- a/server/src/main/java/org/elasticsearch/action/search/ClosePointInTimeResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/ClosePointInTimeResponse.java
@@ -9,8 +9,12 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.rest.RestStatus;
 
 import java.io.IOException;
+
+import static org.elasticsearch.rest.RestStatus.NOT_FOUND;
+import static org.elasticsearch.rest.RestStatus.OK;
 
 public class ClosePointInTimeResponse extends ClearScrollResponse {
     public ClosePointInTimeResponse(boolean succeeded, int numFreed) {
@@ -19,5 +23,14 @@ public class ClosePointInTimeResponse extends ClearScrollResponse {
 
     public ClosePointInTimeResponse(StreamInput in) throws IOException {
         super(in);
+    }
+
+    @Override
+    public RestStatus status() {
+        if (isSucceeded() || getNumFreed() > 0) {
+            return OK;
+        } else {
+            return NOT_FOUND;
+        }
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Closing an empty PIT should return 200 (#94708)