### PR TITLE
[Docs] Ensure breaking-changes tag exists for empty and existing breaking changes

### DIFF
--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -15,10 +15,10 @@ coming::[${majorDotMinorDotRevision}]
 [discrete]
 [[breaking-changes-${majorDotMinor}]]
 === Breaking changes
-<% if (breakingByNotabilityByArea.isEmpty()) { %>
+
 // tag::notable-breaking-changes[]
+<% if (breakingByNotabilityByArea.isEmpty()) { %>
 There are no breaking changes in {es} ${majorDotMinor}.
-// end::notable-breaking-changes[]
 <% } else { %>
 The following changes in {es} ${majorDotMinor} might affect your applications
 and prevent them from operating normally.
@@ -61,10 +61,10 @@ ${breaking.impact.trim()}
             }
         }
     }
-}
+} %>
+// end::notable-breaking-changes[]
 
-if (deprecationsByNotabilityByArea.isEmpty() == false) { %>
-
+<% if (deprecationsByNotabilityByArea.isEmpty() == false) { %>
 [discrete]
 [[deprecated-${majorDotMinor}]]
 === Deprecations

--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -15,10 +15,10 @@ coming::[${majorDotMinorDotRevision}]
 [discrete]
 [[breaking-changes-${majorDotMinor}]]
 === Breaking changes
-
-// tag::notable-breaking-changes[]
 <% if (breakingByNotabilityByArea.isEmpty()) { %>
+// tag::notable-breaking-changes[]
 There are no breaking changes in {es} ${majorDotMinor}.
+// end::notable-breaking-changes[]
 <% } else { %>
 The following changes in {es} ${majorDotMinor} might affect your applications
 and prevent them from operating normally.
@@ -61,10 +61,10 @@ ${breaking.impact.trim()}
             }
         }
     }
-} %>
-// end::notable-breaking-changes[]
+}
 
-<% if (deprecationsByNotabilityByArea.isEmpty() == false) { %>
+if (deprecationsByNotabilityByArea.isEmpty() == false) { %>
+
 [discrete]
 [[deprecated-${majorDotMinor}]]
 === Deprecations

--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -26,6 +26,12 @@ Before upgrading to ${majorDotMinor}, review these changes and take the describe
 to mitigate the impact.
 
 <%
+    if (breakingByNotabilityByArea.getOrDefault(true, []).isEmpty()) { %>
+// tag::notable-breaking-changes[]
+There are no notable breaking changes in {es} ${majorDotMinor}.
+// end::notable-breaking-changes[]
+But there are some minor breaking changes.
+<%  }
     [true, false].each { isNotable ->
         def breakingByArea = breakingByNotabilityByArea.getOrDefault(isNotable, [])
         if (breakingByArea.isEmpty() == false) {

--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -30,7 +30,7 @@ to mitigate the impact.
 // tag::notable-breaking-changes[]
 There are no notable breaking changes in {es} ${majorDotMinor}.
 // end::notable-breaking-changes[]
-But there are some minor breaking changes.
+But there are some less critical breaking changes.
 <%  }
     [true, false].each { isNotable ->
         def breakingByArea = breakingByNotabilityByArea.getOrDefault(isNotable, [])


### PR DESCRIPTION
The original feature only added the tags when there were breaking changes with `notable: true`. Last year we improved this by adding the tag when there were no breaking changes (in 8.3.0). However we missed the case where there are breaking changes, but the `notable: false` means the tags did not get added. This fixes that case.

I manually tested this with three cases:

* No breaking changes
* Only one notable=false
* One notable:false and one notable:true

Fixes #94910 