### PR TITLE
Fixed breaking changes to exclude non-notable

### DIFF
--- a/docs/reference/migration/migrate_8_7.asciidoc
+++ b/docs/reference/migration/migrate_8_7.asciidoc
@@ -22,6 +22,10 @@ Before upgrading to 8.7, review these changes and take the described steps
 to mitigate the impact.
 
 // tag::notable-breaking-changes[]
+There are no notable breaking changes in {es} 8.7.
+// end::notable-breaking-changes[]
+But there are some less critical breaking changes.
+
 [discrete]
 [[breaking_87_ingest_changes]]
 ==== Ingest changes
@@ -42,4 +46,3 @@ were sending invalid JSON data to the `json` processor.
 Ensure your application only sends valid JSON data to the `json` processor, or modify the `json` processors in your pipelines to set
 the `strict_json_parsing` parameter to `false`.
 ====
-// end::notable-breaking-changes[]


### PR DESCRIPTION
Based on the discoveries and fix in https://github.com/elastic/elasticsearch/pull/94911, we manually fixed 8.7