### PR TITLE
Use insecure settings only when no other secure settings are present

### DIFF
--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -159,7 +159,7 @@ public class Environment {
             finalSettings.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataFile.toString());
         }
 
-        if (DiscoveryNode.isStateless(settings)) {
+        if (DiscoveryNode.isStateless(settings) && Objects.isNull(finalSettings.getSecureSettings())) {
             this.settings = StatelessSecureSettings.install(finalSettings.build());
         } else {
             this.settings = finalSettings.build();

--- a/server/src/main/java/org/elasticsearch/env/Environment.java
+++ b/server/src/main/java/org/elasticsearch/env/Environment.java
@@ -159,7 +159,8 @@ public class Environment {
             finalSettings.put(Environment.PATH_SHARED_DATA_SETTING.getKey(), sharedDataFile.toString());
         }
 
-        if (DiscoveryNode.isStateless(settings) && Objects.isNull(finalSettings.getSecureSettings())) {
+        if (DiscoveryNode.isStateless(settings)
+            && (Objects.isNull(finalSettings.getSecureSettings()) || finalSettings.getSecureSettings().getSettingNames().isEmpty())) {
             this.settings = StatelessSecureSettings.install(finalSettings.build());
         } else {
             this.settings = finalSettings.build();


### PR DESCRIPTION
Stateless Elasticsearch can now use file-based secure settings or, in some cases, MockSecureSettings. When file settings or mock settings are present, we shouldn't override them with the "insecure" workaround mechanism.