### PR TITLE
Early terminate shortcut total hit count when collecting hits

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -339,7 +339,6 @@ public class QueryPhaseTests extends IndexShardTestCase {
         dir.close();
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94912")
     public void testTerminateAfterEarlyTermination() throws Exception {
         Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig();

--- a/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorContextTests.java
@@ -16,18 +16,23 @@ import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.document.TextField;
 import org.apache.lucene.index.IndexReader;
+import org.apache.lucene.index.LeafReaderContext;
+import org.apache.lucene.index.Term;
 import org.apache.lucene.search.FieldExistsQuery;
+import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.index.RandomIndexWriter;
 import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
 public class TopDocsCollectorContextTests extends ESTestCase {
 
-    public void testShortcutTotalHitCountTextField() throws IOException {
+    public void testShortcutTotalHitCountTextFieldExists() throws IOException {
         try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
             doc.add(new TextField("text", "value", Field.Store.NO));
@@ -39,13 +44,13 @@ public class TopDocsCollectorContextTests extends ESTestCase {
             iw.commit();
             try (IndexReader reader = iw.getReader()) {
                 final Query testQuery = new FieldExistsQuery("text");
-                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery);
+                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, SearchContext.DEFAULT_TERMINATE_AFTER);
                 assertEquals(-1, hitCount);
             }
         }
     }
 
-    public void testShortcutTotalHitCountStringField() throws IOException {
+    public void testShortcutTotalHitCountStringFieldExists() throws IOException {
         try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
             doc.add(new StringField("string", "value", Field.Store.NO));
@@ -59,13 +64,30 @@ public class TopDocsCollectorContextTests extends ESTestCase {
             iw.commit();
             try (IndexReader reader = iw.getReader()) {
                 final Query testQuery = new FieldExistsQuery("string");
-                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery);
+                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, SearchContext.DEFAULT_TERMINATE_AFTER);
                 assertEquals(2, hitCount);
             }
         }
     }
 
-    public void testShortcutTotalHitCountNumericField() throws IOException {
+    public void testShortcutTotalHitCountStringFieldExistsTerminateAfter() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            int numDocs = randomIntBetween(5, 10);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("string", "value", Field.Store.NO));
+                doc.add(new SortedDocValuesField("string", new BytesRef("value")));
+                iw.addDocument(doc);
+            }
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new FieldExistsQuery("string");
+                assertEquals(hitCountUpTo(reader, 3), TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, 3));
+            }
+        }
+    }
+
+    public void testShortcutTotalHitCountNumericFieldExists() throws IOException {
         try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
             Document doc = new Document();
             doc.add(new IntPoint("int", 10));
@@ -75,9 +97,69 @@ public class TopDocsCollectorContextTests extends ESTestCase {
             iw.commit();
             try (IndexReader reader = iw.getReader()) {
                 final Query testQuery = new FieldExistsQuery("int");
-                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery);
+                int hitCount = TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, SearchContext.DEFAULT_TERMINATE_AFTER);
                 assertEquals(1, hitCount);
             }
         }
+    }
+
+    public void testShortcutTotalHitCountMatchAllQuery() throws IOException{
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            int numDocs = randomIntBetween(5, 10);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                iw.addDocument(doc);
+            }
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new MatchAllDocsQuery();
+                assertEquals(numDocs, TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, 0));
+                assertEquals(hitCountUpTo(reader, 3), TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, 3));
+            }
+        }
+    }
+
+    public void testShortcutTotalHitCountTermQuery() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            int numDocs = randomIntBetween(5, 10);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("string", "value", Field.Store.NO));
+                iw.addDocument(doc);
+            }
+            iw.addDocument(new Document());
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new TermQuery(new Term("string", "value"));
+                assertEquals(numDocs, TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, 0));
+            }
+        }
+    }
+
+    public void testShortcutTotalHitCountTermQueryTerminateAfter() throws IOException {
+        try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
+            int numDocs = randomIntBetween(5, 10);
+            for (int i = 0; i < numDocs; i++) {
+                Document doc = new Document();
+                doc.add(new StringField("string", "value", Field.Store.NO));
+                iw.addDocument(doc);
+            }
+            iw.commit();
+            try (IndexReader reader = iw.getReader()) {
+                final Query testQuery = new TermQuery(new Term("string", "value"));
+                assertEquals(hitCountUpTo(reader, 5), TopDocsCollectorContext.shortcutTotalHitCount(reader, testQuery, 5));
+            }
+        }
+    }
+
+    static int hitCountUpTo(IndexReader reader, int terminateAfter) {
+        int total = 0;
+        for (LeafReaderContext leaf : reader.leaves()) {
+            total += leaf.reader().numDocs();
+            if (total >= terminateAfter) {
+                break;
+            }
+        }
+        return total;
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorContextTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorContextTests.java
@@ -103,7 +103,7 @@ public class TopDocsCollectorContextTests extends ESTestCase {
         }
     }
 
-    public void testShortcutTotalHitCountMatchAllQuery() throws IOException{
+    public void testShortcutTotalHitCountMatchAllQuery() throws IOException {
         try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
             int numDocs = randomIntBetween(5, 10);
             for (int i = 0; i < numDocs; i++) {


### PR DESCRIPTION
With #94889 we return hit count that may be higher than the set terminate_after value. This was done to introduce consistency between the case when size is set to 0, for which we completely delegate to TotalHitCountCollector, and the case when we do collect hits for which we have a manual shortcutTotalHitCount method. The latter should early terminate though when terminate_after is set, and stop incrementing the counter once it reached the provided threshold when retrieving counts from the index statistics of the last segment.

Closes #94912