### PR TITLE
[8.7] Make id parameter optional in logstash.get_pipeline API (#84150)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/logstash.get_pipeline.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/logstash.get_pipeline.json
@@ -12,6 +12,10 @@
     "url":{
       "paths":[
         {
+          "path":"/_logstash/pipeline",
+          "methods":[ "GET" ]
+        },
+        {
           "path":"/_logstash/pipeline/{id}",
           "methods":[ "GET" ],
           "parts":{


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Make id parameter optional in logstash.get_pipeline API (#84150)