### PR TITLE
[8.7] [Docs] Ensure breaking-changes tag exists for empty and existing breaking changes (#94911)

### DIFF
--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -26,6 +26,12 @@ Before upgrading to ${majorDotMinor}, review these changes and take the describe
 to mitigate the impact.
 
 <%
+    if (breakingByNotabilityByArea.getOrDefault(true, []).isEmpty()) { %>
+// tag::notable-breaking-changes[]
+There are no notable breaking changes in {es} ${majorDotMinor}.
+// end::notable-breaking-changes[]
+But there are some less critical breaking changes.
+<%  }
     [true, false].each { isNotable ->
         def breakingByArea = breakingByNotabilityByArea.getOrDefault(isNotable, [])
         if (breakingByArea.isEmpty() == false) {


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [Docs] Ensure breaking-changes tag exists for empty and existing breaking changes (#94911)