### PR TITLE
[Docs] Remove coming 8.7.0 line from migration guide

### DIFF
--- a/docs/reference/migration/migrate_8_7.asciidoc
+++ b/docs/reference/migration/migrate_8_7.asciidoc
@@ -9,9 +9,6 @@ your application to {es} 8.7.
 
 See also {ref-bare}/8.7/release-highlights.html[What's new in 8.7] and <<es-release-notes>>.
 
-coming::[8.7.0]
-
-
 [discrete]
 [[breaking-changes-8.7]]
 === Breaking changes


### PR DESCRIPTION
Noticed in the review of https://github.com/elastic/elasticsearch/pull/94934, was the fact that this line needs to be removed. So we remove it from 8.7 branch also.