### PR TITLE
[DOCS] Remove SNAPSHOT references from stable plugin example

### DIFF
--- a/docs/plugins/development/example-text-analysis-plugin.asciidoc
+++ b/docs/plugins/development/example-text-analysis-plugin.asciidoc
@@ -22,48 +22,48 @@ ext.pluginApiVersion = '8.7.0'
 ext.luceneVersion = '9.5.0'
 
 buildscript {
-    ext.pluginApiVersion = '8.7.0'
-    repositories {
-        mavenCentral()
-    }
-    dependencies {
-        classpath "org.elasticsearch.gradle:build-tools:${pluginApiVersion}"
-    }
+  ext.pluginApiVersion = '8.7.0'
+  repositories {
+      mavenCentral()
+  }
+  dependencies {
+      classpath "org.elasticsearch.gradle:build-tools:${pluginApiVersion}"
+  }
 }
 
 apply plugin: 'elasticsearch.stable-esplugin'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 esplugin {
-    name 'my-plugin'
-    description 'My analysis plugin'
+  name 'my-plugin'
+  description 'My analysis plugin'
 }
 
 group 'org.example'
 version '1.0-SNAPSHOT'
 
 repositories {
-    mavenLocal()
-    mavenCentral()
+  mavenLocal()
+  mavenCentral()
 }
 
 dependencies {
 
-    //TODO transitive dependency off and plugin-api dependency?
-    compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
-    compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
-    compileOnly "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
+  //TODO transitive dependency off and plugin-api dependency?
+  compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
+  compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
+  compileOnly "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
 
-    //TODO for testing this also have to be declared
-    testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
-    testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
-    testImplementation "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
+  //TODO for testing this also have to be declared
+  testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
+  testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
+  testImplementation "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
 
-    testImplementation ('junit:junit:4.13.2'){
-        exclude group: 'org.hamcrest'
-    }
-    testImplementation 'org.mockito:mockito-core:4.4.0'
-    testImplementation 'org.hamcrest:hamcrest:2.2'
+  testImplementation ('junit:junit:4.13.2'){
+      exclude group: 'org.hamcrest'
+  }
+  testImplementation 'org.mockito:mockito-core:4.4.0'
+  testImplementation 'org.hamcrest:hamcrest:2.2'
 
 }
 ----

--- a/docs/plugins/development/example-text-analysis-plugin.asciidoc
+++ b/docs/plugins/development/example-text-analysis-plugin.asciidoc
@@ -18,61 +18,52 @@ directory:
 +
 [source,gradle]
 ----
-ext.pluginApiVersion = '8.7.0-SNAPSHOT'
-ext.luceneVersion = '9.5.0-snapshot-d19c3e2e0ed'
+ext.pluginApiVersion = '8.7.0'
+ext.luceneVersion = '9.5.0'
 
 buildscript {
-  ext.pluginApiVersion = '8.7.0-SNAPSHOT'
-  repositories {
-    maven {
-      url = 'https://snapshots.elastic.co/maven/'
+    ext.pluginApiVersion = '8.7.0'
+    repositories {
+        mavenCentral()
     }
-    mavenCentral()
-  }
-  dependencies {
-    classpath "org.elasticsearch.gradle:build-tools:${pluginApiVersion}"
-  }
+    dependencies {
+        classpath "org.elasticsearch.gradle:build-tools:${pluginApiVersion}"
+    }
 }
 
 apply plugin: 'elasticsearch.stable-esplugin'
 apply plugin: 'elasticsearch.yaml-rest-test'
 
 esplugin {
-  name 'my-plugin'
-  description 'My analysis plugin'
+    name 'my-plugin'
+    description 'My analysis plugin'
 }
 
 group 'org.example'
 version '1.0-SNAPSHOT'
 
 repositories {
-  maven {
-    url = "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/d19c3e2e0ed/"
-  }
-  maven {
-    url = 'https://snapshots.elastic.co/maven/'
-  }
-  mavenLocal()
-  mavenCentral()
+    mavenLocal()
+    mavenCentral()
 }
 
 dependencies {
 
-  //TODO transitive dependency off and plugin-api dependency?
-  compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
-  compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
-  compileOnly "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
+    //TODO transitive dependency off and plugin-api dependency?
+    compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
+    compileOnly "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
+    compileOnly "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
 
-  //TODO for testing this also have to be declared
-  testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
-  testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
-  testImplementation "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
+    //TODO for testing this also have to be declared
+    testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-api:${pluginApiVersion}"
+    testImplementation "org.elasticsearch.plugin:elasticsearch-plugin-analysis-api:${pluginApiVersion}"
+    testImplementation "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
 
-  testImplementation ('junit:junit:4.13.2'){
-    exclude group: 'org.hamcrest'
-  }
-  testImplementation 'org.mockito:mockito-core:4.4.0'
-  testImplementation 'org.hamcrest:hamcrest:2.2'
+    testImplementation ('junit:junit:4.13.2'){
+        exclude group: 'org.hamcrest'
+    }
+    testImplementation 'org.mockito:mockito-core:4.4.0'
+    testImplementation 'org.hamcrest:hamcrest:2.2'
 
 }
 ----

--- a/docs/plugins/development/example-text-analysis-plugin.asciidoc
+++ b/docs/plugins/development/example-text-analysis-plugin.asciidoc
@@ -24,10 +24,10 @@ ext.luceneVersion = '9.5.0'
 buildscript {
   ext.pluginApiVersion = '8.7.0'
   repositories {
-      mavenCentral()
+    mavenCentral()
   }
   dependencies {
-      classpath "org.elasticsearch.gradle:build-tools:${pluginApiVersion}"
+    classpath "org.elasticsearch.gradle:build-tools:${pluginApiVersion}"
   }
 }
 
@@ -60,7 +60,7 @@ dependencies {
   testImplementation "org.apache.lucene:lucene-analysis-common:${luceneVersion}"
 
   testImplementation ('junit:junit:4.13.2'){
-      exclude group: 'org.hamcrest'
+    exclude group: 'org.hamcrest'
   }
   testImplementation 'org.mockito:mockito-core:4.4.0'
   testImplementation 'org.hamcrest:hamcrest:2.2'


### PR DESCRIPTION
Now that 8.7.0 is GA, we can remove the SNAPSHOT version and repository references from the stable plugin example build.gradle file.