### PR TITLE
[8.7] [DOCS] Remove SNAPSHOT references from stable plugin example (#94952)

### DIFF
--- a/docs/plugins/development/example-text-analysis-plugin.asciidoc
+++ b/docs/plugins/development/example-text-analysis-plugin.asciidoc
@@ -18,15 +18,12 @@ directory:
 +
 [source,gradle]
 ----
-ext.pluginApiVersion = '8.7.0-SNAPSHOT'
-ext.luceneVersion = '9.5.0-snapshot-d19c3e2e0ed'
+ext.pluginApiVersion = '8.7.0'
+ext.luceneVersion = '9.5.0'
 
 buildscript {
-  ext.pluginApiVersion = '8.7.0-SNAPSHOT'
+  ext.pluginApiVersion = '8.7.0'
   repositories {
-    maven {
-      url = 'https://snapshots.elastic.co/maven/'
-    }
     mavenCentral()
   }
   dependencies {
@@ -46,12 +43,6 @@ group 'org.example'
 version '1.0-SNAPSHOT'
 
 repositories {
-  maven {
-    url = "https://s3.amazonaws.com/download.elasticsearch.org/lucenesnapshots/d19c3e2e0ed/"
-  }
-  maven {
-    url = 'https://snapshots.elastic.co/maven/'
-  }
   mavenLocal()
   mavenCentral()
 }


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [DOCS] Remove SNAPSHOT references from stable plugin example (#94952)