### PR TITLE
Move the max primary shard docs implicit value to the constructor

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForRolloverReadyStepTests.java
@@ -128,7 +128,7 @@ public class WaitForRolloverReadyStepTests extends AbstractStepTestCase<WaitForR
                 () -> TimeValue.parseTimeValue(randomPositiveTimeValue(), "rollover_action_test")
             );
             case 5 -> maxDocs = randomValueOtherThan(maxDocs, ESTestCase::randomNonNegativeLong);
-            case 6 -> maxPrimaryShardDocs = randomValueOtherThan(maxPrimaryShardDocs, ESTestCase::randomNonNegativeLong);
+            case 6 -> maxPrimaryShardDocs = randomValueOtherThan(maxPrimaryShardDocs, () -> randomLongBetween(1, 200_000_000L - 1));
             case 7 -> minSize = randomValueOtherThan(minSize, () -> {
                 ByteSizeUnit minSizeUnit = randomFrom(ByteSizeUnit.values());
                 return new ByteSizeValue(randomNonNegativeLong() / minSizeUnit.toBytes(1), minSizeUnit);


### PR DESCRIPTION
Moved implicitly setting the `max_primary_shard_docs` from the `org.elasticsearch.xpack.core.ilm.WaitForRolloverReadyStep#createRolloverRequest` to the constructor to avoid re-building the `RolloverConditions`.