### PR TITLE
[RFC] Handle ccs minimize round trips in async search

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/RestHighLevelClient.java
@@ -300,6 +300,10 @@ public class RestHighLevelClient implements Closeable {
         return client;
     }
 
+    public final XContentParserConfiguration getParserConfig() {
+        return parserConfig;
+    }
+
     @Override
     public final void close() throws IOException {
         doClose.accept(client);

--- a/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchProgressListener.java
@@ -33,6 +33,12 @@ public abstract class SearchProgressListener {
     private List<SearchShard> shards;
 
     /**
+     * Executed one when minimize round trips is enabled to indicate the number of remote clusters
+     * that will not be monitored during the search.
+     **/
+    protected void onMinimizeRoundtrips(boolean hasLocalShards, int numRemoteClusters) {}
+
+    /**
      * Executed when shards are ready to be queried.
      *
      * @param shards The list of shards to query.
@@ -95,7 +101,18 @@ public abstract class SearchProgressListener {
      */
     protected void onFetchFailure(int shardIndex, SearchShardTarget shardTarget, Exception exc) {}
 
-    final void notifyListShards(List<SearchShard> shards, List<SearchShard> skippedShards, Clusters clusters, boolean fetchPhase) {
+    final void notifyMinimizeRoundtrips(boolean hasLocalShards, int numRemoteClusters) {
+        try {
+            onMinimizeRoundtrips(hasLocalShards, numRemoteClusters);
+        } catch (Exception e) {
+            logger.warn("Failed to execute progress listener on minimize roundtrips", e);
+        }
+    }
+
+    final void notifyListShards(List<SearchShard> shards,
+                                List<SearchShard> skippedShards,
+                                Clusters clusters,
+                                boolean fetchPhase) {
         this.shards = shards;
         try {
             onListShards(shards, skippedShards, clusters, fetchPhase);

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -399,6 +399,10 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 );
             } else {
                 if (shouldMinimizeRoundtrips(rewritten)) {
+                    /**
+                     * Notifies the task listener that searches on remote clusters will not report their progress.
+                     */
+                    task.getProgressListener().notifyMinimizeRoundtrips(localIndices != null, remoteClusterIndices.size());
                     final TaskId parentTaskId = task.taskInfo(clusterService.localNode().getId(), false).taskId();
                     ccsRemoteReduce(
                         parentTaskId,
@@ -549,7 +553,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 true
             );
             Client remoteClusterClient = remoteClusterService.getRemoteClusterClient(threadPool, clusterAlias);
-            remoteClusterClient.search(ccsSearchRequest, new ActionListener<SearchResponse>() {
+            remoteClusterClient.search(ccsSearchRequest, new ActionListener<>() {
                 @Override
                 public void onResponse(SearchResponse searchResponse) {
                     Map<String, SearchProfileShardResult> profileResults = searchResponse.getProfileResults();
@@ -699,7 +703,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
                 .cluster()
                 .searchShards(
                     searchShardsRequest,
-                    new CCSActionListener<ClusterSearchShardsResponse, Map<String, ClusterSearchShardsResponse>>(
+                    new CCSActionListener<>(
                         clusterAlias,
                         skipUnavailable,
                         responsesCountDown,
@@ -731,7 +735,7 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         int totalClusters,
         ActionListener<SearchResponse> originalListener
     ) {
-        return new CCSActionListener<SearchResponse, SearchResponse>(
+        return new CCSActionListener<>(
             clusterAlias,
             skipUnavailable,
             countDown,

--- a/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/QueryPhaseResultConsumerTests.java
@@ -91,6 +91,7 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
         for (int i = 0; i < 10; i++) {
             searchShards.add(new SearchShard(null, new ShardId("index", "uuid", i)));
         }
+        searchProgressListener.notifyMinimizeRoundtrips(true, 1);
         searchProgressListener.notifyListShards(searchShards, Collections.emptyList(), SearchResponse.Clusters.EMPTY, false);
 
         SearchRequest searchRequest = new SearchRequest("index");
@@ -135,6 +136,11 @@ public class QueryPhaseResultConsumerTests extends ESTestCase {
         private final AtomicInteger onQueryResult = new AtomicInteger(0);
         private final AtomicInteger onPartialReduce = new AtomicInteger(0);
         private final AtomicInteger onFinalReduce = new AtomicInteger(0);
+
+        @Override
+        protected void onMinimizeRoundtrips(boolean hasLocalShards, int numRemoteClusters) {
+            throw new UnsupportedOperationException();
+        }
 
         @Override
         protected void onListShards(

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -41,7 +41,6 @@ class MutableSearchResponse {
     private final Clusters clusters;
     private final AtomicArray<ShardSearchFailure> queryFailures;
     private final ThreadContext threadContext;
-
     private boolean isPartial;
     private int successfulShards;
     private TotalHits totalHits;
@@ -109,11 +108,11 @@ class MutableSearchResponse {
      * Updates the response with the final {@link SearchResponse} once the
      * search is complete.
      */
-    synchronized void updateFinalResponse(SearchResponse response) {
+    synchronized void updateFinalResponse(SearchResponse response, boolean hasRemoteClusterShards) {
         failIfFrozen();
-        assert response.getTotalShards() == totalShards
+        assert (hasRemoteClusterShards && response.getTotalShards() == totalShards) || response.getTotalShards() >= totalShards
             : "received number of total shards differs from the one " + "notified through onListShards";
-        assert response.getSkippedShards() == skippedShards
+        assert (hasRemoteClusterShards && response.getSkippedShards() == skippedShards) || response.getSkippedShards() >= skippedShards
             : "received number of skipped shards differs from the one " + "notified through onListShards";
         this.responseHeaders = threadContext.getResponseHeaders();
         this.finalResponse = response;

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/TransportSubmitAsyncSearchAction.java
@@ -83,6 +83,7 @@ public class TransportSubmitAsyncSearchAction extends HandledTransportAction<Sub
     @Override
     protected void doExecute(Task submitTask, SubmitAsyncSearchRequest request, ActionListener<AsyncSearchResponse> submitListener) {
         final SearchRequest searchRequest = createSearchRequest(request, submitTask, request.getKeepAlive());
+
         try (var ignored = threadContext.newTraceContext()) {
             AsyncSearchTask searchTask = (AsyncSearchTask) taskManager.register("transport", SearchAction.INSTANCE.name(), searchRequest);
             searchAction.execute(searchTask, searchRequest, searchTask.getSearchProgressActionListener());

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/RestSubmitAsyncSearchActionTests.java
@@ -91,6 +91,13 @@ public class RestSubmitAsyncSearchActionTests extends RestActionTestCase {
             batchedReduceSize,
             r -> r.getSearchRequest().getBatchedReduceSize()
         );
+        boolean ccsMinimizeRoundtrips = randomBoolean();
+        doTestParameter(
+            "ccs_minimize_roundtrips",
+            Boolean.toString(ccsMinimizeRoundtrips),
+            ccsMinimizeRoundtrips,
+            r -> r.getSearchRequest().isCcsMinimizeRoundtrips()
+        );
     }
 
     @SuppressWarnings("unchecked")

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SubmitAsyncSearchRequestTests.java
@@ -85,9 +85,7 @@ public class SubmitAsyncSearchRequestTests extends AbstractWireSerializingTransf
         SubmitAsyncSearchRequest req = new SubmitAsyncSearchRequest();
         req.getSearchRequest().setCcsMinimizeRoundtrips(true);
         ActionRequestValidationException exc = req.validate();
-        assertNotNull(exc);
-        assertThat(exc.validationErrors().size(), equalTo(1));
-        assertThat(exc.validationErrors().get(0), containsString("[ccs_minimize_roundtrips]"));
+        assertNull(exc);
     }
 
     public void testValidateScroll() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -83,6 +83,26 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
     }
 
     /**
+     * Returns whether network round-trips should be minimized when executing cross-cluster search requests.
+     * Defaults to <code>false</code>.
+     */
+    public boolean isCcsMinimizeRoundtrips() {
+        return request.isCcsMinimizeRoundtrips();
+    }
+
+    /**
+     * Sets whether network round-trips should be minimized when executing cross-cluster search requests.
+     * Defaults to <code>false</code>.
+     *
+     * <p>WARNING: The progress and partial responses of searches executed on remote clusters will not be available during
+     * the search if {@code ccsMinimizeRoundtrips} is enabled.</p>
+     */
+    public void setCcsMinimizeRoundtrips(boolean ccsMinimizeRoundtrips) {
+        request.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
+    }
+
+
+    /**
      * Sets the minimum time that the request should wait before returning a partial result (defaults to 1 second).
      */
     public SubmitAsyncSearchRequest setWaitForCompletionTimeout(TimeValue waitForCompletionTimeout) {
@@ -137,12 +157,6 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
         if (keepAlive.getMillis() < MIN_KEEP_ALIVE) {
             validationException = addValidationError(
                 "[keep_alive] must be greater or equals than 1 second, got:" + keepAlive.toString(),
-                validationException
-            );
-        }
-        if (request.isCcsMinimizeRoundtrips()) {
-            validationException = addValidationError(
-                "[ccs_minimize_roundtrips] is not supported on async search queries",
                 validationException
             );
         }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/SubmitAsyncSearchRequest.java
@@ -101,7 +101,6 @@ public class SubmitAsyncSearchRequest extends ActionRequest {
         request.setCcsMinimizeRoundtrips(ccsMinimizeRoundtrips);
     }
 
-
     /**
      * Sets the minimum time that the request should wait before returning a partial result (defaults to 1 second).
      */


### PR DESCRIPTION
This PR is a draft to show how we could enable ccs minimize round trips for async search without changing the internals/architecture of the search action. The idea is to disable the progress and partial responses for remote clusters when the option is set. Only local shards will report their progress and partial responses. The final response will contain the results and aggregations for the entire request (remote cluster included). 
Since Kibana doesn't use these features at the moment and only rely on the asynchronous aspect of the search, I am proposing this approach to speed up cross-cluster searches in Kibana until we find a better solution to limit the cost of following the progress and partial responses of remote clusters (see https://elasticsearch-benchmarks.elastic.co/#tracks/cross-clusters-search/nightly/default/90d).
Just an idea that was on my local branch for some time so sharing for awareness.