### PR TITLE
Optimize ContentPath#pathAsText

### DIFF
--- a/docs/changelog/94971.yaml
+++ b/docs/changelog/94971.yaml
@@ -1,0 +1,6 @@
+pr: 94971
+summary: optimize ContentPath#pathAsText
+area: Search
+type: enhancement
+issues:
+  - 94544

--- a/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/ContentPath.java
@@ -51,10 +51,18 @@ public final class ContentPath {
 
     public String pathAsText(String name) {
         sb.setLength(0);
-        for (int i = 0; i < index; i++) {
+        if (index == 0) {
+            return name;
+        }
+        if (index == 1 && path[0].equals(name)) {
+            return name;
+        }
+        for (int i = 0; i < index - 1; i++) {
             sb.append(path[i]).append(DELIMITER);
         }
-        sb.append(name);
+        if (!path[index - 1].equals(name)) {
+            sb.append(name);
+        }
         return sb.toString();
     }
 


### PR DESCRIPTION
I've implemented the following changes in order to reduce the number of unnecessary appends to the StringBuilder, which should improve performance when pathAsText is called frequently:

- If the index is 0, meaning we're at the root, we can return the provided name directly without any additional processing.

- If the index is 1 and the first element of path is equal to the provided name, we can also return the provided name directly. This is because path[0] would have been appended to the StringBuilder during the first call to pathAsText, so we don't need to append it again.

- We iterate through path from the start to the second to last element, appending each element to the StringBuilder followed by the delimiter. This avoids appending the same top-level fields repeatedly.

- If the last element of path is not equal to the provided name, we append the name to the StringBuilder.

This PR addresses issues raised in #94544 



