### PR TITLE
Fix auth unsupported version test after transportversion modification

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationSerializationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationSerializationTests.java
@@ -85,7 +85,7 @@ public class AuthenticationSerializationTests extends ESTestCase {
         final TransportVersion version = TransportVersionUtils.randomVersionBetween(
             random(),
             TransportVersion.V_7_17_0,
-            Authentication.VERSION_CROSS_CLUSTER_ACCESS_REALM
+            TransportVersionUtils.getPreviousVersion(Authentication.VERSION_CROSS_CLUSTER_ACCESS_REALM)
         );
         out.setTransportVersion(version);
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -927,7 +927,7 @@ public class AuthenticationTests extends ESTestCase {
         final TransportVersion olderVersion = TransportVersionUtils.randomVersionBetween(
             random(),
             TransportVersion.V_7_17_0,
-            Authentication.VERSION_REALM_DOMAINS
+            TransportVersionUtils.getPreviousVersion(Authentication.VERSION_REALM_DOMAINS)
         );
         final Authentication authentication = AuthenticationTestHelper.builder()
             .realm() // randomize to test both when realm is null on the original auth and non-null, instead of setting `underDomain`


### PR DESCRIPTION
Didn't exclude the latest version from the random selection. This fixes #94961 and #95008