### PR TITLE
[DOCS] Adds tip to change point agg docs

### DIFF
--- a/docs/reference/aggregations/pipeline/change-point-aggregation.asciidoc
+++ b/docs/reference/aggregations/pipeline/change-point-aggregation.asciidoc
@@ -7,9 +7,14 @@
 
 experimental::[]
 
-A sibling pipeline that detects, spikes, dips, and change points in a metric. Given a distribution of values
-provided by the sibling multi-bucket aggregation, this aggregation indicates the bucket of any spike or dip
-and/or the bucket at which the largest change in the distribution of values, if they are statistically significant.
+A sibling pipeline that detects, spikes, dips, and change points in a metric. 
+Given a distribution of values provided by the sibling multi-bucket aggregation, 
+this aggregation indicates the bucket of any spike or dip and/or the bucket at 
+which the largest change in the distribution of values, if they are 
+statistically significant. 
+
+TIP: It is recommended to use the change point aggregation to detect changes in 
+time-based data, however, you can use any metric to create buckets.
 
 
 
@@ -18,8 +23,8 @@ and/or the bucket at which the largest change in the distribution of values, if 
 
 `buckets_path`::
 (Required, string)
-Path to the buckets that contain one set of values in which to detect a change point. There must be at least 22 bucketed
-values. Fewer than 1,000 is preferred.
+Path to the buckets that contain one set of values in which to detect a change 
+point. There must be at least 22 bucketed values. Fewer than 1,000 is preferred.
 For syntax, see <<buckets-path-syntax>>.
 
 ==== Syntax
@@ -42,8 +47,9 @@ A `change_point` aggregation looks like this in isolation:
 
 `bucket`::
 (Optional, object)
-Values of the bucket that indicates the discovered change point. Not returned if no change point was found.
-All the aggregations in the bucket are returned as well.
+Values of the bucket that indicates the discovered change point. Not returned if 
+no change point was found. All the aggregations in the bucket are returned as 
+well.
 +
 .Properties of bucket
 [%collapsible%open]
@@ -63,11 +69,14 @@ The found change point type and its related values. Possible types:
 +
 --
 * `dip`: a significant dip occurs at this change point
-* `distribution_change`: the overall distribution of the values has changed significantly
-* `non_stationary`: there is no change point, but the values are not from a stationary distribution
+* `distribution_change`: the overall distribution of the values has changed 
+significantly
+* `non_stationary`: there is no change point, but the values are not from a 
+stationary distribution
 * `spike`: a significant spike occurs at this point
 * `stationary`: no change point found
-* `step_change`: the change indicates a statistically significant step up or down in value distribution
+* `step_change`: the change indicates a statistically significant step up or 
+down in value distribution
 * `trend_change`: there is an overall trend change occurring at this point
 --
 
@@ -138,5 +147,6 @@ The request returns a response that is similar to the following:
 <2> The number of documents in that bucket.
 <3> Aggregated values in the bucket.
 <4> Type of change found.
-<5> The `p_value` indicates how extreme the change is; lower values indicate greater change.
+<5> The `p_value` indicates how extreme the change is; lower values indicate 
+greater change.
 <6> The specific bucket where the change occurs (indexing starts at `0`).


### PR DESCRIPTION
## Overview

This PR adds a tip to the change point aggregation docs. It recommends using the aggregation for time series data and also states that using any metrics to create buckets is possible.

### Preview

[Change point agg](https://elasticsearch_94981.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-change-point-aggregation.html) 