### PR TITLE
Return a copy of messages in MockMTAppender

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2541,7 +2541,7 @@ public class InternalEngineTests extends EngineTestCase {
         private final List<String> messages = Collections.synchronizedList(new ArrayList<>());
 
         List<String> messages() {
-            return messages;
+            return new ArrayList<>(messages);
         }
 
         MockMTAppender(final String name) throws IllegalAccessException {

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -2541,7 +2541,7 @@ public class InternalEngineTests extends EngineTestCase {
         private final List<String> messages = Collections.synchronizedList(new ArrayList<>());
 
         List<String> messages() {
-            return new ArrayList<>(messages);
+            return List.copyOf(messages);
         }
 
         MockMTAppender(final String name) throws IllegalAccessException {


### PR DESCRIPTION
Couldn't reproduce the failure, but in principle there is an issue there. Other options are a CopyOnWriteArrayList or just synchronizing on `messages()` return value. Returning a copy should be enough, since this is only used in one place for asserting some test expectations in an `assertBusy`.

Closes https://github.com/elastic/elasticsearch/issues/94559