### PR TITLE
Update description of mandatory timestamp field

### DIFF
--- a/docs/reference/eql/eql.asciidoc
+++ b/docs/reference/eql/eql.asciidoc
@@ -32,7 +32,9 @@ describe activity that goes beyond IOCs.
 
 With the exception of sample queries, EQL searches require that the searched
 data stream or index  contains a _timestamp_ field. By default, EQL uses the
-`@timestamp` field from the {ecs-ref}[Elastic Common Schema (ECS)]. 
+`@timestamp` field from the {ecs-ref}[Elastic Common Schema (ECS)].
+In addition, the `@timestamp` field must have milliseconds granularity, hence
+be mapped as `epoch_millis` or similar.
 
 EQL searches also require an _event category_ field, unless you use the
 <<eql-syntax-match-any-event-category,`any` keyword>> to search for  documents


### PR DESCRIPTION

While experimenting with EQL I noticed it raised this error when the timestamp field was mapped as `date` with format `yyyy-MM-dd HH:mm:ss`:

`search_phase_execution_exception: [parse_exception] Reason: failed to parse date field [1680434649000] with format [yyyy-MM-dd HH:mm:ss]`

In particular, it happens when making a sequence query: https://www.elastic.co/guide/en/elasticsearch/reference/8.7/eql-syntax.html#eql-sequences

This gets solved when formatting the timestamp field as `epoch_millis`.

I'm not sure whether this is expected and fixing the docstring is enough or a bigfix ticket is needed.