### PR TITLE
[Enterprise Search] Add connectors indices and ent-search pipeline on startup

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -46,7 +46,6 @@ import org.elasticsearch.xpack.application.analytics.action.RestPutAnalyticsColl
 import org.elasticsearch.xpack.application.analytics.action.TransportDeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportGetAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportPutAnalyticsCollectionAction;
-import org.elasticsearch.xpack.application.connector.Connector;
 import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.action.DeleteSearchApplicationAction;
@@ -163,7 +162,7 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
 
         final ConnectorIndexService connectorIndexService = new ConnectorIndexService(client, clusterService, namedWriteableRegistry);
 
-        return Arrays.asList(analyticsTemplateRegistry);
+        return Arrays.asList(analyticsTemplateRegistry, connectorIndexService);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -46,6 +46,8 @@ import org.elasticsearch.xpack.application.analytics.action.RestPutAnalyticsColl
 import org.elasticsearch.xpack.application.analytics.action.TransportDeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportGetAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportPutAnalyticsCollectionAction;
+import org.elasticsearch.xpack.application.connector.Connector;
+import org.elasticsearch.xpack.application.connector.ConnectorIndexService;
 import org.elasticsearch.xpack.application.search.SearchApplicationIndexService;
 import org.elasticsearch.xpack.application.search.action.DeleteSearchApplicationAction;
 import org.elasticsearch.xpack.application.search.action.GetSearchApplicationAction;
@@ -158,6 +160,8 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             xContentRegistry
         );
         analyticsTemplateRegistry.initialize();
+
+        final ConnectorIndexService connectorIndexService = new ConnectorIndexService(client, clusterService, namedWriteableRegistry);
 
         return Arrays.asList(analyticsTemplateRegistry);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.application.connector;
 
-
 import org.elasticsearch.xcontent.ParseField;
 
 /**
@@ -30,8 +29,6 @@ public class Connector {
     public static final ParseField SERVICE_TYPE_FIELD = new ParseField("service_type");
     public static final ParseField STATUS_FIELD = new ParseField("status");
     public static final ParseField SYNC_NOW_FIELD = new ParseField("status");
-
-
 
     /**
      * Default public constructor.

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/Connector.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+
+import org.elasticsearch.xcontent.ParseField;
+
+/**
+ * The {@link Connector} model.
+ * Currently only holds the fields we use to construct the connectors index
+ */
+public class Connector {
+
+    public static final ParseField ERROR_FIELD = new ParseField("error");
+    public static final ParseField ID_FIELD = new ParseField("id");
+    public static final ParseField INDEX_NAME_FIELD = new ParseField("index_name");
+    public static final ParseField IS_NATIVE_FIELD = new ParseField("is_native");
+    public static final ParseField LANGUAGE_FIELD = new ParseField("language");
+    public static final ParseField LAST_SEEN_FIELD = new ParseField("last_seen");
+    public static final ParseField LAST_SYNC_ERROR_FIELD = new ParseField("last_sync_error");
+    public static final ParseField LAST_SYNC_STATUS_FIELD = new ParseField("last_sync_status");
+    public static final ParseField LAST_SYNCED_FIELD = new ParseField("last_synced");
+    public static final ParseField LAST_SYNC_SCHEDULED_AT_FIELD = new ParseField("last_sync_scheduled_at");
+    public static final ParseField NAME_FIELD = new ParseField("name");
+    public static final ParseField SERVICE_TYPE_FIELD = new ParseField("service_type");
+    public static final ParseField STATUS_FIELD = new ParseField("status");
+    public static final ParseField SYNC_NOW_FIELD = new ParseField("status");
+
+
+
+    /**
+     * Default public constructor.
+     */
+    public Connector() {}
+
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.action.ingest.GetPipelineResponse;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceAlreadyExistsException;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
+import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
+import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.ingest.GetPipelineRequest;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.XContentType;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+
+import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+/**
+  * A service that manages the persistent {@link Connector} configurations.
+  *
+  */
+public class ConnectorIndexService implements ClusterStateListener {
+    private static final Logger logger = LogManager.getLogger(ConnectorIndexService.class);
+    public static final String CONNECTOR_ALIAS_NAME = ".elastic-connectors";
+    public static final String CONNECTOR_CONCRETE_INDEX_NAME = ".elastic-connectors-v1";
+    public static final String CONNECTOR_SYNC_JOB_ALIAS_NAME = ".elastic-connectors-sync-jobs";
+    public static final String CONNECTOR_SYNC_JOB_CONCRETE_INDEX_NAME = ".elastic-connectors-sync-jobs-v1";
+    public static final String ENT_SEARCH_INGESTION_PIPELINE_NAME = "ent-search-generic-ingestion";
+
+    private final Client clientWithOrigin;
+    private final ClusterService clusterService;
+    public final NamedWriteableRegistry namedWriteableRegistry;
+
+    public ConnectorIndexService(Client client, ClusterService clusterService, NamedWriteableRegistry namedWriteableRegistry) {
+        this.clientWithOrigin = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
+        this.clusterService = clusterService;
+        this.namedWriteableRegistry = namedWriteableRegistry;
+        clusterService.addListener(this);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        if (event.state().blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            // wait for state recovered
+            return;
+        }
+        ensureInternalIndex(
+            this.clientWithOrigin,
+            CONNECTOR_CONCRETE_INDEX_NAME,
+            getConnectorsIndexMappings(),
+            getConnectorsIndexSettings(),
+            CONNECTOR_ALIAS_NAME
+        );
+        ensureInternalIndex(
+            this.clientWithOrigin,
+            CONNECTOR_SYNC_JOB_CONCRETE_INDEX_NAME,
+            getConnectorSyncJobsIndexMappings(),
+            getConnectorSyncJobsIndexSettings(),
+            CONNECTOR_SYNC_JOB_ALIAS_NAME
+        );
+
+        ensurePipeline(clientWithOrigin);
+
+        this.clusterService.removeListener(this);
+    }
+
+    private static void createInternalIndex(Client client, String index, XContentBuilder mappings, Settings settings, String alias) {
+        try {
+            CreateIndexRequest request = new CreateIndexRequest(index).mapping(mappings).settings(settings).alias(new Alias(alias));
+            ThreadContext threadContext = client.threadPool().getThreadContext();
+            executeAsyncWithOrigin(threadContext, ENT_SEARCH_ORIGIN, request, new ActionListener<CreateIndexResponse>() {
+                public void onResponse(CreateIndexResponse createIndexResponse) {
+                    logger.info("Created " + index + " index.");
+                }
+
+                public void onFailure(Exception e) {
+                    final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                    if (cause instanceof ResourceAlreadyExistsException) {
+                        logger.error("Index " + index + " already exists.");
+                    } else {
+                        logger.error("Failed to create " + index + " index " + e.toString());
+                    }
+                }
+            }, client.admin().indices()::create);
+        } catch (Exception e) {
+            logger.error("Error creating index " + index + " ." + e);
+        }
+    }
+
+    private static void createPipeline(Client client) {
+        BytesArray bytes = new BytesArray(EntSearchPipeline.pipelineDefinition.getBytes());
+        PutPipelineRequest putPipelineRequest = new PutPipelineRequest(
+            ENT_SEARCH_INGESTION_PIPELINE_NAME,
+            bytes,
+            XContentType.JSON
+        );
+        client.admin().cluster().putPipeline(putPipelineRequest);
+        logger.info("Created pipeline" + ENT_SEARCH_INGESTION_PIPELINE_NAME);
+    }
+
+    private static void ensureInternalIndex(Client client, String index, XContentBuilder mappings, Settings settings, String alias) {
+        GetIndexRequest getIndexRequest = new GetIndexRequest().indices(CONNECTOR_CONCRETE_INDEX_NAME);
+        ThreadContext threadContext = client.threadPool().getThreadContext();
+        executeAsyncWithOrigin(threadContext, ENT_SEARCH_ORIGIN, getIndexRequest, new ActionListener<GetIndexResponse>() {
+            public void onResponse(GetIndexResponse getIndexResponse) {
+                logger.info("Found " + index + " index.");
+            }
+
+            public void onFailure(Exception e) {
+                final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (cause instanceof ResourceNotFoundException) {
+                    logger.error("Index " + index + " not found.");
+                    createInternalIndex(client, index, mappings, settings, alias);
+                } else {
+                    logger.error("Error getting " + index + " index " + e.toString());
+                }
+            }
+        }, client.admin().indices()::getIndex);
+    }
+
+    private static void ensurePipeline(Client client) {
+        GetPipelineRequest getPipelineRequest = new GetPipelineRequest(ENT_SEARCH_INGESTION_PIPELINE_NAME);
+        ThreadContext threadContext = client.threadPool().getThreadContext();
+        executeAsyncWithOrigin(threadContext, ENT_SEARCH_ORIGIN, getPipelineRequest, new ActionListener<>() {
+            public void onResponse(GetPipelineResponse getPipelineResponse) {
+                if (getPipelineResponse.isFound() == false) {
+                    createPipeline(client);
+                } else {
+                    logger.info("Found " + ENT_SEARCH_INGESTION_PIPELINE_NAME + " pipeline.");
+                }
+            }
+
+            public void onFailure(Exception e) {
+                final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (cause instanceof ResourceNotFoundException) {
+                    logger.error("Pipeline " + ENT_SEARCH_INGESTION_PIPELINE_NAME + " not found.");
+                    createPipeline(client);
+                } else {
+                    logger.error("Error getting " + ENT_SEARCH_INGESTION_PIPELINE_NAME + " index " + e.toString());
+                }
+            }
+        }, client.admin().cluster()::getPipeline);
+    }
+
+    private static Settings getConnectorsIndexSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-3")
+            .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
+            .put("index.refresh_interval", "1s")
+            .build();
+    }
+
+    private static XContentBuilder getConnectorsIndexMappings() {
+        try {
+            final XContentBuilder builder = jsonBuilder();
+            builder.startObject();
+            {
+                builder.startObject("_meta");
+                builder.field("version", Version.CURRENT.toString());
+                builder.endObject();
+
+                builder.field("dynamic", "false");
+                builder.startObject("properties");
+                {
+                    builder.startObject(Connector.ERROR_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.INDEX_NAME_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.IS_NATIVE_FIELD.getPreferredName());
+                    builder.field("type", "boolean");
+                    builder.endObject();
+
+                    builder.startObject(Connector.LANGUAGE_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.LAST_SEEN_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(Connector.LAST_SYNC_ERROR_FIELD.getPreferredName());
+                    builder.field("type", "text");
+                    builder.endObject();
+
+                    builder.startObject(Connector.LAST_SYNC_STATUS_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.LAST_SYNC_SCHEDULED_AT_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(Connector.LAST_SYNCED_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(Connector.NAME_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.SERVICE_TYPE_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.STATUS_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(Connector.SYNC_NOW_FIELD.getPreferredName());
+                    builder.field("type", "boolean");
+                    builder.endObject();
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+            return builder;
+        } catch (IOException e) {
+            logger.fatal("Failed to build " + CONNECTOR_CONCRETE_INDEX_NAME + " index mappings", e);
+            throw new UncheckedIOException("Failed to build " + CONNECTOR_CONCRETE_INDEX_NAME + " index mappings", e);
+        }
+    }
+
+    private static Settings getConnectorSyncJobsIndexSettings() {
+        return Settings.builder()
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-3")
+            .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
+            .put("index.refresh_interval", "1s")
+            .build();
+    }
+
+    private static XContentBuilder getConnectorSyncJobsIndexMappings() {
+        try {
+            final XContentBuilder builder = jsonBuilder();
+            builder.startObject();
+            {
+                builder.startObject("_meta");
+                builder.field("version", Version.CURRENT.toString());
+                builder.endObject();
+
+                builder.field("dynamic", "false");
+                builder.startObject("properties");
+                {
+                    builder.startObject(ConnectorSyncJob.CANCELATION_REQUESTED_AT_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.CANCELED_AT_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.COMPLETED_AT.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.CREATED_AT_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.CONNECTOR_FIELD.getPreferredName());
+                    {
+                        builder.startObject("properties");
+                        {
+                            builder.startObject(Connector.ID_FIELD.getPreferredName());
+                            builder.field("type", "keyword");
+                            builder.endObject();
+
+                            builder.startObject(Connector.INDEX_NAME_FIELD.getPreferredName());
+                            builder.field("type", "keyword");
+                            builder.endObject();
+
+                            builder.startObject(Connector.IS_NATIVE_FIELD.getPreferredName());
+                            builder.field("type", "boolean");
+                            builder.endObject();
+
+                            builder.startObject(Connector.LANGUAGE_FIELD.getPreferredName());
+                            builder.field("type", "keyword");
+                            builder.endObject();
+
+                            builder.startObject(Connector.SERVICE_TYPE_FIELD.getPreferredName());
+                            builder.field("type", "keyword");
+                            builder.endObject();
+                        }
+                        builder.endObject();
+                    }
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.DELETED_DOCUMENT_COUNT_FIELD.getPreferredName());
+                    builder.field("type", "number");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.ERROR_FIELD.getPreferredName());
+                    builder.field("type", "boolean");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.INDEXED_DOCUMENT_COUNT_FIELD.getPreferredName());
+                    builder.field("type", "number");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.INDEXED_DOCUMENT_VOLUME_FIELD.getPreferredName());
+                    builder.field("type", "number");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.LAST_SEEN_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.STARTED_AT_FIELD.getPreferredName());
+                    builder.field("type", "date");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.STATUS_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.TOTAL_DOCUMENT_COUNT_FIELD.getPreferredName());
+                    builder.field("type", "number");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.TRIGGER_METHOD_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+
+                    builder.startObject(ConnectorSyncJob.WORKER_HOSTNAME_FIELD.getPreferredName());
+                    builder.field("type", "keyword");
+                    builder.endObject();
+                }
+                builder.endObject();
+            }
+            builder.endObject();
+            return builder;
+        } catch (IOException e) {
+            logger.fatal("Failed to build " + CONNECTOR_CONCRETE_INDEX_NAME + " index mappings", e);
+            throw new UncheckedIOException("Failed to build " + CONNECTOR_CONCRETE_INDEX_NAME + " index mappings", e);
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorIndexService.java
@@ -7,11 +7,6 @@
 
 package org.elasticsearch.xpack.application.connector;
 
-import org.elasticsearch.action.ingest.GetPipelineResponse;
-import org.elasticsearch.action.ingest.PutPipelineRequest;
-import org.elasticsearch.common.bytes.BytesArray;
-import org.elasticsearch.logging.Logger;
-import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.ResourceNotFoundException;
@@ -23,16 +18,21 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
 import org.elasticsearch.action.admin.indices.get.GetIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
 import org.elasticsearch.action.ingest.GetPipelineRequest;
+import org.elasticsearch.action.ingest.GetPipelineResponse;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -116,12 +116,8 @@ public class ConnectorIndexService implements ClusterStateListener {
     }
 
     private static void createPipeline(Client client) {
-        BytesArray bytes = new BytesArray(EntSearchPipeline.pipelineDefinition.getBytes());
-        PutPipelineRequest putPipelineRequest = new PutPipelineRequest(
-            ENT_SEARCH_INGESTION_PIPELINE_NAME,
-            bytes,
-            XContentType.JSON
-        );
+        BytesArray bytes = new BytesArray(EntSearchPipeline.getPipelineDefinition().getBytes());
+        PutPipelineRequest putPipelineRequest = new PutPipelineRequest(ENT_SEARCH_INGESTION_PIPELINE_NAME, bytes, XContentType.JSON);
         client.admin().cluster().putPipeline(putPipelineRequest);
         logger.info("Created pipeline" + ENT_SEARCH_INGESTION_PIPELINE_NAME);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSyncJob.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorSyncJob.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.xcontent.ParseField;
+
+/**
+ * The {@link ConnectorSyncJob} model.
+ * Currently only holds the fields we use to construct the connectors sync jobs index
+ */
+public class ConnectorSyncJob {
+    public static final ParseField CANCELATION_REQUESTED_AT_FIELD = new ParseField("cancelation_requested_at");
+    public static final ParseField CANCELED_AT_FIELD = new ParseField("canceled_at");
+    public static final ParseField COMPLETED_AT = new ParseField("completed_at");
+    public static final ParseField CONNECTOR_FIELD = new ParseField("connector");
+    public static final ParseField CREATED_AT_FIELD = new ParseField("created_at");
+    public static final ParseField DELETED_DOCUMENT_COUNT_FIELD = new ParseField("deleted_document_count");
+    public static final ParseField ERROR_FIELD = new ParseField("error");
+    public static final ParseField INDEXED_DOCUMENT_COUNT_FIELD = new ParseField("indexed_document_count");
+    public static final ParseField INDEXED_DOCUMENT_VOLUME_FIELD = new ParseField("indexed_document_volume");
+    public static final ParseField LAST_SEEN_FIELD = new ParseField("last_seen");
+    public static final ParseField STARTED_AT_FIELD = new ParseField("started_at");
+    public static final ParseField STATUS_FIELD = new ParseField("status");
+    public static final ParseField TOTAL_DOCUMENT_COUNT_FIELD = new ParseField("total_document_count");
+    public static final ParseField TRIGGER_METHOD_FIELD = new ParseField("trigger_method");
+    public static final ParseField WORKER_HOSTNAME_FIELD = new ParseField("worker_hostname");
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/EntSearchPipeline.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/EntSearchPipeline.java
@@ -12,135 +12,140 @@ package org.elasticsearch.xpack.application.connector;
  */
 public class EntSearchPipeline {
     @SuppressWarnings("checkstyle:LineLength")
-    public static final String pipelineDefinition = """
-        {
-          "version": 1,
-          "description": "Generic Enterprise Search ingest pipeline",
-          "_meta": {
-            "managed_by": "Enterprise Search",
-            "managed": true
-          },
-          "processors": [
-            {
-              "attachment": {
-                "description": "Extract text from binary attachments",
-                "field": "_attachment",
-                "target_field": "_extracted_attachment",
-                "ignore_missing": true,
-                "indexed_chars_field": "_attachment_indexed_chars",
-                "if": "ctx?._extract_binary_content == true",
-                "on_failure": [
-                  {
-                    "append": {
-                      "description": "Record error information",
-                      "field": "_ingestion_errors",
-                      "value": "Processor 'attachment' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+    private static final String pipelineDefinition =
+        """
+                    {
+                      "version": 1,
+                      "description": "Generic Enterprise Search ingest pipeline",
+                      "_meta": {
+                        "managed_by": "Enterprise Search",
+                        "managed": true
+                      },
+                      "processors": [
+                        {
+                          "attachment": {
+                            "description": "Extract text from binary attachments",
+                            "field": "_attachment",
+                            "target_field": "_extracted_attachment",
+                            "ignore_missing": true,
+                            "indexed_chars_field": "_attachment_indexed_chars",
+                            "if": "ctx?._extract_binary_content == true",
+                            "on_failure": [
+                              {
+                                "append": {
+                                  "description": "Record error information",
+                                  "field": "_ingestion_errors",
+                                  "value": "Processor 'attachment' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "set": {
+                            "tag": "set_body",
+                            "description": "Set any extracted text on the 'body' field",
+                            "field": "body",
+                            "copy_from": "_extracted_attachment.content",
+                            "ignore_empty_value": true,
+                            "if": "ctx?._extract_binary_content == true",
+                            "on_failure": [
+                              {
+                                "append": {
+                                  "description": "Record error information",
+                                  "field": "_ingestion_errors",
+                                  "value": "Processor 'set' with tag 'set_body' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "gsub": {
+                            "tag": "remove_replacement_chars",
+                            "description": "Remove unicode 'replacement' characters",
+                            "field": "body",
+                            "pattern": "�",
+                            "replacement": "",
+                            "ignore_missing": true,
+                            "if": "ctx?._extract_binary_content == true",
+                            "on_failure": [
+                              {
+                                "append": {
+                                  "description": "Record error information",
+                                  "field": "_ingestion_errors",
+                                  "value": "Processor 'gsub' with tag 'remove_replacement_chars' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "gsub": {
+                            "tag": "remove_extra_whitespace",
+                            "description": "Squish whitespace",
+                            "field": "body",
+                            "pattern": "\\\\s+",
+                            "replacement": " ",
+                            "ignore_missing": true,
+                            "if": "ctx?._reduce_whitespace == true",
+                            "on_failure": [
+                              {
+                                "append": {
+                                  "description": "Record error information",
+                                  "field": "_ingestion_errors",
+                                  "value": "Processor 'gsub' with tag 'remove_extra_whitespace' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "trim" : {
+                            "description": "Trim leading and trailing whitespace",
+                            "field": "body",
+                            "ignore_missing": true,
+                            "if": "ctx?._reduce_whitespace == true",
+                            "on_failure": [
+                              {
+                                "append": {
+                                  "description": "Record error information",
+                                  "field": "_ingestion_errors",
+                                  "value": "Processor 'trim' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                                }
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "remove": {
+                            "tag": "remove_meta_fields",
+                            "description": "Remove meta fields",
+                            "field": [
+                              "_attachment",
+                              "_attachment_indexed_chars",
+                              "_extracted_attachment",
+                              "_extract_binary_content",
+                              "_reduce_whitespace",
+                              "_run_ml_inference"
+                            ],
+                            "ignore_missing": true,
+                            "on_failure": [
+                              {
+                                "append": {
+                                  "description": "Record error information",
+                                  "field": "_ingestion_errors",
+                                  "value": "Processor 'remove' with tag 'remove_meta_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                                }
+                              }
+                            ]
+                          }
+                        }
+                      ]
                     }
-                  }
-                ]
-              }
-            },
-            {
-              "set": {
-                "tag": "set_body",
-                "description": "Set any extracted text on the 'body' field",
-                "field": "body",
-                "copy_from": "_extracted_attachment.content",
-                "ignore_empty_value": true,
-                "if": "ctx?._extract_binary_content == true",
-                "on_failure": [
-                  {
-                    "append": {
-                      "description": "Record error information",
-                      "field": "_ingestion_errors",
-                      "value": "Processor 'set' with tag 'set_body' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "gsub": {
-                "tag": "remove_replacement_chars",
-                "description": "Remove unicode 'replacement' characters",
-                "field": "body",
-                "pattern": "�",
-                "replacement": "",
-                "ignore_missing": true,
-                "if": "ctx?._extract_binary_content == true",
-                "on_failure": [
-                  {
-                    "append": {
-                      "description": "Record error information",
-                      "field": "_ingestion_errors",
-                      "value": "Processor 'gsub' with tag 'remove_replacement_chars' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "gsub": {
-                "tag": "remove_extra_whitespace",
-                "description": "Squish whitespace",
-                "field": "body",
-                "pattern": "\\\\s+",
-                "replacement": " ",
-                "ignore_missing": true,
-                "if": "ctx?._reduce_whitespace == true",
-                "on_failure": [
-                  {
-                    "append": {
-                      "description": "Record error information",
-                      "field": "_ingestion_errors",
-                      "value": "Processor 'gsub' with tag 'remove_extra_whitespace' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "trim" : {
-                "description": "Trim leading and trailing whitespace",
-                "field": "body",
-                "ignore_missing": true,
-                "if": "ctx?._reduce_whitespace == true",
-                "on_failure": [
-                  {
-                    "append": {
-                      "description": "Record error information",
-                      "field": "_ingestion_errors",
-                      "value": "Processor 'trim' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
-                    }
-                  }
-                ]
-              }
-            },
-            {
-              "remove": {
-                "tag": "remove_meta_fields",
-                "description": "Remove meta fields",
-                "field": [
-                  "_attachment",
-                  "_attachment_indexed_chars",
-                  "_extracted_attachment",
-                  "_extract_binary_content",
-                  "_reduce_whitespace",
-                  "_run_ml_inference"
-                ],
-                "ignore_missing": true,
-                "on_failure": [
-                  {
-                    "append": {
-                      "description": "Record error information",
-                      "field": "_ingestion_errors",
-                      "value": "Processor 'remove' with tag 'remove_meta_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
-                    }
-                  }
-                ]
-              }
-            }
-          ]
-        }
-""";
+            """;
+
+    public static String getPipelineDefinition() {
+        return pipelineDefinition;
+    }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/EntSearchPipeline.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/EntSearchPipeline.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+/**
+ * The default Enterprise Search pipeline used by connectors and crawlers
+ */
+public class EntSearchPipeline {
+    @SuppressWarnings("checkstyle:LineLength")
+    public static final String pipelineDefinition = """
+        {
+          "version": 1,
+          "description": "Generic Enterprise Search ingest pipeline",
+          "_meta": {
+            "managed_by": "Enterprise Search",
+            "managed": true
+          },
+          "processors": [
+            {
+              "attachment": {
+                "description": "Extract text from binary attachments",
+                "field": "_attachment",
+                "target_field": "_extracted_attachment",
+                "ignore_missing": true,
+                "indexed_chars_field": "_attachment_indexed_chars",
+                "if": "ctx?._extract_binary_content == true",
+                "on_failure": [
+                  {
+                    "append": {
+                      "description": "Record error information",
+                      "field": "_ingestion_errors",
+                      "value": "Processor 'attachment' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "set": {
+                "tag": "set_body",
+                "description": "Set any extracted text on the 'body' field",
+                "field": "body",
+                "copy_from": "_extracted_attachment.content",
+                "ignore_empty_value": true,
+                "if": "ctx?._extract_binary_content == true",
+                "on_failure": [
+                  {
+                    "append": {
+                      "description": "Record error information",
+                      "field": "_ingestion_errors",
+                      "value": "Processor 'set' with tag 'set_body' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "gsub": {
+                "tag": "remove_replacement_chars",
+                "description": "Remove unicode 'replacement' characters",
+                "field": "body",
+                "pattern": "�",
+                "replacement": "",
+                "ignore_missing": true,
+                "if": "ctx?._extract_binary_content == true",
+                "on_failure": [
+                  {
+                    "append": {
+                      "description": "Record error information",
+                      "field": "_ingestion_errors",
+                      "value": "Processor 'gsub' with tag 'remove_replacement_chars' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "gsub": {
+                "tag": "remove_extra_whitespace",
+                "description": "Squish whitespace",
+                "field": "body",
+                "pattern": "\\\\s+",
+                "replacement": " ",
+                "ignore_missing": true,
+                "if": "ctx?._reduce_whitespace == true",
+                "on_failure": [
+                  {
+                    "append": {
+                      "description": "Record error information",
+                      "field": "_ingestion_errors",
+                      "value": "Processor 'gsub' with tag 'remove_extra_whitespace' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "trim" : {
+                "description": "Trim leading and trailing whitespace",
+                "field": "body",
+                "ignore_missing": true,
+                "if": "ctx?._reduce_whitespace == true",
+                "on_failure": [
+                  {
+                    "append": {
+                      "description": "Record error information",
+                      "field": "_ingestion_errors",
+                      "value": "Processor 'trim' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                    }
+                  }
+                ]
+              }
+            },
+            {
+              "remove": {
+                "tag": "remove_meta_fields",
+                "description": "Remove meta fields",
+                "field": [
+                  "_attachment",
+                  "_attachment_indexed_chars",
+                  "_extracted_attachment",
+                  "_extract_binary_content",
+                  "_reduce_whitespace",
+                  "_run_ml_inference"
+                ],
+                "ignore_missing": true,
+                "on_failure": [
+                  {
+                    "append": {
+                      "description": "Record error information",
+                      "field": "_ingestion_errors",
+                      "value": "Processor 'remove' with tag 'remove_meta_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        }
+""";
+}


### PR DESCRIPTION
WIP. Tests still to be added. 

This adds the necessary connectors indices and default Enterprise Search ingestion pipeline when Elasticsearch starts up. This allows us to run Connectors and other Enterprise Search features without needing Enterprise Search.

In the long run, we plan to turn these indices into System Indices. The constraints on System Indices currently do not make this a viable path. 

