### PR TITLE
Remove broken URL for cat.component_templates API

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -1,7 +1,7 @@
 {
   "cat.component_templates":{
     "documentation":{
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-component-templates.html",
       "description":"Returns information about existing component_templates templates."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -1,6 +1,7 @@
 {
   "cat.component_templates":{
     "documentation":{
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-component-template.html",
       "description":"Returns information about existing component_templates templates."
     },
     "stability":"stable",

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/cat.component_templates.json
@@ -1,7 +1,6 @@
 {
   "cat.component_templates":{
     "documentation":{
-      "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/cat-compoentn-templates.html",
       "description":"Returns information about existing component_templates templates."
     },
     "stability":"stable",


### PR DESCRIPTION
Updates a broken URL for the `cat.component_templates` API spec. It has a typo, and there is no doc for it, so I linked to the component templates docs instead.

It currently has to be manually removed from the [auto-generated API docs for the JS client](https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#_component_templates) every time we generate them.
