### PR TITLE
Clarify wording in docs, remove 'foo' from example

### DIFF
--- a/docs/reference/search-application/apis/list-search-applications.asciidoc
+++ b/docs/reference/search-application/apis/list-search-applications.asciidoc
@@ -44,11 +44,11 @@ GET _application/search_application/
 ----
 // TEST[skip:TBD]
 
-The following example lists the first three Search Applications matching `foo`:
+The following example lists the first three Search Applications whose names match the query String `app`:
 
 [source,console]
 ----
-GET _application/search_application/?from=0&size=3&q=foo
+GET _application/search_application/?from=0&size=3&q=app
 ----
 // TEST[skip:TBD]
 


### PR DESCRIPTION
Responding to [feedback](https://github.com/elastic/elasticsearch/pull/94381#discussion_r1151097396) from the ent-search-module PR https://github.com/elastic/elasticsearch/pull/94381

- Removes the word `foo` from examples 
- Makes the wording as to what the list call does with a search query more clear. 