### PR TITLE
Fix Grok.match() with offset and suffix pattern

### DIFF
--- a/docs/changelog/95003.yaml
+++ b/docs/changelog/95003.yaml
@@ -1,0 +1,6 @@
+pr: 95003
+summary: Fix Grok.match() with offset and suffix pattern
+area: Ingest Node
+type: bug
+issues:
+ - 95002

--- a/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/Grok.java
@@ -287,7 +287,7 @@ public final class Grok {
         int result;
         try {
             matcherWatchdog.register(matcher);
-            result = matcher.search(offset, length, Option.DEFAULT);
+            result = matcher.search(offset, offset + length, Option.DEFAULT);
         } finally {
             matcherWatchdog.unregister(matcher);
         }

--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -58,6 +58,17 @@ public class GrokTests extends ESTestCase {
     public void testCapturesBytes() {
         testCapturesBytes(false);
         testCapturesBytes(true);
+        testCaptureBytesSuffix(true);
+        testCaptureBytesSuffix(false);
+    }
+
+    private void testCaptureBytesSuffix(boolean ecsCompatibility) {
+        Grok grok = new Grok(GrokBuiltinPatterns.get(ecsCompatibility), "%{WORD:a} %{WORD:b} %{NUMBER:c:int}", logger::warn);
+        byte[] utf8 = "x1 a1 b1 12 x2 a2 b2 13 ".getBytes(StandardCharsets.UTF_8);
+        assertThat(captureBytes(grok, utf8, 0, 12), equalTo(Map.of("a", "a1", "b", "b1", "c", 12)));
+        assertNull(captureBytes(grok, utf8, 0, 9));
+        assertThat(captureBytes(grok, utf8, 12, 12), equalTo(Map.of("a", "a2", "b", "b2", "c", 13)));
+        assertNull(captureBytes(grok, utf8, 12, 9));
     }
 
     private void testCapturesBytes(boolean ecsCompatibility) {


### PR DESCRIPTION
As described in https://github.com/elastic/elasticsearch/issues/95002, `Grok.match(bytes, offset, length, extracter)` fails when using a pattern with partial match (suffix match in particular) and an offset greater than zero.

Eg. with a pattern like `%{WORD:a} %{WORD:b} %{NUMBER:c:int}` and an input string like `x1 a1 b1 12`, the pattern is supposed to discard x1  and match the rest of the input.

Everything works fine as long as the string is stored in a byte[] alone, and the offset used is 0.
If the input of match() is a bigger array, where the string is in the middle and an offset > 0 is used, then the match fails.

The problem seems to be related to how we use Joni `Matcher.search()` API (passing `offset`, `length` vs `offset`, `offset + length`)

This PR proposes this change.

Fixes https://github.com/elastic/elasticsearch/issues/95002