### PR TITLE
Fix version bounds on VersionCheckingStream

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
@@ -37,7 +37,8 @@ public class VersionCheckingStreamOutputTests extends ESTestCase {
         TransportVersion streamVersion = TransportVersionUtils.randomVersionBetween(
             random(),
             TransportVersion.MINIMUM_COMPATIBLE,
-            TransportVersionUtils.getPreviousVersion(TransportVersion.CURRENT));
+            TransportVersionUtils.getPreviousVersion(TransportVersion.CURRENT)
+        );
         try (VersionCheckingStreamOutput out = new VersionCheckingStreamOutput(streamVersion)) {
             out.writeNamedWriteable(QueryBuilders.matchAllQuery());
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/VersionCheckingStreamOutputTests.java
@@ -34,7 +34,10 @@ public class VersionCheckingStreamOutputTests extends ESTestCase {
     }
 
     public void testCheckVersionCompatibility() throws IOException {
-        TransportVersion streamVersion = TransportVersionUtils.randomCompatibleVersion(random());
+        TransportVersion streamVersion = TransportVersionUtils.randomVersionBetween(
+            random(),
+            TransportVersion.MINIMUM_COMPATIBLE,
+            TransportVersionUtils.getPreviousVersion(TransportVersion.CURRENT));
         try (VersionCheckingStreamOutput out = new VersionCheckingStreamOutput(streamVersion)) {
             out.writeNamedWriteable(QueryBuilders.matchAllQuery());
 


### PR DESCRIPTION
2bec7f4d8bf9c6d5252376bd62d15a431419914c added CURRENT to the set of versions it could test against, when it shouldn't have done that. This fixes #95007