### PR TITLE
Revert "Check formatting of after keys at construction time (#94979)"

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/InternalComposite.java
@@ -41,7 +41,6 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
     private final int size;
     private final List<InternalBucket> buckets;
     private final CompositeKey afterKey;
-    private final Map<String, Object> formattedAfterKey;
     private final int[] reverseMuls;
     private final MissingOrder[] missingOrders;
     private final List<String> sourceNames;
@@ -70,7 +69,6 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         this.reverseMuls = reverseMuls;
         this.missingOrders = missingOrders;
         this.earlyTerminated = earlyTerminated;
-        this.formattedAfterKey = afterKey == null ? null : new ArrayMap(sourceNames, formats, afterKey.values());
     }
 
     public InternalComposite(StreamInput in) throws IOException {
@@ -91,7 +89,6 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         this.buckets = in.readList((input) -> new InternalBucket(input, sourceNames, formats, reverseMuls, missingOrders));
         this.afterKey = in.readOptionalWriteable(CompositeKey::new);
         this.earlyTerminated = in.getTransportVersion().onOrAfter(TransportVersion.V_7_6_0) ? in.readBoolean() : false;
-        this.formattedAfterKey = afterKey == null ? null : new ArrayMap(sourceNames, formats, afterKey.values());
     }
 
     @Override
@@ -174,7 +171,10 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
 
     @Override
     public Map<String, Object> afterKey() {
-        return formattedAfterKey;
+        if (afterKey != null) {
+            return new ArrayMap(sourceNames, formats, afterKey.values());
+        }
+        return null;
     }
 
     // Visible for tests
@@ -580,16 +580,13 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
     static class ArrayMap extends AbstractMap<String, Object> implements Comparable<ArrayMap> {
         final List<String> keys;
         final Comparable<?>[] values;
-        final List<Object> formattedValues;
+        final List<DocValueFormat> formats;
 
         ArrayMap(List<String> keys, List<DocValueFormat> formats, Comparable<?>[] values) {
             assert keys.size() == values.length && keys.size() == formats.size();
             this.keys = keys;
+            this.formats = formats;
             this.values = values;
-            this.formattedValues = new ArrayList<>();
-            for (int i = 0; i < values.length; i++) {
-                this.formattedValues.add(formatObject(values[i], formats.get(i)));
-            }
         }
 
         @Override
@@ -601,7 +598,7 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
         public Object get(Object key) {
             for (int i = 0; i < keys.size(); i++) {
                 if (key.equals(keys.get(i))) {
-                    return formattedValues.get(i);
+                    return formatObject(values[i], formats.get(i));
                 }
             }
             return null;
@@ -609,10 +606,10 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
 
         @Override
         public Set<Entry<String, Object>> entrySet() {
-            return new AbstractSet<>() {
+            return new AbstractSet<Entry<String, Object>>() {
                 @Override
                 public Iterator<Entry<String, Object>> iterator() {
-                    return new Iterator<>() {
+                    return new Iterator<Entry<String, Object>>() {
                         int pos = 0;
 
                         @Override
@@ -622,7 +619,10 @@ public class InternalComposite extends InternalMultiBucketAggregation<InternalCo
 
                         @Override
                         public Entry<String, Object> next() {
-                            SimpleEntry<String, Object> entry = new SimpleEntry<>(keys.get(pos), formattedValues.get(pos));
+                            SimpleEntry<String, Object> entry = new SimpleEntry<>(
+                                keys.get(pos),
+                                formatObject(values[pos], formats.get(pos))
+                            );
                             ++pos;
                             return entry;
                         }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/composite/InternalCompositeTests.java
@@ -383,24 +383,6 @@ public class InternalCompositeTests extends InternalMultiBucketAggregationTestCa
         );
         long epoch = 1622060077L; // May 25th 2021, evening
         expectThrows(IllegalArgumentException.class, () -> InternalComposite.formatObject(epoch, weekYearMonth));
-
-        CompositeKey compositeKey = new CompositeKey(epoch);
-        Exception e = expectThrows(
-            IllegalArgumentException.class,
-            () -> new InternalComposite(
-                "name",
-                1,
-                List.of("date"),
-                List.of(weekYearMonth),
-                List.of(),
-                compositeKey,
-                new int[0],
-                new MissingOrder[0],
-                false,
-                null
-            )
-        );
-        assertThat(e.getMessage(), containsString("created output it couldn't parse"));
     }
 
     public void testFormatDateEpochTimezone() {


### PR DESCRIPTION
This reverts commit 092fa8d487e7f41c89a6ac314cd0fa2501752fec.

We can't throw exceptions during construction from a StreamInput, as this 
can kill nodes in mixed clusters.