### PR TITLE
Revert "[DOCS] Migration guide: link to "What's new" page for the same version"

### DIFF
--- a/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/breaking-changes.asciidoc
@@ -7,7 +7,7 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to {es} ${majorDotMinor}.
 
-See also {ref-bare}/${majorDotMinor}/release-highlights.html[What's new in ${majorDotMinor}] and <<es-release-notes>>.
+See also <<release-highlights>> and <<es-release-notes>>.
 <% if (isElasticsearchSnapshot) { %>
 coming::[${majorDotMinorDotRevision}]
 <% } %>

--- a/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/BreakingChangesGeneratorTest.generateMigrationFile.asciidoc
+++ b/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/BreakingChangesGeneratorTest.generateMigrationFile.asciidoc
@@ -7,7 +7,7 @@
 This section discusses the changes that you need to be aware of when migrating
 your application to {es} 8.4.
 
-See also {ref-bare}/8.4/release-highlights.html[What's new in 8.4] and <<es-release-notes>>.
+See also <<release-highlights>> and <<es-release-notes>>.
 
 coming::[8.4.0]
 


### PR DESCRIPTION
This reverts elastic/elasticsearch#92823. It caused issues with references that don't exist yet when these docs are generated.