### PR TITLE
Introduce additional logging for testDelayedAllocationChangeWithSettingTo100ms

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/DelayedAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/DelayedAllocationIT.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.junit.annotations.TestLogging;
 
 import java.util.List;
 
@@ -102,6 +103,10 @@ public class DelayedAllocationIT extends ESIntegTestCase {
      * allocation to a very small value, it kicks the allocation of the unassigned shard
      * even though the node it was hosted on will not come back.
      */
+    @TestLogging(
+        value = "org.elasticsearch.cluster.routing.allocation.allocator:TRACE",
+        reason = "https://github.com/elastic/elasticsearch/issues/93470"
+    )
     public void testDelayedAllocationChangeWithSettingTo100ms() throws Exception {
         internalCluster().startNodes(3);
         prepareCreate("test").setSettings(
@@ -120,6 +125,7 @@ public class DelayedAllocationIT extends ESIntegTestCase {
             )
         );
         assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        logger.info("Setting shorter allocation delay");
         updateIndexSettings(
             Settings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100)),
             "test"


### PR DESCRIPTION
This change enables allocation trace logging to be able to debug occasional CI test failures.

Related to #93470