### PR TITLE
Update rest api spec for ent-search module

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.delete.json
@@ -1,12 +1,11 @@
 {
   "behavioral_analytics.delete": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
       "description": "Delete a behavioral analytics collection."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.list.json
@@ -1,12 +1,11 @@
 {
   "behavioral_analytics.list": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html",
       "description": "Returns the existing behavioral analytics collections."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.put.json
@@ -1,12 +1,11 @@
 {
   "behavioral_analytics.put": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
       "description": "Creates a behavioral analytics collection."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
@@ -1,12 +1,11 @@
 {
   "search_application.delete": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html",
       "description": "Deletes a search application."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
@@ -1,12 +1,11 @@
 {
   "search_application.get": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html",
       "description": "Returns the details about a search application."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
@@ -1,12 +1,11 @@
 {
   "search_application.list": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html",
       "description": "Returns the existing search applications."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
@@ -1,12 +1,11 @@
 {
   "search_application.put": {
     "documentation": {
-      "url": "http://todo.com/tbd",
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html",
       "description": "Creates or updates a search application."
     },
-    "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "stability": "beta",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"


### PR DESCRIPTION
This change sets the stability of ent-search APIs to beta and visibility to public. It also removes the feature flag link since enabling the module is not considered as a feature flag and the module is enabled by default.