### PR TITLE
Collect stats for TransportBroadcastUnpromotableAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -10,9 +10,9 @@ package org.elasticsearch.action.admin.indices.refresh;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.broadcast.unpromotable.UnpromotableShardStats;
 import org.elasticsearch.action.support.replication.BasicReplicationRequest;
 import org.elasticsearch.action.support.replication.ReplicationOperation;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -122,7 +122,7 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
                 unpromotableReplicaRequest,
                 new ActionListenerResponseHandler<>(
                     listener.delegateFailure((l, r) -> l.onResponse(null)),
-                    (in) -> ActionResponse.Empty.INSTANCE,
+                    UnpromotableShardStats::new,
                     ThreadPool.Names.REFRESH
                 )
             );

--- a/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/UnpromotableShardStats.java
+++ b/server/src/main/java/org/elasticsearch/action/support/broadcast/unpromotable/UnpromotableShardStats.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+package org.elasticsearch.action.support.broadcast.unpromotable;
+
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+
+public class UnpromotableShardStats extends ActionResponse {
+    private final int successful;
+    private final int failed;
+
+    public UnpromotableShardStats(int successful, int failed) {
+        this.successful = successful;
+        this.failed = failed;
+    }
+
+    public UnpromotableShardStats(StreamInput in) throws IOException {
+        super(in);
+        this.successful = in.readVInt();
+        this.failed = in.readVInt();
+    }
+
+    public int getSuccessful() {
+        return successful;
+    }
+
+    public int getFailed() {
+        return failed;
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeVInt(successful);
+        out.writeVInt(failed);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
@@ -11,10 +11,10 @@ package org.elasticsearch.action.support.replication;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionListenerResponseHandler;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.refresh.TransportUnpromotableShardRefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.UnpromotableShardRefreshRequest;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.broadcast.unpromotable.UnpromotableShardStats;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.index.shard.IndexShard;
@@ -131,7 +131,7 @@ public class PostWriteRefresh {
             unpromotableReplicaRequest,
             new ActionListenerResponseHandler<>(
                 listener.delegateFailure((l, r) -> l.onResponse(wasForced)),
-                (in) -> ActionResponse.Empty.INSTANCE,
+                UnpromotableShardStats::new,
                 ThreadPool.Names.REFRESH
             )
         );

--- a/server/src/test/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/broadcast/unpromotable/TransportBroadcastUnpromotableActionTests.java
@@ -173,7 +173,7 @@ public class TransportBroadcastUnpromotableActionTests extends ESTestCase {
     }
 
     private int countRequestsForIndex(ClusterState state, String index) {
-        PlainActionFuture<ActionResponse.Empty> response = PlainActionFuture.newFuture();
+        PlainActionFuture<UnpromotableShardStats> response = PlainActionFuture.newFuture();
         state.routingTable().activePrimaryShardsGrouped(new String[] { index }, true).iterator().forEachRemaining(shardId -> {
             logger.debug("--> executing for primary shard id: {}", shardId.shardId());
             ActionTestUtils.execute(
@@ -278,12 +278,12 @@ public class TransportBroadcastUnpromotableActionTests extends ESTestCase {
         }
         IndexShardRoutingTable wrongRoutingTable = wrongRoutingTableBuilder.build();
 
-        PlainActionFuture<ActionResponse.Empty> response = PlainActionFuture.newFuture();
+        PlainActionFuture<UnpromotableShardStats> response = PlainActionFuture.newFuture();
         logger.debug("--> executing for wrong shard routing table: {}", wrongRoutingTable);
         assertThat(
             expectThrows(
                 NodeNotConnectedException.class,
-                () -> PlainActionFuture.<ActionResponse.Empty, Exception>get(
+                () -> PlainActionFuture.<UnpromotableShardStats, Exception>get(
                     f -> ActionTestUtils.execute(
                         broadcastUnpromotableAction,
                         null,
@@ -304,7 +304,7 @@ public class TransportBroadcastUnpromotableActionTests extends ESTestCase {
         assertThat(
             expectThrows(
                 NullPointerException.class,
-                () -> PlainActionFuture.<ActionResponse.Empty, Exception>get(
+                () -> PlainActionFuture.<UnpromotableShardStats, Exception>get(
                     f -> ActionTestUtils.execute(
                         broadcastUnpromotableAction,
                         null,

--- a/server/src/test/java/org/elasticsearch/action/support/replication/PostWriteRefreshTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/PostWriteRefreshTests.java
@@ -10,12 +10,12 @@ package org.elasticsearch.action.support.replication;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.admin.indices.refresh.TransportUnpromotableShardRefreshAction;
 import org.elasticsearch.action.admin.indices.refresh.UnpromotableShardRefreshRequest;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.action.support.broadcast.unpromotable.UnpromotableShardStats;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -62,7 +62,7 @@ public class PostWriteRefreshTests extends IndexShardTestCase {
             UnpromotableShardRefreshRequest::new,
             (request, channel, task) -> {
                 unpromotableRefreshRequestReceived.set(true);
-                channel.sendResponse(ActionResponse.Empty.INSTANCE);
+                channel.sendResponse(new UnpromotableShardStats(1, 0));
             }
         );
 


### PR DESCRIPTION
So `PostWriteRefresh` would know whether to fail the bulk requests if we needed to fail the whole bulk request. 