### PR TITLE
Further determinism improvements to CoordinatorTests

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationMetadata.java
@@ -361,7 +361,8 @@ public class CoordinationMetadata implements Writeable, ToXContentFragment {
 
         @Override
         public String toString() {
-            return "VotingConfiguration{" + String.join(",", nodeIds) + "}";
+            // Sorting the node IDs for deterministic logging until https://github.com/elastic/elasticsearch/issues/94946 is fixed
+            return "VotingConfiguration{" + nodeIds.stream().sorted().collect(Collectors.joining(",")) + "}";
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -915,6 +915,11 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                         }
                     }
                 }
+
+                @Override
+                public String toString() {
+                    return "term change heartbeat listener";
+                }
             })
         );
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/LeaderChecker.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Setting;
@@ -160,7 +161,8 @@ public class LeaderChecker {
      * publication targets, and also called if a leader becomes a non-leader.
      */
     void setCurrentNodes(DiscoveryNodes discoveryNodes) {
-        logger.trace("setCurrentNodes: {}", discoveryNodes);
+        // Sorting the nodes for deterministic logging until https://github.com/elastic/elasticsearch/issues/94946 is fixed
+        logger.trace(() -> Strings.format("setCurrentNodes: {}", discoveryNodes.mastersFirstStream().toList()));
         this.discoveryNodes = discoveryNodes;
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Reconfigurator.java
@@ -13,6 +13,7 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
@@ -91,12 +92,15 @@ public class Reconfigurator {
     ) {
         assert liveNodes.contains(currentMaster) : "liveNodes = " + liveNodes + " master = " + currentMaster;
         logger.trace(
-            "{} reconfiguring {} based on liveNodes={}, retiredNodeIds={}, currentMaster={}",
-            this,
-            currentConfig,
-            liveNodes,
-            retiredNodeIds,
-            currentMaster
+            () -> Strings.format(
+                "%s reconfiguring %s based on liveNodes=%s, retiredNodeIds=%s, currentMaster=%s",
+                this,
+                currentConfig,
+                // Sorting the node IDs for deterministic logging until https://github.com/elastic/elasticsearch/issues/94946 is fixed
+                liveNodes.stream().map(DiscoveryNode::toString).sorted().collect(Collectors.joining(", ", "[", "]")),
+                retiredNodeIds.stream().sorted().collect(Collectors.joining(", ")),
+                currentMaster
+            )
         );
 
         final Set<String> liveNodeIds = liveNodes.stream()

--- a/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/service/FakeThreadPoolMasterService.java
@@ -59,6 +59,11 @@ public class FakeThreadPoolMasterService extends MasterService {
             public void execute(Runnable command) {
                 taskExecutor.accept(threadContext.preserveContext(command));
             }
+
+            @Override
+            public String toString() {
+                return "FakeThreadPoolMasterService executor";
+            }
         };
     }
 


### PR DESCRIPTION
A handful of small changes to make the logging output of `CoordinatorTests` even more deterministic, for easier diffing.

Relates #94946