### PR TITLE
Fix off-by-one bug in RecyclerBytesStreamOutput

### DIFF
--- a/docs/changelog/95036.yaml
+++ b/docs/changelog/95036.yaml
@@ -1,0 +1,5 @@
+pr: 95036
+summary: Fix off-by-one bug in `RecyclerBytesStreamOutput`
+area: Network
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
@@ -230,7 +230,7 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
         if (newPosition > Integer.MAX_VALUE - (Integer.MAX_VALUE % pageSize)) {
             throw new IllegalArgumentException(getClass().getSimpleName() + " cannot hold more than 2GB of data");
         }
-        while (newPosition > currentCapacity) {
+        while (newPosition > currentCapacity - 1) {
             Recycler.V<BytesRef> newPage = recycler.obtain();
             assert pageSize == newPage.v().length;
             pages.add(newPage);

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.PageCacheRecycler;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.BytesRefRecycler;
 
@@ -240,12 +241,43 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         int position = 0;
         assertEquals(position, out.position());
 
-        out.seek(position += 10);
+        final List<Tuple<Integer, Byte>> writes = new ArrayList<>();
+        int randomOffset = randomIntBetween(0, PageCacheRecycler.BYTE_PAGE_SIZE);
+        out.seek(position += randomOffset);
+        if (randomBoolean()) {
+            byte random = randomByte();
+            out.writeByte(random);
+            writes.add(Tuple.tuple(position, random));
+            position++;
+        }
         out.seek(position += PageCacheRecycler.BYTE_PAGE_SIZE);
-        out.seek(position += PageCacheRecycler.BYTE_PAGE_SIZE + 10);
+        if (randomBoolean()) {
+            byte random = randomByte();
+            out.writeByte(random);
+            writes.add(Tuple.tuple(position, random));
+            position++;
+        }
+        out.seek(position += PageCacheRecycler.BYTE_PAGE_SIZE + randomOffset);
+        if (randomBoolean()) {
+            byte random = randomByte();
+            out.writeByte(random);
+            writes.add(Tuple.tuple(position, random));
+            position++;
+        }
         out.seek(position += PageCacheRecycler.BYTE_PAGE_SIZE * 2);
+        if (randomBoolean()) {
+            byte random = randomByte();
+            out.writeByte(random);
+            writes.add(Tuple.tuple(position, random));
+            position++;
+        }
         assertEquals(position, out.position());
-        assertEquals(position, BytesReference.toBytes(out.bytes()).length);
+
+        final BytesReference bytesReference = out.bytes();
+        assertEquals(position, BytesReference.toBytes(bytesReference).length);
+        for (Tuple<Integer, Byte> write : writes) {
+            assertEquals((byte) write.v2(), bytesReference.get(write.v1()));
+        }
 
         IllegalArgumentException iae = expectThrows(IllegalArgumentException.class, () -> out.seek(Integer.MAX_VALUE + 1L));
         assertEquals("RecyclerBytesStreamOutput cannot hold more than 2GB of data", iae.getMessage());

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -1002,4 +1002,12 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
             assertThat(pagesAllocated.get(), equalTo(0L));
         }
     }
+
+    public void testSeekToPageBoundary() {
+        RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
+        out.seek(PageCacheRecycler.BYTE_PAGE_SIZE);
+        byte b = randomByte();
+        out.writeByte(b);
+        assertEquals(b, out.bytes().get(PageCacheRecycler.BYTE_PAGE_SIZE));
+    }
 }


### PR DESCRIPTION
Fixing off by one bug when seeking to first byte in the next page.
This shouldn't be bad yet because we don't have any code that seeks in a way that could trigger this as far as I can see, but I ran into it quickly trying to optimize a message serialization.
