### PR TITLE
Fix RepositoryAnalysisSuccessIT

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisSuccessIT.java
@@ -424,6 +424,7 @@ public class RepositoryAnalysisSuccessIT extends AbstractSnapshotIntegTestCase {
 
         @Override
         public void compareAndExchangeRegister(String key, long expected, long updated, ActionListener<OptionalLong> listener) {
+            firstRegisterRead.set(false);
             if (updated != -1 && randomBoolean() && randomBoolean()) {
                 // updated != -1 so we don't fail the final check because we know there can be no concurrent operations at that point
                 listener.onResponse(OptionalLong.empty());


### PR DESCRIPTION
If all the reads before the final one happen via `compareAndExchangeRegister` then the final one might find `firstRegisterRead` to be set still, permitting it to fail. This commit treats calls to `compareAndExchangeRegister` as reads too, avoiding this problem.

Closes #94664