### PR TITLE
[8.7] Fix off-by-one bug in RecyclerBytesStreamOutput (#95036)

### DIFF
--- a/docs/changelog/95036.yaml
+++ b/docs/changelog/95036.yaml
@@ -1,0 +1,5 @@
+pr: 95036
+summary: Fix off-by-one bug in `RecyclerBytesStreamOutput`
+area: Network
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
@@ -230,7 +230,7 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
         if (newPosition > Integer.MAX_VALUE - (Integer.MAX_VALUE % pageSize)) {
             throw new IllegalArgumentException(getClass().getSimpleName() + " cannot hold more than 2GB of data");
         }
-        while (newPosition > currentCapacity) {
+        while (newPosition > currentCapacity - 1) {
             Recycler.V<BytesRef> newPage = recycler.obtain();
             assert pageSize == newPage.v().length;
             pages.add(newPage);


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix off-by-one bug in RecyclerBytesStreamOutput (#95036)