### PR TITLE
Fix RepositoryAnalysisFailureIT

### DIFF
--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -321,7 +321,19 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
             @Override
             public long onCompareAndExchange(AtomicLong register, long expected, long updated) {
                 if (randomBoolean() && sawSpuriousValue.compareAndSet(false, true)) {
-                    return randomFrom(expectedMax, randomLongBetween(expectedMax, Long.MAX_VALUE), randomLongBetween(Long.MIN_VALUE, -1));
+                    if (register.get() == expectedMax) {
+                        return randomFrom(
+                            randomLongBetween(0L, expectedMax - 1),
+                            randomLongBetween(expectedMax + 1, Long.MAX_VALUE),
+                            randomLongBetween(Long.MIN_VALUE, -1)
+                        );
+                    } else {
+                        return randomFrom(
+                            expectedMax,
+                            randomLongBetween(expectedMax, Long.MAX_VALUE),
+                            randomLongBetween(Long.MIN_VALUE, -1)
+                        );
+                    }
                 }
                 return register.compareAndExchange(expected, updated);
             }


### PR DESCRIPTION
This test is supposed to trigger a failure by exposing a spurious value for the register, but sometimes it exposes `expectedMax` which is what we expect at the end of the register checks. With this commit we ensure that we don't inadvertently return a correct value.

Closes #94410