### PR TITLE
[ML] Add Deployment Id for NLP deployments

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/MlTasks.java
@@ -108,8 +108,10 @@ public final class MlTasks {
         return taskId.substring(DATA_FRAME_ANALYTICS_TASK_ID_PREFIX.length());
     }
 
-    public static String trainedModelAssignmentTaskDescription(String modelId) {
-        return TrainedModelConfig.MODEL_ID.getPreferredName() + "[" + modelId + "]";
+    public static String trainedModelAssignmentTaskDescription(String deploymentId) {
+        // A description containing deployment_id[XXX] is more accurate
+        // than model_id[XXX] but the legacy description cannot be changed now
+        return TrainedModelConfig.MODEL_ID.getPreferredName() + "[" + deploymentId + "]";
     }
 
     @Nullable

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ClearDeploymentCacheAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/ClearDeploymentCacheAction.java
@@ -31,30 +31,30 @@ public class ClearDeploymentCacheAction extends ActionType<ClearDeploymentCacheA
     }
 
     public static class Request extends BaseTasksRequest<Request> {
-        private final String modelId;
+        private final String deploymentId;
 
-        public Request(String modelId) {
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
+        public Request(String deploymentId) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, InferModelAction.Request.ID);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.modelId = in.readString();
+            this.deploymentId = in.readString();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(modelId);
+            out.writeString(deploymentId);
         }
 
-        public String getModelId() {
-            return modelId;
+        public String getDeploymentId() {
+            return deploymentId;
         }
 
         @Override
         public boolean match(Task task) {
-            return StartTrainedModelDeploymentAction.TaskMatcher.match(task, modelId);
+            return StartTrainedModelDeploymentAction.TaskMatcher.match(task, deploymentId);
         }
 
         @Override
@@ -62,12 +62,12 @@ public class ClearDeploymentCacheAction extends ActionType<ClearDeploymentCacheA
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return Objects.equals(modelId, request.modelId);
+            return Objects.equals(deploymentId, request.deploymentId);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId);
+            return Objects.hash(deploymentId);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsAction.java
@@ -38,30 +38,30 @@ public class GetDeploymentStatsAction extends ActionType<GetDeploymentStatsActio
 
     public static class Request extends BaseTasksRequest<GetDeploymentStatsAction.Request> {
 
-        private final String modelId;
+        private final String deploymentId;
         // used internally this should not be set by the REST request
         private List<String> expandedIds;
 
-        public Request(String modelId) {
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
-            this.expandedIds = Collections.singletonList(modelId);
+        public Request(String deploymentId) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, InferModelAction.Request.DEPLOYMENT_ID);
+            this.expandedIds = Collections.singletonList(deploymentId);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.modelId = in.readString();
+            this.deploymentId = in.readString();
             this.expandedIds = in.readStringList();
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(modelId);
+            out.writeString(deploymentId);
             out.writeStringCollection(expandedIds);
         }
 
-        public String getModelId() {
-            return modelId;
+        public String getDeploymentId() {
+            return deploymentId;
         }
 
         public void setExpandedIds(List<String> expandedIds) {
@@ -78,12 +78,12 @@ public class GetDeploymentStatsAction extends ActionType<GetDeploymentStatsActio
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return Objects.equals(modelId, request.modelId) && Objects.equals(expandedIds, request.expandedIds);
+            return Objects.equals(deploymentId, request.deploymentId) && Objects.equals(expandedIds, request.expandedIds);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, expandedIds);
+            return Objects.hash(deploymentId, expandedIds);
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferModelAction.java
@@ -49,14 +49,15 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
     public static class Request extends ActionRequest {
 
-        public static final ParseField MODEL_ID = new ParseField("model_id");
+        public static final ParseField ID = new ParseField("id");
+        public static final ParseField DEPLOYMENT_ID = new ParseField("deployment_id");
         public static final ParseField DOCS = new ParseField("docs");
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField INFERENCE_CONFIG = new ParseField("inference_config");
 
         static final ObjectParser<Builder, Void> PARSER = new ObjectParser<>(NAME, Builder::new);
         static {
-            PARSER.declareString(Builder::setModelId, MODEL_ID);
+            PARSER.declareString(Builder::setId, ID);
             PARSER.declareObjectArray(Builder::setDocs, (p, c) -> p.mapOrdered(), DOCS);
             PARSER.declareString(Builder::setInferenceTimeout, TIMEOUT);
             PARSER.declareNamedObject(
@@ -66,10 +67,10 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             );
         }
 
-        public static Builder parseRequest(String modelId, XContentParser parser) {
+        public static Builder parseRequest(String id, XContentParser parser) {
             Builder builder = PARSER.apply(parser, null);
-            if (modelId != null) {
-                builder.setModelId(modelId);
+            if (id != null) {
+                builder.setId(id);
             }
             return builder;
         }
@@ -77,7 +78,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         public static final TimeValue DEFAULT_TIMEOUT_FOR_API = TimeValue.timeValueSeconds(10);
         public static final TimeValue DEFAULT_TIMEOUT_FOR_INGEST = TimeValue.MAX_VALUE;
 
-        private final String modelId;
+        private final String id;
         private final List<Map<String, Object>> objectsToInfer;
         private final InferenceConfigUpdate update;
         private final boolean previouslyLicensed;
@@ -95,13 +96,13 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
          * to prefer slow ingest over dropping documents.
          */
         public static Request forIngestDocs(
-            String modelId,
+            String id,
             List<Map<String, Object>> docs,
             InferenceConfigUpdate update,
             boolean previouslyLicensed
         ) {
             return new Request(
-                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID),
+                ExceptionsHelper.requireNonNull(id, InferModelAction.Request.ID),
                 update,
                 ExceptionsHelper.requireNonNull(Collections.unmodifiableList(docs), DOCS),
                 null,
@@ -116,9 +117,9 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
          * The inference timeout (how long the request waits in
          * the inference queue for) is set to {@code #DEFAULT_TIMEOUT_FOR_API}
          */
-        public static Request forTextInput(String modelId, InferenceConfigUpdate update, List<String> textInput) {
+        public static Request forTextInput(String id, InferenceConfigUpdate update, List<String> textInput) {
             return new Request(
-                modelId,
+                id,
                 update,
                 List.of(),
                 ExceptionsHelper.requireNonNull(textInput, "inference text input"),
@@ -128,14 +129,14 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         }
 
         Request(
-            String modelId,
+            String id,
             InferenceConfigUpdate inferenceConfigUpdate,
             List<Map<String, Object>> docs,
             List<String> textInput,
             TimeValue inferenceTimeout,
             boolean previouslyLicensed
         ) {
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, MODEL_ID);
+            this.id = ExceptionsHelper.requireNonNull(id, ID);
             this.objectsToInfer = Collections.unmodifiableList(ExceptionsHelper.requireNonNull(docs, DOCS.getPreferredName()));
             this.update = ExceptionsHelper.requireNonNull(inferenceConfigUpdate, "inference_config");
             this.textInput = textInput;
@@ -145,7 +146,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            this.modelId = in.readString();
+            this.id = in.readString();
             this.objectsToInfer = in.readImmutableList(StreamInput::readMap);
             this.update = in.readNamedWriteable(InferenceConfigUpdate.class);
             this.previouslyLicensed = in.readBoolean();
@@ -172,8 +173,8 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             }
         }
 
-        public String getModelId() {
-            return modelId;
+        public String getId() {
+            return id;
         }
 
         public List<Map<String, Object>> getObjectsToInfer() {
@@ -217,7 +218,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(modelId);
+            out.writeString(id);
             out.writeCollection(objectsToInfer, StreamOutput::writeGenericMap);
             out.writeNamedWriteable(update);
             out.writeBoolean(previouslyLicensed);
@@ -237,7 +238,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             InferModelAction.Request that = (InferModelAction.Request) o;
-            return Objects.equals(modelId, that.modelId)
+            return Objects.equals(id, that.id)
                 && Objects.equals(update, that.update)
                 && Objects.equals(previouslyLicensed, that.previouslyLicensed)
                 && Objects.equals(inferenceTimeout, that.inferenceTimeout)
@@ -248,25 +249,25 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         @Override
         public Task createTask(long id, String type, String action, TaskId parentTaskId, Map<String, String> headers) {
-            return new CancellableTask(id, type, action, format("infer_trained_model[%s]", modelId), parentTaskId, headers);
+            return new CancellableTask(id, type, action, format("infer_trained_model[%s]", this.id), parentTaskId, headers);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, objectsToInfer, update, previouslyLicensed, inferenceTimeout, textInput, highPriority);
+            return Objects.hash(id, objectsToInfer, update, previouslyLicensed, inferenceTimeout, textInput, highPriority);
         }
 
         public static class Builder {
 
-            private String modelId;
+            private String id;
             private List<Map<String, Object>> docs;
             private TimeValue timeout;
             private InferenceConfigUpdate update = new EmptyConfigUpdate();
 
             private Builder() {}
 
-            public Builder setModelId(String modelId) {
-                this.modelId = ExceptionsHelper.requireNonNull(modelId, MODEL_ID);
+            public Builder setId(String id) {
+                this.id = ExceptionsHelper.requireNonNull(id, ID);
                 return this;
             }
 
@@ -294,7 +295,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             }
 
             public Request build() {
-                return new Request(modelId, update, docs, null, timeout, false);
+                return new Request(id, update, docs, null, timeout, false);
             }
         }
 
@@ -303,21 +304,21 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
     public static class Response extends ActionResponse implements ToXContentObject {
 
         private final List<InferenceResults> inferenceResults;
-        private final String modelId;
+        private final String id;
         private final boolean isLicensed;
 
-        public Response(List<InferenceResults> inferenceResults, String modelId, boolean isLicensed) {
+        public Response(List<InferenceResults> inferenceResults, String id, boolean isLicensed) {
             super();
             this.inferenceResults = Collections.unmodifiableList(ExceptionsHelper.requireNonNull(inferenceResults, "inferenceResults"));
             this.isLicensed = isLicensed;
-            this.modelId = modelId;
+            this.id = id;
         }
 
         public Response(StreamInput in) throws IOException {
             super(in);
             this.inferenceResults = Collections.unmodifiableList(in.readNamedWriteableList(InferenceResults.class));
             this.isLicensed = in.readBoolean();
-            this.modelId = in.readOptionalString();
+            this.id = in.readOptionalString();
         }
 
         public List<InferenceResults> getInferenceResults() {
@@ -328,15 +329,15 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             return isLicensed;
         }
 
-        public String getModelId() {
-            return modelId;
+        public String getId() {
+            return id;
         }
 
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeNamedWriteableList(inferenceResults);
             out.writeBoolean(isLicensed);
-            out.writeOptionalString(modelId);
+            out.writeOptionalString(id);
         }
 
         @Override
@@ -344,14 +345,12 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             InferModelAction.Response that = (InferModelAction.Response) o;
-            return isLicensed == that.isLicensed
-                && Objects.equals(inferenceResults, that.inferenceResults)
-                && Objects.equals(modelId, that.modelId);
+            return isLicensed == that.isLicensed && Objects.equals(inferenceResults, that.inferenceResults) && Objects.equals(id, that.id);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(inferenceResults, isLicensed, modelId);
+            return Objects.hash(inferenceResults, isLicensed, id);
         }
 
         public static Builder builder() {
@@ -375,7 +374,7 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
 
         public static class Builder {
             private List<InferenceResults> inferenceResults = new ArrayList<>();
-            private String modelId;
+            private String id;
             private boolean isLicensed;
 
             public Builder addInferenceResults(List<InferenceResults> inferenceResults) {
@@ -388,13 +387,13 @@ public class InferModelAction extends ActionType<InferModelAction.Response> {
                 return this;
             }
 
-            public Builder setModelId(String modelId) {
-                this.modelId = modelId;
+            public Builder setId(String id) {
+                this.id = id;
                 return this;
             }
 
             public Response build() {
-                return new Response(inferenceResults, modelId, isLicensed);
+                return new Response(inferenceResults, id, isLicensed);
             }
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -75,7 +75,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
 
         static final ObjectParser<Request.Builder, Void> PARSER = new ObjectParser<>(NAME, Request.Builder::new);
         static {
-            PARSER.declareString(Request.Builder::setModelId, InferModelAction.Request.MODEL_ID);
+            PARSER.declareString(Request.Builder::setModelId, InferModelAction.Request.DEPLOYMENT_ID);
             PARSER.declareObjectArray(Request.Builder::setDocs, (p, c) -> p.mapOrdered(), DOCS);
             PARSER.declareString(Request.Builder::setInferenceTimeout, TIMEOUT);
             PARSER.declareNamedObject(
@@ -110,7 +110,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             TimeValue inferenceTimeout
         ) {
             return new Request(
-                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID),
+                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID),
                 update,
                 ExceptionsHelper.requireNonNull(Collections.unmodifiableList(docs), DOCS),
                 null,
@@ -126,7 +126,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             TimeValue inferenceTimeout
         ) {
             return new Request(
-                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID),
+                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID),
                 update,
                 List.of(),
                 ExceptionsHelper.requireNonNull(textInput, "inference text input"),
@@ -144,7 +144,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             boolean highPriority,
             TimeValue inferenceTimeout
         ) {
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
+            this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID);
             this.docs = docs;
             this.textInput = textInput;
             this.update = update;
@@ -278,7 +278,7 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             private Builder() {}
 
             public Builder setModelId(String modelId) {
-                this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.MODEL_ID);
+                this.modelId = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID);
                 return this;
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -402,7 +402,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         static {
             PARSER.declareString(ConstructingObjectParser.constructorArg(), TrainedModelConfig.MODEL_ID);
-            PARSER.declareString(ConstructingObjectParser.constructorArg(), Request.DEPLOYMENT_ID);
+            PARSER.declareString(ConstructingObjectParser.optionalConstructorArg(), Request.DEPLOYMENT_ID);
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), MODEL_BYTES);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), NUMBER_OF_ALLOCATIONS);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), THREADS_PER_ALLOCATION);
@@ -435,7 +435,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         private TaskParams(
             String modelId,
-            String deploymentId,
+            @Nullable String deploymentId,
             long modelBytes,
             Integer numberOfAllocations,
             Integer threadsPerAllocation,
@@ -447,7 +447,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         ) {
             this(
                 modelId,
-                deploymentId,
+                // deploymentId should only be null in a mixed cluster
+                // with pre-8.8 nodes
+                deploymentId == null ? modelId : deploymentId,
                 modelBytes,
                 numberOfAllocations == null ? legacyModelThreads : numberOfAllocations,
                 threadsPerAllocation == null ? legacyInferenceThreads : threadsPerAllocation,

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentAction.java
@@ -79,6 +79,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         private static final int MAX_QUEUE_CAPACITY = 1_000_000;
 
         public static final ParseField MODEL_ID = new ParseField("model_id");
+        public static final ParseField DEPLOYMENT_ID = new ParseField("deployment_id");
         public static final ParseField TIMEOUT = new ParseField("timeout");
         public static final ParseField WAIT_FOR = new ParseField("wait_for");
         public static final ParseField THREADS_PER_ALLOCATION = new ParseField("threads_per_allocation", "inference_threads");
@@ -91,6 +92,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         static {
             PARSER.declareString(Request::setModelId, MODEL_ID);
+            PARSER.declareString(Request::setDeploymentId, DEPLOYMENT_ID);
             PARSER.declareString((request, val) -> request.setTimeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
             PARSER.declareString((request, waitFor) -> request.setWaitForState(AllocationStatus.State.fromString(waitFor)), WAIT_FOR);
             PARSER.declareInt(Request::setThreadsPerAllocation, THREADS_PER_ALLOCATION);
@@ -105,7 +107,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             PARSER.declareString(Request::setPriority, PRIORITY);
         }
 
-        public static Request parseRequest(String modelId, XContentParser parser) {
+        public static Request parseRequest(String modelId, String deploymentId, XContentParser parser) {
             Request request = PARSER.apply(parser, null);
             if (request.getModelId() == null) {
                 request.setModelId(modelId);
@@ -114,10 +116,15 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
                     Messages.getMessage(Messages.INCONSISTENT_ID, MODEL_ID, request.getModelId(), modelId)
                 );
             }
+
+            if (deploymentId != null) {
+                request.setDeploymentId(deploymentId);
+            }
             return request;
         }
 
         private String modelId;
+        private String deploymentId;
         private TimeValue timeout = DEFAULT_TIMEOUT;
         private AllocationStatus.State waitForState = AllocationStatus.State.STARTED;
         private ByteSizeValue cacheSize;
@@ -128,8 +135,9 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         private Request() {}
 
-        public Request(String modelId) {
+        public Request(String modelId, String deploymentId) {
             setModelId(modelId);
+            setDeploymentId(deploymentId);
         }
 
         public Request(StreamInput in) throws IOException {
@@ -148,14 +156,28 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             } else {
                 this.priority = Priority.NORMAL;
             }
+
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                this.deploymentId = in.readString();
+            } else {
+                this.deploymentId = modelId;
+            }
         }
 
         public final void setModelId(String modelId) {
             this.modelId = ExceptionsHelper.requireNonNull(modelId, MODEL_ID);
         }
 
+        public final void setDeploymentId(String deploymentId) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, DEPLOYMENT_ID);
+        }
+
         public String getModelId() {
             return modelId;
+        }
+
+        public String getDeploymentId() {
+            return deploymentId;
         }
 
         public void setTimeout(TimeValue timeout) {
@@ -230,12 +252,16 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_6_0)) {
                 out.writeEnum(priority);
             }
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                out.writeString(deploymentId);
+            }
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(MODEL_ID.getPreferredName(), modelId);
+            builder.field(DEPLOYMENT_ID.getPreferredName(), deploymentId);
             builder.field(TIMEOUT.getPreferredName(), timeout.getStringRep());
             builder.field(WAIT_FOR.getPreferredName(), waitForState);
             builder.field(NUMBER_OF_ALLOCATIONS.getPreferredName(), numberOfAllocations);
@@ -299,6 +325,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         public int hashCode() {
             return Objects.hash(
                 modelId,
+                deploymentId,
                 timeout,
                 waitForState,
                 numberOfAllocations,
@@ -319,6 +346,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             }
             Request other = (Request) obj;
             return Objects.equals(modelId, other.modelId)
+                && Objects.equals(deploymentId, other.deploymentId)
                 && Objects.equals(timeout, other.timeout)
                 && Objects.equals(waitForState, other.waitForState)
                 && Objects.equals(cacheSize, other.cacheSize)
@@ -360,19 +388,21 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             true,
             a -> new TaskParams(
                 (String) a[0],
-                (Long) a[1],
-                (Integer) a[2],
+                (String) a[1],
+                (Long) a[2],
                 (Integer) a[3],
-                (int) a[4],
-                (ByteSizeValue) a[5],
-                (Integer) a[6],
+                (Integer) a[4],
+                (int) a[5],
+                (ByteSizeValue) a[6],
                 (Integer) a[7],
-                a[8] == null ? null : Priority.fromString((String) a[8])
+                (Integer) a[8],
+                a[9] == null ? null : Priority.fromString((String) a[9])
             )
         );
 
         static {
             PARSER.declareString(ConstructingObjectParser.constructorArg(), TrainedModelConfig.MODEL_ID);
+            PARSER.declareString(ConstructingObjectParser.constructorArg(), Request.DEPLOYMENT_ID);
             PARSER.declareLong(ConstructingObjectParser.constructorArg(), MODEL_BYTES);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), NUMBER_OF_ALLOCATIONS);
             PARSER.declareInt(ConstructingObjectParser.optionalConstructorArg(), THREADS_PER_ALLOCATION);
@@ -393,6 +423,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         }
 
         private final String modelId;
+        private final String deploymentId;
         private final ByteSizeValue cacheSize;
         private final long modelBytes;
         // How many threads are used by the model during inference. Used to increase inference speed.
@@ -404,6 +435,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         private TaskParams(
             String modelId,
+            String deploymentId,
             long modelBytes,
             Integer numberOfAllocations,
             Integer threadsPerAllocation,
@@ -415,6 +447,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
         ) {
             this(
                 modelId,
+                deploymentId,
                 modelBytes,
                 numberOfAllocations == null ? legacyModelThreads : numberOfAllocations,
                 threadsPerAllocation == null ? legacyInferenceThreads : threadsPerAllocation,
@@ -426,6 +459,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         public TaskParams(
             String modelId,
+            String deploymentId,
             long modelBytes,
             int numberOfAllocations,
             int threadsPerAllocation,
@@ -434,6 +468,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             Priority priority
         ) {
             this.modelId = Objects.requireNonNull(modelId);
+            this.deploymentId = Objects.requireNonNull(deploymentId);
             this.modelBytes = modelBytes;
             this.threadsPerAllocation = threadsPerAllocation;
             this.numberOfAllocations = numberOfAllocations;
@@ -458,10 +493,19 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             } else {
                 this.priority = Priority.NORMAL;
             }
+            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                this.deploymentId = in.readString();
+            } else {
+                this.deploymentId = modelId;
+            }
         }
 
         public String getModelId() {
             return modelId;
+        }
+
+        public String getDeploymentId() {
+            return deploymentId;
         }
 
         public long estimateMemoryUsageBytes() {
@@ -490,12 +534,16 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_6_0)) {
                 out.writeEnum(priority);
             }
+            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+                out.writeString(deploymentId);
+            }
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
             builder.field(TrainedModelConfig.MODEL_ID.getPreferredName(), modelId);
+            builder.field(Request.DEPLOYMENT_ID.getPreferredName(), deploymentId);
             builder.field(MODEL_BYTES.getPreferredName(), modelBytes);
             builder.field(THREADS_PER_ALLOCATION.getPreferredName(), threadsPerAllocation);
             builder.field(NUMBER_OF_ALLOCATIONS.getPreferredName(), numberOfAllocations);
@@ -510,7 +558,16 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, modelBytes, threadsPerAllocation, numberOfAllocations, queueCapacity, cacheSize, priority);
+            return Objects.hash(
+                modelId,
+                deploymentId,
+                modelBytes,
+                threadsPerAllocation,
+                numberOfAllocations,
+                queueCapacity,
+                cacheSize,
+                priority
+            );
         }
 
         @Override
@@ -520,6 +577,7 @@ public class StartTrainedModelDeploymentAction extends ActionType<CreateTrainedM
 
             TaskParams other = (TaskParams) o;
             return Objects.equals(modelId, other.modelId)
+                && Objects.equals(deploymentId, other.deploymentId)
                 && modelBytes == other.modelBytes
                 && threadsPerAllocation == other.threadsPerAllocation
                 && numberOfAllocations == other.numberOfAllocations

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateTrainedModelAssignmentRoutingInfoAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateTrainedModelAssignmentRoutingInfoAction.java
@@ -29,19 +29,19 @@ public class UpdateTrainedModelAssignmentRoutingInfoAction extends ActionType<Ac
 
     public static class Request extends MasterNodeRequest<Request> {
         private final String nodeId;
-        private final String modelId;
+        private final String deploymentId;
         private final RoutingInfoUpdate update;
 
-        public Request(String nodeId, String modelId, RoutingInfoUpdate update) {
+        public Request(String nodeId, String deploymentId, RoutingInfoUpdate update) {
             this.nodeId = ExceptionsHelper.requireNonNull(nodeId, "node_id");
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, "model_id");
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, "deployment_id");
             this.update = ExceptionsHelper.requireNonNull(update, "update");
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.nodeId = in.readString();
-            this.modelId = in.readString();
+            this.deploymentId = in.readString();
             this.update = new RoutingInfoUpdate(in);
         }
 
@@ -49,8 +49,8 @@ public class UpdateTrainedModelAssignmentRoutingInfoAction extends ActionType<Ac
             return nodeId;
         }
 
-        public String getModelId() {
-            return modelId;
+        public String getDeploymentId() {
+            return deploymentId;
         }
 
         public RoutingInfoUpdate getUpdate() {
@@ -66,7 +66,7 @@ public class UpdateTrainedModelAssignmentRoutingInfoAction extends ActionType<Ac
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             out.writeString(nodeId);
-            out.writeString(modelId);
+            out.writeString(deploymentId);
             update.writeTo(out);
         }
 
@@ -76,18 +76,18 @@ public class UpdateTrainedModelAssignmentRoutingInfoAction extends ActionType<Ac
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
             return Objects.equals(nodeId, request.nodeId)
-                && Objects.equals(modelId, request.modelId)
+                && Objects.equals(deploymentId, request.deploymentId)
                 && Objects.equals(update, request.update);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(nodeId, modelId, update);
+            return Objects.hash(nodeId, deploymentId, update);
         }
 
         @Override
         public String toString() {
-            return "Request{" + "nodeId='" + nodeId + '\'' + ", modelId='" + modelId + '\'' + ", update=" + update + '}';
+            return "Request{" + "nodeId='" + nodeId + '\'' + ", deploymentId='" + deploymentId + '\'' + ", update=" + update + '}';
         }
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/UpdateTrainedModelDeploymentAction.java
@@ -44,44 +44,44 @@ public class UpdateTrainedModelDeploymentAction extends ActionType<CreateTrained
         public static final ParseField TIMEOUT = new ParseField("timeout");
 
         static {
-            PARSER.declareString(Request::setModelId, MODEL_ID);
+            PARSER.declareString(Request::setDeploymentId, MODEL_ID);
             PARSER.declareInt(Request::setNumberOfAllocations, NUMBER_OF_ALLOCATIONS);
             PARSER.declareString((r, val) -> r.timeout(TimeValue.parseTimeValue(val, TIMEOUT.getPreferredName())), TIMEOUT);
         }
 
-        public static Request parseRequest(String modelId, XContentParser parser) {
+        public static Request parseRequest(String deploymentId, XContentParser parser) {
             Request request = PARSER.apply(parser, null);
-            if (request.getModelId() == null) {
-                request.setModelId(modelId);
-            } else if (Strings.isNullOrEmpty(modelId) == false && modelId.equals(request.getModelId()) == false) {
+            if (request.getDeploymentId() == null) {
+                request.setDeploymentId(deploymentId);
+            } else if (Strings.isNullOrEmpty(deploymentId) == false && deploymentId.equals(request.getDeploymentId()) == false) {
                 throw ExceptionsHelper.badRequestException(
-                    Messages.getMessage(Messages.INCONSISTENT_ID, MODEL_ID, request.getModelId(), modelId)
+                    Messages.getMessage(Messages.INCONSISTENT_ID, MODEL_ID, request.getDeploymentId(), deploymentId)
                 );
             }
             return request;
         }
 
-        private String modelId;
+        private String deploymentId;
         private int numberOfAllocations;
 
         private Request() {}
 
-        public Request(String modelId) {
-            setModelId(modelId);
+        public Request(String deploymentId) {
+            setDeploymentId(deploymentId);
         }
 
         public Request(StreamInput in) throws IOException {
             super(in);
-            modelId = in.readString();
+            deploymentId = in.readString();
             numberOfAllocations = in.readVInt();
         }
 
-        public final void setModelId(String modelId) {
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, MODEL_ID);
+        public final void setDeploymentId(String deploymentId) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, MODEL_ID);
         }
 
-        public String getModelId() {
-            return modelId;
+        public String getDeploymentId() {
+            return deploymentId;
         }
 
         public void setNumberOfAllocations(int numberOfAllocations) {
@@ -95,14 +95,14 @@ public class UpdateTrainedModelDeploymentAction extends ActionType<CreateTrained
         @Override
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
-            out.writeString(modelId);
+            out.writeString(deploymentId);
             out.writeVInt(numberOfAllocations);
         }
 
         @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.startObject();
-            builder.field(MODEL_ID.getPreferredName(), modelId);
+            builder.field(MODEL_ID.getPreferredName(), deploymentId);
             builder.field(NUMBER_OF_ALLOCATIONS.getPreferredName(), numberOfAllocations);
             builder.endObject();
             return builder;
@@ -119,7 +119,7 @@ public class UpdateTrainedModelDeploymentAction extends ActionType<CreateTrained
 
         @Override
         public int hashCode() {
-            return Objects.hash(modelId, numberOfAllocations);
+            return Objects.hash(deploymentId, numberOfAllocations);
         }
 
         @Override
@@ -131,7 +131,7 @@ public class UpdateTrainedModelDeploymentAction extends ActionType<CreateTrained
                 return false;
             }
             Request other = (Request) obj;
-            return Objects.equals(modelId, other.modelId) && numberOfAllocations == other.numberOfAllocations;
+            return Objects.equals(deploymentId, other.deploymentId) && numberOfAllocations == other.numberOfAllocations;
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignment.java
@@ -162,6 +162,10 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         return taskParams.getModelId();
     }
 
+    public String getDeploymentId() {
+        return taskParams.getDeploymentId();
+    }
+
     public StartTrainedModelDeploymentAction.TaskParams getTaskParams() {
         return taskParams;
     }
@@ -375,9 +379,10 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         public Builder addRoutingEntry(String nodeId, RoutingInfo routingInfo) {
             if (nodeRoutingTable.containsKey(nodeId)) {
                 throw new ResourceAlreadyExistsException(
-                    "routing entry for node [{}] for model [{}] already exists",
+                    "routing entry for node [{}] for model [{}] deployment [{}] already exists",
                     nodeId,
-                    taskParams.getModelId()
+                    taskParams.getModelId(),
+                    taskParams.getDeploymentId()
                 );
             }
             nodeRoutingTable.put(nodeId, routingInfo);
@@ -388,9 +393,10 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
             RoutingInfo existingRoutingInfo = nodeRoutingTable.get(nodeId);
             if (existingRoutingInfo == null) {
                 throw new ResourceNotFoundException(
-                    "routing entry for node [{}] for model [{}] does not exist",
+                    "routing entry for node [{}] for model [{}] deployment [{}] does not exist",
                     nodeId,
-                    taskParams.getModelId()
+                    taskParams.getModelId(),
+                    taskParams.getDeploymentId()
                 );
             }
             if (existingRoutingInfo.equals(routingInfo)) {
@@ -458,6 +464,7 @@ public class TrainedModelAssignment implements SimpleDiffable<TrainedModelAssign
         public Builder setNumberOfAllocations(int numberOfAllocations) {
             this.taskParams = new StartTrainedModelDeploymentAction.TaskParams(
                 taskParams.getModelId(),
+                taskParams.getDeploymentId(),
                 taskParams.getModelBytes(),
                 numberOfAllocations,
                 taskParams.getThreadsPerAllocation(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDeploymentStatsActionResponseTests.java
@@ -39,7 +39,7 @@ public class GetDeploymentStatsActionResponseTests extends AbstractWireSerializi
         for (var i = 0; i < numStats; i++) {
             stats.add(randomDeploymentStats());
         }
-        stats.sort(Comparator.comparing(AssignmentStats::getModelId));
+        stats.sort(Comparator.comparing(AssignmentStats::getDeploymentId));
         return new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), stats, stats.size());
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
@@ -29,8 +29,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
 
     @Override
     protected Response createTestInstance() {
-        // int listSize = randomInt(10);
-        int listSize = 1;
+        int listSize = 1; // randomInt(10);
         List<Response.TrainedModelStats> trainedModelStats = Stream.generate(() -> randomAlphaOfLength(10))
             .limit(listSize)
             .map(
@@ -117,6 +116,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                     ? null
                                     : new AssignmentStats(
                                         stats.getDeploymentStats().getModelId(),
+                                        stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getThreadsPerAllocation(),
                                         stats.getDeploymentStats().getNumberOfAllocations(),
                                         stats.getDeploymentStats().getQueueCapacity(),
@@ -173,6 +173,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                 stats.getDeploymentStats() == null
                                     ? null
                                     : new AssignmentStats(
+                                        stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getThreadsPerAllocation(),
                                         stats.getDeploymentStats().getNumberOfAllocations(),
@@ -231,6 +232,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                     ? null
                                     : new AssignmentStats(
                                         stats.getDeploymentStats().getModelId(),
+                                        stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getThreadsPerAllocation(),
                                         stats.getDeploymentStats().getNumberOfAllocations(),
                                         stats.getDeploymentStats().getQueueCapacity(),
@@ -288,6 +290,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                     ? null
                                     : new AssignmentStats(
                                         stats.getDeploymentStats().getModelId(),
+                                        stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getThreadsPerAllocation(),
                                         stats.getDeploymentStats().getNumberOfAllocations(),
                                         stats.getDeploymentStats().getQueueCapacity(),
@@ -329,6 +332,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                 )
             );
         } else if (version.before(TransportVersion.V_8_6_0)) {
+            // priority added
             return new Response(
                 new QueryPage<>(
                     instance.getResources()
@@ -344,6 +348,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                 stats.getDeploymentStats() == null
                                     ? null
                                     : new AssignmentStats(
+                                        stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getModelId(),
                                         stats.getDeploymentStats().getThreadsPerAllocation(),
                                         stats.getDeploymentStats().getNumberOfAllocations(),
@@ -377,6 +382,65 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
                                             )
                                             .toList(),
                                         Priority.NORMAL
+                                    )
+                            )
+                        )
+                        .toList(),
+                    instance.getResources().count(),
+                    RESULTS_FIELD
+                )
+            );
+        } else if (version.before(TransportVersion.V_8_8_0)) {
+            // deployment_id added
+            return new Response(
+                new QueryPage<>(
+                    instance.getResources()
+                        .results()
+                        .stream()
+                        .map(
+                            stats -> new Response.TrainedModelStats(
+                                stats.getModelId(),
+                                stats.getModelSizeStats(),
+                                stats.getIngestStats(),
+                                stats.getPipelineCount(),
+                                stats.getInferenceStats(),
+                                stats.getDeploymentStats() == null
+                                    ? null
+                                    : new AssignmentStats(
+                                        stats.getDeploymentStats().getModelId(),
+                                        stats.getDeploymentStats().getModelId(),
+                                        stats.getDeploymentStats().getThreadsPerAllocation(),
+                                        stats.getDeploymentStats().getNumberOfAllocations(),
+                                        stats.getDeploymentStats().getQueueCapacity(),
+                                        stats.getDeploymentStats().getCacheSize(),
+                                        stats.getDeploymentStats().getStartTime(),
+                                        stats.getDeploymentStats()
+                                            .getNodeStats()
+                                            .stream()
+                                            .map(
+                                                nodeStats -> new AssignmentStats.NodeStats(
+                                                    nodeStats.getNode(),
+                                                    nodeStats.getInferenceCount().orElse(null),
+                                                    nodeStats.getAvgInferenceTime().orElse(null),
+                                                    nodeStats.getAvgInferenceTimeExcludingCacheHit().orElse(null),
+                                                    nodeStats.getLastAccess(),
+                                                    nodeStats.getPendingCount(),
+                                                    nodeStats.getErrorCount(),
+                                                    nodeStats.getCacheHitCount().orElse(null),
+                                                    nodeStats.getRejectedExecutionCount(),
+                                                    nodeStats.getTimeoutCount(),
+                                                    nodeStats.getRoutingState(),
+                                                    nodeStats.getStartTime(),
+                                                    nodeStats.getThreadsPerAllocation(),
+                                                    nodeStats.getNumberOfAllocations(),
+                                                    nodeStats.getPeakThroughput(),
+                                                    nodeStats.getThroughputLastPeriod(),
+                                                    nodeStats.getAvgInferenceTimeLastPeriod(),
+                                                    nodeStats.getCacheHitCountLastPeriod().orElse(null)
+                                                )
+                                            )
+                                            .toList(),
+                                        stats.getDeploymentStats().getPriority()
                                     )
                             )
                         )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsActionResponseTests.java
@@ -29,7 +29,7 @@ public class GetTrainedModelsStatsActionResponseTests extends AbstractBWCWireSer
 
     @Override
     protected Response createTestInstance() {
-        int listSize = 1; // randomInt(10);
+        int listSize = randomInt(10);
         List<Response.TrainedModelStats> trainedModelStats = Stream.generate(() -> randomAlphaOfLength(10))
             .limit(listSize)
             .map(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionRequestTests.java
@@ -68,7 +68,7 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
     @Override
     protected Request mutateInstance(Request instance) {
 
-        var modelId = instance.getModelId();
+        var modelId = instance.getId();
         var objectsToInfer = instance.getObjectsToInfer();
         var highPriority = instance.isHighPriority();
         var textInput = instance.getTextInput();
@@ -181,7 +181,7 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
 
         if (version.before(TransportVersion.V_8_3_0)) {
             return new Request(
-                instance.getModelId(),
+                instance.getId(),
                 adjustedUpdate,
                 instance.getObjectsToInfer(),
                 null,
@@ -190,7 +190,7 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
             );
         } else if (version.before(TransportVersion.V_8_7_0)) {
             return new Request(
-                instance.getModelId(),
+                instance.getId(),
                 adjustedUpdate,
                 instance.getObjectsToInfer(),
                 null,
@@ -199,7 +199,7 @@ public class InferModelActionRequestTests extends AbstractBWCWireSerializationTe
             );
         } else if (version.before(TransportVersion.V_8_8_0)) {
             var r = new Request(
-                instance.getModelId(),
+                instance.getId(),
                 adjustedUpdate,
                 instance.getObjectsToInfer(),
                 instance.getTextInput(),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionResponseTests.java
@@ -66,7 +66,7 @@ public class InferModelActionResponseTests extends AbstractWireSerializingTestCa
 
     @Override
     protected Response mutateInstance(Response instance) {
-        var modelId = instance.getModelId();
+        var modelId = instance.getId();
         var isLicensed = instance.isLicensed();
         if (randomBoolean()) {
             modelId = modelId + "foo";

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentRequestTests.java
@@ -32,7 +32,7 @@ public class StartTrainedModelDeploymentRequestTests extends AbstractXContentSer
 
     @Override
     protected Request doParseInstance(XContentParser parser) throws IOException {
-        return Request.parseRequest(null, parser);
+        return Request.parseRequest(null, null, parser);
     }
 
     @Override
@@ -51,7 +51,9 @@ public class StartTrainedModelDeploymentRequestTests extends AbstractXContentSer
     }
 
     public static Request createRandom() {
-        Request request = new Request(randomAlphaOfLength(10));
+        boolean deploymemtIdSameAsModelId = randomBoolean();
+        String modelId = randomAlphaOfLength(10);
+        Request request = new Request(modelId, deploymemtIdSameAsModelId ? modelId : randomAlphaOfLength(10));
         if (randomBoolean()) {
             request.setTimeout(TimeValue.parseTimeValue(randomPositiveTimeValue(), Request.TIMEOUT.getPreferredName()));
         }
@@ -225,7 +227,7 @@ public class StartTrainedModelDeploymentRequestTests extends AbstractXContentSer
     }
 
     public void testDefaults() {
-        Request request = new Request(randomAlphaOfLength(10));
+        Request request = new Request(randomAlphaOfLength(10), randomAlphaOfLength(10));
         assertThat(request.getTimeout(), equalTo(TimeValue.timeValueSeconds(30)));
         assertThat(request.getWaitForState(), equalTo(AllocationStatus.State.STARTED));
         assertThat(request.getNumberOfAllocations(), equalTo(1));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentTaskParamsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/StartTrainedModelDeploymentTaskParamsTests.java
@@ -41,6 +41,7 @@ public class StartTrainedModelDeploymentTaskParamsTests extends AbstractXContent
     public static StartTrainedModelDeploymentAction.TaskParams createRandom() {
         return new TaskParams(
             randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
             randomNonNegativeLong(),
             randomIntBetween(1, 8),
             randomIntBetween(1, 8),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStatsTests.java
@@ -43,8 +43,11 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
 
         nodeStatsList.sort(Comparator.comparing(n -> n.getNode().getId()));
 
+        String deploymentId = randomAlphaOfLength(5);
+        String modelId = randomBoolean() ? deploymentId : randomAlphaOfLength(5);
         return new AssignmentStats(
-            randomAlphaOfLength(5),
+            deploymentId,
+            modelId,
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 10000),
@@ -95,6 +98,7 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
         String modelId = randomAlphaOfLength(10);
 
         AssignmentStats existingStats = new AssignmentStats(
+            modelId,
             modelId,
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
@@ -159,6 +163,7 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
 
         AssignmentStats existingStats = new AssignmentStats(
             modelId,
+            modelId,
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 10000),
@@ -175,8 +180,10 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
 
     public void testGetOverallInferenceStatsWithOnlyStoppedNodes() {
         String modelId = randomAlphaOfLength(10);
+        String deploymentId = randomAlphaOfLength(10);
 
         AssignmentStats existingStats = new AssignmentStats(
+            deploymentId,
             modelId,
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/TrainedModelAssignmentTests.java
@@ -290,6 +290,7 @@ public class TrainedModelAssignmentTests extends AbstractXContentSerializingTest
         long modelSize = randomNonNegativeLong();
         return new StartTrainedModelDeploymentAction.TaskParams(
             randomAlphaOfLength(10),
+            randomAlphaOfLength(10),
             modelSize,
             numberOfAllocations,
             randomIntBetween(1, 8),

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/AutoscalingIT.java
@@ -190,6 +190,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
     @AwaitsFix(bugUrl = "Cannot be fixed until we move estimation to config and not rely on definition length only")
     public void testMLAutoscalingForLargeModelAssignment() {
         String modelId = "really_big_model";
+        String deploymentId = "really_big_model_deployment";
         SortedMap<String, Settings> deciders = new TreeMap<>();
         deciders.put(
             MlAutoscalingDeciderService.NAME,
@@ -201,8 +202,8 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
             deciders
         );
         assertAcked(client().execute(PutAutoscalingPolicyAction.INSTANCE, request).actionGet());
-        putAndStartModelDeployment("smaller1", ByteSizeValue.ofMb(100).getBytes(), AllocationStatus.State.STARTED);
-        putAndStartModelDeployment("smaller2", ByteSizeValue.ofMb(100).getBytes(), AllocationStatus.State.STARTED);
+        putAndStartModelDeployment("smaller1", "dep1", ByteSizeValue.ofMb(100).getBytes(), AllocationStatus.State.STARTED);
+        putAndStartModelDeployment("smaller2", "dep2", ByteSizeValue.ofMb(100).getBytes(), AllocationStatus.State.STARTED);
         long expectedTierBytes = (long) Math.ceil(
             ByteSizeValue.ofMb(100 + PER_JOB_OVERHEAD_MB + 200 + PER_JOB_OVERHEAD_MB + PER_NODE_OVERHEAD_MB).getBytes() * 100 / 30.0
         );
@@ -218,7 +219,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         );
 
         long modelSize = ByteSizeValue.ofMb(50_000).getBytes();
-        putAndStartModelDeployment(modelId, modelSize, AllocationStatus.State.STARTING);
+        putAndStartModelDeployment(modelId, deploymentId, modelSize, AllocationStatus.State.STARTING);
 
         long lowestMlMemory = admin().cluster()
             .prepareNodesInfo()
@@ -281,7 +282,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         putJob(job);
     }
 
-    private void putAndStartModelDeployment(String modelId, long memoryUse, AllocationStatus.State state) {
+    private void putAndStartModelDeployment(String modelId, String deploymentId, long memoryUse, AllocationStatus.State state) {
         client().execute(
             PutTrainedModelAction.INSTANCE,
             new PutTrainedModelAction.Request(
@@ -315,7 +316,7 @@ public class AutoscalingIT extends MlNativeAutodetectIntegTestCase {
         ).actionGet();
         client().execute(
             StartTrainedModelDeploymentAction.INSTANCE,
-            new StartTrainedModelDeploymentAction.Request(modelId).setWaitForState(state)
+            new StartTrainedModelDeploymentAction.Request(modelId, deploymentId).setWaitForState(state)
         ).actionGet();
     }
 }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlMemoryIT.java
@@ -157,6 +157,7 @@ public class MlMemoryIT extends MlNativeDataFrameAnalyticsIntegTestCase {
 
     private void deployTrainedModel() {
         String modelId = "pytorch";
+        String deploymentId = "deployment-foo";
         client().execute(
             PutTrainedModelAction.INSTANCE,
             new PutTrainedModelAction.Request(
@@ -190,7 +191,7 @@ public class MlMemoryIT extends MlNativeDataFrameAnalyticsIntegTestCase {
         ).actionGet();
         client().execute(
             StartTrainedModelDeploymentAction.INSTANCE,
-            new StartTrainedModelDeploymentAction.Request(modelId).setWaitForState(AllocationStatus.State.STARTED)
+            new StartTrainedModelDeploymentAction.Request(modelId, deploymentId).setWaitForState(AllocationStatus.State.STARTED)
         ).actionGet();
     }
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -968,7 +968,7 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
     public void testUpdateDeployment_GivenMissingModel() throws IOException {
         ResponseException ex = expectThrows(ResponseException.class, () -> updateDeployment("missing", 4));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));
-        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("deployment for model with id [missing] not found"));
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("deployment with id [missing] not found"));
     }
 
     public void testUpdateDeployment_GivenAllocationsAreIncreased() throws Exception {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/TestFeatureResetIT.java
@@ -68,6 +68,7 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
     private final Set<String> jobIds = new HashSet<>();
     private final Set<String> datafeedIds = new HashSet<>();
     private static final String TRAINED_MODEL_ID = "trained-model-to-reset";
+    private static final String DEPLOYMENT_ID = "deployment-to-reset";
 
     void cleanupDatafeed(String datafeedId) {
         try {
@@ -214,8 +215,10 @@ public class TestFeatureResetIT extends MlNativeAutodetectIntegTestCase {
                 List.of()
             )
         ).actionGet();
-        client().execute(StartTrainedModelDeploymentAction.INSTANCE, new StartTrainedModelDeploymentAction.Request(TRAINED_MODEL_ID))
-            .actionGet();
+        client().execute(
+            StartTrainedModelDeploymentAction.INSTANCE,
+            new StartTrainedModelDeploymentAction.Request(TRAINED_MODEL_ID, DEPLOYMENT_ID)
+        ).actionGet();
     }
 
     private boolean isResetMode() {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
@@ -130,9 +130,10 @@ public class JobsAndModelsIT extends BaseMlIntegTestCase {
             )
         ).actionGet();
 
+        logger.info("starting deployment: " + model.getModelId());
         client().execute(
             StartTrainedModelDeploymentAction.INSTANCE,
-            new StartTrainedModelDeploymentAction.Request(model.getModelId(), "deployment-foo")
+            new StartTrainedModelDeploymentAction.Request(model.getModelId(), model.getModelId())
         ).actionGet();
 
         setMlIndicesDelayedNodeLeftTimeoutToZero();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobsAndModelsIT.java
@@ -130,8 +130,10 @@ public class JobsAndModelsIT extends BaseMlIntegTestCase {
             )
         ).actionGet();
 
-        client().execute(StartTrainedModelDeploymentAction.INSTANCE, new StartTrainedModelDeploymentAction.Request(model.getModelId()))
-            .actionGet();
+        client().execute(
+            StartTrainedModelDeploymentAction.INSTANCE,
+            new StartTrainedModelDeploymentAction.Request(model.getModelId(), "deployment-foo")
+        ).actionGet();
 
         setMlIndicesDelayedNodeLeftTimeoutToZero();
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
@@ -69,9 +69,9 @@ public class TransportClearDeploymentCacheAction extends TransportTasksAction<Tr
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final ClusterState clusterState = clusterService.state();
         final TrainedModelAssignmentMetadata assignment = TrainedModelAssignmentMetadata.fromState(clusterState);
-        TrainedModelAssignment trainedModelAssignment = assignment.getModelAssignment(request.getModelId());
+        TrainedModelAssignment trainedModelAssignment = assignment.getDeploymentAssignment(request.getDeploymentId());
         if (trainedModelAssignment == null) {
-            listener.onFailure(new ResourceNotFoundException("assignment for model with id [{}] not found", request.getModelId()));
+            listener.onFailure(new ResourceNotFoundException("assignment for model with id [{}] not found", request.getDeploymentId()));
             return;
         }
         String[] nodes = trainedModelAssignment.getNodeRoutingTable()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsAction.java
@@ -76,14 +76,14 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         List<TaskOperationFailure> taskOperationFailures,
         List<FailedNodeException> failedNodeExceptions
     ) {
-        // group the stats by model and merge individual node stats
-        var mergedNodeStatsByModel = taskResponse.stream()
-            .collect(Collectors.toMap(AssignmentStats::getModelId, Function.identity(), (l, r) -> {
+        // group the stats by deployment and merge individual node stats
+        var mergedNodeStatsByDeployment = taskResponse.stream()
+            .collect(Collectors.toMap(AssignmentStats::getDeploymentId, Function.identity(), (l, r) -> {
                 l.getNodeStats().addAll(r.getNodeStats());
                 return l;
             }, TreeMap::new));
 
-        List<AssignmentStats> bunchedAndSorted = new ArrayList<>(mergedNodeStatsByModel.values());
+        List<AssignmentStats> bunchedAndSorted = new ArrayList<>(mergedNodeStatsByDeployment.values());
 
         return new GetDeploymentStatsAction.Response(
             taskOperationFailures,
@@ -102,16 +102,16 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         final ClusterState clusterState = clusterService.state();
         final TrainedModelAssignmentMetadata assignment = TrainedModelAssignmentMetadata.fromState(clusterState);
 
-        String[] tokenizedRequestIds = Strings.tokenizeToStringArray(request.getModelId(), ",");
+        String[] tokenizedRequestIds = Strings.tokenizeToStringArray(request.getDeploymentId(), ",");
         ExpandedIdsMatcher.SimpleIdsMatcher idsMatcher = new ExpandedIdsMatcher.SimpleIdsMatcher(tokenizedRequestIds);
 
-        List<String> matchedModelIds = new ArrayList<>();
+        List<String> matchedIds = new ArrayList<>();
         Set<String> taskNodes = new HashSet<>();
         Map<TrainedModelAssignment, Map<String, RoutingInfo>> assignmentNonStartedRoutes = new HashMap<>();
-        for (var assignmentEntry : assignment.modelAssignments().entrySet()) {
-            String modelId = assignmentEntry.getKey();
-            if (idsMatcher.idMatches(modelId)) {
-                matchedModelIds.add(modelId);
+        for (var assignmentEntry : assignment.allAssignments().entrySet()) {
+            String deploymentId = assignmentEntry.getKey();
+            if (idsMatcher.idMatches(deploymentId)) {
+                matchedIds.add(deploymentId);
 
                 taskNodes.addAll(Arrays.asList(assignmentEntry.getValue().getStartedNodes()));
 
@@ -126,7 +126,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
             }
         }
 
-        if (matchedModelIds.isEmpty()) {
+        if (matchedIds.isEmpty()) {
             listener.onResponse(
                 new GetDeploymentStatsAction.Response(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), 0L)
             );
@@ -134,13 +134,13 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         }
 
         request.setNodes(taskNodes.toArray(String[]::new));
-        request.setExpandedIds(matchedModelIds);
+        request.setExpandedIds(matchedIds);
 
         ActionListener<GetDeploymentStatsAction.Response> addFailedListener = listener.delegateFailure((l, response) -> {
             var updatedResponse = addFailedRoutes(response, assignmentNonStartedRoutes, clusterState.nodes());
             // Set the allocation state and reason if we have it
             for (AssignmentStats stats : updatedResponse.getStats().results()) {
-                TrainedModelAssignment trainedModelAssignment = assignment.getModelAssignment(stats.getModelId());
+                TrainedModelAssignment trainedModelAssignment = assignment.getDeploymentAssignment(stats.getDeploymentId());
                 if (trainedModelAssignment != null) {
                     stats.setState(trainedModelAssignment.getAssignmentState()).setReason(trainedModelAssignment.getReason().orElse(null));
                     if (trainedModelAssignment.getNodeRoutingTable().isEmpty() == false
@@ -182,24 +182,24 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         Map<TrainedModelAssignment, Map<String, RoutingInfo>> assignmentNonStartedRoutes,
         DiscoveryNodes nodes
     ) {
-        final Map<String, TrainedModelAssignment> modelToAssignmentWithNonStartedRoutes = assignmentNonStartedRoutes.keySet()
+        final Map<String, TrainedModelAssignment> deploymentToAssignmentWithNonStartedRoutes = assignmentNonStartedRoutes.keySet()
             .stream()
-            .collect(Collectors.toMap(TrainedModelAssignment::getModelId, Function.identity()));
+            .collect(Collectors.toMap(TrainedModelAssignment::getDeploymentId, Function.identity()));
 
         final List<AssignmentStats> updatedAssignmentStats = new ArrayList<>();
 
         for (AssignmentStats stat : tasksResponse.getStats().results()) {
-            if (modelToAssignmentWithNonStartedRoutes.containsKey(stat.getModelId())) {
+            if (deploymentToAssignmentWithNonStartedRoutes.containsKey(stat.getDeploymentId())) {
                 // there is merging to be done
                 Map<String, RoutingInfo> nodeToRoutingStates = assignmentNonStartedRoutes.get(
-                    modelToAssignmentWithNonStartedRoutes.get(stat.getModelId())
+                    deploymentToAssignmentWithNonStartedRoutes.get(stat.getDeploymentId())
                 );
                 List<AssignmentStats.NodeStats> updatedNodeStats = new ArrayList<>();
 
                 Set<String> visitedNodes = new HashSet<>();
                 for (var nodeStat : stat.getNodeStats()) {
                     if (nodeToRoutingStates.containsKey(nodeStat.getNode().getId())) {
-                        // conflict as there is both a task response for the model/node pair
+                        // conflict as there is both a task response for the deployment/node pair
                         // and we have a non-started routing entry.
                         // Prefer the entry from assignmentNonStartedRoutes as we cannot be sure
                         // of the state of the task - it may be starting, started, stopping, or stopped.
@@ -234,6 +234,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
                 updatedNodeStats.sort(Comparator.comparing(n -> n.getNode().getId()));
                 updatedAssignmentStats.add(
                     new AssignmentStats(
+                        stat.getDeploymentId(),
                         stat.getModelId(),
                         stat.getThreadsPerAllocation(),
                         stat.getNumberOfAllocations(),
@@ -252,8 +253,8 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         // Merge any models in the non-started that were not in the task responses
         for (var nonStartedEntries : assignmentNonStartedRoutes.entrySet()) {
             final TrainedModelAssignment assignment = nonStartedEntries.getKey();
-            final String modelId = assignment.getTaskParams().getModelId();
-            if (tasksResponse.getStats().results().stream().anyMatch(e -> modelId.equals(e.getModelId())) == false) {
+            final String deploymentId = assignment.getDeploymentId();
+            if (tasksResponse.getStats().results().stream().anyMatch(e -> deploymentId.equals(e.getDeploymentId())) == false) {
 
                 // no tasks for this model so build the assignment stats from the non-started states
                 List<AssignmentStats.NodeStats> nodeStats = new ArrayList<>();
@@ -272,7 +273,8 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
 
                 updatedAssignmentStats.add(
                     new AssignmentStats(
-                        modelId,
+                        deploymentId,
+                        assignment.getModelId(),
                         assignment.getTaskParams().getThreadsPerAllocation(),
                         assignment.getTaskParams().getNumberOfAllocations(),
                         assignment.getTaskParams().getQueueCapacity(),
@@ -285,7 +287,7 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
             }
         }
 
-        updatedAssignmentStats.sort(Comparator.comparing(AssignmentStats::getModelId));
+        updatedAssignmentStats.sort(Comparator.comparing(AssignmentStats::getDeploymentId));
 
         return new GetDeploymentStatsAction.Response(
             tasksResponse.getTaskFailures(),
@@ -336,16 +338,19 @@ public class TransportGetDeploymentStatsAction extends TransportTasksAction<
         }
 
         TrainedModelAssignment assignment = TrainedModelAssignmentMetadata.fromState(clusterService.state())
-            .getModelAssignment(task.getModelId());
+            .getDeploymentAssignment(task.getDeploymentId());
 
         listener.onResponse(
             new AssignmentStats(
-                task.getModelId(),
+                task.getDeploymentId(),
+                task.getParams().getModelId(),
                 task.getParams().getThreadsPerAllocation(),
                 assignment == null ? task.getParams().getNumberOfAllocations() : assignment.getTaskParams().getNumberOfAllocations(),
                 task.getParams().getQueueCapacity(),
                 task.getParams().getCacheSize().orElse(null),
-                TrainedModelAssignmentMetadata.fromState(clusterService.state()).getModelAssignment(task.getModelId()).getStartTime(),
+                TrainedModelAssignmentMetadata.fromState(clusterService.state())
+                    .getDeploymentAssignment(task.getDeploymentId())
+                    .getStartTime(),
                 nodeStats,
                 task.getParams().getPriority()
             )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -100,7 +100,10 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
 
         ActionListener<GetDeploymentStatsAction.Response> deploymentStatsListener = ActionListener.wrap(deploymentStats -> {
             responseBuilder.setDeploymentStatsByModelId(
-                deploymentStats.getStats().results().stream().collect(Collectors.toMap(AssignmentStats::getModelId, Function.identity()))
+                deploymentStats.getStats()
+                    .results()
+                    .stream()
+                    .collect(Collectors.toMap(AssignmentStats::getDeploymentId, Function.identity()))
             );
             modelSizeStats(responseBuilder.getExpandedIdsWithAliases(), request.isAllowNoResources(), parentTaskId, modelSizeStatsListener);
         }, listener::onFailure);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -148,7 +148,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             return;
         }
 
-        if (TrainedModelAssignmentMetadata.fromState(state).modelAssignments().size() >= MachineLearning.MAX_TRAINED_MODEL_DEPLOYMENTS) {
+        if (TrainedModelAssignmentMetadata.fromState(state).allAssignments().size() >= MachineLearning.MAX_TRAINED_MODEL_DEPLOYMENTS) {
             listener.onFailure(
                 new ElasticsearchStatusException(
                     "Could not start model deployment because existing deployments reached the limit of [{}]",
@@ -160,9 +160,9 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         }
 
         ActionListener<CreateTrainedModelAssignmentAction.Response> waitForDeploymentToStart = ActionListener.wrap(
-            modelAssignment -> waitForDeploymentState(request.getModelId(), request.getTimeout(), request.getWaitForState(), listener),
+            modelAssignment -> waitForDeploymentState(request.getDeploymentId(), request.getTimeout(), request.getWaitForState(), listener),
             e -> {
-                logger.warn(() -> "[" + request.getModelId() + "] creating new assignment failed", e);
+                logger.warn(() -> "[" + request.getModelId() + "] creating new assignment [" + request.getDeploymentId() + "] failed", e);
                 if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
                     e = new ElasticsearchStatusException(
                         "Cannot start deployment [{}] because it has already been started",
@@ -208,6 +208,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
                 ActionListener.wrap(validate -> getModelBytes(trainedModelConfig, ActionListener.wrap(modelBytes -> {
                     TaskParams taskParams = new TaskParams(
                         trainedModelConfig.getModelId(),
+                        request.getDeploymentId(),
                         modelBytes,
                         request.getNumberOfAllocations(),
                         request.getThreadsPerAllocation(),
@@ -256,23 +257,23 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
     }
 
     private void waitForDeploymentState(
-        String modelId,
+        String deploymentId,
         TimeValue timeout,
         AllocationStatus.State state,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) {
-        DeploymentStartedPredicate predicate = new DeploymentStartedPredicate(modelId, state);
+        DeploymentStartedPredicate predicate = new DeploymentStartedPredicate(deploymentId, state);
         trainedModelAssignmentService.waitForAssignmentCondition(
-            modelId,
+            deploymentId,
             predicate,
             timeout,
             new TrainedModelAssignmentService.WaitForAssignmentListener() {
                 @Override
                 public void onResponse(TrainedModelAssignment assignment) {
                     if (predicate.exception != null) {
-                        deleteFailedDeployment(modelId, predicate.exception, listener);
+                        deleteFailedDeployment(deploymentId, predicate.exception, listener);
                     } else {
-                        auditor.info(assignment.getModelId(), Messages.INFERENCE_DEPLOYMENT_STARTED);
+                        auditor.info(assignment.getDeploymentId(), Messages.INFERENCE_DEPLOYMENT_STARTED);
                         listener.onResponse(new CreateTrainedModelAssignmentAction.Response(assignment));
                     }
                 }
@@ -286,16 +287,16 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
     }
 
     private void deleteFailedDeployment(
-        String modelId,
+        String deploymentId,
         Exception exception,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) {
-        logger.trace(() -> format("[%s] Deleting failed deployment", modelId), exception);
-        trainedModelAssignmentService.deleteModelAssignment(modelId, ActionListener.wrap(pTask -> listener.onFailure(exception), e -> {
+        logger.trace(() -> format("[%s] Deleting failed deployment", deploymentId), exception);
+        trainedModelAssignmentService.deleteModelAssignment(deploymentId, ActionListener.wrap(pTask -> listener.onFailure(exception), e -> {
             logger.error(
                 () -> format(
                     "[%s] Failed to delete model allocation that had failed with the reason [%s]",
-                    modelId,
+                    deploymentId,
                     exception.getMessage()
                 ),
                 e
@@ -421,21 +422,23 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         private volatile Exception exception;
 
         // for logging
-        private final String modelId;
+        private final String deploymentId;
         private final AllocationStatus.State waitForState;
 
-        DeploymentStartedPredicate(String modelId, AllocationStatus.State waitForState) {
-            this.modelId = ExceptionsHelper.requireNonNull(modelId, "model_id");
+        DeploymentStartedPredicate(String deploymentId, AllocationStatus.State waitForState) {
+            this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, "deployment_id");
             this.waitForState = waitForState;
         }
 
         @Override
         public boolean test(ClusterState clusterState) {
-            TrainedModelAssignment trainedModelAssignment = TrainedModelAssignmentMetadata.assignmentForModelId(clusterState, modelId)
-                .orElse(null);
+            TrainedModelAssignment trainedModelAssignment = TrainedModelAssignmentMetadata.assignmentForDeploymentId(
+                clusterState,
+                deploymentId
+            ).orElse(null);
             if (trainedModelAssignment == null) {
                 // Something weird happened, it should NEVER be null...
-                logger.trace(() -> format("[%s] assignment was null while waiting for state [%s]", modelId, waitForState));
+                logger.trace(() -> format("[%s] assignment was null while waiting for state [%s]", deploymentId, waitForState));
                 return true;
             }
 
@@ -478,7 +481,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
             logger.trace(
                 () -> format(
                     "[%s] tested with state [%s] and nodes %s still initializing",
-                    modelId,
+                    deploymentId,
                     trainedModelAssignment.getAssignmentState(),
                     nodesStillInitializing
                 )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -131,7 +131,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         ClusterState state,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) throws Exception {
-        logger.trace(() -> "[" + request.getModelId() + "] received deploy request");
+        logger.info(() -> "[" + request.getModelId() + "/" + request.getDeploymentId() + "] received deploy request");
         if (MachineLearningField.ML_API_FEATURE.check(licenseState) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStartTrainedModelDeploymentAction.java
@@ -131,7 +131,7 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         ClusterState state,
         ActionListener<CreateTrainedModelAssignmentAction.Response> listener
     ) throws Exception {
-        logger.info(() -> "[" + request.getModelId() + "/" + request.getDeploymentId() + "] received deploy request");
+        logger.debug(() -> "[" + request.getDeploymentId() + "] received deploy request for model [" + request.getModelId() + "]");
         if (MachineLearningField.ML_API_FEATURE.check(licenseState) == false) {
             listener.onFailure(LicenseUtils.newComplianceException(XPackField.MACHINE_LEARNING));
             return;
@@ -162,13 +162,16 @@ public class TransportStartTrainedModelDeploymentAction extends TransportMasterN
         ActionListener<CreateTrainedModelAssignmentAction.Response> waitForDeploymentToStart = ActionListener.wrap(
             modelAssignment -> waitForDeploymentState(request.getDeploymentId(), request.getTimeout(), request.getWaitForState(), listener),
             e -> {
-                logger.warn(() -> "[" + request.getModelId() + "] creating new assignment [" + request.getDeploymentId() + "] failed", e);
+                logger.warn(
+                    () -> "[" + request.getDeploymentId() + "] creating new assignment for model [" + request.getModelId() + "] failed",
+                    e
+                );
                 if (ExceptionsHelper.unwrapCause(e) instanceof ResourceAlreadyExistsException) {
                     e = new ElasticsearchStatusException(
                         "Cannot start deployment [{}] because it has already been started",
                         RestStatus.CONFLICT,
                         e,
-                        request.getModelId()
+                        request.getDeploymentId()
                     );
                 }
                 listener.onFailure(e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopTrainedModelDeploymentAction.java
@@ -125,7 +125,7 @@ public class TransportStopTrainedModelDeploymentAction extends TransportTasksAct
                 return;
             }
 
-            Optional<TrainedModelAssignment> maybeAssignment = TrainedModelAssignmentMetadata.assignmentForModelId(
+            Optional<TrainedModelAssignment> maybeAssignment = TrainedModelAssignmentMetadata.assignmentForDeploymentId(
                 clusterService.state(),
                 models.get(0).getModelId()
             );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportUpdateTrainedModelDeploymentAction.java
@@ -75,17 +75,17 @@ public class TransportUpdateTrainedModelDeploymentAction extends TransportMaster
         logger.debug(
             () -> format(
                 "[%s] received request to update number of allocations to [%s]",
-                request.getModelId(),
+                request.getDeploymentId(),
                 request.getNumberOfAllocations()
             )
         );
 
         trainedModelAssignmentClusterService.updateNumberOfAllocations(
-            request.getModelId(),
+            request.getDeploymentId(),
             request.getNumberOfAllocations(),
             ActionListener.wrap(updatedAssignment -> {
                 auditor.info(
-                    request.getModelId(),
+                    request.getDeploymentId(),
                     Messages.getMessage(Messages.INFERENCE_DEPLOYMENT_UPDATED_NUMBER_OF_ALLOCATIONS, request.getNumberOfAllocations())
                 );
                 listener.onResponse(new CreateTrainedModelAssignmentAction.Response(updatedAssignment));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingContext.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlAutoscalingContext.java
@@ -67,7 +67,7 @@ class MlAutoscalingContext {
         anomalyDetectionTasks = anomalyDetectionTasks(tasks);
         snapshotUpgradeTasks = snapshotUpgradeTasks(tasks);
         dataframeAnalyticsTasks = dataframeAnalyticsTasks(tasks);
-        modelAssignments = TrainedModelAssignmentMetadata.fromState(clusterState).modelAssignments();
+        modelAssignments = TrainedModelAssignmentMetadata.fromState(clusterState).allAssignments();
 
         waitingAnomalyJobs = anomalyDetectionTasks.stream()
             .filter(t -> AWAITING_LAZY_ASSIGNMENT.equals(t.getAssignment()))

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDecider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDecider.java
@@ -63,7 +63,7 @@ class MlProcessorAutoscalingDecider {
         }
 
         if (MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
-            trainedModelAssignmentMetadata.modelAssignments().values(),
+            trainedModelAssignmentMetadata.allAssignments().values(),
             mlContext.mlNodes
         )) {
             return MlProcessorAutoscalingCapacity.builder(currentCapacity.nodeProcessors(), currentCapacity.tierProcessors())
@@ -104,7 +104,7 @@ class MlProcessorAutoscalingDecider {
 
     private boolean hasUnsatisfiedDeployments(TrainedModelAssignmentMetadata trainedModelAssignmentMetadata, List<DiscoveryNode> mlNodes) {
         final Set<String> mlNodeIds = mlNodes.stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
-        return trainedModelAssignmentMetadata.modelAssignments()
+        return trainedModelAssignmentMetadata.allAssignments()
             .values()
             .stream()
             .filter(deployment -> deployment.getTaskParams().getPriority() == Priority.NORMAL)
@@ -115,7 +115,7 @@ class MlProcessorAutoscalingDecider {
         int maxThreadsPerAllocation = 0;
         double processorCount = 0;
         boolean hasLowPriorityDeployments = false;
-        for (TrainedModelAssignment assignment : trainedModelAssignmentMetadata.modelAssignments().values()) {
+        for (TrainedModelAssignment assignment : trainedModelAssignmentMetadata.allAssignments().values()) {
             if (assignment.getTaskParams().getPriority() == Priority.LOW) {
                 hasLowPriorityDeployments = true;
                 continue;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -209,7 +209,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             event.nodesDelta().removedNodes().stream().map(DiscoveryNode::getId).forEach(removedOrShuttingDownNodeIds::add);
 
             TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(event.state());
-            for (TrainedModelAssignment assignment : metadata.modelAssignments().values()) {
+            for (TrainedModelAssignment assignment : metadata.allAssignments().values()) {
                 if (Sets.intersection(removedOrShuttingDownNodeIds, assignment.getNodeRoutingTable().keySet()).isEmpty() == false) {
                     return true;
                 }
@@ -223,19 +223,19 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         Set<String> assignableNodes = getAssignableNodes(currentState).stream().map(DiscoveryNode::getId).collect(Collectors.toSet());
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
-        for (TrainedModelAssignment assignment : metadata.modelAssignments().values()) {
+        for (TrainedModelAssignment assignment : metadata.allAssignments().values()) {
             Set<String> routedNodeIdsToRemove = Sets.difference(assignment.getNodeRoutingTable().keySet(), assignableNodes);
             if (routedNodeIdsToRemove.isEmpty() == false) {
                 logger.debug(
                     () -> format(
                         "[%s] removing routing entries to nodes %s because they have been removed or are shutting down",
-                        assignment.getModelId(),
+                        assignment.getDeploymentId(),
                         routedNodeIdsToRemove
                     )
                 );
                 TrainedModelAssignment.Builder assignmentBuilder = TrainedModelAssignment.Builder.fromAssignment(assignment);
                 routedNodeIdsToRemove.forEach(assignmentBuilder::removeRoutingEntry);
-                builder.updateAssignment(assignment.getModelId(), assignmentBuilder.calculateAndSetAssignmentState());
+                builder.updateAssignment(assignment.getDeploymentId(), assignmentBuilder.calculateAndSetAssignmentState());
             }
         }
         return update(currentState, builder);
@@ -248,7 +248,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         logger.debug(
             () -> format(
                 "[%s] updating routing table entry for node [%s], update [%s]",
-                request.getModelId(),
+                request.getDeploymentId(),
                 request.getNodeId(),
                 request.getUpdate()
             )
@@ -299,7 +299,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         }
 
         rebalanceAssignments(clusterService.state(), Optional.of(params), "model deployment started", ActionListener.wrap(newMetadata -> {
-            TrainedModelAssignment assignment = newMetadata.getModelAssignment(params.getModelId());
+            TrainedModelAssignment assignment = newMetadata.getDeploymentAssignment(params.getDeploymentId());
             if (assignment == null) {
                 // If we could not allocate the model anywhere then it is possible the assignment
                 // here is null. We should notify the listener of an empty assignment as the
@@ -329,11 +329,11 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         });
     }
 
-    public void removeModelAssignment(String modelId, ActionListener<AcknowledgedResponse> listener) {
-        submitUnbatchedTask("delete model assignment", new ClusterStateUpdateTask() {
+    public void removeModelAssignment(String deploymentId, ActionListener<AcknowledgedResponse> listener) {
+        submitUnbatchedTask("delete model deployment assignment", new ClusterStateUpdateTask() {
             @Override
             public ClusterState execute(ClusterState currentState) {
-                return removeAssignment(currentState, modelId);
+                return removeAssignment(currentState, deploymentId);
             }
 
             @Override
@@ -351,10 +351,13 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     "model deployment stopped",
                     ActionListener.wrap(
                         metadataAfterRebalance -> logger.debug(
-                            () -> format("Successfully rebalanced model deployments after deployment for model [%s] was stopped", modelId)
+                            () -> format(
+                                "Successfully rebalanced model deployments after deployment for model [%s] was stopped",
+                                deploymentId
+                            )
                         ),
                         e -> logger.error(
-                            format("Failed to rebalance model deployments after deployment for model [%s] was stopped", modelId),
+                            format("Failed to rebalance model deployments after deployment for model [%s] was stopped", deploymentId),
                             e
                         )
                     )
@@ -556,20 +559,20 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             || (smallestMLNode.isPresent() && smallestMLNode.getAsLong() < maxMLNodeSize);
     }
 
-    public void updateNumberOfAllocations(String modelId, int numberOfAllocations, ActionListener<TrainedModelAssignment> listener) {
-        updateNumberOfAllocations(clusterService.state(), modelId, numberOfAllocations, listener);
+    public void updateNumberOfAllocations(String deploymentId, int numberOfAllocations, ActionListener<TrainedModelAssignment> listener) {
+        updateNumberOfAllocations(clusterService.state(), deploymentId, numberOfAllocations, listener);
     }
 
     private void updateNumberOfAllocations(
         ClusterState clusterState,
-        String modelId,
+        String deploymentId,
         int numberOfAllocations,
         ActionListener<TrainedModelAssignment> listener
     ) {
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(clusterState);
-        final TrainedModelAssignment existingAssignment = metadata.getModelAssignment(modelId);
+        final TrainedModelAssignment existingAssignment = metadata.getDeploymentAssignment(deploymentId);
         if (existingAssignment == null) {
-            throw new ResourceNotFoundException("deployment for model with id [{}] not found", modelId);
+            throw new ResourceNotFoundException("deployment for model with id [{}] not found", deploymentId);
         }
         if (existingAssignment.getTaskParams().getNumberOfAllocations() == numberOfAllocations) {
             listener.onResponse(existingAssignment);
@@ -590,7 +593,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 new ElasticsearchStatusException(
                     "cannot update number_of_allocations for deployment with model id [{}] while there are nodes older than version [{}]",
                     RestStatus.CONFLICT,
-                    modelId,
+                    deploymentId,
                     DISTRIBUTED_MODEL_ALLOCATION_VERSION
                 )
             );
@@ -608,8 +611,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                         isUpdated = true;
                         return updatedState;
                     }
-                    logger.debug(() -> format("[%s] Retrying update as cluster state has been modified", modelId));
-                    updateNumberOfAllocations(currentState, modelId, numberOfAllocations, listener);
+                    logger.debug(() -> format("[%s] Retrying update as cluster state has been modified", deploymentId));
+                    updateNumberOfAllocations(currentState, deploymentId, numberOfAllocations, listener);
                     return currentState;
                 }
 
@@ -622,7 +625,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 public void clusterStateProcessed(ClusterState oldState, ClusterState newState) {
                     if (isUpdated) {
                         TrainedModelAssignment updatedAssignment = TrainedModelAssignmentMetadata.fromState(newState)
-                            .getModelAssignment(modelId);
+                            .getDeploymentAssignment(deploymentId);
                         if (updatedAssignment.totalTargetAllocations() > existingAssignment.totalTargetAllocations()) {
                             threadPool.executor(MachineLearning.UTILITY_THREAD_POOL_NAME)
                                 .execute(
@@ -667,13 +670,13 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                 clusterState,
                 TrainedModelAssignmentMetadata.builder(clusterState)
                     .updateAssignment(
-                        assignment.getModelId(),
+                        assignment.getDeploymentId(),
                         TrainedModelAssignment.Builder.fromAssignment(assignment).setNumberOfAllocations(numberOfAllocations)
                     )
             );
             TrainedModelAssignmentMetadata.Builder rebalancedMetadata = rebalanceAssignments(updatedClusterState, Optional.empty());
             if (isScalingPossible(getAssignableNodes(clusterState)) == false
-                && rebalancedMetadata.getAssignment(assignment.getModelId()).build().totalTargetAllocations() < numberOfAllocations) {
+                && rebalancedMetadata.getAssignment(assignment.getDeploymentId()).build().totalTargetAllocations() < numberOfAllocations) {
                 listener.onFailure(
                     new ElasticsearchStatusException(
                         "Could not update deployment because there are not enough resources to provide all requested allocations",
@@ -706,13 +709,13 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             updatedAssignment.setReason(null);
         }
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(clusterState);
-        builder.updateAssignment(assignment.getModelId(), updatedAssignment);
+        builder.updateAssignment(assignment.getDeploymentId(), updatedAssignment);
         listener.onResponse(update(clusterState, builder));
     }
 
     static ClusterState setToStopping(ClusterState clusterState, String modelId, String reason) {
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(clusterState);
-        final TrainedModelAssignment existingAssignment = metadata.getModelAssignment(modelId);
+        final TrainedModelAssignment existingAssignment = metadata.getDeploymentAssignment(modelId);
         if (existingAssignment == null) {
             throw new ResourceNotFoundException("assignment for model with id [{}] not found", modelId);
         }
@@ -726,11 +729,11 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
     }
 
     static ClusterState updateModelRoutingTable(ClusterState currentState, UpdateTrainedModelAssignmentRoutingInfoAction.Request request) {
-        final String modelId = request.getModelId();
+        final String deploymentId = request.getDeploymentId();
         final String nodeId = request.getNodeId();
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(currentState);
-        logger.trace(() -> format("[%s] [%s] current metadata before update %s", modelId, nodeId, Strings.toString(metadata)));
-        final TrainedModelAssignment existingAssignment = metadata.getModelAssignment(modelId);
+        logger.trace(() -> format("[%s] [%s] current metadata before update %s", deploymentId, nodeId, Strings.toString(metadata)));
+        final TrainedModelAssignment existingAssignment = metadata.getDeploymentAssignment(deploymentId);
         final TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
         // If state is stopped, this indicates the node process is closed, remove the node from the assignment
         if (request.getUpdate().getStateAndReason().isPresent()
@@ -738,42 +741,47 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
             if (existingAssignment == null || existingAssignment.isRoutedToNode(nodeId) == false) {
                 return currentState;
             }
-            builder.getAssignment(modelId).removeRoutingEntry(nodeId).calculateAndSetAssignmentState();
+            builder.getAssignment(deploymentId).removeRoutingEntry(nodeId).calculateAndSetAssignmentState();
             return update(currentState, builder);
         }
 
         if (existingAssignment == null) {
-            throw new ResourceNotFoundException("assignment for model with id [{}] not found", modelId);
+            throw new ResourceNotFoundException("assignment for model with id [{}] not found", deploymentId);
         }
         // If we are stopping, don't update anything
         if (existingAssignment.getAssignmentState().equals(AssignmentState.STOPPING)) {
             logger.debug(
-                () -> format("[%s] requested update from node [%s] while stopping; update was [%s]", modelId, nodeId, request.getUpdate())
+                () -> format(
+                    "[%s] requested update from node [%s] while stopping; update was [%s]",
+                    deploymentId,
+                    nodeId,
+                    request.getUpdate()
+                )
             );
             return currentState;
         }
         if (existingAssignment.isRoutedToNode(nodeId) == false) {
-            throw new ResourceNotFoundException("assignment for model with id [{}]] is not routed to node [{}]", modelId, nodeId);
+            throw new ResourceNotFoundException("assignment for model with id [{}]] is not routed to node [{}]", deploymentId, nodeId);
         }
         RoutingInfo routingInfo = existingAssignment.getNodeRoutingTable().get(nodeId);
-        builder.getAssignment(modelId)
+        builder.getAssignment(deploymentId)
             .updateExistingRoutingEntry(nodeId, request.getUpdate().apply(routingInfo))
             .calculateAndSetAssignmentState();
 
         return update(currentState, builder);
     }
 
-    static ClusterState removeAssignment(ClusterState currentState, String modelId) {
+    static ClusterState removeAssignment(ClusterState currentState, String deploymentId) {
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(currentState);
-        if (builder.hasModel(modelId) == false) {
-            throw new ResourceNotFoundException("assignment for model with id [{}] not found", modelId);
+        if (builder.hasModelDeployment(deploymentId) == false) {
+            throw new ResourceNotFoundException("assignment for model deployment with id [{}] not found", deploymentId);
         }
-        logger.debug(() -> format("[%s] removing assignment", modelId));
-        return update(currentState, builder.removeAssignment(modelId));
+        logger.debug(() -> format("[%s] removing assignment", deploymentId));
+        return update(currentState, builder.removeAssignment(deploymentId));
     }
 
     static ClusterState removeAllAssignments(ClusterState currentState) {
-        if (TrainedModelAssignmentMetadata.fromState(currentState).modelAssignments().isEmpty()) {
+        if (TrainedModelAssignmentMetadata.fromState(currentState).allAssignments().isEmpty()) {
             return currentState;
         }
         return forceUpdate(currentState, TrainedModelAssignmentMetadata.Builder.empty());
@@ -782,7 +790,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
     static Optional<String> detectReasonToRebalanceModels(final ClusterChangedEvent event) {
         // If there are no assignments created at all, there is nothing to update
         final TrainedModelAssignmentMetadata newMetadata = TrainedModelAssignmentMetadata.fromState(event.state());
-        if (newMetadata == null || newMetadata.modelAssignments().isEmpty()) {
+        if (newMetadata == null || newMetadata.allAssignments().isEmpty()) {
             return Optional.empty();
         }
 
@@ -885,7 +893,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     exitingShutDownNodes
                 )
             );
-            for (TrainedModelAssignment trainedModelAssignment : newMetadata.modelAssignments().values()) {
+            for (TrainedModelAssignment trainedModelAssignment : newMetadata.allAssignments().values()) {
                 if (trainedModelAssignment.getAssignmentState().equals(AssignmentState.STOPPING)) {
                     continue;
                 }
@@ -893,8 +901,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     if (trainedModelAssignment.isRoutedToNode(nodeId)) {
                         logger.debug(
                             () -> format(
-                                "should rebalance because model [%s] has allocations on shutting down node [%s]",
-                                trainedModelAssignment.getModelId(),
+                                "should rebalance because model deployment [%s] has allocations on shutting down node [%s]",
+                                trainedModelAssignment.getDeploymentId(),
                                 nodeId
                             )
                         );
@@ -906,8 +914,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
                     if (trainedModelAssignment.isRoutedToNode(nodeId) && shuttingDownNodes.contains(nodeId) == false) {
                         logger.debug(
                             () -> format(
-                                "should rebalance because model [%s] has allocations on removed node [%s]",
-                                trainedModelAssignment.getModelId(),
+                                "should rebalance because model deployment [%s] has allocations on removed node [%s]",
+                                trainedModelAssignment.getDeploymentId(),
                                 nodeId
                             )
                         );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -491,7 +491,7 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         );
         TrainedModelAssignmentMetadata.Builder rebalanced = rebalancer.rebalance();
         if (modelToAdd.isPresent()) {
-            checkModelIsFullyAllocatedIfScalingIsNotPossible(modelToAdd.get().getModelId(), rebalanced, nodes);
+            checkModelIsFullyAllocatedIfScalingIsNotPossible(modelToAdd.get().getDeploymentId(), rebalanced, nodes);
         }
         return rebalanced;
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -29,10 +29,12 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.Metadata.ALL_CONTEXTS;
 
@@ -41,7 +43,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
     private static final TrainedModelAssignmentMetadata EMPTY = new TrainedModelAssignmentMetadata(Collections.emptyMap());
     public static final String DEPRECATED_NAME = "trained_model_allocation";
     public static final String NAME = "trained_model_assignment";
-    private final Map<String, TrainedModelAssignment> modelRoutingEntries;
+    private final Map<String, TrainedModelAssignment> deploymentRoutingEntries;
     private final String writeableName;
 
     public static TrainedModelAssignmentMetadata fromXContent(XContentParser parser) throws IOException {
@@ -76,9 +78,18 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         return trainedModelAssignmentMetadata == null ? EMPTY : trainedModelAssignmentMetadata;
     }
 
-    public static Optional<TrainedModelAssignment> assignmentForModelId(ClusterState clusterState, String modelId) {
+    public static List<TrainedModelAssignment> assignmentsForModelId(ClusterState clusterState, String modelId) {
+        return TrainedModelAssignmentMetadata.fromState(clusterState)
+            .allAssignments()
+            .values()
+            .stream()
+            .filter(assignment -> modelId.equals(assignment.getModelId()))
+            .collect(Collectors.toList());
+    }
+
+    public static Optional<TrainedModelAssignment> assignmentForDeploymentId(ClusterState clusterState, String deploymentId) {
         return Optional.ofNullable(TrainedModelAssignmentMetadata.fromState(clusterState))
-            .map(metadata -> metadata.getModelAssignment(modelId));
+            .map(metadata -> metadata.getDeploymentAssignment(deploymentId));
     }
 
     public TrainedModelAssignmentMetadata(Map<String, TrainedModelAssignment> modelRoutingEntries) {
@@ -86,30 +97,30 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
     }
 
     private TrainedModelAssignmentMetadata(Map<String, TrainedModelAssignment> modelRoutingEntries, String writeableName) {
-        this.modelRoutingEntries = ExceptionsHelper.requireNonNull(modelRoutingEntries, NAME);
+        this.deploymentRoutingEntries = ExceptionsHelper.requireNonNull(modelRoutingEntries, NAME);
         this.writeableName = writeableName;
     }
 
     private TrainedModelAssignmentMetadata(StreamInput in, String writeableName) throws IOException {
-        this.modelRoutingEntries = in.readOrderedMap(StreamInput::readString, TrainedModelAssignment::new);
+        this.deploymentRoutingEntries = in.readOrderedMap(StreamInput::readString, TrainedModelAssignment::new);
         this.writeableName = writeableName;
     }
 
-    public TrainedModelAssignment getModelAssignment(String modelId) {
-        return modelRoutingEntries.get(modelId);
+    public TrainedModelAssignment getDeploymentAssignment(String deploymentId) {
+        return deploymentRoutingEntries.get(deploymentId);
     }
 
-    public boolean isAssigned(String modelId) {
-        return modelRoutingEntries.containsKey(modelId);
+    public boolean isAssigned(String deploymentId) {
+        return deploymentRoutingEntries.containsKey(deploymentId);
     }
 
-    public Map<String, TrainedModelAssignment> modelAssignments() {
-        return Collections.unmodifiableMap(modelRoutingEntries);
+    public Map<String, TrainedModelAssignment> allAssignments() {
+        return Collections.unmodifiableMap(deploymentRoutingEntries);
     }
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params ignored) {
-        return modelRoutingEntries.entrySet()
+        return deploymentRoutingEntries.entrySet()
             .stream()
             .map(entry -> (ToXContent) (builder, params) -> entry.getValue().toXContent(builder.field(entry.getKey()), params))
             .iterator();
@@ -137,7 +148,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
-        out.writeMap(modelRoutingEntries, StreamOutput::writeString, (o, w) -> w.writeTo(o));
+        out.writeMap(deploymentRoutingEntries, StreamOutput::writeString, (o, w) -> w.writeTo(o));
     }
 
     @Override
@@ -145,12 +156,12 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         TrainedModelAssignmentMetadata that = (TrainedModelAssignmentMetadata) o;
-        return Objects.equals(modelRoutingEntries, that.modelRoutingEntries);
+        return Objects.equals(deploymentRoutingEntries, that.deploymentRoutingEntries);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(modelRoutingEntries);
+        return Objects.hash(deploymentRoutingEntries);
     }
 
     @Override
@@ -159,11 +170,11 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
     }
 
     public boolean hasOutdatedAssignments() {
-        return modelRoutingEntries.values().stream().anyMatch(TrainedModelAssignment::hasOutdatedRoutingEntries);
+        return deploymentRoutingEntries.values().stream().anyMatch(TrainedModelAssignment::hasOutdatedRoutingEntries);
     }
 
-    public boolean hasModel(String modelId) {
-        return modelRoutingEntries.containsKey(modelId);
+    public boolean hasDeployment(String deploymentId) {
+        return deploymentRoutingEntries.containsKey(deploymentId);
     }
 
     public static class Builder {
@@ -172,49 +183,52 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
             return new Builder();
         }
 
-        private final Map<String, TrainedModelAssignment.Builder> modelRoutingEntries;
+        private final Map<String, TrainedModelAssignment.Builder> deploymentRoutingEntries;
 
         public static Builder fromMetadata(TrainedModelAssignmentMetadata modelAssignmentMetadata) {
             return new Builder(modelAssignmentMetadata);
         }
 
         private Builder() {
-            modelRoutingEntries = new LinkedHashMap<>();
+            deploymentRoutingEntries = new LinkedHashMap<>();
         }
 
         private Builder(TrainedModelAssignmentMetadata modelAssignmentMetadata) {
-            this.modelRoutingEntries = new LinkedHashMap<>();
-            modelAssignmentMetadata.modelRoutingEntries.forEach(
-                (modelId, assignment) -> modelRoutingEntries.put(modelId, TrainedModelAssignment.Builder.fromAssignment(assignment))
+            this.deploymentRoutingEntries = new LinkedHashMap<>();
+            modelAssignmentMetadata.deploymentRoutingEntries.forEach(
+                (deploymentId, assignment) -> deploymentRoutingEntries.put(
+                    deploymentId,
+                    TrainedModelAssignment.Builder.fromAssignment(assignment)
+                )
             );
         }
 
-        public boolean hasModel(String modelId) {
-            return modelRoutingEntries.containsKey(modelId);
+        public boolean hasModelDeployment(String deploymentId) {
+            return deploymentRoutingEntries.containsKey(deploymentId);
         }
 
-        public Builder addNewAssignment(String modelId, TrainedModelAssignment.Builder assignment) {
-            if (modelRoutingEntries.containsKey(modelId)) {
-                throw new ResourceAlreadyExistsException("[{}] assignment already exists", modelId);
+        public Builder addNewAssignment(String deploymentId, TrainedModelAssignment.Builder assignment) {
+            if (deploymentRoutingEntries.containsKey(deploymentId)) {
+                throw new ResourceAlreadyExistsException("[{}] assignment already exists", deploymentId);
             }
-            modelRoutingEntries.put(modelId, assignment);
+            deploymentRoutingEntries.put(deploymentId, assignment);
             return this;
         }
 
-        public Builder updateAssignment(String modelId, TrainedModelAssignment.Builder assignment) {
-            if (modelRoutingEntries.containsKey(modelId) == false) {
-                throw new ResourceNotFoundException("[{}] assignment does not exist", modelId);
+        public Builder updateAssignment(String deploymentId, TrainedModelAssignment.Builder assignment) {
+            if (deploymentRoutingEntries.containsKey(deploymentId) == false) {
+                throw new ResourceNotFoundException("[{}] assignment does not exist", deploymentId);
             }
-            modelRoutingEntries.put(modelId, assignment);
+            deploymentRoutingEntries.put(deploymentId, assignment);
             return this;
         }
 
-        public TrainedModelAssignment.Builder getAssignment(String modelId) {
-            return modelRoutingEntries.get(modelId);
+        public TrainedModelAssignment.Builder getAssignment(String deploymentId) {
+            return deploymentRoutingEntries.get(deploymentId);
         }
 
-        public Builder removeAssignment(String modelId) {
-            modelRoutingEntries.remove(modelId);
+        public Builder removeAssignment(String deploymentId) {
+            deploymentRoutingEntries.remove(deploymentId);
             return this;
         }
 
@@ -228,7 +242,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
         private TrainedModelAssignmentMetadata build(String writeableName) {
             Map<String, TrainedModelAssignment> assignments = new LinkedHashMap<>();
-            modelRoutingEntries.forEach((modelId, assignment) -> assignments.put(modelId, assignment.build()));
+            deploymentRoutingEntries.forEach((deploymentId, assignment) -> assignments.put(deploymentId, assignment.build()));
             return new TrainedModelAssignmentMetadata(assignments, writeableName);
         }
     }
@@ -244,8 +258,8 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
 
         public TrainedModeAssignmentDiff(TrainedModelAssignmentMetadata before, TrainedModelAssignmentMetadata after) {
             this.modelRoutingEntries = DiffableUtils.diff(
-                before.modelRoutingEntries,
-                after.modelRoutingEntries,
+                before.deploymentRoutingEntries,
+                after.deploymentRoutingEntries,
                 DiffableUtils.getStringKeySerializer()
             );
             this.writeableName = NAME;
@@ -274,7 +288,7 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         @Override
         public Metadata.Custom apply(Metadata.Custom part) {
             return new TrainedModelAssignmentMetadata(
-                new TreeMap<>(modelRoutingEntries.apply(((TrainedModelAssignmentMetadata) part).modelRoutingEntries))
+                new TreeMap<>(modelRoutingEntries.apply(((TrainedModelAssignmentMetadata) part).deploymentRoutingEntries))
             );
         }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -65,14 +65,14 @@ import static org.elasticsearch.xpack.ml.MachineLearning.ML_PYTORCH_MODEL_INFERE
 public class TrainedModelAssignmentNodeService implements ClusterStateListener {
 
     private static final String NODE_NO_LONGER_REFERENCED = "node no longer referenced in model routing table";
-    private static final String ASSIGNMENT_NO_LONGER_EXISTS = "model assignment no longer exists";
+    private static final String ASSIGNMENT_NO_LONGER_EXISTS = "deployment assignment no longer exists";
     private static final TimeValue MODEL_LOADING_CHECK_INTERVAL = TimeValue.timeValueSeconds(1);
     private static final TimeValue CONTROL_MESSAGE_TIMEOUT = TimeValue.timeValueSeconds(60);
     private static final Logger logger = LogManager.getLogger(TrainedModelAssignmentNodeService.class);
     private final TrainedModelAssignmentService trainedModelAssignmentService;
     private final DeploymentManager deploymentManager;
     private final TaskManager taskManager;
-    private final Map<String, TrainedModelDeploymentTask> modelIdToTask;
+    private final Map<String, TrainedModelDeploymentTask> deploymentIdToTask;
     private final ThreadPool threadPool;
     private final Deque<TrainedModelDeploymentTask> loadingModels;
     private final XPackLicenseState licenseState;
@@ -94,7 +94,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         this.trainedModelAssignmentService = trainedModelAssignmentService;
         this.deploymentManager = deploymentManager;
         this.taskManager = taskManager;
-        this.modelIdToTask = new ConcurrentHashMap<>();
+        this.deploymentIdToTask = new ConcurrentHashMap<>();
         this.loadingModels = new ConcurrentLinkedDeque<>();
         this.threadPool = threadPool;
         this.licenseState = licenseState;
@@ -126,7 +126,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         this.trainedModelAssignmentService = trainedModelAssignmentService;
         this.deploymentManager = deploymentManager;
         this.taskManager = taskManager;
-        this.modelIdToTask = new ConcurrentHashMap<>();
+        this.deploymentIdToTask = new ConcurrentHashMap<>();
         this.loadingModels = new ConcurrentLinkedDeque<>();
         this.threadPool = threadPool;
         this.nodeId = nodeId;
@@ -155,7 +155,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
             try {
                 deploymentManager.stopDeployment(task);
                 taskManager.unregister(task);
-                modelIdToTask.remove(task.getModelId());
+                deploymentIdToTask.remove(task.getDeploymentId());
                 listener.onResponse(null);
             } catch (Exception e) {
                 listener.onFailure(e);
@@ -204,18 +204,17 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         // NOTE: As soon as this method exits, the timer for the scheduler starts ticking
         Deque<TrainedModelDeploymentTask> loadingToRetry = new ArrayDeque<>();
         while ((loadingTask = loadingModels.poll()) != null) {
-            final String modelId = loadingTask.getModelId();
+            final String deploymentId = loadingTask.getDeploymentId();
             if (loadingTask.isStopped()) {
                 if (logger.isTraceEnabled()) {
                     String reason = loadingTask.stoppedReason().orElse("_unknown_");
-                    logger.trace("[{}] attempted to load stopped task with reason [{}]", modelId, reason);
+                    logger.trace("[{}] attempted to load stopped task with reason [{}]", deploymentId, reason);
                 }
                 continue;
             }
             if (stopped) {
                 return;
             }
-            logger.trace(() -> "[" + modelId + "] attempting to load model");
             final PlainActionFuture<TrainedModelDeploymentTask> listener = new PlainActionFuture<>();
             try {
                 deploymentManager.startDeployment(loadingTask, listener);
@@ -224,12 +223,13 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                 // kicks off asynchronous cluster state update
                 handleLoadSuccess(deployedTask);
             } catch (Exception ex) {
-                logger.warn(() -> "[" + modelId + "] Start deployment failed", ex);
+                logger.warn(() -> "[" + deploymentId + "] Start deployment failed", ex);
                 if (ExceptionsHelper.unwrapCause(ex) instanceof ResourceNotFoundException) {
-                    logger.debug(() -> "[" + modelId + "] Start deployment failed as model was not found", ex);
+                    String modelId = loadingTask.getParams().getModelId();
+                    logger.debug(() -> "[" + deploymentId + "] Start deployment failed as model [" + modelId + "] was not found", ex);
                     handleLoadFailure(loadingTask, ExceptionsHelper.missingTrainedModel(modelId, ex));
                 } else if (ExceptionsHelper.unwrapCause(ex) instanceof SearchPhaseExecutionException) {
-                    logger.debug(() -> "[" + modelId + "] Start deployment failed, will retry", ex);
+                    logger.debug(() -> "[" + deploymentId + "] Start deployment failed, will retry", ex);
                     // A search phase execution failure should be retried, push task back to the queue
                     loadingToRetry.add(loadingTask);
                 } else {
@@ -246,25 +246,25 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         );
 
         ActionListener<Void> notifyDeploymentOfStopped = ActionListener.wrap(
-            _void -> updateStoredState(task.getModelId(), updateToStopped, listener),
+            _void -> updateStoredState(task.getDeploymentId(), updateToStopped, listener),
             failed -> { // if we failed to stop the process, something strange is going on, but we should still notify of stop
-                logger.warn(() -> "[" + task.getModelId() + "] failed to stop due to error", failed);
-                updateStoredState(task.getModelId(), updateToStopped, listener);
+                logger.warn(() -> "[" + task.getDeploymentId() + "] failed to stop due to error", failed);
+                updateStoredState(task.getDeploymentId(), updateToStopped, listener);
             }
         );
         updateStoredState(
-            task.getModelId(),
+            task.getDeploymentId(),
             RoutingInfoUpdate.updateStateAndReason(new RoutingStateAndReason(RoutingState.STOPPING, reason)),
             ActionListener.wrap(success -> stopDeploymentAsync(task, reason, notifyDeploymentOfStopped), e -> {
                 if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
                     logger.debug(
-                        () -> format("[%s] failed to set routing state to stopping as assignment already removed", task.getModelId()),
+                        () -> format("[%s] failed to set routing state to stopping as assignment already removed", task.getDeploymentId()),
                         e
                     );
                 } else {
                     // this is an unexpected error
                     // TODO this means requests may still be routed here, should we not stop deployment?
-                    logger.warn(() -> "[" + task.getModelId() + "] failed to set routing state to stopping due to error", e);
+                    logger.warn(() -> "[" + task.getDeploymentId() + "] failed to set routing state to stopping due to error", e);
                 }
                 stopDeploymentAsync(task, reason, notifyDeploymentOfStopped);
             })
@@ -296,7 +296,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         return new TaskAwareRequest() {
             @Override
             public void setParentTask(TaskId taskId) {
-                throw new UnsupportedOperationException("parent task id for model assignment tasks shouldn't change");
+                throw new UnsupportedOperationException("parent task id for model deployment tasks shouldn't change");
             }
 
             @Override
@@ -342,28 +342,29 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                 updateNumberOfAllocations(modelAssignmentMetadata);
             }
 
-            for (TrainedModelAssignment trainedModelAssignment : modelAssignmentMetadata.modelAssignments().values()) {
+            for (TrainedModelAssignment trainedModelAssignment : modelAssignmentMetadata.allAssignments().values()) {
                 RoutingInfo routingInfo = trainedModelAssignment.getNodeRoutingTable().get(currentNode);
                 // Add new models to start loading
                 if (routingInfo != null && isNewAllocationSupported) {
                     if (routingInfo.getState() == RoutingState.STARTING
-                        && modelIdToTask.containsKey(trainedModelAssignment.getModelId())
-                        && modelIdToTask.get(trainedModelAssignment.getModelId()).isFailed()) {
+                        && deploymentIdToTask.containsKey(trainedModelAssignment.getDeploymentId())
+                        && deploymentIdToTask.get(trainedModelAssignment.getDeploymentId()).isFailed()) {
                         // This is a failed assignment and we are restarting it. For this we need to remove the task first.
-                        taskManager.unregister(modelIdToTask.get(trainedModelAssignment.getModelId()));
-                        modelIdToTask.remove(trainedModelAssignment.getModelId());
+                        taskManager.unregister(deploymentIdToTask.get(trainedModelAssignment.getDeploymentId()));
+                        deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
                     }
                     if (routingInfo.getState().isAnyOf(RoutingState.STARTING, RoutingState.STARTED) // periodic retries of `failed` should
                                                                                                     // be handled in a separate process
                         // This means we don't already have a task and should attempt creating one and starting the model loading
                         // If we don't have a task but are STARTED, this means the cluster state had a started assignment,
                         // the node crashed and then started again
-                        && modelIdToTask.containsKey(trainedModelAssignment.getTaskParams().getModelId()) == false
+                        && deploymentIdToTask.containsKey(trainedModelAssignment.getTaskParams().getModelId()) == false
                         // If we are in reset mode, don't start loading a new model on this node.
                         && isResetMode == false) {
                         prepareModelToLoad(
                             new StartTrainedModelDeploymentAction.TaskParams(
-                                trainedModelAssignment.getModelId(),
+                                trainedModelAssignment.getTaskParams().getModelId(),
+                                trainedModelAssignment.getDeploymentId(),
                                 trainedModelAssignment.getTaskParams().getModelBytes(),
                                 routingInfo.getCurrentAllocations(),
                                 trainedModelAssignment.getTaskParams().getThreadsPerAllocation(),
@@ -376,22 +377,22 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                 }
                 // This model is not routed to the current node at all
                 if (routingInfo == null) {
-                    TrainedModelDeploymentTask task = modelIdToTask.remove(trainedModelAssignment.getTaskParams().getModelId());
+                    TrainedModelDeploymentTask task = deploymentIdToTask.remove(trainedModelAssignment.getDeploymentId());
                     if (task != null) {
                         stopDeploymentAsync(
                             task,
                             NODE_NO_LONGER_REFERENCED,
                             ActionListener.wrap(
-                                r -> logger.trace(() -> "[" + task.getModelId() + "] stopped deployment"),
-                                e -> logger.warn(() -> "[" + task.getModelId() + "] failed to fully stop deployment", e)
+                                r -> logger.trace(() -> "[" + task.getDeploymentId() + "] stopped deployment"),
+                                e -> logger.warn(() -> "[" + task.getDeploymentId() + "] failed to fully stop deployment", e)
                             )
                         );
                     }
                 }
             }
             List<TrainedModelDeploymentTask> toCancel = new ArrayList<>();
-            for (String modelIds : Sets.difference(modelIdToTask.keySet(), modelAssignmentMetadata.modelAssignments().keySet())) {
-                toCancel.add(modelIdToTask.remove(modelIds));
+            for (String deploymentIds : Sets.difference(deploymentIdToTask.keySet(), modelAssignmentMetadata.allAssignments().keySet())) {
+                toCancel.add(deploymentIdToTask.remove(deploymentIds));
             }
             // should all be stopped in the same executor thread?
             for (TrainedModelDeploymentTask t : toCancel) {
@@ -399,8 +400,8 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                     t,
                     ASSIGNMENT_NO_LONGER_EXISTS,
                     ActionListener.wrap(
-                        r -> logger.trace(() -> "[" + t.getModelId() + "] stopped deployment"),
-                        e -> logger.warn(() -> "[" + t.getModelId() + "] failed to fully stop deployment", e)
+                        r -> logger.trace(() -> "[" + t.getDeploymentId() + "] stopped deployment"),
+                        e -> logger.warn(() -> "[" + t.getDeploymentId() + "] failed to fully stop deployment", e)
                     )
                 );
             }
@@ -408,7 +409,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
     }
 
     private void updateNumberOfAllocations(TrainedModelAssignmentMetadata assignments) {
-        List<TrainedModelAssignment> modelsToUpdate = assignments.modelAssignments()
+        List<TrainedModelAssignment> assignmentsToUpdate = assignments.allAssignments()
             .values()
             .stream()
             .filter(a -> hasStartingAssignments(a) == false)
@@ -420,10 +421,10 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
             })
             .toList();
 
-        for (TrainedModelAssignment assignment : modelsToUpdate) {
-            TrainedModelDeploymentTask task = modelIdToTask.get(assignment.getModelId());
+        for (TrainedModelAssignment assignment : assignmentsToUpdate) {
+            TrainedModelDeploymentTask task = deploymentIdToTask.get(assignment.getDeploymentId());
             if (task == null) {
-                logger.debug(() -> format("[%s] task was removed whilst updating number of allocations", assignment.getModelId()));
+                logger.debug(() -> format("[%s] task was removed whilst updating number of allocations", assignment.getDeploymentId()));
                 continue;
             }
             RoutingInfo routingInfo = assignment.getNodeRoutingTable().get(nodeId);
@@ -432,10 +433,14 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                 assignment.getNodeRoutingTable().get(nodeId).getTargetAllocations(),
                 CONTROL_MESSAGE_TIMEOUT,
                 ActionListener.wrap(threadSettings -> {
-                    logger.debug("[{}] Updated number of allocations to [{}]", assignment.getModelId(), threadSettings.numAllocations());
+                    logger.debug(
+                        "[{}] Updated number of allocations to [{}]",
+                        assignment.getDeploymentId(),
+                        threadSettings.numAllocations()
+                    );
                     task.updateNumberOfAllocations(threadSettings.numAllocations());
                     updateStoredState(
-                        assignment.getModelId(),
+                        assignment.getDeploymentId(),
                         RoutingInfoUpdate.updateNumberOfAllocations(threadSettings.numAllocations()),
                         ActionListener.noop()
                     );
@@ -443,7 +448,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                     e -> logger.error(
                         format(
                             "[%s] Could not update number of allocations to [%s]",
-                            assignment.getModelId(),
+                            assignment.getDeploymentId(),
                             routingInfo.getTargetAllocations()
                         ),
                         e
@@ -461,12 +466,19 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
     }
 
     // For testing purposes
-    TrainedModelDeploymentTask getTask(String modelId) {
-        return modelIdToTask.get(modelId);
+    TrainedModelDeploymentTask getTask(String deploymentId) {
+        return deploymentIdToTask.get(deploymentId);
     }
 
     void prepareModelToLoad(StartTrainedModelDeploymentAction.TaskParams taskParams) {
-        logger.debug(() -> format("[%s] preparing to load model with task params: %s", taskParams.getModelId(), taskParams));
+        logger.debug(
+            () -> format(
+                "[%s] preparing to load model [%s] with task params: %s",
+                taskParams.getDeploymentId(),
+                taskParams.getModelId(),
+                taskParams
+            )
+        );
         TrainedModelDeploymentTask task = (TrainedModelDeploymentTask) taskManager.register(
             TRAINED_MODEL_ASSIGNMENT_TASK_TYPE,
             TRAINED_MODEL_ASSIGNMENT_TASK_ACTION,
@@ -474,22 +486,28 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
             false
         );
         // threadsafe check to verify we are not loading/loaded the model
-        if (modelIdToTask.putIfAbsent(taskParams.getModelId(), task) == null) {
+        if (deploymentIdToTask.putIfAbsent(taskParams.getDeploymentId(), task) == null) {
             loadingModels.add(task);
         } else {
-            // If there is already a task for the model, unregister the new task
+            // If there is already a task for the deployment, unregister the new task
             taskManager.unregister(task);
         }
     }
 
     private void handleLoadSuccess(TrainedModelDeploymentTask task) {
-        final String modelId = task.getModelId();
-        logger.debug(() -> "[" + modelId + "] model successfully loaded and ready for inference. Notifying master node");
+        logger.debug(
+            () -> "["
+                + task.getParams().getDeploymentId()
+                + "] model ["
+                + task.getParams().getModelId()
+                + "] successfully loaded and ready for inference. Notifying master node"
+        );
         if (task.isStopped()) {
             logger.debug(
                 () -> format(
-                    "[%s] model loaded successfully, but stopped before routing table was updated; reason [%s]",
-                    modelId,
+                    "[%s] model [%s] loaded successfully, but stopped before routing table was updated; reason [%s]",
+                    task.getDeploymentId(),
+                    task.getParams().getModelId(),
                     task.stoppedReason().orElse("_unknown_")
                 )
             );
@@ -497,49 +515,58 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
         }
 
         updateStoredState(
-            modelId,
+            task.getDeploymentId(),
             RoutingInfoUpdate.updateStateAndReason(new RoutingStateAndReason(RoutingState.STARTED, "")),
-            ActionListener.wrap(r -> logger.debug(() -> "[" + modelId + "] model loaded and accepting routes"), e -> {
+            ActionListener.wrap(r -> logger.debug(() -> "[" + task.getDeploymentId() + "] model loaded and accepting routes"), e -> {
                 // This means that either the assignment has been deleted, or this node's particular route has been removed
                 if (ExceptionsHelper.unwrapCause(e) instanceof ResourceNotFoundException) {
                     logger.debug(
                         () -> format(
-                            "[%s] model loaded but failed to start accepting routes as assignment to this node was removed",
-                            modelId
+                            "[%s] model [%s] loaded but failed to start accepting routes as assignment to this node was removed",
+                            task.getDeploymentId(),
+                            task.getParams().getModelId()
                         ),
                         e
                     );
                 } else {
                     // this is an unexpected error
-                    logger.warn(() -> "[" + modelId + "] model loaded but failed to start accepting routes", e);
+                    logger.warn(
+                        () -> "["
+                            + task.getDeploymentId()
+                            + "] model ["
+                            + task.getParams().getModelId()
+                            + "] loaded but failed to start accepting routes",
+                        e
+                    );
                 }
             })
         );
     }
 
-    private void updateStoredState(String modelId, RoutingInfoUpdate update, ActionListener<AcknowledgedResponse> listener) {
+    private void updateStoredState(String deploymentId, RoutingInfoUpdate update, ActionListener<AcknowledgedResponse> listener) {
         if (stopped) {
             return;
         }
         trainedModelAssignmentService.updateModelAssignmentState(
-            new UpdateTrainedModelAssignmentRoutingInfoAction.Request(nodeId, modelId, update),
+            new UpdateTrainedModelAssignmentRoutingInfoAction.Request(nodeId, deploymentId, update),
             ActionListener.wrap(success -> {
-                logger.debug(() -> format("[%s] model routing info was updated with [%s] and master notified", modelId, update));
+                logger.debug(() -> format("[%s] deployment routing info was updated with [%s] and master notified", deploymentId, update));
                 listener.onResponse(AcknowledgedResponse.TRUE);
             }, error -> {
-                logger.warn(() -> format("[%s] failed to update model routing info with [%s]", modelId, update), error);
+                logger.warn(() -> format("[%s] failed to update deployment routing info with [%s]", deploymentId, update), error);
                 listener.onFailure(error);
             })
         );
     }
 
     private void handleLoadFailure(TrainedModelDeploymentTask task, Exception ex) {
-        logger.error(() -> "[" + task.getModelId() + "] model failed to load", ex);
+        logger.error(() -> "[" + task.getDeploymentId() + "] model [" + task.getParams().getModelId() + "] failed to load", ex);
         if (task.isStopped()) {
             logger.debug(
                 () -> format(
-                    "[%s] model failed to load, but is now stopped; reason [%s]",
-                    task.getModelId(),
+                    "[%s] model [" + task.getParams().getModelId() + "] failed to load, but is now stopped; reason [%s]",
+                    task.getDeploymentId(),
+                    task.getParams().getModelId(),
                     task.stoppedReason().orElse("_unknown_")
                 )
             );
@@ -552,7 +579,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
             ActionListener.noop()
         );
         updateStoredState(
-            task.getModelId(),
+            task.getDeploymentId(),
             RoutingInfoUpdate.updateStateAndReason(
                 new RoutingStateAndReason(RoutingState.FAILED, ExceptionsHelper.unwrapCause(ex).getMessage())
             ),
@@ -562,13 +589,13 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
 
     public void failAssignment(TrainedModelDeploymentTask task, String reason) {
         updateStoredState(
-            task.getModelId(),
+            task.getDeploymentId(),
             RoutingInfoUpdate.updateStateAndReason(new RoutingStateAndReason(RoutingState.FAILED, reason)),
             ActionListener.wrap(
                 r -> logger.debug(
                     () -> format(
                         "[%s] Successfully updating assignment state to [%s] with reason [%s]",
-                        task.getModelId(),
+                        task.getDeploymentId(),
                         RoutingState.FAILED,
                         reason
                     )
@@ -576,7 +603,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                 e -> logger.error(
                     () -> format(
                         "[%s] Error while updating assignment state to [%s] with reason [%s]",
-                        task.getModelId(),
+                        task.getDeploymentId(),
                         RoutingState.FAILED,
                         reason
                     ),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeService.java
@@ -358,7 +358,7 @@ public class TrainedModelAssignmentNodeService implements ClusterStateListener {
                         // This means we don't already have a task and should attempt creating one and starting the model loading
                         // If we don't have a task but are STARTED, this means the cluster state had a started assignment,
                         // the node crashed and then started again
-                        && deploymentIdToTask.containsKey(trainedModelAssignment.getTaskParams().getModelId()) == false
+                        && deploymentIdToTask.containsKey(trainedModelAssignment.getDeploymentId()) == false
                         // If we are in reset mode, don't start loading a new model on this node.
                         && isResetMode == false) {
                         prepareModelToLoad(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentService.java
@@ -61,7 +61,7 @@ public class TrainedModelAssignmentService {
         ClusterStateObserver observer = new ClusterStateObserver(currentState, clusterService, null, logger, threadPool.getThreadContext());
         DiscoveryNode masterNode = currentState.nodes().getMasterNode();
         if (masterNode == null) {
-            logger.warn("[{}] no master known for assignment update [{}]", request.getModelId(), request.getUpdate());
+            logger.warn("[{}] no master known for assignment update [{}]", request.getDeploymentId(), request.getUpdate());
             waitForNewMasterAndRetry(observer, UpdateTrainedModelAssignmentRoutingInfoAction.INSTANCE, request, listener);
             return;
         }
@@ -72,7 +72,7 @@ public class TrainedModelAssignmentService {
                 if (isMasterChannelException(failure)) {
                     logger.info(
                         "[{}] master channel exception will retry on new master node for assignment update [{}]",
-                        request.getModelId(),
+                        request.getDeploymentId(),
                         request.getUpdate()
                     );
                     waitForNewMasterAndRetry(observer, UpdateTrainedModelAssignmentRoutingInfoAction.INSTANCE, request, listener);
@@ -95,7 +95,7 @@ public class TrainedModelAssignmentService {
     }
 
     public void waitForAssignmentCondition(
-        final String modelId,
+        final String deploymentId,
         final Predicate<ClusterState> predicate,
         final @Nullable TimeValue timeout,
         final WaitForAssignmentListener listener
@@ -104,12 +104,12 @@ public class TrainedModelAssignmentService {
         final ClusterStateObserver observer = new ClusterStateObserver(clusterService, timeout, logger, threadPool.getThreadContext());
         final ClusterState clusterState = observer.setAndGetObservedState();
         if (predicate.test(clusterState)) {
-            listener.onResponse(TrainedModelAssignmentMetadata.assignmentForModelId(clusterState, modelId).orElse(null));
+            listener.onResponse(TrainedModelAssignmentMetadata.assignmentForDeploymentId(clusterState, deploymentId).orElse(null));
         } else {
             observer.waitForNextChange(new ClusterStateObserver.Listener() {
                 @Override
                 public void onNewClusterState(ClusterState state) {
-                    listener.onResponse(TrainedModelAssignmentMetadata.assignmentForModelId(state, modelId).orElse(null));
+                    listener.onResponse(TrainedModelAssignmentMetadata.assignmentForDeploymentId(state, deploymentId).orElse(null));
                 }
 
                 @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducer.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducer.java
@@ -106,7 +106,7 @@ public class AllocationReducer {
                 logger.debug(
                     () -> format(
                         "[%s] removing assignment with [%s] allocations on node [%s]",
-                        assignment.getModelId(),
+                        assignment.getDeploymentId(),
                         smallestAssignmentInLargestZone.getValue(),
                         smallestAssignmentInLargestZone.getKey()
                     )
@@ -118,7 +118,7 @@ public class AllocationReducer {
                 logger.debug(
                     () -> format(
                         "[%s] removing 1 allocation from assignment with [%s] allocations on node [%s]",
-                        assignment.getModelId(),
+                        assignment.getDeploymentId(),
                         smallestAssignmentInLargestZone.getValue(),
                         smallestAssignmentInLargestZone.getKey()
                     )

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlan.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlan.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
  */
 public class AssignmentPlan implements Comparable<AssignmentPlan> {
 
-    public record Model(
+    public record Deployment(
         String id,
         long memoryBytes,
         int allocations,
@@ -38,7 +38,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         Priority priority
     ) {
 
-        public Model(
+        public Deployment(
             String id,
             long memoryBytes,
             int allocations,
@@ -87,17 +87,17 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
      * is a {@link Map<Node, Integer>} where the value is the number
      * of allocations for each node.
      */
-    private final Map<Model, Map<Node, Integer>> assignments;
+    private final Map<Deployment, Map<Node, Integer>> assignments;
 
     private final Map<String, Long> remainingNodeMemory;
     private final Map<String, Integer> remainingNodeCores;
-    private final Map<Model, Integer> remainingModelAllocations;
+    private final Map<Deployment, Integer> remainingModelAllocations;
 
     private AssignmentPlan(
-        Map<Model, Map<Node, Integer>> assignments,
+        Map<Deployment, Map<Node, Integer>> assignments,
         Map<Node, Long> remainingNodeMemory,
         Map<Node, Integer> remainingNodeCores,
-        Map<Model, Integer> remainingModelAllocations
+        Map<Deployment, Integer> remainingModelAllocations
     ) {
         this.assignments = Objects.requireNonNull(assignments);
         this.remainingNodeMemory = remainingNodeMemory.entrySet()
@@ -107,7 +107,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         this.remainingModelAllocations = Objects.requireNonNull(remainingModelAllocations);
     }
 
-    public Set<Model> models() {
+    public Set<Deployment> models() {
         return assignments.keySet();
     }
 
@@ -115,11 +115,11 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
      * The assignments of that model to each node. Each assignment
      * is a {@link Map<Node, Integer>} where the value is the number
      * of allocations for each node.
-     * @param model the model for which assignments are returned
+     * @param deployment the model for which assignments are returned
      * @return the model assignments per node. The Optional will be empty if the model has no assignments.
      */
-    public Optional<Map<Node, Integer>> assignments(Model model) {
-        Map<Node, Integer> modelAssignments = assignments.get(model);
+    public Optional<Map<Node, Integer>> assignments(Deployment deployment) {
+        Map<Node, Integer> modelAssignments = assignments.get(deployment);
         return (modelAssignments == null || modelAssignments.isEmpty()) ? Optional.empty() : Optional.of(modelAssignments);
     }
 
@@ -132,7 +132,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         return models().stream().allMatch(this::isSatisfyingCurrentAssignmentsForModel);
     }
 
-    private boolean isSatisfyingCurrentAssignmentsForModel(Model m) {
+    private boolean isSatisfyingCurrentAssignmentsForModel(Deployment m) {
         if (m.currentAllocationsByNodeId().isEmpty()) {
             return true;
         }
@@ -141,7 +141,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         return currentAllocations >= m.getCurrentAssignedAllocations();
     }
 
-    public boolean satisfiesAllocations(Model m) {
+    public boolean satisfiesAllocations(Deployment m) {
         return remainingModelAllocations.getOrDefault(m, 0) == 0;
     }
 
@@ -151,14 +151,14 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
 
     public boolean arePreviouslyAssignedModelsAssigned() {
         return models().stream()
-            .filter(Model::hasEverBeenAllocated)
+            .filter(Deployment::hasEverBeenAllocated)
             .map(this::totalAllocations)
             .allMatch(totalAllocations -> totalAllocations > 0);
     }
 
     public long countPreviouslyAssignedModelsThatAreStillAssigned() {
         return models().stream()
-            .filter(Model::hasEverBeenAllocated)
+            .filter(Deployment::hasEverBeenAllocated)
             .map(this::totalAllocations)
             .filter(totalAllocations -> totalAllocations > 0)
             .count();
@@ -172,7 +172,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         return remainingNodeMemory.getOrDefault(nodeId, 0L);
     }
 
-    public int totalAllocations(Model m) {
+    public int totalAllocations(Deployment m) {
         if (assignments.containsKey(m) == false) {
             return 0;
         }
@@ -184,8 +184,8 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         double weighedAllocationsScore = 0;
         double memoryScore = 0;
 
-        for (Map.Entry<Model, Map<Node, Integer>> entry : assignments.entrySet()) {
-            Model m = entry.getKey();
+        for (Map.Entry<Deployment, Map<Node, Integer>> entry : assignments.entrySet()) {
+            Deployment m = entry.getKey();
             isSatisfyingPreviousAssignments = isSatisfyingPreviousAssignments && isSatisfyingCurrentAssignmentsForModel(m);
             Map<Node, Integer> modelAssignments = entry.getValue();
             if (modelAssignments != null) {
@@ -205,10 +205,10 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
             return "Empty plan";
         }
 
-        Map<Node, List<Tuple<Model, Integer>>> nodeToModel = new HashMap<>();
-        for (Model m : assignments.keySet()) {
+        Map<Node, List<Tuple<Deployment, Integer>>> nodeToModel = new HashMap<>();
+        for (Deployment m : assignments.keySet()) {
             for (Node n : assignments.get(m).keySet()) {
-                List<Tuple<Model, Integer>> allocationsPerModel = nodeToModel.containsKey(n) ? nodeToModel.get(n) : new ArrayList<>();
+                List<Tuple<Deployment, Integer>> allocationsPerModel = nodeToModel.containsKey(n) ? nodeToModel.get(n) : new ArrayList<>();
                 allocationsPerModel.add(Tuple.tuple(m, assignments.get(m).get(n)));
                 nodeToModel.put(n, allocationsPerModel);
             }
@@ -220,7 +220,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
             Node n = nodes.get(i);
             msg.append(n);
             msg.append(" ->");
-            for (Tuple<Model, Integer> modelAllocations : nodeToModel.get(n)
+            for (Tuple<Deployment, Integer> modelAllocations : nodeToModel.get(n)
                 .stream()
                 .sorted(Comparator.comparing(x -> x.v1().id()))
                 .collect(Collectors.toList())) {
@@ -247,36 +247,36 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
         return msg.toString();
     }
 
-    public static Builder builder(Collection<Node> nodes, Collection<Model> models) {
-        return new Builder(nodes, models);
+    public static Builder builder(Collection<Node> nodes, Collection<Deployment> deployments) {
+        return new Builder(nodes, deployments);
     }
 
     public static class Builder {
 
-        private final Map<Model, Map<Node, Integer>> assignments;
+        private final Map<Deployment, Map<Node, Integer>> assignments;
         private final Map<Node, Long> remainingNodeMemory;
         private final Map<Node, Integer> remainingNodeCores;
-        private final Map<Model, Integer> remainingModelAllocations;
+        private final Map<Deployment, Integer> remainingModelAllocations;
 
-        private Builder(Collection<Node> nodes, Collection<Model> models) {
+        private Builder(Collection<Node> nodes, Collection<Deployment> deployments) {
             if (nodes.stream().collect(Collectors.toSet()).size() != nodes.size()) {
                 throw new IllegalArgumentException("there should be no duplicate nodes");
             }
-            if (models.stream().collect(Collectors.toSet()).size() != models.size()) {
+            if (deployments.stream().collect(Collectors.toSet()).size() != deployments.size()) {
                 throw new IllegalArgumentException("there should be no duplicate models");
             }
 
-            assignments = Maps.newHashMapWithExpectedSize(nodes.size() * models.size());
+            assignments = Maps.newHashMapWithExpectedSize(nodes.size() * deployments.size());
             remainingNodeMemory = Maps.newHashMapWithExpectedSize(nodes.size());
             remainingNodeCores = Maps.newHashMapWithExpectedSize(nodes.size());
-            remainingModelAllocations = Maps.newHashMapWithExpectedSize(models.size());
+            remainingModelAllocations = Maps.newHashMapWithExpectedSize(deployments.size());
 
             nodes.forEach(n -> {
                 remainingNodeMemory.put(n, n.availableMemoryBytes());
                 remainingNodeCores.put(n, n.cores());
             });
 
-            for (Model m : models) {
+            for (Deployment m : deployments) {
                 Map<Node, Integer> nodeAssignments = new HashMap<>();
                 for (Node n : nodes) {
                     nodeAssignments.put(n, 0);
@@ -294,62 +294,65 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
             return remainingNodeMemory.get(n);
         }
 
-        int getRemainingThreads(Model m) {
+        int getRemainingThreads(Deployment m) {
             return remainingModelAllocations.get(m) * m.threadsPerAllocation();
         }
 
-        int getRemainingAllocations(Model m) {
+        int getRemainingAllocations(Deployment m) {
             return remainingModelAllocations.get(m);
         }
 
-        boolean canAssign(Model model, Node node, int allocations) {
-            return (isAlreadyAssigned(model, node)
-                || (model.memoryBytes() <= remainingNodeMemory.get(node))
-                    && (model.priority == Priority.LOW || allocations * model.threadsPerAllocation() <= remainingNodeCores.get(node)));
+        boolean canAssign(Deployment deployment, Node node, int allocations) {
+            return (isAlreadyAssigned(deployment, node)
+                || (deployment.memoryBytes() <= remainingNodeMemory.get(node))
+                    && (deployment.priority == Priority.LOW
+                        || allocations * deployment.threadsPerAllocation() <= remainingNodeCores.get(node)));
         }
 
-        public Builder assignModelToNode(Model model, Node node, int allocations) {
+        public Builder assignModelToNode(Deployment deployment, Node node, int allocations) {
             if (allocations <= 0) {
                 return this;
             }
-            if (isAlreadyAssigned(model, node) == false && model.memoryBytes() > remainingNodeMemory.get(node)) {
-                throw new IllegalArgumentException("not enough memory on node [" + node.id() + "] to assign model [" + model.id() + "]");
+            if (isAlreadyAssigned(deployment, node) == false && deployment.memoryBytes() > remainingNodeMemory.get(node)) {
+                throw new IllegalArgumentException(
+                    "not enough memory on node [" + node.id() + "] to assign model [" + deployment.id() + "]"
+                );
             }
-            if (model.priority == Priority.NORMAL && allocations * model.threadsPerAllocation() > remainingNodeCores.get(node)) {
+            if (deployment.priority == Priority.NORMAL && allocations * deployment.threadsPerAllocation() > remainingNodeCores.get(node)) {
                 throw new IllegalArgumentException(
                     "not enough cores on node ["
                         + node.id()
                         + "] to assign ["
                         + allocations
                         + "] allocations to model ["
-                        + model.id()
+                        + deployment.id()
                         + "]; required threads per allocation ["
-                        + model.threadsPerAllocation()
+                        + deployment.threadsPerAllocation()
                         + "]"
                 );
             }
 
-            long additionalModelMemory = isAlreadyAssigned(model, node) ? 0 : model.memoryBytes;
-            assignments.get(model).compute(node, (n, remAllocations) -> remAllocations + allocations);
+            long additionalModelMemory = isAlreadyAssigned(deployment, node) ? 0 : deployment.memoryBytes;
+            assignments.get(deployment).compute(node, (n, remAllocations) -> remAllocations + allocations);
             remainingNodeMemory.compute(node, (n, remMemory) -> remMemory - additionalModelMemory);
-            if (model.priority == Priority.NORMAL) {
-                remainingNodeCores.compute(node, (n, remCores) -> remCores - allocations * model.threadsPerAllocation());
+            if (deployment.priority == Priority.NORMAL) {
+                remainingNodeCores.compute(node, (n, remCores) -> remCores - allocations * deployment.threadsPerAllocation());
             }
-            remainingModelAllocations.compute(model, (m, remModelThreads) -> remModelThreads - allocations);
+            remainingModelAllocations.compute(deployment, (m, remModelThreads) -> remModelThreads - allocations);
             return this;
         }
 
-        private boolean isAlreadyAssigned(Model model, Node node) {
-            return model.currentAllocationsByNodeId().containsKey(node.id()) || assignments.get(model).get(node) > 0;
+        private boolean isAlreadyAssigned(Deployment deployment, Node node) {
+            return deployment.currentAllocationsByNodeId().containsKey(node.id()) || assignments.get(deployment).get(node) > 0;
         }
 
-        public void accountMemory(Model m, Node n) {
+        public void accountMemory(Deployment m, Node n) {
             remainingNodeMemory.computeIfPresent(n, (k, v) -> v - m.memoryBytes());
         }
 
         public AssignmentPlan build() {
-            Map<Model, Map<Node, Integer>> finalAssignments = new HashMap<>();
-            for (Model m : assignments.keySet()) {
+            Map<Deployment, Map<Node, Integer>> finalAssignments = new HashMap<>();
+            for (Deployment m : assignments.keySet()) {
                 Map<Node, Integer> allocationsPerNode = new HashMap<>();
                 for (Map.Entry<Node, Integer> entry : assignments.get(m).entrySet()) {
                     if (entry.getValue() > 0) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlan.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlan.java
@@ -324,7 +324,7 @@ public class AssignmentPlan implements Comparable<AssignmentPlan> {
                         + node.id()
                         + "] to assign ["
                         + allocations
-                        + "] allocations to model ["
+                        + "] allocations to deployment ["
                         + deployment.id()
                         + "]; required threads per allocation ["
                         + deployment.threadsPerAllocation()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
@@ -10,7 +10,6 @@ package org.elasticsearch.xpack.ml.inference.assignment.planning;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.Comparator;
@@ -47,11 +46,11 @@ public class AssignmentPlanner {
     private static final Logger logger = LogManager.getLogger(AssignmentPlanner.class);
 
     private final List<Node> nodes;
-    private final List<Model> models;
+    private final List<AssignmentPlan.Deployment> deployments;
 
-    public AssignmentPlanner(List<Node> nodes, List<Model> models) {
+    public AssignmentPlanner(List<Node> nodes, List<AssignmentPlan.Deployment> deployments) {
         this.nodes = nodes.stream().sorted(Comparator.comparing(Node::id)).toList();
-        this.models = models.stream().sorted(Comparator.comparing(Model::id)).toList();
+        this.deployments = deployments.stream().sorted(Comparator.comparing(AssignmentPlan.Deployment::id)).toList();
     }
 
     public AssignmentPlan computePlan() {
@@ -59,7 +58,7 @@ public class AssignmentPlanner {
     }
 
     public AssignmentPlan computePlan(boolean tryAssigningPreviouslyAssignedModels) {
-        logger.debug(() -> format("Computing plan for nodes = %s; models = %s", nodes, models));
+        logger.debug(() -> format("Computing plan for nodes = %s; models = %s", nodes, deployments));
 
         AssignmentPlan bestPlan;
         AssignmentPlan planSatisfyingCurrentAssignments = solveSatisfyingCurrentAssignments();
@@ -108,10 +107,10 @@ public class AssignmentPlanner {
 
     private AssignmentPlan solveAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated() {
         logger.debug(() -> "Attempting to solve assigning at least one allocation to previously assigned models");
-        List<Model> previouslyAssignedModelsOnly = models.stream()
+        List<AssignmentPlan.Deployment> previouslyAssignedModelsOnly = deployments.stream()
             .filter(m -> m.hasEverBeenAllocated())
             .map(
-                m -> new Model(
+                m -> new AssignmentPlan.Deployment(
                     m.id(),
                     m.memoryBytes(),
                     1,
@@ -127,7 +126,7 @@ public class AssignmentPlanner {
         ).solvePlan(true);
 
         Map<String, String> modelIdToNodeIdWithSingleAllocation = new HashMap<>();
-        for (Model m : planWithSingleAllocationForPreviouslyAssignedModels.models()) {
+        for (AssignmentPlan.Deployment m : planWithSingleAllocationForPreviouslyAssignedModels.models()) {
             Optional<Map<Node, Integer>> assignments = planWithSingleAllocationForPreviouslyAssignedModels.assignments(m);
             Set<Node> nodes = assignments.orElse(Map.of()).keySet();
             if (nodes.isEmpty() == false) {
@@ -136,11 +135,11 @@ public class AssignmentPlanner {
             }
         }
 
-        List<Model> planModels = models.stream().map(m -> {
+        List<AssignmentPlan.Deployment> planDeployments = deployments.stream().map(m -> {
             Map<String, Integer> currentAllocationsByNodeId = modelIdToNodeIdWithSingleAllocation.containsKey(m.id())
                 ? Map.of(modelIdToNodeIdWithSingleAllocation.get(m.id()), 1)
                 : Map.of();
-            return new Model(
+            return new AssignmentPlan.Deployment(
                 m.id(),
                 m.memoryBytes(),
                 m.allocations(),
@@ -150,27 +149,27 @@ public class AssignmentPlanner {
             );
         }).toList();
 
-        return new AssignmentPlanner(nodes, planModels).computePlan(false);
+        return new AssignmentPlanner(nodes, planDeployments).computePlan(false);
     }
 
     private AssignmentPlan solveKeepingOneAllocationOnCurrentAssignments() {
         // We do not want to ever completely unassign a model from a node so we
         // can move allocations without having temporary impact on performance.
         logger.trace(() -> format("Solving preserving one allocation on current assignments"));
-        return solvePreservingCurrentAssignments(new PreserveOneAllocation(nodes, models));
+        return solvePreservingCurrentAssignments(new PreserveOneAllocation(nodes, deployments));
     }
 
     private AssignmentPlan solvePreservingAllAllocationsOnCurrentAssignments() {
         logger.trace(() -> format("Solving preserving all allocations on current assignments"));
-        return solvePreservingCurrentAssignments(new PreserveAllAllocations(nodes, models));
+        return solvePreservingCurrentAssignments(new PreserveAllAllocations(nodes, deployments));
     }
 
     private AssignmentPlan solvePreservingCurrentAssignments(AbstractPreserveAllocations preserveAllocations) {
         List<Node> planNodes = preserveAllocations.nodesPreservingAllocations();
-        List<Model> planModels = preserveAllocations.modelsPreservingAllocations();
+        List<AssignmentPlan.Deployment> planDeployments = preserveAllocations.modelsPreservingAllocations();
         logger.trace(() -> format("Nodes after applying allocation preserving strategy = %s", planNodes));
-        logger.trace(() -> format("Models after applying allocation preserving strategy = %s", planModels));
-        AssignmentPlan assignmentPlan = new LinearProgrammingPlanSolver(planNodes, planModels).solvePlan(false);
+        logger.trace(() -> format("Models after applying allocation preserving strategy = %s", planDeployments));
+        AssignmentPlan assignmentPlan = new LinearProgrammingPlanSolver(planNodes, planDeployments).solvePlan(false);
         return preserveAllocations.mergePreservedAllocations(assignmentPlan);
     }
 
@@ -181,7 +180,7 @@ public class AssignmentPlanner {
         long totalAvailableMem = nodes.stream().map(Node::availableMemoryBytes).mapToLong(Long::longValue).sum();
         int totalCores = nodes.stream().map(Node::cores).mapToInt(Integer::intValue).sum();
         long totalUsedMem = 0;
-        for (Model m : models) {
+        for (AssignmentPlan.Deployment m : deployments) {
             totalAllocationsRequired += m.allocations();
             if (assignmentPlan.assignments(m).isPresent()) {
                 int allocations = assignmentPlan.assignments(m).get().values().stream().mapToInt(Integer::intValue).sum();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanner.java
@@ -37,9 +37,9 @@ import static org.elasticsearch.core.Strings.format;
  * Furthermore, the planner preserves at least one allocation for all existing
  * assignments. This way, the new plan will only have new assignments and the
  * transition can happen with minimal impact on performance of started deployments.
- * However, if previously assigned models do not receive any allocation, then we
- * attempt to find a solution that provides at least one allocation to
- * previously assigned models.
+ * However, if previously assigned model deployments do not receive any allocation,
+ * then we attempt to find a solution that provides at least one allocation to
+ * previously assigned model deployments.
  */
 public class AssignmentPlanner {
 
@@ -58,7 +58,7 @@ public class AssignmentPlanner {
     }
 
     public AssignmentPlan computePlan(boolean tryAssigningPreviouslyAssignedModels) {
-        logger.debug(() -> format("Computing plan for nodes = %s; models = %s", nodes, deployments));
+        logger.debug(() -> format("Computing plan for nodes = %s; deployments = %s", nodes, deployments));
 
         AssignmentPlan bestPlan;
         AssignmentPlan planSatisfyingCurrentAssignments = solveSatisfyingCurrentAssignments();
@@ -106,7 +106,7 @@ public class AssignmentPlanner {
     }
 
     private AssignmentPlan solveAllocatingAtLeastOnceModelsThatWerePreviouslyAllocated() {
-        logger.debug(() -> "Attempting to solve assigning at least one allocation to previously assigned models");
+        logger.debug(() -> "Attempting to solve assigning at least one allocation to previously assigned deployments");
         List<AssignmentPlan.Deployment> previouslyAssignedModelsOnly = deployments.stream()
             .filter(m -> m.hasEverBeenAllocated())
             .map(
@@ -168,7 +168,7 @@ public class AssignmentPlanner {
         List<Node> planNodes = preserveAllocations.nodesPreservingAllocations();
         List<AssignmentPlan.Deployment> planDeployments = preserveAllocations.modelsPreservingAllocations();
         logger.trace(() -> format("Nodes after applying allocation preserving strategy = %s", planNodes));
-        logger.trace(() -> format("Models after applying allocation preserving strategy = %s", planDeployments));
+        logger.trace(() -> format("Deployments after applying allocation preserving strategy = %s", planDeployments));
         AssignmentPlan assignmentPlan = new LinearProgrammingPlanSolver(planNodes, planDeployments).solvePlan(false);
         return preserveAllocations.mergePreservedAllocations(assignmentPlan);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocations.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocations.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.ml.inference.assignment.planning;
 
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Deployment;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.List;
@@ -16,27 +16,27 @@ import java.util.stream.Collectors;
 
 public class PreserveAllAllocations extends AbstractPreserveAllocations {
 
-    protected PreserveAllAllocations(List<Node> nodes, List<Model> models) {
-        super(nodes, models);
+    protected PreserveAllAllocations(List<Node> nodes, List<Deployment> deployments) {
+        super(nodes, deployments);
     }
 
     @Override
-    protected int calculateUsedCores(Node n, Model m) {
+    protected int calculateUsedCores(Node n, Deployment m) {
         return m.currentAllocationsByNodeId().get(n.id()) * m.threadsPerAllocation();
     }
 
     @Override
-    protected Map<String, Integer> calculateAllocationsPerNodeToPreserve(Model m) {
+    protected Map<String, Integer> calculateAllocationsPerNodeToPreserve(Deployment m) {
         return m.currentAllocationsByNodeId().entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> 0));
     }
 
     @Override
-    protected int calculatePreservedAllocations(Model m) {
+    protected int calculatePreservedAllocations(Deployment m) {
         return m.currentAllocationsByNodeId().values().stream().mapToInt(Integer::intValue).sum();
     }
 
     @Override
-    protected int addPreservedAllocations(Node n, Model m) {
+    protected int addPreservedAllocations(Node n, Deployment m) {
         return m.currentAllocationsByNodeId().get(n.id());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocation.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.ml.inference.assignment.planning;
 
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Deployment;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.List;
@@ -16,27 +16,27 @@ import java.util.stream.Collectors;
 
 public class PreserveOneAllocation extends AbstractPreserveAllocations {
 
-    protected PreserveOneAllocation(List<Node> nodes, List<Model> models) {
-        super(nodes, models);
+    protected PreserveOneAllocation(List<Node> nodes, List<AssignmentPlan.Deployment> deployments) {
+        super(nodes, deployments);
     }
 
     @Override
-    protected int calculateUsedCores(Node n, Model m) {
+    protected int calculateUsedCores(Node n, AssignmentPlan.Deployment m) {
         return m.threadsPerAllocation();
     }
 
     @Override
-    protected Map<String, Integer> calculateAllocationsPerNodeToPreserve(Model m) {
+    protected Map<String, Integer> calculateAllocationsPerNodeToPreserve(Deployment m) {
         return m.currentAllocationsByNodeId().entrySet().stream().collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue() - 1));
     }
 
     @Override
-    protected int calculatePreservedAllocations(Model m) {
+    protected int calculatePreservedAllocations(AssignmentPlan.Deployment m) {
         return (int) m.currentAllocationsByNodeId().values().stream().filter(v -> v > 0).count();
     }
 
     @Override
-    protected int addPreservedAllocations(Node n, Model m) {
+    protected int addPreservedAllocations(Node n, AssignmentPlan.Deployment m) {
         return 1;
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/ZoneAwareAssignmentPlanner.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/planning/ZoneAwareAssignmentPlanner.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.ml.inference.assignment.planning;
 
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.ArrayList;
@@ -39,11 +38,11 @@ public class ZoneAwareAssignmentPlanner {
      */
     private final Map<List<String>, List<Node>> nodesByZone;
 
-    private final List<Model> models;
+    private final List<AssignmentPlan.Deployment> deployments;
 
-    public ZoneAwareAssignmentPlanner(Map<List<String>, List<Node>> nodesByZone, List<Model> models) {
+    public ZoneAwareAssignmentPlanner(Map<List<String>, List<Node>> nodesByZone, List<AssignmentPlan.Deployment> deployments) {
         this.nodesByZone = sortByZone(Objects.requireNonNull(nodesByZone));
-        this.models = Objects.requireNonNull(models);
+        this.deployments = Objects.requireNonNull(deployments);
     }
 
     private static Map<List<String>, List<Node>> sortByZone(Map<List<String>, List<Node>> nodesByZone) {
@@ -57,7 +56,7 @@ public class ZoneAwareAssignmentPlanner {
     public AssignmentPlan computePlan() {
         // There is only one zone; we can optimize and compute a plan directly.
         if (nodesByZone.size() == 1) {
-            return new AssignmentPlanner(nodesByZone.values().iterator().next(), models).computePlan(true);
+            return new AssignmentPlanner(nodesByZone.values().iterator().next(), deployments).computePlan(true);
         }
 
         // First we try to compute a plan without forcing assigning previously assigned models as this may
@@ -83,7 +82,8 @@ public class ZoneAwareAssignmentPlanner {
         // allocated on the first per zone assignment plans.
 
         int remainingZones = nodesByZone.size();
-        Map<String, Integer> modelIdToRemainingAllocations = models.stream().collect(Collectors.toMap(Model::id, Model::allocations));
+        Map<String, Integer> modelIdToRemainingAllocations = deployments.stream()
+            .collect(Collectors.toMap(AssignmentPlan.Deployment::id, AssignmentPlan.Deployment::allocations));
         List<AssignmentPlan> plans = new ArrayList<>();
         for (var zoneToNodes : nodesByZone.entrySet()) {
             logger.debug(() -> format("computing plan for availability zone %s", zoneToNodes.getKey()));
@@ -119,10 +119,10 @@ public class ZoneAwareAssignmentPlanner {
             .filter(e -> e.getValue() > 0)
             .collect(Collectors.toMap(e -> e.getKey(), e -> (e.getValue() - 1) / remainingZones + 1));
 
-        List<Model> modifiedModels = models.stream()
+        List<AssignmentPlan.Deployment> modifiedDeployments = deployments.stream()
             .filter(m -> modelIdToTargetAllocations.getOrDefault(m.id(), 0) > 0)
             .map(
-                m -> new Model(
+                m -> new AssignmentPlan.Deployment(
                     m.id(),
                     m.memoryBytes(),
                     modelIdToTargetAllocations.get(m.id()),
@@ -135,7 +135,7 @@ public class ZoneAwareAssignmentPlanner {
                 )
             )
             .toList();
-        return new AssignmentPlanner(nodes, modifiedModels).computePlan(tryAssigningPreviouslyAssignedModels);
+        return new AssignmentPlanner(nodes, modifiedDeployments).computePlan(tryAssigningPreviouslyAssignedModels);
     }
 
     private AssignmentPlan computePlanAcrossAllNodes(List<AssignmentPlan> plans) {
@@ -145,9 +145,9 @@ public class ZoneAwareAssignmentPlanner {
 
         Map<String, Map<String, Integer>> allocationsByNodeIdByModelId = mergeAllocationsByNodeIdByModelId(plans);
 
-        List<Model> modelsAccountingPlans = models.stream()
+        List<AssignmentPlan.Deployment> modelsAccountingPlans = deployments.stream()
             .map(
-                m -> new Model(
+                m -> new AssignmentPlan.Deployment(
                     m.id(),
                     m.memoryBytes(),
                     m.allocations(),
@@ -160,23 +160,28 @@ public class ZoneAwareAssignmentPlanner {
 
         PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(allNodes, modelsAccountingPlans);
         List<Node> planNodes = preserveAllAllocations.nodesPreservingAllocations();
-        List<Model> planModels = preserveAllAllocations.modelsPreservingAllocations();
-        AssignmentPlan plan = new LinearProgrammingPlanSolver(planNodes, planModels).solvePlan(false);
+        List<AssignmentPlan.Deployment> planDeployments = preserveAllAllocations.modelsPreservingAllocations();
+        AssignmentPlan plan = new LinearProgrammingPlanSolver(planNodes, planDeployments).solvePlan(false);
         plan = preserveAllAllocations.mergePreservedAllocations(plan);
         return swapOriginalModelsInPlan(plan, allNodes, modelsAccountingPlans);
     }
 
-    private AssignmentPlan swapOriginalModelsInPlan(AssignmentPlan plan, List<Node> allNodes, List<Model> planModels) {
-        final Map<String, Model> originalModelById = models.stream().collect(Collectors.toMap(Model::id, Function.identity()));
+    private AssignmentPlan swapOriginalModelsInPlan(
+        AssignmentPlan plan,
+        List<Node> allNodes,
+        List<AssignmentPlan.Deployment> planDeployments
+    ) {
+        final Map<String, AssignmentPlan.Deployment> originalModelById = deployments.stream()
+            .collect(Collectors.toMap(AssignmentPlan.Deployment::id, Function.identity()));
         final Map<String, Node> originalNodeById = allNodes.stream().collect(Collectors.toMap(Node::id, Function.identity()));
-        AssignmentPlan.Builder planBuilder = AssignmentPlan.builder(allNodes, models);
-        for (Model m : planModels) {
-            Model originalModel = originalModelById.get(m.id());
+        AssignmentPlan.Builder planBuilder = AssignmentPlan.builder(allNodes, deployments);
+        for (AssignmentPlan.Deployment m : planDeployments) {
+            AssignmentPlan.Deployment originalDeployment = originalModelById.get(m.id());
             Map<Node, Integer> nodeAssignments = plan.assignments(m).orElse(Map.of());
             for (Map.Entry<Node, Integer> assignment : nodeAssignments.entrySet()) {
                 Node originalNode = originalNodeById.get(assignment.getKey().id());
-                planBuilder.assignModelToNode(originalModel, originalNode, assignment.getValue());
-                if (originalModel.currentAllocationsByNodeId().containsKey(originalNode.id())) {
+                planBuilder.assignModelToNode(originalDeployment, originalNode, assignment.getValue());
+                if (originalDeployment.currentAllocationsByNodeId().containsKey(originalNode.id())) {
                     // As the node has all its available memory we need to manually account memory of models with
                     // current allocations.
                     planBuilder.accountMemory(m, originalNode);
@@ -188,9 +193,9 @@ public class ZoneAwareAssignmentPlanner {
 
     private Map<String, Map<String, Integer>> mergeAllocationsByNodeIdByModelId(List<AssignmentPlan> plans) {
         Map<String, Map<String, Integer>> allocationsByNodeIdByModelId = new HashMap<>();
-        models.forEach(m -> allocationsByNodeIdByModelId.put(m.id(), new HashMap<>()));
+        deployments.forEach(m -> allocationsByNodeIdByModelId.put(m.id(), new HashMap<>()));
         for (AssignmentPlan plan : plans) {
-            for (Model m : plan.models()) {
+            for (AssignmentPlan.Deployment m : plan.models()) {
                 Map<String, Integer> nodeIdToAllocations = allocationsByNodeIdByModelId.get(m.id());
                 Optional<Map<Node, Integer>> assignments = plan.assignments(m);
                 if (assignments.isPresent()) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractControlMessagePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractControlMessagePyTorchAction.java
@@ -32,14 +32,14 @@ abstract class AbstractControlMessagePyTorchAction<T> extends AbstractPyTorchAct
     };
 
     AbstractControlMessagePyTorchAction(
-        String modelId,
+        String deploymentId,
         long requestId,
         TimeValue timeout,
         DeploymentManager.ProcessContext processContext,
         ThreadPool threadPool,
         ActionListener<T> listener
     ) {
-        super(modelId, requestId, timeout, processContext, threadPool, listener);
+        super(deploymentId, requestId, timeout, processContext, threadPool, listener);
     }
 
     abstract int controlOrdinal();
@@ -52,7 +52,9 @@ abstract class AbstractControlMessagePyTorchAction<T> extends AbstractPyTorchAct
     protected void doRun() throws Exception {
         if (isNotified()) {
             // Should not execute request as it has already timed out while waiting in the queue
-            logger.debug(() -> format("[%s] skipping control message on request [%s] as it has timed out", getModelId(), getRequestId()));
+            logger.debug(
+                () -> format("[%s] skipping control message on request [%s] as it has timed out", getDeploymentId(), getRequestId())
+            );
             return;
         }
 
@@ -65,7 +67,7 @@ abstract class AbstractControlMessagePyTorchAction<T> extends AbstractPyTorchAct
 
             getProcessContext().getProcess().get().writeInferenceRequest(message);
         } catch (IOException e) {
-            logger.error(() -> "[" + getModelId() + "] error writing control message to the inference process", e);
+            logger.error(() -> "[" + getDeploymentId() + "] error writing control message to the inference process", e);
             onFailure(ExceptionsHelper.serverError("Error writing control message to the inference process", e));
         } catch (Exception e) {
             onFailure(e);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractPyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/AbstractPyTorchAction.java
@@ -24,7 +24,7 @@ import static org.elasticsearch.core.Strings.format;
 
 abstract class AbstractPyTorchAction<T> extends AbstractInitializableRunnable {
 
-    private final String modelId;
+    private final String deploymentId;
     private final long requestId;
     private final TimeValue timeout;
     private Scheduler.Cancellable timeoutHandler;
@@ -34,14 +34,14 @@ abstract class AbstractPyTorchAction<T> extends AbstractInitializableRunnable {
     private final ThreadPool threadPool;
 
     protected AbstractPyTorchAction(
-        String modelId,
+        String deploymentId,
         long requestId,
         TimeValue timeout,
         DeploymentManager.ProcessContext processContext,
         ThreadPool threadPool,
         ActionListener<T> listener
     ) {
-        this.modelId = ExceptionsHelper.requireNonNull(modelId, "modelId");
+        this.deploymentId = ExceptionsHelper.requireNonNull(deploymentId, "deploymentId");
         this.requestId = requestId;
         this.timeout = ExceptionsHelper.requireNonNull(timeout, "timeout");
         this.processContext = ExceptionsHelper.requireNonNull(processContext, "processContext");
@@ -69,7 +69,7 @@ abstract class AbstractPyTorchAction<T> extends AbstractInitializableRunnable {
             );
             return;
         }
-        getLogger().debug("[{}] request [{}] received timeout after [{}] but listener already alerted", modelId, requestId, timeout);
+        getLogger().debug("[{}] request [{}] received timeout after [{}] but listener already alerted", deploymentId, requestId, timeout);
     }
 
     void onSuccess(T result) {
@@ -82,7 +82,7 @@ abstract class AbstractPyTorchAction<T> extends AbstractInitializableRunnable {
             listener.onResponse(result);
             return;
         }
-        getLogger().debug("[{}] request [{}] received inference response but listener already notified", modelId, requestId);
+        getLogger().debug("[{}] request [{}] received inference response but listener already notified", deploymentId, requestId);
     }
 
     @Override
@@ -103,7 +103,7 @@ abstract class AbstractPyTorchAction<T> extends AbstractInitializableRunnable {
             listener.onFailure(e);
             return;
         }
-        getLogger().debug(() -> format("[%s] request [%s] received failure but listener already notified", modelId, requestId), e);
+        getLogger().debug(() -> format("[%s] request [%s] received failure but listener already notified", deploymentId, requestId), e);
     }
 
     protected void onFailure(String errorMessage) {
@@ -118,8 +118,8 @@ abstract class AbstractPyTorchAction<T> extends AbstractInitializableRunnable {
         return requestId;
     }
 
-    String getModelId() {
-        return modelId;
+    String getDeploymentId() {
+        return deploymentId;
     }
 
     DeploymentManager.ProcessContext getProcessContext() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -127,13 +127,13 @@ public class DeploymentManager {
     }
 
     public void startDeployment(TrainedModelDeploymentTask task, ActionListener<TrainedModelDeploymentTask> finalListener) {
-        logger.info("[{}] Starting model deployment", task.getModelId());
+        logger.info("[{}] Starting model deployment", task.getDeploymentId());
 
         if (processContextByAllocation.size() >= maxProcesses) {
             finalListener.onFailure(
                 ExceptionsHelper.serverError(
                     "[{}] Could not start inference process as the node reached the max number [{}] of processes",
-                    task.getModelId(),
+                    task.getDeploymentId(),
                     maxProcesses
                 )
             );
@@ -143,7 +143,7 @@ public class DeploymentManager {
         ProcessContext processContext = new ProcessContext(task);
         if (addProcessContext(task.getId(), processContext) != null) {
             finalListener.onFailure(
-                ExceptionsHelper.serverError("[{}] Could not create inference process as one already exists", task.getModelId())
+                ExceptionsHelper.serverError("[{}] Could not create inference process as one already exists", task.getDeploymentId())
             );
             return;
         }
@@ -176,7 +176,7 @@ public class DeploymentManager {
                             new ResourceNotFoundException(
                                 Messages.getMessage(
                                     Messages.VOCABULARY_NOT_FOUND,
-                                    task.getModelId(),
+                                    modelConfig.getModelId(),
                                     VocabularyConfig.docId(modelConfig.getModelId())
                                 )
                             )
@@ -210,7 +210,7 @@ public class DeploymentManager {
             client,
             ML_ORIGIN,
             GetTrainedModelsAction.INSTANCE,
-            new GetTrainedModelsAction.Request(task.getModelId()),
+            new GetTrainedModelsAction.Request(task.getParams().getModelId()),
             getModelListener
         );
     }
@@ -243,10 +243,10 @@ public class DeploymentManager {
     public void stopDeployment(TrainedModelDeploymentTask task) {
         ProcessContext processContext = processContextByAllocation.remove(task.getId());
         if (processContext != null) {
-            logger.info("[{}] Stopping deployment, reason [{}]", task.getModelId(), task.stoppedReason().orElse("unknown"));
+            logger.info("[{}] Stopping deployment, reason [{}]", task.getDeploymentId(), task.stoppedReason().orElse("unknown"));
             processContext.stopProcess();
         } else {
-            logger.warn("[{}] No process context to stop", task.getModelId());
+            logger.warn("[{}] No process context to stop", task.getDeploymentId());
         }
     }
 
@@ -267,7 +267,7 @@ public class DeploymentManager {
 
         final long requestId = requestIdCounter.getAndIncrement();
         InferencePyTorchAction inferenceAction = new InferencePyTorchAction(
-            task.getModelId(),
+            task.getDeploymentId(),
             requestId,
             timeout,
             processContext,
@@ -299,7 +299,7 @@ public class DeploymentManager {
 
         final long requestId = requestIdCounter.getAndIncrement();
         ThreadSettingsControlMessagePytorchAction controlMessageAction = new ThreadSettingsControlMessagePytorchAction(
-            task.getModelId(),
+            task.getDeploymentId(),
             requestId,
             numAllocationThreads,
             timeout,
@@ -320,7 +320,7 @@ public class DeploymentManager {
 
         final long requestId = requestIdCounter.getAndIncrement();
         ClearCacheControlMessagePytorchAction controlMessageAction = new ClearCacheControlMessagePytorchAction(
-            task.getModelId(),
+            task.getDeploymentId(),
             requestId,
             timeout,
             processContext,
@@ -351,7 +351,7 @@ public class DeploymentManager {
             errorConsumer.accept(
                 ExceptionsHelper.conflictStatusException(
                     "[{}] is stopping or stopped due to [{}]",
-                    task.getModelId(),
+                    task.getDeploymentId(),
                     task.stoppedReason().orElse("")
                 )
             );
@@ -360,7 +360,7 @@ public class DeploymentManager {
 
         ProcessContext processContext = processContextByAllocation.get(task.getId());
         if (processContext == null) {
-            errorConsumer.accept(ExceptionsHelper.conflictStatusException("[{}] process context missing", task.getModelId()));
+            errorConsumer.accept(ExceptionsHelper.conflictStatusException("[{}] process context missing", task.getDeploymentId()));
             return null;
         }
 
@@ -385,7 +385,7 @@ public class DeploymentManager {
 
         ProcessContext(TrainedModelDeploymentTask task) {
             this.task = Objects.requireNonNull(task);
-            resultProcessor = new PyTorchResultProcessor(task.getModelId(), threadSettings -> {
+            resultProcessor = new PyTorchResultProcessor(task.getDeploymentId(), threadSettings -> {
                 this.numThreadsPerAllocation = threadSettings.numThreadsPerAllocation();
                 this.numAllocations = threadSettings.numAllocations();
             });
@@ -411,25 +411,25 @@ public class DeploymentManager {
                 : format("Must execute from [%s] but thread is [%s]", UTILITY_THREAD_POOL_NAME, Thread.currentThread().getName());
 
             if (isStopped) {
-                logger.debug("[{}] model stopped before it is started", task.getModelId());
+                logger.debug("[{}] model stopped before it is started", task.getDeploymentId());
                 loadedListener.onFailure(new IllegalArgumentException("model stopped before it is started"));
                 return;
             }
 
-            logger.debug("[{}] start and load", task.getModelId());
+            logger.debug("[{}] start and load", task.getDeploymentId());
             process.set(pyTorchProcessFactory.createProcess(task, executorServiceForProcess, this::onProcessCrash));
             startTime = Instant.now();
-            logger.debug("[{}] process started", task.getModelId());
+            logger.debug("[{}] process started", task.getDeploymentId());
             try {
                 loadModel(modelLocation, ActionListener.wrap(success -> {
                     if (isStopped) {
-                        logger.debug("[{}] model loaded but process is stopped", task.getModelId());
+                        logger.debug("[{}] model loaded but process is stopped", task.getDeploymentId());
                         killProcessIfPresent();
                         loadedListener.onFailure(new IllegalStateException("model loaded but process is stopped"));
                         return;
                     }
 
-                    logger.debug("[{}] model loaded, starting priority process worker thread", task.getModelId());
+                    logger.debug("[{}] model loaded, starting priority process worker thread", task.getDeploymentId());
                     startPriorityProcessWorker();
                     loadedListener.onResponse(success);
                 }, loadedListener::onFailure));
@@ -460,12 +460,12 @@ public class DeploymentManager {
                 }
                 process.get().kill(true);
             } catch (IOException e) {
-                logger.error(() -> "[" + task.getModelId() + "] Failed to kill process", e);
+                logger.error(() -> "[" + task.getDeploymentId() + "] Failed to kill process", e);
             }
         }
 
         private void onProcessCrash(String reason) {
-            logger.error("[{}] inference process crashed due to reason [{}]", task.getModelId(), reason);
+            logger.error("[{}] inference process crashed due to reason [{}]", task.getDeploymentId(), reason);
             processContextByAllocation.remove(task.getId());
             isStopped = true;
             resultProcessor.stop();
@@ -487,7 +487,7 @@ public class DeploymentManager {
                 // we need to return to the utility thread pool to avoid leaking the thread we used.
                 process.get()
                     .loadModel(
-                        task.getModelId(),
+                        task.getParams().getModelId(),
                         indexLocation.getIndexName(),
                         stateStreamer,
                         ActionListener.wrap(

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/InferencePyTorchAction.java
@@ -39,7 +39,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
     private final Task parentActionTask;
 
     InferencePyTorchAction(
-        String modelId,
+        String deploymentId,
         long requestId,
         TimeValue timeout,
         DeploymentManager.ProcessContext processContext,
@@ -49,7 +49,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
         @Nullable Task parentActionTask,
         ActionListener<InferenceResults> listener
     ) {
-        super(modelId, requestId, timeout, processContext, threadPool, listener);
+        super(deploymentId, requestId, timeout, processContext, threadPool, listener);
         this.config = config;
         this.input = input;
         this.parentActionTask = parentActionTask;
@@ -60,7 +60,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             try {
                 cancellableTask.ensureNotCancelled();
             } catch (TaskCancelledException ex) {
-                logger.warn(() -> format("[%s] %s", getModelId(), ex.getMessage()));
+                logger.warn(() -> format("[%s] %s", getDeploymentId(), ex.getMessage()));
                 return true;
             }
         }
@@ -71,7 +71,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
     protected void doRun() throws Exception {
         if (isNotified()) {
             // Should not execute request as it has already timed out while waiting in the queue
-            logger.debug(() -> format("[%s] skipping inference on request [%s] as it has timed out", getModelId(), getRequestId()));
+            logger.debug(() -> format("[%s] skipping inference on request [%s] as it has timed out", getDeploymentId(), getRequestId()));
             return;
         }
         if (isCancelled()) {
@@ -90,10 +90,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             NlpConfig nlpConfig = (NlpConfig) config;
             NlpTask.Request request = processor.getRequestBuilder(nlpConfig)
                 .buildRequest(text, requestIdStr, nlpConfig.getTokenization().getTruncate(), nlpConfig.getTokenization().getSpan());
-            logger.debug(() -> format("handling request [%s]", requestIdStr));
-            if (request.tokenization().anyTruncated()) {
-                logger.debug("[{}] [{}] input truncated", getModelId(), getRequestId());
-            }
+            logger.trace(() -> format("handling request [%s]", requestIdStr));
 
             // Tokenization is non-trivial, so check for cancellation one last time before sending request to the native process
             if (isCancelled()) {
@@ -110,7 +107,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
                 );
             getProcessContext().getProcess().get().writeInferenceRequest(request.processInput());
         } catch (IOException e) {
-            logger.error(() -> "[" + getModelId() + "] error writing to inference process", e);
+            logger.error(() -> "[" + getDeploymentId() + "] error writing to inference process", e);
             onFailure(ExceptionsHelper.serverError("Error writing to inference process", e));
         } catch (Exception e) {
             onFailure(e);
@@ -127,11 +124,15 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             return;
         }
 
-        logger.debug(() -> format("[%s] retrieved result for request [%s]", getModelId(), getRequestId()));
+        logger.debug(() -> format("[%s] retrieved result for request [%s]", getDeploymentId(), getRequestId()));
         if (isNotified()) {
             // The request has timed out. No need to spend cycles processing the result.
             logger.debug(
-                () -> format("[%s] skipping result processing for request [%s] as the request has timed out", getModelId(), getRequestId())
+                () -> format(
+                    "[%s] skipping result processing for request [%s] as the request has timed out",
+                    getDeploymentId(),
+                    getRequestId()
+                )
             );
             return;
         }
@@ -140,7 +141,7 @@ class InferencePyTorchAction extends AbstractPyTorchAction<InferenceResults> {
             return;
         }
         InferenceResults results = inferenceResultsProcessor.processResult(tokenization, pyTorchResult.inferenceResult());
-        logger.trace(() -> format("[%s] processed result for request [%s]", getModelId(), getRequestId()));
+        logger.trace(() -> format("[%s] processed result for request [%s]", getDeploymentId(), getRequestId()));
         onSuccess(results);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ThreadSettingsControlMessagePytorchAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/ThreadSettingsControlMessagePytorchAction.java
@@ -20,7 +20,7 @@ public class ThreadSettingsControlMessagePytorchAction extends AbstractControlMe
     private final int numAllocationThreads;
 
     ThreadSettingsControlMessagePytorchAction(
-        String modelId,
+        String deploymentId,
         long requestId,
         int numAllocationThreads,
         TimeValue timeout,
@@ -28,7 +28,7 @@ public class ThreadSettingsControlMessagePytorchAction extends AbstractControlMe
         ThreadPool threadPool,
         ActionListener<ThreadSettings> listener
     ) {
-        super(modelId, requestId, timeout, processContext, threadPool, listener);
+        super(deploymentId, requestId, timeout, processContext, threadPool, listener);
         this.numAllocationThreads = numAllocationThreads;
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -174,7 +174,7 @@ public class InferenceProcessor extends AbstractProcessor {
             response.getInferenceResults().get(0),
             ingestDocument,
             targetField,
-            response.getModelId() != null ? response.getModelId() : modelId
+            response.getId() != null ? response.getId() : modelId
         );
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/process/NativePyTorchProcessFactory.java
@@ -63,7 +63,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
             NAMED_PIPE_HELPER,
             processConnectTimeout,
             PyTorchBuilder.PROCESS_NAME,
-            task.getModelId(),
+            task.getDeploymentId(),
             null,
             false,
             true,
@@ -75,7 +75,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
         executeProcess(processPipes, task);
 
         NativePyTorchProcess process = new NativePyTorchProcess(
-            task.getModelId(),
+            task.getDeploymentId(),
             nativeController,
             processPipes,
             0,
@@ -86,7 +86,7 @@ public class NativePyTorchProcessFactory implements PyTorchProcessFactory {
         try {
             process.start(executorService);
         } catch (IOException | EsRejectedExecutionException e) {
-            String msg = "Failed to connect to pytorch process for job " + task.getModelId();
+            String msg = "Failed to connect to pytorch process for job " + task.getDeploymentId();
             logger.error(msg);
             try {
                 IOUtils.close(process);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/NodeLoadDetector.java
@@ -137,8 +137,8 @@ public class NodeLoadDetector {
     }
 
     private void updateLoadGivenModelAssignments(NodeLoad.Builder nodeLoad, TrainedModelAssignmentMetadata trainedModelAssignmentMetadata) {
-        if (trainedModelAssignmentMetadata != null && trainedModelAssignmentMetadata.modelAssignments().isEmpty() == false) {
-            for (TrainedModelAssignment assignment : trainedModelAssignmentMetadata.modelAssignments().values()) {
+        if (trainedModelAssignmentMetadata != null && trainedModelAssignmentMetadata.allAssignments().isEmpty() == false) {
+            for (TrainedModelAssignment assignment : trainedModelAssignmentMetadata.allAssignments().values()) {
                 if (Optional.ofNullable(assignment.getNodeRoutingTable().get(nodeLoad.getNodeId()))
                     .map(RoutingInfo::getState)
                     .orElse(RoutingState.STOPPED)

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlMemoryTracker.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/process/MlMemoryTracker.java
@@ -266,7 +266,7 @@ public class MlMemoryTracker implements LocalNodeMasterListener {
             return null;
         }
 
-        return Optional.ofNullable(TrainedModelAssignmentMetadata.fromState(clusterService.state()).modelAssignments().get(modelId))
+        return Optional.ofNullable(TrainedModelAssignmentMetadata.fromState(clusterService.state()).allAssignments().get(modelId))
             .map(TrainedModelAssignment::getTaskParams)
             .map(StartTrainedModelDeploymentAction.TaskParams::estimateMemoryUsageBytes)
             .orElse(null);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStartTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/inference/RestStartTrainedModelDeploymentAction.java
@@ -54,11 +54,16 @@ public class RestStartTrainedModelDeploymentAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         String modelId = restRequest.param(StartTrainedModelDeploymentAction.Request.MODEL_ID.getPreferredName());
+        String deploymentId = restRequest.param(StartTrainedModelDeploymentAction.Request.DEPLOYMENT_ID.getPreferredName(), modelId);
         StartTrainedModelDeploymentAction.Request request;
         if (restRequest.hasContentOrSourceParam()) {
-            request = StartTrainedModelDeploymentAction.Request.parseRequest(modelId, restRequest.contentOrSourceParamParser());
+            request = StartTrainedModelDeploymentAction.Request.parseRequest(
+                modelId,
+                deploymentId,
+                restRequest.contentOrSourceParamParser()
+            );
         } else {
-            request = new StartTrainedModelDeploymentAction.Request(modelId);
+            request = new StartTrainedModelDeploymentAction.Request(modelId, deploymentId);
             if (restRequest.hasParam(TIMEOUT.getPreferredName())) {
                 TimeValue openTimeout = restRequest.paramAsTime(
                     TIMEOUT.getPreferredName(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
@@ -18,6 +18,7 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.action.InferModelAction;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
 import org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfigUpdate;
@@ -42,7 +43,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
     );
 
     static {
-        PARSER.declareString(constructorArg(), InferModelAction.Request.DEPLOYMENT_ID);
+        PARSER.declareString(constructorArg(), TrainedModelConfig.MODEL_ID);
         PARSER.declareString(constructorArg(), MODEL_TEXT);
     }
 
@@ -82,7 +83,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(InferModelAction.Request.DEPLOYMENT_ID.getPreferredName(), modelId);
+        builder.field(TrainedModelConfig.MODEL_ID.getPreferredName(), modelId);
         builder.field(MODEL_TEXT.getPreferredName(), modelText);
         builder.endObject();
         return builder;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilder.java
@@ -42,7 +42,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
     );
 
     static {
-        PARSER.declareString(constructorArg(), InferModelAction.Request.MODEL_ID);
+        PARSER.declareString(constructorArg(), InferModelAction.Request.DEPLOYMENT_ID);
         PARSER.declareString(constructorArg(), MODEL_TEXT);
     }
 
@@ -82,7 +82,7 @@ public class TextEmbeddingQueryVectorBuilder implements QueryVectorBuilder {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
-        builder.field(InferModelAction.Request.MODEL_ID.getPreferredName(), modelId);
+        builder.field(InferModelAction.Request.DEPLOYMENT_ID.getPreferredName(), modelId);
         builder.field(MODEL_TEXT.getPreferredName(), modelText);
         builder.endObject();
         return builder;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -347,9 +347,17 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             ),
                             3,
                             null,
-                            new AssignmentStats("model_3", null, null, null, null, Instant.now(), List.of(), Priority.NORMAL).setState(
-                                AssignmentState.STOPPING
-                            )
+                            new AssignmentStats(
+                                "deployment_3",
+                                "model_3",
+                                null,
+                                null,
+                                null,
+                                null,
+                                Instant.now(),
+                                List.of(),
+                                Priority.NORMAL
+                            ).setState(AssignmentState.STOPPING)
                         ),
                         new GetTrainedModelsStatsAction.Response.TrainedModelStats(
                             trainedModel4.getModelId(),
@@ -371,6 +379,7 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                             4,
                             null,
                             new AssignmentStats(
+                                "deployment_4",
                                 "model_4",
                                 2,
                                 2,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
@@ -64,7 +64,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
         var modified = TransportGetDeploymentStatsAction.addFailedRoutes(emptyResponse, badRoutes, nodes);
         List<AssignmentStats> results = modified.getStats().results();
         assertThat(results, hasSize(2));
-        assertEquals("model1", results.get(0).getModelId());
+        assertEquals("model1", results.get(0).getDeploymentId());
         assertThat(results.get(0).getNodeStats(), hasSize(2));
         assertEquals("nodeA", results.get(0).getNodeStats().get(0).getNode().getId());
         assertEquals("nodeB", results.get(0).getNodeStats().get(1).getNode().getId());
@@ -81,6 +81,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
 
         var model1 = new AssignmentStats(
             "model1",
+            "deployment1",
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 10000),
@@ -118,6 +119,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
 
         var model1 = new AssignmentStats(
             "model1",
+            "deployment1",
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 8),
             randomBoolean() ? null : randomIntBetween(1, 10000),
@@ -157,7 +159,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
 
     private static TrainedModelAssignment createAssignment(String modelId) {
         return TrainedModelAssignment.Builder.empty(
-            new StartTrainedModelDeploymentAction.TaskParams(modelId, 1024, 1, 1, 1, ByteSizeValue.ofBytes(1024), Priority.NORMAL)
+            new StartTrainedModelDeploymentAction.TaskParams(modelId, modelId, 1024, 1, 1, 1, ByteSizeValue.ofBytes(1024), Priority.NORMAL)
         ).build();
     }
 }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlMemoryAutoscalingDeciderTests.java
@@ -1054,10 +1054,28 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
                 List.of(
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 2, 3, 100, null, Priority.NORMAL)
+                        new StartTrainedModelDeploymentAction.TaskParams(
+                            "model1",
+                            "deployment_1",
+                            TEST_JOB_SIZE,
+                            2,
+                            3,
+                            100,
+                            null,
+                            Priority.NORMAL
+                        )
                     ).build(),
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 1, 100, null, Priority.NORMAL)
+                        new StartTrainedModelDeploymentAction.TaskParams(
+                            "model1",
+                            "deployment_1",
+                            TEST_JOB_SIZE,
+                            1,
+                            1,
+                            100,
+                            null,
+                            Priority.NORMAL
+                        )
                     ).build()
                 ),
                 withMlNodes("ml_node_1", "ml_node_2")
@@ -1067,10 +1085,28 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
                 List.of(
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 3, 100, null, Priority.NORMAL)
+                        new StartTrainedModelDeploymentAction.TaskParams(
+                            "model1",
+                            "deployment_1",
+                            TEST_JOB_SIZE,
+                            1,
+                            3,
+                            100,
+                            null,
+                            Priority.NORMAL
+                        )
                     ).build(),
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 1, 100, null, Priority.NORMAL)
+                        new StartTrainedModelDeploymentAction.TaskParams(
+                            "model1",
+                            "deployment_1",
+                            TEST_JOB_SIZE,
+                            1,
+                            1,
+                            100,
+                            null,
+                            Priority.NORMAL
+                        )
                     ).build()
                 ),
                 withMlNodes("ml_node_1", "ml_node_2")
@@ -1080,10 +1116,28 @@ public class MlMemoryAutoscalingDeciderTests extends ESTestCase {
             MlMemoryAutoscalingDecider.modelAssignmentsRequireMoreThanHalfCpu(
                 List.of(
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 3, 100, null, Priority.NORMAL)
+                        new StartTrainedModelDeploymentAction.TaskParams(
+                            "model1",
+                            "deployment_1",
+                            TEST_JOB_SIZE,
+                            1,
+                            3,
+                            100,
+                            null,
+                            Priority.NORMAL
+                        )
                     ).build(),
                     TrainedModelAssignment.Builder.empty(
-                        new StartTrainedModelDeploymentAction.TaskParams("model1", TEST_JOB_SIZE, 1, 1, 100, null, Priority.NORMAL)
+                        new StartTrainedModelDeploymentAction.TaskParams(
+                            "model1",
+                            "deployment_1",
+                            TEST_JOB_SIZE,
+                            1,
+                            1,
+                            100,
+                            null,
+                            Priority.NORMAL
+                        )
                     ).build()
                 ),
                 withMlNodes("ml_node_1", "ml_node_2", "ml_node_3", "ml_node_4")

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDeciderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/autoscaling/MlProcessorAutoscalingDeciderTests.java
@@ -70,6 +70,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         2,
                                         3,
@@ -83,6 +84,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         10,
@@ -137,6 +139,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         1,
                                         8,
@@ -150,6 +153,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         3,
@@ -204,6 +208,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         1,
                                         1,
@@ -217,6 +222,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         2,
@@ -271,6 +277,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         2,
                                         2,
@@ -284,6 +291,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         1,
@@ -339,6 +347,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         2,
                                         2,
@@ -352,6 +361,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         1,
@@ -405,6 +415,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         2,
                                         2,
@@ -418,6 +429,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         1,
@@ -475,6 +487,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         modelId1,
+                                        modelId1,
                                         42L,
                                         1,
                                         1,
@@ -488,6 +501,7 @@ public class MlProcessorAutoscalingDeciderTests extends ESTestCase {
                                 modelId2,
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
+                                        modelId2,
                                         modelId2,
                                         42L,
                                         1,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -375,7 +375,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
                         assertThat(((ElasticsearchStatusException) e).status(), equalTo(RestStatus.CONFLICT));
                         assertThat(
                             e.getMessage(),
-                            equalTo("cannot create new assignment for model [new-model] while feature reset is in progress.")
+                            equalTo("cannot create new assignment [new-model] for model [new-model] while feature reset is in progress.")
                         );
                     }
                 ),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterServiceTests.java
@@ -145,7 +145,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         );
 
         assertThat(
-            TrainedModelAssignmentMetadata.fromState(currentState).getModelAssignment(modelId).getAssignmentState(),
+            TrainedModelAssignmentMetadata.fromState(currentState).getDeploymentAssignment(modelId).getAssignmentState(),
             equalTo(AssignmentState.STARTING)
         );
 
@@ -155,14 +155,14 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         );
         assertThat(
             TrainedModelAssignmentMetadata.fromState(newState)
-                .getModelAssignment(modelId)
+                .getDeploymentAssignment(modelId)
                 .getNodeRoutingTable()
                 .get(startedNode)
                 .getState(),
             equalTo(RoutingState.STARTED)
         );
         assertThat(
-            TrainedModelAssignmentMetadata.fromState(newState).getModelAssignment(modelId).getAssignmentState(),
+            TrainedModelAssignmentMetadata.fromState(newState).getDeploymentAssignment(modelId).getAssignmentState(),
             equalTo(AssignmentState.STARTED)
         );
 
@@ -210,11 +210,11 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
             )
         );
         assertThat(
-            TrainedModelAssignmentMetadata.fromState(updateState).getModelAssignment(modelId).getNodeRoutingTable(),
+            TrainedModelAssignmentMetadata.fromState(updateState).getDeploymentAssignment(modelId).getNodeRoutingTable(),
             not(hasKey(nodeId))
         );
         assertThat(
-            TrainedModelAssignmentMetadata.fromState(updateState).getModelAssignment(modelId).getAssignmentState(),
+            TrainedModelAssignmentMetadata.fromState(updateState).getDeploymentAssignment(modelId).getAssignmentState(),
             equalTo(AssignmentState.STARTED)
         );
     }
@@ -243,10 +243,13 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
                     .build()
             )
             .build();
-        assertThat(TrainedModelAssignmentMetadata.fromState(clusterStateWithAssignment).getModelAssignment(modelId), is(not(nullValue())));
+        assertThat(
+            TrainedModelAssignmentMetadata.fromState(clusterStateWithAssignment).getDeploymentAssignment(modelId),
+            is(not(nullValue()))
+        );
 
         ClusterState modified = TrainedModelAssignmentClusterService.removeAssignment(clusterStateWithAssignment, modelId);
-        assertThat(TrainedModelAssignmentMetadata.fromState(modified).getModelAssignment(modelId), is(nullValue()));
+        assertThat(TrainedModelAssignmentMetadata.fromState(modified).getDeploymentAssignment(modelId), is(nullValue()));
     }
 
     public void testRemoveAllAssignments() {
@@ -267,7 +270,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
             )
             .build();
         ClusterState modified = TrainedModelAssignmentClusterService.removeAllAssignments(clusterStateWithAssignments);
-        assertThat(TrainedModelAssignmentMetadata.fromState(modified).modelAssignments(), is(anEmptyMap()));
+        assertThat(TrainedModelAssignmentMetadata.fromState(modified).allAssignments(), is(anEmptyMap()));
     }
 
     public void testCreateAssignment_GivenModelCannotByFullyAllocated_AndScalingIsPossible() throws Exception {
@@ -292,7 +295,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
 
         TrainedModelAssignmentClusterService trainedModelAssignmentClusterService = createClusterService(5);
         ClusterState newState = trainedModelAssignmentClusterService.createModelAssignment(currentState, newParams("new-model", 150, 4, 1));
-        TrainedModelAssignment createdAssignment = TrainedModelAssignmentMetadata.fromState(newState).getModelAssignment("new-model");
+        TrainedModelAssignment createdAssignment = TrainedModelAssignmentMetadata.fromState(newState).getDeploymentAssignment("new-model");
 
         assertThat(createdAssignment, is(not(nullValue())));
         assertThat(createdAssignment.getNodeRoutingTable().keySet(), hasSize(1));
@@ -1360,9 +1363,9 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         ClusterState resultState = TrainedModelAssignmentClusterService.removeRoutingToUnassignableNodes(currentState);
 
         TrainedModelAssignmentMetadata trainedModelAssignmentMetadata = TrainedModelAssignmentMetadata.fromState(resultState);
-        assertThat(trainedModelAssignmentMetadata.modelAssignments(), is(aMapWithSize(2)));
+        assertThat(trainedModelAssignmentMetadata.allAssignments(), is(aMapWithSize(2)));
         for (String modelId : List.of(modelId1, modelId2)) {
-            TrainedModelAssignment assignment = trainedModelAssignmentMetadata.getModelAssignment(modelId);
+            TrainedModelAssignment assignment = trainedModelAssignmentMetadata.getDeploymentAssignment(modelId);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
             assertThat(assignment.getNodeRoutingTable(), hasKey(nodeId1));
@@ -1418,12 +1421,12 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
             )
             .build();
         TrainedModelAssignmentMetadata before = TrainedModelAssignmentMetadata.fromState(clusterStateWithAllocation);
-        assertThat(before.getModelAssignment(modelId), is(not(nullValue())));
-        assertThat(before.getModelAssignment(modelId).getAssignmentState(), equalTo(AssignmentState.STARTING));
+        assertThat(before.getDeploymentAssignment(modelId), is(not(nullValue())));
+        assertThat(before.getDeploymentAssignment(modelId).getAssignmentState(), equalTo(AssignmentState.STARTING));
 
         ClusterState modified = TrainedModelAssignmentClusterService.setToStopping(clusterStateWithAllocation, modelId, "test");
         assertThat(
-            TrainedModelAssignmentMetadata.fromState(modified).getModelAssignment(modelId).getAssignmentState(),
+            TrainedModelAssignmentMetadata.fromState(modified).getDeploymentAssignment(modelId).getAssignmentState(),
             equalTo(AssignmentState.STOPPING)
         );
     }
@@ -1433,11 +1436,11 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         ClusterState original
     ) {
         TrainedModelAssignmentMetadata tempMetadata = TrainedModelAssignmentMetadata.fromState(original);
-        if (tempMetadata.modelAssignments().isEmpty()) {
+        if (tempMetadata.allAssignments().isEmpty()) {
             return;
         }
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.builder(original);
-        for (String modelId : tempMetadata.modelAssignments().keySet()) {
+        for (String modelId : tempMetadata.allAssignments().keySet()) {
             builder.getAssignment(modelId).stopAssignment("test");
         }
         TrainedModelAssignmentMetadata metadataWithStopping = builder.build();
@@ -1501,6 +1504,7 @@ public class TrainedModelAssignmentClusterServiceTests extends ESTestCase {
         int threadsPerAllocation
     ) {
         return new StartTrainedModelDeploymentAction.TaskParams(
+            modelId,
             modelId,
             modelSize,
             numberOfAllocations,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadataTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadataTests.java
@@ -58,16 +58,21 @@ public class TrainedModelAssignmentMetadataTests extends AbstractChunkedSerializ
 
     public void testIsAllocated() {
         String allocatedModelId = "test_model_id";
+        String allocatedDeploymentId = "test_deployment";
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.Builder.empty()
-            .addNewAssignment(allocatedModelId, TrainedModelAssignment.Builder.empty(randomParams(allocatedModelId)))
+            .addNewAssignment(
+                allocatedDeploymentId,
+                TrainedModelAssignment.Builder.empty(randomParams(allocatedDeploymentId, allocatedModelId))
+            )
             .build();
-        assertThat(metadata.isAssigned(allocatedModelId), is(true));
+        assertThat(metadata.isAssigned(allocatedDeploymentId), is(true));
         assertThat(metadata.isAssigned("unknown_model_id"), is(false));
     }
 
-    private static StartTrainedModelDeploymentAction.TaskParams randomParams(String modelId) {
+    private static StartTrainedModelDeploymentAction.TaskParams randomParams(String deploymentId, String modelId) {
         return new StartTrainedModelDeploymentAction.TaskParams(
             modelId,
+            deploymentId,
             randomNonNegativeLong(),
             randomIntBetween(1, 8),
             randomIntBetween(1, 8),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
@@ -45,6 +45,7 @@ import org.junit.Before;
 import org.mockito.ArgumentCaptor;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -117,13 +118,14 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
 
         String modelToLoad = "loading-model";
         String anotherModel = "loading-model-again";
+        String deploymentId = "foo";
+        String anotherDeployment = "bar";
 
-        givenAssignmentsInClusterStateForModels(modelToLoad, anotherModel);
+        givenAssignmentsInClusterStateForModels(List.of(deploymentId, anotherDeployment), List.of(modelToLoad, anotherModel));
 
         // Should only load each model once
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad));
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad));
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(anotherModel));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(deploymentId, modelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(anotherDeployment, anotherModel));
 
         trainedModelAssignmentNodeService.loadQueuedModels();
 
@@ -135,17 +137,17 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         verify(trainedModelAssignmentService, times(2)).updateModelAssignmentState(requestCapture.capture(), any());
 
         assertThat(taskCapture.getAllValues().get(0).getModelId(), equalTo(modelToLoad));
-        assertThat(requestCapture.getAllValues().get(0).getModelId(), equalTo(modelToLoad));
+        assertThat(requestCapture.getAllValues().get(0).getDeploymentId(), equalTo(deploymentId));
         assertThat(requestCapture.getAllValues().get(0).getNodeId(), equalTo(NODE_ID));
         assertThat(requestCapture.getAllValues().get(0).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
 
         assertThat(taskCapture.getAllValues().get(1).getModelId(), equalTo(anotherModel));
-        assertThat(requestCapture.getAllValues().get(1).getModelId(), equalTo(anotherModel));
+        assertThat(requestCapture.getAllValues().get(1).getDeploymentId(), equalTo(anotherDeployment));
         assertThat(requestCapture.getAllValues().get(1).getNodeId(), equalTo(NODE_ID));
         assertThat(requestCapture.getAllValues().get(1).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
 
         // Since models are loaded, there shouldn't be any more loadings to occur
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(anotherModel));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(anotherDeployment, anotherModel));
         trainedModelAssignmentNodeService.loadQueuedModels();
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }
@@ -153,12 +155,15 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
     public void testLoadQueuedModelsWhenFailureIsRetried() {
         String modelToLoad = "loading-model";
         String failedModelToLoad = "failed-search-loading-model";
-        givenAssignmentsInClusterStateForModels(modelToLoad, failedModelToLoad);
+        String deploymentId = "foo";
+        String failedDeploymentId = "failed-foo";
+
+        givenAssignmentsInClusterStateForModels(List.of(deploymentId, failedDeploymentId), List.of(modelToLoad, failedModelToLoad));
         withSearchingLoadFailure(failedModelToLoad);
         TrainedModelAssignmentNodeService trainedModelAssignmentNodeService = createService();
 
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad));
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(failedModelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(deploymentId, modelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(failedDeploymentId, failedModelToLoad));
 
         trainedModelAssignmentNodeService.loadQueuedModels();
 
@@ -173,12 +178,14 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         verify(trainedModelAssignmentService, times(1)).updateModelAssignmentState(requestCapture.capture(), any());
 
         assertThat(startTaskCapture.getAllValues().get(0).getModelId(), equalTo(modelToLoad));
-        assertThat(requestCapture.getAllValues().get(0).getModelId(), equalTo(modelToLoad));
+        assertThat(requestCapture.getAllValues().get(0).getDeploymentId(), equalTo(deploymentId));
         assertThat(requestCapture.getAllValues().get(0).getNodeId(), equalTo(NODE_ID));
         assertThat(requestCapture.getAllValues().get(0).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
 
         assertThat(startTaskCapture.getAllValues().get(1).getModelId(), equalTo(failedModelToLoad));
+        assertThat(startTaskCapture.getAllValues().get(1).getDeploymentId(), equalTo(failedDeploymentId));
         assertThat(startTaskCapture.getAllValues().get(2).getModelId(), equalTo(failedModelToLoad));
+        assertThat(startTaskCapture.getAllValues().get(2).getDeploymentId(), equalTo(failedDeploymentId));
 
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }
@@ -190,7 +197,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         String modelToLoad = "loading-model";
 
         // Should only load each model once
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad, modelToLoad));
         trainedModelAssignmentNodeService.stop();
 
         trainedModelAssignmentNodeService.loadQueuedModels();
@@ -203,19 +210,25 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         // When there are no queued models
         String modelToLoad = "loading-model";
         String stoppedModelToLoad = "stopped-loading-model";
+        String loadingDeploymentId = "loading-foo";
+        String stoppedLoadingDeploymentId = "stopped-loading-foo";
 
-        givenAssignmentsInClusterStateForModels(modelToLoad, stoppedModelToLoad);
+        givenAssignmentsInClusterStateForModels(
+            List.of(loadingDeploymentId, stoppedLoadingDeploymentId),
+            List.of(modelToLoad, stoppedModelToLoad)
+        );
 
         // Only one model should be loaded, the other should be stopped
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad));
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(stoppedModelToLoad));
-        trainedModelAssignmentNodeService.getTask(stoppedModelToLoad).stop("testing", ActionListener.noop());
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(loadingDeploymentId, modelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(stoppedLoadingDeploymentId, stoppedModelToLoad));
+        trainedModelAssignmentNodeService.getTask(stoppedLoadingDeploymentId).stop("testing", ActionListener.noop());
         trainedModelAssignmentNodeService.loadQueuedModels();
 
         assertBusy(() -> {
             ArgumentCaptor<TrainedModelDeploymentTask> stoppedTaskCapture = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
             verify(deploymentManager, times(1)).stopDeployment(stoppedTaskCapture.capture());
             assertThat(stoppedTaskCapture.getValue().getModelId(), equalTo(stoppedModelToLoad));
+            assertThat(stoppedTaskCapture.getValue().getDeploymentId(), equalTo(stoppedLoadingDeploymentId));
         });
         ArgumentCaptor<TrainedModelDeploymentTask> startTaskCapture = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
         ArgumentCaptor<UpdateTrainedModelAssignmentRoutingInfoAction.Request> requestCapture = ArgumentCaptor.forClass(
@@ -228,7 +241,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         for (int i = 0; i < 3; i++) {
             UpdateTrainedModelAssignmentRoutingInfoAction.Request request = requestCapture.getAllValues().get(i);
             assertThat(request.getNodeId(), equalTo(NODE_ID));
-            if (request.getModelId().equals(stoppedModelToLoad)) {
+            if (request.getDeploymentId().equals(stoppedLoadingDeploymentId)) {
                 if (seenStopping) {
                     assertThat(request.getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STOPPED));
                 } else {
@@ -236,7 +249,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                     seenStopping = true;
                 }
             } else {
-                assertThat(request.getModelId(), equalTo(modelToLoad));
+                assertThat(request.getDeploymentId(), equalTo(loadingDeploymentId));
                 assertThat(request.getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
             }
         }
@@ -248,12 +261,18 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
     public void testLoadQueuedModelsWhenOneFails() throws InterruptedException {
         String modelToLoad = "loading-model";
         String failedModelToLoad = "failed-loading-model";
-        givenAssignmentsInClusterStateForModels(modelToLoad, failedModelToLoad);
+        String loadingDeploymentId = "loading-foo";
+        String failedLoadingDeploymentId = "failed-loading-foo";
+
+        givenAssignmentsInClusterStateForModels(
+            List.of(loadingDeploymentId, failedLoadingDeploymentId),
+            List.of(modelToLoad, failedModelToLoad)
+        );
         withLoadFailure(failedModelToLoad);
         TrainedModelAssignmentNodeService trainedModelAssignmentNodeService = createService();
 
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelToLoad));
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(failedModelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(loadingDeploymentId, modelToLoad));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(failedLoadingDeploymentId, failedModelToLoad));
 
         CountDownLatch latch = new CountDownLatch(1);
         doAnswer(invocationOnMock -> {
@@ -276,12 +295,12 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         verify(deploymentManager).stopDeployment(stopTaskCapture.capture());
 
         assertThat(startTaskCapture.getAllValues().get(0).getModelId(), equalTo(modelToLoad));
-        assertThat(requestCapture.getAllValues().get(0).getModelId(), equalTo(modelToLoad));
+        assertThat(requestCapture.getAllValues().get(0).getDeploymentId(), equalTo(loadingDeploymentId));
         assertThat(requestCapture.getAllValues().get(0).getNodeId(), equalTo(NODE_ID));
         assertThat(requestCapture.getAllValues().get(0).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
 
         assertThat(startTaskCapture.getAllValues().get(1).getModelId(), equalTo(failedModelToLoad));
-        assertThat(requestCapture.getAllValues().get(1).getModelId(), equalTo(failedModelToLoad));
+        assertThat(requestCapture.getAllValues().get(1).getDeploymentId(), equalTo(failedLoadingDeploymentId));
         assertThat(requestCapture.getAllValues().get(1).getNodeId(), equalTo(NODE_ID));
         assertThat(requestCapture.getAllValues().get(1).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.FAILED));
 
@@ -308,6 +327,10 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         String modelOne = "model-1";
         String modelTwo = "model-2";
         String notUsedModel = "model-3";
+        String deploymentOne = "deployment-1";
+        String deploymentTwo = "deployment-2";
+        String notUsedDeployment = "deployment-3";
+
         ClusterChangedEvent event = new ClusterChangedEvent(
             "testClusterChanged",
             ClusterState.builder(new ClusterName("testClusterChanged"))
@@ -319,17 +342,17 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                             TrainedModelAssignmentMetadata.Builder.empty()
                                 .addNewAssignment(
                                     modelOne,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelOne))
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentOne, modelOne))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .addNewAssignment(
                                     modelTwo,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelTwo))
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentTwo, modelTwo))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .addNewAssignment(
                                     notUsedModel,
-                                    TrainedModelAssignment.Builder.empty(newParams(notUsedModel))
+                                    TrainedModelAssignment.Builder.empty(newParams(notUsedDeployment, notUsedModel))
                                         .addRoutingEntry("some-other-node", new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .build()
@@ -365,7 +388,15 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         String modelTwo = "model-2";
         String notUsedModel = "model-3";
         String previouslyUsedModel = "model-4";
-        givenAssignmentsInClusterStateForModels(modelOne, modelTwo, previouslyUsedModel);
+        String deploymentOne = "deployment-1";
+        String deploymentTwo = "deployment-2";
+        String notUsedDeployment = "deployment-3";
+        String previouslyUsedDeployment = "deployment-4";
+
+        givenAssignmentsInClusterStateForModels(
+            List.of(deploymentOne, deploymentTwo, notUsedDeployment),
+            List.of(modelOne, modelTwo, notUsedModel)
+        );
         ClusterChangedEvent event = new ClusterChangedEvent(
             "testClusterChanged",
             ClusterState.builder(new ClusterName("testClusterChanged"))
@@ -376,13 +407,13 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                             TrainedModelAssignmentMetadata.NAME,
                             TrainedModelAssignmentMetadata.Builder.empty()
                                 .addNewAssignment(
-                                    modelOne,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelOne))
+                                    deploymentOne,
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentOne, modelOne))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .addNewAssignment(
-                                    modelTwo,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelTwo))
+                                    deploymentTwo,
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentTwo, modelTwo))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                         .updateExistingRoutingEntry(
                                             NODE_ID,
@@ -395,8 +426,8 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                                         )
                                 )
                                 .addNewAssignment(
-                                    previouslyUsedModel,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelTwo))
+                                    previouslyUsedDeployment,
+                                    TrainedModelAssignment.Builder.empty(newParams(previouslyUsedDeployment, modelTwo))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                         .updateExistingRoutingEntry(
                                             NODE_ID,
@@ -409,8 +440,8 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                                         )
                                 )
                                 .addNewAssignment(
-                                    notUsedModel,
-                                    TrainedModelAssignment.Builder.empty(newParams(notUsedModel))
+                                    notUsedDeployment,
+                                    TrainedModelAssignment.Builder.empty(newParams(notUsedDeployment, notUsedModel))
                                         .addRoutingEntry("some-other-node", new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .build()
@@ -433,18 +464,18 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                             TrainedModelAssignmentMetadata.NAME,
                             TrainedModelAssignmentMetadata.Builder.empty()
                                 .addNewAssignment(
-                                    modelOne,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelOne))
+                                    deploymentOne,
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentOne, modelOne))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .addNewAssignment(
-                                    modelTwo,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelTwo))
+                                    deploymentTwo,
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentTwo, modelTwo))
                                         .addRoutingEntry("some-other-node", new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .addNewAssignment(
-                                    notUsedModel,
-                                    TrainedModelAssignment.Builder.empty(newParams(notUsedModel))
+                                    notUsedDeployment,
+                                    TrainedModelAssignment.Builder.empty(newParams(notUsedDeployment, notUsedModel))
                                         .addRoutingEntry("some-other-node", new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .build()
@@ -471,7 +502,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         verify(trainedModelAssignmentService, times(1)).updateModelAssignmentState(requestCapture.capture(), any());
 
         assertThat(startTaskCapture.getAllValues().get(0).getModelId(), equalTo(modelOne));
-        assertThat(requestCapture.getAllValues().get(0).getModelId(), equalTo(modelOne));
+        assertThat(requestCapture.getAllValues().get(0).getDeploymentId(), equalTo(deploymentOne));
         assertThat(requestCapture.getAllValues().get(0).getNodeId(), equalTo(NODE_ID));
         assertThat(requestCapture.getAllValues().get(0).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
 
@@ -486,7 +517,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                             TrainedModelAssignmentMetadata.Builder.empty()
                                 .addNewAssignment(
                                     modelOne,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelOne))
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentOne, modelOne))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )
                                 .build()
@@ -520,9 +551,11 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
             .build();
         String modelOne = "model-1";
         String modelTwo = "model-2";
-        givenAssignmentsInClusterStateForModels(modelOne, modelTwo);
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelOne));
-        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(modelTwo));
+        String deploymentOne = "deployment-1";
+        String deploymentTwo = "deployment-2";
+        givenAssignmentsInClusterStateForModels(List.of(deploymentOne, deploymentTwo), List.of(modelOne, modelTwo));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(deploymentOne, modelOne));
+        trainedModelAssignmentNodeService.prepareModelToLoad(newParams(deploymentTwo, modelTwo));
         trainedModelAssignmentNodeService.loadQueuedModels();
 
         ClusterChangedEvent event = new ClusterChangedEvent(
@@ -535,13 +568,13 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                             TrainedModelAssignmentMetadata.NAME,
                             TrainedModelAssignmentMetadata.Builder.empty()
                                 .addNewAssignment(
-                                    modelOne,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelOne))
+                                    deploymentOne,
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentOne, modelOne))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 3, RoutingState.STARTED, ""))
                                 )
                                 .addNewAssignment(
-                                    modelTwo,
-                                    TrainedModelAssignment.Builder.empty(newParams(modelTwo))
+                                    deploymentTwo,
+                                    TrainedModelAssignment.Builder.empty(newParams(deploymentTwo, modelTwo))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(2, 1, RoutingState.STARTED, ""))
                                 )
                                 .build()
@@ -559,7 +592,9 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
             ArgumentCaptor<Integer> updatedAllocations = ArgumentCaptor.forClass(Integer.class);
             verify(deploymentManager, times(2)).updateNumAllocations(updatedTasks.capture(), updatedAllocations.capture(), any(), any());
             assertThat(updatedTasks.getAllValues().get(0).getModelId(), equalTo(modelOne));
+            assertThat(updatedTasks.getAllValues().get(0).getDeploymentId(), equalTo(deploymentOne));
             assertThat(updatedTasks.getAllValues().get(1).getModelId(), equalTo(modelTwo));
+            assertThat(updatedTasks.getAllValues().get(1).getDeploymentId(), equalTo(deploymentTwo));
         });
         ArgumentCaptor<TrainedModelDeploymentTask> startTaskCapture = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
         ArgumentCaptor<UpdateTrainedModelAssignmentRoutingInfoAction.Request> updateCapture = ArgumentCaptor.forClass(
@@ -570,22 +605,23 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
 
         assertThat(startTaskCapture.getAllValues().get(0).getModelId(), equalTo(modelOne));
         assertThat(startTaskCapture.getAllValues().get(1).getModelId(), equalTo(modelTwo));
-        assertThat(updateCapture.getAllValues().get(0).getModelId(), equalTo(modelOne));
+        assertThat(updateCapture.getAllValues().get(0).getDeploymentId(), equalTo(deploymentOne));
         assertThat(updateCapture.getAllValues().get(0).getNodeId(), equalTo(NODE_ID));
         assertThat(updateCapture.getAllValues().get(0).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
-        assertThat(updateCapture.getAllValues().get(1).getModelId(), equalTo(modelTwo));
+        assertThat(updateCapture.getAllValues().get(1).getDeploymentId(), equalTo(deploymentTwo));
         assertThat(updateCapture.getAllValues().get(1).getNodeId(), equalTo(NODE_ID));
         assertThat(updateCapture.getAllValues().get(1).getUpdate().getStateAndReason().get().getState(), equalTo(RoutingState.STARTED));
 
         verifyNoMoreInteractions(deploymentManager, trainedModelAssignmentService);
     }
 
-    private void givenAssignmentsInClusterStateForModels(String... modelIds) {
+    private void givenAssignmentsInClusterStateForModels(List<String> deploymentIds, List<String> modelIds) {
+        assertEquals(deploymentIds.size(), modelIds.size());
         TrainedModelAssignmentMetadata.Builder builder = TrainedModelAssignmentMetadata.Builder.empty();
-        for (String modelId : modelIds) {
+        for (int i = 0; i < modelIds.size(); i++) {
             builder.addNewAssignment(
-                modelId,
-                TrainedModelAssignment.Builder.empty(newParams(modelId))
+                deploymentIds.get(i),
+                TrainedModelAssignment.Builder.empty(newParams(deploymentIds.get(i), modelIds.get(i)))
                     .addRoutingEntry("test-node", new RoutingInfo(1, 1, RoutingState.STARTING, ""))
             );
         }
@@ -625,9 +661,10 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         }).when(deploymentManager).startDeployment(any(), any());
     }
 
-    private static StartTrainedModelDeploymentAction.TaskParams newParams(String modelId) {
+    private static StartTrainedModelDeploymentAction.TaskParams newParams(String deploymentId, String modelId) {
         return new StartTrainedModelDeploymentAction.TaskParams(
             modelId,
+            deploymentId,
             randomNonNegativeLong(),
             1,
             1,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentNodeServiceTests.java
@@ -394,8 +394,8 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         String previouslyUsedDeployment = "deployment-4";
 
         givenAssignmentsInClusterStateForModels(
-            List.of(deploymentOne, deploymentTwo, notUsedDeployment),
-            List.of(modelOne, modelTwo, notUsedModel)
+            List.of(deploymentOne, deploymentTwo, previouslyUsedDeployment),
+            List.of(modelOne, modelTwo, previouslyUsedModel)
         );
         ClusterChangedEvent event = new ClusterChangedEvent(
             "testClusterChanged",
@@ -427,7 +427,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                                 )
                                 .addNewAssignment(
                                     previouslyUsedDeployment,
-                                    TrainedModelAssignment.Builder.empty(newParams(previouslyUsedDeployment, modelTwo))
+                                    TrainedModelAssignment.Builder.empty(newParams(previouslyUsedDeployment, previouslyUsedModel))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                         .updateExistingRoutingEntry(
                                             NODE_ID,
@@ -492,7 +492,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
         assertBusy(() -> {
             ArgumentCaptor<TrainedModelDeploymentTask> stoppedTaskCapture = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
             verify(deploymentManager, times(1)).stopDeployment(stoppedTaskCapture.capture());
-            assertThat(stoppedTaskCapture.getAllValues().get(0).getModelId(), equalTo(modelTwo));
+            assertThat(stoppedTaskCapture.getAllValues().get(0).getDeploymentId(), equalTo(deploymentTwo));
         });
         ArgumentCaptor<TrainedModelDeploymentTask> startTaskCapture = ArgumentCaptor.forClass(TrainedModelDeploymentTask.class);
         ArgumentCaptor<UpdateTrainedModelAssignmentRoutingInfoAction.Request> requestCapture = ArgumentCaptor.forClass(
@@ -516,7 +516,7 @@ public class TrainedModelAssignmentNodeServiceTests extends ESTestCase {
                             TrainedModelAssignmentMetadata.NAME,
                             TrainedModelAssignmentMetadata.Builder.empty()
                                 .addNewAssignment(
-                                    modelOne,
+                                    deploymentOne,
                                     TrainedModelAssignment.Builder.empty(newParams(deploymentOne, modelOne))
                                         .addRoutingEntry(NODE_ID, new RoutingInfo(1, 1, RoutingState.STARTING, ""))
                                 )

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentRebalancerTests.java
@@ -47,21 +47,23 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Map.of(),
             Optional.empty()
         ).rebalance().build();
-        assertThat(result.modelAssignments().isEmpty(), is(true));
+        assertThat(result.allAssignments().isEmpty(), is(true));
     }
 
     public void testRebalance_GivenAllAssignmentsAreSatisfied_ShouldMakeNoChanges() throws Exception {
         String modelId1 = "model-1";
         String modelId2 = "model-2";
-        StartTrainedModelDeploymentAction.TaskParams taskParams1 = normalPriorityParams(modelId1, 1024L, 1, 2);
-        StartTrainedModelDeploymentAction.TaskParams taskParams2 = normalPriorityParams(modelId2, 1024L, 4, 1);
+        String deploymentId1 = "deployment-1";
+        String deploymentId2 = "deployment-2";
+        StartTrainedModelDeploymentAction.TaskParams taskParams1 = normalPriorityParams(deploymentId1, modelId1, 1024L, 1, 2);
+        StartTrainedModelDeploymentAction.TaskParams taskParams2 = normalPriorityParams(deploymentId2, modelId2, 1024L, 4, 1);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                modelId1,
+                deploymentId1,
                 TrainedModelAssignment.Builder.empty(taskParams1).addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .addNewAssignment(
-                modelId2,
+                deploymentId2,
                 TrainedModelAssignment.Builder.empty(taskParams2)
                     .addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(3, 3, RoutingState.STARTED, ""))
@@ -86,15 +88,17 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
 
         String modelId1 = "model-1";
         String modelId2 = "model-2";
-        StartTrainedModelDeploymentAction.TaskParams taskParams1 = normalPriorityParams(modelId1, 1024L, 1, 2);
-        StartTrainedModelDeploymentAction.TaskParams taskParams2 = normalPriorityParams(modelId2, 1024L, 4, 1);
+        String deploymentId1 = "deployment-1";
+        String deploymentId2 = "deployment-2";
+        StartTrainedModelDeploymentAction.TaskParams taskParams1 = normalPriorityParams(deploymentId1, modelId1, 1024L, 1, 2);
+        StartTrainedModelDeploymentAction.TaskParams taskParams2 = normalPriorityParams(deploymentId2, modelId2, 1024L, 4, 1);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                modelId1,
+                deploymentId1,
                 TrainedModelAssignment.Builder.empty(taskParams1).addRoutingEntry("node-1", new RoutingInfo(0, 0, RoutingState.STARTED, ""))
             )
             .addNewAssignment(
-                modelId2,
+                deploymentId2,
                 TrainedModelAssignment.Builder.empty(taskParams2)
                     .addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(3, 3, RoutingState.STARTED, ""))
@@ -111,22 +115,22 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.empty()
         ).rebalance().build();
 
-        assertThat(result.modelAssignments(), is(aMapWithSize(2)));
+        assertThat(result.allAssignments(), is(aMapWithSize(2)));
 
-        for (String modelId : List.of(modelId1, modelId2)) {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        for (String deploymentId : List.of(deploymentId1, deploymentId2)) {
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(deploymentId);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.hasOutdatedRoutingEntries(), is(false));
             assertThat(
                 assignment.getNodeRoutingTable().values().stream().mapToInt(RoutingInfo::getTargetAllocations).sum(),
-                equalTo(currentMetadata.getModelAssignment(modelId).getTaskParams().getNumberOfAllocations())
+                equalTo(currentMetadata.getDeploymentAssignment(deploymentId).getTaskParams().getNumberOfAllocations())
             );
         }
     }
 
     public void testRebalance_GivenModelToAddAlreadyExists() {
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, 1024L, 1, 1);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, modelId, 1024L, 1, 1);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(modelId, TrainedModelAssignment.Builder.empty(taskParams))
             .build();
@@ -138,7 +142,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
 
     public void testRebalance_GivenFirstModelToAdd_NoMLNodes() throws Exception {
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, 1024L, 1, 1);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, modelId, 1024L, 1, 1);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
 
         TrainedModelAssignmentMetadata result = new TrainedModelAssignmentRebalancer(
@@ -148,7 +152,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -161,7 +165,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         DiscoveryNode node = buildNode("node-1", nodeMemoryBytes, 3);
 
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, 1024L, 1, 4);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, modelId, 1024L, 1, 4);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
         Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
 
@@ -174,7 +178,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -190,7 +194,13 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
 
     public void testRebalance_GivenFirstModelToAdd_NotEnoughMemory() throws Exception {
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, ByteSizeValue.ofGb(2).getBytes(), 1, 1);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(
+            modelId,
+            modelId,
+            ByteSizeValue.ofGb(2).getBytes(),
+            1,
+            1
+        );
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
         Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
         long nodeMemoryBytes = ByteSizeValue.ofGb(1).getBytes();
@@ -203,7 +213,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -216,7 +226,13 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
 
     public void testRebalance_GivenFirstModelToAdd_ErrorDetectingNodeLoad() throws Exception {
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, ByteSizeValue.ofGb(2).getBytes(), 1, 1);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(
+            modelId,
+            modelId,
+            ByteSizeValue.ofGb(2).getBytes(),
+            1,
+            1
+        );
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
         Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
         long nodeMemoryBytes = ByteSizeValue.ofGb(1).getBytes();
@@ -232,7 +248,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -248,7 +264,13 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         DiscoveryNode node2 = buildNode("node-2", ByteSizeValue.ofGb(10).getBytes(), 3);
 
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, ByteSizeValue.ofGb(2).getBytes(), 1, 4);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(
+            modelId,
+            modelId,
+            ByteSizeValue.ofGb(2).getBytes(),
+            1,
+            4
+        );
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
         Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
         nodeLoads.put(node1, NodeLoad.builder("node-1").setMaxMemory(ByteSizeValue.ofGb(1).getBytes()).build());
@@ -261,7 +283,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -281,7 +303,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         DiscoveryNode node1 = buildNode("node-1", nodeMemoryBytes, 4);
 
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, 1024L, 1, 1);
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelId, modelId, 1024L, 1, 1);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
         Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
         nodeLoads.put(node1, NodeLoad.builder("node-1").setMaxMemory(nodeMemoryBytes).build());
@@ -293,7 +315,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -309,13 +331,13 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         DiscoveryNode node1 = buildNode("node-1", nodeMemoryBytes, 4);
         DiscoveryNode node2 = buildNode("node-2", nodeMemoryBytes, 4);
 
-        String modelToAddId = "model-to-add";
-        String previousModelId = "previous-model";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(modelToAddId, 1024L, 1, 2);
+        String deploymentToAddId = "model-to-add";
+        String previousDeploymentId = "previous-model";
+        StartTrainedModelDeploymentAction.TaskParams taskParams = normalPriorityParams(deploymentToAddId, deploymentToAddId, 1024L, 1, 2);
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                previousModelId,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModelId, 1024L, 3, 2))
+                previousDeploymentId,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeploymentId, previousDeploymentId, 1024L, 3, 2))
                     .addRoutingEntry("node-1", new RoutingInfo(2, 2, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
@@ -331,10 +353,10 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        assertThat(result.modelAssignments(), is(aMapWithSize(2)));
+        assertThat(result.allAssignments(), is(aMapWithSize(2)));
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelToAddId);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(deploymentToAddId);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -345,7 +367,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getReason().isPresent(), is(false));
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModelId);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeploymentId);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(2)));
@@ -367,18 +389,18 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         DiscoveryNode node2 = buildNode("node-2", nodeMemoryBytes, 4);
         DiscoveryNode node3 = buildNode("node-3", nodeMemoryBytes, 4);
 
-        String previousModel1Id = "previous-model-1";
-        String previousModel2Id = "previous-model-2";
+        String previousDeployment1Id = "previous-model-1";
+        String previousDeployment2Id = "previous-model-2";
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                previousModel1Id,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModel1Id, 1024L, 3, 2))
+                previousDeployment1Id,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeployment1Id, 1024L, 3, 2))
                     .addRoutingEntry("node-1", new RoutingInfo(2, 2, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .addNewAssignment(
-                previousModel2Id,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModel2Id, 1024L, 4, 1))
+                previousDeployment2Id,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeployment2Id, 1024L, 4, 1))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .build();
@@ -394,10 +416,10 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.empty()
         ).rebalance().build();
 
-        assertThat(result.modelAssignments(), is(aMapWithSize(2)));
+        assertThat(result.allAssignments(), is(aMapWithSize(2)));
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModel1Id);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeployment1Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(2)));
@@ -412,7 +434,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getReason().isPresent(), is(false));
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModel2Id);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeployment2Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(2)));
@@ -432,18 +454,18 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         long nodeMemoryBytes = ByteSizeValue.ofGb(1).getBytes();
         DiscoveryNode node1 = buildNode("node-1", nodeMemoryBytes, 4);
 
-        String previousModel1Id = "previous-model-1";
-        String previousModel2Id = "previous-model-2";
+        String previousDeployment1Id = "previous-deployment-1";
+        String previousDeployment2Id = "previous-deployment-2";
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                previousModel1Id,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModel1Id, 1024L, 3, 2))
+                previousDeployment1Id,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeployment1Id, 1024L, 3, 2))
                     .addRoutingEntry("node-1", new RoutingInfo(2, 2, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .addNewAssignment(
-                previousModel2Id,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModel2Id, 1024L, 4, 1))
+                previousDeployment2Id,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeployment2Id, 1024L, 4, 1))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .build();
@@ -457,10 +479,10 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.empty()
         ).rebalance().build();
 
-        assertThat(result.modelAssignments(), is(aMapWithSize(2)));
+        assertThat(result.allAssignments(), is(aMapWithSize(2)));
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModel1Id);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeployment1Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -478,7 +500,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             );
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModel2Id);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeployment2Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -501,18 +523,18 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         long nodeMemoryBytes = ByteSizeValue.ofGb(1).getBytes();
         DiscoveryNode node1 = buildNode("node-1", nodeMemoryBytes, 7);
 
-        String previousModel1Id = "previous-model-1";
-        String previousModel2Id = "previous-model-2";
+        String previousDeployment1Id = "previous-deployment-1";
+        String previousDeployment2Id = "previous-deployment-2";
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                previousModel1Id,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModel1Id, 1024L, 3, 2))
+                previousDeployment1Id,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeployment1Id, 1024L, 3, 2))
                     .addRoutingEntry("node-1", new RoutingInfo(2, 2, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .addNewAssignment(
-                previousModel2Id,
-                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousModel2Id, 1024L, 1, 1))
+                previousDeployment2Id,
+                TrainedModelAssignment.Builder.empty(normalPriorityParams(previousDeployment2Id, 1024L, 1, 1))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
             )
             .build();
@@ -526,10 +548,10 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.empty()
         ).rebalance().build();
 
-        assertThat(result.modelAssignments(), is(aMapWithSize(2)));
+        assertThat(result.allAssignments(), is(aMapWithSize(2)));
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModel1Id);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeployment1Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -540,7 +562,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getReason().isPresent(), is(false));
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(previousModel2Id);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(previousDeployment2Id);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -574,9 +596,9 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.empty()
         ).rebalance().build();
 
-        assertThat(result.modelAssignments(), is(aMapWithSize(1)));
+        assertThat(result.allAssignments(), is(aMapWithSize(1)));
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -589,7 +611,12 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
 
     public void testRebalance_GivenLowPriorityModelToAdd_OnlyModel_NotEnoughMemory() throws Exception {
         String modelId = "model-to-add";
-        StartTrainedModelDeploymentAction.TaskParams taskParams = lowPriorityParams(modelId, ByteSizeValue.ofGb(2).getBytes());
+        String deploymentId = "deployment-to-add";
+        StartTrainedModelDeploymentAction.TaskParams taskParams = lowPriorityParams(
+            deploymentId,
+            modelId,
+            ByteSizeValue.ofGb(2).getBytes()
+        );
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty().build();
         Map<DiscoveryNode, NodeLoad> nodeLoads = new HashMap<>();
         long nodeMemoryBytes = ByteSizeValue.ofGb(1).getBytes();
@@ -602,7 +629,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(deploymentId);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -622,13 +649,18 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         nodeLoads.put(node1, NodeLoad.builder("node-1").setMaxMemory(nodeMemoryBytes).build());
         nodeLoads.put(node2, NodeLoad.builder("node-2").setMaxMemory(nodeMemoryBytes).build());
 
-        String modelId1 = "model-1";
-        StartTrainedModelDeploymentAction.TaskParams taskParams1 = lowPriorityParams(modelId1, ByteSizeValue.ofMb(300).getBytes());
-        String modelId2 = "model-2";
-        StartTrainedModelDeploymentAction.TaskParams taskParams2 = normalPriorityParams(modelId2, ByteSizeValue.ofMb(300).getBytes(), 2, 1);
+        String deployment1 = "deployment-1";
+        StartTrainedModelDeploymentAction.TaskParams taskParams1 = lowPriorityParams(deployment1, ByteSizeValue.ofMb(300).getBytes());
+        String deployment2 = "deployment-2";
+        StartTrainedModelDeploymentAction.TaskParams taskParams2 = normalPriorityParams(
+            deployment2,
+            ByteSizeValue.ofMb(300).getBytes(),
+            2,
+            1
+        );
         TrainedModelAssignmentMetadata currentMetadata = TrainedModelAssignmentMetadata.Builder.empty()
             .addNewAssignment(
-                modelId2,
+                deployment2,
                 TrainedModelAssignment.Builder.empty(taskParams2)
                     .addRoutingEntry("node-1", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
                     .addRoutingEntry("node-2", new RoutingInfo(1, 1, RoutingState.STARTED, ""))
@@ -642,7 +674,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             Optional.of(taskParams1)
         ).rebalance().build();
 
-        TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+        TrainedModelAssignment assignment = result.getDeploymentAssignment(deployment1);
         assertThat(assignment, is(notNullValue()));
         assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
         assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -681,7 +713,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         ).rebalance().build();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -692,7 +724,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             );
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -735,7 +767,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         List<String> assignedNodes = new ArrayList<>();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -747,7 +779,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assignedNodes.add(assignedNode);
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -786,7 +818,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         ).rebalance().build();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -797,7 +829,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             );
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -835,7 +867,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         ).rebalance().build();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -846,7 +878,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getReason().isPresent(), is(false));
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -884,7 +916,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         ).rebalance().build();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(anEmptyMap()));
@@ -895,7 +927,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             );
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -935,7 +967,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         ).rebalance().build();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTED));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -946,7 +978,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getReason().isPresent(), is(false));
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -986,7 +1018,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         ).rebalance().build();
 
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId1);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId1);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -997,7 +1029,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
             assertThat(assignment.getReason().isPresent(), is(false));
         }
         {
-            TrainedModelAssignment assignment = result.getModelAssignment(modelId2);
+            TrainedModelAssignment assignment = result.getDeploymentAssignment(modelId2);
             assertThat(assignment, is(notNullValue()));
             assertThat(assignment.getAssignmentState(), equalTo(AssignmentState.STARTING));
             assertThat(assignment.getNodeRoutingTable(), is(aMapWithSize(1)));
@@ -1009,9 +1041,14 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
         }
     }
 
-    private static StartTrainedModelDeploymentAction.TaskParams lowPriorityParams(String modelId, long modelSize) {
+    private static StartTrainedModelDeploymentAction.TaskParams lowPriorityParams(String deploymentId, long modelSize) {
+        return lowPriorityParams(deploymentId, deploymentId, modelSize);
+    }
+
+    private static StartTrainedModelDeploymentAction.TaskParams lowPriorityParams(String deploymentId, String modelId, long modelSize) {
         return new StartTrainedModelDeploymentAction.TaskParams(
             modelId,
+            deploymentId,
             modelSize,
             1,
             1,
@@ -1022,6 +1059,16 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
     }
 
     private static StartTrainedModelDeploymentAction.TaskParams normalPriorityParams(
+        String deploymentId,
+        long modelSize,
+        int numberOfAllocations,
+        int threadsPerAllocation
+    ) {
+        return normalPriorityParams(deploymentId, deploymentId, modelSize, numberOfAllocations, threadsPerAllocation);
+    }
+
+    private static StartTrainedModelDeploymentAction.TaskParams normalPriorityParams(
+        String deploymentId,
         String modelId,
         long modelSize,
         int numberOfAllocations,
@@ -1029,6 +1076,7 @@ public class TrainedModelAssignmentRebalancerTests extends ESTestCase {
     ) {
         return new StartTrainedModelDeploymentAction.TaskParams(
             modelId,
+            deploymentId,
             modelSize,
             numberOfAllocations,
             threadsPerAllocation,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AllocationReducerTests.java
@@ -29,19 +29,19 @@ public class AllocationReducerTests extends ESTestCase {
 
     public void testReduceTo_ValueEqualToCurrentAllocations() {
         Map<List<String>, Collection<DiscoveryNode>> nodesByZone = Map.of(List.of("z"), List.of(buildNode("n")));
-        TrainedModelAssignment assignment = createAssignment("m", 2, Map.of("n", 2));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 2, Map.of("n", 2));
         expectThrows(IllegalArgumentException.class, () -> new AllocationReducer(assignment, nodesByZone).reduceTo(2));
     }
 
     public void testReduceTo_ValueLargerThanCurrentAllocations() {
         Map<List<String>, Collection<DiscoveryNode>> nodesByZone = Map.of(List.of("z"), List.of(buildNode("n")));
-        TrainedModelAssignment assignment = createAssignment("m", 2, Map.of("n", 2));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 2, Map.of("n", 2));
         expectThrows(IllegalArgumentException.class, () -> new AllocationReducer(assignment, nodesByZone).reduceTo(3));
     }
 
     public void testReduceTo_GivenOneZone_OneAssignment_ReductionByOne() {
         Map<List<String>, Collection<DiscoveryNode>> nodesByZone = Map.of(List.of("z"), List.of(buildNode("n")));
-        TrainedModelAssignment assignment = createAssignment("m", 2, Map.of("n", 2));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 2, Map.of("n", 2));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(1).build();
 
@@ -55,7 +55,7 @@ public class AllocationReducerTests extends ESTestCase {
 
     public void testReduceTo_GivenOneZone_OneAssignment_ReductionByMany() {
         Map<List<String>, Collection<DiscoveryNode>> nodesByZone = Map.of(List.of("z"), List.of(buildNode("n")));
-        TrainedModelAssignment assignment = createAssignment("m", 5, Map.of("n", 5));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 5, Map.of("n", 5));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(2).build();
 
@@ -72,7 +72,7 @@ public class AllocationReducerTests extends ESTestCase {
             List.of("z"),
             List.of(buildNode("n_1"), buildNode("n_2"), buildNode("n_3"))
         );
-        TrainedModelAssignment assignment = createAssignment("m", 6, Map.of("n_1", 3, "n_2", 2, "n_3", 1));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 6, Map.of("n_1", 3, "n_2", 2, "n_3", 1));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(3).build();
 
@@ -89,7 +89,7 @@ public class AllocationReducerTests extends ESTestCase {
             List.of("z"),
             List.of(buildNode("n_1"), buildNode("n_2"), buildNode("n_3"))
         );
-        TrainedModelAssignment assignment = createAssignment("m", 6, Map.of("n_1", 2, "n_2", 2, "n_3", 2));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 6, Map.of("n_1", 2, "n_2", 2, "n_3", 2));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(5).build();
 
@@ -110,7 +110,7 @@ public class AllocationReducerTests extends ESTestCase {
             List.of("z_2"),
             List.of(buildNode("n_3"))
         );
-        TrainedModelAssignment assignment = createAssignment("m", 5, Map.of("n_1", 3, "n_2", 1, "n_3", 1));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 5, Map.of("n_1", 3, "n_2", 1, "n_3", 1));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(4).build();
 
@@ -131,7 +131,7 @@ public class AllocationReducerTests extends ESTestCase {
             List.of("z_2"),
             List.of(buildNode("n_2"))
         );
-        TrainedModelAssignment assignment = createAssignment("m", 6, Map.of("n_1", 3, "n_2", 3));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 6, Map.of("n_1", 3, "n_2", 3));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(4).build();
 
@@ -152,7 +152,7 @@ public class AllocationReducerTests extends ESTestCase {
             List.of("z_2"),
             List.of(buildNode("n_2"))
         );
-        TrainedModelAssignment assignment = createAssignment("m", 2, Map.of("n_1", 1, "n_2", 1));
+        TrainedModelAssignment assignment = createAssignment("d", "m", 2, Map.of("n_1", 1, "n_2", 1));
 
         TrainedModelAssignment updatedAssignment = new AllocationReducer(assignment, nodesByZone).reduceTo(1).build();
 
@@ -165,6 +165,7 @@ public class AllocationReducerTests extends ESTestCase {
     }
 
     private static TrainedModelAssignment createAssignment(
+        String deploymentId,
         String modelId,
         int numberOfAllocations,
         Map<String, Integer> allocationsByNode
@@ -172,6 +173,7 @@ public class AllocationReducerTests extends ESTestCase {
         TrainedModelAssignment.Builder builder = TrainedModelAssignment.Builder.empty(
             new StartTrainedModelDeploymentAction.TaskParams(
                 modelId,
+                deploymentId,
                 randomNonNegativeLong(),
                 numberOfAllocations,
                 randomIntBetween(1, 16),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.ml.inference.assignment.planning;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Deployment;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.List;
@@ -24,21 +24,21 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testBuilderCtor_GivenDuplicateNode() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 1, 2, Map.of(), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 40, 1, 2, Map.of(), 0);
 
         expectThrows(IllegalArgumentException.class, () -> AssignmentPlan.builder(List.of(n, n), List.of(m)));
     }
 
     public void testBuilderCtor_GivenDuplicateModel() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 1, 2, Map.of(), 0);
+        Deployment m = new AssignmentPlan.Deployment("m_1", 40, 1, 2, Map.of(), 0);
 
         expectThrows(IllegalArgumentException.class, () -> AssignmentPlan.builder(List.of(n), List.of(m, m)));
     }
 
     public void testAssignModelToNode_GivenNoPreviousAssignment() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 1, 2, Map.of(), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 40, 1, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -63,7 +63,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenNewPlanSatisfiesCurrentAssignment() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 2, 2, Map.of("n_1", 1), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 40, 2, 2, Map.of("n_1", 1), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -83,7 +83,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenNewPlanDoesNotSatisfyCurrentAssignment() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 40, 2, 2, Map.of("n_1", 2), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 40, 2, 2, Map.of("n_1", 2), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -103,7 +103,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenPreviouslyUnassignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 101, 2, 2, Map.of(), 0);
+        Deployment m = new AssignmentPlan.Deployment("m_1", 101, 2, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         Exception e = expectThrows(IllegalArgumentException.class, () -> builder.assignModelToNode(m, n, 1));
@@ -113,7 +113,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenPreviouslyAssignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 101, 2, 2, Map.of("n_1", 1), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 101, 2, 2, Map.of("n_1", 1), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         builder.assignModelToNode(m, n, 2);
@@ -126,7 +126,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenNotEnoughCores_AndSingleThreadPerAllocation() {
         Node n = new Node("n_1", 100, 4);
-        Model m = new Model("m_1", 100, 5, 1, Map.of(), 0);
+        Deployment m = new AssignmentPlan.Deployment("m_1", 100, 5, 1, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         Exception e = expectThrows(IllegalArgumentException.class, () -> builder.assignModelToNode(m, n, 5));
@@ -139,7 +139,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenNotEnoughCores_AndMultipleThreadsPerAllocation() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 100, 3, 2, Map.of(), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 100, 3, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
         Exception e = expectThrows(IllegalArgumentException.class, () -> builder.assignModelToNode(m, n, 3));
@@ -152,7 +152,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testAssignModelToNode_GivenSameModelAssignedTwice() {
         Node n = new Node("n_1", 100, 8);
-        Model m = new Model("m_1", 60, 4, 2, Map.of(), 0);
+        Deployment m = new AssignmentPlan.Deployment("m_1", 60, 4, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -186,7 +186,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testCanAssign_GivenPreviouslyUnassignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 101, 1, 1, Map.of(), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 101, 1, 1, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -195,7 +195,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testCanAssign_GivenPreviouslyAssignedModelDoesNotFit() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 101, 1, 1, Map.of("n_1", 1), 0);
+        Deployment m = new AssignmentPlan.Deployment("m_1", 101, 1, 1, Map.of("n_1", 1), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -204,7 +204,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
     public void testCanAssign_GivenEnoughMemory() {
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 100, 3, 2, Map.of(), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 100, 3, 2, Map.of(), 0);
 
         AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
 
@@ -219,13 +219,13 @@ public class AssignmentPlanTests extends ESTestCase {
         Node n = new Node("n_1", 100, 5);
 
         {
-            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 2), 0);
+            Deployment m = new AssignmentPlan.Deployment("m_1", 100, 3, 2, Map.of("n_1", 2), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planSatisfyingPreviousAssignments = builder.build();
         }
         {
-            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 3), 0);
+            AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 100, 3, 2, Map.of("n_1", 3), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planNotSatisfyingPreviousAssignments = builder.build();
@@ -239,7 +239,7 @@ public class AssignmentPlanTests extends ESTestCase {
         AssignmentPlan planWithMoreAllocations;
         AssignmentPlan planWithFewerAllocations;
         Node n = new Node("n_1", 100, 5);
-        Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 1), 0);
+        AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 100, 3, 2, Map.of("n_1", 1), 0);
 
         {
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
@@ -262,13 +262,13 @@ public class AssignmentPlanTests extends ESTestCase {
         Node n = new Node("n_1", 100, 5);
 
         {
-            Model m = new Model("m_1", 100, 3, 2, Map.of("n_1", 1), 0);
+            Deployment m = new AssignmentPlan.Deployment("m_1", 100, 3, 2, Map.of("n_1", 1), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planUsingMoreMemory = builder.build();
         }
         {
-            Model m = new Model("m_1", 99, 3, 2, Map.of("n_1", 1), 0);
+            AssignmentPlan.Deployment m = new AssignmentPlan.Deployment("m_1", 99, 3, 2, Map.of("n_1", 1), 0);
             AssignmentPlan.Builder builder = AssignmentPlan.builder(List.of(n), List.of(m));
             builder.assignModelToNode(m, n, 2);
             planUsingLessMemory = builder.build();
@@ -281,14 +281,14 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testSatisfiesAllModels_GivenAllModelsAreSatisfied() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 0);
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 0);
-        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 0);
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
-            .assignModelToNode(model1, node1, 1)
-            .assignModelToNode(model2, node2, 2)
-            .assignModelToNode(model3, node1, 2)
-            .assignModelToNode(model3, node2, 2)
+        AssignmentPlan.Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 50, 1, 2, Map.of(), 0);
+        AssignmentPlan.Deployment deployment2 = new AssignmentPlan.Deployment("m_2", 30, 2, 1, Map.of(), 0);
+        AssignmentPlan.Deployment deployment3 = new AssignmentPlan.Deployment("m_3", 20, 4, 1, Map.of(), 0);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2, deployment3))
+            .assignModelToNode(deployment1, node1, 1)
+            .assignModelToNode(deployment2, node2, 2)
+            .assignModelToNode(deployment3, node1, 2)
+            .assignModelToNode(deployment3, node2, 2)
             .build();
         assertThat(plan.satisfiesAllModels(), is(true));
     }
@@ -296,14 +296,14 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testSatisfiesAllModels_GivenOneModelHasOneAllocationLess() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 0);
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 0);
-        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 0);
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
-            .assignModelToNode(model1, node1, 1)
-            .assignModelToNode(model2, node2, 2)
-            .assignModelToNode(model3, node1, 1)
-            .assignModelToNode(model3, node2, 2)
+        AssignmentPlan.Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 50, 1, 2, Map.of(), 0);
+        AssignmentPlan.Deployment deployment2 = new AssignmentPlan.Deployment("m_2", 30, 2, 1, Map.of(), 0);
+        Deployment deployment3 = new Deployment("m_3", 20, 4, 1, Map.of(), 0);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2, deployment3))
+            .assignModelToNode(deployment1, node1, 1)
+            .assignModelToNode(deployment2, node2, 2)
+            .assignModelToNode(deployment3, node1, 1)
+            .assignModelToNode(deployment3, node2, 2)
             .build();
         assertThat(plan.satisfiesAllModels(), is(false));
     }
@@ -311,12 +311,12 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testArePreviouslyAssignedModelsAssigned_GivenTrue() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 3);
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 4);
-        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 0);
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3))
-            .assignModelToNode(model1, node1, 1)
-            .assignModelToNode(model2, node2, 1)
+        AssignmentPlan.Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 50, 1, 2, Map.of(), 3);
+        AssignmentPlan.Deployment deployment2 = new Deployment("m_2", 30, 2, 1, Map.of(), 4);
+        AssignmentPlan.Deployment deployment3 = new AssignmentPlan.Deployment("m_3", 20, 4, 1, Map.of(), 0);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2, deployment3))
+            .assignModelToNode(deployment1, node1, 1)
+            .assignModelToNode(deployment2, node2, 1)
             .build();
         assertThat(plan.arePreviouslyAssignedModelsAssigned(), is(true));
     }
@@ -324,10 +324,10 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testArePreviouslyAssignedModelsAssigned_GivenFalse() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 3);
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 4);
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2))
-            .assignModelToNode(model1, node1, 1)
+        AssignmentPlan.Deployment deployment1 = new Deployment("m_1", 50, 1, 2, Map.of(), 3);
+        AssignmentPlan.Deployment deployment2 = new AssignmentPlan.Deployment("m_2", 30, 2, 1, Map.of(), 4);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2))
+            .assignModelToNode(deployment1, node1, 1)
             .build();
         assertThat(plan.arePreviouslyAssignedModelsAssigned(), is(false));
     }
@@ -335,13 +335,13 @@ public class AssignmentPlanTests extends ESTestCase {
     public void testCountPreviouslyAssignedThatAreStillAssigned() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 50, 1, 2, Map.of(), 3);
-        Model model2 = new Model("m_2", 30, 2, 1, Map.of(), 4);
-        Model model3 = new Model("m_3", 20, 4, 1, Map.of(), 1);
-        Model model4 = new Model("m_4", 20, 4, 1, Map.of(), 0);
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2, model3, model4))
-            .assignModelToNode(model1, node1, 1)
-            .assignModelToNode(model2, node2, 1)
+        Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 50, 1, 2, Map.of(), 3);
+        AssignmentPlan.Deployment deployment2 = new AssignmentPlan.Deployment("m_2", 30, 2, 1, Map.of(), 4);
+        AssignmentPlan.Deployment deployment3 = new AssignmentPlan.Deployment("m_3", 20, 4, 1, Map.of(), 1);
+        AssignmentPlan.Deployment deployment4 = new AssignmentPlan.Deployment("m_4", 20, 4, 1, Map.of(), 0);
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2, deployment3, deployment4))
+            .assignModelToNode(deployment1, node1, 1)
+            .assignModelToNode(deployment2, node2, 1)
             .build();
         assertThat(plan.countPreviouslyAssignedModelsThatAreStillAssigned(), equalTo(2L));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/AssignmentPlanTests.java
@@ -133,7 +133,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
         assertThat(
             e.getMessage(),
-            equalTo("not enough cores on node [n_1] to assign [5] allocations to model [m_1]; required threads per allocation [1]")
+            equalTo("not enough cores on node [n_1] to assign [5] allocations to deployment [m_1]; required threads per allocation [1]")
         );
     }
 
@@ -146,7 +146,7 @@ public class AssignmentPlanTests extends ESTestCase {
 
         assertThat(
             e.getMessage(),
-            equalTo("not enough cores on node [n_1] to assign [3] allocations to model [m_1]; required threads per allocation [2]")
+            equalTo("not enough cores on node [n_1] to assign [3] allocations to deployment [m_1]; required threads per allocation [2]")
         );
     }
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocationsTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveAllAllocationsTests.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.ml.inference.assignment.planning;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Deployment;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.List;
@@ -24,23 +24,29 @@ public class PreserveAllAllocationsTests extends ESTestCase {
     public void testGivenNoPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of(), 0);
-        Model model2 = new Model("m_2", 30, 2, 4, Map.of(), 0);
-        PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node1, node2), List.of(model1, model2));
+        Deployment deployment1 = new Deployment("m_1", 30, 2, 1, Map.of(), 0);
+        Deployment deployment2 = new Deployment("m_2", 30, 2, 4, Map.of(), 0);
+        PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(
+            List.of(node1, node2),
+            List.of(deployment1, deployment2)
+        );
 
         List<Node> nodesPreservingAllocations = preserveAllAllocations.nodesPreservingAllocations();
         assertThat(nodesPreservingAllocations, contains(node1, node2));
 
-        List<Model> modelsPreservingAllocations = preserveAllAllocations.modelsPreservingAllocations();
-        assertThat(modelsPreservingAllocations, contains(model1, model2));
+        List<AssignmentPlan.Deployment> modelsPreservingAllocations = preserveAllAllocations.modelsPreservingAllocations();
+        assertThat(modelsPreservingAllocations, contains(deployment1, deployment2));
     }
 
     public void testGivenPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 8);
         Node node2 = new Node("n_2", 100, 8);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of("n_1", 1), 1);
-        Model model2 = new Model("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2), 3);
-        PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node1, node2), List.of(model1, model2));
+        Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 30, 2, 1, Map.of("n_1", 1), 1);
+        Deployment deployment2 = new Deployment("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2), 3);
+        PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(
+            List.of(node1, node2),
+            List.of(deployment1, deployment2)
+        );
 
         List<Node> nodesPreservingAllocations = preserveAllAllocations.nodesPreservingAllocations();
         assertThat(nodesPreservingAllocations, hasSize(2));
@@ -53,7 +59,7 @@ public class PreserveAllAllocationsTests extends ESTestCase {
         assertThat(nodesPreservingAllocations.get(1).availableMemoryBytes(), equalTo(50L));
         assertThat(nodesPreservingAllocations.get(1).cores(), equalTo(0));
 
-        List<Model> modelsPreservingAllocations = preserveAllAllocations.modelsPreservingAllocations();
+        List<AssignmentPlan.Deployment> modelsPreservingAllocations = preserveAllAllocations.modelsPreservingAllocations();
         assertThat(modelsPreservingAllocations, hasSize(2));
 
         assertThat(modelsPreservingAllocations.get(0).id(), equalTo("m_1"));
@@ -68,16 +74,16 @@ public class PreserveAllAllocationsTests extends ESTestCase {
         assertThat(modelsPreservingAllocations.get(1).threadsPerAllocation(), equalTo(4));
         assertThat(modelsPreservingAllocations.get(1).currentAllocationsByNodeId(), equalTo(Map.of("n_1", 0, "n_2", 0)));
 
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2))
-            .assignModelToNode(model1, node1, 2)
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2))
+            .assignModelToNode(deployment1, node1, 2)
             .build();
-        assertThat(plan.assignments(model1).get(), equalTo(Map.of(node1, 2)));
-        assertThat(plan.assignments(model2).isEmpty(), is(true));
+        assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 2)));
+        assertThat(plan.assignments(deployment2).isEmpty(), is(true));
 
         plan = preserveAllAllocations.mergePreservedAllocations(plan);
 
-        assertThat(plan.assignments(model1).get(), equalTo(Map.of(node1, 3)));
-        assertThat(plan.assignments(model2).get(), equalTo(Map.of(node1, 1, node2, 2)));
+        assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 3)));
+        assertThat(plan.assignments(deployment2).get(), equalTo(Map.of(node1, 1, node2, 2)));
         assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(20L));
         assertThat(plan.getRemainingNodeCores("n_1"), equalTo(1));
         assertThat(plan.getRemainingNodeMemory("n_2"), equalTo(50L));
@@ -86,15 +92,15 @@ public class PreserveAllAllocationsTests extends ESTestCase {
 
     public void testGivenModelWithPreviousAssignments_AndPlanToMergeHasNoAssignments() {
         Node node = new Node("n_1", 100, 4);
-        Model model = new Model("m_1", 30, 2, 2, Map.of("n_1", 2), 2);
-        PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node), List.of(model));
+        AssignmentPlan.Deployment deployment = new Deployment("m_1", 30, 2, 2, Map.of("n_1", 2), 2);
+        PreserveAllAllocations preserveAllAllocations = new PreserveAllAllocations(List.of(node), List.of(deployment));
 
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(model)).build();
-        assertThat(plan.assignments(model).isEmpty(), is(true));
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(deployment)).build();
+        assertThat(plan.assignments(deployment).isEmpty(), is(true));
 
         plan = preserveAllAllocations.mergePreservedAllocations(plan);
-        assertThat(plan.assignments(model).isPresent(), is(true));
-        assertThat(plan.assignments(model).get(), equalTo(Map.of(node, 2)));
+        assertThat(plan.assignments(deployment).isPresent(), is(true));
+        assertThat(plan.assignments(deployment).get(), equalTo(Map.of(node, 2)));
         assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(70L));
         assertThat(plan.getRemainingNodeCores("n_1"), equalTo(0));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/assignment/planning/PreserveOneAllocationTests.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.ml.inference.assignment.planning;
 
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Model;
+import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Deployment;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AssignmentPlan.Node;
 
 import java.util.List;
@@ -24,23 +24,23 @@ public class PreserveOneAllocationTests extends ESTestCase {
     public void testGivenNoPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 4);
         Node node2 = new Node("n_2", 100, 4);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of(), 0);
-        Model model2 = new Model("m_2", 30, 2, 4, Map.of(), 0);
-        PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node1, node2), List.of(model1, model2));
+        Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 30, 2, 1, Map.of(), 0);
+        AssignmentPlan.Deployment deployment2 = new Deployment("m_2", 30, 2, 4, Map.of(), 0);
+        PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node1, node2), List.of(deployment1, deployment2));
 
         List<Node> nodesPreservingAllocations = preserveOneAllocation.nodesPreservingAllocations();
         assertThat(nodesPreservingAllocations, contains(node1, node2));
 
-        List<Model> modelsPreservingAllocations = preserveOneAllocation.modelsPreservingAllocations();
-        assertThat(modelsPreservingAllocations, contains(model1, model2));
+        List<AssignmentPlan.Deployment> modelsPreservingAllocations = preserveOneAllocation.modelsPreservingAllocations();
+        assertThat(modelsPreservingAllocations, contains(deployment1, deployment2));
     }
 
     public void testGivenPreviousAssignments() {
         Node node1 = new Node("n_1", 100, 8);
         Node node2 = new Node("n_2", 100, 8);
-        Model model1 = new Model("m_1", 30, 2, 1, Map.of("n_1", 1), 1);
-        Model model2 = new Model("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2), 3);
-        PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node1, node2), List.of(model1, model2));
+        AssignmentPlan.Deployment deployment1 = new AssignmentPlan.Deployment("m_1", 30, 2, 1, Map.of("n_1", 1), 1);
+        AssignmentPlan.Deployment deployment2 = new Deployment("m_2", 50, 6, 4, Map.of("n_1", 1, "n_2", 2), 3);
+        PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node1, node2), List.of(deployment1, deployment2));
 
         List<Node> nodesPreservingAllocations = preserveOneAllocation.nodesPreservingAllocations();
         assertThat(nodesPreservingAllocations, hasSize(2));
@@ -53,7 +53,7 @@ public class PreserveOneAllocationTests extends ESTestCase {
         assertThat(nodesPreservingAllocations.get(1).availableMemoryBytes(), equalTo(50L));
         assertThat(nodesPreservingAllocations.get(1).cores(), equalTo(4));
 
-        List<Model> modelsPreservingAllocations = preserveOneAllocation.modelsPreservingAllocations();
+        List<AssignmentPlan.Deployment> modelsPreservingAllocations = preserveOneAllocation.modelsPreservingAllocations();
         assertThat(modelsPreservingAllocations, hasSize(2));
 
         assertThat(modelsPreservingAllocations.get(0).id(), equalTo("m_1"));
@@ -68,17 +68,17 @@ public class PreserveOneAllocationTests extends ESTestCase {
         assertThat(modelsPreservingAllocations.get(1).threadsPerAllocation(), equalTo(4));
         assertThat(modelsPreservingAllocations.get(1).currentAllocationsByNodeId(), equalTo(Map.of("n_1", 0, "n_2", 1)));
 
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(model1, model2))
-            .assignModelToNode(model1, node1, 2)
-            .assignModelToNode(model2, node2, 1)
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node1, node2), List.of(deployment1, deployment2))
+            .assignModelToNode(deployment1, node1, 2)
+            .assignModelToNode(deployment2, node2, 1)
             .build();
-        assertThat(plan.assignments(model1).get(), equalTo(Map.of(node1, 2)));
-        assertThat(plan.assignments(model2).get(), equalTo(Map.of(node2, 1)));
+        assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 2)));
+        assertThat(plan.assignments(deployment2).get(), equalTo(Map.of(node2, 1)));
 
         plan = preserveOneAllocation.mergePreservedAllocations(plan);
 
-        assertThat(plan.assignments(model1).get(), equalTo(Map.of(node1, 3)));
-        assertThat(plan.assignments(model2).get(), equalTo(Map.of(node1, 1, node2, 2)));
+        assertThat(plan.assignments(deployment1).get(), equalTo(Map.of(node1, 3)));
+        assertThat(plan.assignments(deployment2).get(), equalTo(Map.of(node1, 1, node2, 2)));
         assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(20L));
         assertThat(plan.getRemainingNodeCores("n_1"), equalTo(1));
         assertThat(plan.getRemainingNodeMemory("n_2"), equalTo(50L));
@@ -87,15 +87,15 @@ public class PreserveOneAllocationTests extends ESTestCase {
 
     public void testGivenModelWithPreviousAssignments_AndPlanToMergeHasNoAssignments() {
         Node node = new Node("n_1", 100, 4);
-        Model model = new Model("m_1", 30, 2, 2, Map.of("n_1", 2), 2);
-        PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node), List.of(model));
+        AssignmentPlan.Deployment deployment = new Deployment("m_1", 30, 2, 2, Map.of("n_1", 2), 2);
+        PreserveOneAllocation preserveOneAllocation = new PreserveOneAllocation(List.of(node), List.of(deployment));
 
-        AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(model)).build();
-        assertThat(plan.assignments(model).isEmpty(), is(true));
+        AssignmentPlan plan = AssignmentPlan.builder(List.of(node), List.of(deployment)).build();
+        assertThat(plan.assignments(deployment).isEmpty(), is(true));
 
         plan = preserveOneAllocation.mergePreservedAllocations(plan);
-        assertThat(plan.assignments(model).isPresent(), is(true));
-        assertThat(plan.assignments(model).get(), equalTo(Map.of(node, 1)));
+        assertThat(plan.assignments(deployment).isPresent(), is(true));
+        assertThat(plan.assignments(deployment).get(), equalTo(Map.of(node, 1)));
         assertThat(plan.getRemainingNodeMemory("n_1"), equalTo(70L));
         assertThat(plan.getRemainingNodeCores("n_1"), equalTo(2));
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -70,6 +70,7 @@ public class DeploymentManagerTests extends ESTestCase {
         when(task.getId()).thenReturn(taskId);
         when(task.isStopped()).thenReturn(Boolean.FALSE);
         when(task.getModelId()).thenReturn("test-rejected");
+        when(task.getDeploymentId()).thenReturn("test-rejected-deployment");
 
         DeploymentManager deploymentManager = new DeploymentManager(
             mock(Client.class),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/TrainedModelDeploymentTaskTests.java
@@ -33,7 +33,7 @@ import static org.mockito.Mockito.verify;
 
 public class TrainedModelDeploymentTaskTests extends ESTestCase {
 
-    void assertTrackingComplete(Consumer<TrainedModelDeploymentTask> method, String modelId) {
+    void assertTrackingComplete(Consumer<TrainedModelDeploymentTask> method, String modelId, String deploymentId) {
         XPackLicenseState licenseState = mock(XPackLicenseState.class);
         LicensedFeature.Persistent feature = mock(LicensedFeature.Persistent.class);
         TrainedModelAssignmentNodeService nodeService = mock(TrainedModelAssignmentNodeService.class);
@@ -53,6 +53,7 @@ public class TrainedModelDeploymentTaskTests extends ESTestCase {
             Map.of(),
             new StartTrainedModelDeploymentAction.TaskParams(
                 modelId,
+                deploymentId,
                 randomLongBetween(1, Long.MAX_VALUE),
                 randomInt(5),
                 randomInt(5),
@@ -72,20 +73,21 @@ public class TrainedModelDeploymentTaskTests extends ESTestCase {
     }
 
     public void testMarkAsStopped() {
-        assertTrackingComplete(t -> t.markAsStopped("foo"), randomAlphaOfLength(10));
+        assertTrackingComplete(t -> t.markAsStopped("foo"), randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public void testOnStop() {
-        assertTrackingComplete(t -> t.stop("foo", ActionListener.noop()), randomAlphaOfLength(10));
+        assertTrackingComplete(t -> t.stop("foo", ActionListener.noop()), randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public void testCancelled() {
-        assertTrackingComplete(TrainedModelDeploymentTask::onCancelled, randomAlphaOfLength(10));
+        assertTrackingComplete(TrainedModelDeploymentTask::onCancelled, randomAlphaOfLength(10), randomAlphaOfLength(10));
     }
 
     public void testUpdateNumberOfAllocations() {
         StartTrainedModelDeploymentAction.TaskParams initialParams = new StartTrainedModelDeploymentAction.TaskParams(
             "test-model",
+            "test-deployment",
             randomLongBetween(1, Long.MAX_VALUE),
             randomIntBetween(1, 32),
             randomIntBetween(1, 32),
@@ -112,6 +114,7 @@ public class TrainedModelDeploymentTaskTests extends ESTestCase {
 
         StartTrainedModelDeploymentAction.TaskParams updatedParams = task.getParams();
         assertThat(updatedParams.getModelId(), equalTo(initialParams.getModelId()));
+        assertThat(updatedParams.getDeploymentId(), equalTo(initialParams.getDeploymentId()));
         assertThat(updatedParams.getModelBytes(), equalTo(initialParams.getModelBytes()));
         assertThat(updatedParams.getNumberOfAllocations(), equalTo(newNumberOfAllocations));
         assertThat(updatedParams.getThreadsPerAllocation(), equalTo(initialParams.getThreadsPerAllocation()));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/pytorch/process/PyTorchBuilderTests.java
@@ -51,7 +51,7 @@ public class PyTorchBuilderTests extends ESTestCase {
         new PyTorchBuilder(
             nativeController,
             processPipes,
-            new TaskParams("my_model", 42L, 4, 2, 1024, ByteSizeValue.ofBytes(12), Priority.NORMAL)
+            new TaskParams("my_model", "my_deployment", 42L, 4, 2, 1024, ByteSizeValue.ofBytes(12), Priority.NORMAL)
         ).build();
 
         verify(nativeController).startProcess(commandCaptor.capture());
@@ -70,8 +70,11 @@ public class PyTorchBuilderTests extends ESTestCase {
     }
 
     public void testBuildWithNoCache() throws IOException, InterruptedException {
-        new PyTorchBuilder(nativeController, processPipes, new TaskParams("my_model", 42L, 4, 2, 1024, ByteSizeValue.ZERO, Priority.NORMAL))
-            .build();
+        new PyTorchBuilder(
+            nativeController,
+            processPipes,
+            new TaskParams("my_model", "my_deployment", 42L, 4, 2, 1024, ByteSizeValue.ZERO, Priority.NORMAL)
+        ).build();
 
         verify(nativeController).startProcess(commandCaptor.capture());
 
@@ -91,7 +94,7 @@ public class PyTorchBuilderTests extends ESTestCase {
         new PyTorchBuilder(
             nativeController,
             processPipes,
-            new TaskParams("my_model", 42L, 1, 1, 1024, ByteSizeValue.ofBytes(42), Priority.LOW)
+            new TaskParams("my_model", "my_deployment", 42L, 1, 1, 1024, ByteSizeValue.ofBytes(42), Priority.LOW)
         ).build();
 
         verify(nativeController).startProcess(commandCaptor.capture());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadDetectorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/NodeLoadDetectorTests.java
@@ -129,6 +129,7 @@ public class NodeLoadDetectorTests extends ESTestCase {
                                 TrainedModelAssignment.Builder.empty(
                                     new StartTrainedModelDeploymentAction.TaskParams(
                                         "model1",
+                                        "deployment1",
                                         MODEL_MEMORY_REQUIREMENT,
                                         1,
                                         1,

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -90,7 +90,7 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
         }
 
         var response = InferModelAction.Response.builder()
-            .setModelId(request.getModelId())
+            .setId(request.getId())
             .addInferenceResults(List.of(new TextExpansionResults("foo", tokens, randomBoolean())))
             .build();
         @SuppressWarnings("unchecked")  // We matched the method above.

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/vectors/TextEmbeddingQueryVectorBuilderTests.java
@@ -37,7 +37,7 @@ public class TextEmbeddingQueryVectorBuilderTests extends AbstractQueryVectorBui
         InferModelAction.Request inferRequest = (InferModelAction.Request) request;
         assertThat(inferRequest.getTextInput(), hasSize(1));
         assertEquals(builder.getModelText(), inferRequest.getTextInput().get(0));
-        assertEquals(builder.getModelId(), inferRequest.getModelId());
+        assertEquals(builder.getModelId(), inferRequest.getId());
     }
 
     public ActionResponse createResponse(float[] array, TextEmbeddingQueryVectorBuilder builder) {


### PR DESCRIPTION
This change is largely a refactor renaming parameters and getters to `deploymentId` etc. The task params and some of the request objects have had a new field added. This refactor does not change any functionality that will follow later as the PR is very large already.
