### PR TITLE
95017 fix downsampling step

### DIFF
--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -295,7 +295,7 @@ as well as the various CPU and memory time series metrics.
 // TEST[skip:todo]
 // TEST[continued]
 
-Next, run a terms aggregation on the set of time series dimensions (`_tsid`) to
+Next, you can run a terms aggregation on the set of time series dimensions (`_tsid`) to
 create a date histogram on a fixed interval of one day.
 
 [source,console]
@@ -336,14 +336,6 @@ GET /sample-01*/_search
         }
     }
 }
-----
-// TEST[continued]
-
-Re-run your search query to view the aggregated time series data.
-
-[source,console]
-----
-GET /sample-01*/_search
 ----
 // TEST[continued]
 

--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -296,7 +296,7 @@ as well as the various CPU and memory time series metrics.
 // TEST[continued]
 
 Next, you can run a terms aggregation on the set of time series dimensions (`_tsid`) to
-create a date histogram on a fixed interval of one day.
+view a date histogram on a fixed interval of one day.
 
 [source,console]
 ----


### PR DESCRIPTION
The [manual downsampling example](https://www.elastic.co/guide/en/elasticsearch/reference/current/downsampling-manual.html) in our docs has an extra, unneeded and incorrect step, so this removes it.

```
Re-run your search query to view the aggregated time series data.
GET /sample-01*/_search
```

The re-run of `GET /sample-01*/_search` appears later in the page, after the user has run downsampling.

Closes #95017 