### PR TITLE
Deeper chunking of node stats response

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ToXContent.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ToXContent.java
@@ -122,4 +122,5 @@ public interface ToXContent {
         return true;
     }
 
+    ToXContent EMPTY = (b, p) -> b;
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/TasksIT.java
@@ -456,7 +456,7 @@ public class TasksIT extends ESIntegTestCase {
             // Need to run the task in a separate thread because node client's .execute() is blocked by our task listener
             index = new Thread(() -> {
                 IndexResponse indexResponse = client().prepareIndex("test").setSource("test", "test").get();
-                assertArrayEquals(ReplicationResponse.EMPTY, indexResponse.getShardInfo().getFailures());
+                assertArrayEquals(ReplicationResponse.NO_FAILURES, indexResponse.getShardInfo().getFailures());
             });
             index.start();
             assertTrue(taskRegistered.await(10, TimeUnit.SECONDS)); // waiting for at least one task to be registered

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -11,8 +11,10 @@ package org.elasticsearch.action.admin.cluster.node.stats;
 import org.elasticsearch.action.support.nodes.BaseNodeResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.discovery.DiscoveryStats;
 import org.elasticsearch.http.HttpStats;
@@ -29,16 +31,17 @@ import org.elasticsearch.script.ScriptCacheStats;
 import org.elasticsearch.script.ScriptStats;
 import org.elasticsearch.threadpool.ThreadPoolStats;
 import org.elasticsearch.transport.TransportStats;
-import org.elasticsearch.xcontent.ToXContentFragment;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
+import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Node statistics (dynamic, changes depending on when created).
  */
-public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
+public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
 
     private final long timestamp;
 
@@ -275,72 +278,63 @@ public class NodeStats extends BaseNodeResponse implements ToXContentFragment {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
 
-        builder.field("name", getNode().getName());
-        builder.field("transport_address", getNode().getAddress().toString());
-        builder.field("host", getNode().getHostName());
-        builder.field("ip", getNode().getAddress());
+        return Iterators.concat(Iterators.single((builder, params) -> {
+            builder.field("name", getNode().getName());
+            builder.field("transport_address", getNode().getAddress().toString());
+            builder.field("host", getNode().getHostName());
+            builder.field("ip", getNode().getAddress());
 
-        builder.startArray("roles");
-        for (DiscoveryNodeRole role : getNode().getRoles()) {
-            builder.value(role.roleName());
-        }
-        builder.endArray();
-
-        if (getNode().getAttributes().isEmpty() == false) {
-            builder.startObject("attributes");
-            for (Map.Entry<String, String> attrEntry : getNode().getAttributes().entrySet()) {
-                builder.field(attrEntry.getKey(), attrEntry.getValue());
+            builder.startArray("roles");
+            for (DiscoveryNodeRole role : getNode().getRoles()) {
+                builder.value(role.roleName());
             }
-            builder.endObject();
-        }
+            builder.endArray();
 
-        if (getIndices() != null) {
-            getIndices().toXContent(builder, params);
-        }
-        if (getOs() != null) {
-            getOs().toXContent(builder, params);
-        }
-        if (getProcess() != null) {
-            getProcess().toXContent(builder, params);
-        }
-        if (getJvm() != null) {
-            getJvm().toXContent(builder, params);
-        }
-        if (getThreadPool() != null) {
-            getThreadPool().toXContent(builder, params);
-        }
-        if (getFs() != null) {
-            getFs().toXContent(builder, params);
-        }
-        if (getTransport() != null) {
-            getTransport().toXContent(builder, params);
-        }
-        if (getHttp() != null) {
-            getHttp().toXContent(builder, params);
-        }
-        if (getBreaker() != null) {
-            getBreaker().toXContent(builder, params);
-        }
-        if (getScriptStats() != null) {
-            getScriptStats().toXContent(builder, params);
-        }
-        if (getDiscoveryStats() != null) {
-            getDiscoveryStats().toXContent(builder, params);
-        }
-        if (getIngestStats() != null) {
-            getIngestStats().toXContent(builder, params);
-        }
-        if (getAdaptiveSelectionStats() != null) {
-            getAdaptiveSelectionStats().toXContent(builder, params);
-        }
-        if (getScriptCacheStats() != null) {
-            getScriptCacheStats().toXContent(builder, params);
-        }
-        if (getIndexingPressureStats() != null) {
-            getIndexingPressureStats().toXContent(builder, params);
-        }
-        return builder;
+            if (getNode().getAttributes().isEmpty() == false) {
+                builder.startObject("attributes");
+                for (Map.Entry<String, String> attrEntry : getNode().getAttributes().entrySet()) {
+                    builder.field(attrEntry.getKey(), attrEntry.getValue());
+                }
+                builder.endObject();
+            }
+
+            return builder;
+        }),
+
+            ifPresent(getIndices()).toXContentChunked(outerParams),
+
+            Iterators.single((builder, params) -> {
+                ifPresent(getOs()).toXContent(builder, params);
+                ifPresent(getProcess()).toXContent(builder, params);
+                ifPresent(getJvm()).toXContent(builder, params);
+                ifPresent(getThreadPool()).toXContent(builder, params);
+                ifPresent(getFs()).toXContent(builder, params);
+                return builder;
+            }),
+
+            ifPresent(getTransport()).toXContentChunked(outerParams),
+            ifPresent(getHttp()).toXContentChunked(outerParams),
+
+            Iterators.single((builder, params) -> {
+                ifPresent(getBreaker()).toXContent(builder, params);
+                ifPresent(getScriptStats()).toXContent(builder, params);
+                ifPresent(getDiscoveryStats()).toXContent(builder, params);
+                ifPresent(getIngestStats()).toXContent(builder, params);
+                ifPresent(getAdaptiveSelectionStats()).toXContent(builder, params);
+                ifPresent(getScriptCacheStats()).toXContent(builder, params);
+                ifPresent(getIndexingPressureStats()).toXContent(builder, params);
+                return builder;
+            })
+        );
+    }
+
+    private static ChunkedToXContent ifPresent(@Nullable ChunkedToXContent chunkedToXContent) {
+        return Objects.requireNonNullElse(chunkedToXContent, ChunkedToXContent.EMPTY);
+    }
+
+    private static ToXContent ifPresent(@Nullable ToXContent toXContent) {
+        return Objects.requireNonNullElse(toXContent, ToXContent.EMPTY);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -280,28 +280,30 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
 
-        return Iterators.concat(Iterators.single((builder, params) -> {
-            builder.field("name", getNode().getName());
-            builder.field("transport_address", getNode().getAddress().toString());
-            builder.field("host", getNode().getHostName());
-            builder.field("ip", getNode().getAddress());
+        return Iterators.concat(
 
-            builder.startArray("roles");
-            for (DiscoveryNodeRole role : getNode().getRoles()) {
-                builder.value(role.roleName());
-            }
-            builder.endArray();
+            Iterators.single((builder, params) -> {
+                builder.field("name", getNode().getName());
+                builder.field("transport_address", getNode().getAddress().toString());
+                builder.field("host", getNode().getHostName());
+                builder.field("ip", getNode().getAddress());
 
-            if (getNode().getAttributes().isEmpty() == false) {
-                builder.startObject("attributes");
-                for (Map.Entry<String, String> attrEntry : getNode().getAttributes().entrySet()) {
-                    builder.field(attrEntry.getKey(), attrEntry.getValue());
+                builder.startArray("roles");
+                for (DiscoveryNodeRole role : getNode().getRoles()) {
+                    builder.value(role.roleName());
                 }
-                builder.endObject();
-            }
+                builder.endArray();
 
-            return builder;
-        }),
+                if (getNode().getAttributes().isEmpty() == false) {
+                    builder.startObject("attributes");
+                    for (Map.Entry<String, String> attrEntry : getNode().getAttributes().entrySet()) {
+                        builder.field(attrEntry.getKey(), attrEntry.getValue());
+                    }
+                    builder.endObject();
+                }
+
+                return builder;
+            }),
 
             ifPresent(getIndices()).toXContentChunked(outerParams),
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodesStatsResponse.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
@@ -42,16 +43,15 @@ public class NodesStatsResponse extends BaseNodesXContentResponse<NodeStats> {
     }
 
     @Override
-    protected Iterator<? extends ToXContent> xContentChunks() {
+    protected Iterator<? extends ToXContent> xContentChunks(ToXContent.Params outerParams) {
         return Iterators.concat(
-            Iterators.single((b, p) -> b.startObject("nodes")),
-            getNodes().stream().map(nodeStats -> (ToXContent) (b, p) -> {
-                b.startObject(nodeStats.getNode().getId());
-                b.field("timestamp", nodeStats.getTimestamp());
-                nodeStats.toXContent(b, p);
-                return b.endObject();
-            }).iterator(),
-            Iterators.single((b, p) -> b.endObject())
+            ChunkedToXContentHelper.startObject("nodes"),
+            Iterators.flatMap(getNodes().iterator(), nodeStats -> Iterators.concat(Iterators.single((builder, params) -> {
+                builder.startObject(nodeStats.getNode().getId());
+                builder.field("timestamp", nodeStats.getTimestamp());
+                return builder;
+            }), nodeStats.toXContentChunked(outerParams), ChunkedToXContentHelper.endObject())),
+            ChunkedToXContentHelper.endObject()
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/nodes/BaseNodesXContentResponse.java
@@ -13,6 +13,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.rest.action.RestActions;
 import org.elasticsearch.xcontent.ToXContent;
 
@@ -38,8 +39,8 @@ public abstract class BaseNodesXContentResponse<TNodeResponse extends BaseNodeRe
             b.startObject();
             RestActions.buildNodesHeader(b, p, this);
             return b.field("cluster_name", getClusterName().value());
-        }), xContentChunks(), Iterators.single((ToXContent) (b, p) -> b.endObject()));
+        }), xContentChunks(params), ChunkedToXContentHelper.endObject());
     }
 
-    protected abstract Iterator<? extends ToXContent> xContentChunks();
+    protected abstract Iterator<? extends ToXContent> xContentChunks(ToXContent.Params outerParams);
 }

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationOperation.java
@@ -465,7 +465,7 @@ public class ReplicationOperation<
         if (finished.compareAndSet(false, true)) {
             final ReplicationResponse.ShardInfo.Failure[] failuresArray;
             if (shardReplicaFailures.isEmpty()) {
-                failuresArray = ReplicationResponse.EMPTY;
+                failuresArray = ReplicationResponse.NO_FAILURES;
             } else {
                 failuresArray = new ReplicationResponse.ShardInfo.Failure[shardReplicaFailures.size()];
                 shardReplicaFailures.toArray(failuresArray);

--- a/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/ReplicationResponse.java
@@ -35,7 +35,7 @@ import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpect
  */
 public class ReplicationResponse extends ActionResponse {
 
-    public static final ReplicationResponse.ShardInfo.Failure[] EMPTY = new ReplicationResponse.ShardInfo.Failure[0];
+    public static final ReplicationResponse.ShardInfo.Failure[] NO_FAILURES = new ReplicationResponse.ShardInfo.Failure[0];
 
     private ShardInfo shardInfo;
 
@@ -68,7 +68,7 @@ public class ReplicationResponse extends ActionResponse {
 
         private int total;
         private int successful;
-        private Failure[] failures = EMPTY;
+        private Failure[] failures = ReplicationResponse.NO_FAILURES;
 
         public ShardInfo() {}
 
@@ -186,7 +186,7 @@ public class ReplicationResponse extends ActionResponse {
                     parser.skipChildren(); // skip potential inner arrays for forward compatibility
                 }
             }
-            Failure[] failures = EMPTY;
+            Failure[] failures = ReplicationResponse.NO_FAILURES;
             if (failuresList != null) {
                 failures = failuresList.toArray(new Failure[failuresList.size()]);
             }

--- a/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/xcontent/ChunkedToXContent.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Iterator;
 
 /**
@@ -84,4 +85,9 @@ public interface ChunkedToXContent {
     default boolean isFragment() {
         return true;
     }
+
+    /**
+     * A {@link ChunkedToXContent} that yields no chunks
+     */
+    ChunkedToXContent EMPTY = params -> Collections.emptyIterator();
 }

--- a/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
+++ b/server/src/main/java/org/elasticsearch/indices/NodeIndicesStats.java
@@ -13,9 +13,12 @@ import org.elasticsearch.action.NodeStatsLevel;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
+import org.elasticsearch.common.xcontent.ChunkedToXContentHelper;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.bulk.stats.BulkStats;
@@ -37,12 +40,13 @@ import org.elasticsearch.index.store.StoreStats;
 import org.elasticsearch.index.translog.TranslogStats;
 import org.elasticsearch.index.warmer.WarmerStats;
 import org.elasticsearch.search.suggest.completion.CompletionStats;
-import org.elasticsearch.xcontent.ToXContentFragment;
-import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.ToXContent;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -50,7 +54,7 @@ import java.util.Objects;
 /**
  * Global information on indices stats running on a specific node.
  */
-public class NodeIndicesStats implements Writeable, ToXContentFragment {
+public class NodeIndicesStats implements Writeable, ChunkedToXContent {
 
     private static final TransportVersion VERSION_SUPPORTING_STATS_BY_INDEX = TransportVersion.V_8_5_0;
 
@@ -216,40 +220,50 @@ public class NodeIndicesStats implements Writeable, ToXContentFragment {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        final NodeStatsLevel level = NodeStatsLevel.of(params, NodeStatsLevel.NODE);
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
 
-        // "node" level
-        builder.startObject(Fields.INDICES);
-        stats.toXContent(builder, params);
-
-        if (level == NodeStatsLevel.INDICES) {
-            Map<Index, CommonStats> indexStats = createCommonStatsByIndex();
+        return Iterators.concat(Iterators.single((builder, params) -> {
             builder.startObject(Fields.INDICES);
-            for (Map.Entry<Index, CommonStats> entry : indexStats.entrySet()) {
-                builder.startObject(entry.getKey().getName());
-                entry.getValue().toXContent(builder, params);
-                builder.endObject();
-            }
-            builder.endObject();
-        } else if (level == NodeStatsLevel.SHARDS) {
-            builder.startObject(Fields.SHARDS);
-            for (Map.Entry<Index, List<IndexShardStats>> entry : statsByShard.entrySet()) {
-                builder.startArray(entry.getKey().getName());
-                for (IndexShardStats indexShardStats : entry.getValue()) {
-                    builder.startObject().startObject(String.valueOf(indexShardStats.getShardId().getId()));
-                    for (ShardStats shardStats : indexShardStats.getShards()) {
-                        shardStats.toXContent(builder, params);
-                    }
-                    builder.endObject().endObject();
-                }
-                builder.endArray();
-            }
-            builder.endObject();
-        }
+            return stats.toXContent(builder, params);
+        }), switch (NodeStatsLevel.of(outerParams, NodeStatsLevel.NODE)) {
 
-        builder.endObject();
-        return builder;
+            case NODE -> Collections.<ToXContent>emptyIterator();
+
+            case INDICES -> Iterators.concat(
+                ChunkedToXContentHelper.startObject(Fields.INDICES),
+                Iterators.flatMap(
+                    createCommonStatsByIndex().entrySet().iterator(),
+                    entry -> Iterators.<ToXContent>single((builder, params) -> {
+                        builder.startObject(entry.getKey().getName());
+                        entry.getValue().toXContent(builder, params);
+                        return builder.endObject();
+                    })
+                ),
+                ChunkedToXContentHelper.endObject()
+            );
+
+            case SHARDS -> Iterators.concat(
+                ChunkedToXContentHelper.startObject(Fields.SHARDS),
+                Iterators.flatMap(
+                    statsByShard.entrySet().iterator(),
+                    entry -> Iterators.concat(
+                        ChunkedToXContentHelper.startArray(entry.getKey().getName()),
+                        Iterators.flatMap(
+                            entry.getValue().iterator(),
+                            indexShardStats -> Iterators.<ToXContent>concat(
+                                Iterators.single(
+                                    (b, p) -> b.startObject().startObject(String.valueOf(indexShardStats.getShardId().getId()))
+                                ),
+                                Iterators.flatMap(Iterators.forArray(indexShardStats.getShards()), Iterators::<ToXContent>single),
+                                Iterators.single((b, p) -> b.endObject().endObject())
+                            )
+                        ),
+                        ChunkedToXContentHelper.endArray()
+                    )
+                ),
+                ChunkedToXContentHelper.endObject()
+            );
+        }, ChunkedToXContentHelper.endObject());
     }
 
     private Map<Index, CommonStats> createCommonStatsByIndex() {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorFactories.java
@@ -389,7 +389,7 @@ public class AggregatorFactories {
 
         public AggregatorFactories build(AggregationContext context, AggregatorFactory parent) throws IOException {
             if (aggregationBuilders.isEmpty() && pipelineAggregatorBuilders.isEmpty()) {
-                return EMPTY;
+                return AggregatorFactories.EMPTY;
             }
             AggregatorFactory[] aggFactories = new AggregatorFactory[aggregationBuilders.size()];
             int i = 0;

--- a/server/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -10,21 +10,24 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
+import org.elasticsearch.common.collect.Iterators;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.network.HandlingTimeTracker;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.xcontent.ToXContentFragment;
+import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.Map;
 
-public class TransportStats implements Writeable, ToXContentFragment {
+public class TransportStats implements Writeable, ChunkedToXContent {
 
     private final long serverOpen;
     private final long totalOutboundConnections;
@@ -182,34 +185,39 @@ public class TransportStats implements Writeable, ToXContentFragment {
     }
 
     @Override
-    public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-        builder.startObject(Fields.TRANSPORT);
-        builder.field(Fields.SERVER_OPEN, serverOpen);
-        builder.field(Fields.TOTAL_OUTBOUND_CONNECTIONS, totalOutboundConnections);
-        builder.field(Fields.RX_COUNT, rxCount);
-        builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, ByteSizeValue.ofBytes(rxSize));
-        builder.field(Fields.TX_COUNT, txCount);
-        builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, ByteSizeValue.ofBytes(txSize));
-        if (inboundHandlingTimeBucketFrequencies.length > 0) {
-            histogramToXContent(builder, inboundHandlingTimeBucketFrequencies, Fields.INBOUND_HANDLING_TIME_HISTOGRAM);
-            histogramToXContent(builder, outboundHandlingTimeBucketFrequencies, Fields.OUTBOUND_HANDLING_TIME_HISTOGRAM);
-        } else {
-            // Stats came from before v8.1
-            assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
-        }
-        if (transportActionStats.isEmpty() == false) {
-            builder.startObject(Fields.ACTIONS);
-            for (final var entry : transportActionStats.entrySet()) {
-                builder.field(entry.getKey());
-                entry.getValue().toXContent(builder, params);
+    public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
+        return Iterators.<ToXContent>concat(Iterators.single((builder, params) -> {
+            builder.startObject(Fields.TRANSPORT);
+            builder.field(Fields.SERVER_OPEN, serverOpen);
+            builder.field(Fields.TOTAL_OUTBOUND_CONNECTIONS, totalOutboundConnections);
+            builder.field(Fields.RX_COUNT, rxCount);
+            builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, ByteSizeValue.ofBytes(rxSize));
+            builder.field(Fields.TX_COUNT, txCount);
+            builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, ByteSizeValue.ofBytes(txSize));
+            if (inboundHandlingTimeBucketFrequencies.length > 0) {
+                histogramToXContent(builder, inboundHandlingTimeBucketFrequencies, Fields.INBOUND_HANDLING_TIME_HISTOGRAM);
+                histogramToXContent(builder, outboundHandlingTimeBucketFrequencies, Fields.OUTBOUND_HANDLING_TIME_HISTOGRAM);
+            } else {
+                // Stats came from before v8.1
+                assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
             }
-            builder.endObject();
-        } else {
-            // Stats came from before v8.8
-            assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
-        }
-        builder.endObject();
-        return builder;
+            if (transportActionStats.isEmpty() == false) {
+                builder.startObject(Fields.ACTIONS);
+            } else {
+                // Stats came from before v8.8
+                assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
+            }
+            return builder;
+        }), Iterators.flatMap(transportActionStats.entrySet().iterator(), entry -> Iterators.single((builder, params) -> {
+            builder.field(entry.getKey());
+            entry.getValue().toXContent(builder, params);
+            return builder;
+        })), Iterators.single((builder, params) -> {
+            if (transportActionStats.isEmpty() == false) {
+                builder.endObject();
+            }
+            return builder.endObject();
+        }));
     }
 
     static void histogramToXContent(XContentBuilder builder, long[] bucketFrequencies, String fieldName) throws IOException {

--- a/server/src/main/java/org/elasticsearch/transport/TransportStats.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportStats.java
@@ -186,38 +186,45 @@ public class TransportStats implements Writeable, ChunkedToXContent {
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params outerParams) {
-        return Iterators.<ToXContent>concat(Iterators.single((builder, params) -> {
-            builder.startObject(Fields.TRANSPORT);
-            builder.field(Fields.SERVER_OPEN, serverOpen);
-            builder.field(Fields.TOTAL_OUTBOUND_CONNECTIONS, totalOutboundConnections);
-            builder.field(Fields.RX_COUNT, rxCount);
-            builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, ByteSizeValue.ofBytes(rxSize));
-            builder.field(Fields.TX_COUNT, txCount);
-            builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, ByteSizeValue.ofBytes(txSize));
-            if (inboundHandlingTimeBucketFrequencies.length > 0) {
-                histogramToXContent(builder, inboundHandlingTimeBucketFrequencies, Fields.INBOUND_HANDLING_TIME_HISTOGRAM);
-                histogramToXContent(builder, outboundHandlingTimeBucketFrequencies, Fields.OUTBOUND_HANDLING_TIME_HISTOGRAM);
-            } else {
-                // Stats came from before v8.1
-                assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
-            }
-            if (transportActionStats.isEmpty() == false) {
-                builder.startObject(Fields.ACTIONS);
-            } else {
-                // Stats came from before v8.8
-                assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
-            }
-            return builder;
-        }), Iterators.flatMap(transportActionStats.entrySet().iterator(), entry -> Iterators.single((builder, params) -> {
-            builder.field(entry.getKey());
-            entry.getValue().toXContent(builder, params);
-            return builder;
-        })), Iterators.single((builder, params) -> {
-            if (transportActionStats.isEmpty() == false) {
-                builder.endObject();
-            }
-            return builder.endObject();
-        }));
+        return Iterators.<ToXContent>concat(
+
+            Iterators.single((builder, params) -> {
+                builder.startObject(Fields.TRANSPORT);
+                builder.field(Fields.SERVER_OPEN, serverOpen);
+                builder.field(Fields.TOTAL_OUTBOUND_CONNECTIONS, totalOutboundConnections);
+                builder.field(Fields.RX_COUNT, rxCount);
+                builder.humanReadableField(Fields.RX_SIZE_IN_BYTES, Fields.RX_SIZE, ByteSizeValue.ofBytes(rxSize));
+                builder.field(Fields.TX_COUNT, txCount);
+                builder.humanReadableField(Fields.TX_SIZE_IN_BYTES, Fields.TX_SIZE, ByteSizeValue.ofBytes(txSize));
+                if (inboundHandlingTimeBucketFrequencies.length > 0) {
+                    histogramToXContent(builder, inboundHandlingTimeBucketFrequencies, Fields.INBOUND_HANDLING_TIME_HISTOGRAM);
+                    histogramToXContent(builder, outboundHandlingTimeBucketFrequencies, Fields.OUTBOUND_HANDLING_TIME_HISTOGRAM);
+                } else {
+                    // Stats came from before v8.1
+                    assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
+                }
+                if (transportActionStats.isEmpty() == false) {
+                    builder.startObject(Fields.ACTIONS);
+                } else {
+                    // Stats came from before v8.8
+                    assert Version.CURRENT.major == Version.V_7_0_0.major + 1;
+                }
+                return builder;
+            }),
+
+            Iterators.flatMap(transportActionStats.entrySet().iterator(), entry -> Iterators.single((builder, params) -> {
+                builder.field(entry.getKey());
+                entry.getValue().toXContent(builder, params);
+                return builder;
+            })),
+
+            Iterators.single((builder, params) -> {
+                if (transportActionStats.isEmpty() == false) {
+                    builder.endObject();
+                }
+                return builder.endObject();
+            })
+        );
     }
 
     static void histogramToXContent(XContentBuilder builder, long[] bucketFrequencies, String fieldName) throws IOException {

--- a/server/src/test/java/org/elasticsearch/indices/NodeIndicesStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/NodeIndicesStatsTests.java
@@ -22,7 +22,7 @@ public class NodeIndicesStatsTests extends ESTestCase {
         final NodeIndicesStats stats = new NodeIndicesStats(null, Collections.emptyMap(), Collections.emptyMap());
         final String level = randomAlphaOfLength(16);
         final ToXContent.Params params = new ToXContent.MapParams(Collections.singletonMap("level", level));
-        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> stats.toXContent(null, params));
+        final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> stats.toXContentChunked(params));
         assertThat(
             e,
             hasToString(containsString("level parameter must be one of [node] or [indices] or [shards] but was [" + level + "]"))

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDoc.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDoc.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.monitoring.collector.node;
 
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
+import org.elasticsearch.common.xcontent.ChunkedToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xpack.core.monitoring.MonitoredSystem;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
@@ -69,7 +70,7 @@ public class NodeStatsMonitoringDoc extends FilteredMonitoringDoc {
             builder.field("node_id", nodeId);
             builder.field("node_master", nodeMaster);
             builder.field("mlockall", mlockall);
-            nodeStats.toXContent(builder, params);
+            ChunkedToXContent.wrapAsToXContent(nodeStats).toXContent(builder, params);
         }
         builder.endObject();
     }

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/FilteredMonitoringDoc.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/exporter/FilteredMonitoringDoc.java
@@ -10,6 +10,7 @@ import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
@@ -19,8 +20,6 @@ import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringDoc;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
-
-import static org.elasticsearch.xcontent.NamedXContentRegistry.EMPTY;
 
 /**
  * {@link FilteredMonitoringDoc} are a kind of {@link MonitoringDoc} whose XContent
@@ -66,7 +65,7 @@ public abstract class FilteredMonitoringDoc extends MonitoringDoc {
             }
             try (
                 InputStream stream = out.bytes().streamInput();
-                XContentParser parser = xContent.createParser(EMPTY, LoggingDeprecationHandler.INSTANCE, stream)
+                XContentParser parser = xContent.createParser(NamedXContentRegistry.EMPTY, LoggingDeprecationHandler.INSTANCE, stream)
             ) {
                 return builder.copyCurrentStructure(parser);
             }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/node/NodeStatsMonitoringDocTests.java
@@ -38,6 +38,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
@@ -47,7 +48,9 @@ import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCase<NodeStatsMonitoringDoc> {
 
@@ -63,6 +66,7 @@ public class NodeStatsMonitoringDocTests extends BaseFilteredMonitoringDocTestCa
         nodeId = randomAlphaOfLength(5);
         isMaster = randomBoolean();
         nodeStats = mock(NodeStats.class);
+        when(nodeStats.toXContentChunked(any())).thenReturn(Collections.emptyIterator());
         mlockall = randomBoolean();
     }
 


### PR DESCRIPTION
Pushes the chunking of `GET _nodes/stats` down to avoid creating unboundedly large chunks. With this commit we yield one chunk per shard (if `?level=shards`) or index (if `?level=indices`) and per HTTP client and per transport action.

Closes #93985