### PR TITLE
Align search application and behavioral analytics APIs with current guidelines

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
@@ -9,9 +9,6 @@
     "headers": {
       "accept": [
         "application/json"
-      ],
-      "content_type": [
-        "application/json"
       ]
     },
     "url": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete_behavioral_analytics.json
@@ -1,16 +1,13 @@
 {
-  "behavioral_analytics.put": {
+  "search_application.delete_behavioral_analytics": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
-      "description": "Creates a behavioral analytics collection."
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
+      "description": "Delete a behavioral analytics collection."
     },
     "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [
-        "application/json"
-      ],
-      "content_type": [
         "application/json"
       ]
     },
@@ -19,12 +16,12 @@
         {
           "path": "/_application/analytics/{name}",
           "methods": [
-            "PUT"
+            "DELETE"
           ],
           "parts": {
             "name": {
               "type": "string",
-              "description": "The name of the analytics collection to be created or updated"
+              "description": "The name of the analytics collection to be deleted"
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
@@ -9,9 +9,6 @@
     "headers": {
       "accept": [
         "application/json"
-      ],
-      "content_type": [
-        "application/json"
       ]
     },
     "url": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get_behavioral_analytics.json
@@ -1,5 +1,5 @@
 {
-  "behavioral_analytics.list": {
+  "search_application.get_behavioral_analytics": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html",
       "description": "Returns the existing behavioral analytics collections."
@@ -8,9 +8,6 @@
     "visibility": "public",
     "headers": {
       "accept": [
-        "application/json"
-      ],
-      "content_type": [
         "application/json"
       ]
     },

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
@@ -9,9 +9,6 @@
     "headers": {
       "accept": [
         "application/json"
-      ],
-      "content_type": [
-        "application/json"
       ]
     },
     "url": {

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
@@ -1,5 +1,5 @@
 {
-  "search_application.put_behavior_analytics": {
+  "search_application.put_behavioral_analytics": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
       "description": "Creates a behavioral analytics collection."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
@@ -1,16 +1,13 @@
 {
-  "behavioral_analytics.delete": {
+  "search_application.put_behavior_analytics": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
-      "description": "Delete a behavioral analytics collection."
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
+      "description": "Creates a behavioral analytics collection."
     },
     "stability": "beta",
     "visibility": "public",
     "headers": {
       "accept": [
-        "application/json"
-      ],
-      "content_type": [
         "application/json"
       ]
     },
@@ -19,12 +16,12 @@
         {
           "path": "/_application/analytics/{name}",
           "methods": [
-            "DELETE"
+            "PUT"
           ],
           "parts": {
             "name": {
               "type": "string",
-              "description": "The name of the analytics collection to be deleted"
+              "description": "The name of the analytics collection to be created or updated"
             }
           }
         }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
@@ -1,23 +1,23 @@
 setup:
   - do:
-      behavioral_analytics.put:
+      search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
 
   - do:
-      behavioral_analytics.put:
+      search_application.put_behavioral_analytics:
         name: my-test-analytics-collection2
 
 ---
 teardown:
   - do:
-      behavioral_analytics.delete:
+      search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
         ignore: 404
 
 ---
 "Get Analytics Collection for a particular collection":
   - do:
-      behavioral_analytics.list:
+      search_application.get_behavioral_analytics:
         name: my-test-analytics-collection
 
   - match: {
@@ -31,7 +31,7 @@ teardown:
 ---
 "Get Analytics Collection list":
   - do:
-      behavioral_analytics.list:
+      search_application.get_behavioral_analytics:
         name:
 
   - match: {
@@ -53,6 +53,6 @@ teardown:
 "Get Analytics Collection - Resource does not exist":
   - do:
       catch: "missing"
-      behavioral_analytics.list:
+      search_application.get_behavioral_analytics:
         name: test-nonexistent-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/70_behavioral_analytics_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/70_behavioral_analytics_put.yml
@@ -1,13 +1,13 @@
 teardown:
   - do:
-      behavioral_analytics.delete:
+      search_application.delete_behavioral_analytics:
         name: test-analytics-collection
         ignore: 404
 
 ---
 "Create Analytics Collection":
   - do:
-      behavioral_analytics.put:
+      search_application.put_behavioral_analytics:
         name: test-analytics-collection
 
   - match: { acknowledged: true }
@@ -16,14 +16,14 @@ teardown:
 ---
 "Create Analytics Collection - analytics collection already exists":
   - do:
-      behavioral_analytics.put:
+      search_application.put_behavioral_analytics:
         name: test-analytics-collection
 
   - match: { acknowledged: true }
 
   - do:
       catch: bad_request
-      behavioral_analytics.put:
+      search_application.put_behavioral_analytics:
         name: test-analytics-collection
 
   - match: { error.type: "resource_already_exists_exception" }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/80_behavioral_analytics_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/80_behavioral_analytics_delete.yml
@@ -1,32 +1,32 @@
 setup:
   - do:
-      behavioral_analytics.put:
+      search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
 
 ---
 teardown:
   - do:
-      behavioral_analytics.delete:
+      search_application.delete_behavioral_analytics:
         name: test-analytics-collection-to-delete
         ignore: 404
 
 ---
 "Delete Analytics Collection":
   - do:
-      behavioral_analytics.delete:
+      search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
 
   - match: { acknowledged: true }
 
   - do:
       catch: "missing"
-      behavioral_analytics.list:
+      search_application.get_behavioral_analytics:
         name: my-test-analytics-collection
 
 ---
 "Delete Analytics Collection - Analytics Collection does not exist":
   - do:
       catch: "missing"
-      behavioral_analytics.delete:
+      search_application.delete_behavioral_analytics:
         name: test-nonexistent-analytics-collection
 


### PR DESCRIPTION
Follow-up from https://github.com/elastic/elasticsearch/pull/95020, this aligns the API specs for Search Applications and Behavioral Analytics with the Elasticsearch API design guidelines.

- URL root path segment matches API namespace (`/_application` -> `search_application`, removes the `behavioral_analytics` API namespace in favor of `search_application`)
- `content_type` header implies a request body, `GET` and `DELETE` API calls don't have a request body.
- Changes the prefix from `list` to `get` to match the ES standard of being able to fetch a specific Search Application model, more than one, or with wild-carding.