### PR TITLE
[Ingest Processor] Add `ignore_missing` param to the `uri_parts` ingest processor.

### DIFF
--- a/docs/changelog/95068.yaml
+++ b/docs/changelog/95068.yaml
@@ -1,0 +1,6 @@
+pr: 95068
+summary: "[Ingest Processor] Add `ignore_missing` param to the `uri_parts` ingest\
+  \ processor"
+area: Ingest Node
+type: enhancement
+issues: []

--- a/docs/reference/ingest/processors/uri-parts.asciidoc
+++ b/docs/reference/ingest/processors/uri-parts.asciidoc
@@ -21,6 +21,7 @@ unparsed URI to `<target_field>.original`.
 | `remove_if_successful` | no    | false   | If `true`, the processor removes
 the `field` after parsing the URI string. If parsing fails, the processor does not
 remove the `field`.
+| `ignore_missing`   | no        | `false`          | If `true` and `field` does not exist, the processor quietly exits without modifying the document
 
 include::common-options.asciidoc[]
 |======

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -64,6 +64,10 @@ public class UriPartsProcessor extends AbstractProcessor {
         return keepOriginal;
     }
 
+    public Object getIgnoreMissing() {
+        return ignoreMissing;
+    }
+
     @Override
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         String value = ingestDocument.getFieldValue(field, String.class, ignoreMissing);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -20,7 +20,6 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 
 public class UriPartsProcessor extends AbstractProcessor {
 
@@ -69,7 +68,7 @@ public class UriPartsProcessor extends AbstractProcessor {
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         String value = ingestDocument.getFieldValue(field, String.class, ignoreMissing);
 
-        if (null == value) {
+        if (ignoreMissing && null == value) {
             return ingestDocument;
         }
         var uriParts = apply(value);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -69,7 +69,7 @@ public class UriPartsProcessor extends AbstractProcessor {
     public IngestDocument execute(IngestDocument ingestDocument) throws Exception {
         String value = ingestDocument.getFieldValue(field, String.class, ignoreMissing);
 
-        if (Objects.isNull(value)) {
+        if (null == value) {
             return ingestDocument;
         }
         var uriParts = apply(value);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/UriPartsProcessor.java
@@ -182,7 +182,7 @@ public class UriPartsProcessor extends AbstractProcessor {
             String targetField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "target_field", "url");
             boolean removeIfSuccessful = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "remove_if_successful", false);
             boolean keepOriginal = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "keep_original", true);
-            boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", true);
+            boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", false);
             return new UriPartsProcessor(processorTag, description, field, targetField, removeIfSuccessful, keepOriginal, ignoreMissing);
         }
     }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorFactoryTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorFactoryTests.java
@@ -40,6 +40,9 @@ public class UriPartsProcessorFactoryTests extends ESTestCase {
         boolean keepOriginal = randomBoolean();
         config.put("keep_original", keepOriginal);
 
+        boolean ignoreMissing = randomBoolean();
+        config.put("ignore_missing", ignoreMissing);
+
         String processorTag = randomAlphaOfLength(10);
         UriPartsProcessor uriPartsProcessor = factory.create(null, processorTag, null, config);
         assertThat(uriPartsProcessor.getTag(), equalTo(processorTag));
@@ -47,6 +50,7 @@ public class UriPartsProcessorFactoryTests extends ESTestCase {
         assertThat(uriPartsProcessor.getTargetField(), equalTo(targetField));
         assertThat(uriPartsProcessor.getRemoveIfSuccessful(), equalTo(removeIfSuccessful));
         assertThat(uriPartsProcessor.getKeepOriginal(), equalTo(keepOriginal));
+        assertThat(uriPartsProcessor.getIgnoreMissing(), equalTo(ignoreMissing));
     }
 
     public void testCreateNoFieldPresent() throws Exception {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
@@ -209,6 +209,16 @@ public class UriPartsProcessorTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("unable to parse URI [" + uri + "]"));
     }
 
+    public void testNullValue() {
+        Map<String, Object> source = new HashMap<>();
+        source.put("field", null);
+        IngestDocument input = TestIngestDocument.withDefaultVersion(source);
+
+        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", true, false, false);
+
+        expectThrows(NullPointerException.class, () -> processor.execute(input));
+    }
+
     public void testMissingField() {
         Map<String, Object> source = new HashMap<>();
         IngestDocument input = TestIngestDocument.withDefaultVersion(source);

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/UriPartsProcessorTests.java
@@ -17,6 +17,7 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasSize;
 
 public class UriPartsProcessorTests extends ESTestCase {
 
@@ -182,7 +183,7 @@ public class UriPartsProcessorTests extends ESTestCase {
 
     public void testRemoveIfSuccessfulDoesNotRemoveTargetField() throws Exception {
         String field = "field";
-        UriPartsProcessor processor = new UriPartsProcessor(null, null, field, field, true, false);
+        UriPartsProcessor processor = new UriPartsProcessor(null, null, field, field, true, false, false);
 
         Map<String, Object> source = new HashMap<>();
         source.put(field, "http://www.google.com");
@@ -198,7 +199,7 @@ public class UriPartsProcessorTests extends ESTestCase {
 
     public void testInvalidUri() {
         String uri = "not:\\/_a_valid_uri";
-        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", true, false);
+        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", true, false, false);
 
         Map<String, Object> source = new HashMap<>();
         source.put("field", uri);
@@ -208,13 +209,40 @@ public class UriPartsProcessorTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("unable to parse URI [" + uri + "]"));
     }
 
+    public void testMissingField() {
+        Map<String, Object> source = new HashMap<>();
+        IngestDocument input = TestIngestDocument.withDefaultVersion(source);
+
+        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", true, false, false);
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> processor.execute(input));
+        assertThat(e.getMessage(), containsString("field [field] not present as part of path [field]"));
+    }
+
+    public void testIgnoreMissingField() throws Exception {
+        Map<String, Object> source = new HashMap<>();
+        // Adding a random field, so we can check the doc is leaved unchanged.
+        source.put(randomIdentifier(), randomIdentifier());
+        IngestDocument input = TestIngestDocument.withDefaultVersion(source);
+        Map<String, Object> expectedSourceAndMetadata = Map.copyOf(input.getSourceAndMetadata());
+
+        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", true, false, true);
+        IngestDocument output = processor.execute(input);
+
+        assertThat(output.getSourceAndMetadata().entrySet(), hasSize(expectedSourceAndMetadata.size()));
+
+        for (Map.Entry<String, Object> entry : expectedSourceAndMetadata.entrySet()) {
+            assertThat(output.getSourceAndMetadata(), hasEntry(entry.getKey(), entry.getValue()));
+        }
+    }
+
     private void testUriParsing(String uri, Map<String, Object> expectedValues) throws Exception {
         testUriParsing(false, false, uri, expectedValues);
     }
 
     private void testUriParsing(boolean keepOriginal, boolean removeIfSuccessful, String uri, Map<String, Object> expectedValues)
         throws Exception {
-        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", removeIfSuccessful, keepOriginal);
+        UriPartsProcessor processor = new UriPartsProcessor(null, null, "field", "url", removeIfSuccessful, keepOriginal, false);
 
         Map<String, Object> source = new HashMap<>();
         source.put("field", uri);


### PR DESCRIPTION
### Summary

Add `ignore_missing` param to the `uri_parts`

The default value is `false` so the behavior is unchanged when the param is not specified.

### Context

It may seems a useless enhancement because we are usually implementing the same behavior using a conditional:

```json
{
  "uri_parts": {
    "field": "page_url",
    "if": "ctx.page_url != null"
  }
}
```
It becomes tricky when using a foreach processor like in the following example:

```json
{
  "foreach": {
    "field": "items",
    "processor": {
       "uri_parts": {
         "field": "_ingest._value.page_url"
       }
    }
  }
}
```

In this situation there is no way to write a working condition. As mentioned in the #60470, it seems to be a non trivial task to modify the context to support this use case.

Adding the `ignore_missing` param seems a good workaround to unblock an enterprise search use case while waiting for a more complete solution #60470 using conditionals. The foreach processor can become:

```json
{
  "foreach": {
    "field": "items",
    "processor": {
       "uri_parts": {
         "field": "_ingest._value.page_url",
         "ignore_missing": true
       }
    }
  }
}
```