### PR TITLE
Weaken node-replacement decider during reconciliation

### DIFF
--- a/docs/changelog/95070.yaml
+++ b/docs/changelog/95070.yaml
@@ -1,0 +1,5 @@
+pr: 95070
+summary: Ignore node-replacement decider during reconciliation
+area: Allocation
+type: bug
+issues: []

--- a/docs/changelog/95070.yaml
+++ b/docs/changelog/95070.yaml
@@ -1,5 +1,5 @@
 pr: 95070
-summary: Ignore node-replacement decider during reconciliation
+summary: Weaken node-replacement decider during reconciliation
 area: Allocation
 type: bug
 issues: []

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/RoutingAllocation.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.decider.AllocationDeciders;
 import org.elasticsearch.cluster.routing.allocation.decider.Decision;
 import org.elasticsearch.core.Nullable;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.snapshots.RestoreService.RestoreInProgressUpdater;
 import org.elasticsearch.snapshots.SnapshotShardSizeInfo;
@@ -64,6 +65,7 @@ public class RoutingAllocation {
 
     private final long currentNanoTime;
     private final boolean isSimulating;
+    private boolean isReconciling;
 
     private final IndexMetadataUpdater indexMetadataUpdater = new IndexMetadataUpdater();
     private final RoutingNodesChangedObserver nodesChangedObserver = new RoutingNodesChangedObserver();
@@ -399,6 +401,23 @@ public class RoutingAllocation {
      */
     public boolean isSimulating() {
         return isSimulating;
+    }
+
+    /**
+     * @return {@code true} if this allocation computation is trying to reconcile towards a previously-computed allocation and therefore
+     *                      path-dependent allocation blockers should be ignored.
+     */
+    public boolean isReconciling() {
+        return isReconciling;
+    }
+
+    /**
+     * Set the {@link #isReconciling} flag, and return a {@link Releasable} which clears it again.
+     */
+    public Releasable withReconcilingFlag() {
+        assert isReconciling == false : "already reconciling";
+        isReconciling = true;
+        return () -> isReconciling = false;
     }
 
     public void setSimulatedClusterInfo(ClusterInfo clusterInfo) {

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
@@ -46,15 +46,15 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
         } else if (isReplacementSource(allocation, shardRouting.currentNodeId())) {
             if (allocation.isReconciling()) {
                 return YES__RECONCILING;
-            } else {
-                return Decision.single(
-                    Decision.Type.NO,
-                    NAME,
-                    "node [%s] is being replaced, and its shards may only be allocated to the replacement target [%s]",
-                    shardRouting.currentNodeId(),
-                    getReplacementName(allocation, shardRouting.currentNodeId())
-                );
             }
+
+            return Decision.single(
+                Decision.Type.NO,
+                NAME,
+                "node [%s] is being replaced, and its shards may only be allocated to the replacement target [%s]",
+                shardRouting.currentNodeId(),
+                getReplacementName(allocation, shardRouting.currentNodeId())
+            );
         } else if (isReplacementSource(allocation, node.nodeId())) {
             return Decision.single(
                 Decision.Type.NO,
@@ -65,6 +65,10 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
                 shardRouting.currentNodeId()
             );
         } else if (isReplacementTargetName(allocation, node.node().getName())) {
+            if (allocation.isReconciling() && shardRouting.unassigned() == false) {
+                return YES__RECONCILING;
+            }
+
             final SingleNodeShutdownMetadata shutdown = allocation.replacementTargetShutdowns().get(node.node().getName());
             return Decision.single(
                 Decision.Type.NO,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
@@ -45,6 +45,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
             );
         } else if (isReplacementSource(allocation, shardRouting.currentNodeId())) {
             if (allocation.isReconciling()) {
+                // We permit moving shards off the source node during reconcilation so that they can go onto their desired nodes even if
+                // the desired node is different from the replacement target.
                 return YES__RECONCILING;
             }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
@@ -66,6 +66,9 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
             );
         } else if (isReplacementTargetName(allocation, node.node().getName())) {
             if (allocation.isReconciling() && shardRouting.unassigned() == false) {
+                // We permit moving _existing_ shards onto the target during reconcilation so that they stay out of the way of other shards
+                // moving off the source node. But we don't allow any unassigned shards to be assigned to the target since this could
+                // prevent the node from being vacated.
                 return YES__RECONCILING;
             }
 

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDeciderTests.java
@@ -40,7 +40,6 @@ import java.util.Collections;
 import java.util.HashMap;
 
 import static org.elasticsearch.common.settings.ClusterSettings.createBuiltInClusterSettings;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase {
@@ -55,7 +54,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
         ShardRouting.Role.DEFAULT
     );
     private final ClusterSettings clusterSettings = createBuiltInClusterSettings();
-    private NodeReplacementAllocationDecider decider = new NodeReplacementAllocationDecider();
+    private final NodeReplacementAllocationDecider decider = new NodeReplacementAllocationDecider();
     private final AllocationDeciders allocationDeciders = new AllocationDeciders(
         Arrays.asList(
             decider,
@@ -98,11 +97,11 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
         Decision decision = decider.canAllocate(shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS.getExplanation()));
+        assertThat(decision.getExplanation(), equalTo(NodeReplacementAllocationDecider.YES__NO_REPLACEMENTS.getExplanation()));
 
         decision = decider.canRemain(null, shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), equalTo(NodeReplacementAllocationDecider.NO_REPLACEMENTS.getExplanation()));
+        assertThat(decision.getExplanation(), equalTo(NodeReplacementAllocationDecider.YES__NO_REPLACEMENTS.getExplanation()));
     }
 
     public void testCanForceAllocate() {
@@ -174,13 +173,13 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
         decision = decider.canRemain(indexMetadata, shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), equalTo("node [" + NODE_B.getId() + "] is not being replaced"));
+        assertEquals(NodeReplacementAllocationDecider.YES__NO_APPLICABLE_REPLACEMENTS, decision);
 
         routingNode = RoutingNodesHelper.routingNode(NODE_C.getId(), NODE_C, shard);
 
         decision = decider.canRemain(indexMetadata, shard, routingNode, allocation);
         assertThat(decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), equalTo("node [" + NODE_C.getId() + "] is not being replaced"));
+        assertEquals(NodeReplacementAllocationDecider.YES__NO_APPLICABLE_REPLACEMENTS, decision);
     }
 
     public void testCanAllocateToNeitherSourceNorTarget() {
@@ -225,7 +224,7 @@ public class NodeReplacementAllocationDeciderTests extends ESAllocationTestCase 
 
         decision = decider.canAllocate(testShard, routingNode, allocation);
         assertThat(decision.getExplanation(), decision.type(), equalTo(Decision.Type.YES));
-        assertThat(decision.getExplanation(), containsString("neither the source nor target node are part of an ongoing node replacement"));
+        assertEquals(NodeReplacementAllocationDecider.YES__NO_APPLICABLE_REPLACEMENTS, decision);
     }
 
     private ClusterState prepareState(ClusterState initialState, String sourceNodeId, String targetNodeName) {

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
@@ -41,7 +41,7 @@ public class DesiredBalanceShutdownIT extends ESIntegTestCase {
         createIndex(
             INDEX,
             Settings.builder()
-                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5))
                 .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
                 .put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name", oldNodeName)
                 .build()
@@ -89,7 +89,6 @@ public class DesiredBalanceShutdownIT extends ESIntegTestCase {
                     .stream()
                     .allMatch(s -> s.overallStatus() == SingleNodeShutdownMetadata.Status.COMPLETE)
             );
-        });
+        }, 120, TimeUnit.SECONDS);
     }
-
 }


### PR DESCRIPTION
The node-replacement allocation decider requires shard movements to follow a specific route, from source to replacement target. However during the shutdown there may be other changes in the system that make the replacement target unsuitable for the final destination of the shard. Having simulated the move of the shard onto the replacement target we are free to simulate its movement elsewhere, but today this causes the reconciler to get stuck: it cannot move the shard to its desired location because of the ongoing replacement, and it will not move the shard onto the replacement target because that's not its desired location.

This commit weakens this decider during reconciliation which allows the reconcilier to skip the intermediate target node and move the shard straight to its desired location.