### PR TITLE
[8.7] [DOCS] Add privileges on privileges.asciidoc (#94614)

### DIFF
--- a/x-pack/docs/en/security/authorization/privileges.asciidoc
+++ b/x-pack/docs/en/security/authorization/privileges.asciidoc
@@ -130,6 +130,16 @@ Service.
 `manage_transform`::
 All operations related to managing {transforms}.
 
+`manage_autoscaling`::
+All operations related to managing autoscaling policies.
+
+`manage_data_frame_transforms`::
+All operations related to managing {transforms}.
+deprecated[7.5] Use `manage_transform` instead.
+
+`manage_enrich`::
+All operations related to managing and executing enrich policies.
+
 `manage_watcher`::
 All watcher operations, such as putting watches, executing, activate or acknowledging.
 +


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[DOCS] Add privileges on privileges.asciidoc (#94614)](https://github.com/elastic/elasticsearch/pull/94614)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)