### PR TITLE
[Stable Plugin Api] Change the group name in stable-api diff plugin

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
@@ -33,12 +33,9 @@ BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString(ex
     if (unreleasedVersion) {
       // For unreleased snapshot versions, build them from source
       "oldJar${baseName}"(files(project(unreleasedVersion.gradleProjectPath).tasks.named(buildBwcTaskName(project.name))))
-    } else if(bwcVersion.onOrAfter('8.7.0')) {
-      //there was a package rename in 8.7.0
-      "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
     } else {
       // For released versions, download it
-      "oldJar${baseName}"("org.elasticsearch:${project.name}:${bwcVersion}")
+      "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
     }
   }
 

--- a/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
@@ -33,9 +33,12 @@ BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString(ex
     if (unreleasedVersion) {
       // For unreleased snapshot versions, build them from source
       "oldJar${baseName}"(files(project(unreleasedVersion.gradleProjectPath).tasks.named(buildBwcTaskName(project.name))))
+    } else if(bwcVersion.onOrAfter('8.7.0')) {
+      //there was a package rename in 8.7.0
+      "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
     } else {
       // For released versions, download it
-      "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
+      "oldJar${baseName}"("org.elasticsearch:${project.name}:${bwcVersion}")
     }
   }
 

--- a/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
@@ -33,6 +33,9 @@ BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString(ex
     if (unreleasedVersion) {
       // For unreleased snapshot versions, build them from source
       "oldJar${baseName}"(files(project(unreleasedVersion.gradleProjectPath).tasks.named(buildBwcTaskName(project.name))))
+    } else if(bwcVersion.onOrAfter('8.7.0')) {
+      //there was a package rename in 8.7.0
+      "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
     } else {
       // For released versions, download it
       "oldJar${baseName}"("org.elasticsearch:${project.name}:${bwcVersion}")

--- a/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
@@ -33,8 +33,8 @@ BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString(ex
     if (unreleasedVersion) {
       // For unreleased snapshot versions, build them from source
       "oldJar${baseName}"(files(project(unreleasedVersion.gradleProjectPath).tasks.named(buildBwcTaskName(project.name))))
-    } else if(bwcVersion.onOrAfter('8.7.0')) {
-      //there was a package rename in 8.7.0
+    } else if(bwcVersion.onOrAfter('8.7.0') && project.name.endsWith("elasticsearch-logging")==false) {
+      //there was a package rename in 8.7.0, except for es-logging
       "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
     } else {
       // For released versions, download it


### PR DESCRIPTION
the https://github.com/elastic/elasticsearch/pull/92776 introduced a bwc test to make sure we do not break stable plugin API. The change was merged to 8.7.0
At the same time an artifact group rename was merged into 8.7.0 https://github.com/elastic/elasticsearch/pull/92905/files

This commit fixes the group name used in a plugin