### PR TITLE
docs logging configuration: removed dead link and added javadoc reference instead.

### DIFF
--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -272,7 +272,7 @@ and x-opaque-id so that if a feature is repeatedly used, it will not overload th
 This applies to both indexed deprecation logs and logs emitted to log files.
 You can disable the use of `x-opaque-id` in throttling by changing
 `cluster.deprecation_indexing.x_opaque_id_used.enabled` to false,
-see this class {es-rate-limiting-filter-java-doc}[javadoc] for more details.
+refer to this class {es-rate-limiting-filter-java-doc}[javadoc] for more details.
 
 [discrete]
 [[json-logging]]

--- a/docs/reference/setup/logging-config.asciidoc
+++ b/docs/reference/setup/logging-config.asciidoc
@@ -266,12 +266,13 @@ Deprecation logs can be indexed into `.logs-deprecation.elasticsearch-default` d
 `cluster.deprecation_indexing.enabled` setting is set to true.
 
 ==== Deprecation logs throttling
+:es-rate-limiting-filter-java-doc: {elasticsearch-javadoc}/org/elasticsearch/common/logging/RateLimitingFilter.html
 Deprecation logs are deduplicated based on a deprecated feature key
 and x-opaque-id so that if a feature is repeatedly used, it will not overload the deprecation logs.
 This applies to both indexed deprecation logs and logs emitted to log files.
 You can disable the use of `x-opaque-id` in throttling by changing
-`cluster.deprecation_indexing.x_opaque_id_used.enabled` to false
-See link:./server/src/main/java/org/elasticsearch/common/logging/RateLimitingFilter.java[RateLimitingFilter]
+`cluster.deprecation_indexing.x_opaque_id_used.enabled` to false,
+see this class {es-rate-limiting-filter-java-doc}[javadoc] for more details.
 
 [discrete]
 [[json-logging]]


### PR DESCRIPTION
Removed a link pointing nowhere and added javadoc reference instead.
