### PR TITLE
Unmute get-lifecycle.asciidoc test

### DIFF
--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -115,7 +115,6 @@ If the request succeeds, the body of the response contains the policy definition
   }
 }
 --------------------------------------------------
-// TEST[skip:https://github.com/elastic/elasticsearch/issues/89623]
 // TESTRESPONSE[s/"modified_date": 82392349/"modified_date": $body.my_policy.modified_date/]
 
 <1> The policy version is incremented whenever the policy is updated


### PR DESCRIPTION
Because it has been a while since this failure and I wasn't able to reproduce it locally, I will unmute to see if it will still happen in CI.

Closes: #89623 