### PR TITLE
Ensure we skip old repository version tests on Windows

### DIFF
--- a/x-pack/qa/repository-old-versions/build.gradle
+++ b/x-pack/qa/repository-old-versions/build.gradle
@@ -51,7 +51,7 @@ if (OS.current() == OS.MAC && Architecture.current() == Architecture.AARCH64) {
   jdks.legacy.distributionVersion = '8.56.0.23'
 }
 
-if (OS.current() != OS.WINDOWS) {
+if (OS.current() == OS.WINDOWS) {
   logger.warn("Disabling repository-old-versions tests because we can't get the pid file on windows")
 } else {
   /* Register a gradle artifact transformation to unpack resolved elasticsearch distributions. We only resolve


### PR DESCRIPTION
It looks like this conditional was mistakenly flipped as part of #94612. We don't want to run these tests on Windows.