### PR TITLE
Fixing BulkProcessor2RetryIT

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2RetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2RetryIT.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.refresh.RefreshRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.query.QueryBuilders;
@@ -34,6 +35,12 @@ import static org.hamcrest.Matchers.lessThanOrEqualTo;
 public class BulkProcessor2RetryIT extends ESIntegTestCase {
     private static final String INDEX_NAME = "test";
     Map<String, Integer> requestToExecutionCountMap = new ConcurrentHashMap<>();
+    /*
+     * We can't call ESIntegTestCase.client() from a transport thread because it winds up calling a blocking operation that trips an
+     * assertion error if you're doing it from the transport thread. So we stash a random client in this variable for use when we nned a
+     * client in a transport thread.
+     */
+    private Client clientsForTransportThread;
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal, Settings otherSettings) {
@@ -65,6 +72,7 @@ public class BulkProcessor2RetryIT extends ESIntegTestCase {
 
     @SuppressWarnings("unchecked")
     private void executeBulkRejectionLoad(int maxRetries, boolean rejectedExecutionExpected) throws Throwable {
+        clientsForTransportThread = client();
         int numberOfAsyncOps = randomIntBetween(600, 700);
         final CountDownLatch latch = new CountDownLatch(numberOfAsyncOps);
         final Set<BulkResponse> successfulResponses = Collections.newSetFromMap(new ConcurrentHashMap<>());
@@ -109,6 +117,8 @@ public class BulkProcessor2RetryIT extends ESIntegTestCase {
                             }
                             rejectedAfterAllRetries = true;
                         }
+                    } else if (failure.getStatus() == RestStatus.SERVICE_UNAVAILABLE) {
+                        // The test framework throws this at us sometimes
                     } else {
                         throw new AssertionError("Unexpected failure status: " + failure.getStatus());
                     }
@@ -165,7 +175,7 @@ public class BulkProcessor2RetryIT extends ESIntegTestCase {
         for (DocWriteRequest<?> docWriteRequest : request.requests) {
             requestToExecutionCountMap.compute(docWriteRequest.id(), (key, value) -> value == null ? 1 : value + 1);
         }
-        client().bulk(request, listener);
+        clientsForTransportThread.bulk(request, listener);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2RetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2RetryIT.java
@@ -58,7 +58,6 @@ public class BulkProcessor2RetryIT extends ESIntegTestCase {
     // value = "org.elasticsearch.action.bulk.Retry2:trace",
     // reason = "Logging information about locks useful for tracking down deadlock"
     // )
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94941")
     public void testBulkRejectionLoadWithBackoff() throws Throwable {
         boolean rejectedExecutionExpected = false;
         executeBulkRejectionLoad(8, rejectedExecutionExpected);
@@ -128,6 +127,8 @@ public class BulkProcessor2RetryIT extends ESIntegTestCase {
                     rejectedAfterAllRetries = true;
                 }
                 // ignored, we exceeded the write queue size when dispatching the initial bulk request
+            } else if (ExceptionsHelper.status(failureTuple.v2()) == RestStatus.SERVICE_UNAVAILABLE) {
+                // The test framework throws this at us sometimes
             } else {
                 Throwable t = failureTuple.v2();
                 // we're not expecting any other errors

--- a/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
+++ b/server/src/main/java/org/elasticsearch/client/transport/TransportClientNodesService.java
@@ -410,64 +410,50 @@ final class TransportClientNodesService implements Closeable {
             HashSet<DiscoveryNode> newNodes = new HashSet<>();
             ArrayList<DiscoveryNode> newFilteredNodes = new ArrayList<>();
             for (DiscoveryNode listedNode : listedNodes) {
-                transportService.openConnection(listedNode, LISTED_NODES_PROFILE, new ActionListener<Transport.Connection>() {
-                    @Override
-                    public void onResponse(Transport.Connection connection) {
-                        try {
-                            final PlainTransportFuture<LivenessResponse> handler = new PlainTransportFuture<>(
-                                new FutureTransportResponseHandler<LivenessResponse>() {
-                                    @Override
-                                    public LivenessResponse read(StreamInput in) throws IOException {
-                                        return new LivenessResponse(in);
-                                    }
-                                }
-                            );
-                            transportService.sendRequest(
-                                connection,
-                                TransportLivenessAction.NAME,
-                                new LivenessRequest(),
-                                TransportRequestOptions.of(pingTimeout, TransportRequestOptions.Type.STATE),
-                                handler
-                            );
-                            final LivenessResponse livenessResponse = handler.txGet();
-                            if (ignoreClusterName == false && clusterName.equals(livenessResponse.getClusterName()) == false) {
-                                logger.warn("node {} not part of the cluster {}, ignoring...", listedNode, clusterName);
-                                newFilteredNodes.add(listedNode);
-                            } else {
-                                // use discovered information but do keep the original transport address,
-                                // so people can control which address is exactly used.
-                                DiscoveryNode nodeWithInfo = livenessResponse.getDiscoveryNode();
-                                newNodes.add(
-                                    new DiscoveryNode(
-                                        nodeWithInfo.getName(),
-                                        nodeWithInfo.getId(),
-                                        nodeWithInfo.getEphemeralId(),
-                                        nodeWithInfo.getHostName(),
-                                        nodeWithInfo.getHostAddress(),
-                                        listedNode.getAddress(),
-                                        nodeWithInfo.getAttributes(),
-                                        nodeWithInfo.getRoles(),
-                                        nodeWithInfo.getVersion()
-                                    )
-                                );
-                            }
-                        } catch (ConnectTransportException e) {
-                            logger.debug(() -> new ParameterizedMessage("failed to connect to node [{}], ignoring...", listedNode), e);
-                            hostFailureListener.onNodeDisconnected(listedNode, e);
-                        } catch (Exception e) {
-                            logger.info(() -> new ParameterizedMessage("failed to get node info for {}, disconnecting...", listedNode), e);
-                        } finally {
-                            if (connection != null) {
-                                connection.close();
+                try (Transport.Connection connection = transportService.openConnection(listedNode, LISTED_NODES_PROFILE)) {
+                    final PlainTransportFuture<LivenessResponse> handler = new PlainTransportFuture<>(
+                        new FutureTransportResponseHandler<LivenessResponse>() {
+                            @Override
+                            public LivenessResponse read(StreamInput in) throws IOException {
+                                return new LivenessResponse(in);
                             }
                         }
+                    );
+                    transportService.sendRequest(
+                        connection,
+                        TransportLivenessAction.NAME,
+                        new LivenessRequest(),
+                        TransportRequestOptions.of(pingTimeout, TransportRequestOptions.Type.STATE),
+                        handler
+                    );
+                    final LivenessResponse livenessResponse = handler.txGet();
+                    if (ignoreClusterName == false && clusterName.equals(livenessResponse.getClusterName()) == false) {
+                        logger.warn("node {} not part of the cluster {}, ignoring...", listedNode, clusterName);
+                        newFilteredNodes.add(listedNode);
+                    } else {
+                        // use discovered information but do keep the original transport address,
+                        // so people can control which address is exactly used.
+                        DiscoveryNode nodeWithInfo = livenessResponse.getDiscoveryNode();
+                        newNodes.add(
+                            new DiscoveryNode(
+                                nodeWithInfo.getName(),
+                                nodeWithInfo.getId(),
+                                nodeWithInfo.getEphemeralId(),
+                                nodeWithInfo.getHostName(),
+                                nodeWithInfo.getHostAddress(),
+                                listedNode.getAddress(),
+                                nodeWithInfo.getAttributes(),
+                                nodeWithInfo.getRoles(),
+                                nodeWithInfo.getVersion()
+                            )
+                        );
                     }
-
-                    @Override
-                    public void onFailure(Exception e) {
-                        logger.warn("Unable to open connection", e);
-                    }
-                });
+                } catch (ConnectTransportException e) {
+                    logger.debug(() -> new ParameterizedMessage("failed to connect to node [{}], ignoring...", listedNode), e);
+                    hostFailureListener.onNodeDisconnected(listedNode, e);
+                } catch (Exception e) {
+                    logger.info(() -> new ParameterizedMessage("failed to get node info for {}, disconnecting...", listedNode), e);
+                }
             }
 
             nodes = establishNodeConnections(newNodes);


### PR DESCRIPTION
BulkProcessor2RetryIT.testBulkRejectionLoadWithBackoff was failing for a couple of reasons:
(1) The test cluster sometimes intentionally times out requests, which can lead to failures.
(2) The client() method sometimes calls a method that triggers an assertion failure if you're running in a transport thread (which part of our test is):
```
        java.lang.AssertionError: Expected current thread [Thread[elasticsearch[node_s2][transport_worker][T#1],5,TGRP-BulkProcessor2RetryIT]] to not be a transport thread. Reason: [Blocking operation]
            at __randomizedtesting.SeedInfo.seed([7979906EFF34169B]:0)
            at org.elasticsearch.transport.Transports.assertNotTransportThread(Transports.java:56)
            at org.elasticsearch.common.util.concurrent.BaseFuture.blockingAllowed(BaseFuture.java:80)
            at org.elasticsearch.common.util.concurrent.BaseFuture.get(BaseFuture.java:74)
            at org.elasticsearch.common.util.concurrent.FutureUtils.get(FutureUtils.java:45)
            at org.elasticsearch.action.support.AdapterActionFuture.actionGet(AdapterActionFuture.java:26)
            at org.elasticsearch.action.support.PlainActionFuture.get(PlainActionFuture.java:24)
            at org.elasticsearch.transport.TransportService.openConnection(TransportService.java:483)
            at org.elasticsearch.client.transport.TransportClientNodesService$SimpleNodeSampler.doSample(TransportClientNodesService.java:413)
            at org.elasticsearch.client.transport.TransportClientNodesService$NodeSampler.sample(TransportClientNodesService.java:364)
            at org.elasticsearch.client.transport.TransportClientNodesService.addTransportAddresses(TransportClientNodesService.java:200)
            at org.elasticsearch.client.transport.TransportClient.addTransportAddress(TransportClient.java:416)
            at org.elasticsearch.test.InternalTestCluster$TransportClientFactory.client(InternalTestCluster.java:1224)
            at org.elasticsearch.test.InternalTestCluster$NodeAndClient.getOrBuildTransportClient(InternalTestCluster.java:1040)
            at org.elasticsearch.test.InternalTestCluster$NodeAndClient.client(InternalTestCluster.java:994)
            at org.elasticsearch.test.InternalTestCluster.client(InternalTestCluster.java:849)
            at org.elasticsearch.test.ESIntegTestCase.client(ESIntegTestCase.java:677)
            at org.elasticsearch.test.ESIntegTestCase.client(ESIntegTestCase.java:670)
            at org.elasticsearch.action.bulk.BulkProcessor2RetryIT.countAndBulk(BulkProcessor2RetryIT.java:167)
```
This PR fixes both of those.
Closes #94452 
Closes #94941