### PR TITLE
[Enterprise Search] Add connectors indices

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1827,6 +1827,9 @@ public abstract class ESRestTestCase extends ESTestCase {
         if (name.startsWith("profiling-")) {
             return true;
         }
+        if (name.startsWith("elastic-connectors")) {
+            return true;
+        }
         switch (name) {
             case ".watches":
             case "security_audit_log":
@@ -1849,6 +1852,7 @@ public abstract class ESRestTestCase extends ESTestCase {
             case "security-index-template":
             case "data-streams-mappings":
             case "ecs@dynamic_templates":
+            case "search-acl-filter":
                 return true;
             default:
                 return false;

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-mappings.json
@@ -1,0 +1,316 @@
+{
+  "template": {
+    "aliases": {
+      ".elastic-connectors":  {}
+    },
+    "mappings": {
+      "dynamic": "false",
+      "_meta": {
+        "pipeline": {
+          "default_name": "ent-search-generic-ingestion",
+          "default_extract_binary_content": true,
+          "default_run_ml_inference": true,
+          "default_reduce_whitespace": true
+        },
+        "version": ${xpack.application.connector.template.version}
+      },
+      "properties": {
+        "api_key_id": {
+          "type": "keyword"
+        },
+        "configuration": {
+          "type": "object"
+        },
+        "custom_scheduling": {
+          "type": "object"
+        },
+        "description": {
+          "type": "text"
+        },
+        "error": {
+          "type": "keyword"
+        },
+        "features": {
+          "properties": {
+            "filtering_advanced_config": {
+              "type": "boolean"
+            },
+            "filtering_rules": {
+              "type": "boolean"
+            },
+            "incremental_sync": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "sync_rules": {
+              "properties": {
+                "advanced": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                },
+                "basic": {
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "filtering": {
+          "properties": {
+            "active": {
+              "properties": {
+                "advanced_snippet": {
+                  "properties": {
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "value": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "rules": {
+                  "properties": {
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "field": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "order": {
+                      "type": "short"
+                    },
+                    "policy": {
+                      "type": "keyword"
+                    },
+                    "rule": {
+                      "type": "keyword"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "value": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "validation": {
+                  "properties": {
+                    "errors": {
+                      "properties": {
+                        "ids": {
+                          "type": "keyword"
+                        },
+                        "messages": {
+                          "type": "text"
+                        }
+                      }
+                    },
+                    "state": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            },
+            "domain": {
+              "type": "keyword"
+            },
+            "draft": {
+              "properties": {
+                "advanced_snippet": {
+                  "properties": {
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "value": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "rules": {
+                  "properties": {
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "field": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "order": {
+                      "type": "short"
+                    },
+                    "policy": {
+                      "type": "keyword"
+                    },
+                    "rule": {
+                      "type": "keyword"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "value": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "validation": {
+                  "properties": {
+                    "errors": {
+                      "properties": {
+                        "ids": {
+                          "type": "keyword"
+                        },
+                        "messages": {
+                          "type": "text"
+                        }
+                      }
+                    },
+                    "state": {
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "index_name": {
+          "type": "keyword"
+        },
+        "is_native": {
+          "type": "boolean"
+        },
+        "language": {
+          "type": "keyword"
+        },
+        "last_access_control_sync_error": {
+          "type": "keyword"
+        },
+        "last_access_control_sync_scheduled_at": {
+          "type": "date"
+        },
+        "last_access_control_sync_status": {
+          "type": "keyword"
+        },
+        "last_deleted_document_count": {
+          "type": "long"
+        },
+        "last_incremental_sync_scheduled_at": {
+          "type": "date"
+        },
+        "last_indexed_document_count": {
+          "type": "long"
+        },
+        "last_seen": {
+          "type": "date"
+        },
+        "last_sync_error": {
+          "type": "keyword"
+        },
+        "last_sync_scheduled_at": {
+          "type": "date"
+        },
+        "last_sync_status": {
+          "type": "keyword"
+        },
+        "last_synced": {
+          "type": "date"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "pipeline": {
+          "properties": {
+            "extract_binary_content": {
+              "type": "boolean"
+            },
+            "name": {
+              "type": "keyword"
+            },
+            "reduce_whitespace": {
+              "type": "boolean"
+            },
+            "run_ml_inference": {
+              "type": "boolean"
+            }
+          }
+        },
+        "scheduling": {
+          "properties": {
+            "access_control": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "text"
+                }
+              }
+            },
+            "full": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "text"
+                }
+              }
+            },
+            "incremental": {
+              "properties": {
+                "enabled": {
+                  "type": "boolean"
+                },
+                "interval": {
+                  "type": "text"
+                }
+              }
+            }
+          }
+        },
+        "service_type": {
+          "type": "keyword"
+        },
+        "status": {
+          "type": "keyword"
+        },
+        "sync_cursor": {
+          "type": "object"
+        },
+        "sync_now": {
+          "type": "boolean"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "Built-in mappings applied by default to elastic-connectors indices",
+    "managed": true
+  },
+  "version": ${xpack.application.connector.template.version}
+}
+
+

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-settings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-settings.json
@@ -1,0 +1,15 @@
+{
+  "template": {
+    "settings": {
+      "hidden": true,
+      "number_of_shards": "1",
+      "auto_expand_replicas": "0-3",
+      "number_of_replicas": "0"
+    }
+  },
+  "_meta": {
+    "description": "Built-in settings applied by default to connector management indices",
+    "managed": true
+  },
+  "version": ${xpack.application.connector.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-sync-jobs-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-sync-jobs-mappings.json
@@ -1,0 +1,164 @@
+{
+  "template": {
+    "aliases": {
+      ".elastic-connectors-sync-jobs":  {}
+    },
+    "mappings": {
+      "dynamic": "false",
+      "_meta": {
+        "version": ${xpack.application.connector.template.version}
+      },
+      "properties": {
+        "cancelation_requested_at": {
+          "type": "date"
+        },
+        "canceled_at": {
+          "type": "date"
+        },
+        "completed_at": {
+          "type": "date"
+        },
+        "connector": {
+          "properties": {
+            "configuration": {
+              "type": "object"
+            },
+            "filtering": {
+              "properties": {
+                "advanced_snippet": {
+                  "properties": {
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "value": {
+                      "type": "object"
+                    }
+                  }
+                },
+                "domain": {
+                  "type": "keyword"
+                },
+                "rules": {
+                  "properties": {
+                    "created_at": {
+                      "type": "date"
+                    },
+                    "field": {
+                      "type": "keyword"
+                    },
+                    "id": {
+                      "type": "keyword"
+                    },
+                    "order": {
+                      "type": "short"
+                    },
+                    "policy": {
+                      "type": "keyword"
+                    },
+                    "rule": {
+                      "type": "keyword"
+                    },
+                    "updated_at": {
+                      "type": "date"
+                    },
+                    "value": {
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "warnings": {
+                  "properties": {
+                    "ids": {
+                      "type": "keyword"
+                    },
+                    "messages": {
+                      "type": "text"
+                    }
+                  }
+                }
+              }
+            },
+            "id": {
+              "type": "keyword"
+            },
+            "index_name": {
+              "type": "keyword"
+            },
+            "language": {
+              "type": "keyword"
+            },
+            "pipeline": {
+              "properties": {
+                "extract_binary_content": {
+                  "type": "boolean"
+                },
+                "name": {
+                  "type": "keyword"
+                },
+                "reduce_whitespace": {
+                  "type": "boolean"
+                },
+                "run_ml_inference": {
+                  "type": "boolean"
+                }
+              }
+            },
+            "service_type": {
+              "type": "keyword"
+            },
+            "sync_cursor": {
+              "type": "object"
+            }
+          }
+        },
+        "created_at": {
+          "type": "date"
+        },
+        "deleted_document_count": {
+          "type": "integer"
+        },
+        "error": {
+          "type": "keyword"
+        },
+        "indexed_document_count": {
+          "type": "integer"
+        },
+        "indexed_document_volume": {
+          "type": "integer"
+        },
+        "job_type": {
+          "type": "keyword"
+        },
+        "last_seen": {
+          "type": "date"
+        },
+        "metadata": {
+          "type": "object"
+        },
+        "started_at": {
+          "type": "date"
+        },
+        "status": {
+          "type": "keyword"
+        },
+        "total_document_count": {
+          "type": "integer"
+        },
+        "trigger_method": {
+          "type": "keyword"
+        },
+        "worker_hostname": {
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "Built-in mappings applied by default to elastic-connectors indices",
+    "managed": true
+  },
+  "version": ${xpack.application.connector.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-sync-jobs.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors-sync-jobs.json
@@ -1,0 +1,14 @@
+{
+  "index_patterns": ["${connectors-sync-jobs.index_pattern}"],
+  "priority": 100,
+  "composed_of": [
+    "elastic-connectors-settings",
+    "elastic-connectors-sync-jobs-mappings"
+  ],
+  "allow_auto_create": true,
+  "_meta": {
+    "description": "Built-in template for elastic-connectors-sync-jobs",
+    "managed": true
+  },
+  "version": ${xpack.application.connector.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/elastic-connectors.json
@@ -1,0 +1,14 @@
+{
+  "index_patterns": ["${connectors.index_pattern}"],
+  "priority": 100,
+  "composed_of": [
+    "elastic-connectors-settings",
+    "elastic-connectors-mappings"
+  ],
+  "allow_auto_create": true,
+  "_meta": {
+    "description": "Built-in template for elastic-connectors",
+    "managed": true
+  },
+  "version": ${xpack.application.connector.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/search-acl-filter.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/connector/search-acl-filter.json
@@ -1,0 +1,27 @@
+{
+  "index_patterns": ["${access-control.index_pattern}"],
+  "priority": 100,
+  "template": {
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "created_at": {
+          "type": "date"
+        }
+      }
+    },
+    "settings": {
+      "index": {
+        "hidden": true,
+        "number_of_shards": 1,
+        "number_of_replicas": 1
+      }
+    }
+  },
+  "allow_auto_create": true,
+  "_meta": {
+    "description": "Built-in template for access control indices",
+    "managed": true
+  },
+  "version": ${xpack.application.connector.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/generic_ingestion_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/application/generic_ingestion_pipeline.json
@@ -1,0 +1,129 @@
+{
+  "version": 1,
+  "description": "Generic Enterprise Search ingest pipeline",
+  "_meta": {
+    "managed_by": "Enterprise Search",
+    "managed": true
+  },
+  "processors": [
+    {
+      "attachment": {
+        "description": "Extract text from binary attachments",
+        "field": "_attachment",
+        "target_field": "_extracted_attachment",
+        "ignore_missing": true,
+        "indexed_chars_field": "_attachment_indexed_chars",
+        "if": "ctx?._extract_binary_content == true",
+        "on_failure": [
+          {
+            "append": {
+              "description": "Record error information",
+              "field": "_ingestion_errors",
+              "value": "Processor 'attachment' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "set": {
+        "tag": "set_body",
+        "description": "Set any extracted text on the 'body' field",
+        "field": "body",
+        "copy_from": "_extracted_attachment.content",
+        "ignore_empty_value": true,
+        "if": "ctx?._extract_binary_content == true",
+        "on_failure": [
+          {
+            "append": {
+              "description": "Record error information",
+              "field": "_ingestion_errors",
+              "value": "Processor 'set' with tag 'set_body' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "gsub": {
+        "tag": "remove_replacement_chars",
+        "description": "Remove unicode 'replacement' characters",
+        "field": "body",
+        "pattern": "�",
+        "replacement": "",
+        "ignore_missing": true,
+        "if": "ctx?._extract_binary_content == true",
+        "on_failure": [
+          {
+            "append": {
+              "description": "Record error information",
+              "field": "_ingestion_errors",
+              "value": "Processor 'gsub' with tag 'remove_replacement_chars' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "gsub": {
+        "tag": "remove_extra_whitespace",
+        "description": "Squish whitespace",
+        "field": "body",
+        "pattern": "\\s+",
+        "replacement": " ",
+        "ignore_missing": true,
+        "if": "ctx?._reduce_whitespace == true",
+        "on_failure": [
+          {
+            "append": {
+              "description": "Record error information",
+              "field": "_ingestion_errors",
+              "value": "Processor 'gsub' with tag 'remove_extra_whitespace' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "trim" : {
+        "description": "Trim leading and trailing whitespace",
+        "field": "body",
+        "ignore_missing": true,
+        "if": "ctx?._reduce_whitespace == true",
+        "on_failure": [
+          {
+            "append": {
+              "description": "Record error information",
+              "field": "_ingestion_errors",
+              "value": "Processor 'trim' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "remove": {
+        "tag": "remove_meta_fields",
+        "description": "Remove meta fields",
+        "field": [
+          "_attachment",
+          "_attachment_indexed_chars",
+          "_extracted_attachment",
+          "_extract_binary_content",
+          "_reduce_whitespace",
+          "_run_ml_inference"
+        ],
+        "ignore_missing": true,
+        "on_failure": [
+          {
+            "append": {
+              "description": "Record error information",
+              "field": "_ingestion_errors",
+              "value": "Processor 'remove' with tag 'remove_meta_fields' in pipeline '{{ _ingest.on_failure_pipeline }}' failed with message '{{ _ingest.on_failure_message }}'"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -26,8 +26,6 @@ import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.SystemIndexDescriptor;
 import org.elasticsearch.license.XPackLicenseState;
-import org.elasticsearch.logging.LogManager;
-import org.elasticsearch.logging.Logger;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.SystemIndexPlugin;
@@ -53,6 +51,7 @@ import org.elasticsearch.xpack.application.analytics.action.TransportGetAnalytic
 import org.elasticsearch.xpack.application.analytics.action.TransportPostAnalyticsEventAction;
 import org.elasticsearch.xpack.application.analytics.action.TransportPutAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.ingest.AnalyticsEventIngestConfig;
+import org.elasticsearch.xpack.application.connector.ConnectorTemplateRegistry;
 import org.elasticsearch.xpack.application.rules.QueryRulesIndexService;
 import org.elasticsearch.xpack.application.rules.action.DeleteQueryRulesetAction;
 import org.elasticsearch.xpack.application.rules.action.GetQueryRulesetAction;
@@ -106,8 +105,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
     public static final String BEHAVIORAL_ANALYTICS_API_ENDPOINT = APPLICATION_API_ENDPOINT + "/analytics";
 
     public static final String QUERY_RULES_API_ENDPOINT = "_query_rules";
-
-    private static final Logger logger = LogManager.getLogger(EnterpriseSearch.class);
 
     public static final String FEATURE_NAME = "ent_search";
 
@@ -228,7 +225,16 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         );
         analyticsTemplateRegistry.initialize();
 
-        return List.of(analyticsTemplateRegistry);
+        // Connector components
+        final ConnectorTemplateRegistry connectorTemplateRegistry = new ConnectorTemplateRegistry(
+            clusterService,
+            threadPool,
+            client,
+            xContentRegistry
+        );
+        connectorTemplateRegistry.initialize();
+
+        return Arrays.asList(analyticsTemplateRegistry, connectorTemplateRegistry);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConstants.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorConstants.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+public class ConnectorConstants {
+    // Connector indices constants
+    public static final String CONNECTOR_INDEX_NAME_PATTERN = ".elastic-connectors-*";
+    public static final String CONNECTOR_TEMPLATE_NAME = "elastic-connectors";
+
+    public static final String CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN = ".elastic-connectors-sync-jobs-*";
+    public static final String CONNECTOR_SYNC_JOBS_TEMPLATE_NAME = "elastic-connectors-sync-jobs";
+
+    public static final String ACCESS_CONTROL_INDEX_NAME_PATTERN = ".search-acl-filter-*";
+    public static final String ACCESS_CONTROL_TEMPLATE_NAME = "search-acl-filter";
+
+    // Pipeline constants
+
+    public static final String ENT_SEARCH_GENERIC_PIPELINE_NAME = "ent-search-generic-ingestion";
+    public static final String ENT_SEARCH_GENERIC_PIPELINE_FILE = "generic_ingestion_pipeline";
+
+    // Resource config
+    public static final String ROOT_RESOURCE_PATH = "/org/elasticsearch/xpack/application/";
+    public static final String ROOT_TEMPLATE_RESOURCE_PATH = ROOT_RESOURCE_PATH + "connector/";
+
+    // Pipeline constants
+    public static final String TEMPLATE_VERSION_VARIABLE = "xpack.application.connector.template.version";
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistry.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentParserConfiguration;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.core.template.IndexTemplateConfig;
+import org.elasticsearch.xpack.core.template.IndexTemplateRegistry;
+import org.elasticsearch.xpack.core.template.IngestPipelineConfig;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.ACCESS_CONTROL_INDEX_NAME_PATTERN;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.ACCESS_CONTROL_TEMPLATE_NAME;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.CONNECTOR_INDEX_NAME_PATTERN;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.CONNECTOR_TEMPLATE_NAME;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.CONNECTOR_SYNC_JOBS_TEMPLATE_NAME;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.ENT_SEARCH_GENERIC_PIPELINE_FILE;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.ENT_SEARCH_GENERIC_PIPELINE_NAME;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.ROOT_RESOURCE_PATH;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.ROOT_TEMPLATE_RESOURCE_PATH;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.TEMPLATE_VERSION_VARIABLE;
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
+
+public class ConnectorTemplateRegistry extends IndexTemplateRegistry {
+
+    static final Version MIN_NODE_VERSION = Version.V_8_10_0;
+
+    // This number must be incremented when we make changes to built-in templates.
+    static final int REGISTRY_VERSION = 1;
+
+    static final Map<String, ComponentTemplate> COMPONENT_TEMPLATES;
+
+    static {
+        final Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
+        for (IndexTemplateConfig config : List.of(
+            new IndexTemplateConfig(
+                CONNECTOR_TEMPLATE_NAME + "-mappings",
+                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + "-mappings.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE
+            ),
+            new IndexTemplateConfig(
+                CONNECTOR_TEMPLATE_NAME + "-settings",
+                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + "-settings.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE
+            ),
+            new IndexTemplateConfig(
+                CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + "-mappings",
+                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + "-mappings.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE
+            ),
+            new IndexTemplateConfig(
+                CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + "-settings",
+                ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + "-settings.json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE
+            )
+        )) {
+
+            try {
+                componentTemplates.put(
+                    config.getTemplateName(),
+                    ComponentTemplate.parse(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, config.loadBytes()))
+                );
+            } catch (IOException e) {
+                throw new AssertionError(e);
+            }
+        }
+        COMPONENT_TEMPLATES = Map.copyOf(componentTemplates);
+    }
+
+    @Override
+    protected List<IngestPipelineConfig> getIngestPipelines() {
+        return List.of(
+            new IngestPipelineConfig(
+                ENT_SEARCH_GENERIC_PIPELINE_NAME,
+                ROOT_RESOURCE_PATH + ENT_SEARCH_GENERIC_PIPELINE_FILE + ".json",
+                REGISTRY_VERSION,
+                TEMPLATE_VERSION_VARIABLE
+            )
+        );
+    }
+
+    static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATES = parseComposableTemplates(
+        new IndexTemplateConfig(
+            CONNECTOR_TEMPLATE_NAME,
+            ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_TEMPLATE_NAME + ".json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            Map.of("connector.index_pattern", CONNECTOR_INDEX_NAME_PATTERN)
+        ),
+        new IndexTemplateConfig(
+            CONNECTOR_SYNC_JOBS_TEMPLATE_NAME,
+            ROOT_TEMPLATE_RESOURCE_PATH + CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + ".json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            Map.of("connector-sync-jobs.index_pattern", CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN)
+        ),
+        new IndexTemplateConfig(
+            ACCESS_CONTROL_TEMPLATE_NAME,
+            ROOT_TEMPLATE_RESOURCE_PATH + ACCESS_CONTROL_TEMPLATE_NAME + ".json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE,
+            Map.of("access-control.index_pattern", ACCESS_CONTROL_INDEX_NAME_PATTERN)
+        )
+    );
+
+    public ConnectorTemplateRegistry(
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        Client client,
+        NamedXContentRegistry xContentRegistry
+    ) {
+        super(Settings.EMPTY, clusterService, threadPool, client, xContentRegistry);
+    }
+
+    @Override
+    protected String getOrigin() {
+        return ENT_SEARCH_ORIGIN;
+    }
+
+    @Override
+    protected Map<String, ComponentTemplate> getComponentTemplateConfigs() {
+        return COMPONENT_TEMPLATES;
+    }
+
+    @Override
+    protected Map<String, ComposableIndexTemplate> getComposableTemplateConfigs() {
+        return COMPOSABLE_INDEX_TEMPLATES;
+    }
+
+    @Override
+    protected boolean requiresMasterNode() {
+        // We are using the composable index template and component APIs,
+        // these APIs aren't supported in 7.7 and earlier and in mixed cluster
+        // environments this can cause a lot of ActionNotFoundTransportException
+        // errors in the logs during rolling upgrades. If these templates
+        // are only installed via elected master node then the APIs are always
+        // there and the ActionNotFoundTransportException errors are then prevented.
+        return true;
+    }
+
+    @Override
+    protected boolean isClusterReady(ClusterChangedEvent event) {
+        // Ensure templates are installed only once all nodes are updated to 8.8.0.
+        Version minNodeVersion = event.state().nodes().getMinNodeVersion();
+        return minNodeVersion.onOrAfter(MIN_NODE_VERSION);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/connector/ConnectorTemplateRegistryTests.java
@@ -1,0 +1,500 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.connector;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.admin.indices.template.put.PutComponentTemplateAction;
+import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
+import org.elasticsearch.action.ingest.PutPipelineAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.ComponentTemplate;
+import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.ilm.IndexLifecycleMetadata;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicy;
+import org.elasticsearch.xpack.core.ilm.LifecyclePolicyMetadata;
+import org.elasticsearch.xpack.core.ilm.OperationMode;
+import org.elasticsearch.xpack.core.ilm.action.PutLifecycleAction;
+import org.junit.After;
+import org.junit.Before;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.CONNECTOR_INDEX_NAME_PATTERN;
+import static org.elasticsearch.xpack.application.connector.ConnectorConstants.CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class ConnectorTemplateRegistryTests extends ESTestCase {
+    private ConnectorTemplateRegistry registry;
+    private ThreadPool threadPool;
+    private VerifyingClient client;
+
+    @Before
+    public void createRegistryAndClient() {
+        threadPool = new TestThreadPool(this.getClass().getName());
+        client = new VerifyingClient(threadPool);
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        registry = new ConnectorTemplateRegistry(clusterService, threadPool, client, NamedXContentRegistry.EMPTY);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public void testThatNonExistingComposableTemplatesAreAddedImmediately() throws Exception {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+        Map<String, Integer> existingComponentTemplates = Map.of(
+            ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-mappings",
+            ConnectorTemplateRegistry.REGISTRY_VERSION,
+            ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-settings",
+            ConnectorTemplateRegistry.REGISTRY_VERSION,
+            ConnectorConstants.CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + "-mappings",
+            ConnectorTemplateRegistry.REGISTRY_VERSION,
+            ConnectorConstants.CONNECTOR_SYNC_JOBS_TEMPLATE_NAME + "-settings",
+            ConnectorTemplateRegistry.REGISTRY_VERSION,
+            ConnectorConstants.ACCESS_CONTROL_TEMPLATE_NAME,
+            ConnectorTemplateRegistry.REGISTRY_VERSION
+        );
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), existingComponentTemplates, nodes);
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> verifyComposableTemplateInstalled(calledTimes, action, request, listener));
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getComposableTemplateConfigs().size())));
+
+        calledTimes.set(0);
+
+        // attempting to register the event multiple times as a race condition can yield this test flaky, namely:
+        // when calling registry.clusterChanged(newEvent) the templateCreationsInProgress state that the IndexTemplateRegistry maintains
+        // might've not yet been updated to reflect that the first template registration was complete, so a second template registration
+        // will not be issued anymore, leaving calledTimes to 0
+        assertBusy(() -> {
+            // now delete one template from the cluster state and let's retry
+            ClusterChangedEvent newEvent = createClusterChangedEvent(Collections.emptyMap(), existingComponentTemplates, nodes);
+            registry.clusterChanged(newEvent);
+            assertThat(calledTimes.get(), greaterThan(1));
+        });
+    }
+
+    public void testThatNonExistingComponentTemplatesAreAddedImmediately() throws Exception {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        ClusterChangedEvent event = createClusterChangedEvent(
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            Collections.singletonMap(ConnectorConstants.ENT_SEARCH_GENERIC_PIPELINE_NAME, ConnectorTemplateRegistry.REGISTRY_VERSION),
+            Collections.emptyMap(),
+            nodes
+        );
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> verifyComponentTemplateInstalled(calledTimes, action, request, listener));
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getComponentTemplateConfigs().size())));
+
+        calledTimes.set(0);
+
+        // attempting to register the event multiple times as a race condition can yield this test flaky, namely:
+        // when calling registry.clusterChanged(newEvent) the templateCreationsInProgress state that the IndexTemplateRegistry maintains
+        // might've not yet been updated to reflect that the first template registration was complete, so a second template registration
+        // will not be issued anymore, leaving calledTimes to 0
+        assertBusy(() -> {
+            // now delete one template from the cluster state and let's retry
+            ClusterChangedEvent newEvent = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
+            registry.clusterChanged(newEvent);
+            assertThat(calledTimes.get(), greaterThan(1));
+        });
+    }
+    public void testThatVersionedOldComponentTemplatesAreUpgraded() throws Exception {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        ClusterChangedEvent event = createClusterChangedEvent(
+            Collections.emptyMap(),
+            Collections.singletonMap(
+                ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-settings",
+                ConnectorTemplateRegistry.REGISTRY_VERSION - 1
+            ),
+            Collections.singletonMap(ConnectorConstants.ENT_SEARCH_GENERIC_PIPELINE_NAME, ConnectorTemplateRegistry.REGISTRY_VERSION),
+            Collections.emptyMap(),
+            nodes
+        );
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> verifyComponentTemplateInstalled(calledTimes, action, request, listener));
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getComponentTemplateConfigs().size())));
+    }
+
+    public void testThatUnversionedOldComponentTemplatesAreUpgraded() throws Exception {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        ClusterChangedEvent event = createClusterChangedEvent(
+            Collections.emptyMap(),
+            Collections.singletonMap(ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-mappings", null),
+            Collections.singletonMap(ConnectorConstants.ENT_SEARCH_GENERIC_PIPELINE_NAME, ConnectorTemplateRegistry.REGISTRY_VERSION),
+            Collections.emptyMap(),
+            nodes
+        );
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> verifyComponentTemplateInstalled(calledTimes, action, request, listener));
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getComponentTemplateConfigs().size())));
+    }
+
+    @TestLogging(value = "org.elasticsearch.xpack.core.template:DEBUG", reason = "test")
+    public void testSameOrHigherVersionComponentTemplateNotUpgraded() {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        Map<String, Integer> versions = new HashMap<>();
+        versions.put(ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-mappings", ConnectorTemplateRegistry.REGISTRY_VERSION);
+        versions.put(ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-settings", ConnectorTemplateRegistry.REGISTRY_VERSION);
+        ClusterChangedEvent sameVersionEvent = createClusterChangedEvent(Collections.emptyMap(), versions, nodes);
+        client.setVerifier((action, request, listener) -> {
+            if (action instanceof PutPipelineAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            }
+            if (action instanceof PutComponentTemplateAction) {
+                fail("template should not have been re-installed");
+                return null;
+            } else if (action instanceof PutLifecycleAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutComposableIndexTemplateAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else {
+                fail("client called with unexpected request:" + request.toString());
+                return null;
+            }
+        });
+        registry.clusterChanged(sameVersionEvent);
+
+        versions.clear();
+        versions.put(
+            ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-mappings",
+            ConnectorTemplateRegistry.REGISTRY_VERSION + randomIntBetween(1, 1000)
+        );
+        versions.put(
+            ConnectorConstants.CONNECTOR_TEMPLATE_NAME + "-settings",
+            ConnectorTemplateRegistry.REGISTRY_VERSION + randomIntBetween(1, 1000)
+        );
+        ClusterChangedEvent higherVersionEvent = createClusterChangedEvent(Collections.emptyMap(), versions, nodes);
+        registry.clusterChanged(higherVersionEvent);
+    }
+
+    public void testThatMissingMasterNodeDoesNothing() {
+        DiscoveryNode localNode = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
+
+        client.setVerifier((a, r, l) -> {
+            fail("if the master is missing nothing should happen");
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(
+            Collections.singletonMap(ConnectorConstants.CONNECTOR_TEMPLATE_NAME, null),
+            Collections.emptyMap(),
+            nodes
+        );
+        registry.clusterChanged(event);
+    }
+
+    public void testThatNonExistingPipelinesAreAddedImmediately() throws Exception {
+        DiscoveryNode node = DiscoveryNodeUtils.create("node");
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> {
+            if (action instanceof PutPipelineAction) {
+                calledTimes.incrementAndGet();
+                return AcknowledgedResponse.TRUE;
+            }
+            if (action instanceof PutComponentTemplateAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutLifecycleAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else if (action instanceof PutComposableIndexTemplateAction) {
+                // Ignore this, it's verified in another test
+                return AcknowledgedResponse.TRUE;
+            } else {
+                fail("client called with unexpected request: " + request.toString());
+            }
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getIngestPipelines().size())));
+    }
+
+    public void testThatNothingIsInstalledWhenAllNodesAreNotUpdated() {
+        DiscoveryNode updatedNode = DiscoveryNodeUtils.create("updatedNode");
+        DiscoveryNode outdatedNode = DiscoveryNodeUtils.create("outdatedNode", ESTestCase.buildNewFakeTransportAddress(), Version.V_8_7_0);
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .localNodeId("updatedNode")
+            .masterNodeId("updatedNode")
+            .add(updatedNode)
+            .add(outdatedNode)
+            .build();
+
+        client.setVerifier((a, r, l) -> {
+            fail("if some cluster mode are not updated to at least v.8.8.0 nothing should happen");
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
+        registry.clusterChanged(event);
+    }
+
+    // -------------
+
+    /**
+     * A client that delegates to a verifying function for action/request/listener
+     */
+    public static class VerifyingClient extends NoOpClient {
+
+        private TriFunction<ActionType<?>, ActionRequest, ActionListener<?>, ActionResponse> verifier = (a, r, l) -> {
+            fail("verifier not set");
+            return null;
+        };
+
+        VerifyingClient(ThreadPool threadPool) {
+            super(threadPool);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {
+            try {
+                listener.onResponse((Response) verifier.apply(action, request, listener));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+
+        public VerifyingClient setVerifier(TriFunction<ActionType<?>, ActionRequest, ActionListener<?>, ActionResponse> verifier) {
+            this.verifier = verifier;
+            return this;
+        }
+    }
+
+    private ActionResponse verifyComposableTemplateInstalled(
+        AtomicInteger calledTimes,
+        ActionType<?> action,
+        ActionRequest request,
+        ActionListener<?> listener
+    ) {
+        if (action instanceof PutPipelineAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
+        }
+        if (action instanceof PutComponentTemplateAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
+        } else if (action instanceof PutLifecycleAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
+        } else if (action instanceof PutComposableIndexTemplateAction) {
+            calledTimes.incrementAndGet();
+            assertThat(action, instanceOf(PutComposableIndexTemplateAction.class));
+            assertThat(request, instanceOf(PutComposableIndexTemplateAction.Request.class));
+            final PutComposableIndexTemplateAction.Request putRequest = (PutComposableIndexTemplateAction.Request) request;
+            assertThat(putRequest.indexTemplate().version(), equalTo((long) ConnectorTemplateRegistry.REGISTRY_VERSION));
+            final List<String> indexPatterns = putRequest.indexTemplate().indexPatterns();
+            assertThat(indexPatterns, hasSize(1));
+            assertThat(indexPatterns.get(0), equalTo(CONNECTOR_INDEX_NAME_PATTERN));
+            assertThat(indexPatterns.get(1), equalTo(CONNECTOR_SYNC_JOBS_INDEX_NAME_PATTERN));
+            assertNotNull(listener);
+            return new TestPutIndexTemplateResponse(true);
+        } else {
+            fail("client called with unexpected request:" + request.toString());
+            return null;
+        }
+    }
+
+    private ActionResponse verifyComponentTemplateInstalled(
+        AtomicInteger calledTimes,
+        ActionType<?> action,
+        ActionRequest request,
+        ActionListener<?> listener
+    ) {
+        if (action instanceof PutPipelineAction) {
+            return AcknowledgedResponse.TRUE;
+        }
+        if (action instanceof PutComponentTemplateAction) {
+            calledTimes.incrementAndGet();
+            assertThat(action, instanceOf(PutComponentTemplateAction.class));
+            assertThat(request, instanceOf(PutComponentTemplateAction.Request.class));
+            final PutComponentTemplateAction.Request putRequest = (PutComponentTemplateAction.Request) request;
+            assertThat(putRequest.componentTemplate().version(), equalTo((long) ConnectorTemplateRegistry.REGISTRY_VERSION));
+            assertNotNull(listener);
+            return new TestPutIndexTemplateResponse(true);
+        } else if (action instanceof PutLifecycleAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
+        } else if (action instanceof PutComposableIndexTemplateAction) {
+            // Ignore this, it's verified in another test
+            return AcknowledgedResponse.TRUE;
+        } else {
+            fail("client called with unexpected request:" + request.toString());
+            return null;
+        }
+    }
+
+    private ClusterChangedEvent createClusterChangedEvent(
+        Map<String, Integer> existingComposableTemplates,
+        Map<String, Integer> existingComponentTemplates,
+        DiscoveryNodes nodes
+    ) {
+        return createClusterChangedEvent(
+            existingComposableTemplates,
+            existingComponentTemplates,
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            nodes
+        );
+    }
+
+    private ClusterChangedEvent createClusterChangedEvent(
+        Map<String, Integer> existingComposableTemplates,
+        Map<String, Integer> existingComponentTemplates,
+        Map<String, Integer> existingIngestPipelines,
+        Map<String, LifecyclePolicy> existingPolicies,
+        DiscoveryNodes nodes
+    ) {
+        ClusterState cs = createClusterState(
+            existingComposableTemplates,
+            existingComponentTemplates,
+            existingIngestPipelines,
+            existingPolicies,
+            nodes
+        );
+        ClusterChangedEvent realEvent = new ClusterChangedEvent(
+            "created-from-test",
+            cs,
+            ClusterState.builder(new ClusterName("test")).build()
+        );
+        ClusterChangedEvent event = spy(realEvent);
+        when(event.localNodeMaster()).thenReturn(nodes.isLocalNodeElectedMaster());
+
+        return event;
+    }
+
+    private ClusterState createClusterState(
+        Map<String, Integer> existingComposableTemplates,
+        Map<String, Integer> existingComponentTemplates,
+        Map<String, Integer> existingIngestPipelines,
+        Map<String, LifecyclePolicy> existingPolicies,
+        DiscoveryNodes nodes
+    ) {
+        Map<String, ComposableIndexTemplate> composableTemplates = new HashMap<>();
+        for (Map.Entry<String, Integer> template : existingComposableTemplates.entrySet()) {
+            ComposableIndexTemplate mockTemplate = mock(ComposableIndexTemplate.class);
+            when(mockTemplate.version()).thenReturn(template.getValue() == null ? null : (long) template.getValue());
+            composableTemplates.put(template.getKey(), mockTemplate);
+        }
+
+        Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
+        for (Map.Entry<String, Integer> template : existingComponentTemplates.entrySet()) {
+            ComponentTemplate mockTemplate = mock(ComponentTemplate.class);
+            when(mockTemplate.version()).thenReturn(template.getValue() == null ? null : (long) template.getValue());
+            componentTemplates.put(template.getKey(), mockTemplate);
+        }
+
+        Map<String, PipelineConfiguration> ingestPipelines = new HashMap<>();
+        for (Map.Entry<String, Integer> pipelineEntry : existingIngestPipelines.entrySet()) {
+            // we cannot mock PipelineConfiguration as it is a final class
+            ingestPipelines.put(
+                pipelineEntry.getKey(),
+                new PipelineConfiguration(
+                    pipelineEntry.getKey(),
+                    new BytesArray(Strings.format("{\"version\": %d}", pipelineEntry.getValue())),
+                    XContentType.JSON
+                )
+            );
+        }
+        IngestMetadata ingestMetadata = new IngestMetadata(ingestPipelines);
+
+        Map<String, LifecyclePolicyMetadata> existingILMMeta = existingPolicies.entrySet()
+            .stream()
+            .collect(Collectors.toMap(Map.Entry::getKey, e -> new LifecyclePolicyMetadata(e.getValue(), Collections.emptyMap(), 1, 1)));
+        IndexLifecycleMetadata ilmMeta = new IndexLifecycleMetadata(existingILMMeta, OperationMode.RUNNING);
+
+        return ClusterState.builder(new ClusterName("test"))
+            .metadata(
+                Metadata.builder()
+                    .indexTemplates(composableTemplates)
+                    .componentTemplates(componentTemplates)
+                    .transientSettings(Settings.EMPTY)
+                    .putCustom(IngestMetadata.TYPE, ingestMetadata)
+                    .putCustom(IndexLifecycleMetadata.TYPE, ilmMeta)
+                    .build()
+            )
+            .blocks(new ClusterBlocks.Builder().build())
+            .nodes(nodes)
+            .build();
+    }
+
+    private static class TestPutIndexTemplateResponse extends AcknowledgedResponse {
+        TestPutIndexTemplateResponse(boolean acknowledged) {
+            super(acknowledged);
+        }
+    }
+}


### PR DESCRIPTION
This adds the connectors indices `.elastic-connectors-v1` and `.elastic-connectors-sync-jobs-v1` on startup, as well as the ingest pipeline `ent-search-generic-ingestion`. This way we no longer have to rely on Enterprise Search to be running to use these connectors indices. 

The future plan is to convert these to system indices, but the fact that these are deployed in the wild with permissions insufficient to access these indices as system indices means we cannot do this work yet. 