### PR TITLE
Remove noop isFragment overrides in ToXContent implementations

### DIFF
--- a/modules/lang-painless/src/doc/java/org/elasticsearch/painless/JavadocExtractor.java
+++ b/modules/lang-painless/src/doc/java/org/elasticsearch/painless/JavadocExtractor.java
@@ -270,11 +270,6 @@ public class JavadocExtractor {
             builder.endObject();
             return builder;
         }
-
-        @Override
-        public boolean isFragment() {
-            return true;
-        }
     }
 
     public static ParsedJavadoc clean(Javadoc javadoc) {

--- a/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
+++ b/server/src/main/java/org/elasticsearch/cluster/SnapshotsInProgress.java
@@ -32,6 +32,7 @@ import org.elasticsearch.snapshots.Snapshot;
 import org.elasticsearch.snapshots.SnapshotFeatureInfo;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -648,7 +649,7 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
         }
     }
 
-    public static class Entry implements Writeable, ToXContent, RepositoryOperation, Diffable<Entry> {
+    public static class Entry implements Writeable, ToXContentObject, RepositoryOperation, Diffable<Entry> {
         private final State state;
         private final Snapshot snapshot;
         private final boolean includeGlobalState;
@@ -1340,11 +1341,6 @@ public class SnapshotsInProgress extends AbstractNamedDiffable<Custom> implement
                 out.writeMap(shardStatusByRepoShardId);
             }
             out.writeList(featureStates);
-        }
-
-        @Override
-        public boolean isFragment() {
-            return false;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
+++ b/server/src/main/java/org/elasticsearch/common/compress/CompressedXContent.java
@@ -19,6 +19,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentParser;
@@ -162,17 +163,11 @@ public final class CompressedXContent {
      * @return compressed x-content normalized to not contain any whitespaces
      */
     public static CompressedXContent fromJSON(String json) throws IOException {
-        return new CompressedXContent(new ToXContent() {
-            @Override
-            public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
-                return builder.copyCurrentStructure(JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json));
-            }
-
-            @Override
-            public boolean isFragment() {
-                return false;
-            }
-        });
+        return new CompressedXContent(
+            (ToXContentObject) (builder, params) -> builder.copyCurrentStructure(
+                JsonXContent.jsonXContent.createParser(XContentParserConfiguration.EMPTY, json)
+            )
+        );
     }
 
     public CompressedXContent(String str) throws IOException {

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadata.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadata.java
@@ -252,11 +252,6 @@ public final class HealthMetadata extends AbstractNamedDiffable<ClusterState.Cus
         }
 
         @Override
-        public boolean isFragment() {
-            return true;
-        }
-
-        @Override
         public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
             builder.field(HIGH_WATERMARK_FIELD.getPreferredName(), describeHighWatermark());
             builder.field(HIGH_MAX_HEADROOM_FIELD.getPreferredName(), highMaxHeadroom);

--- a/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/RetentionLease.java
@@ -161,11 +161,6 @@ public final class RetentionLease implements ToXContentObject, Writeable {
         return builder;
     }
 
-    @Override
-    public boolean isFragment() {
-        return false;
-    }
-
     /**
      * Parses a retention lease from {@link org.elasticsearch.xcontent.XContent}. This method assumes that the retention lease was
      * converted to {@link org.elasticsearch.xcontent.XContent} via {@link #toXContent(XContentBuilder, Params)}.

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -474,11 +474,6 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
             builder.endObject();
             return builder;
         }
-
-        @Override
-        public boolean isFragment() {
-            return false;
-        }
     }
 
     private static class TaskBuilder<Params extends PersistentTaskParams> {

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksNodeService.java
@@ -366,11 +366,6 @@ public class PersistentTasksNodeService implements ClusterStateListener {
         }
 
         @Override
-        public boolean isFragment() {
-            return false;
-        }
-
-        @Override
         public boolean equals(Object o) {
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;

--- a/server/src/main/java/org/elasticsearch/script/field/IPAddress.java
+++ b/server/src/main/java/org/elasticsearch/script/field/IPAddress.java
@@ -9,7 +9,7 @@
 package org.elasticsearch.script.field;
 
 import org.elasticsearch.common.network.InetAddresses;
-import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -20,7 +20,7 @@ import java.net.InetAddress;
 /**
  * IP address for use in scripting.
  */
-public class IPAddress implements ToXContent {
+public class IPAddress implements ToXContentObject {
     protected final InetAddress address;
 
     IPAddress(InetAddress address) {
@@ -49,8 +49,4 @@ public class IPAddress implements ToXContent {
         return builder.value(this.toString());
     }
 
-    @Override
-    public boolean isFragment() {
-        return false;
-    }
 }

--- a/server/src/main/java/org/elasticsearch/upgrades/SingleFeatureMigrationResult.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/SingleFeatureMigrationResult.java
@@ -16,7 +16,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
 import org.elasticsearch.xcontent.ParseField;
-import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 
@@ -26,7 +26,7 @@ import java.util.Objects;
 /**
  * Holds the results of migrating a single feature. See also {@link FeatureMigrationResults}.
  */
-public class SingleFeatureMigrationResult implements SimpleDiffable<SingleFeatureMigrationResult>, Writeable, ToXContent {
+public class SingleFeatureMigrationResult implements SimpleDiffable<SingleFeatureMigrationResult>, Writeable, ToXContentObject {
     private static final String NAME = "feature_migration_status";
     private static final ParseField SUCCESS_FIELD = new ParseField("successful");
     private static final ParseField FAILED_INDEX_NAME_FIELD = new ParseField("failed_index");
@@ -143,11 +143,6 @@ public class SingleFeatureMigrationResult implements SimpleDiffable<SingleFeatur
         }
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public boolean isFragment() {
-        return false;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
+++ b/server/src/test/java/org/elasticsearch/persistent/TestPersistentTasksPlugin.java
@@ -261,11 +261,6 @@ public class TestPersistentTasksPlugin extends Plugin implements ActionPlugin, P
         }
 
         @Override
-        public boolean isFragment() {
-            return false;
-        }
-
-        @Override
         public void writeTo(StreamOutput out) throws IOException {
             out.writeString(phase);
         }

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingCapacity.java
@@ -15,7 +15,7 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.unit.Processors;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -24,12 +24,12 @@ import java.util.Objects;
 /**
  * Represents current/required capacity of a single tier.
  */
-public class AutoscalingCapacity implements ToXContent, Writeable {
+public class AutoscalingCapacity implements ToXContentObject, Writeable {
 
     private final AutoscalingResources total;
     private final AutoscalingResources node;
 
-    public static class AutoscalingResources implements ToXContent, Writeable {
+    public static class AutoscalingResources implements ToXContentObject, Writeable {
         private final ByteSizeValue storage;
         private final ByteSizeValue memory;
         private final Processors processors;
@@ -82,11 +82,6 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
             }
             builder.endObject();
             return builder;
-        }
-
-        @Override
-        public boolean isFragment() {
-            return false;
         }
 
         @Override
@@ -239,11 +234,6 @@ public class AutoscalingCapacity implements ToXContent, Writeable {
         builder.field("total", total);
         builder.endObject();
         return builder;
-    }
-
-    @Override
-    public boolean isFragment() {
-        return false;
     }
 
     public static AutoscalingCapacity upperBound(AutoscalingCapacity c1, AutoscalingCapacity c2) {

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
@@ -12,7 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.ToXContentObject;
 import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
@@ -31,7 +31,7 @@ import static org.elasticsearch.cluster.node.DiscoveryNode.DISCOVERY_NODE_COMPAR
  * Represents a collection of individual autoscaling decider results that can be aggregated into a single autoscaling capacity for a
  * policy
  */
-public class AutoscalingDeciderResults implements ToXContent, Writeable {
+public class AutoscalingDeciderResults implements ToXContentObject, Writeable {
 
     private final AutoscalingCapacity currentCapacity;
     private final SortedSet<DiscoveryNode> currentNodes;
@@ -72,11 +72,6 @@ public class AutoscalingDeciderResults implements ToXContent, Writeable {
         currentCapacity.writeTo(out);
         out.writeCollection(currentNodes);
         out.writeMap(results, StreamOutput::writeString, (output, result) -> result.writeTo(output));
-    }
-
-    @Override
-    public boolean isFragment() {
-        return false;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedState.java
@@ -65,11 +65,6 @@ public enum DatafeedState implements PersistentTaskState {
         return builder;
     }
 
-    @Override
-    public boolean isFragment() {
-        return false;
-    }
-
     public static DatafeedState fromXContent(XContentParser parser) throws IOException {
         return PARSER.parse(parser, null);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/JobTaskState.java
@@ -104,11 +104,6 @@ public class JobTaskState implements PersistentTaskState {
     }
 
     @Override
-    public boolean isFragment() {
-        return false;
-    }
-
-    @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         builder.startObject();
         builder.field(STATE.getPreferredName(), state.value());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/TemplateRoleName.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/mapper/TemplateRoleName.java
@@ -172,11 +172,6 @@ public class TemplateRoleName implements ToXContentObject, Writeable {
     }
 
     @Override
-    public boolean isFragment() {
-        return false;
-    }
-
-    @Override
     public boolean equals(Object o) {
         if (this == o) {
             return true;


### PR DESCRIPTION
Just removing some dead code I found while looking into xcontent chunking.
