### PR TITLE
Cache modification time of translog writer file

### DIFF
--- a/docs/changelog/95107.yaml
+++ b/docs/changelog/95107.yaml
@@ -1,0 +1,5 @@
+pr: 95107
+summary: Cache mtime of translog writer file which not be written anymore
+area: Engine
+type: enhancement
+issues: []

--- a/docs/changelog/95107.yaml
+++ b/docs/changelog/95107.yaml
@@ -1,5 +1,5 @@
 pr: 95107
-summary: Cache mtime of translog writer file which not be written anymore
+summary: Cache modification time of translog writer file
 area: Engine
 type: enhancement
 issues: []

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1586,6 +1586,40 @@ public class TranslogTests extends ESTestCase {
         }
     }
 
+    public void testTranslogWriterLastModifiedTime() throws IOException {
+        Path tempDir = createTempDir();
+        try (Translog translog = create(tempDir)) {
+            long mtime = translog.getCurrent().getLastModifiedTime();
+            TranslogWriter.LastModifiedTimeCache mtimeCache = translog.getCurrent().lastModifiedTimeCache;
+            // no ops
+            long lastMtime = translog.getCurrent().getLastModifiedTime();
+            TranslogWriter.LastModifiedTimeCache lastMtimeCache = translog.getCurrent().lastModifiedTimeCache;
+            assertThat(lastMtime, equalTo(mtime));
+            assertEquals(lastMtimeCache, mtimeCache);
+
+            mtime = lastMtime;
+            mtimeCache = lastMtimeCache;
+            // add ops
+            int count = randomInt(100);
+            for (int i = 0; i < count; i++) {
+                translog.add(indexOp(randomAlphaOfLength(128), i, primaryTerm.get()));
+            }
+            lastMtime = translog.getCurrent().getLastModifiedTime();
+            lastMtimeCache = translog.getCurrent().lastModifiedTimeCache;
+            assertThat(lastMtime, greaterThanOrEqualTo(mtime));
+            assertThat(lastMtimeCache.totalOffset(), greaterThan(mtimeCache.totalOffset()));
+
+            mtime = lastMtime;
+            mtimeCache = lastMtimeCache;
+            // sync ops
+            translog.sync();
+            lastMtime = translog.getCurrent().getLastModifiedTime();
+            lastMtimeCache = translog.getCurrent().lastModifiedTimeCache;
+            assertThat(lastMtime, greaterThanOrEqualTo(mtime));
+            assertThat(lastMtimeCache.syncedOffset(), greaterThan(mtimeCache.syncedOffset()));
+        }
+    }
+
     public void testTranslogOperationListener() throws IOException {
         Path tempDir = createTempDir();
         final Settings settings = Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build();

--- a/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
+++ b/server/src/test/java/org/elasticsearch/index/translog/TranslogTests.java
@@ -1600,7 +1600,7 @@ public class TranslogTests extends ESTestCase {
             mtime = lastMtime;
             mtimeCache = lastMtimeCache;
             // add ops
-            int count = randomInt(100);
+            int count = randomIntBetween(1, 100);
             for (int i = 0; i < count; i++) {
                 translog.add(indexOp(randomAlphaOfLength(128), i, primaryTerm.get()));
             }


### PR DESCRIPTION
Usually, several indices are written even the cluster has a lot of indices, so we can cache modified time of translog writer file which already not be written to reduce cost time of nodes and indices stats