### PR TITLE
Fix IntelliJ compilation

### DIFF
--- a/x-pack/plugin/ml/src/main/java/module-info.java
+++ b/x-pack/plugin/ml/src/main/java/module-info.java
@@ -25,6 +25,7 @@ module org.elasticsearch.ml {
     requires org.apache.lucene.core;
     requires org.apache.lucene.join;
     requires commons.math3;
+    requires ojalgo;
 
     opens org.elasticsearch.xpack.ml to org.elasticsearch.painless.spi; // whitelist resource access
     opens org.elasticsearch.xpack.ml.utils; // for exact.properties access


### PR DESCRIPTION
In #95057 we turned ML into a proper module, but omitted a `requires` directive that IntelliJ reports as a compilation error. This commit adds the missing directive.