### PR TITLE
Use 'indices' namespace for the Explain Data Lifecycle API

### DIFF
--- a/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/10_explain_lifecycle.yml
+++ b/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/10_explain_lifecycle.yml
@@ -33,7 +33,7 @@
       data_streams.0.indices.0.index_name: backing_index
 
   - do:
-      dlm.explain_lifecycle:
+      indices.explain_data_lifecycle:
         index: $backing_index
   - match: { indices.$backing_index.managed_by_dlm: true }
   - match: { indices.$backing_index.lifecycle.data_retention: '30d' }
@@ -41,7 +41,7 @@
 
 
   - do:
-      dlm.explain_lifecycle:
+      indices.explain_data_lifecycle:
         index: $backing_index
         include_defaults: true
   - match: { indices.$backing_index.managed_by_dlm: true }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
@@ -1,5 +1,5 @@
 {
-  "dlm.explain_lifecycle": {
+  "indices.explain_data_lifecycle": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/current/dlm-explain-lifecycle.html",
       "description": "Retrieves information about the index's current DLM lifecycle, such as any potential encountered error, time since creation etc."


### PR DESCRIPTION
Instead of creating a new `dlm` namespace, this PR proposes to match the other DLM APIs and use the `indices` namespace for the API.