### PR TITLE
Fix RecyclerBytesStreamOutput corrupting when ending write on page boundary

### DIFF
--- a/docs/changelog/95114.yaml
+++ b/docs/changelog/95114.yaml
@@ -1,0 +1,5 @@
+pr: 95114
+summary: Fix `RecyclerBytesStreamOutput` corrupting when ending write on page boundary
+area: Network
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
@@ -144,13 +144,6 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
         }
     }
 
-    public void reset() {
-        Releasables.close(pages);
-        pages.clear();
-        pageIndex = -1;
-        currentPageOffset = pageSize;
-    }
-
     @Override
     public void flush() {
         // nothing to do
@@ -235,11 +228,11 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
             assert pageSize == newPage.v().length;
             pages.add(newPage);
             // We are at the end of the current page, increment page index
-            if (currentPageOffset == pageSize) {
-                pageIndex++;
-                currentPageOffset = 0;
-            }
             currentCapacity += pageSize;
+        }
+        if (currentPageOffset == pageSize) {
+            pageIndex++;
+            currentPageOffset = 0;
         }
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -712,6 +712,22 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         }
     }
 
+    public void testWriteLongToCompletePage() throws IOException {
+        try (RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler)) {
+            out.seek(PageCacheRecycler.BYTE_PAGE_SIZE + 1);
+            int longPos = PageCacheRecycler.BYTE_PAGE_SIZE - Long.BYTES;
+            out.seek(longPos);
+            long longValue = randomLong();
+            out.writeLong(longValue);
+            byte byteValue = randomByte();
+            out.writeByte(byteValue);
+            var input = out.bytes().streamInput();
+            assertEquals(longPos, input.skip(longPos));
+            assertEquals(longValue, input.readLong());
+            assertEquals(byteValue, input.readByte());
+        }
+    }
+
     private static class TestWriteable implements Writeable {
 
         private boolean value;


### PR DESCRIPTION
Fixes the fact that we don't put the current page offset to zero when we already have capacity in the buffer but are not on the last page because of a seek.
Also removes unused `reset()` method since it added one needless place for me to check when trying to reason this out.