### PR TITLE
Tiny javadoc fix

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
+++ b/server/src/main/java/org/elasticsearch/common/util/LongLongHash.java
@@ -47,7 +47,7 @@ public final class LongLongHash extends AbstractHash {
     }
 
     /**
-     * Return the first key at {@code 0 &lt;= index &lt;= capacity()}. The
+     * Return the first key at {@code 0 <= index <= capacity()}. The
      * result is undefined if the slot is unused.
      */
     public long getKey1(long id) {


### PR DESCRIPTION
Just noticed this while digging around.  Renders wrong in Intellij, doesn't follow the [javadoc spec](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDJGIJB).  Code tags shouldn't use HTML entities.