### PR TITLE
Async creation of IndexShard instances

### DIFF
--- a/docs/changelog/94545.yaml
+++ b/docs/changelog/94545.yaml
@@ -1,0 +1,5 @@
+pr: 94545
+summary: Async creation of `IndexShard` instances
+area: Recovery
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.cluster;
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.LogEvent;
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.routing.allocation.decider.MaxRetryAllocationDecider;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.index.IndexNotFoundException;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.test.MockLogAppender;
+import org.elasticsearch.test.junit.annotations.TestLogging;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+
+public class ShardLockFailureIT extends ESIntegTestCase {
+
+    @TestLogging(reason = "checking DEBUG logs from ICSS", value = "org.elasticsearch.indices.cluster.IndicesClusterStateService:DEBUG")
+    public void testShardLockFailure() throws Exception {
+        final var node = internalCluster().startDataOnlyNode(
+            Settings.builder()
+                .put(IndicesClusterStateService.SHARD_LOCK_RETRY_INTERVAL_SETTING.getKey(), TimeValue.timeValueMillis(10))
+                .put(IndicesClusterStateService.SHARD_LOCK_RETRY_TIMEOUT_SETTING.getKey(), TimeValue.timeValueDays(10))
+                .build()
+        );
+
+        final var indexName = "testindex";
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", node)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+                .build()
+        );
+        ensureGreen(indexName);
+
+        final var shardId = new ShardId(resolveIndex(indexName), 0);
+
+        internalCluster().getCurrentMasterNodeInstance(ClusterService.class).addListener(event -> {
+            try {
+                assertTrue(
+                    event.state()
+                        .routingTable()
+                        .shardRoutingTable(shardId)
+                        .allShards()
+                        .noneMatch(sr -> sr.unassigned() && sr.unassignedInfo().getNumFailedAllocations() > 0)
+                );
+            } catch (IndexNotFoundException e) {
+                // ok
+            }
+        });
+
+        var mockLogAppender = new MockLogAppender();
+        try (
+            var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
+            var ignored2 = mockLogAppender.capturing(IndicesClusterStateService.class);
+        ) {
+            final CountDownLatch countDownLatch = new CountDownLatch(1);
+
+            mockLogAppender.addExpectation(new MockLogAppender.LoggingExpectation() {
+                int debugMessagesSeen = 0;
+                int warnMessagesSeen = 0;
+
+                @Override
+                public synchronized void match(LogEvent event) {
+                    try {
+                        assertEquals("org.elasticsearch.indices.cluster.IndicesClusterStateService", event.getLoggerName());
+                        if (event.getMessage().getFormattedMessage().matches("shard lock for .* has been unavailable for at least .*")) {
+                            if (event.getLevel() == Level.WARN) {
+                                warnMessagesSeen += 1;
+                                assertEquals(29L * warnMessagesSeen - 24, debugMessagesSeen);
+                                if (warnMessagesSeen == 3) {
+                                    countDownLatch.countDown();
+                                }
+                            } else if (event.getLevel() == Level.DEBUG) {
+                                debugMessagesSeen += 1;
+                            } else {
+                                fail("unexpected log level: " + event.getLevel());
+                            }
+                        }
+                    } catch (Throwable t) {
+                        ExceptionsHelper.maybeDieOnAnotherThread(new AssertionError("unexpected", t));
+                    }
+                }
+
+                @Override
+                public void assertMatched() {}
+            });
+
+            updateIndexSettings(indexName, Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name"));
+            ensureYellow(indexName);
+            assertTrue(countDownLatch.await(30, TimeUnit.SECONDS));
+            assertEquals(ClusterHealthStatus.YELLOW, client().admin().cluster().prepareHealth(indexName).get().getStatus());
+            mockLogAppender.assertAllExpectationsMatched();
+        }
+
+        ensureGreen(indexName);
+    }
+
+    @TestLogging(reason = "checking WARN logs from ICSS", value = "org.elasticsearch.indices.cluster.IndicesClusterStateService:WARN")
+    public void testShardLockTimeout() throws Exception {
+        final var node = internalCluster().startDataOnlyNode(
+            Settings.builder()
+                .put(IndicesClusterStateService.SHARD_LOCK_RETRY_INTERVAL_SETTING.getKey(), TimeValue.timeValueMillis(10))
+                .put(IndicesClusterStateService.SHARD_LOCK_RETRY_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100))
+                .build()
+        );
+
+        final var indexName = "testindex";
+        createIndex(
+            indexName,
+            Settings.builder()
+                .put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", node)
+                .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+                .put(IndexMetadata.SETTING_AUTO_EXPAND_REPLICAS, "0-all")
+                .put(MaxRetryAllocationDecider.SETTING_ALLOCATION_MAX_RETRY.getKey(), 1)
+                .build()
+        );
+        ensureGreen(indexName);
+
+        final var shardId = new ShardId(resolveIndex(indexName), 0);
+
+        var mockLogAppender = new MockLogAppender();
+        try (
+            var ignored1 = internalCluster().getInstance(NodeEnvironment.class, node).shardLock(shardId, "blocked for test");
+            var ignored2 = mockLogAppender.capturing(IndicesClusterStateService.class);
+        ) {
+            mockLogAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "timeout message",
+                    "org.elasticsearch.indices.cluster.IndicesClusterStateService",
+                    Level.WARN,
+                    """
+                        timed out after [indices.store.shard_lock_retry.timeout=100ms/100ms] \
+                        while waiting to acquire shard lock for [testindex][0]"""
+                )
+            );
+
+            updateIndexSettings(indexName, Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name"));
+            assertBusy(mockLogAppender::assertAllExpectationsMatched);
+            final var clusterHealthResponse = client().admin()
+                .cluster()
+                .prepareHealth(indexName)
+                .setWaitForEvents(Priority.LANGUID)
+                .setTimeout(TimeValue.timeValueSeconds(10))
+                .setWaitForNoInitializingShards(true)
+                .setWaitForNoRelocatingShards(true)
+                .get();
+            assertFalse(clusterHealthResponse.isTimedOut());
+            assertEquals(ClusterHealthStatus.YELLOW, clusterHealthResponse.getStatus());
+            assertEquals(1, clusterHealthResponse.getUnassignedShards());
+        }
+
+        assertAcked(client().admin().cluster().prepareReroute().setRetryFailed(true));
+        ensureGreen(indexName);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/IndexShardRoutingTable.java
@@ -33,6 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Stream;
 
 /**
  * {@link IndexShardRoutingTable} encapsulates all instances of a single shard.
@@ -133,6 +134,10 @@ public class IndexShardRoutingTable {
 
     public ShardRouting shard(int idx) {
         return shards[idx];
+    }
+
+    public Stream<ShardRouting> allShards() {
+        return Stream.of(shards);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/service/ClusterApplierService.java
@@ -33,6 +33,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.store.IndicesStore;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -282,12 +283,10 @@ public class ClusterApplierService extends AbstractLifecycleComponent implements
     }
 
     /**
-     * Run the given clusterStateConsumer on the applier thread. Should only be used in tests and by {@link IndicesStore} when it's deleting
-     * the data behind a shard that moved away from a node.
-     *
-     * @param priority              {@link Priority#HIGH} unless in tests.
+     * Run the given {@code clusterStateConsumer} on the applier thread. Should only be used in tests, by {@link IndicesClusterStateService}
+     * when trying to acquire shard locks and create shards, and by {@link IndicesStore} when it's deleting the data behind a shard that
+     * moved away from a node.
      */
-    // TODO get rid of this, make it so that shard data can be deleted without blocking the applier thread.
     public void runOnApplierThread(
         String source,
         Priority priority,

--- a/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/ClusterSettings.java
@@ -85,6 +85,7 @@ import org.elasticsearch.indices.ShardLimitValidator;
 import org.elasticsearch.indices.analysis.HunspellService;
 import org.elasticsearch.indices.breaker.BreakerSettings;
 import org.elasticsearch.indices.breaker.HierarchyCircuitBreakerService;
+import org.elasticsearch.indices.cluster.IndicesClusterStateService;
 import org.elasticsearch.indices.fielddata.cache.IndicesFieldDataCache;
 import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.store.IndicesStore;
@@ -565,7 +566,9 @@ public final class ClusterSettings extends AbstractScopedSettings {
         TcpTransport.isUntrustedRemoteClusterEnabled() ? RemoteClusterPortSettings.TCP_NO_DELAY : null,
         TcpTransport.isUntrustedRemoteClusterEnabled() ? RemoteClusterPortSettings.TCP_REUSE_ADDRESS : null,
         TcpTransport.isUntrustedRemoteClusterEnabled() ? RemoteClusterPortSettings.TCP_SEND_BUFFER_SIZE : null,
-        StatelessSecureSettings.STATELESS_SECURE_SETTINGS
+        StatelessSecureSettings.STATELESS_SECURE_SETTINGS,
+        IndicesClusterStateService.SHARD_LOCK_RETRY_INTERVAL_SETTING,
+        IndicesClusterStateService.SHARD_LOCK_RETRY_TIMEOUT_SETTING
     ).filter(Objects::nonNull).collect(Collectors.toSet());
 
     static List<SettingUpgrader<?>> BUILT_IN_SETTING_UPGRADERS = Collections.emptyList();

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -36,7 +36,6 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.env.ShardLock;
-import org.elasticsearch.env.ShardLockObtainFailedException;
 import org.elasticsearch.gateway.MetadataStateFormat;
 import org.elasticsearch.gateway.WriteStateException;
 import org.elasticsearch.index.analysis.IndexAnalyzers;
@@ -434,7 +433,9 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         ShardLock lock = null;
         eventListener.beforeIndexShardCreated(routing, indexSettings);
         try {
-            lock = nodeEnv.shardLock(shardId, "starting shard", TimeUnit.SECONDS.toMillis(5));
+            // Try and acquire the shard lock, but we are on the cluster applier thread so we do not wait if it is unavailable; in that
+            // case, the IndicesClusterStateService will try again (in the background)
+            lock = nodeEnv.shardLock(shardId, "starting shard");
             ShardPath path;
             try {
                 path = ShardPath.loadShardPath(logger, nodeEnv, shardId, this.indexSettings.customDataPath());
@@ -533,8 +534,6 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
             shards = Maps.copyMapWithAddedEntry(shards, shardId.id(), indexShard);
             success = true;
             return indexShard;
-        } catch (ShardLockObtainFailedException e) {
-            throw new IOException("failed to obtain in-memory shard lock", e);
         } finally {
             if (success == false) {
                 if (lock != null) {

--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -8,9 +8,12 @@
 
 package org.elasticsearch.indices.cluster;
 
+import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.store.AlreadyClosedException;
+import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceAlreadyExistsException;
 import org.elasticsearch.action.ActionListener;
@@ -27,9 +30,13 @@ import org.elasticsearch.cluster.routing.RecoverySource.Type;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Priority;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.component.AbstractLifecycleComponent;
 import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
@@ -86,6 +93,18 @@ import static org.elasticsearch.indices.cluster.IndicesClusterStateService.Alloc
 public class IndicesClusterStateService extends AbstractLifecycleComponent implements ClusterStateApplier {
     private static final Logger logger = LogManager.getLogger(IndicesClusterStateService.class);
 
+    public static final Setting<TimeValue> SHARD_LOCK_RETRY_INTERVAL_SETTING = Setting.timeSetting(
+        "indices.store.shard_lock_retry.interval",
+        TimeValue.timeValueSeconds(1),
+        Setting.Property.NodeScope
+    );
+
+    public static final Setting<TimeValue> SHARD_LOCK_RETRY_TIMEOUT_SETTING = Setting.timeSetting(
+        "indices.store.shard_lock_retry.timeout",
+        TimeValue.timeValueMinutes(1),
+        Setting.Property.NodeScope
+    );
+
     final AllocatedIndices<? extends Shard, ? extends AllocatedIndex<? extends Shard>> indicesService;
     private final ClusterService clusterService;
     private final ThreadPool threadPool;
@@ -96,6 +115,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     // a list of shards that failed during recovery
     // we keep track of these shards in order to prevent repeated recovery of these shards on each cluster state update
     final ConcurrentMap<ShardId, ShardRouting> failedShardsCache = ConcurrentCollections.newConcurrentMap();
+    private final Map<ShardId, PendingShardCreation> pendingShardCreations = new HashMap<>();
     private final RepositoriesService repositoriesService;
 
     private final FailedShardHandler failedShardHandler = new FailedShardHandler();
@@ -104,6 +124,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
     private final PrimaryReplicaSyncer primaryReplicaSyncer;
     private final RetentionLeaseSyncer retentionLeaseSyncer;
     private final NodeClient client;
+    private final TimeValue shardLockRetryInterval;
+    private final TimeValue shardLockRetryTimeout;
 
     @Inject
     public IndicesClusterStateService(
@@ -165,6 +187,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         this.primaryReplicaSyncer = primaryReplicaSyncer;
         this.retentionLeaseSyncer = retentionLeaseSyncer;
         this.client = client;
+        this.shardLockRetryInterval = SHARD_LOCK_RETRY_INTERVAL_SETTING.get(settings);
+        this.shardLockRetryTimeout = SHARD_LOCK_RETRY_TIMEOUT_SETTING.get(settings);
     }
 
     @Override
@@ -432,13 +456,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
      * @param state new cluster state
      */
     private void createIndicesAndUpdateShards(final ClusterState state) {
-        DiscoveryNodes nodes = state.nodes();
-        RoutingNode localRoutingNode = state.getRoutingNodes().node(nodes.getLocalNodeId());
+        RoutingNode localRoutingNode = state.getRoutingNodes().node(state.nodes().getLocalNodeId());
         if (localRoutingNode == null) {
             return;
         }
-
-        RoutingTable routingTable = state.routingTable();
 
         // create map of indices to create with shards to fail if index creation fails or create or update shards if an existing index
         // service is found
@@ -460,7 +481,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     if (indexService == null) {
                         indicesToCreate.computeIfAbsent(index, k -> new ArrayList<>()).add(shardRouting);
                     } else {
-                        createOrUpdateShard(state, nodes, routingTable, shardRouting, indexService);
+                        createOrUpdateShard(state, shardRouting, indexService);
                     }
                 }
             }
@@ -490,24 +511,18 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             }
             // we succeeded in creating the index service, so now we can create the missing shards assigned to this node
             for (ShardRouting shardRouting : entry.getValue()) {
-                createOrUpdateShard(state, nodes, routingTable, shardRouting, indexService);
+                createOrUpdateShard(state, shardRouting, indexService);
             }
         }
     }
 
-    private void createOrUpdateShard(
-        ClusterState state,
-        DiscoveryNodes nodes,
-        RoutingTable routingTable,
-        ShardRouting shardRouting,
-        AllocatedIndex<? extends Shard> indexService
-    ) {
+    private void createOrUpdateShard(ClusterState state, ShardRouting shardRouting, AllocatedIndex<? extends Shard> indexService) {
         Shard shard = indexService.getShardOrNull(shardRouting.shardId().id());
         if (shard == null) {
             assert shardRouting.initializing() : shardRouting + " should have been removed by failMissingShards";
-            createShard(nodes, routingTable, shardRouting, state);
+            createShard(shardRouting, state);
         } else {
-            updateShard(nodes, shardRouting, shard, routingTable, state);
+            updateShard(shardRouting, shard, state);
         }
     }
 
@@ -551,21 +566,79 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         }
     }
 
-    private void createShard(DiscoveryNodes nodes, RoutingTable routingTable, ShardRouting shardRouting, ClusterState state) {
+    private void createShard(ShardRouting shardRouting, ClusterState state) {
         assert shardRouting.initializing() : "only allow shard creation for initializing shard but was " + shardRouting;
-
-        DiscoveryNode sourceNode = null;
-        if (shardRouting.recoverySource().getType() == Type.PEER) {
-            sourceNode = findSourceNodeForPeerRecovery(routingTable, nodes, shardRouting);
-            if (sourceNode == null) {
-                logger.trace("ignoring initializing shard {} - no source node can be found.", shardRouting.shardId());
-                return;
-            }
-        }
+        final var shardId = shardRouting.shardId();
 
         try {
-            final long primaryTerm = state.metadata().index(shardRouting.index()).primaryTerm(shardRouting.id());
-            logger.debug("{} creating shard with primary term [{}]", shardRouting.shardId(), primaryTerm);
+            final DiscoveryNode sourceNode;
+            if (shardRouting.recoverySource().getType() == Type.PEER) {
+                sourceNode = findSourceNodeForPeerRecovery(state.routingTable(), state.nodes(), shardRouting);
+                if (sourceNode == null) {
+                    logger.trace("ignoring initializing shard {} - no source node can be found.", shardId);
+                    return;
+                }
+            } else {
+                sourceNode = null;
+            }
+            final var primaryTerm = state.metadata().index(shardRouting.index()).primaryTerm(shardRouting.id());
+
+            final var pendingShardCreation = createOrRefreshPendingShardCreation(shardId, state.stateUUID());
+            createShardWhenLockAvailable(
+                shardRouting,
+                state,
+                sourceNode,
+                primaryTerm,
+                0,
+                0L,
+                ActionListener.runBefore(new ActionListener<>() {
+                    @Override
+                    public void onResponse(Boolean success) {
+                        if (Boolean.TRUE.equals(success)) {
+                            logger.debug("{} created shard with primary term [{}]", shardId, primaryTerm);
+                        } else {
+                            logger.debug("{} gave up while trying to create shard", shardId);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        failAndRemoveShard(shardRouting, true, "failed to create shard", e, state);
+                    }
+                }, () -> {
+                    assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
+                    pendingShardCreations.remove(shardId, pendingShardCreation);
+                })
+            );
+        } catch (Exception e) {
+            assert pendingShardCreations.get(shardId) == null
+                || pendingShardCreations.get(shardId).clusterStateUUID().equals(state.stateUUID()) == false;
+            failAndRemoveShard(shardRouting, true, "failed to create shard", e, state);
+        }
+    }
+
+    private PendingShardCreation createOrRefreshPendingShardCreation(ShardId shardId, String clusterStateUUID) {
+        assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
+        final var currentPendingShardCreation = pendingShardCreations.get(shardId);
+        final var newPendingShardCreation = new PendingShardCreation(
+            clusterStateUUID,
+            currentPendingShardCreation == null ? threadPool.relativeTimeInMillis() : currentPendingShardCreation.startTimeMillis()
+        );
+        pendingShardCreations.put(shardId, newPendingShardCreation);
+        return newPendingShardCreation;
+    }
+
+    private void createShardWhenLockAvailable(
+        ShardRouting shardRouting,
+        ClusterState originalState,
+        DiscoveryNode sourceNode,
+        long primaryTerm,
+        int iteration,
+        long delayMillis,
+        ActionListener<Boolean> listener
+    ) {
+        try {
+            logger.debug("{} creating shard with primary term [{}], iteration [{}]", shardRouting.shardId(), primaryTerm, iteration);
             indicesService.createShard(
                 shardRouting,
                 recoveryTargetService,
@@ -574,21 +647,105 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                 failedShardHandler,
                 this::updateGlobalCheckpointForShard,
                 retentionLeaseSyncer,
-                nodes.getLocalNode(),
+                originalState.nodes().getLocalNode(),
                 sourceNode
             );
+            listener.onResponse(true);
+        } catch (ShardLockObtainFailedException e) {
+            if (e.getCause() instanceof InterruptedException || Thread.currentThread().isInterrupted()) {
+                logger.warn(Strings.format("interrupted while creating shard [{}]", shardRouting), e);
+                listener.onFailure(e);
+                return;
+            }
+            logger.log(
+                (iteration + 25) % 30 == 0 ? Level.WARN : Level.DEBUG,
+                """
+                    shard lock for [{}] has been unavailable for at least [{}/{}ms], \
+                    attempting to create shard while applying cluster state [version={},uuid={}], will retry in [{}]: [{}]""",
+                shardRouting,
+                TimeValue.timeValueMillis(delayMillis),
+                delayMillis,
+                originalState.version(),
+                originalState.stateUUID(),
+                shardLockRetryInterval,
+                e.getMessage()
+            );
+            // TODO could we instead subscribe to the shard lock and trigger the retry exactly when it is released rather than polling?
+            threadPool.scheduleUnlessShuttingDown(
+                shardLockRetryInterval,
+                ThreadPool.Names.SAME,
+                () -> clusterService.getClusterApplierService()
+                    .runOnApplierThread("create shard " + shardRouting, Priority.NORMAL, currentState -> {
+
+                        assert ThreadPool.assertCurrentThreadPool(ClusterApplierService.CLUSTER_UPDATE_THREAD_NAME);
+                        final var pendingShardCreation = pendingShardCreations.get(shardRouting.shardId());
+                        if (pendingShardCreation == null) {
+                            listener.onResponse(false);
+                            return;
+                        }
+
+                        if (originalState.stateUUID().equals(currentState.stateUUID()) == false) {
+                            logger.debug(
+                                "cluster state updated from version [{}/{}] to version [{}/{}] before creation of shard {}",
+                                originalState.version(),
+                                originalState.stateUUID(),
+                                currentState.version(),
+                                currentState.stateUUID(),
+                                shardRouting.shardId()
+                            );
+                            listener.onResponse(false);
+                            return;
+                        }
+                        assert pendingShardCreation.clusterStateUUID().equals(currentState.stateUUID());
+
+                        final var newDelayMillis = threadPool.relativeTimeInMillis() - pendingShardCreation.startTimeMillis();
+                        if (newDelayMillis > shardLockRetryTimeout.millis()) {
+                            logger.warn(
+                                "timed out after [{}={}/{}ms] while waiting to acquire shard lock for {}",
+                                SHARD_LOCK_RETRY_TIMEOUT_SETTING.getKey(),
+                                shardLockRetryTimeout,
+                                shardLockRetryTimeout.millis(),
+                                shardRouting
+                            );
+                            listener.onFailure(
+                                new ElasticsearchTimeoutException("timed out while waiting to acquire shard lock for " + shardRouting)
+                            );
+                            return;
+                        }
+
+                        final var indexService = indicesService.indexService(shardRouting.index());
+                        if (indexService == null) {
+                            final var message = "index service unexpectedly not found for " + shardRouting;
+                            assert false : message;
+                            listener.onFailure(new ElasticsearchException(message));
+                            return;
+                        }
+
+                        if (indexService.getShardOrNull(shardRouting.shardId().id()) != null) {
+                            final var message = "index shard unexpectedly found for " + shardRouting;
+                            assert false : message;
+                            listener.onFailure(new ElasticsearchException(message));
+                            return;
+                        }
+
+                        createShardWhenLockAvailable(
+                            shardRouting,
+                            originalState,
+                            sourceNode,
+                            primaryTerm,
+                            iteration + 1,
+                            newDelayMillis,
+                            listener
+                        );
+
+                    }, ActionListener.noop())
+            );
         } catch (Exception e) {
-            failAndRemoveShard(shardRouting, true, "failed to create shard", e, state);
+            listener.onFailure(e);
         }
     }
 
-    private void updateShard(
-        DiscoveryNodes nodes,
-        ShardRouting shardRouting,
-        Shard shard,
-        RoutingTable routingTable,
-        ClusterState clusterState
-    ) {
+    private void updateShard(ShardRouting shardRouting, Shard shard, ClusterState clusterState) {
         final ShardRouting currentRoutingEntry = shard.routingEntry();
         assert currentRoutingEntry.isSameAllocation(shardRouting)
             : "local shard has a different allocation id but wasn't cleaned by removeShards. "
@@ -602,7 +759,7 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
             final IndexMetadata indexMetadata = clusterState.metadata().index(shard.shardId().getIndex());
             primaryTerm = indexMetadata.primaryTerm(shard.shardId().id());
             final Set<String> inSyncIds = indexMetadata.inSyncAllocationIds(shard.shardId().id());
-            final IndexShardRoutingTable indexShardRoutingTable = routingTable.shardRoutingTable(shardRouting.shardId());
+            final IndexShardRoutingTable indexShardRoutingTable = clusterState.routingTable().shardRoutingTable(shardRouting.shardId());
             shard.updateShardState(
                 shardRouting,
                 primaryTerm,
@@ -626,15 +783,15 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
                     "{} master marked shard as initializing, but shard has state [{}], resending shard started to {}",
                     shardRouting.shardId(),
                     state,
-                    nodes.getMasterNode()
+                    clusterState.nodes().getMasterNode()
                 );
             }
-            if (nodes.getMasterNode() != null) {
+            if (clusterState.nodes().getMasterNode() != null) {
                 shardStateAction.shardStarted(
                     shardRouting,
                     primaryTerm,
                     "master "
-                        + nodes.getMasterNode()
+                        + clusterState.nodes().getMasterNode()
                         + " marked shard as initializing, but shard state is ["
                         + state
                         + "], mark shard as started",
@@ -679,6 +836,8 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         }
         return sourceNode;
     }
+
+    private record PendingShardCreation(String clusterStateUUID, long startTimeMillis) {}
 
     private class RecoveryListener implements PeerRecoveryTargetService.RecoveryListener {
 

--- a/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
@@ -317,6 +317,11 @@ public class DeterministicTaskQueue {
             };
 
             @Override
+            public long relativeTimeInNanos() {
+                throw new AssertionError("DeterministicTaskQueue does not support nanosecond-precision timestamps");
+            }
+
+            @Override
             public long relativeTimeInMillis() {
                 return currentTimeMillis;
             }


### PR DESCRIPTION
Today when applying a new cluster state we block the cluster applier thread for up to 5s while waiting to acquire each shard lock. Failure to acquire the shard lock is treated as an allocation failure, so after 5 retries (by default) we give up on the allocation.

The shard lock may be held by some other actor, typically the previous incarnation of the shard which is still shutting down, but it will eventually be released. Yet, 5 retries of 5s each is sometimes not enough time to wait. Knowing that the shard lock will eventually be released, we can retry much more tenaciously.

Moreover there's no reason why we have to create the `IndexShard` while applying the cluster state, because the shard remains in state `INITIALIZING`, and therefore unused, while it coordinates its own recovery.

With this commit we try and acquire the shard lock during cluster state application, but do not wait if the lock is unavailable. Instead, we schedule a retry (also executed on the cluster state applier thread) and proceed with the rest of the cluster state application process.

Relates #24530
Backport of #94545 and #94623 (and a little bit of #94417) to 8.7