### PR TITLE
[8.7] Compute balancer threshold based on max shard size (#95090)

### DIFF
--- a/docs/changelog/95090.yaml
+++ b/docs/changelog/95090.yaml
@@ -1,0 +1,5 @@
+pr: 95090
+summary: Compute balancer threshold based on max shard size
+area: Allocation
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/BalancedShardsAllocatorTests.java
@@ -466,7 +466,7 @@ public class BalancedShardsAllocatorTests extends ESAllocationTestCase {
             )
         );
 
-        assertSame(clusterState, reroute(allocationService, clusterState));
+        assertSame(clusterState, allocationService.reroute(clusterState, "test", ActionListener.noop()));
     }
 
     private Map<String, Integer> getTargetShardPerNodeCount(IndexRoutingTable indexRoutingTable) {


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Compute balancer threshold based on max shard size (#95090)