### PR TITLE
[8.7] [Stable Plugin Api] Change the group name in stable-api diff plugin (#95076)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
@@ -31,6 +31,9 @@ BuildParams.bwcVersions.withIndexCompatible({ it.onOrAfter(Version.fromString(ex
     if (unreleasedVersion) {
       // For unreleased snapshot versions, build them from source
       "oldJar${baseName}"(files(project(unreleasedVersion.gradleProjectPath).tasks.named(buildBwcTaskName(project.name))))
+    } else if(bwcVersion.onOrAfter('8.7.0') && project.name.endsWith("elasticsearch-logging")==false) {
+      //there was a package rename in 8.7.0, except for es-logging
+      "oldJar${baseName}"("org.elasticsearch.plugin:${project.name}:${bwcVersion}")
     } else {
       // For released versions, download it
       "oldJar${baseName}"("org.elasticsearch:${project.name}:${bwcVersion}")


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [Stable Plugin Api] Change the group name in stable-api diff plugin (#95076)