### PR TITLE
fix: stale AsyncActionStep

### DIFF
--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IndexLifecycleClusterStateUpdateTask.java
@@ -15,6 +15,9 @@ import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.ilm.Step;
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Base class for index lifecycle cluster state update tasks that requires implementing {@code equals} and {@code hashCode} to allow
  * for these tasks to be deduplicated by {@link IndexLifecycleRunner}.
@@ -38,6 +41,10 @@ public abstract class IndexLifecycleClusterStateUpdateTask implements ClusterSta
 
     final Step.StepKey getCurrentStepKey() {
         return currentStepKey;
+    }
+
+    public List<Step.StepKey> getDedupKeys() {
+        return Arrays.asList(currentStepKey);
     }
 
     private boolean executed;

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/MoveToNextStepUpdateTask.java
@@ -14,6 +14,8 @@ import org.elasticsearch.cluster.metadata.LifecycleExecutionState;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.xpack.core.ilm.Step;
 
+import java.util.Arrays;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import java.util.function.LongSupplier;
@@ -64,6 +66,11 @@ public class MoveToNextStepUpdateTask extends IndexLifecycleClusterStateUpdateTa
             // either case we don't want to do anything now
             return currentState;
         }
+    }
+
+    @Override
+    public List<Step.StepKey> getDedupKeys() {
+        return Arrays.asList(currentStepKey, nextStepKey);
     }
 
     @Override


### PR DESCRIPTION
When I test ilm, I got a status where index stale on the `{"phase":"delete","action":"delete","name":"delete"}`, although the ilm run periodic, the index don't move any.
I think It's happened as follow
1. index in the step before `{"phase":"delete","action":"delete","name":"delete"}`
2. after the the step finish, we try to move to next step, ie. `{"phase":"delete","action":"delete","name":"delete"}`
3. it commit a task `MoveToNextStepUpdateTask`, then publish() -> onClusterStateProcessed() -> maybeRunAsyncAction()
4. in maybeRunAsyncAction() it send request to master to delete index, with `TimeValue.MAX_VALUE`
5. I restart master at this time
6. the callback `onFailure` can't submit tasks now

I try to fix this rarely happened case,but once it happened then it can't recovery