### PR TITLE
Do not require a DirectoryReader in PersistedClusterStateService#loadOnDiskStateMetadataFromUserData

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/gateway/PersistedClusterStateService.java
@@ -632,7 +632,9 @@ public class PersistedClusterStateService {
             builder.put(indexMetadata, false);
         });
 
-        OnDiskStateMetadata onDiskStateMetadata = readOnDiskStateMetadata(reader);
+        final Map<String, String> userData = reader.getIndexCommit().getUserData();
+        logger.trace("loaded metadata [{}] from [{}]", userData, reader.directory());
+        OnDiskStateMetadata onDiskStateMetadata = loadOnDiskStateMetadataFromUserData(userData);
         return new OnDiskState(
             onDiskStateMetadata.nodeId(),
             dataPath,
@@ -644,9 +646,7 @@ public class PersistedClusterStateService {
         );
     }
 
-    public OnDiskStateMetadata readOnDiskStateMetadata(DirectoryReader reader) throws IOException {
-        final Map<String, String> userData = reader.getIndexCommit().getUserData();
-        logger.trace("loaded metadata [{}] from [{}]", userData, reader.directory());
+    public OnDiskStateMetadata loadOnDiskStateMetadataFromUserData(Map<String, String> userData) {
         assert userData.get(CURRENT_TERM_KEY) != null;
         assert userData.get(LAST_ACCEPTED_VERSION_KEY) != null;
         assert userData.get(NODE_ID_KEY) != null;


### PR DESCRIPTION
No need to read all the segment info files referenced by the commit in this method.

Relates #95079 
