### PR TITLE
Remove jar name override for preallocate

### DIFF
--- a/libs/preallocate/build.gradle
+++ b/libs/preallocate/build.gradle
@@ -7,8 +7,6 @@
 
 apply plugin: 'elasticsearch.build'
 
-archivesBaseName = 'preallocate'
-
 dependencies {
   implementation project(':libs:elasticsearch-core')
   implementation project(':libs:elasticsearch-logging')

--- a/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
+++ b/server/src/main/resources/org/elasticsearch/bootstrap/security.policy
@@ -76,7 +76,7 @@ grant codeBase "${codebase.log4j-api}" {
   permission java.lang.RuntimePermission "getClassLoader";
 };
 
-grant codeBase "${codebase.preallocate}" {
+grant codeBase "${codebase.elasticsearch-preallocate}" {
   // for registering native methods
   permission java.lang.RuntimePermission "accessDeclaredMembers";
   // for accessing the file descriptor field in FileChannel


### PR DESCRIPTION
The preallocate lib should be named similar to other libs, with the elasticsearch- prefix.