### PR TITLE
Export preallocate to jna

### DIFF
--- a/libs/preallocate/src/main/java/module-info.java
+++ b/libs/preallocate/src/main/java/module-info.java
@@ -11,7 +11,7 @@ module org.elasticsearch.preallocate {
     requires org.elasticsearch.logging;
     requires com.sun.jna;
 
-    exports org.elasticsearch.preallocate to org.elasticsearch.blobcache;
+    exports org.elasticsearch.preallocate to org.elasticsearch.blobcache, com.sun.jna;
 
     provides org.elasticsearch.jdk.ModuleQualifiedExportsService with org.elasticsearch.preallocate.PreallocateModuleExportsService;
 }


### PR DESCRIPTION
On MacOS, jna reflectively constructs preallocate classes, so the package needs to be exported to jna.

closes #95125