### PR TITLE
[8.7] [DOCS] Rerun agg at the end of manual downsampling example (#95122)

### DIFF
--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -376,7 +376,7 @@ DELETE /sample-01
 ==== View the results
 
 
-Now, re-run your search query:
+Re-run your search query:
 
 [source,console]
 ----
@@ -449,6 +449,51 @@ been calculated: `min`, `max`, `sum`, and `value_count`.
 ...
 ----
 // TEST[skip:todo]
+
+You can now re-run the earlier aggregation. Even though the aggregation runs on
+the downsampled data stream that only contains 288 documents, it returns the
+same results as the earlier aggregation on the original data stream.
+
+[source,console]
+----
+GET /sample-01*/_search
+{
+    "size": 0,
+    "aggs": {
+        "tsid": {
+            "terms": {
+                "field": "_tsid"
+            },
+            "aggs": {
+                "over_time": {
+                    "date_histogram": {
+                        "field": "@timestamp",
+                        "fixed_interval": "1d"
+                    },
+                    "aggs": {
+                        "min": {
+                            "min": {
+                                "field": "kubernetes.container.memory.usage.bytes"
+                            }
+                        },
+                        "max": {
+                            "max": {
+                                "field": "kubernetes.container.memory.usage.bytes"
+                            }
+                        },
+                        "avg": {
+                            "avg": {
+                                "field": "kubernetes.container.memory.usage.bytes"
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+----
+// TEST[continued]
 
 This example demonstrates how downsampling can dramatically reduce the number of
 records stored for time series data, within whatever time boundaries you choose.


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [DOCS] Rerun agg at the end of manual downsampling example (#95122)