### PR TITLE
[8.7] Document counter field limitation. (#95155)

### DIFF
--- a/docs/reference/data-streams/tsds.asciidoc
+++ b/docs/reference/data-streams/tsds.asciidoc
@@ -147,6 +147,8 @@ example, a count of errors or completed tasks.
 Only numeric and `aggregate_metric_double` fields support the `counter` metric
 type.
 
+NOTE: Counter fields do come with a limitation in aggregations. Only the following aggregations are supported with the `counter` field: `rate`, `histogram`, `range`, `min`, `max`, `top_metrics` and `variable_width_histogram`.
+
 // tag::time-series-metric-gauge[]
 `gauge`:: A number that can increase or decrease. For example, a temperature or
 available disk space.


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Document counter field limitation. (#95155)