### PR TITLE
Ensure checking indices privileges work with nested-limited-role

### DIFF
--- a/docs/changelog/95170.yaml
+++ b/docs/changelog/95170.yaml
@@ -1,0 +1,5 @@
+pr: 95170
+summary: Ensure checking indices privileges work with nested-limited-role
+area: Authorization
+type: enhancement
+issues: []

--- a/docs/changelog/95170.yaml
+++ b/docs/changelog/95170.yaml
@@ -1,5 +1,5 @@
 pr: 95170
-summary: Ensure checking indices privileges work with nested-limited-role
+summary: Ensure checking indices privileges works with nested-limited-role
 area: Authorization
 type: enhancement
 issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
@@ -211,14 +211,22 @@ public final class LimitedRole implements Role {
         Set<String> checkForPrivileges,
         @Nullable ResourcePrivilegesMap.Builder resourcePrivilegesMapBuilder
     ) {
-        boolean baseRoleCheck = baseRole.indices()
-            .checkResourcePrivileges(checkForIndexPatterns, allowRestrictedIndices, checkForPrivileges, resourcePrivilegesMapBuilder);
+        boolean baseRoleCheck = baseRole.checkIndicesPrivileges(
+            checkForIndexPatterns,
+            allowRestrictedIndices,
+            checkForPrivileges,
+            resourcePrivilegesMapBuilder
+        );
         if (false == baseRoleCheck && null == resourcePrivilegesMapBuilder) {
             // short-circuit only if not interested in the detailed individual check results
             return false;
         }
-        boolean limitedByRoleCheck = limitedByRole.indices()
-            .checkResourcePrivileges(checkForIndexPatterns, allowRestrictedIndices, checkForPrivileges, resourcePrivilegesMapBuilder);
+        boolean limitedByRoleCheck = limitedByRole.checkIndicesPrivileges(
+            checkForIndexPatterns,
+            allowRestrictedIndices,
+            checkForPrivileges,
+            resourcePrivilegesMapBuilder
+        );
         return baseRoleCheck && limitedByRoleCheck;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRoleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRoleTests.java
@@ -641,6 +641,12 @@ public class LimitedRoleTests extends ESTestCase {
 
         {
             Role limitedByRole = Role.builder(EMPTY_RESTRICTED_INDICES, "limited-role").add(IndexPrivilege.READ, "ind-1", "ind-2").build();
+            if (randomBoolean()) {
+                final Role nestedLimitedRole = Role.builder(EMPTY_RESTRICTED_INDICES, "nested-limited-role")
+                    .add(IndexPrivilege.READ, "*")
+                    .build();
+                limitedByRole = randomBoolean() ? limitedByRole.limitedBy(nestedLimitedRole) : nestedLimitedRole.limitedBy(limitedByRole);
+            }
 
             verifyResourcesPrivileges(
                 limitedByRole,
@@ -717,6 +723,12 @@ public class LimitedRoleTests extends ESTestCase {
             );
 
             Role limitedByRole = Role.builder(EMPTY_RESTRICTED_INDICES, "limited-role").add(IndexPrivilege.READ, "ind-1", "ind-2").build();
+            if (randomBoolean()) {
+                final Role nestedLimitedRole = Role.builder(EMPTY_RESTRICTED_INDICES, "nested-limited-role")
+                    .add(IndexPrivilege.READ, "*")
+                    .build();
+                limitedByRole = randomBoolean() ? limitedByRole.limitedBy(nestedLimitedRole) : nestedLimitedRole.limitedBy(limitedByRole);
+            }
 
             verifyResourcesPrivileges(
                 limitedByRole,


### PR DESCRIPTION
Currently LimitedRole.checkIndicesPrivileges assumes both its based role and limiting role are SimpleRole. It will not be true in future with progress of RCS work. This PR removes the assumption and ensure the method keep working with future nested-limited-roles.

Relates: #93306
