### PR TITLE
[ML] Add embedding_size to text embedding config

### DIFF
--- a/docs/changelog/95176.yaml
+++ b/docs/changelog/95176.yaml
@@ -1,0 +1,5 @@
+pr: 95176
+summary: Add `embedding_size` to text embedding config
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -1070,6 +1070,10 @@ context. These embeddings can be used in a <<dense-vector,dense vector>> field
 for powerful insights.
 end::inference-config-text-embedding[]
 
+tag::inference-config-text-embedding-size[]
+The number of dimensions in the embedding vector produced by the model.
+end::inference-config-text-embedding-size[]
+
 tag::inference-config-text-similarity[]
 Text similarity takes an input sequence and compares it with another input sequence. This is commonly referred to
 as cross-encoding. This task is useful for ranking document text when comparing it to another provided text input.

--- a/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models.asciidoc
@@ -602,6 +602,14 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-embedding
 .Properties of text_embedding inference
 [%collapsible%open]
 ======
+`embedding_size`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-embedding-size]
+
+`results_field`::::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]
+
 `tokenization`::::
 (Optional, object)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenization]

--- a/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models.asciidoc
@@ -939,6 +939,10 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-embedding
 .Properties of text_embedding inference
 [%collapsible%open]
 =====
+`embedding_size`::::
+(Optional, integer)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-text-embedding-size]
+
 `results_field`::::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-results-field]

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfig.java
@@ -81,6 +81,13 @@ public class TextEmbeddingConfig implements NlpConfig {
             .orElse(new VocabularyConfig(InferenceIndexConstants.nativeDefinitionStore()));
         this.tokenization = tokenization == null ? Tokenization.createDefault() : tokenization;
         this.resultsField = resultsField;
+        if (embeddingSize != null && embeddingSize <= 0) {
+            throw ExceptionsHelper.badRequestException(
+                "[{}] must be a number greater than 0; configured size [{}]",
+                EMBEDDING_SIZE.getPreferredName(),
+                embeddingSize
+            );
+        }
         this.embeddingSize = embeddingSize;
         if (this.tokenization.span != -1) {
             throw ExceptionsHelper.badRequestException(

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfig.java
@@ -13,6 +13,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
+import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConstants;
@@ -26,6 +27,8 @@ import java.util.Optional;
 public class TextEmbeddingConfig implements NlpConfig {
 
     public static final String NAME = "text_embedding";
+
+    public static ParseField EMBEDDING_SIZE = new ParseField("embedding_size");
 
     public static TextEmbeddingConfig fromXContentStrict(XContentParser parser) {
         return STRICT_PARSER.apply(parser, null);
@@ -42,7 +45,7 @@ public class TextEmbeddingConfig implements NlpConfig {
         ConstructingObjectParser<TextEmbeddingConfig, Void> parser = new ConstructingObjectParser<>(
             NAME,
             ignoreUnknownFields,
-            a -> new TextEmbeddingConfig((VocabularyConfig) a[0], (Tokenization) a[1], (String) a[2])
+            a -> new TextEmbeddingConfig((VocabularyConfig) a[0], (Tokenization) a[1], (String) a[2], (Integer) a[3])
         );
         parser.declareObject(ConstructingObjectParser.optionalConstructorArg(), (p, c) -> {
             if (ignoreUnknownFields == false) {
@@ -59,22 +62,26 @@ public class TextEmbeddingConfig implements NlpConfig {
             TOKENIZATION
         );
         parser.declareString(ConstructingObjectParser.optionalConstructorArg(), RESULTS_FIELD);
+        parser.declareInt(ConstructingObjectParser.optionalConstructorArg(), EMBEDDING_SIZE);
         return parser;
     }
 
     private final VocabularyConfig vocabularyConfig;
     private final Tokenization tokenization;
     private final String resultsField;
+    private final Integer embeddingSize;
 
     public TextEmbeddingConfig(
         @Nullable VocabularyConfig vocabularyConfig,
         @Nullable Tokenization tokenization,
-        @Nullable String resultsField
+        @Nullable String resultsField,
+        @Nullable Integer embeddingSize
     ) {
         this.vocabularyConfig = Optional.ofNullable(vocabularyConfig)
             .orElse(new VocabularyConfig(InferenceIndexConstants.nativeDefinitionStore()));
         this.tokenization = tokenization == null ? Tokenization.createDefault() : tokenization;
         this.resultsField = resultsField;
+        this.embeddingSize = embeddingSize;
         if (this.tokenization.span != -1) {
             throw ExceptionsHelper.badRequestException(
                 "[{}] does not support windowing long text sequences; configured span [{}]",
@@ -88,6 +95,11 @@ public class TextEmbeddingConfig implements NlpConfig {
         vocabularyConfig = new VocabularyConfig(in);
         tokenization = in.readNamedWriteable(Tokenization.class);
         resultsField = in.readOptionalString();
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            embeddingSize = in.readOptionalVInt();
+        } else {
+            embeddingSize = null;
+        }
     }
 
     @Override
@@ -97,6 +109,9 @@ public class TextEmbeddingConfig implements NlpConfig {
         NamedXContentObjectHelper.writeNamedObject(builder, params, TOKENIZATION.getPreferredName(), tokenization);
         if (resultsField != null) {
             builder.field(RESULTS_FIELD.getPreferredName(), resultsField);
+        }
+        if (embeddingSize != null) {
+            builder.field(EMBEDDING_SIZE.getPreferredName(), embeddingSize);
         }
         builder.endObject();
         return builder;
@@ -112,6 +127,9 @@ public class TextEmbeddingConfig implements NlpConfig {
         vocabularyConfig.writeTo(out);
         out.writeNamedWriteable(tokenization);
         out.writeOptionalString(resultsField);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
+            out.writeOptionalVInt(embeddingSize);
+        }
     }
 
     @Override
@@ -147,12 +165,13 @@ public class TextEmbeddingConfig implements NlpConfig {
         TextEmbeddingConfig that = (TextEmbeddingConfig) o;
         return Objects.equals(vocabularyConfig, that.vocabularyConfig)
             && Objects.equals(tokenization, that.tokenization)
-            && Objects.equals(resultsField, that.resultsField);
+            && Objects.equals(resultsField, that.resultsField)
+            && Objects.equals(embeddingSize, that.embeddingSize);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(vocabularyConfig, tokenization, resultsField);
+        return Objects.hash(vocabularyConfig, tokenization, resultsField, embeddingSize);
     }
 
     @Override
@@ -168,5 +187,9 @@ public class TextEmbeddingConfig implements NlpConfig {
     @Override
     public String getResultsField() {
         return resultsField;
+    }
+
+    public Integer getEmbeddingSize() {
+        return embeddingSize;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdate.java
@@ -121,7 +121,8 @@ public class TextEmbeddingConfigUpdate extends NlpConfigUpdate implements NamedX
         return new TextEmbeddingConfig(
             embeddingConfig.getVocabularyConfig(),
             tokenizationUpdate == null ? embeddingConfig.getTokenization() : tokenizationUpdate.apply(embeddingConfig.getTokenization()),
-            resultsField == null ? embeddingConfig.getResultsField() : resultsField
+            resultsField == null ? embeddingConfig.getResultsField() : resultsField,
+            embeddingConfig.getEmbeddingSize()
         );
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigTests.java
@@ -18,11 +18,21 @@ import java.util.function.Predicate;
 public class TextEmbeddingConfigTests extends InferenceConfigItemTestCase<TextEmbeddingConfig> {
 
     public static TextEmbeddingConfig mutateForVersion(TextEmbeddingConfig instance, TransportVersion version) {
-        return new TextEmbeddingConfig(
-            instance.getVocabularyConfig(),
-            InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
-            instance.getResultsField()
-        );
+        if (version.before(TransportVersion.V_8_8_0)) {
+            return new TextEmbeddingConfig(
+                instance.getVocabularyConfig(),
+                InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+                instance.getResultsField(),
+                null
+            );
+        } else {
+            return new TextEmbeddingConfig(
+                instance.getVocabularyConfig(),
+                InferenceConfigTestScaffolding.mutateTokenizationForVersion(instance.getTokenization(), version),
+                instance.getResultsField(),
+                instance.getEmbeddingSize()
+            );
+        }
     }
 
     @Override
@@ -70,7 +80,8 @@ public class TextEmbeddingConfigTests extends InferenceConfigItemTestCase<TextEm
                     MPNetTokenizationTests.createRandom(),
                     RobertaTokenizationTests.createRandom()
                 ),
-            randomBoolean() ? null : randomAlphaOfLength(7)
+            randomBoolean() ? null : randomAlphaOfLength(7),
+            randomBoolean() ? null : randomIntBetween(1, 1000)
         );
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/TextEmbeddingConfigUpdateTests.java
@@ -63,14 +63,24 @@ public class TextEmbeddingConfigUpdateTests extends AbstractNlpConfigUpdateTestC
         assertThat(originalConfig, sameInstance(new TextEmbeddingConfigUpdate.Builder().build().apply(originalConfig)));
 
         assertThat(
-            new TextEmbeddingConfig(originalConfig.getVocabularyConfig(), originalConfig.getTokenization(), "ml-results"),
+            new TextEmbeddingConfig(
+                originalConfig.getVocabularyConfig(),
+                originalConfig.getTokenization(),
+                "ml-results",
+                originalConfig.getEmbeddingSize()
+            ),
             equalTo(new TextEmbeddingConfigUpdate.Builder().setResultsField("ml-results").build().apply(originalConfig))
         );
 
         Tokenization.Truncate truncate = randomFrom(Tokenization.Truncate.values());
         Tokenization tokenization = cloneWithNewTruncation(originalConfig.getTokenization(), truncate);
         assertThat(
-            new TextEmbeddingConfig(originalConfig.getVocabularyConfig(), tokenization, originalConfig.getResultsField()),
+            new TextEmbeddingConfig(
+                originalConfig.getVocabularyConfig(),
+                tokenization,
+                originalConfig.getResultsField(),
+                originalConfig.getEmbeddingSize()
+            ),
             equalTo(
                 new TextEmbeddingConfigUpdate.Builder().setTokenizationUpdate(
                     createTokenizationUpdate(originalConfig.getTokenization(), truncate, null)


### PR DESCRIPTION
Adds an optional field `embedding_size` to the text embedding config for NLP models. The field should be set at model creation and cannot be modified later.  If defined `embedding_size` should be used to set the number of dimensions for the dense_vector field mapping the embedding will be indexed in. 