### PR TITLE
[8.7] Update field-caps.asciidoc to add information about `include_unmapped` (#94888)

### DIFF
--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -74,8 +74,8 @@ Defaults to `open`.
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailable]
 
 `include_unmapped`::
-  (Optional, Boolean) If `true`, unmapped fields are included in the response.
-  Defaults to `false`.
+  (Optional, Boolean) If `true`, unmapped fields that are mapped in one index but not in another are included in the response. Fields that don't have any mapping are never included.
+  Defaults to `false`. 
 
 `filters`::
 (Optional, string) Comma-separated list of filters to apply to the response.


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [Update field-caps.asciidoc to add information about `include_unmapped` (#94888)](https://github.com/elastic/elasticsearch/pull/94888)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)