### PR TITLE
fix typo in `cron.asciidoc`

### DIFF
--- a/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
+++ b/x-pack/docs/en/watcher/trigger/schedule/cron.asciidoc
@@ -5,7 +5,7 @@
 ++++
 
 Defines a <<trigger-schedule, `schedule`>> using a <<cron-expressions, cron expression>> 
-that specifiues when to execute a watch.
+that specifies when to execute a watch.
 
 TIP:  While cron expressions are powerful, a regularly occurring schedule 
 is easier to configure with the other schedule types. 


### PR DESCRIPTION
this fix was added by @nrousset-socgen in #94488 but he hasn't answered in a while

closes #94488 