### PR TITLE
[DOCS] Remove 'coming in 8.7.0' from release notes in main

### DIFF
--- a/docs/reference/release-notes/8.7.0.asciidoc
+++ b/docs/reference/release-notes/8.7.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.7.0]]
 == {es} version 8.7.0
 
-coming[8.7.0]
-
 Also see <<breaking-changes-8.7,Breaking changes in 8.7>>.
 
 [[breaking-8.7.0]]


### PR DESCRIPTION
This PR removes the "Coming in 8.7.0" text from the documentation in the `main` branch.