### PR TITLE
[DOCS] Remove 'coming in 8.7.0' from release notes in 8.7

### DIFF
--- a/docs/reference/release-notes/8.7.0.asciidoc
+++ b/docs/reference/release-notes/8.7.0.asciidoc
@@ -1,8 +1,6 @@
 [[release-notes-8.7.0]]
 == {es} version 8.7.0
 
-coming[8.7.0]
-
 Also see <<breaking-changes-8.7,Breaking changes in 8.7>>.
 
 [[breaking-8.7.0]]

--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -1,8 +1,6 @@
 [[release-highlights]]
 == What's new in {minor-version}
 
-coming::[{minor-version}]
-
 Here are the highlights of what's new and improved in {es} {minor-version}!
 ifeval::[\{release-state}\"!=\"unreleased\"]
 For detailed information about this release, see the <<es-release-notes>> and


### PR DESCRIPTION
This PR removes the "Coming in 8.7.0" text from the documentation in the `8.7` branch.