### PR TITLE
[Transform] Fix privileges check failures by adding `allow_restricted_indices` flag

### DIFF
--- a/docs/changelog/95187.yaml
+++ b/docs/changelog/95187.yaml
@@ -1,0 +1,5 @@
+pr: 95187
+summary: Fix privileges check failures by adding `allow_restricted_indices` flag
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
+++ b/x-pack/plugin/transform/qa/multi-node-tests/build.gradle
@@ -50,4 +50,5 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   user username: "john_junior", password: "x-pack-test-password", role: "transform_admin"
   user username: "bill_senior", password: "x-pack-test-password", role: "transform_admin,source_index_access"
   user username: "not_a_transform_admin", password: "x-pack-test-password", role: "source_index_access"
+  user username: "fleet_access", password: "x-pack-test-password", role: "transform_admin,source_index_access,fleet_index_access"
 }

--- a/x-pack/plugin/transform/qa/multi-node-tests/roles.yml
+++ b/x-pack/plugin/transform/qa/multi-node-tests/roles.yml
@@ -15,3 +15,11 @@ source_index_access:
         - view_index_metadata
         - indices:data/write/bulk
         - indices:data/write/index
+
+fleet_index_access:
+  indices:
+    # Give access to the Fleet indices (which are system indices)
+    - names: [ '.fleet*' ]
+      privileges:
+        - all
+      allow_restricted_indices: true

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeChecker.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeChecker.java
@@ -95,6 +95,7 @@ final class TransformPrivilegeChecker {
                 .indices(sourceIndex)
                 // We need to read the source indices mapping to deduce the destination mapping, hence the need for view_index_metadata
                 .privileges("read", "view_index_metadata")
+                .allowRestrictedIndices(true)
                 .build();
             indicesPrivileges.add(sourceIndexPrivileges);
         }
@@ -121,6 +122,7 @@ final class TransformPrivilegeChecker {
             RoleDescriptor.IndicesPrivileges destIndexPrivileges = RoleDescriptor.IndicesPrivileges.builder()
                 .indices(destIndex)
                 .privileges(destPrivileges)
+                .allowRestrictedIndices(true)
                 .build();
             indicesPrivileges.add(destIndexPrivileges);
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
@@ -127,6 +127,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges sourceIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
+                assertThat(sourceIndicesPrivileges.allowRestrictedIndices(), is(true));
             }, e -> fail(e.getMessage()))
         );
     }
@@ -169,9 +170,11 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges sourceIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
+                assertThat(sourceIndicesPrivileges.allowRestrictedIndices(), is(true));
                 RoleDescriptor.IndicesPrivileges destIndicesPrivileges = request.indexPrivileges()[1];
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index", "create_index")));
+                assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
             }, e -> fail(e.getMessage()))
         );
     }
@@ -201,9 +204,11 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges sourceIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
+                assertThat(sourceIndicesPrivileges.allowRestrictedIndices(), is(true));
                 RoleDescriptor.IndicesPrivileges destIndicesPrivileges = request.indexPrivileges()[1];
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index")));
+                assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
             }, e -> fail(e.getMessage()))
         );
     }
@@ -235,6 +240,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges destIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index")));
+                assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
             }, e -> fail(e.getMessage()))
         );
     }
@@ -267,9 +273,11 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 RoleDescriptor.IndicesPrivileges sourceIndicesPrivileges = request.indexPrivileges()[0];
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
+                assertThat(sourceIndicesPrivileges.allowRestrictedIndices(), is(true));
                 RoleDescriptor.IndicesPrivileges destIndicesPrivileges = request.indexPrivileges()[1];
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index", "delete")));
+                assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
             }, e -> fail(e.getMessage()))
         );
     }


### PR DESCRIPTION
This PR adds `allow_restricted_indices` flag to the `HasPrivilegesRequest`s issued by `TransformPrivilegeChecker`.
This allows having restricted indices as transforms' source indices so cases like Fleet are supported.

Relates https://github.com/elastic/elasticsearch/issues/93259