### PR TITLE
Only remove telltale response headers in case of 401 or 403

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -34,6 +34,7 @@ import static java.util.Collections.singletonMap;
 import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE;
 import static org.elasticsearch.ElasticsearchException.REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT;
 import static org.elasticsearch.common.xcontent.XContentParserUtils.ensureExpectedToken;
+import static org.elasticsearch.rest.RestController.ELASTIC_PRODUCT_HTTP_HEADER;
 
 public class RestResponse {
 
@@ -248,6 +249,14 @@ public class RestResponse {
     }
 
     public Map<String, List<String>> filterHeaders(Map<String, List<String>> headers) {
+        if (status() == RestStatus.UNAUTHORIZED || status() == RestStatus.FORBIDDEN) {
+            if (headers.containsKey("Warning")) {
+                headers = Maps.copyMapWithRemovedEntry(headers, "Warning");
+            }
+            if (headers.containsKey(ELASTIC_PRODUCT_HTTP_HEADER)) {
+                headers = Maps.copyMapWithRemovedEntry(headers, ELASTIC_PRODUCT_HTTP_HEADER);
+            }
+        }
         return headers;
     }
 }

--- a/server/src/main/java/org/elasticsearch/rest/RestResponse.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestResponse.java
@@ -103,6 +103,7 @@ public class RestResponse {
     }
 
     public RestResponse(RestChannel channel, RestStatus status, Exception e) throws IOException {
+        this.status = status;
         ToXContent.Params params = paramsFromRequest(channel.request());
         if (params.paramAsBoolean(REST_EXCEPTION_SKIP_STACK_TRACE, REST_EXCEPTION_SKIP_STACK_TRACE_DEFAULT) && e != null) {
             // log exception only if it is not returned in the response
@@ -118,7 +119,6 @@ public class RestResponse {
                 SUPPRESSED_ERROR_LOGGER.warn(messageSupplier, e);
             }
         }
-        this.status = status;
         try (XContentBuilder builder = channel.newErrorBuilder()) {
             build(builder, params, status, channel.detailedErrorsEnabled(), e);
             this.content = BytesReference.bytes(builder);
@@ -161,7 +161,7 @@ public class RestResponse {
     }
 
     protected boolean skipStackTrace() {
-        return false;
+        return status() == RestStatus.UNAUTHORIZED;
     }
 
     private static void build(

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/SecurityRestFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/SecurityRestFilter.java
@@ -11,7 +11,6 @@ import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.util.Supplier;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.node.NodeClient;
-import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestChannel;
 import org.elasticsearch.rest.RestHandler;
@@ -19,13 +18,11 @@ import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestRequest.Method;
 import org.elasticsearch.rest.RestRequestFilter;
 import org.elasticsearch.rest.RestResponse;
-import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.xpack.security.audit.AuditTrailService;
 import org.elasticsearch.xpack.security.authc.AuthenticationService;
 import org.elasticsearch.xpack.security.authc.support.SecondaryAuthenticator;
 
 import java.util.List;
-import java.util.Map;
 
 import static org.elasticsearch.core.Strings.format;
 
@@ -125,24 +122,7 @@ public class SecurityRestFilter implements RestHandler {
         logger.debug(() -> format("%s failed for REST request [%s]", actionType, request.uri()), e);
         threadContext.sanitizeHeaders();
         try {
-            channel.sendResponse(new RestResponse(channel, e) {
-
-                @Override
-                public Map<String, List<String>> filterHeaders(Map<String, List<String>> headers) {
-                    if (actionType != ActionType.RequestHandling
-                        || status() == RestStatus.UNAUTHORIZED
-                        || status() == RestStatus.FORBIDDEN) {
-                        if (headers.containsKey("Warning")) {
-                            headers = Maps.copyMapWithRemovedEntry(headers, "Warning");
-                        }
-                        if (headers.containsKey("X-elastic-product")) {
-                            headers = Maps.copyMapWithRemovedEntry(headers, "X-elastic-product");
-                        }
-                    }
-                    return headers;
-                }
-
-            });
+            channel.sendResponse(new RestResponse(channel, e));
         } catch (Exception inner) {
             inner.addSuppressed(e);
             logger.error((Supplier<?>) () -> "failed to send failure response for uri [" + request.uri() + "]", inner);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterWarningHeadersTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/rest/SecurityRestFilterWarningHeadersTests.java
@@ -66,17 +66,17 @@ public class SecurityRestFilterWarningHeadersTests extends ESTestCase {
         headers.put("X-elastic-product", Collections.singletonList("Some product header"));
         Map<String, List<String>> afterHeaders;
 
-        // Remove all the headers on authentication failures
+        // only remove the response headers for 401 and 403
         afterHeaders = testProcessAuthenticationFailed(RestStatus.BAD_REQUEST, headers);
-        assertEquals(afterHeaders.size(), 0);
+        assertEquals(afterHeaders.size(), 2);
         afterHeaders = testProcessAuthenticationFailed(RestStatus.INTERNAL_SERVER_ERROR, headers);
-        assertEquals(afterHeaders.size(), 0);
+        assertEquals(afterHeaders.size(), 2);
         afterHeaders = testProcessAuthenticationFailed(RestStatus.UNAUTHORIZED, headers);
         assertEquals(afterHeaders.size(), 0);
         afterHeaders = testProcessAuthenticationFailed(RestStatus.FORBIDDEN, headers);
         assertEquals(afterHeaders.size(), 0);
 
-        // On rest handling failures only remove headers if rest status is UNAUTHORIZED or FORBIDDEN
+        // only remove the response headers for 401 and 403
         afterHeaders = testProcessRestHandlingFailed(RestStatus.BAD_REQUEST, headers);
         assertEquals(afterHeaders.size(), 2);
         afterHeaders = testProcessRestHandlingFailed(RestStatus.INTERNAL_SERVER_ERROR, headers);


### PR DESCRIPTION
This ensures that `Warning` and `X-elastic-product` response
headers are only removed in case of 401 or 403 HTTP error
response codes.
Previously, the response headers were also removed in non
401 and 403 conditions, in case of esoteric errors during authN,
but this behavior displaced the response-filtering logic to
an uncomfortable code site from a reusability pov.