### PR TITLE
GET _lifecycle returns data streams without lifecycle

### DIFF
--- a/docs/reference/dlm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/dlm/apis/get-lifecycle.asciidoc
@@ -18,6 +18,8 @@ Gets the lifecycle of a set of data streams.
 
 Gets the lifecycle of the specified data streams. If multiple data streams are requested but at least one of them
 does not exist, then the API will respond with `404` since at least one of the requested resources could not be retrieved.
+If the requested data streams do not have a lifecycle configured they will still be included in the API response but the
+`lifecycle` key will be missing.
 
 [[dlm-get-lifecycle-path-params]]
 ==== {api-path-parms-title}
@@ -53,18 +55,18 @@ Contains information about retrieved data stream lifecycles.
 (string)
 Name of the data stream.
 `lifecycle`::
-(object)
+(Optional, object)
 +
 .Properties of `lifecycle`
 [%collapsible%open]
 =====
 `data_retention`::
-(string)
+(Optional, string)
 If defined, every document added to this data stream will be stored at least for this time frame. Any time after this
 duration the document could be deleted. When undefined, every document in this data stream will be stored indefinitely.
 
 `rollover`::
-(object)
+(Optional, object)
 The conditions which will trigger the rollover of a backing index as configured by the cluster setting
 `cluster.dlm.default.rollover`. This property is an implementation detail and it will only be retrieved when the query
 param `include_defaults` is set to `true`. The contents of this field are subject to change.

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/CrudDataLifecycleIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/CrudDataLifecycleIT.java
@@ -24,6 +24,7 @@ import java.util.List;
 import static org.elasticsearch.dlm.DLMFixtures.putComposableIndexTemplate;
 import static org.elasticsearch.dlm.DLMFixtures.randomDataLifecycle;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
@@ -62,11 +63,13 @@ public class CrudDataLifecycleIT extends ESIntegTestCase {
         {
             GetDataLifecycleAction.Request getDataLifecycleRequest = new GetDataLifecycleAction.Request(new String[] { "*" });
             GetDataLifecycleAction.Response response = client().execute(GetDataLifecycleAction.INSTANCE, getDataLifecycleRequest).get();
-            assertThat(response.getDataStreamLifecycles().size(), equalTo(2));
+            assertThat(response.getDataStreamLifecycles().size(), equalTo(3));
             assertThat(response.getDataStreamLifecycles().get(0).dataStreamName(), equalTo("with-lifecycle-1"));
             assertThat(response.getDataStreamLifecycles().get(0).lifecycle(), equalTo(lifecycle));
             assertThat(response.getDataStreamLifecycles().get(1).dataStreamName(), equalTo("with-lifecycle-2"));
             assertThat(response.getDataStreamLifecycles().get(1).lifecycle(), equalTo(lifecycle));
+            assertThat(response.getDataStreamLifecycles().get(2).dataStreamName(), equalTo("without-lifecycle"));
+            assertThat(response.getDataStreamLifecycles().get(2).lifecycle(), is(nullValue()));
             assertThat(response.getRolloverConfiguration(), nullValue());
         }
 
@@ -101,11 +104,13 @@ public class CrudDataLifecycleIT extends ESIntegTestCase {
             GetDataLifecycleAction.INSTANCE,
             getDataLifecycleRequestWithDefaults
         ).get();
-        assertThat(responseWithRollover.getDataStreamLifecycles().size(), equalTo(2));
+        assertThat(responseWithRollover.getDataStreamLifecycles().size(), equalTo(3));
         assertThat(responseWithRollover.getDataStreamLifecycles().get(0).dataStreamName(), equalTo("with-lifecycle-1"));
         assertThat(responseWithRollover.getDataStreamLifecycles().get(0).lifecycle(), equalTo(lifecycle));
         assertThat(responseWithRollover.getDataStreamLifecycles().get(1).dataStreamName(), equalTo("with-lifecycle-2"));
         assertThat(responseWithRollover.getDataStreamLifecycles().get(1).lifecycle(), equalTo(lifecycle));
+        assertThat(responseWithRollover.getDataStreamLifecycles().get(2).dataStreamName(), equalTo("without-lifecycle"));
+        assertThat(responseWithRollover.getDataStreamLifecycles().get(2).lifecycle(), is(nullValue()));
         assertThat(responseWithRollover.getRolloverConfiguration(), notNullValue());
     }
 
@@ -119,7 +124,10 @@ public class CrudDataLifecycleIT extends ESIntegTestCase {
         {
             GetDataLifecycleAction.Request getDataLifecycleRequest = new GetDataLifecycleAction.Request(new String[] { "my-data-stream" });
             GetDataLifecycleAction.Response response = client().execute(GetDataLifecycleAction.INSTANCE, getDataLifecycleRequest).get();
-            assertThat(response.getDataStreamLifecycles().isEmpty(), equalTo(true));
+            assertThat(response.getDataStreamLifecycles().isEmpty(), equalTo(false));
+            GetDataLifecycleAction.Response.DataStreamLifecycle dataStreamLifecycle = response.getDataStreamLifecycles().get(0);
+            assertThat(dataStreamLifecycle.dataStreamName(), is(dataStreamName));
+            assertThat(dataStreamLifecycle.lifecycle(), is(nullValue()));
         }
 
         // Set lifecycle
@@ -173,9 +181,13 @@ public class CrudDataLifecycleIT extends ESIntegTestCase {
             );
             GetDataLifecycleAction.Request getDataLifecycleRequest = new GetDataLifecycleAction.Request(new String[] { "with-lifecycle*" });
             GetDataLifecycleAction.Response response = client().execute(GetDataLifecycleAction.INSTANCE, getDataLifecycleRequest).get();
-            assertThat(response.getDataStreamLifecycles().size(), equalTo(2));
-            assertThat(response.getDataStreamLifecycles().get(0).dataStreamName(), equalTo("with-lifecycle-2"));
-            assertThat(response.getDataStreamLifecycles().get(1).dataStreamName(), equalTo("with-lifecycle-3"));
+            assertThat(response.getDataStreamLifecycles().size(), equalTo(3));
+            GetDataLifecycleAction.Response.DataStreamLifecycle dataStreamLifecycle = response.getDataStreamLifecycles().get(0);
+            assertThat(dataStreamLifecycle.dataStreamName(), is("with-lifecycle-1"));
+            assertThat(dataStreamLifecycle.lifecycle(), is(nullValue()));
+            assertThat(response.getDataStreamLifecycles().get(1).dataStreamName(), equalTo("with-lifecycle-2"));
+            assertThat(response.getDataStreamLifecycles().get(2).dataStreamName(), equalTo("with-lifecycle-3"));
+
         }
 
         // Remove lifecycle from all data streams
@@ -187,7 +199,14 @@ public class CrudDataLifecycleIT extends ESIntegTestCase {
             );
             GetDataLifecycleAction.Request getDataLifecycleRequest = new GetDataLifecycleAction.Request(new String[] { "with-lifecycle*" });
             GetDataLifecycleAction.Response response = client().execute(GetDataLifecycleAction.INSTANCE, getDataLifecycleRequest).get();
-            assertThat(response.getDataStreamLifecycles().isEmpty(), equalTo(true));
+            assertThat(response.getDataStreamLifecycles().size(), equalTo(3));
+            assertThat(response.getDataStreamLifecycles().get(0).dataStreamName(), equalTo("with-lifecycle-1"));
+            assertThat(response.getDataStreamLifecycles().get(1).dataStreamName(), equalTo("with-lifecycle-2"));
+            assertThat(response.getDataStreamLifecycles().get(2).dataStreamName(), equalTo("with-lifecycle-3"));
+
+            for (GetDataLifecycleAction.Response.DataStreamLifecycle dataStreamLifecycle : response.getDataStreamLifecycles()) {
+                assertThat(dataStreamLifecycle.lifecycle(), nullValue());
+            }
         }
     }
 }

--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/action/GetDataLifecycleAction.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/action/GetDataLifecycleAction.java
@@ -139,7 +139,7 @@ public class GetDataLifecycleAction extends ActionType<GetDataLifecycleAction.Re
     public static class Response extends ActionResponse implements ChunkedToXContentObject {
         public static final ParseField DATA_STREAMS_FIELD = new ParseField("data_streams");
 
-        public record DataStreamLifecycle(String dataStreamName, DataLifecycle lifecycle) implements Writeable, ToXContentObject {
+        public record DataStreamLifecycle(String dataStreamName, @Nullable DataLifecycle lifecycle) implements Writeable, ToXContentObject {
 
             public static final ParseField NAME_FIELD = new ParseField("name");
             public static final ParseField LIFECYCLE_FIELD = new ParseField("lifecycle");
@@ -167,7 +167,9 @@ public class GetDataLifecycleAction extends ActionType<GetDataLifecycleAction.Re
                 builder.startObject();
                 builder.field(NAME_FIELD.getPreferredName(), dataStreamName);
                 builder.field(LIFECYCLE_FIELD.getPreferredName());
-                lifecycle.toXContent(builder, params, rolloverConfiguration);
+                if (lifecycle != null) {
+                    lifecycle.toXContent(builder, params, rolloverConfiguration);
+                }
                 builder.endObject();
                 return builder;
             }

--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/action/GetDataLifecycleAction.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/action/GetDataLifecycleAction.java
@@ -166,8 +166,8 @@ public class GetDataLifecycleAction extends ActionType<GetDataLifecycleAction.Re
                 throws IOException {
                 builder.startObject();
                 builder.field(NAME_FIELD.getPreferredName(), dataStreamName);
-                builder.field(LIFECYCLE_FIELD.getPreferredName());
                 if (lifecycle != null) {
+                    builder.field(LIFECYCLE_FIELD.getPreferredName());
                     lifecycle.toXContent(builder, params, rolloverConfiguration);
                 }
                 builder.endObject();

--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/action/TransportGetDataLifecycleAction.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/action/TransportGetDataLifecycleAction.java
@@ -27,6 +27,7 @@ import org.elasticsearch.transport.TransportService;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * Collects the data streams from the cluster state, filters the ones that do not have a lifecycle configured and then returns
@@ -78,7 +79,7 @@ public class TransportGetDataLifecycleAction extends TransportMasterNodeReadActi
             new GetDataLifecycleAction.Response(
                 results.stream()
                     .map(dataStreams::get)
-                    .filter(dataStream -> dataStream != null && dataStream.getLifecycle() != null)
+                    .filter(Objects::nonNull)
                     .map(
                         dataStream -> new GetDataLifecycleAction.Response.DataStreamLifecycle(
                             dataStream.getName(),

--- a/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/20_basic.yml
+++ b/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/20_basic.yml
@@ -43,7 +43,7 @@ setup:
 
   - do:
       indices.get_data_lifecycle:
-        name: "*"
+        name: "data-stream-with-lifecycle"
   - length: { data_streams: 1}
   - match: { data_streams.0.name: data-stream-with-lifecycle }
   - match: { data_streams.0.lifecycle.data_retention: '10d' }
@@ -93,8 +93,10 @@ setup:
 
   - do:
       indices.get_data_lifecycle:
-        name: "*"
-  - length: { data_streams: 2 }
+        name: "simple-data-stream1"
+  - length: { data_streams: 1 }
+  - match: { data_streams.0.name: simple-data-stream1 }
+  - match: { data_streams.0.lifecycle.data_retention: '30d' }
 
   - do:
       indices.delete_data_lifecycle:
@@ -103,7 +105,7 @@ setup:
 
   - do:
       indices.get_data_lifecycle:
-        name: "*"
+        name: "simple-data-stream1"
   - length: { data_streams: 1 }
-  - match: { data_streams.0.name: data-stream-with-lifecycle }
-  - match: { data_streams.0.lifecycle.data_retention: '10d' }
+  - match: { data_streams.0.name: simple-data-stream1 }
+  - is_false: data_streams.0.lifecycle


### PR DESCRIPTION
This changes the `GET _data_stream/ds_name/_lifecycle` endpoint to return the data stream name even if it doesn't have a lifecycle configured.

e.g.
```
{
  "data_streams": [
    {
      "name": "logs-nginx"
    }
  ]
}
```
Relates to https://github.com/elastic/elasticsearch/issues/93596