### PR TITLE
[ML] Add missing text_similarity config support to the Inference Processor 

### DIFF
--- a/docs/changelog/95190.yaml
+++ b/docs/changelog/95190.yaml
@@ -1,0 +1,5 @@
+pr: 95190
+summary: Add missing `text_similarity` config support to the Inference Processor
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/InferModelActionResponseTests.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -26,13 +27,31 @@ import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResu
 import org.elasticsearch.xpack.core.ml.inference.results.RegressionInferenceResultsTests;
 import org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResults;
 import org.elasticsearch.xpack.core.ml.inference.results.TextEmbeddingResultsTests;
+import org.elasticsearch.xpack.core.ml.inference.results.TextSimilarityInferenceResults;
+import org.elasticsearch.xpack.core.ml.inference.results.TextSimilarityInferenceResultsTests;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.results.WarningInferenceResultsTests;
 
+import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+
 public class InferModelActionResponseTests extends AbstractWireSerializingTestCase<Response> {
+
+    private static List<String> INFERENCE_RESULT_TYPES = List.of(
+        ClassificationInferenceResults.NAME,
+        NerResults.NAME,
+        FillMaskResults.NAME,
+        PyTorchPassThroughResults.NAME,
+        QuestionAnsweringInferenceResults.NAME,
+        RegressionInferenceResults.NAME,
+        TextEmbeddingResults.NAME,
+        TextSimilarityInferenceResults.NAME,
+        WarningInferenceResults.NAME
+    );
 
     @Override
     protected Response createTestInstance() {
@@ -59,26 +78,26 @@ public class InferModelActionResponseTests extends AbstractWireSerializingTestCa
     }
 
     private static InferenceResults randomInferenceResult(String resultType) {
-        switch (resultType) {
-            case ClassificationInferenceResults.NAME:
-                return ClassificationInferenceResultsTests.createRandomResults();
-            case RegressionInferenceResults.NAME:
-                return RegressionInferenceResultsTests.createRandomResults();
-            case NerResults.NAME:
-                return NerResultsTests.createRandomResults();
-            case TextEmbeddingResults.NAME:
-                return TextEmbeddingResultsTests.createRandomResults();
-            case PyTorchPassThroughResults.NAME:
-                return PyTorchPassThroughResultsTests.createRandomResults();
-            case FillMaskResults.NAME:
-                return FillMaskResultsTests.createRandomResults();
-            case WarningInferenceResults.NAME:
-                return WarningInferenceResultsTests.createRandomResults();
-            case QuestionAnsweringInferenceResults.NAME:
-                return QuestionAnsweringInferenceResultsTests.createRandomResults();
-            default:
-                fail("unexpected result type [" + resultType + "]");
-                return null;
+        return switch (resultType) {
+            case ClassificationInferenceResults.NAME -> ClassificationInferenceResultsTests.createRandomResults();
+            case NerResults.NAME -> NerResultsTests.createRandomResults();
+            case FillMaskResults.NAME -> FillMaskResultsTests.createRandomResults();
+            case PyTorchPassThroughResults.NAME -> PyTorchPassThroughResultsTests.createRandomResults();
+            case QuestionAnsweringInferenceResults.NAME -> QuestionAnsweringInferenceResultsTests.createRandomResults();
+            case RegressionInferenceResults.NAME -> RegressionInferenceResultsTests.createRandomResults();
+            case TextEmbeddingResults.NAME -> TextEmbeddingResultsTests.createRandomResults();
+            case TextSimilarityInferenceResults.NAME -> TextSimilarityInferenceResultsTests.createRandomResults();
+            case WarningInferenceResults.NAME -> WarningInferenceResultsTests.createRandomResults();
+            default -> throw new AssertionError("unexpected result type [" + resultType + "]");
+        };
+    }
+
+    public void testToXContentString() {
+        // assert that the toXContent method does not error
+        for (var inferenceType : INFERENCE_RESULT_TYPES) {
+            var s = Strings.toString(randomInferenceResult(inferenceType));
+            assertNotNull(s);
+            assertThat(s, not(containsString("error")));
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessor.java
@@ -41,12 +41,12 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.QuestionAnsweringC
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.QuestionAnsweringConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfigUpdate;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.SlimConfig;
-import org.elasticsearch.xpack.core.ml.inference.trainedmodel.SlimConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfigUpdate;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfigUpdate;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfigUpdate;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
@@ -308,15 +308,15 @@ public class InferenceProcessor extends AbstractProcessor {
             } else if (configMap.containsKey(RegressionConfig.NAME.getPreferredName())) {
                 checkSupportedVersion(RegressionConfig.EMPTY_PARAMS);
                 return RegressionConfigUpdate.fromMap(valueMap);
-            } else if (configMap.containsKey(SlimConfig.NAME)) {
-                checkNlpSupported(SlimConfig.NAME);
-                return SlimConfigUpdate.fromMap(valueMap);
             } else if (configMap.containsKey(TextClassificationConfig.NAME)) {
                 checkNlpSupported(TextClassificationConfig.NAME);
                 return TextClassificationConfigUpdate.fromMap(valueMap);
             } else if (configMap.containsKey(TextEmbeddingConfig.NAME)) {
                 checkNlpSupported(TextEmbeddingConfig.NAME);
                 return TextEmbeddingConfigUpdate.fromMap(valueMap);
+            } else if (configMap.containsKey(TextSimilarityConfig.NAME)) {
+                checkNlpSupported(TextSimilarityConfig.NAME);
+                return TextSimilarityConfigUpdate.fromMap(valueMap);
             } else if (configMap.containsKey(ZeroShotClassificationConfig.NAME)) {
                 checkNlpSupported(ZeroShotClassificationConfig.NAME);
                 return ZeroShotClassificationConfigUpdate.fromMap(valueMap);
@@ -333,8 +333,10 @@ public class InferenceProcessor extends AbstractProcessor {
                         FillMaskConfig.NAME,
                         NerConfig.NAME,
                         PassThroughConfig.NAME,
+                        QuestionAnsweringConfig.NAME,
                         TextClassificationConfig.NAME,
                         TextEmbeddingConfig.NAME,
+                        TextSimilarityConfig.NAME,
                         ZeroShotClassificationConfig.NAME
                     )
                 );

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.QuestionAnsweringC
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.RegressionConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextClassificationConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextEmbeddingConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TextSimilarityConfig;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ZeroShotClassificationConfig;
 import org.junit.Before;
 
@@ -128,7 +129,8 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             equalTo(
                 "unrecognized inference configuration type [unknown_type]."
                     + " Supported types [classification, regression, fill_mask, ner, pass_through, "
-                    + "text_classification, text_embedding, zero_shot_classification]"
+                    + "question_answering, text_classification, text_embedding, "
+                    + "text_similarity, zero_shot_classification]"
             )
         );
 
@@ -219,8 +221,10 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             FillMaskConfig.NAME,
             NerConfig.NAME,
             PassThroughConfig.NAME,
+            QuestionAnsweringConfig.NAME,
             TextClassificationConfig.NAME,
             TextEmbeddingConfig.NAME,
+            TextSimilarityConfig.NAME,
             ZeroShotClassificationConfig.NAME
         )) {
             ElasticsearchException ex = expectThrows(
@@ -230,6 +234,17 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             assertThat(
                 ex.getMessage(),
                 equalTo("Configuration [" + name + "] requires minimum node version [8.0.0] (current minimum node version [7.5.0]")
+            );
+        }
+
+        for (String name : List.of(ClassificationConfig.NAME.getPreferredName(), RegressionConfig.NAME.getPreferredName())) {
+            ElasticsearchException ex = expectThrows(
+                ElasticsearchException.class,
+                () -> processorFactory.inferenceConfigUpdateFromMap(Map.of(name, Map.of()))
+            );
+            assertThat(
+                ex.getMessage(),
+                equalTo("Configuration [" + name + "] requires minimum node version [7.6.0] (current minimum node version [7.5.0]")
             );
         }
     }


### PR DESCRIPTION
Back port of #95190
