### PR TITLE
[Behavioral Analytics] Add a final_pipeline to event data streams.

### DIFF
--- a/docs/changelog/95198.yaml
+++ b/docs/changelog/95198.yaml
@@ -1,0 +1,5 @@
+pr: 95198
+summary: "[Behavioral Analytics] Add a `final_pipeline` to event data streams"
+area: Application
+type: feature
+issues: []

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
@@ -1,0 +1,40 @@
+{
+  "description": "Built ingest pipeline applied by as default final pipeline to behavioral analytics event data streams.",
+  "processors": [
+    {
+      "user_agent": {
+        "field": "event.user_agent",
+        "ignore_missing": true
+      }
+    },
+    {
+      "uri_parts": {
+        "field": "event.page_url",
+        "if": "ctx.event.page_url != null",
+        "target_field": "url",
+        "keep_original": false,
+        "remove_if_successful": true
+      }
+    },
+    {
+      "remove": {
+        "field": [
+          "agent.ephemeral_id",
+          "agent.id",
+          "agent.name",
+          "agent.type",
+          "agent.version",
+          "host.name",
+          "input.type",
+          "log.file.path",
+          "log.offset"
+        ],
+        "ignore_missing": true
+      }
+    }
+  ],
+  "_meta": {
+    "managed": true
+  },
+  "version": ${xpack.entsearch.analytics.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
@@ -1,19 +1,30 @@
 {
-  "description": "Built ingest pipeline applied by as default final pipeline to behavioral analytics event data streams.",
+  "description": "Built-in ingest pipeline applied by default as final pipeline to behavioral analytics event data streams.",
   "processors": [
     {
-      "user_agent": {
-        "field": "event.user_agent",
+      "uri_parts": {
+        "field": "page.url",
+        "target_field": "page.url",
         "ignore_missing": true
       }
     },
     {
       "uri_parts": {
-        "field": "event.page_url",
-        "if": "ctx.event.page_url != null",
-        "target_field": "url",
-        "keep_original": false,
-        "remove_if_successful": true
+        "field": "page.referrer",
+        "target_field": "page.referrer",
+        "ignore_missing": true
+      }
+    },
+    {
+      "foreach": {
+        "field": "search.results.items",
+        "ignore_missing": true,
+        "processor": {
+          "uri_parts": {
+            "field": "_ingest._value.page.url",
+            "target_field": "_ingest._value.page.url"
+          }
+        }
       }
     },
     {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
@@ -22,25 +22,10 @@
         "processor": {
           "uri_parts": {
             "field": "_ingest._value.page.url",
-            "target_field": "_ingest._value.page.url"
+            "target_field": "_ingest._value.page.url",
+            "ignore_missing": true
           }
         }
-      }
-    },
-    {
-      "remove": {
-        "field": [
-          "agent.ephemeral_id",
-          "agent.id",
-          "agent.name",
-          "agent.type",
-          "agent.version",
-          "host.name",
-          "input.type",
-          "log.file.path",
-          "log.offset"
-        ],
-        "ignore_missing": true
       }
     }
   ],

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-mappings.json
@@ -62,16 +62,84 @@
         "page": {
           "properties": {
             "url": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "extension": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "fragment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "path": {
+                  "type": "wildcard"
+                },
+                "port": {
+                  "type": "long"
+                },
+                "query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "scheme": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             },
             "title": {
               "ignore_above": 1024,
               "type": "keyword"
             },
             "referrer": {
-              "ignore_above": 1024,
-              "type": "keyword"
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "extension": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "fragment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original": {
+                  "fields": {
+                    "text": {
+                      "type": "match_only_text"
+                    }
+                  },
+                  "type": "wildcard"
+                },
+                "path": {
+                  "type": "wildcard"
+                },
+                "port": {
+                  "type": "long"
+                },
+                "query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "scheme": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
             }
           }
         },
@@ -133,8 +201,42 @@
                     "page": {
                       "properties": {
                         "url": {
-                          "type": "keyword",
-                          "ignore_above": 1024
+                          "properties": {
+                            "domain": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "extension": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "fragment": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "original": {
+                              "fields": {
+                                "text": {
+                                  "type": "match_only_text"
+                                }
+                              },
+                              "type": "wildcard"
+                            },
+                            "path": {
+                              "type": "wildcard"
+                            },
+                            "port": {
+                              "type": "long"
+                            },
+                            "query": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            },
+                            "scheme": {
+                              "ignore_above": 1024,
+                              "type": "keyword"
+                            }
+                          }
                         },
                         "title": {
                           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-settings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-settings.json
@@ -9,7 +9,8 @@
         "refresh_interval": "1s",
         "number_of_shards": 1,
         "number_of_replicas": 0,
-        "auto_expand_replicas": "0-1"
+        "auto_expand_replicas": "0-1",
+        "final_pipeline": "behavioral_analytics-events-final_pipeline"
       }
     }
   },

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -37,6 +37,7 @@ import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xcontent.NamedXContentRegistry;
+import org.elasticsearch.xpack.application.analytics.AnalyticsIngestPipelineRegistry;
 import org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry;
 import org.elasticsearch.xpack.application.analytics.action.DeleteAnalyticsCollectionAction;
 import org.elasticsearch.xpack.application.analytics.action.GetAnalyticsCollectionAction;
@@ -171,7 +172,14 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
         );
         analyticsTemplateRegistry.initialize();
 
-        return Arrays.asList(analyticsTemplateRegistry);
+        final AnalyticsIngestPipelineRegistry analyticsPipelineRegistry = new AnalyticsIngestPipelineRegistry(
+            clusterService,
+            threadPool,
+            client
+        );
+        analyticsPipelineRegistry.initialize();
+
+        return Arrays.asList(analyticsTemplateRegistry, analyticsPipelineRegistry);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/EnterpriseSearch.java
@@ -177,7 +177,6 @@ public class EnterpriseSearch extends Plugin implements ActionPlugin, SystemInde
             threadPool,
             client
         );
-        analyticsPipelineRegistry.initialize();
 
         return Arrays.asList(analyticsTemplateRegistry, analyticsPipelineRegistry);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollection.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollection.java
@@ -24,6 +24,8 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.util.Objects;
 
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PREFIX;
+
 /**
  * The {@link AnalyticsCollection} model.
  */
@@ -68,7 +70,7 @@ public class AnalyticsCollection implements Writeable, ToXContentObject {
      * @return Event data stream name/
      */
     public String getEventDataStream() {
-        return AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + name;
+        return EVENT_DATA_STREAM_INDEX_PREFIX + name;
     }
 
     /**
@@ -114,13 +116,13 @@ public class AnalyticsCollection implements Writeable, ToXContentObject {
     }
 
     public static AnalyticsCollection fromDataStreamName(String dataStreamName) {
-        if (dataStreamName.startsWith(AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX) == false) {
+        if (dataStreamName.startsWith(EVENT_DATA_STREAM_INDEX_PREFIX) == false) {
             throw new IllegalArgumentException(
-                "Data stream name (" + dataStreamName + " must start with " + AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX
+                "Data stream name (" + dataStreamName + " must start with " + EVENT_DATA_STREAM_INDEX_PREFIX
             );
         }
 
-        return new AnalyticsCollection(dataStreamName.replaceFirst(AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX, ""));
+        return new AnalyticsCollection(dataStreamName.replaceFirst(EVENT_DATA_STREAM_INDEX_PREFIX, ""));
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionResolver.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionResolver.java
@@ -24,6 +24,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static java.util.function.Predicate.not;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PATTERN;
 
 /**
  * A service that allows the resolution of {@link AnalyticsCollection} by name.
@@ -82,7 +83,7 @@ public class AnalyticsCollectionResolver {
         List<String> dataStreams = indexNameExpressionResolver.dataStreamNames(
             state,
             IndicesOptions.lenientExpandOpen(),
-            AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PATTERN
+            EVENT_DATA_STREAM_INDEX_PATTERN
         );
 
         Map<String, AnalyticsCollection> collections = dataStreams.stream()

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
@@ -8,6 +8,9 @@
 package org.elasticsearch.xpack.application.analytics;
 
 public class AnalyticsConstants {
+
+    private AnalyticsConstants() {}
+
     // Data stream related constants.
     public static final String EVENT_DATA_STREAM_DATASET = "events";
     public static final String EVENT_DATA_STREAM_TYPE = "behavioral_analytics";

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+public class AnalyticsConstants {
+    // Data stream related constants.
+    public static final String EVENT_DATA_STREAM_DATASET = "events";
+    public static final String EVENT_DATA_STREAM_TYPE = "behavioral_analytics";
+    public static final String EVENT_DATA_STREAM_INDEX_PREFIX = EVENT_DATA_STREAM_TYPE + "-" + EVENT_DATA_STREAM_DATASET + "-";
+    public static final String EVENT_DATA_STREAM_INDEX_PATTERN = EVENT_DATA_STREAM_INDEX_PREFIX + "*";
+
+    // Resource config.
+    public static final String ROOT_RESOURCE_PATH = "/org/elasticsearch/xpack/entsearch/analytics/";
+
+    // The variable to be replaced with the template version number
+    public static final String TEMPLATE_VERSION_VARIABLE = "xpack.entsearch.analytics.template.version";
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.application.utils.ingest.PipelineRegistry;
+import org.elasticsearch.xpack.application.utils.ingest.PipelineTemplateConfiguration;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.REGISTRY_VERSION;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.ROOT_RESOURCE_PATH;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.TEMPLATE_VERSION_VARIABLE;
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
+
+public class AnalyticsIngestPipelineRegistry extends PipelineRegistry {
+
+    // Ingest pipelines configuration.
+    private static final String EVENT_DATA_STREAM_INGEST_PIPELINE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "final_pipeline";
+    private static final List<PipelineTemplateConfiguration> INGEST_PIPELINES = Collections.singletonList(
+        new PipelineTemplateConfiguration(
+            EVENT_DATA_STREAM_INGEST_PIPELINE_NAME,
+            ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_INGEST_PIPELINE_NAME + ".json",
+            REGISTRY_VERSION,
+            TEMPLATE_VERSION_VARIABLE
+        )
+    );
+
+    public AnalyticsIngestPipelineRegistry(ClusterService clusterService, ThreadPool threadPool, Client client) {
+        super(clusterService, threadPool, client);
+    }
+
+    @Override
+    protected String getOrigin() {
+        return ENT_SEARCH_ORIGIN;
+    }
+
+    @Override
+    protected List<PipelineTemplateConfiguration> getIngestPipelineConfigs() {
+        return INGEST_PIPELINES;
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
@@ -21,11 +21,14 @@ import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateReg
 import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.TEMPLATE_VERSION_VARIABLE;
 import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
+/**
+ * Set up the behavioral analytics ingest pipelines.
+ */
 public class AnalyticsIngestPipelineRegistry extends PipelineRegistry {
 
     // Ingest pipelines configuration.
-    private static final String EVENT_DATA_STREAM_INGEST_PIPELINE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "final_pipeline";
-    private static final List<PipelineTemplateConfiguration> INGEST_PIPELINES = Collections.singletonList(
+    protected static final String EVENT_DATA_STREAM_INGEST_PIPELINE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "final_pipeline";
+    protected static final List<PipelineTemplateConfiguration> INGEST_PIPELINES = Collections.singletonList(
         new PipelineTemplateConfiguration(
             EVENT_DATA_STREAM_INGEST_PIPELINE_NAME,
             ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_INGEST_PIPELINE_NAME + ".json",

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
@@ -15,10 +15,10 @@ import org.elasticsearch.xpack.application.utils.ingest.PipelineTemplateConfigur
 import java.util.Collections;
 import java.util.List;
 
-import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PREFIX;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.ROOT_RESOURCE_PATH;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.TEMPLATE_VERSION_VARIABLE;
 import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.REGISTRY_VERSION;
-import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.ROOT_RESOURCE_PATH;
-import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.TEMPLATE_VERSION_VARIABLE;
 import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
 /**
@@ -27,8 +27,8 @@ import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 public class AnalyticsIngestPipelineRegistry extends PipelineRegistry {
 
     // Ingest pipelines configuration.
-    protected static final String EVENT_DATA_STREAM_INGEST_PIPELINE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "final_pipeline";
-    protected static final List<PipelineTemplateConfiguration> INGEST_PIPELINES = Collections.singletonList(
+    static final String EVENT_DATA_STREAM_INGEST_PIPELINE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "final_pipeline";
+    static final List<PipelineTemplateConfiguration> INGEST_PIPELINES = Collections.singletonList(
         new PipelineTemplateConfiguration(
             EVENT_DATA_STREAM_INGEST_PIPELINE_NAME,
             ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_INGEST_PIPELINE_NAME + ".json",

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistry.java
@@ -26,37 +26,29 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PATTERN;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PREFIX;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.ROOT_RESOURCE_PATH;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.TEMPLATE_VERSION_VARIABLE;
 import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
 public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
 
-    // Data stream related constants.
-    public static final String EVENT_DATA_STREAM_DATASET = "events";
-    public static final String EVENT_DATA_STREAM_TYPE = "behavioral_analytics";
-    public static final String EVENT_DATA_STREAM_INDEX_PREFIX = EVENT_DATA_STREAM_TYPE + "-" + EVENT_DATA_STREAM_DATASET + "-";
-    public static final String EVENT_DATA_STREAM_INDEX_PATTERN = EVENT_DATA_STREAM_INDEX_PREFIX + "*";
-
-    // Resource config.
-    protected static final String ROOT_RESOURCE_PATH = "/org/elasticsearch/xpack/entsearch/analytics/";
-
     // This number must be incremented when we make changes to built-in templates.
-    protected static final int REGISTRY_VERSION = 1;
-
-    // The variable to be replaced with the template version number
-    protected static final String TEMPLATE_VERSION_VARIABLE = "xpack.entsearch.analytics.template.version";
+    static final int REGISTRY_VERSION = 1;
 
     // ILM Policies configuration
-    protected static final String EVENT_DATA_STREAM_ILM_POLICY_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "default_policy";
+    static final String EVENT_DATA_STREAM_ILM_POLICY_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "default_policy";
 
-    protected static final List<LifecyclePolicy> LIFECYCLE_POLICIES = Stream.of(
+    static final List<LifecyclePolicy> LIFECYCLE_POLICIES = Stream.of(
         new LifecyclePolicyConfig(EVENT_DATA_STREAM_ILM_POLICY_NAME, ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_ILM_POLICY_NAME + ".json")
     ).map(config -> config.load(LifecyclePolicyConfig.DEFAULT_X_CONTENT_REGISTRY)).toList();
 
     // Index template components configuration
-    protected static final String EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "settings";
-    protected static final String EVENT_DATA_STREAM_MAPPINGS_COMPONENT_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "mappings";
+    static final String EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "settings";
+    static final String EVENT_DATA_STREAM_MAPPINGS_COMPONENT_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "mappings";
 
-    protected static final Map<String, ComponentTemplate> COMPONENT_TEMPLATES;
+    static final Map<String, ComponentTemplate> COMPONENT_TEMPLATES;
 
     static {
         final Map<String, ComponentTemplate> componentTemplates = new HashMap<>();
@@ -87,11 +79,10 @@ public class AnalyticsTemplateRegistry extends IndexTemplateRegistry {
     }
 
     // Composable index templates configuration.
+    static final String EVENT_DATA_STREAM_TEMPLATE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "default";
+    static final String EVENT_DATA_STREAM_TEMPLATE_FILENAME = EVENT_DATA_STREAM_INDEX_PREFIX + "template";
 
-    protected static final String EVENT_DATA_STREAM_TEMPLATE_NAME = EVENT_DATA_STREAM_INDEX_PREFIX + "default";
-    protected static final String EVENT_DATA_STREAM_TEMPLATE_FILENAME = EVENT_DATA_STREAM_INDEX_PREFIX + "template";
-
-    protected static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATES = parseComposableTemplates(
+    static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATES = parseComposableTemplates(
         new IndexTemplateConfig(
             EVENT_DATA_STREAM_TEMPLATE_NAME,
             ROOT_RESOURCE_PATH + EVENT_DATA_STREAM_TEMPLATE_FILENAME + ".json",

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
@@ -20,12 +20,14 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 import org.elasticsearch.xpack.application.analytics.AnalyticsCollection;
-import org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry;
 
 import java.io.IOException;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_DATASET;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_TYPE;
 
 /**
  * This class represents Analytics events object meant to be emitted to the event queue.
@@ -181,8 +183,8 @@ public class AnalyticsEvent implements Writeable, ToXContentObject {
 
             builder.startObject(DATA_STREAM_FIELD.getPreferredName());
             {
-                builder.field(DATA_STREAM_TYPE_FIELD.getPreferredName(), AnalyticsTemplateRegistry.EVENT_DATA_STREAM_TYPE);
-                builder.field(DATA_STREAM_DATASET_FIELD.getPreferredName(), AnalyticsTemplateRegistry.EVENT_DATA_STREAM_DATASET);
+                builder.field(DATA_STREAM_TYPE_FIELD.getPreferredName(), EVENT_DATA_STREAM_TYPE);
+                builder.field(DATA_STREAM_DATASET_FIELD.getPreferredName(), EVENT_DATA_STREAM_DATASET);
                 builder.field(DATA_STREAM_NAMESPACE_FIELD.getPreferredName(), eventCollectionName());
 
             }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
@@ -1,0 +1,218 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.utils.ingest;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ingest.PutPipelineAction;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.gateway.GatewayService;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.elasticsearch.core.Strings.format;
+import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
+
+public abstract class PipelineRegistry implements ClusterStateListener {
+
+    private static final Logger logger = LogManager.getLogger(PipelineRegistry.class);
+    private final ClusterService clusterService;
+    private final ThreadPool threadPool;
+    private final Client client;
+
+    private final ConcurrentMap<String, AtomicBoolean> pipelineCreationsInProgress = new ConcurrentHashMap<>();
+
+    public PipelineRegistry(
+        ClusterService clusterService,
+        ThreadPool threadPool,
+        Client client
+    ) {
+        this.clusterService = clusterService;
+        this.threadPool = threadPool;
+        this.client = client;
+    }
+
+    /**
+     * Initialize the template registry, adding it as a listener so templates will be installed as necessary
+     */
+    public void initialize() {
+        clusterService.addListener(this);
+    }
+
+    @Override
+    public void clusterChanged(ClusterChangedEvent event) {
+        ClusterState state = event.state();
+        if (state.blocks().hasGlobalBlock(GatewayService.STATE_NOT_RECOVERED_BLOCK)) {
+            // wait until the gateway has recovered from disk, otherwise we think may not have the index templates,
+            // while they actually do exist
+            return;
+        }
+
+        // no master node, exit immediately
+        DiscoveryNode masterNode = event.state().getNodes().getMasterNode();
+        if (masterNode == null) {
+            return;
+        }
+
+        // This registry requires to run on a master node.
+        // If not a master node, exit.
+        if (state.nodes().isLocalNodeElectedMaster() == false) {
+            return;
+        }
+
+        // if this node is newer than the master node, we probably need to add the template, which might be newer than the
+        // template the master node has, so we need potentially add new templates despite being not the master node
+        DiscoveryNode localNode = event.state().getNodes().getLocalNode();
+        boolean localNodeVersionAfterMaster = localNode.getVersion().after(masterNode.getVersion());
+
+        if (event.localNodeMaster() || localNodeVersionAfterMaster) {
+            addIngestPipelinesIfMissing(state);
+        }
+    }
+
+    protected abstract String getOrigin();
+
+    protected abstract List<PipelineTemplateConfiguration> getIngestPipelineConfigs();
+
+    private void addIngestPipelinesIfMissing(ClusterState state) {
+        for (PipelineTemplateConfiguration pipelineTemplateConfig : getIngestPipelineConfigs()) {
+            PipelineConfiguration newPipeline = pipelineTemplateConfig.load();
+            final AtomicBoolean creationCheck = pipelineCreationsInProgress.computeIfAbsent(
+                newPipeline.getId(),
+                key -> new AtomicBoolean(false)
+            );
+
+            if (creationCheck.compareAndSet(false, true)) {
+                if (ingestPipelineExists(state, newPipeline.getId())) {
+                    IngestMetadata ingestMetadata = state.metadata().custom(IngestMetadata.TYPE);
+                    PipelineConfiguration existingPipeline = ingestMetadata.getPipelines().get(newPipeline.getId());
+                    boolean newPipelineHasVersion = Objects.isNull(newPipeline.getVersion()) == false;
+                    boolean oldPipelineHasVersion = Objects.isNull(existingPipeline.getVersion()) == false;
+                    if (newPipelineHasVersion
+                        && (oldPipelineHasVersion == false || existingPipeline.getVersion() < newPipeline.getVersion())) {
+                        logger.info(
+                            "upgrading ingest pipeline [{}] for [{}] from version [{}] to version [{}]",
+                            newPipeline.getId(),
+                            getOrigin(),
+                            existingPipeline.getVersion(),
+                            newPipeline.getVersion()
+                        );
+                        putIngestPipeline(newPipeline, creationCheck);
+                    } else {
+                        logger.debug(
+                            "not adding ingest pipeline [{}] for [{}], because it already exists",
+                            newPipeline.getId(),
+                            getOrigin()
+                        );
+                        creationCheck.set(false);
+                    }
+                } else {
+                    logger.debug("adding ingest pipeline [{}] for [{}], because it doesn't exist", newPipeline.getId(), getOrigin());
+                    putIngestPipeline(newPipeline, creationCheck);
+                }
+            }
+        }
+    }
+
+    private static boolean ingestPipelineExists(ClusterState state, String pipelineId) {
+        Optional<IngestMetadata> maybeMeta = Optional.ofNullable(state.metadata().custom(IngestMetadata.TYPE));
+        return maybeMeta.isPresent() && maybeMeta.get().getPipelines().containsKey(pipelineId);
+    }
+
+    private void putIngestPipeline(final PipelineConfiguration pipelineConfig, final AtomicBoolean creationCheck) {
+        final Executor executor = threadPool.generic();
+        executor.execute(() -> {
+            try {
+                executeAsyncWithOrigin(
+                    client.threadPool().getThreadContext(),
+                    getOrigin(),
+                    createPutPipelineRequest(pipelineConfig),
+                    new ActionListener<AcknowledgedResponse>() {
+                        @Override
+                        public void onResponse(AcknowledgedResponse response) {
+                            creationCheck.set(false);
+                            if (response.isAcknowledged() == false) {
+                                logger.error(
+                                    "error adding ingest pipeline [{}] for [{}], request was not acknowledged",
+                                    pipelineConfig.getId(),
+                                    getOrigin()
+                                );
+                            } else {
+                                logger.info("adding ingest pipeline {}", pipelineConfig.getId());
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(Exception e) {
+                            creationCheck.set(false);
+                            onPutPipelineFailure(pipelineConfig.getId(), e);
+                        }
+                    },
+                    (req, listener) -> client.execute(PutPipelineAction.INSTANCE, req, listener)
+                );
+
+            } catch (IOException e) {
+                creationCheck.set(false);
+                logger.error(
+                    Strings.format(
+                        "not adding ingest pipeline [{}] for [{}], because of an error when reading the config",
+                        pipelineConfig.getId(),
+                        getOrigin()
+                    ),
+                    e
+                );
+            }
+        });
+    }
+
+    private PutPipelineRequest createPutPipelineRequest(PipelineConfiguration pipelineConfiguration) throws IOException {
+        try (XContentBuilder builder = JsonXContent.contentBuilder()) {
+            PutPipelineRequest request = new PutPipelineRequest(
+                pipelineConfiguration.getId(),
+                BytesReference.bytes(builder.map(pipelineConfiguration.getConfigAsMap())),
+                builder.contentType()
+            );
+
+            request.masterNodeTimeout(TimeValue.timeValueMinutes(1));
+            return request;
+        }
+    }
+
+    /**
+     * Called when creation of an ingest pipeline fails.
+     *
+     * @param pipelineId the pipeline that failed to be created.
+     * @param e The exception that caused the failure.
+     */
+    protected void onPutPipelineFailure(String pipelineId, Exception e) {
+        logger.error(() -> format("error adding ingest pipeline template [%s] for [%s]", pipelineId, getOrigin()), e);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
@@ -94,7 +94,7 @@ public abstract class PipelineRegistry implements ClusterStateListener {
                     IngestMetadata ingestMetadata = state.metadata().custom(IngestMetadata.TYPE);
                     PipelineConfiguration existingPipeline = ingestMetadata.getPipelines().get(newPipeline.getId());
                     boolean newPipelineHasVersion = Objects.nonNull(newPipeline.getVersion());
-                    boolean oldPipelineHasVersion = Objects.isNull(existingPipeline.getVersion());
+                    boolean oldPipelineHasVersion = Objects.nonNull(existingPipeline.getVersion());
                     if (newPipelineHasVersion
                         && (oldPipelineHasVersion == false || existingPipeline.getVersion() < newPipeline.getVersion())) {
                         logger.info(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
@@ -54,11 +54,7 @@ public abstract class PipelineRegistry implements ClusterStateListener {
 
     private final ConcurrentMap<String, AtomicBoolean> pipelineCreationsInProgress = new ConcurrentHashMap<>();
 
-    public PipelineRegistry(
-        ClusterService clusterService,
-        ThreadPool threadPool,
-        Client client
-    ) {
+    public PipelineRegistry(ClusterService clusterService, ThreadPool threadPool, Client client) {
         this.threadPool = threadPool;
         this.client = client;
         clusterService.addListener(this);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
@@ -93,8 +93,8 @@ public abstract class PipelineRegistry implements ClusterStateListener {
                 if (ingestPipelineExists(state, newPipeline.getId())) {
                     IngestMetadata ingestMetadata = state.metadata().custom(IngestMetadata.TYPE);
                     PipelineConfiguration existingPipeline = ingestMetadata.getPipelines().get(newPipeline.getId());
-                    boolean newPipelineHasVersion = Objects.isNull(newPipeline.getVersion()) == false;
-                    boolean oldPipelineHasVersion = Objects.isNull(existingPipeline.getVersion()) == false;
+                    boolean newPipelineHasVersion = Objects.nonNull(newPipeline.getVersion());
+                    boolean oldPipelineHasVersion = Objects.isNull(existingPipeline.getVersion());
                     if (newPipelineHasVersion
                         && (oldPipelineHasVersion == false || existingPipeline.getVersion() < newPipeline.getVersion())) {
                         logger.info(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineTemplateConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineTemplateConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.utils.ingest;
+
+import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.template.TemplateUtils;
+
+import java.util.Objects;
+
+public class PipelineTemplateConfiguration {
+
+    private final String id;
+    private final String resource;
+    private final String version;
+    private final String versionProperty;
+
+    public PipelineTemplateConfiguration(String id, String resource, int version, String versionProperty) {
+        this.id = Objects.requireNonNull(id);
+        this.resource = Objects.requireNonNull(resource);
+        this.version = String.valueOf(version);
+        this.versionProperty = Objects.requireNonNull(versionProperty);
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public PipelineConfiguration load() {
+        String config = TemplateUtils.loadTemplate(resource, version, versionProperty);
+
+        return new PipelineConfiguration(id, new BytesArray(config), XContentType.JSON);
+    }
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineTemplateConfiguration.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineTemplateConfiguration.java
@@ -18,13 +18,13 @@ public class PipelineTemplateConfiguration {
 
     private final String id;
     private final String resource;
-    private final String version;
+    private final int version;
     private final String versionProperty;
 
     public PipelineTemplateConfiguration(String id, String resource, int version, String versionProperty) {
         this.id = Objects.requireNonNull(id);
         this.resource = Objects.requireNonNull(resource);
-        this.version = String.valueOf(version);
+        this.version = version;
         this.versionProperty = Objects.requireNonNull(versionProperty);
     }
 
@@ -32,8 +32,12 @@ public class PipelineTemplateConfiguration {
         return id;
     }
 
+    public int getVersion() {
+        return version;
+    }
+
     public PipelineConfiguration load() {
-        String config = TemplateUtils.loadTemplate(resource, version, versionProperty);
+        String config = TemplateUtils.loadTemplate(resource, String.valueOf(version), versionProperty);
 
         return new PipelineConfiguration(id, new BytesArray(config), XContentType.JSON);
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionResolverTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionResolverTests.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.newInstance;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PREFIX;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -32,7 +33,7 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
 
     public void testResolveExistingAnalyticsCollection() {
         String collectionName = randomIdentifier();
-        String dataStreamName = AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collectionName;
+        String dataStreamName = EVENT_DATA_STREAM_INDEX_PREFIX + collectionName;
 
         ClusterState state = createClusterState(dataStreamName);
         AnalyticsCollectionResolver resolver = new AnalyticsCollectionResolver(
@@ -69,10 +70,7 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
         ClusterState state = createClusterState();
         IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(indexNameExpressionResolver.dataStreamNames(eq(state), any(), any())).thenReturn(
-            Arrays.asList(
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collectionName1,
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collectionName2
-            )
+            Arrays.asList(EVENT_DATA_STREAM_INDEX_PREFIX + collectionName1, EVENT_DATA_STREAM_INDEX_PREFIX + collectionName2)
         );
 
         AnalyticsCollectionResolver resolver = new AnalyticsCollectionResolver(indexNameExpressionResolver, mock(ClusterService.class));
@@ -85,7 +83,7 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
 
     public void testResolveEmptyExpressionCollections() {
         String collectionName = randomIdentifier();
-        String dataStreamName = AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collectionName;
+        String dataStreamName = EVENT_DATA_STREAM_INDEX_PREFIX + collectionName;
         ClusterState state = createClusterState();
         IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(indexNameExpressionResolver.dataStreamNames(eq(state), any(), any())).thenReturn(Collections.singletonList(dataStreamName));
@@ -102,10 +100,10 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
         IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(indexNameExpressionResolver.dataStreamNames(eq(state), any(), any())).thenReturn(
             Arrays.asList(
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "foo",
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "bar",
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "baz",
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "buz"
+                EVENT_DATA_STREAM_INDEX_PREFIX + "foo",
+                EVENT_DATA_STREAM_INDEX_PREFIX + "bar",
+                EVENT_DATA_STREAM_INDEX_PREFIX + "baz",
+                EVENT_DATA_STREAM_INDEX_PREFIX + "buz"
             )
         );
 
@@ -121,10 +119,10 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
         IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(indexNameExpressionResolver.dataStreamNames(eq(state), any(), any())).thenReturn(
             Arrays.asList(
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "foo",
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "bar",
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "baz",
-                AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "buz"
+                EVENT_DATA_STREAM_INDEX_PREFIX + "foo",
+                EVENT_DATA_STREAM_INDEX_PREFIX + "bar",
+                EVENT_DATA_STREAM_INDEX_PREFIX + "baz",
+                EVENT_DATA_STREAM_INDEX_PREFIX + "buz"
             )
         );
 
@@ -140,7 +138,7 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
         ClusterState state = createClusterState();
         IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(indexNameExpressionResolver.dataStreamNames(eq(state), any(), any())).thenReturn(
-            Collections.singletonList(AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "foo")
+            Collections.singletonList(EVENT_DATA_STREAM_INDEX_PREFIX + "foo")
         );
 
         AnalyticsCollectionResolver resolver = new AnalyticsCollectionResolver(indexNameExpressionResolver, mock(ClusterService.class));
@@ -155,7 +153,7 @@ public class AnalyticsCollectionResolverTests extends ESTestCase {
         ClusterState state = createClusterState();
         IndexNameExpressionResolver indexNameExpressionResolver = mock(IndexNameExpressionResolver.class);
         when(indexNameExpressionResolver.dataStreamNames(eq(state), any(), any())).thenReturn(
-            Collections.singletonList(AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + "foo")
+            Collections.singletonList(EVENT_DATA_STREAM_INDEX_PREFIX + "foo")
         );
         AnalyticsCollectionResolver resolver = new AnalyticsCollectionResolver(indexNameExpressionResolver, mock(ClusterService.class));
         assertTrue(resolver.collections(state, "ba*").isEmpty());

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionServiceTests.java
@@ -40,6 +40,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PREFIX;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.eq;
@@ -124,10 +125,7 @@ public class AnalyticsCollectionServiceTests extends ESTestCase {
         client.setVerifier((action, request, listener) -> {
             if (action instanceof CreateDataStreamAction) {
                 CreateDataStreamAction.Request createDataStreamRequest = (CreateDataStreamAction.Request) request;
-                assertThat(
-                    createDataStreamRequest.getName(),
-                    equalTo(AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collectionName)
-                );
+                assertThat(createDataStreamRequest.getName(), equalTo(EVENT_DATA_STREAM_INDEX_PREFIX + collectionName));
                 calledTimes.incrementAndGet();
                 return AcknowledgedResponse.TRUE;
             } else {
@@ -243,7 +241,7 @@ public class AnalyticsCollectionServiceTests extends ESTestCase {
 
     public void testDeleteAnalyticsCollection() throws Exception {
         String collectionName = randomIdentifier();
-        String dataStreamName = AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collectionName;
+        String dataStreamName = EVENT_DATA_STREAM_INDEX_PREFIX + collectionName;
         ClusterState clusterState = createClusterState();
 
         AnalyticsCollectionResolver analyticsCollectionResolver = mock(AnalyticsCollectionResolver.class);

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsCollectionTests.java
@@ -26,6 +26,7 @@ import java.util.List;
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.common.xcontent.XContentHelper.toXContent;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertToXContentEquivalent;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PREFIX;
 import static org.hamcrest.CoreMatchers.equalTo;
 
 public class AnalyticsCollectionTests extends ESTestCase {
@@ -42,7 +43,7 @@ public class AnalyticsCollectionTests extends ESTestCase {
 
     public void testDataStreamName() {
         AnalyticsCollection collection = randomAnalyticsCollection();
-        String expectedDataStreamName = AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PREFIX + collection.getName();
+        String expectedDataStreamName = EVENT_DATA_STREAM_INDEX_PREFIX + collection.getName();
         assertEquals(expectedDataStreamName, collection.getEventDataStream());
     }
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.ingest.PutPipelineAction;
+import org.elasticsearch.action.ingest.PutPipelineRequest;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.block.ClusterBlocks;
+import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.TriFunction;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.ingest.IngestMetadata;
+import org.elasticsearch.ingest.PipelineConfiguration;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.client.NoOpClient;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xcontent.XContentBuilder;
+import org.elasticsearch.xcontent.json.JsonXContent;
+import org.elasticsearch.xpack.application.utils.ingest.PipelineTemplateConfiguration;
+import org.junit.After;
+import org.junit.Before;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.application.analytics.AnalyticsIngestPipelineRegistry.EVENT_DATA_STREAM_INGEST_PIPELINE_NAME;
+import static org.elasticsearch.xpack.application.analytics.AnalyticsTemplateRegistry.REGISTRY_VERSION;
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
+    private AnalyticsIngestPipelineRegistry registry;
+    private ThreadPool threadPool;
+    private VerifyingClient client;
+
+    @Before
+    public void createRegistryAndClient() {
+        threadPool = new TestThreadPool(this.getClass().getName());
+        client = new VerifyingClient(threadPool);
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        registry = new AnalyticsIngestPipelineRegistry(clusterService, threadPool, client);
+    }
+
+    @After
+    @Override
+    public void tearDown() throws Exception {
+        super.tearDown();
+        threadPool.shutdownNow();
+    }
+
+    public void testThatNonExistingPipelinesAreAddedImmediately() throws Exception {
+        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> verifyIngestPipelinesInstalled(calledTimes, action, request, listener));
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getIngestPipelineConfigs().size())));
+    }
+
+    public void testIngestPipelinesAlreadyExists() {
+        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        client.setVerifier((action, request, listener) -> {
+            if (action instanceof PutPipelineAction) {
+                fail("if the pipeline already exists it should not be re-put");
+            } else {
+                fail("client called with unexpected request: " + request.toString());
+            }
+            return null;
+        });
+
+        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs().stream().collect(Collectors.toMap(
+            PipelineTemplateConfiguration::getId, PipelineTemplateConfiguration::getVersion
+        ));
+
+        ClusterChangedEvent event = createClusterChangedEvent(existingPipelines, nodes);
+        registry.clusterChanged(event);
+    }
+
+    public void testThatVersionedOldPipelinesAreUpgraded() throws Exception {
+        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs().stream().collect(Collectors.toMap(
+            PipelineTemplateConfiguration::getId, pipelineConfig -> pipelineConfig.getVersion() - 1
+        ));
+
+        ClusterChangedEvent event = createClusterChangedEvent(existingPipelines, nodes);
+
+        AtomicInteger calledTimes = new AtomicInteger(0);
+        client.setVerifier((action, request, listener) -> verifyIngestPipelinesInstalled(calledTimes, action, request, listener));
+        registry.clusterChanged(event);
+        assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getIngestPipelineConfigs().size())));
+    }
+
+    public void testThatNewerPipelinesAreNotUpgraded() throws Exception {
+        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
+
+        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs().stream().collect(Collectors.toMap(
+            PipelineTemplateConfiguration::getId, pipelineConfig -> pipelineConfig.getVersion() + 1
+        ));
+
+        ClusterChangedEvent event = createClusterChangedEvent(existingPipelines, nodes);
+
+        client.setVerifier((action, request, listener) -> {
+            if (action instanceof PutPipelineAction) {
+                fail("if the pipeline already exists it should not be re-put");
+            } else {
+                fail("client called with unexpected request: " + request.toString());
+            }
+            return null;
+        });
+
+        registry.clusterChanged(event);
+    }
+
+    public void testThatMissingMasterNodeDoesNothing() {
+        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
+
+        client.setVerifier((a, r, l) -> {
+            fail("if the master is missing nothing should happen");
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
+        registry.clusterChanged(event);
+    }
+
+   public static class VerifyingClient extends NoOpClient {
+        private TriFunction<ActionType<?>, ActionRequest, ActionListener<?>, ActionResponse> verifier = (a, r, l) -> {
+            fail("verifier not set");
+            return null;
+        };
+
+        VerifyingClient(ThreadPool threadPool) {
+            super(threadPool);
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {
+            try {
+                listener.onResponse((Response) verifier.apply(action, request, listener));
+            } catch (Exception e) {
+                listener.onFailure(e);
+            }
+        }
+
+        public VerifyingClient setVerifier(TriFunction<ActionType<?>, ActionRequest, ActionListener<?>, ActionResponse> verifier) {
+            this.verifier = verifier;
+            return this;
+        }
+    }
+
+    private ActionResponse verifyIngestPipelinesInstalled(
+        AtomicInteger calledTimes,
+        ActionType<?> action,
+        ActionRequest request,
+        ActionListener<?> listener
+    ) {
+        if (action instanceof PutPipelineAction) {
+            calledTimes.incrementAndGet();
+            assertThat(request, instanceOf(PutPipelineRequest.class));
+            final PutPipelineRequest putRequest = (PutPipelineRequest) request;
+            assertThat(putRequest.getId(), equalTo(EVENT_DATA_STREAM_INGEST_PIPELINE_NAME));
+            Map<String, ?> requestContentMap = XContentHelper.convertToMap(putRequest.getSource(), false, putRequest.getXContentType()).v2();
+            assertThat(requestContentMap.get("version"), equalTo(REGISTRY_VERSION));
+            assertNotNull(listener);
+            return AcknowledgedResponse.TRUE;
+        } else {
+            fail("client called with unexpected request:" + request.toString());
+            return null;
+        }
+    }
+
+    private ClusterChangedEvent createClusterChangedEvent(Map<String, Integer> existingIngestPipelines, DiscoveryNodes nodes) {
+        ClusterState cs = createClusterState(existingIngestPipelines, nodes);
+        ClusterChangedEvent realEvent = new ClusterChangedEvent(
+            "created-from-test",
+            cs,
+            ClusterState.builder(new ClusterName("test")).build()
+        );
+        ClusterChangedEvent event = spy(realEvent);
+        when(event.localNodeMaster()).thenReturn(nodes.isLocalNodeElectedMaster());
+
+        return event;
+    }
+
+    private ClusterState createClusterState(Map<String, Integer> existingIngestPipelines, DiscoveryNodes nodes) {
+        Map<String, PipelineConfiguration> pipelines = new HashMap<>();
+        for (Map.Entry<String, Integer> e : existingIngestPipelines.entrySet()) {
+            pipelines.put(e.getKey(), createMockPipelineConfiguration(e.getKey(), e.getValue()));
+        }
+
+        return ClusterState.builder(new ClusterName("test"))
+            .metadata(
+                Metadata.builder().transientSettings(Settings.EMPTY).putCustom(IngestMetadata.TYPE, new IngestMetadata(pipelines)).build()
+            )
+            .blocks(new ClusterBlocks.Builder().build())
+            .nodes(nodes)
+            .build();
+    }
+
+    private PipelineConfiguration createMockPipelineConfiguration(String pipelineId, int version) {
+        try(XContentBuilder configBuilder = JsonXContent.contentBuilder().startObject().field("version", version).endObject()) {
+            BytesReference config = BytesReference.bytes(configBuilder);
+            return new PipelineConfiguration(pipelineId, config, configBuilder.contentType());
+        } catch (IOException e) {
+            return null;
+        }
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
@@ -99,9 +99,9 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
             return null;
         });
 
-        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs().stream().collect(Collectors.toMap(
-            PipelineTemplateConfiguration::getId, PipelineTemplateConfiguration::getVersion
-        ));
+        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs()
+            .stream()
+            .collect(Collectors.toMap(PipelineTemplateConfiguration::getId, PipelineTemplateConfiguration::getVersion));
 
         ClusterChangedEvent event = createClusterChangedEvent(existingPipelines, nodes);
         registry.clusterChanged(event);
@@ -111,9 +111,9 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
         DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
-        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs().stream().collect(Collectors.toMap(
-            PipelineTemplateConfiguration::getId, pipelineConfig -> pipelineConfig.getVersion() - 1
-        ));
+        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs()
+            .stream()
+            .collect(Collectors.toMap(PipelineTemplateConfiguration::getId, pipelineConfig -> pipelineConfig.getVersion() - 1));
 
         ClusterChangedEvent event = createClusterChangedEvent(existingPipelines, nodes);
 
@@ -127,9 +127,9 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
         DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
-        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs().stream().collect(Collectors.toMap(
-            PipelineTemplateConfiguration::getId, pipelineConfig -> pipelineConfig.getVersion() + 1
-        ));
+        Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs()
+            .stream()
+            .collect(Collectors.toMap(PipelineTemplateConfiguration::getId, pipelineConfig -> pipelineConfig.getVersion() + 1));
 
         ClusterChangedEvent event = createClusterChangedEvent(existingPipelines, nodes);
 
@@ -158,7 +158,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
         registry.clusterChanged(event);
     }
 
-   public static class VerifyingClient extends NoOpClient {
+    public static class VerifyingClient extends NoOpClient {
         private TriFunction<ActionType<?>, ActionRequest, ActionListener<?>, ActionResponse> verifier = (a, r, l) -> {
             fail("verifier not set");
             return null;
@@ -199,7 +199,8 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
             assertThat(request, instanceOf(PutPipelineRequest.class));
             final PutPipelineRequest putRequest = (PutPipelineRequest) request;
             assertThat(putRequest.getId(), equalTo(EVENT_DATA_STREAM_INGEST_PIPELINE_NAME));
-            Map<String, ?> requestContentMap = XContentHelper.convertToMap(putRequest.getSource(), false, putRequest.getXContentType()).v2();
+            Map<String, ?> requestContentMap = XContentHelper.convertToMap(putRequest.getSource(), false, putRequest.getXContentType())
+                .v2();
             assertThat(requestContentMap.get("version"), equalTo(REGISTRY_VERSION));
             assertNotNull(listener);
             return AcknowledgedResponse.TRUE;
@@ -238,7 +239,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
     }
 
     private PipelineConfiguration createMockPipelineConfiguration(String pipelineId, int version) {
-        try(XContentBuilder configBuilder = JsonXContent.contentBuilder().startObject().field("version", version).endObject()) {
+        try (XContentBuilder configBuilder = JsonXContent.contentBuilder().startObject().field("version", version).endObject()) {
             BytesReference config = BytesReference.bytes(configBuilder);
             return new PipelineConfiguration(pipelineId, config, configBuilder.contentType());
         } catch (IOException e) {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -56,6 +56,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PATTERN;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -387,7 +388,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
             assertThat(putRequest.indexTemplate().version(), equalTo((long) AnalyticsTemplateRegistry.REGISTRY_VERSION));
             final List<String> indexPatterns = putRequest.indexTemplate().indexPatterns();
             assertThat(indexPatterns, hasSize(1));
-            assertThat(indexPatterns.get(0), equalTo(AnalyticsTemplateRegistry.EVENT_DATA_STREAM_INDEX_PATTERN));
+            assertThat(indexPatterns.get(0), equalTo(EVENT_DATA_STREAM_INDEX_PATTERN));
             assertNotNull(listener);
             return new TestPutIndexTemplateResponse(true);
         } else {


### PR DESCRIPTION
## Description:
- [X] Add a final_pipeline to behavioral analytics events data streams
- [X] Process URLs in the event (`page.url`, `page.referrer` and `search.results.items[*].page.url`
- [x] Mapping update
   - [x] Update `page.url` to be an object
   - [x] Update `page.referrer` to be an object
   - [x] Update `search.results.items[*].page.url` to be an object
   
## Other:
- ~Blocked by #95068~