### PR TITLE
Remove the lifecycle field in the PUT _lifecycle request

### DIFF
--- a/docs/reference/dlm/apis/put-lifecycle.asciidoc
+++ b/docs/reference/dlm/apis/put-lifecycle.asciidoc
@@ -58,9 +58,7 @@ The following example sets the lifecycle of `my-data-stream`:
 --------------------------------------------------
 PUT _data_stream/my-data-stream/_lifecycle
 {
-  "lifecycle": {
-    "data_retention": "7d"
-  }
+  "data_retention": "7d"
 }
 --------------------------------------------------
 // TEST[setup:my_data_stream]

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/CrudDataLifecycleIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/CrudDataLifecycleIT.java
@@ -125,7 +125,10 @@ public class CrudDataLifecycleIT extends ESIntegTestCase {
         // Set lifecycle
         {
             DataLifecycle lifecycle = randomDataLifecycle();
-            PutDataLifecycleAction.Request putDataLifecycleRequest = new PutDataLifecycleAction.Request(new String[] { "*" }, lifecycle);
+            PutDataLifecycleAction.Request putDataLifecycleRequest = new PutDataLifecycleAction.Request(
+                new String[] { "*" },
+                lifecycle.getDataRetention()
+            );
             assertThat(client().execute(PutDataLifecycleAction.INSTANCE, putDataLifecycleRequest).get().isAcknowledged(), equalTo(true));
             GetDataLifecycleAction.Request getDataLifecycleRequest = new GetDataLifecycleAction.Request(new String[] { "my-data-stream" });
             GetDataLifecycleAction.Response response = client().execute(GetDataLifecycleAction.INSTANCE, getDataLifecycleRequest).get();

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/CrudDataLifecycleSystemDataStreamIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/CrudDataLifecycleSystemDataStreamIT.java
@@ -143,7 +143,6 @@ public class CrudDataLifecycleSystemDataStreamIT extends ESIntegTestCase {
                 Request putRequest = new Request("PUT", "/_data_stream/" + systemDataStream + "/_lifecycle");
                 putRequest.setJsonEntity("""
                     {
-                      "lifecycle": {}
                     }""");
                 // No header
                 ResponseException re = expectThrows(ResponseException.class, () -> restClient.performRequest(putRequest));

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
@@ -157,7 +157,7 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
             });
         }
         // Update the lifecycle of the data stream
-        updateLifecycle(dataStreamName, new DataLifecycle(TimeValue.timeValueMillis(1)));
+        updateLifecycle(dataStreamName, TimeValue.timeValueMillis(1));
         // Verify that the retention has changed for all backing indices
         assertBusy(() -> {
             GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
@@ -281,7 +281,7 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
         // mark the first generation index as read-only so deletion fails when we enable the retention configuration
         updateIndexSettings(Settings.builder().put(READ_ONLY.settingName(), true), firstGenerationIndex);
         try {
-            updateLifecycle(dataStreamName, new DataLifecycle(TimeValue.timeValueSeconds(1)));
+            updateLifecycle(dataStreamName, TimeValue.timeValueSeconds(1));
 
             assertBusy(() -> {
                 GetDataStreamAction.Request getDataStreamRequest = new GetDataStreamAction.Request(new String[] { dataStreamName });
@@ -382,10 +382,10 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
         client().execute(PutComposableIndexTemplateAction.INSTANCE, request).actionGet();
     }
 
-    static void updateLifecycle(String dataStreamName, DataLifecycle dataLifecycle) {
+    static void updateLifecycle(String dataStreamName, TimeValue dataRetention) {
         PutDataLifecycleAction.Request putDataLifecycleRequest = new PutDataLifecycleAction.Request(
             new String[] { dataStreamName },
-            dataLifecycle
+            dataRetention
         );
         AcknowledgedResponse putDataLifecycleResponse = client().execute(PutDataLifecycleAction.INSTANCE, putDataLifecycleRequest)
             .actionGet();

--- a/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/20_basic.yml
+++ b/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/20_basic.yml
@@ -55,8 +55,7 @@ setup:
       indices.put_data_lifecycle:
         name: "*"
         body:
-          lifecycle:
-            data_retention: '30d'
+          data_retention: '30d'
   - is_true: acknowledged
 
   - do:
@@ -87,8 +86,7 @@ setup:
       indices.put_data_lifecycle:
         name: "simple-data-stream1"
         body:
-          lifecycle:
-            data_retention: '30d'
+          data_retention: '30d'
   - is_true: acknowledged
 
   - do:

--- a/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/30_not_found.yml
+++ b/modules/dlm/src/yamlRestTest/resources/rest-api-spec/test/dlm/30_not_found.yml
@@ -48,8 +48,7 @@ setup:
       indices.put_data_lifecycle:
         name: "my-data-stream-1,does-not-exist"
         body:
-          lifecycle:
-            data_retention: '30d'
+          data_retention: '30d'
   - match: { error.reason: "no such index [does-not-exist]" }
 
   - do:

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
@@ -46,7 +46,7 @@ public class DataLifecycle implements SimpleDiffable<DataLifecycle>, ToXContentO
     public static final DataLifecycle EMPTY = new DataLifecycle();
     public static final String DLM_ORIGIN = "data_lifecycle";
 
-    private static final ParseField DATA_RETENTION_FIELD = new ParseField("data_retention");
+    public static final ParseField DATA_RETENTION_FIELD = new ParseField("data_retention");
     private static final ParseField ROLLOVER_FIELD = new ParseField("rollover");
 
     public static final ConstructingObjectParser<DataLifecycle, Void> PARSER = new ConstructingObjectParser<>(


### PR DESCRIPTION
This removes a redundant `lifecycle` field in the `PUT _lifecycle` request.

Before we had
```
PUT _data_stream/logs-nginx/_lifecycle
{
    "lifecycle": {
        "data_retention": "7d"
    }
}
```

This changes the request to
```
PUT _data_stream/logs-nginx/_lifecycle
{
  "data_retention": "7d"
}
```

To configure a lifecycle with infinite retention the following request is needed:
```
PUT _data_stream/logs-nginx/_lifecycle
{
}
```


Relates to https://github.com/elastic/elasticsearch/issues/93596