### PR TITLE
[Test] Use random port instead of fixed port to avoid conflict

### DIFF
--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -525,7 +525,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
         final Settings fcSettings = Settings.builder()
             .put("remote_cluster_server.enabled", "true")
-            .put("remote_cluster.port", "9999")
+            .put("remote_cluster.port", "0")
             .put("xpack.security.remote_cluster_server.ssl.key", testnodeKey)
             .put("xpack.security.remote_cluster_server.ssl.certificate", testnodeCert)
             .put("xpack.security.remote_cluster_server.ssl.client_authentication", "none")
@@ -647,7 +647,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
         final Settings fcSettings = Settings.builder()
             .put("remote_cluster_server.enabled", "true")
-            .put("remote_cluster.port", "9999")
+            .put("remote_cluster.port", "0")
             .put("xpack.security.remote_cluster_server.ssl.enabled", "false")
             .build();
 


### PR DESCRIPTION
This PR makes the remote cluster transport to bind with a random port instead of a fixed one since a fixed port could sometimes fails to bind because previous test may not release it properly.

Resolves: #94653
