### PR TITLE
[Profiling] Use terms query for id lookup

### DIFF
--- a/x-pack/plugin/profiler/src/internalClusterTest/resources/executables.json
+++ b/x-pack/plugin/profiler/src/internalClusterTest/resources/executables.json
@@ -1,7 +1,8 @@
 {
   "settings": {
     "index": {
-      "refresh_interval": "10s"
+      "refresh_interval": "10s",
+      "max_result_window": 100000
     }
   },
   "mappings": {

--- a/x-pack/plugin/profiler/src/internalClusterTest/resources/stackframes.json
+++ b/x-pack/plugin/profiler/src/internalClusterTest/resources/stackframes.json
@@ -2,7 +2,8 @@
   "settings": {
     "index": {
       "number_of_shards": "16",
-      "refresh_interval": "10s"
+      "refresh_interval": "10s",
+      "max_result_window": 100000
     }
   },
   "mappings": {

--- a/x-pack/plugin/profiler/src/internalClusterTest/resources/stacktraces.json
+++ b/x-pack/plugin/profiler/src/internalClusterTest/resources/stacktraces.json
@@ -3,6 +3,7 @@
     "index": {
       "number_of_shards": "16",
       "refresh_interval": "10s",
+      "max_result_window": 100000,
       "sort": {
         "field": [
           "Stacktrace.frame.ids"

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingPlugin.java
@@ -116,8 +116,7 @@ public class ProfilingPlugin extends Plugin implements ActionPlugin {
         return List.of(
             PROFILING_ENABLED,
             TransportGetProfilingAction.PROFILING_MAX_STACKTRACE_QUERY_SLICES,
-            TransportGetProfilingAction.PROFILING_MAX_DETAIL_QUERY_SLICES,
-            TransportGetProfilingAction.PROFILING_QUERY_REALTIME
+            TransportGetProfilingAction.PROFILING_MAX_DETAIL_QUERY_SLICES
         );
     }
 


### PR DESCRIPTION
With this commit we switch from the `mget` API to `terms` queries to lookup documents by `_id` in the profiling plugin. We do this for several reasons:

1. With a change in how K/V indices are written (use only one write index, have an alias point to all indices as outlined in https://github.com/elastic/elasticsearch/issues/85273#issuecomment-1245969035) we can switch from a client-side implementation of "ILM" (currently implemented in
https://github.com/elastic/apm-server/blob/main/x-pack/apm-server/profiling/ilm.go) to Elasticsearch's ILM feature, which is more mature and also familiar to users.
2. In the future it lets us migrate K/V indices to the warm / cold tier. This will require a small change to filter for [`_tier`](https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-tier-field.html) to keep latency low for queries that should only hit the hot tier. This will be done in a future PR.

This change is agnostic to how data are written (i.e. this change is forward-compatible). Also, in our experiments so far, query latency was not negatively affected.

Relates #85273
Relates elastic/prodfiler#3189