### PR TITLE
[Behavioral analytics] Implement search filters into events.

### DIFF
--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -21,6 +21,7 @@
             "Aggregations",
             "Allocation",
             "Analysis",
+            "Application",
             "Audit",
             "Authentication",
             "Authorization",
@@ -85,8 +86,7 @@
             "Transform",
             "TSDB",
             "Vector Search",
-            "Watcher",
-            "Application"
+            "Watcher"
           ]
         },
         "type": {

--- a/build-tools-internal/src/main/resources/changelog-schema.json
+++ b/build-tools-internal/src/main/resources/changelog-schema.json
@@ -85,7 +85,8 @@
             "Transform",
             "TSDB",
             "Vector Search",
-            "Watcher"
+            "Watcher",
+            "Application"
           ]
         },
         "type": {

--- a/docs/changelog/95212.yaml
+++ b/docs/changelog/95212.yaml
@@ -1,0 +1,5 @@
+pr: 95212
+summary: "[Behavioral analytics] Implement search filters into events"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-mappings.json
@@ -86,16 +86,7 @@
                 "ignore_above": 1024
             },
             "filters": {
-              "properties": {
-                "field": {
-                    "type": "keyword",
-                    "ignore_above": 1024
-                },
-                "value": {
-                    "type": "keyword",
-                    "ignore_above": 1024
-                }
-              }
+              "type": "flattened"
             },
             "page": {
               "properties": {

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
@@ -210,6 +210,24 @@ teardown:
                     id: "getting-started"
                     index: elastic-documentation-en
 
+---
+"Post search analytics event - With filters":
+  - do:
+      search_application.post_behavioral_analytics_event:
+        collection_name: my-test-analytics-collection
+        event_type: "search"
+        body:
+          session:
+            id: "123"
+          user:
+            id: "456"
+          search:
+            query: "test-query"
+            filters:
+              brand: "elastic"
+              products: ["elasticsearch", "kibana"]
+              rating: "[3-5]"
+
 # Search click event tests #######################################
 ---
 "Post search_click analytics event":

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchAnalyticsEventField.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.PaginationAnalyticsEventField.PAGINATION_FIELD;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchFiltersAnalyticsEventField.SEARCH_FILTERS_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SortOrderAnalyticsEventField.SORT_FIELD;
 
 public class SearchAnalyticsEventField {
@@ -37,6 +38,11 @@ public class SearchAnalyticsEventField {
         PARSER.declareString((b, v) -> b.put(SEARCH_QUERY_FIELD.getPreferredName(), v), SEARCH_QUERY_FIELD);
         PARSER.declareString((b, v) -> b.put(SEARCH_APPLICATION_FIELD.getPreferredName(), v), SEARCH_APPLICATION_FIELD);
         PARSER.declareObject((b, v) -> b.put(SORT_FIELD.getPreferredName(), v), SortOrderAnalyticsEventField::fromXContent, SORT_FIELD);
+        PARSER.declareObject(
+            (b, v) -> b.put(SEARCH_FILTERS_FIELD.getPreferredName(), v),
+            SearchFiltersAnalyticsEventField::fromXContent,
+            SEARCH_FILTERS_FIELD
+        );
         PARSER.declareObject(
             (b, v) -> b.put(PAGINATION_FIELD.getPreferredName(), v),
             PaginationAnalyticsEventField::fromXContent,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchFiltersAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchFiltersAnalyticsEventField.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.event.parser.field;
+
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.xcontent.ObjectParser;
+import org.elasticsearch.xcontent.ParseField;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.application.analytics.event.AnalyticsEvent;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class SearchFiltersAnalyticsEventField {
+    public static ParseField SEARCH_FILTERS_FIELD = new ParseField("filters");
+
+    private static final ObjectParser<MapBuilder<String, List<String>>, AnalyticsEvent.Context> PARSER = new ObjectParser<>(
+        SEARCH_FILTERS_FIELD.getPreferredName(),
+        SearchFiltersAnalyticsEventField::parseValue,
+        MapBuilder::newMapBuilder
+    );
+
+    private SearchFiltersAnalyticsEventField() {}
+
+    public static Map<String, List<String>> fromXContent(XContentParser parser, AnalyticsEvent.Context context) throws IOException {
+        return PARSER.parse(parser, context).immutableMap();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void parseValue(MapBuilder<String, List<String>> builder, String field, Object value) {
+        if (value instanceof String) {
+            builder.put(field, List.of((String) value));
+            return;
+        } else if (value instanceof List && ((List<?>) value).stream().allMatch(v -> v instanceof String)) {
+            builder.put(field, (List<String>) value);
+            return;
+        }
+
+        throw new IllegalArgumentException(Strings.format("[%s] must be a string or an array of string.", field));
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchAnalyticsEventFieldTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchAnalyticsEventFieldTests.java
@@ -15,12 +15,14 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import static org.elasticsearch.xpack.application.analytics.event.parser.field.AnalyticsEventSearchResultFieldTests.randomEventSearchResultField;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.PaginationAnalyticsEventField.PAGINATION_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.PaginationAnalyticsEventFieldTests.randomEventSearchPaginationField;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchAnalyticsEventField.SEARCH_APPLICATION_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchAnalyticsEventField.SEARCH_QUERY_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchAnalyticsEventField.SEARCH_RESULTS_FIELD;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchFiltersAnalyticsEventField.SEARCH_FILTERS_FIELD;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchFiltersAnalyticsEventFieldTests.randomEventSearchFiltersField;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchResultAnalyticsEventFieldTests.randomEventSearchResultField;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SortOrderAnalyticsEventField.SORT_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SortOrderAnalyticsEventFieldTests.randomEventSearchSortOrderField;
 
@@ -47,6 +49,7 @@ public class SearchAnalyticsEventFieldTests extends AnalyticsEventFieldParserTes
             .put(SORT_FIELD.getPreferredName(), randomEventSearchSortOrderField())
             .put(PAGINATION_FIELD.getPreferredName(), randomEventSearchPaginationField())
             .put(SEARCH_RESULTS_FIELD.getPreferredName(), randomEventSearchResultField())
+            .put(SEARCH_FILTERS_FIELD.getPreferredName(), randomEventSearchFiltersField())
             .map();
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchFiltersAnalyticsEventFieldTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchFiltersAnalyticsEventFieldTests.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.application.analytics.event.parser.field;
+
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.core.Strings;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xcontent.ContextParser;
+import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.xpack.application.analytics.event.AnalyticsEvent;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.convertMapToJson;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.Mockito.mock;
+
+public class SearchFiltersAnalyticsEventFieldTests extends AnalyticsEventFieldParserTestCase<List<String>> {
+    @Override
+    public void testParsingWithInvalidField() {
+        // No invalid field since we are parsing a map.
+    }
+
+    public void testParsingInvalidFiltersValues() throws IOException {
+
+        List<Object> invalidValues = List.of(
+            randomInt(),
+            randomDouble(),
+            randomBoolean(),
+            randomMap(1, 10, () -> new Tuple<>(randomIdentifier(), randomIdentifier())),
+            randomList(10, ESTestCase::randomInt),
+            randomList(10, ESTestCase::randomBoolean)
+        );
+
+        for (Object value : invalidValues) {
+            String fieldName = randomIdentifier();
+            Map<String, Object> jsonMap = new MapBuilder<String, Object>().put(fieldName, value).immutableMap();
+
+            BytesReference json = convertMapToJson(jsonMap);
+
+            try (XContentParser xContentParser = createXContentParser(json)) {
+                Exception e = expectThrows(
+                    IllegalArgumentException.class,
+                    () -> parser().parse(xContentParser, mock(AnalyticsEvent.Context.class))
+                );
+                assertThat(e.getMessage(), containsString(Strings.format("[%s] must be a string or an array of string.", fieldName)));
+            }
+        }
+    }
+
+    @Override
+    public List<String> requiredFields() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    protected Map<String, List<String>> createTestInstance() {
+        return randomEventSearchFiltersField();
+    }
+
+    @Override
+    protected ContextParser<AnalyticsEvent.Context, Map<String, List<String>>> parser() {
+        return SearchFiltersAnalyticsEventField::fromXContent;
+    }
+
+    public static Map<String, List<String>> randomEventSearchFiltersField() {
+        return randomMap(1, 10, () -> new Tuple<>(randomIdentifier(), randomFilterValue()));
+    }
+
+    private static List<String> randomFilterValue() {
+        return randomList(1, 10, ESTestCase::randomIdentifier);
+    }
+}

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchResultAnalyticsEventFieldTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SearchResultAnalyticsEventFieldTests.java
@@ -21,7 +21,7 @@ import static org.elasticsearch.xpack.application.analytics.event.parser.field.P
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchResultAnalyticsEventField.SEARCH_RESULTS_TOTAL_FIELD;
 import static org.elasticsearch.xpack.application.analytics.event.parser.field.SearchResultAnalyticsEventField.SEARCH_RESULT_ITEMS_FIELD;
 
-public class AnalyticsEventSearchResultFieldTests extends AnalyticsEventFieldParserTestCase<Object> {
+public class SearchResultAnalyticsEventFieldTests extends AnalyticsEventFieldParserTestCase<Object> {
     @Override
     public List<String> requiredFields() {
         return Collections.emptyList();


### PR DESCRIPTION
Now supporting filters into search and search_click events:

Example payload:

```json
{
  "search": {
    "query": "air jordan", 
    "filters": { 
      "brand": "nike", 
      "categories": ["shoes", "sales"]
    },
    "search_application": "website"
  },
  "user": {
    "id": "d682f5af-c73e-46c3-bae7-14f11e191178"
  },
  "session": {
    "id": "ae045ac4-8a37-4b60-9125-0610227b27fd"
  }
}
```