### PR TITLE
Fix failing test `DownsampleActionIT.testRollupIndex()` 

### DIFF
--- a/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
+++ b/x-pack/plugin/ilm/qa/multi-node/src/javaRestTest/java/org/elasticsearch/xpack/ilm/actions/DownsampleActionIT.java
@@ -109,6 +109,11 @@ public class DownsampleActionIT extends ESRestTestCase {
         );
     }
 
+    @Before
+    public void updatePollInterval() throws IOException {
+        updateClusterSettings(client(), Settings.builder().put("indices.lifecycle.poll_interval", "5s").build());
+    }
+
     private void createIndex(String index, String alias, boolean isTimeSeries) throws IOException {
         Settings.Builder settings = Settings.builder()
             .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)


### PR DESCRIPTION
Test `DownsampleActionIT.testRollupIndex()` has been failing after PR https://github.com/elastic/elasticsearch/pull/94835 got merged. 

Most probably, because The PR removed the following line from the `testRollupIndex()` method
```java
updateClusterSettings(client(), Settings.builder().put("indices.lifecycle.poll_interval", "5s").build());
```

To fix the test, we set the `indices.lifecycle.poll_interval` setting before all tests run.

Closes #95156