### PR TITLE
[Test] Replace getPortRange with getPort

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4BadRequestTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4BadRequestTests.java
@@ -75,7 +75,7 @@ public class Netty4BadRequestTests extends ESTestCase {
             }
         };
 
-        Settings settings = Settings.builder().put(HttpTransportSettings.SETTING_HTTP_PORT.getKey(), getPortRange()).build();
+        Settings settings = Settings.builder().put(HttpTransportSettings.SETTING_HTTP_PORT.getKey(), getPort()).build();
         try (
             HttpServerTransport httpServerTransport = new Netty4HttpServerTransport(
                 settings,

--- a/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/http/netty4/Netty4HttpServerTransportTests.java
@@ -648,6 +648,6 @@ public class Netty4HttpServerTransportTests extends AbstractHttpServerTransportT
     }
 
     private Settings.Builder createBuilderWithPort() {
-        return Settings.builder().put(HttpTransportSettings.SETTING_HTTP_PORT.getKey(), getPortRange());
+        return Settings.builder().put(HttpTransportSettings.SETTING_HTTP_PORT.getKey(), getPort());
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/single/SingleNodeDiscoveryIT.java
@@ -48,7 +48,7 @@ public class SingleNodeDiscoveryIT extends ESIntegTestCase {
         return Settings.builder()
             .put(super.nodeSettings(nodeOrdinal, otherSettings))
             .put(DISCOVERY_TYPE_SETTING.getKey(), SINGLE_NODE_DISCOVERY_TYPE)
-            .put("transport.port", getPortRange())
+            .put("transport.port", getPort())
             .build();
     }
 

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/tasks/TaskManagerTestCase.java
@@ -79,10 +79,7 @@ public abstract class TaskManagerTestCase extends ESTestCase {
     public void setupTestNodes(Settings settings) {
         nodesCount = randomIntBetween(2, 10);
         testNodes = new TestNode[nodesCount];
-        final Settings reservedPortRangeSettings = Settings.builder()
-            .put(TransportSettings.PORT.getKey(), getPortRange())
-            .put(settings)
-            .build();
+        final Settings reservedPortRangeSettings = Settings.builder().put(TransportSettings.PORT.getKey(), getPort()).put(settings).build();
         for (int i = 0; i < testNodes.length; i++) {
             testNodes[i] = new TestNode("node" + i, threadPool, reservedPortRangeSettings);
         }

--- a/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
+++ b/test/framework/src/main/java/org/elasticsearch/node/MockNode.java
@@ -88,7 +88,7 @@ public class MockNode extends Node {
     ) {
         this(
             InternalSettingsPreparer.prepareEnvironment(
-                Settings.builder().put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange()).put(settings).build(),
+                Settings.builder().put(TransportSettings.PORT.getKey(), ESTestCase.getPort()).put(settings).build(),
                 Collections.emptyMap(),
                 configPath,
                 () -> "mock_ node"

--- a/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESSingleNodeTestCase.java
@@ -243,7 +243,7 @@ public abstract class ESSingleNodeTestCase extends ESTestCase {
             .put(Node.NODE_NAME_SETTING.getKey(), nodeName)
             .put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), 1) // limit the number of threads created
             .put("transport.type", getTestTransportType())
-            .put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange())
+            .put(TransportSettings.PORT.getKey(), ESTestCase.getPort())
             .put(dataNode())
             .put(NodeEnvironment.NODE_ID_SEED_SETTING.getKey(), random().nextLong())
             // default the watermarks low values to prevent tests from failing on nodes without enough disk space

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1794,14 +1794,19 @@ public abstract class ESTestCase extends LuceneTestCase {
         assert getWorkerBasePort(MAX_EFFECTIVE_WORKER_ID) + PORTS_PER_WORKER - 1 <= MAX_PRIVATE_PORT;
     }
 
+    private static final AtomicInteger PER_WORKER_PORT_COUNTER = new AtomicInteger();
+
     /**
-     * Returns a port range for this JVM according to its Gradle worker ID. See also [NOTE: Port ranges for tests].
+     * Returns a port for this JVM according to its Gradle worker ID. See also [NOTE: Port ranges for tests].
      */
-    public static String getPortRange() {
-        final var firstPort = getWorkerBasePort();
-        final var lastPort = firstPort + PORTS_PER_WORKER - 1; // upper bound is inclusive
-        assert MIN_PRIVATE_PORT <= firstPort && lastPort <= MAX_PRIVATE_PORT;
-        return firstPort + "-" + lastPort;
+    public static String getPort() {
+        final var basePort = getWorkerBasePort();
+        // We use port sequentially in the range of [basePort, basePort + PORTS_PER_WORKER)
+        // The port number wraps around when it reaches the maximum.
+        final var port = basePort + PER_WORKER_PORT_COUNTER.getAndIncrement() % PORTS_PER_WORKER;
+        assert MIN_PRIVATE_PORT <= basePort && port <= MAX_PRIVATE_PORT;
+        System.out.println("generate port " + port);
+        return String.valueOf(port);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ExternalTestCluster.java
@@ -84,7 +84,7 @@ public final class ExternalTestCluster extends TestCluster {
             .putList("node.roles", Collections.emptyList())
             .put("node.name", EXTERNAL_CLUSTER_PREFIX + counter.getAndIncrement())
             .put("cluster.name", clusterName)
-            .put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange())
+            .put(TransportSettings.PORT.getKey(), ESTestCase.getPort())
             .putList(
                 "discovery.seed_hosts",
                 Arrays.stream(transportAddresses).map(TransportAddress::toString).collect(Collectors.toList())

--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -381,8 +381,8 @@ public final class InternalTestCluster extends TestCluster {
         Builder builder = Settings.builder();
         builder.put(Environment.PATH_HOME_SETTING.getKey(), baseDir);
         builder.put(Environment.PATH_REPO_SETTING.getKey(), baseDir.resolve("repos"));
-        builder.put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange());
-        builder.put("http.port", ESTestCase.getPortRange());
+        builder.put(TransportSettings.PORT.getKey(), ESTestCase.getPort());
+        builder.put("http.port", ESTestCase.getPort());
         if (Strings.hasLength(System.getProperty("tests.es.logger.level"))) {
             builder.put("logger.level", System.getProperty("tests.es.logger.level"));
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/MockTransportService.java
@@ -122,7 +122,7 @@ public class MockTransportService extends TransportService {
     }
 
     public static TcpTransport newMockTransport(Settings settings, TransportVersion version, ThreadPool threadPool) {
-        settings = Settings.builder().put(TransportSettings.PORT.getKey(), ESTestCase.getPortRange()).put(settings).build();
+        settings = Settings.builder().put(TransportSettings.PORT.getKey(), ESTestCase.getPort()).put(settings).build();
         NamedWriteableRegistry namedWriteableRegistry = new NamedWriteableRegistry(ClusterModule.getNamedWriteables());
         return new Netty4Transport(
             settings,

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -207,7 +207,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         TransportInterceptor interceptor
     ) {
         Settings updatedSettings = Settings.builder()
-            .put(TransportSettings.PORT.getKey(), getPortRange())
+            .put(TransportSettings.PORT.getKey(), getPort())
             .put(settings)
             .put(Node.NODE_NAME_SETTING.getKey(), name)
             .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true) // suppress assertions to test production error-handling

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -38,6 +38,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -56,6 +57,32 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class AuthenticationTests extends ESTestCase {
+
+    static class Base {
+        static AtomicInteger counter = new AtomicInteger();
+    }
+
+    static class A extends Base {
+
+        void m() {
+            System.out.println("A " + counter.getAndIncrement());
+        }
+    }
+
+    static class B extends Base {
+        void m() {
+            System.out.println("B " + counter.getAndIncrement());
+        }
+    }
+
+    public void test() {
+        final var a = new A();
+        a.m();
+        a.m();
+        final var b = new B();
+        b.m();
+        b.m();
+    }
 
     public void testIsFailedRunAs() {
         final Authentication failedAuthentication = randomRealmAuthentication(randomBoolean()).runAs(randomUser(), null);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authc/AuthenticationTests.java
@@ -38,7 +38,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
@@ -57,32 +56,6 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 
 public class AuthenticationTests extends ESTestCase {
-
-    static class Base {
-        static AtomicInteger counter = new AtomicInteger();
-    }
-
-    static class A extends Base {
-
-        void m() {
-            System.out.println("A " + counter.getAndIncrement());
-        }
-    }
-
-    static class B extends Base {
-        void m() {
-            System.out.println("B " + counter.getAndIncrement());
-        }
-    }
-
-    public void test() {
-        final var a = new A();
-        a.m();
-        a.m();
-        final var b = new B();
-        b.m();
-        b.m();
-    }
 
     public void testIsFailedRunAs() {
         final Authentication failedAuthentication = randomRealmAuthentication(randomBoolean()).runAs(randomUser(), null);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -525,7 +525,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
         final Settings fcSettings = Settings.builder()
             .put("remote_cluster_server.enabled", "true")
-            .put("remote_cluster.port", "0")
+            .put("remote_cluster.port", getPort())
             .put("xpack.security.remote_cluster_server.ssl.key", testnodeKey)
             .put("xpack.security.remote_cluster_server.ssl.certificate", testnodeCert)
             .put("xpack.security.remote_cluster_server.ssl.client_authentication", "none")
@@ -647,7 +647,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
 
         final Settings fcSettings = Settings.builder()
             .put("remote_cluster_server.enabled", "true")
-            .put("remote_cluster.port", "0")
+            .put("remote_cluster.port", getPort())
             .put("xpack.security.remote_cluster_server.ssl.enabled", "false")
             .build();
 


### PR DESCRIPTION
This PR replace the getPortRange method with getPort which returns a single port instead of a range. The goal is to have a tigther control over what port is used for each test cases to avoid conflicts.

See also https://github.com/elastic/elasticsearch/pull/95205#issuecomment-1506532222
