### PR TITLE
Replace feature flag with index setting and enable TSDB encoding and decoding

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/IndexScopedSettings.java
@@ -168,6 +168,7 @@ public final class IndexScopedSettings extends AbstractScopedSettings {
         IndexSettings.BLOOM_FILTER_ID_FIELD_ENABLED_SETTING,
         IndexSettings.LIFECYCLE_ORIGINATION_DATE_SETTING,
         IndexSettings.LIFECYCLE_PARSE_ORIGINATION_DATE_SETTING,
+        IndexSettings.TIME_SERIES_ES87TSDB_CODEC_ENABLED_SETTING,
 
         // validate that built-in similarities don't get redefined
         Setting.groupSetting("index.similarity.", (s) -> {

--- a/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/PerFieldMapperCodec.java
@@ -107,18 +107,18 @@ public class PerFieldMapperCodec extends Lucene95Codec {
         return docValuesFormat;
     }
 
-    private boolean useTSDBDocValuesFormat(final String field) {
-        return IndexSettings.isTimeSeriesModeEnabled()
+    boolean useTSDBDocValuesFormat(final String field) {
+        return mapperService.getIndexSettings().isES87TSDBCodecEnabled()
             && isTimeSeriesModeIndex()
             && isNotSpecialField(field)
-            && (isCounterMetricType(field) || isTimestampField(field));
+            && (isCounterOrGaugeMetricType(field) || isTimestampField(field));
     }
 
     private boolean isTimeSeriesModeIndex() {
         return IndexMode.TIME_SERIES.equals(mapperService.getIndexSettings().getMode());
     }
 
-    private boolean isCounterMetricType(String field) {
+    private boolean isCounterOrGaugeMetricType(String field) {
         if (mapperService != null) {
             final MappingLookup mappingLookup = mapperService.mappingLookup();
             if (mappingLookup.getMapper(field) instanceof NumberFieldMapper) {

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -16,6 +16,29 @@ import org.apache.lucene.util.packed.PackedInts;
 import java.io.IOException;
 import java.util.Arrays;
 
+/**
+ * This class provides encoding and decoding of doc values using the following schemes:
+ * * delta encoding: encodes numeric fields in such a way to store the initial value and the difference between the initial value and
+ * all subsequent values. Delta values normally require much less bits than the original 32 or 64 bits.
+ * * offset encoding: encodes numeric fields in such a way to store values in range [0, max - min] instead of [min, max]. Reducing the
+ * range makes delta encoding much more effective since numbers in range [0, max - min] require less bits than values in range [min, max].
+ * * gcd encoding: encodes numeric fields in such a way to store values divided by their Greatest Common Divisor. Diving values by their
+ * GCD reduces values magnitude making delta encoding much more effective as a result of the fact that dividing a number by another number
+ * reduces its magnitude and, as a result, the bits required to represent it.
+ * * (f)or encoding: encodes numeric fields in such a way to store the initial value and then the XOR between each value and the previous
+ * one, making delta encoding much more effective. Values sharing common values for higher bits will require less bits when delta encoded.
+ * This is expected to be effective especially with floating point values sharing a common exponent and sign bit.
+ *
+ * Notice that encoding and decoding are written in a nested way, for instance {@link ES87TSDBDocValuesEncoder#deltaEncode} calling
+ * {@link ES87TSDBDocValuesEncoder#removeOffset} and so on. This allows us to easily introduce new encoding schemes or remove existing
+ * (non-effective) encoding schemes in a backward-compatible way.
+ *
+ * A token is used as a bitmask to represent which encoding is applied and allows us to detect the applied encoding scheme at decoding time.
+ * This encoding and decoding scheme is meant to work on blocks of 128 values. Larger block sizes incur a decoding penalty when random
+ * access to doc values is required since a full block must be decoded.
+ *
+ * Of course, decoding follows the opposite order with respect to encoding.
+ */
 public class ES87TSDBDocValuesEncoder {
     private final DocValuesForUtil forUtil;
 

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -18,16 +18,30 @@ import java.util.Arrays;
 
 /**
  * This class provides encoding and decoding of doc values using the following schemes:
- * * delta encoding: encodes numeric fields in such a way to store the initial value and the difference between the initial value and
- * all subsequent values. Delta values normally require much less bits than the original 32 or 64 bits.
- * * offset encoding: encodes numeric fields in such a way to store values in range [0, max - min] instead of [min, max]. Reducing the
- * range makes delta encoding much more effective since numbers in range [0, max - min] require less bits than values in range [min, max].
- * * gcd encoding: encodes numeric fields in such a way to store values divided by their Greatest Common Divisor. Diving values by their
- * GCD reduces values magnitude making delta encoding much more effective as a result of the fact that dividing a number by another number
- * reduces its magnitude and, as a result, the bits required to represent it.
- * * (f)or encoding: encodes numeric fields in such a way to store the initial value and then the XOR between each value and the previous
- * one, making delta encoding much more effective. Values sharing common values for higher bits will require less bits when delta encoded.
- * This is expected to be effective especially with floating point values sharing a common exponent and sign bit.
+ * <ul>
+ * <li>
+ *     delta encoding: encodes numeric fields in such a way to store the initial value and the difference between the initial value and
+ *     all subsequent values. Delta values normally require much less bits than the original 32 or 64 bits.
+ * </li>
+ *
+ * <il>
+ *     offset encoding: encodes numeric fields in such a way to store values in range [0, max - min] instead of [min, max]. Reducing the
+ *     range makes delta encoding much more effective since numbers in range [0, max - min] require less bits than values in range
+ *     [min, max].
+ * </il>
+ *
+ * <li>
+ *     gcd encoding: encodes numeric fields in such a way to store values divided by their Greatest Common Divisor. Diving values by their
+ *     GCD reduces values magnitude making delta encoding much more effective as a result of the fact that dividing a number by another
+ *     number reduces its magnitude and, as a result, the bits required to represent it.
+ * </li>
+ *
+ * <li>
+ *     (f)or encoding: encodes numeric fields in such a way to store the initial value and then the XOR between each value and the previous
+ *     one, making delta encoding much more effective. Values sharing common values for higher bits will require less bits when delta encoded.
+ *     This is expected to be effective especially with floating point values sharing a common exponent and sign bit.
+ * </li>
+ * </ul>
  *
  * Notice that encoding and decoding are written in a nested way, for instance {@link ES87TSDBDocValuesEncoder#deltaEncode} calling
  * {@link ES87TSDBDocValuesEncoder#removeOffset} and so on. This allows us to easily introduce new encoding schemes or remove existing

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -24,11 +24,11 @@ import java.util.Arrays;
  *     all subsequent values. Delta values normally require much less bits than the original 32 or 64 bits.
  * </li>
  *
- * <il>
+ * <li>
  *     offset encoding: encodes numeric fields in such a way to store values in range [0, max - min] instead of [min, max]. Reducing the
  *     range makes delta encoding much more effective since numbers in range [0, max - min] require less bits than values in range
  *     [min, max].
- * </il>
+ * </li>
  *
  * <li>
  *     gcd encoding: encodes numeric fields in such a way to store values divided by their Greatest Common Divisor. Diving values by their

--- a/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
+++ b/server/src/main/java/org/elasticsearch/index/codec/tsdb/ES87TSDBDocValuesEncoder.java
@@ -38,8 +38,8 @@ import java.util.Arrays;
  *
  * <li>
  *     (f)or encoding: encodes numeric fields in such a way to store the initial value and then the XOR between each value and the previous
- *     one, making delta encoding much more effective. Values sharing common values for higher bits will require less bits when delta encoded.
- *     This is expected to be effective especially with floating point values sharing a common exponent and sign bit.
+ *     one, making delta encoding much more effective. Values sharing common values for higher bits will require less bits when delta
+ *     encoded. This is expected to be effective especially with floating point values sharing a common exponent and sign bit.
  * </li>
  * </ul>
  *

--- a/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
+++ b/server/src/test/java/org/elasticsearch/index/codec/PerFieldMapperCodecTests.java
@@ -49,6 +49,100 @@ public class PerFieldMapperCodecTests extends ESTestCase {
         );
     }
 
+    public void testUseES87TSDBEncodingForTimestampField() throws IOException {
+        PerFieldMapperCodec perFieldMapperCodec = createCodec(true, true, true);
+        assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("@timestamp")), is(true));
+    }
+
+    public void testDoNotUseES87TSDBEncodingForTimestampFieldNonTimeSeriesIndex() throws IOException {
+        PerFieldMapperCodec perFieldMapperCodec = createCodec(true, false, true);
+        assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("@timestamp")), is(false));
+    }
+
+    public void testUseES87TSDBEncodingForCounterField() throws IOException {
+        String mapping = """
+            {
+                "_data_stream_timestamp": {
+                    "enabled": true
+                },
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    },
+                    "counter": {
+                        "type": "long",
+                        "time_series_metric": "counter"
+                    }
+                }
+            }
+            """;
+        PerFieldMapperCodec perFieldMapperCodec = createCodec(true, mapping);
+        assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("counter")), is(true));
+    }
+
+    public void testUseES87TSDBEncodingForCounterFieldNonTimeSeriesIndex() throws IOException {
+        String mapping = """
+            {
+                "_data_stream_timestamp": {
+                    "enabled": true
+                },
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    },
+                    "counter": {
+                        "type": "long",
+                        "time_series_metric": "counter"
+                    }
+                }
+            }
+            """;
+        PerFieldMapperCodec perFieldMapperCodec = createCodec(false, mapping);
+        assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("counter")), is(false));
+    }
+
+    public void testUseES87TSDBEncodingForGaugeField() throws IOException {
+        String mapping = """
+            {
+                "_data_stream_timestamp": {
+                    "enabled": true
+                },
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    },
+                    "gauge": {
+                        "type": "long",
+                        "time_series_metric": "gauge"
+                    }
+                }
+            }
+            """;
+        PerFieldMapperCodec perFieldMapperCodec = createCodec(true, mapping);
+        assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("gauge")), is(true));
+    }
+
+    public void testUseES87TSDBEncodingForGaugeFieldNonTimeSeriesIndex() throws IOException {
+        String mapping = """
+            {
+                "_data_stream_timestamp": {
+                    "enabled": true
+                },
+                "properties": {
+                    "@timestamp": {
+                        "type": "date"
+                    },
+                    "gauge": {
+                        "type": "long",
+                        "time_series_metric": "gauge"
+                    }
+                }
+            }
+            """;
+        PerFieldMapperCodec perFieldMapperCodec = createCodec(false, mapping);
+        assertThat((perFieldMapperCodec.useTSDBDocValuesFormat("gauge")), is(false));
+    }
+
     private PerFieldMapperCodec createCodec(boolean timestampField, boolean timeSeries, boolean disableBloomFilter) throws IOException {
         Settings.Builder settings = Settings.builder();
         if (timeSeries) {
@@ -74,6 +168,17 @@ public class PerFieldMapperCodecTests extends ESTestCase {
                 """;
             mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         }
+        return new PerFieldMapperCodec(Lucene95Codec.Mode.BEST_SPEED, mapperService, BigArrays.NON_RECYCLING_INSTANCE);
+    }
+
+    private PerFieldMapperCodec createCodec(boolean timeSeries, String mapping) throws IOException {
+        Settings.Builder settings = Settings.builder();
+        if (timeSeries) {
+            settings.put(IndexSettings.MODE.getKey(), "time_series");
+            settings.put(IndexMetadata.INDEX_ROUTING_PATH.getKey(), "field");
+        }
+        MapperService mapperService = MapperTestUtils.newMapperService(xContentRegistry(), createTempDir(), settings.build(), "test");
+        mapperService.merge("type", new CompressedXContent(mapping), MapperService.MergeReason.MAPPING_UPDATE);
         return new PerFieldMapperCodec(Lucene95Codec.Mode.BEST_SPEED, mapperService, BigArrays.NON_RECYCLING_INSTANCE);
     }
 


### PR DESCRIPTION
The index setting controls if the TSDB codec is enabled or not.
The codec applies a set of encoding schemes to gauges and counter
fields in time series indices including delta encoding, gcd encoding
offset encoding and so on. Encoding of values requiring less than 32
bits is vectorized.

Here we also enable encoding and decoding by default.