### PR TITLE
stop using array elements for grok modes

### DIFF
--- a/libs/grok/src/main/java/org/elasticsearch/grok/GrokBuiltinPatterns.java
+++ b/libs/grok/src/main/java/org/elasticsearch/grok/GrokBuiltinPatterns.java
@@ -13,14 +13,17 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 public class GrokBuiltinPatterns {
-    public static final String[] ECS_COMPATIBILITY_MODES = { "disabled", "v1" };
+
+    public static final String ECS_COMPATIBILITY_DISABLED = "disabled";
+    public static final String ECS_COMPATIBILITY_V1 = "v1";
+    public static final List<String> ECS_COMPATIBILITY_MODES = List.of(ECS_COMPATIBILITY_DISABLED, ECS_COMPATIBILITY_V1);
+
     /**
      * Patterns built in to the grok library.
      */
@@ -54,14 +57,14 @@ public class GrokBuiltinPatterns {
 
     public static Map<String, String> get(String ecsCompatibility) {
         if (isValidEcsCompatibilityMode(ecsCompatibility)) {
-            return get(ECS_COMPATIBILITY_MODES[1].equals(ecsCompatibility));
+            return get(ECS_COMPATIBILITY_V1.equals(ecsCompatibility));
         } else {
             throw new IllegalArgumentException("unsupported ECS compatibility mode [" + ecsCompatibility + "]");
         }
     }
 
     public static boolean isValidEcsCompatibilityMode(String ecsCompatibility) {
-        return Arrays.asList(ECS_COMPATIBILITY_MODES).contains(ecsCompatibility);
+        return ECS_COMPATIBILITY_MODES.contains(ecsCompatibility);
     }
 
     private static Map<String, String> loadLegacyPatterns() {

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessor.java
@@ -22,12 +22,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_DISABLED;
 import static org.elasticsearch.ingest.ConfigurationUtils.newConfigurationException;
 
 public final class GrokProcessor extends AbstractProcessor {
 
     public static final String TYPE = "grok";
-    public static final String DEFAULT_ECS_COMPATIBILITY_MODE = GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[0];
+    public static final String DEFAULT_ECS_COMPATIBILITY_MODE = ECS_COMPATIBILITY_DISABLED;
 
     private static final String PATTERN_MATCH_KEY = "_ingest._grok_match_index";
     private static final Logger logger = LogManager.getLogger(GrokProcessor.class);

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_DISABLED;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 public class GrokProcessorGetAction extends ActionType<GrokProcessorGetAction.Response> {
@@ -149,7 +150,7 @@ public class GrokProcessorGetAction extends ActionType<GrokProcessorGetAction.Re
             ActionListener.completeWith(
                 listener,
                 () -> new Response(
-                    request.getEcsCompatibility().equals(GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[0])
+                    request.getEcsCompatibility().equals(ECS_COMPATIBILITY_DISABLED)
                         ? request.sorted() ? sortedLegacyGrokPatterns : legacyGrokPatterns
                         : request.sorted() ? sortedEcsV1GrokPatterns
                         : ecsV1GrokPatterns

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorGetActionTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/GrokProcessorGetActionTests.java
@@ -14,7 +14,6 @@ import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.grok.GrokBuiltinPatterns;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.ToXContent;
@@ -26,6 +25,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_V1;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
@@ -115,21 +115,17 @@ public class GrokProcessorGetActionTests extends ESTestCase {
             ECS_TEST_PATTERNS
         );
         GrokProcessorGetAction.Response[] receivedResponse = new GrokProcessorGetAction.Response[1];
-        transportAction.doExecute(
-            null,
-            new GrokProcessorGetAction.Request(true, GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[1]),
-            new ActionListener<>() {
-                @Override
-                public void onResponse(GrokProcessorGetAction.Response response) {
-                    receivedResponse[0] = response;
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    fail();
-                }
+        transportAction.doExecute(null, new GrokProcessorGetAction.Request(true, ECS_COMPATIBILITY_V1), new ActionListener<>() {
+            @Override
+            public void onResponse(GrokProcessorGetAction.Response response) {
+                receivedResponse[0] = response;
             }
-        );
+
+            @Override
+            public void onFailure(Exception e) {
+                fail();
+            }
+        });
         assertThat(receivedResponse[0], notNullValue());
         assertThat(receivedResponse[0].getGrokPatterns().keySet().toArray(), equalTo(sortedKeys.toArray()));
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/action/FindStructureAction.java
@@ -32,8 +32,6 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
 public class FindStructureAction extends ActionType<FindStructureAction.Response> {
-    public static final String ECS_COMPATIBILITY_DISABLED = GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[0];
-    public static final String ECS_COMPATIBILITY_V1 = GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[1];
 
     public static final FindStructureAction INSTANCE = new FindStructureAction();
     public static final String NAME = "cluster:monitor/text_structure/findstructure";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -27,6 +27,8 @@ import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_DISABLED;
+
 /**
  * Stores the determined file format.
  */
@@ -131,7 +133,7 @@ public class TextStructure implements ToXContentObject, Writeable {
     }
 
     private static String getNonNullEcsCompatibilityString(String ecsCompatibility) {
-        return (ecsCompatibility == null || ecsCompatibility.isEmpty()) ? GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[0] : ecsCompatibility;
+        return (ecsCompatibility == null || ecsCompatibility.isEmpty()) ? ECS_COMPATIBILITY_DISABLED : ecsCompatibility;
     }
 
     private final int numLinesAnalyzed;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/textstructure/action/FindTextStructureActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/textstructure/action/FindTextStructureActionRequestTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
 
 import java.util.Arrays;
 
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_DISABLED;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.startsWith;
 
@@ -173,7 +174,7 @@ public class FindTextStructureActionRequestTests extends AbstractWireSerializing
         request.setSample(new BytesArray("foo\n"));
 
         ActionRequestValidationException e = request.validate();
-        if (FindStructureAction.ECS_COMPATIBILITY_DISABLED.equalsIgnoreCase(ecsCompatibility) == false) {
+        if (ECS_COMPATIBILITY_DISABLED.equalsIgnoreCase(ecsCompatibility) == false) {
             assertNotNull(e);
             assertThat(e.getMessage(), startsWith("Validation Failed: "));
             assertThat(e.getMessage(), containsString(" [ecs_compatibility] must be one of [disabled, v1] if specified"));

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinder.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/LogTextStructureFinder.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.textstructure.structurefinder;
 
 import org.elasticsearch.core.Tuple;
-import org.elasticsearch.grok.GrokBuiltinPatterns;
 import org.elasticsearch.xpack.core.textstructure.action.FindStructureAction;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.FieldStats;
 import org.elasticsearch.xpack.core.textstructure.structurefinder.TextStructure;
@@ -23,6 +22,8 @@ import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_V1;
 
 public class LogTextStructureFinder implements TextStructureFinder {
 
@@ -69,7 +70,7 @@ public class LogTextStructureFinder implements TextStructureFinder {
             fieldStats,
             customGrokPatternDefinitions,
             timeoutChecker,
-            GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[1].equals(overrides.getEcsCompatibility())
+            ECS_COMPATIBILITY_V1.equals(overrides.getEcsCompatibility())
         );
 
         String grokPattern = overrides.getGrokPattern();
@@ -237,7 +238,7 @@ public class LogTextStructureFinder implements TextStructureFinder {
             fieldStats,
             customGrokPatternDefinitions,
             timeoutChecker,
-            GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[1].equals(overrides.getEcsCompatibility())
+            ECS_COMPATIBILITY_V1.equals(overrides.getEcsCompatibility())
         );
 
         // We can't parse directly into @timestamp using Grok, so parse to some other time field, which the date filter will then remove
@@ -360,7 +361,7 @@ public class LogTextStructureFinder implements TextStructureFinder {
             false,
             false,
             timeoutChecker,
-            GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[1].equals(overrides.getEcsCompatibility())
+            ECS_COMPATIBILITY_V1.equals(overrides.getEcsCompatibility())
         );
 
         for (String sampleLine : sampleLines) {

--- a/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
+++ b/x-pack/plugin/text-structure/src/main/java/org/elasticsearch/xpack/textstructure/structurefinder/TextStructureUtils.java
@@ -28,6 +28,9 @@ import java.util.TreeMap;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_DISABLED;
+import static org.elasticsearch.grok.GrokBuiltinPatterns.ECS_COMPATIBILITY_V1;
+
 public final class TextStructureUtils {
 
     // The ECS Grok pattern compatibility mode to use when no ecs_compatibility parameter is specified in the request.
@@ -229,7 +232,7 @@ public final class TextStructureUtils {
                         true,
                         true,
                         timeoutChecker,
-                        GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[1].equals(overrides.getEcsCompatibility())
+                        ECS_COMPATIBILITY_V1.equals(overrides.getEcsCompatibility())
                     );
                     try {
                         timestampFormatFinder.addSample(value.toString());
@@ -643,7 +646,7 @@ public final class TextStructureUtils {
             }
             grokProcessorSettings.put(
                 "ecs_compatibility",
-                (ecsCompatibility == null || ecsCompatibility.isEmpty()) ? GrokBuiltinPatterns.ECS_COMPATIBILITY_MODES[0] : ecsCompatibility
+                (ecsCompatibility == null || ecsCompatibility.isEmpty()) ? ECS_COMPATIBILITY_DISABLED : ecsCompatibility
             );
             processors.add(Collections.singletonMap("grok", grokProcessorSettings));
         } else {


### PR DESCRIPTION
Adds 2 new constants to hold the possible ECS compatibility modes. Then uses these values instead to pick them up from the array of available modes.

Relates #93982 