### PR TITLE
Simulate ingest pipeline API verbose bug

### DIFF
--- a/docs/changelog/95232.yaml
+++ b/docs/changelog/95232.yaml
@@ -1,0 +1,5 @@
+pr: 95232
+summary: Simulate ingest pipeline API verbose bug
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
+++ b/modules/ingest-common/src/yamlRestTest/resources/rest-api-spec/test/ingest/90_simulate.yml
@@ -263,12 +263,18 @@ teardown:
                   "lowercase" : {
                     "field" : "foo.bar.0.item"
                   }
+                },
+                {
+                  "set" : {
+                    "field" : "_index",
+                    "value" : "index-2"
+                  }
                 }
               ]
             },
             "docs": [
               {
-                "_index": "index",
+                "_index": "index-1",
                 "_id": "id",
                 "_source": {
                   "foo": {
@@ -279,8 +285,10 @@ teardown:
             ]
           }
   - length: { docs: 1 }
-  - length: { docs.0.processor_results: 4 }
+  - length: { docs.0.processor_results: 5 }
   - match: { docs.0.processor_results.0.tag: "processor[set]-0" }
+  - match: { docs.0.processor_results.0.doc._index: "index-1" }
+  - match: { docs.0.processor_results.0.doc._id: "id" }
   - length: { docs.0.processor_results.0.doc._source: 2 }
   - match: { docs.0.processor_results.0.doc._source.foo.bar.0.item: "HELLO" }
   - match: { docs.0.processor_results.0.doc._source.field2.value: "_value" }
@@ -308,6 +316,12 @@ teardown:
   - length: { docs.0.processor_results.3.doc._ingest: 2 }
   - is_true: docs.0.processor_results.3.doc._ingest.timestamp
   - is_true: docs.0.processor_results.3.doc._ingest.pipeline
+  - length: { docs.0.processor_results.4.doc._source: 3 }
+  - match: { docs.0.processor_results.4.doc._index: "index-2" }
+  - match: { docs.0.processor_results.4.doc._id: "id" }
+  - length: { docs.0.processor_results.4.doc._ingest: 2 }
+  - is_true: docs.0.processor_results.4.doc._ingest.timestamp
+  - is_true: docs.0.processor_results.4.doc._ingest.pipeline
 
 ---
 "Test simulate with exception thrown":

--- a/server/src/main/java/org/elasticsearch/ingest/IngestDocMetadata.java
+++ b/server/src/main/java/org/elasticsearch/ingest/IngestDocMetadata.java
@@ -14,6 +14,7 @@ import org.elasticsearch.script.Metadata;
 
 import java.time.ZonedDateTime;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
@@ -79,7 +80,7 @@ class IngestDocMetadata extends Metadata {
 
     @Override
     public IngestDocMetadata clone() {
-        return new IngestDocMetadata(map, timestamp);
+        return new IngestDocMetadata(new HashMap<>(map), timestamp);
     }
 
     private static void versionTypeValidator(String key, String value) {

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -1033,9 +1033,16 @@ public class IngestDocumentTests extends ESTestCase {
     }
 
     public void testCopyConstructor() {
+        // generic test with a random document and copy
         IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
         IngestDocument copy = new IngestDocument(ingestDocument);
+
+        // these fields should not be the same instance
         assertThat(ingestDocument.getSourceAndMetadata(), not(sameInstance(copy.getSourceAndMetadata())));
+        assertThat(ingestDocument.getCtxMap(), not(sameInstance(copy.getCtxMap())));
+        assertThat(ingestDocument.getCtxMap().getMetadata(), not(sameInstance(copy.getCtxMap().getMetadata())));
+
+        // but the two objects should be very much equal to each other
         assertIngestDocument(ingestDocument, copy);
     }
 

--- a/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestDocumentTests.java
@@ -1033,17 +1033,41 @@ public class IngestDocumentTests extends ESTestCase {
     }
 
     public void testCopyConstructor() {
-        // generic test with a random document and copy
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
-        IngestDocument copy = new IngestDocument(ingestDocument);
+        {
+            // generic test with a random document and copy
+            IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+            IngestDocument copy = new IngestDocument(ingestDocument);
 
-        // these fields should not be the same instance
-        assertThat(ingestDocument.getSourceAndMetadata(), not(sameInstance(copy.getSourceAndMetadata())));
-        assertThat(ingestDocument.getCtxMap(), not(sameInstance(copy.getCtxMap())));
-        assertThat(ingestDocument.getCtxMap().getMetadata(), not(sameInstance(copy.getCtxMap().getMetadata())));
+            // these fields should not be the same instance
+            assertThat(ingestDocument.getSourceAndMetadata(), not(sameInstance(copy.getSourceAndMetadata())));
+            assertThat(ingestDocument.getCtxMap(), not(sameInstance(copy.getCtxMap())));
+            assertThat(ingestDocument.getCtxMap().getMetadata(), not(sameInstance(copy.getCtxMap().getMetadata())));
 
-        // but the two objects should be very much equal to each other
-        assertIngestDocument(ingestDocument, copy);
+            // but the two objects should be very much equal to each other
+            assertIngestDocument(ingestDocument, copy);
+        }
+
+        {
+            // manually punch in a few values
+            IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random());
+            ingestDocument.setFieldValue("_index", "foo1");
+            ingestDocument.setFieldValue("_id", "bar1");
+            ingestDocument.setFieldValue("hello", "world1");
+            IngestDocument copy = new IngestDocument(ingestDocument);
+
+            // make sure the copy matches
+            assertIngestDocument(ingestDocument, copy);
+
+            // change the copy
+            copy.setFieldValue("_index", "foo2");
+            copy.setFieldValue("_id", "bar2");
+            copy.setFieldValue("hello", "world2");
+
+            // the original shouldn't have changed
+            assertThat(ingestDocument.getFieldValue("_index", String.class), equalTo("foo1"));
+            assertThat(ingestDocument.getFieldValue("_id", String.class), equalTo("bar1"));
+            assertThat(ingestDocument.getFieldValue("hello", String.class), equalTo("world1"));
+        }
     }
 
     public void testCopyConstructorWithZonedDateTime() {


### PR DESCRIPTION
```
POST /_ingest/pipeline/_simulate?verbose=true
{
  "pipeline" : {
    "processors" : [
      {
        "set" : {
          "field" : "_index",
          "value" : "index2"
        }
      },
      {
        "set" : {
          "field" : "_id",
          "value" : "id2"
        }
      },
      {
        "set" : {
          "field" : "hello",
          "value" : "simulation"
        }
      }
    ]
  },
  "docs" : [
    {
      "_index" : "index1",
      "_id" : "id1",
      "_source" : {
        "hello" : "world"
      }
    }
  ]
}
```

gives this result:

```
{
  "docs" : [
    {
      "processor_results" : [
        {
          "processor_type" : "set",
          "status" : "success",
          "doc" : {
            "_index" : "index2",
            "_id" : "id2", # <----------<<< WAT!
            "_version" : "-3",
            "_source" : {
              "hello" : "world"
            },
            "_ingest" : {
              "pipeline" : "_simulate_pipeline",
              "timestamp" : "2023-04-13T15:16:35.478097Z"
            }
          }
        },
        {
          "processor_type" : "set",
          "status" : "success",
          "doc" : {
            "_index" : "index2",
            "_id" : "id2",
            "_version" : "-3",
            "_source" : {
              "hello" : "world"
            },
            "_ingest" : {
              "pipeline" : "_simulate_pipeline",
              "timestamp" : "2023-04-13T15:16:35.478097Z"
            }
          }
        },
        {
          "processor_type" : "set",
          "status" : "success",
          "doc" : {
            "_index" : "index2",
            "_id" : "id2",
            "_version" : "-3",
            "_source" : {
              "hello" : "simulation"
            },
            "_ingest" : {
              "pipeline" : "_simulate_pipeline",
              "timestamp" : "2023-04-13T15:16:35.478097Z"
            }
          }
        }
      ]
    }
  ]
}
```

But that's actually nonsense! The `_index` and `_id` are changed **throughout** the entire response, rather than only after the associated `set` processor actually changes the value in question.

The issue is that when we use a copy constructor to duplicate the `IngestDocument`, one of the underlying maps way deep down is actually still a shared object, so all the processors are banging on the same one map (rather than independent copies).

This only affects `verbose` simulations, because the final result does end up correct in the regular (non-verbose) case.