### PR TITLE
Switch to getMinTransportVersion in SearchApplicationIndexService

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -463,7 +463,8 @@ public class SearchApplicationIndexService {
         return new SearchApplication(in);
     }
 
-    static void writeSearchApplicationBinaryWithVersion(SearchApplication app, OutputStream os, TransportVersion minTransportVersion) throws IOException {
+    static void writeSearchApplicationBinaryWithVersion(SearchApplication app, OutputStream os, TransportVersion minTransportVersion)
+        throws IOException {
         // do not close the output
         os = Streams.noCloseStream(os);
         TransportVersion.writeVersion(minTransportVersion, new OutputStreamStreamOutput(os));

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -283,7 +283,7 @@ public class SearchApplicationIndexService {
                     .field(SearchApplication.UPDATED_AT_MILLIS_FIELD.getPreferredName(), app.updatedAtMillis())
                     .directFieldAsBase64(
                         SearchApplication.BINARY_CONTENT_FIELD.getPreferredName(),
-                        os -> writeSearchApplicationBinaryWithVersion(app, os, clusterService.state().nodes().getMinNodeVersion())
+                        os -> writeSearchApplicationBinaryWithVersion(app, os, clusterService.state().getMinTransportVersion())
                     )
                     .endObject();
             }
@@ -463,12 +463,12 @@ public class SearchApplicationIndexService {
         return new SearchApplication(in);
     }
 
-    static void writeSearchApplicationBinaryWithVersion(SearchApplication app, OutputStream os, Version minNodeVersion) throws IOException {
+    static void writeSearchApplicationBinaryWithVersion(SearchApplication app, OutputStream os, TransportVersion minTransportVersion) throws IOException {
         // do not close the output
         os = Streams.noCloseStream(os);
-        TransportVersion.writeVersion(minNodeVersion.transportVersion, new OutputStreamStreamOutput(os));
+        TransportVersion.writeVersion(minTransportVersion, new OutputStreamStreamOutput(os));
         try (OutputStreamStreamOutput out = new OutputStreamStreamOutput(os)) {
-            out.setTransportVersion(minNodeVersion.transportVersion);
+            out.setTransportVersion(minTransportVersion);
             app.writeTo(out);
         }
     }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationTests.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.application.search;
 
-import org.elasticsearch.Version;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -49,7 +49,7 @@ public class SearchApplicationTests extends ESTestCase {
             SearchApplication testInstance = SearchApplicationTestUtils.randomSearchApplication();
             assertTransportSerialization(testInstance);
             assertXContent(testInstance, randomBoolean());
-            assertIndexSerialization(testInstance, Version.CURRENT);
+            assertIndexSerialization(testInstance);
         }
     }
 
@@ -128,24 +128,19 @@ public class SearchApplicationTests extends ESTestCase {
     }
 
     private SearchApplication assertTransportSerialization(SearchApplication testInstance) throws IOException {
-        return assertTransportSerialization(testInstance, Version.CURRENT);
-    }
-
-    private SearchApplication assertTransportSerialization(SearchApplication testInstance, Version version) throws IOException {
-        SearchApplication deserializedInstance = copyInstance(testInstance, version);
+        SearchApplication deserializedInstance = copyInstance(testInstance);
         assertNotSame(testInstance, deserializedInstance);
         assertThat(testInstance, equalTo(deserializedInstance));
         return deserializedInstance;
     }
 
-    private SearchApplication assertIndexSerialization(SearchApplication testInstance, Version version) throws IOException {
+    private SearchApplication assertIndexSerialization(SearchApplication testInstance) throws IOException {
         final SearchApplication deserializedInstance;
         try (BytesStreamOutput output = new BytesStreamOutput()) {
-            output.setTransportVersion(version.transportVersion);
             SearchApplicationIndexService.writeSearchApplicationBinaryWithVersion(
                 testInstance,
                 output,
-                version.minimumCompatibilityVersion()
+                TransportVersion.MINIMUM_COMPATIBLE
             );
             try (
                 StreamInput in = new NamedWriteableAwareStreamInput(
@@ -161,7 +156,7 @@ public class SearchApplicationTests extends ESTestCase {
         return deserializedInstance;
     }
 
-    private SearchApplication copyInstance(SearchApplication instance, Version version) throws IOException {
-        return copyWriteable(instance, namedWriteableRegistry, SearchApplication::new, version.transportVersion);
+    private SearchApplication copyInstance(SearchApplication instance) throws IOException {
+        return copyWriteable(instance, namedWriteableRegistry, SearchApplication::new);
     }
 }


### PR DESCRIPTION
Use `getMinTransportVersion` rather than `getMinNodeVersion`, to remove the link between Version and TransportVersion