### PR TITLE
Add default template to search application

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -97,7 +97,7 @@ teardown:
       }
     }
 ---
-"Update Search Application":
+"Update Search Application with null template, results in default template being applied":
   - do:
       search_application.put:
         name: test-updated-search-application
@@ -121,7 +121,18 @@ teardown:
   - do:
      search_application.get:
        name: test-updated-search-application
-  - match: { template: null }
+  - match: {
+    template: {
+      script: {
+        source: "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"{{default_field}}\" } } }",
+        params: {
+          query_string: "*",
+          default_field: "*"
+        },
+        lang: "mustache"
+      }
+    }
+  }
   - match: { indices: [ "test-index3", "test-index4" ] }
 
 ---

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -44,6 +44,11 @@ teardown:
 
   - do:
       search_application.delete:
+        name: another-test-search-application
+        ignore: 404
+
+  - do:
+      search_application.delete:
         name: test-updated-search-application
         ignore: 404
 
@@ -96,6 +101,37 @@ teardown:
         }
       }
     }
+---
+"Create Search Application with string encoded template script":
+  - do:
+      search_application.put:
+        name: another-test-search-application
+        body:
+          indices: [ "test-index1", "test-index2" ]
+          template:
+            script: {
+              source: "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"_all\" } } }",
+              params: {
+                query_string: "elastic"
+              },
+              lang: "mustache"
+            }
+
+  - do:
+      search_application.get:
+        name: another-test-search-application
+  - match: {
+    template: {
+      script: {
+        source: "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"_all\" } } }",
+        params: {
+          query_string: "elastic"
+        },
+        lang: "mustache"
+      }
+    }
+  }
+  - match: { indices: [ "test-index1", "test-index2" ] }
 ---
 "Update Search Application with null template, results in default template being applied":
   - do:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/20_search_application_put.yml
@@ -160,7 +160,7 @@ teardown:
   - match: {
     template: {
       script: {
-        source: "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"{{default_field}}\" } } }",
+        source: "{\n  \"query\": {\n    \"query_string\": {\n        \"query\": \"{{query_string}}\",\n        \"default_field\": \"{{default_field}}\"\n        }\n    }\n}\n",
         params: {
           query_string: "*",
           default_field: "*"

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -21,7 +21,7 @@ setup:
       search_application.put:
         name: test-search-application-1
         body:
-          indices: [ "test-index1", "test-index2"]
+          indices: [ "test-index1", "test-index2" ]
           analytics_collection_name: "test-analytics"
           template:
             script:
@@ -58,26 +58,26 @@ teardown:
   - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
   - match: {
-      template: {
-        script: {
-          source: {
-            query: {
-              query_string: {
-                query: "{{query_string}}"
-              }
+    template: {
+      script: {
+        source: {
+          query: {
+            query_string: {
+              query: "{{query_string}}"
             }
-          },
-          lang: "mustache",
-          options: {
-            content_type: "application/json;charset=utf-8"
           }
+        },
+        lang: "mustache",
+        options: {
+          content_type: "application/json;charset=utf-8"
         }
       }
     }
+  }
   - gte: { updated_at_millis: 0 }
 
 ---
-"Get Search Application with no template":
+"Get Search Application with no template specified returns default template":
   - do:
       search_application.get:
         name: test-search-application-2
@@ -85,7 +85,18 @@ teardown:
   - match: { name: "test-search-application-2" }
   - match: { indices: [ "test-index1", "test-index2" ] }
   - match: { analytics_collection_name: "test-analytics" }
-  - match: { template: null }
+  - match: {
+    template: {
+      script: {
+        source:  "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"{{default_field}}\" } } }",
+        params: {
+            query_string: "*",
+            default_field: "*"
+        },
+        lang: "mustache"
+      }
+    }
+  }
   - gte: { updated_at_millis: 0 }
 
 ---

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/30_search_application_get.yml
@@ -88,7 +88,7 @@ teardown:
   - match: {
     template: {
       script: {
-        source:  "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"{{default_field}}\" } } }",
+        source:  "{\n  \"query\": {\n    \"query_string\": {\n        \"query\": \"{{query_string}}\",\n        \"default_field\": \"{{default_field}}\"\n        }\n    }\n}\n",
         params: {
             query_string: "*",
             default_field: "*"

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -83,7 +83,8 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
         this.analyticsCollectionName = analyticsCollectionName;
         this.updatedAtMillis = updatedAtMillis;
-        this.searchApplicationTemplate = searchApplicationTemplate;
+        this.searchApplicationTemplate =
+            searchApplicationTemplate != null ? searchApplicationTemplate : SearchApplicationTemplate.DEFAULT_TEMPLATE;
     }
 
     public SearchApplication(StreamInput in) throws IOException {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplication.java
@@ -83,8 +83,9 @@ public class SearchApplication implements Writeable, ToXContentObject {
 
         this.analyticsCollectionName = analyticsCollectionName;
         this.updatedAtMillis = updatedAtMillis;
-        this.searchApplicationTemplate =
-            searchApplicationTemplate != null ? searchApplicationTemplate : SearchApplicationTemplate.DEFAULT_TEMPLATE;
+        this.searchApplicationTemplate = searchApplicationTemplate != null
+            ? searchApplicationTemplate
+            : SearchApplicationTemplate.DEFAULT_TEMPLATE;
     }
 
     public SearchApplication(StreamInput in) throws IOException {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplate.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplate.java
@@ -7,15 +7,10 @@
 
 package org.elasticsearch.xpack.application.search;
 
-import org.apache.lucene.search.Query;
-import org.apache.lucene.search.QueryVisitor;
-import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
-import org.elasticsearch.ingest.ValueSource;
 import org.elasticsearch.script.Script;
-import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MustacheScriptEngine;
 import org.elasticsearch.xcontent.ConstructingObjectParser;
@@ -26,9 +21,6 @@ import org.elasticsearch.xpack.application.search.action.QuerySearchApplicationA
 import org.elasticsearch.xpack.application.search.action.QuerySearchApplicationAction.Request;
 
 import java.io.IOException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 
@@ -109,7 +101,7 @@ public class SearchApplicationTemplate implements ToXContentObject, Writeable {
     }
 
     private static SearchApplicationTemplate buildDefaultTemplate() {
-        Map<String,Object> params = Map.of("query_string", "*", "default_field", "*");
+        Map<String, Object> params = Map.of("query_string", "*", "default_field", "*");
         String query = """
             {
                 "query": {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplate.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplate.java
@@ -102,16 +102,7 @@ public class SearchApplicationTemplate implements ToXContentObject, Writeable {
 
     private static SearchApplicationTemplate buildDefaultTemplate() {
         Map<String, Object> params = Map.of("query_string", "*", "default_field", "*");
-        String query = """
-            {
-                "query": {
-                  "query_string":{
-                    "query": "{{query_string}}",
-                    "default_field": "{{default_field}}"
-                  }
-                }
-              }
-            """;
+        String query = "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"{{default_field}}\" } } }";
         final Script script = new Script(ScriptType.INLINE, "mustache", query, params);
         return new SearchApplicationTemplate(script);
     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplate.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplate.java
@@ -32,7 +32,18 @@ import static org.elasticsearch.xcontent.ConstructingObjectParser.optionalConstr
  */
 public class SearchApplicationTemplate implements ToXContentObject, Writeable {
 
-    public static final SearchApplicationTemplate DEFAULT_TEMPLATE = buildDefaultTemplate();
+    public static final SearchApplicationTemplate DEFAULT_TEMPLATE = new SearchApplicationTemplate(
+        new Script(ScriptType.INLINE, MustacheScriptEngine.NAME, """
+            {
+              "query": {
+                "query_string": {
+                    "query": "{{query_string}}",
+                    "default_field": "{{default_field}}"
+                    }
+                }
+            }
+            """, Map.of("query_string", "*", "default_field", "*"))
+    );
     private final Script script;
 
     public SearchApplicationTemplate(StreamInput in) throws IOException {
@@ -98,13 +109,6 @@ public class SearchApplicationTemplate implements ToXContentObject, Writeable {
 
     public Script script() {
         return script;
-    }
-
-    private static SearchApplicationTemplate buildDefaultTemplate() {
-        Map<String, Object> params = Map.of("query_string", "*", "default_field", "*");
-        String query = "{ \"query\": { \"query_string\":{ \"query\": \"{{query_string}}\", \"default_field\": \"{{default_field}}\" } } }";
-        final Script script = new Script(ScriptType.INLINE, "mustache", query, params);
-        return new SearchApplicationTemplate(script);
     }
 
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexServiceTests.java
@@ -85,6 +85,8 @@ public class SearchApplicationIndexServiceTests extends ESSingleNodeTestCase {
         assertThat(getSearchApp, equalTo(searchApp));
         checkAliases(searchApp);
 
+        assertThat(getSearchApp.searchApplicationTemplate(), equalTo(SearchApplicationTemplate.DEFAULT_TEMPLATE));
+
         expectThrows(VersionConflictEngineException.class, () -> awaitPutSearchApplication(searchApp, true));
     }
 


### PR DESCRIPTION
Adds a simple default search template to search applications if none are specified, and adds tests for search applications created with a string mustache script input. 

If you create/update a search application that does not specify or removes an existing template from the search application, we will create a default template: 
```
"template": {
      "script": {
        "source": """
        {
          "query": {
            "query_string":{
              "query": "{{query_string}}",
              "default_field": "{{default_field}}"
            }
          }
        }
        """,
        "params": {
          "query_string": "*",
          "default_field": "*"
        }
      }
    }
```

