### PR TITLE
Update ilm-searchable-snapshot.asciidoc

### DIFF
--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -40,7 +40,8 @@ indices. These costs are typically lower but, in some environments, may be
 higher. See <<searchable-snapshots-costs>> for more details.
 
 By default, this snapshot is deleted by the <<ilm-delete, delete action>> in the delete phase.
-To keep the snapshot, set `delete_searchable_snapshot` to `false` in the delete action.
+To keep the snapshot, set `delete_searchable_snapshot` to `false` in the delete action. This 
+snapshot retention runs off ILM and is not effected by SLM policies.
 
 [[ilm-searchable-snapshot-options]]
 ==== Options

--- a/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
+++ b/docs/reference/ilm/actions/ilm-searchable-snapshot.asciidoc
@@ -41,7 +41,7 @@ higher. See <<searchable-snapshots-costs>> for more details.
 
 By default, this snapshot is deleted by the <<ilm-delete, delete action>> in the delete phase.
 To keep the snapshot, set `delete_searchable_snapshot` to `false` in the delete action. This 
-snapshot retention runs off ILM and is not effected by SLM policies.
+snapshot retention runs off the index lifecycle management (ILM) policies and is not effected by snapshot lifecycle management (SLM) policies.
 
 [[ilm-searchable-snapshot-options]]
 ==== Options


### PR DESCRIPTION
👋🏼 howdy, team! Can we explicate that ILM Searchable Snapshot retention ([doc](https://www.elastic.co/guide/en/elasticsearch/reference/master/ilm-searchable-snapshot.html)) is not effected by SLM policies? Advanced users can deduce this via the [SLM policy doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get-policy.html), but I'd like to make it easier / less time consuming for users to confirm.  TIA!