### PR TITLE
[8.7] Fix Watcher email actions not using WebhookService for HTTP requests (#95196)

### DIFF
--- a/docs/changelog/95196.yaml
+++ b/docs/changelog/95196.yaml
@@ -1,0 +1,5 @@
+pr: 95196
+summary: Add logging for debug to Watcher webhook service
+area: Watcher
+type: bug
+issues: []

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/Watcher.java
@@ -352,11 +352,11 @@ public class Watcher extends Plugin implements SystemIndexPlugin, ScriptPlugin, 
 
         TextTemplateEngine templateEngine = new TextTemplateEngine(scriptService);
         Map<String, EmailAttachmentParser<?>> emailAttachmentParsers = new HashMap<>();
-        emailAttachmentParsers.put(HttpEmailAttachementParser.TYPE, new HttpEmailAttachementParser(httpClient, templateEngine));
+        emailAttachmentParsers.put(HttpEmailAttachementParser.TYPE, new HttpEmailAttachementParser(webhookService, templateEngine));
         emailAttachmentParsers.put(DataAttachmentParser.TYPE, new DataAttachmentParser());
         emailAttachmentParsers.put(
             ReportingAttachmentParser.TYPE,
-            new ReportingAttachmentParser(settings, httpClient, templateEngine, clusterService.getClusterSettings())
+            new ReportingAttachmentParser(settings, webhookService, templateEngine, clusterService.getClusterSettings())
         );
         EmailAttachmentsParser emailAttachmentsParser = new EmailAttachmentsParser(emailAttachmentParsers);
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/WebhookService.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsException;
 import org.elasticsearch.common.util.LazyInitializable;
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
 import org.elasticsearch.xpack.core.watcher.actions.Action;
@@ -121,10 +122,41 @@ public class WebhookService extends NotificationService<WebhookService.WebhookAc
         Map<String, Object> model = Variables.createCtxParamsMap(ctx, payload);
 
         // Render the original request
-        HttpRequest request = action.getRequest().render(templateEngine, model);
+        HttpRequest originalRequest = action.getRequest().render(templateEngine, model);
 
-        // If applicable, add the extra token to the headers
-        boolean tokenAdded = false;
+        if (ctx.simulateAction(actionId)) {
+            HttpRequest request = maybeModifyHttpRequest(originalRequest);
+            // If the request was modified, then the request has had the token added
+            boolean tokenAdded = originalRequest != request;
+            // Skip execution, return only the simulated (and redacted if necessary) response
+            return new WebhookAction.Result.Simulated(
+                tokenAdded ? request.copy().setHeader(TOKEN_HEADER_NAME, WatcherXContentParser.REDACTED_PASSWORD).build() : request
+            );
+        }
+
+        final Tuple<HttpRequest, HttpResponse> respTup = modifyAndExecuteHttpRequest(originalRequest);
+        final HttpRequest request = respTup.v1();
+        final HttpResponse response = respTup.v2();
+        // If the request was modified, then the request has had the token added
+        final boolean tokenAdded = originalRequest != request;
+
+        final Function<HttpRequest, HttpRequest> redactToken = tokenAdded
+            ? req -> req.copy().setHeader(TOKEN_HEADER_NAME, WatcherXContentParser.REDACTED_PASSWORD).build()
+            : Function.identity();
+
+        if (response.status() >= 400) {
+            return new WebhookAction.Result.Failure(redactToken.apply(request), response);
+        } else {
+            return new WebhookAction.Result.Success(redactToken.apply(request), response);
+        }
+    }
+
+    /**
+     * Makes any additional modifications to the {@link HttpRequest} if necessary.
+     * If no modifications are made the same instance is returned, otherwise a new
+     * HttpRequest is returned.
+     */
+    HttpRequest maybeModifyHttpRequest(HttpRequest request) {
         WebhookAccount account = getAccount(NAME);
         if (this.additionalTokenEnabled && account.hostTokenMap.size() > 0) {
             // Generate a string like example.com:9200 to match against the list of hosts where the
@@ -133,27 +165,35 @@ public class WebhookService extends NotificationService<WebhookService.WebhookAc
             String reqHostAndPort = request.host() + ":" + request.port();
             if (Strings.hasText(account.hostTokenMap.get(reqHostAndPort))) {
                 // Add the additional token
-                tokenAdded = true;
-                request = request.copy().setHeader(TOKEN_HEADER_NAME, account.hostTokenMap.get(reqHostAndPort)).build();
+                logger.debug(
+                    "additional [{}] header token added to watcher webhook request for {}://{}:{}",
+                    TOKEN_HEADER_NAME,
+                    request.scheme().scheme(),
+                    request.host(),
+                    request.port()
+                );
+                return request.copy().setHeader(TOKEN_HEADER_NAME, account.hostTokenMap.get(reqHostAndPort)).build();
             }
         }
+        return request;
+    }
 
-        final Function<HttpRequest, HttpRequest> redactToken = tokenAdded
-            ? req -> req.copy().setHeader(TOKEN_HEADER_NAME, WatcherXContentParser.REDACTED_PASSWORD).build()
-            : Function.identity();
-
-        if (ctx.simulateAction(actionId)) {
-            // Skip execution, return only the simulated (and redacted if necessary) response
-            return new WebhookAction.Result.Simulated(redactToken.apply(request));
-        }
-
-        HttpResponse response = httpClient.execute(request);
-
-        if (response.status() >= 400) {
-            return new WebhookAction.Result.Failure(redactToken.apply(request), response);
-        } else {
-            return new WebhookAction.Result.Success(redactToken.apply(request), response);
-        }
+    /**
+     * Executes the given {@link HttpRequest} after any necessary modifications.
+     * A tuple of the modified (or unmodified) {@link HttpRequest} and
+     * {@link HttpResponse} is returned.
+     */
+    public Tuple<HttpRequest, HttpResponse> modifyAndExecuteHttpRequest(HttpRequest request) throws IOException {
+        final HttpRequest modifiedRequest = maybeModifyHttpRequest(request);
+        final HttpResponse response = httpClient.execute(modifiedRequest);
+        logger.debug(
+            "executed watcher webhook request for {}://{}:{}, response code: {}",
+            modifiedRequest.scheme().scheme(),
+            modifiedRequest.host(),
+            modifiedRequest.port(),
+            response.status()
+        );
+        return Tuple.tuple(modifiedRequest, response);
     }
 
     public static final class WebhookAccount {

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/HttpEmailAttachementParser.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/notification/email/attachment/HttpEmailAttachementParser.java
@@ -14,11 +14,11 @@ import org.elasticsearch.xcontent.ParseField;
 import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xpack.core.watcher.execution.WatchExecutionContext;
 import org.elasticsearch.xpack.core.watcher.watch.Payload;
-import org.elasticsearch.xpack.watcher.common.http.HttpClient;
 import org.elasticsearch.xpack.watcher.common.http.HttpRequest;
 import org.elasticsearch.xpack.watcher.common.http.HttpRequestTemplate;
 import org.elasticsearch.xpack.watcher.common.http.HttpResponse;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 import org.elasticsearch.xpack.watcher.notification.email.Attachment;
 import org.elasticsearch.xpack.watcher.support.Variables;
 
@@ -34,11 +34,11 @@ public class HttpEmailAttachementParser implements EmailAttachmentParser<HttpReq
     }
 
     public static final String TYPE = "http";
-    private final HttpClient httpClient;
+    private final WebhookService webhookService;
     private final TextTemplateEngine templateEngine;
 
-    public HttpEmailAttachementParser(HttpClient httpClient, TextTemplateEngine templateEngine) {
-        this.httpClient = httpClient;
+    public HttpEmailAttachementParser(WebhookService webhookService, TextTemplateEngine templateEngine) {
+        this.webhookService = webhookService;
         this.templateEngine = templateEngine;
     }
 
@@ -82,7 +82,7 @@ public class HttpEmailAttachementParser implements EmailAttachmentParser<HttpReq
         Map<String, Object> model = Variables.createCtxParamsMap(context, payload);
         HttpRequest httpRequest = attachment.getRequestTemplate().render(templateEngine, model);
 
-        HttpResponse response = httpClient.execute(httpRequest);
+        HttpResponse response = webhookService.modifyAndExecuteHttpRequest(httpRequest).v2();
         // check for status 200, only then append attachment
         if (response.status() >= 200 && response.status() < 300) {
             if (response.hasContent()) {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/WebhookServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/WebhookServiceTests.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.watcher.notification;
+
+import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.MockSecureSettings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.watcher.common.http.HttpClient;
+import org.elasticsearch.xpack.watcher.common.http.HttpMethod;
+import org.elasticsearch.xpack.watcher.common.http.HttpRequest;
+import org.elasticsearch.xpack.watcher.common.http.HttpResponse;
+import org.elasticsearch.xpack.watcher.common.http.Scheme;
+
+import java.io.IOException;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class WebhookServiceTests extends ESTestCase {
+    public void testModifyRequest() throws IOException {
+        Settings.Builder builder = Settings.builder();
+        builder.put(WebhookService.SETTING_WEBHOOK_TOKEN_ENABLED.getKey(), true);
+        MockSecureSettings secureSettings = new MockSecureSettings();
+        secureSettings.setString(
+            WebhookService.SETTING_WEBHOOK_HOST_TOKEN_PAIRS.getKey(),
+            "host1.com:1234=token1234,host2.org:2345=token2345"
+        );
+        builder.setSecureSettings(secureSettings);
+        Settings finalSettings = builder.build();
+
+        HttpClient mockClient = mock(HttpClient.class);
+        WebhookService service = new WebhookService(
+            finalSettings,
+            mockClient,
+            new ClusterSettings(
+                finalSettings,
+                Set.of(WebhookService.SETTING_WEBHOOK_TOKEN_ENABLED, WebhookService.SETTING_WEBHOOK_HOST_TOKEN_PAIRS)
+            )
+        );
+
+        HttpRequest nonTokenReq = new HttpRequest(
+            "example.com",
+            80,
+            Scheme.HTTP,
+            HttpMethod.GET,
+            "/",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        HttpRequest host1Req = new HttpRequest(
+            "host1.com",
+            1234,
+            Scheme.HTTP,
+            HttpMethod.GET,
+            "/",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        HttpRequest host1WrongPortReq = new HttpRequest(
+            "host1.com",
+            3456,
+            Scheme.HTTP,
+            HttpMethod.GET,
+            "/",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+        HttpRequest host2Req = new HttpRequest(
+            "host2.org",
+            2345,
+            Scheme.HTTP,
+            HttpMethod.GET,
+            "/",
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        );
+
+        assertSame(service.maybeModifyHttpRequest(nonTokenReq), nonTokenReq);
+        assertSame(service.maybeModifyHttpRequest(host1WrongPortReq), host1WrongPortReq);
+        assertThat(service.maybeModifyHttpRequest(host2Req).headers().get(WebhookService.TOKEN_HEADER_NAME), equalTo("token2345"));
+
+        HttpRequest host1ModReq = service.maybeModifyHttpRequest(host1Req);
+        assertThat(host1ModReq.headers().get(WebhookService.TOKEN_HEADER_NAME), equalTo("token1234"));
+        when(mockClient.execute(any(HttpRequest.class))).thenReturn(new HttpResponse(200, "{}"));
+        service.modifyAndExecuteHttpRequest(host1Req);
+        verify(mockClient).execute(host1ModReq);
+    }
+}

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParserTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/notification/email/attachment/ReportingAttachmentParserTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.xpack.watcher.common.http.HttpRequest;
 import org.elasticsearch.xpack.watcher.common.http.HttpResponse;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplate;
 import org.elasticsearch.xpack.watcher.common.text.TextTemplateEngine;
+import org.elasticsearch.xpack.watcher.notification.WebhookService;
 import org.elasticsearch.xpack.watcher.notification.email.Attachment;
 import org.elasticsearch.xpack.watcher.notification.email.attachment.EmailAttachmentParser.EmailAttachment;
 import org.elasticsearch.xpack.watcher.test.MockTextTemplateEngine;
@@ -83,7 +84,8 @@ public class ReportingAttachmentParserTests extends ESTestCase {
     public void init() throws Exception {
         httpClient = mock(HttpClient.class);
         clusterSettings = mockClusterService().getClusterSettings();
-        reportingAttachmentParser = new ReportingAttachmentParser(Settings.EMPTY, httpClient, templateEngine, clusterSettings);
+        WebhookService webhookService = new WebhookService(Settings.EMPTY, httpClient, clusterSettings);
+        reportingAttachmentParser = new ReportingAttachmentParser(Settings.EMPTY, webhookService, templateEngine, clusterSettings);
         attachmentParsers.put(ReportingAttachmentParser.TYPE, reportingAttachmentParser);
         emailAttachmentsParser = new EmailAttachmentsParser(attachmentParsers);
     }
@@ -413,7 +415,12 @@ public class ReportingAttachmentParserTests extends ESTestCase {
 
         Settings settings = Settings.builder().put(INTERVAL_SETTING.getKey(), "1ms").put(RETRIES_SETTING.getKey(), retries).build();
 
-        reportingAttachmentParser = new ReportingAttachmentParser(settings, httpClient, templateEngine, clusterSettings);
+        reportingAttachmentParser = new ReportingAttachmentParser(
+            settings,
+            new WebhookService(settings, httpClient, clusterSettings),
+            templateEngine,
+            clusterSettings
+        );
         expectThrows(
             ElasticsearchException.class,
             () -> reportingAttachmentParser.toAttachment(createWatchExecutionContext(), Payload.EMPTY, attachment)
@@ -445,7 +452,7 @@ public class ReportingAttachmentParserTests extends ESTestCase {
         );
         reportingAttachmentParser = new ReportingAttachmentParser(
             Settings.EMPTY,
-            httpClient,
+            new WebhookService(Settings.EMPTY, httpClient, clusterSettings),
             replaceHttpWithHttpsTemplateEngine,
             clusterSettings
         );
@@ -468,7 +475,12 @@ public class ReportingAttachmentParserTests extends ESTestCase {
         Settings invalidSettings = Settings.builder().put("xpack.notification.reporting.retries", -10).build();
         e = expectThrows(
             IllegalArgumentException.class,
-            () -> new ReportingAttachmentParser(invalidSettings, httpClient, templateEngine, clusterSettings)
+            () -> new ReportingAttachmentParser(
+                invalidSettings,
+                new WebhookService(invalidSettings, httpClient, clusterSettings),
+                templateEngine,
+                clusterSettings
+            )
         );
         assertThat(e.getMessage(), is("Failed to parse value [-10] for setting [xpack.notification.reporting.retries] must be >= 0"));
     }


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix Watcher email actions not using WebhookService for HTTP requests (#95196)