### PR TITLE
Increase max number of vector dims to 2048

### DIFF
--- a/docs/changelog/95257.yaml
+++ b/docs/changelog/95257.yaml
@@ -1,0 +1,5 @@
+pr: 95257
+summary: Increase max number of vector dims to 2048
+area: Vector Search
+type: enhancement
+issues: []

--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -112,8 +112,7 @@ integer values between -128 to 127, inclusive for both indexing and searching.
 
 `dims`::
 (Required, integer)
-Number of vector dimensions. Can't exceed `1024` for indexed vectors
-(`"index": true`), or `2048` for non-indexed vectors.
+Number of vector dimensions. Can't exceed `2048`.
 
 `index`::
 (Optional, Boolean)

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapper.java
@@ -189,7 +189,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
             @Override
             KnnByteVectorField createKnnVectorField(String name, byte[] vector, VectorSimilarityFunction function) {
-                return new KnnByteVectorField(name, vector, function);
+                return new XKnnByteVectorField(name, vector, function);
             }
 
             @Override
@@ -374,7 +374,7 @@ public class DenseVectorFieldMapper extends FieldMapper {
 
             @Override
             KnnFloatVectorField createKnnVectorField(String name, float[] vector, VectorSimilarityFunction function) {
-                return new KnnFloatVectorField(name, vector, function);
+                return new XKnnFloatVectorField(name, vector, function);
             }
 
             @Override

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnByteVectorField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnByteVectorField.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+/**
+ * This class extends {@link org.apache.lucene.document.KnnByteVectorField}
+ * with a single goal to override the Lucene's limit of max vector dimensions,
+ * and set it to {@link org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMENSIONS}
+ */
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnByteVectorField;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+public class XKnnByteVectorField extends KnnByteVectorField {
+
+    private static FieldType createType(byte[] v, VectorSimilarityFunction similarityFunction) {
+        if (v == null) {
+            throw new IllegalArgumentException("vector value must not be null");
+        }
+        int dimension = v.length;
+        if (dimension == 0) {
+            throw new IllegalArgumentException("cannot index an empty vector");
+        }
+        if (dimension > DenseVectorFieldMapper.MAX_DIMS_COUNT) {
+            throw new IllegalArgumentException("cannot index vectors with dimension greater than " + DenseVectorFieldMapper.MAX_DIMS_COUNT);
+        }
+        if (similarityFunction == null) {
+            throw new IllegalArgumentException("similarity function must not be null");
+        }
+        FieldType type = new FieldType() {
+            @Override
+            public int vectorDimension() {
+                return dimension;
+            }
+
+            @Override
+            public VectorEncoding vectorEncoding() {
+                return VectorEncoding.BYTE;
+            }
+
+            @Override
+            public VectorSimilarityFunction vectorSimilarityFunction() {
+                return similarityFunction;
+            }
+        };
+        type.freeze();
+
+        return type;
+    }
+
+    public XKnnByteVectorField(String name, byte[] vector, VectorSimilarityFunction similarityFunction) {
+        super(name, vector, createType(vector, similarityFunction));
+    }
+
+    public XKnnByteVectorField(String name, byte[] vector) {
+        this(name, vector, VectorSimilarityFunction.EUCLIDEAN);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnFloatVectorField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnFloatVectorField.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.index.mapper.vectors;
+
+/**
+ * This class extends {@link org.apache.lucene.document.KnnFloatVectorField}
+ * with a single goal to override the Lucene's limit of max vector dimensions,
+ * and set it to {@link org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMENSIONS}
+ */
+
+import org.apache.lucene.document.FieldType;
+import org.apache.lucene.document.KnnFloatVectorField;
+import org.apache.lucene.index.VectorEncoding;
+import org.apache.lucene.index.VectorSimilarityFunction;
+
+public class XKnnFloatVectorField extends KnnFloatVectorField {
+    private static FieldType createType(float[] v, VectorSimilarityFunction similarityFunction) {
+        if (v == null) {
+            throw new IllegalArgumentException("vector value must not be null");
+        }
+        int dimension = v.length;
+        if (dimension == 0) {
+            throw new IllegalArgumentException("cannot index an empty vector");
+        }
+        if (dimension > DenseVectorFieldMapper.MAX_DIMS_COUNT) {
+            throw new IllegalArgumentException("cannot index vectors with dimension greater than " + DenseVectorFieldMapper.MAX_DIMS_COUNT);
+        }
+        if (similarityFunction == null) {
+            throw new IllegalArgumentException("similarity function must not be null");
+        }
+        FieldType type = new FieldType() {
+            @Override
+            public int vectorDimension() {
+                return dimension;
+            }
+
+            @Override
+            public VectorEncoding vectorEncoding() {
+                return VectorEncoding.FLOAT32;
+            }
+
+            @Override
+            public VectorSimilarityFunction vectorSimilarityFunction() {
+                return similarityFunction;
+            }
+        };
+        type.freeze();
+
+        return type;
+    }
+
+    public XKnnFloatVectorField(String name, float[] vector, VectorSimilarityFunction similarityFunction) {
+        super(name, vector, createType(vector, similarityFunction));
+    }
+
+    public XKnnFloatVectorField(String name, float[] vector) {
+        this(name, vector, VectorSimilarityFunction.EUCLIDEAN);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerTests.java
@@ -24,7 +24,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.LatLonShape;
 import org.apache.lucene.document.LongPoint;
 import org.apache.lucene.document.NumericDocValuesField;
@@ -67,6 +66,7 @@ import org.apache.lucene.util.BytesRef;
 import org.apache.lucene.util.FixedBitSet;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.mapper.vectors.XKnnFloatVectorField;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.index.store.LuceneFilesExtensions;
 import org.elasticsearch.test.ESTestCase;
@@ -257,7 +257,7 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
 
             indexRandomly(dir, codec, numDocs, doc -> {
                 float[] vector = randomVector(dimension);
-                doc.add(new KnnFloatVectorField("vector", vector, similarity));
+                doc.add(new XKnnFloatVectorField("vector", vector, similarity));
             });
             final IndexDiskUsageStats stats = IndexDiskUsageAnalyzer.analyze(testShardId(), lastCommit(dir), () -> {});
             logger.info("--> stats {}", stats);
@@ -520,7 +520,7 @@ public class IndexDiskUsageAnalyzerTests extends ESTestCase {
     static void addRandomKnnVectors(Document doc) {
         int numFields = randomFrom(1, 3);
         for (int f = 0; f < numFields; f++) {
-            doc.add(new KnnFloatVectorField("knnvector-" + f, randomVector(DEFAULT_VECTOR_DIMENSION)));
+            doc.add(new XKnnFloatVectorField("knnvector-" + f, randomVector(DEFAULT_VECTOR_DIMENSION)));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -14,9 +14,8 @@ import org.apache.lucene.codecs.Codec;
 import org.apache.lucene.codecs.KnnVectorsFormat;
 import org.apache.lucene.codecs.lucene95.Lucene95HnswVectorsFormat;
 import org.apache.lucene.document.BinaryDocValuesField;
-import org.apache.lucene.document.KnnByteVectorField;
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.IndexableField;
+import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.search.FieldExistsQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
@@ -233,9 +232,9 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
         assertEquals(1, fields.size());
-        assertThat(fields.get(0), instanceOf(KnnFloatVectorField.class));
+        assertThat(fields.get(0), instanceOf(XKnnFloatVectorField.class));
 
-        KnnFloatVectorField vectorField = (KnnFloatVectorField) fields.get(0);
+        XKnnFloatVectorField vectorField = (XKnnFloatVectorField) fields.get(0);
         assertArrayEquals("Parsed vector is not equal to original.", vector, vectorField.vectorValue(), 0.001f);
         assertEquals(similarity.function, vectorField.fieldType().vectorSimilarityFunction());
     }
@@ -257,9 +256,9 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
 
         List<IndexableField> fields = doc1.rootDoc().getFields("field");
         assertEquals(1, fields.size());
-        assertThat(fields.get(0), instanceOf(KnnByteVectorField.class));
+        assertThat(fields.get(0), instanceOf(XKnnByteVectorField.class));
 
-        KnnByteVectorField vectorField = (KnnByteVectorField) fields.get(0);
+        XKnnByteVectorField vectorField = (XKnnByteVectorField) fields.get(0);
         vectorField.vectorValue();
         assertArrayEquals(
             "Parsed vector is not equal to original.",
@@ -491,6 +490,67 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
                 containsString("has a different number of dimensions [2] than defined in the mapping [3]")
             );
         }
+    }
+
+    /**
+     * Test that max dimensions limit for float dense_vector field
+     * is 2048 as defined by {@link XKnnFloatVectorField}
+     */
+    public void testMaxDimsFloatVector() throws IOException {
+        final int dims = 2048;
+        VectorSimilarity similarity = VectorSimilarity.COSINE;
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(b -> b.field("type", "dense_vector").field("dims", dims).field("index", true).field("similarity", similarity))
+        );
+
+        float[] vector = new float[dims];
+        for (int i = 0; i < dims; i++) {
+            vector[i] = randomFloat();
+        }
+        ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", vector)));
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
+
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(XKnnFloatVectorField.class));
+        XKnnFloatVectorField vectorField = (XKnnFloatVectorField) fields.get(0);
+        assertEquals(dims, vectorField.fieldType().vectorDimension());
+        assertEquals(VectorEncoding.FLOAT32, vectorField.fieldType().vectorEncoding());
+        assertEquals(similarity.function, vectorField.fieldType().vectorSimilarityFunction());
+        assertArrayEquals("Parsed vector is not equal to original.", vector, vectorField.vectorValue(), 0.001f);
+    }
+
+    /**
+     * Test that max dimensions limit for byte dense_vector field
+     * is 2048 as defined by {@link XKnnByteVectorField}
+     */
+    public void testMaxDimsByteVector() throws IOException {
+        final int dims = 2048;
+        VectorSimilarity similarity = VectorSimilarity.COSINE;
+        ;
+        DocumentMapper mapper = createDocumentMapper(
+            fieldMapping(
+                b -> b.field("type", "dense_vector")
+                    .field("dims", dims)
+                    .field("index", true)
+                    .field("similarity", similarity)
+                    .field("element_type", "byte")
+            )
+        );
+
+        byte[] vector = new byte[dims];
+        for (int i = 0; i < dims; i++) {
+            vector[i] = randomByte();
+        }
+        ParsedDocument doc1 = mapper.parse(source(b -> b.array("field", vector)));
+        List<IndexableField> fields = doc1.rootDoc().getFields("field");
+
+        assertEquals(1, fields.size());
+        assertThat(fields.get(0), instanceOf(XKnnByteVectorField.class));
+        XKnnByteVectorField vectorField = (XKnnByteVectorField) fields.get(0);
+        assertEquals(dims, vectorField.fieldType().vectorDimension());
+        assertEquals(VectorEncoding.BYTE, vectorField.fieldType().vectorEncoding());
+        assertEquals(similarity.function, vectorField.fieldType().vectorSimilarityFunction());
+        assertArrayEquals("Parsed vector is not equal to original.", vector, vectorField.vectorValue());
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldMapperTests.java
@@ -177,9 +177,25 @@ public class DenseVectorFieldMapperTests extends MapperTestCase {
                 )
             );
         }
+        // test max limit for non-indexed vectors
         {
             Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
                 b.field("type", "dense_vector");
+                b.field("dims", 3000);
+            })));
+            assertThat(
+                e.getMessage(),
+                equalTo(
+                    "Failed to parse mapping: "
+                        + "The number of dimensions for field [field] should be in the range [1, 2048] but was [3000]"
+                )
+            );
+        }
+        // test max limit for indexed vectors
+        {
+            Exception e = expectThrows(MapperParsingException.class, () -> createMapperService(fieldMapping(b -> {
+                b.field("type", "dense_vector");
+                b.field("index", "true");
                 b.field("dims", 3000);
             })));
             assertThat(

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -8,6 +8,9 @@
 
 package org.elasticsearch.index.mapper.vectors;
 
+import org.apache.lucene.search.KnnByteVectorQuery;
+import org.apache.lucene.search.KnnFloatVectorQuery;
+import org.apache.lucene.search.Query;
 import org.elasticsearch.Version;
 import org.elasticsearch.index.fielddata.FieldDataContext;
 import org.elasticsearch.index.mapper.FieldTypeTestCase;
@@ -21,6 +24,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
 
 public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
     private final boolean indexed;
@@ -151,6 +155,22 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             () -> cosineField.createKnnQuery(new float[] { 0.0f, 0.0f, 0.0f }, 10, null, null)
         );
         assertThat(e.getMessage(), containsString("The [cosine] similarity does not support vectors with zero magnitude."));
+
+        DenseVectorFieldType fieldWith2048dims = new DenseVectorFieldType(
+            "f",
+            Version.CURRENT,
+            DenseVectorFieldMapper.ElementType.FLOAT,
+            2048,
+            true,
+            VectorSimilarity.COSINE,
+            Collections.emptyMap()
+        );
+        float[] queryVector = new float[2048];
+        for (int i = 0; i < 2048; i++) {
+            queryVector[i] = randomFloat();
+        }
+        Query query = fieldWith2048dims.createKnnQuery(queryVector, 10, null, null);
+        assertThat(query, instanceOf(KnnFloatVectorQuery.class));
     }
 
     public void testByteCreateKnnQuery() {
@@ -186,5 +206,21 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
 
         e = expectThrows(IllegalArgumentException.class, () -> cosineField.createKnnQuery(new byte[] { 0, 0, 0 }, 10, null, null));
         assertThat(e.getMessage(), containsString("The [cosine] similarity does not support vectors with zero magnitude."));
+
+        DenseVectorFieldType fieldWith2048dims = new DenseVectorFieldType(
+            "f",
+            Version.CURRENT,
+            DenseVectorFieldMapper.ElementType.BYTE,
+            2048,
+            true,
+            VectorSimilarity.COSINE,
+            Collections.emptyMap()
+        );
+        byte[] queryVector = new byte[2048];
+        for (int i = 0; i < 2048; i++) {
+            queryVector[i] = randomByte();
+        }
+        Query query = fieldWith2048dims.createKnnQuery(queryVector, 10, null, null);
+        assertThat(query, instanceOf(KnnByteVectorQuery.class));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/vectors/DenseVectorFieldTypeTests.java
@@ -155,22 +155,44 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
             () -> cosineField.createKnnQuery(new float[] { 0.0f, 0.0f, 0.0f }, 10, null, null)
         );
         assertThat(e.getMessage(), containsString("The [cosine] similarity does not support vectors with zero magnitude."));
+    }
 
-        DenseVectorFieldType fieldWith2048dims = new DenseVectorFieldType(
-            "f",
-            Version.CURRENT,
-            DenseVectorFieldMapper.ElementType.FLOAT,
-            2048,
-            true,
-            VectorSimilarity.COSINE,
-            Collections.emptyMap()
-        );
-        float[] queryVector = new float[2048];
-        for (int i = 0; i < 2048; i++) {
-            queryVector[i] = randomFloat();
+    public void testCreateKnnQueryMaxDims() {
+        {   // float type with 2048 dims
+            DenseVectorFieldType fieldWith2048dims = new DenseVectorFieldType(
+                "f",
+                Version.CURRENT,
+                DenseVectorFieldMapper.ElementType.FLOAT,
+                2048,
+                true,
+                VectorSimilarity.COSINE,
+                Collections.emptyMap()
+            );
+            float[] queryVector = new float[2048];
+            for (int i = 0; i < 2048; i++) {
+                queryVector[i] = randomFloat();
+            }
+            Query query = fieldWith2048dims.createKnnQuery(queryVector, 10, null, null);
+            assertThat(query, instanceOf(KnnFloatVectorQuery.class));
         }
-        Query query = fieldWith2048dims.createKnnQuery(queryVector, 10, null, null);
-        assertThat(query, instanceOf(KnnFloatVectorQuery.class));
+
+        {   // byte type with 2048 dims
+            DenseVectorFieldType fieldWith2048dims = new DenseVectorFieldType(
+                "f",
+                Version.CURRENT,
+                DenseVectorFieldMapper.ElementType.BYTE,
+                2048,
+                true,
+                VectorSimilarity.COSINE,
+                Collections.emptyMap()
+            );
+            byte[] queryVector = new byte[2048];
+            for (int i = 0; i < 2048; i++) {
+                queryVector[i] = randomByte();
+            }
+            Query query = fieldWith2048dims.createKnnQuery(queryVector, 10, null, null);
+            assertThat(query, instanceOf(KnnByteVectorQuery.class));
+        }
     }
 
     public void testByteCreateKnnQuery() {
@@ -206,21 +228,5 @@ public class DenseVectorFieldTypeTests extends FieldTypeTestCase {
 
         e = expectThrows(IllegalArgumentException.class, () -> cosineField.createKnnQuery(new byte[] { 0, 0, 0 }, 10, null, null));
         assertThat(e.getMessage(), containsString("The [cosine] similarity does not support vectors with zero magnitude."));
-
-        DenseVectorFieldType fieldWith2048dims = new DenseVectorFieldType(
-            "f",
-            Version.CURRENT,
-            DenseVectorFieldMapper.ElementType.BYTE,
-            2048,
-            true,
-            VectorSimilarity.COSINE,
-            Collections.emptyMap()
-        );
-        byte[] queryVector = new byte[2048];
-        for (int i = 0; i < 2048; i++) {
-            queryVector[i] = randomByte();
-        }
-        Query query = fieldWith2048dims.createKnnQuery(queryVector, 10, null, null);
-        assertThat(query, instanceOf(KnnByteVectorQuery.class));
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/SearchCancellationTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchCancellationTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.StringField;
 import org.apache.lucene.index.FloatVectorValues;
 import org.apache.lucene.index.IndexReader;
@@ -28,6 +27,7 @@ import org.apache.lucene.tests.util.TestUtil;
 import org.apache.lucene.util.automaton.CompiledAutomaton;
 import org.apache.lucene.util.automaton.RegExp;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.index.mapper.vectors.XKnnFloatVectorField;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.test.ESTestCase;
@@ -67,7 +67,7 @@ public class SearchCancellationTests extends ESTestCase {
             Document doc = new Document();
             doc.add(new StringField(STRING_FIELD_NAME, "a".repeat(i), Field.Store.NO));
             doc.add(new IntPoint(POINT_FIELD_NAME, i, i + 1));
-            doc.add(new KnnFloatVectorField(KNN_FIELD_NAME, new float[] { 1.0f, 0.5f, 42.0f }));
+            doc.add(new XKnnFloatVectorField(KNN_FIELD_NAME, new float[] { 1.0f, 0.5f, 42.0f }));
             w.addDocument(doc);
         }
     }

--- a/server/src/test/java/org/elasticsearch/search/vectors/VectorSimilarityQueryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/vectors/VectorSimilarityQueryTests.java
@@ -25,6 +25,7 @@ import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.Weight;
 import org.apache.lucene.store.Directory;
 import org.elasticsearch.common.lucene.LuceneTests;
+import org.elasticsearch.index.mapper.vectors.XKnnFloatVectorField;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -40,7 +41,7 @@ public class VectorSimilarityQueryTests extends ESTestCase {
         try (Directory d = newDirectory()) {
             try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
                 Document document = new Document();
-                KnnFloatVectorField vectorField = new KnnFloatVectorField("float_vector", new float[] { 1, 1, 1 });
+                KnnFloatVectorField vectorField = new XKnnFloatVectorField("float_vector", new float[] { 1, 1, 1 });
                 document.add(vectorField);
                 w.addDocument(document);
                 vectorField.setVectorValue(new float[] { 2, 1, 1 });
@@ -81,7 +82,7 @@ public class VectorSimilarityQueryTests extends ESTestCase {
         Supplier<float[]> vectorValue = () -> new float[] { randomFloat(), randomFloat(), randomFloat(), randomFloat() };
         try (Directory d = newDirectory()) {
             try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
-                KnnFloatVectorField vectorField = new KnnFloatVectorField(fieldName, vectorValue.get());
+                KnnFloatVectorField vectorField = new XKnnFloatVectorField(fieldName, vectorValue.get());
                 Document document = new Document();
                 document.add(vectorField);
                 for (int i = 0; i < n; i++) {
@@ -112,7 +113,7 @@ public class VectorSimilarityQueryTests extends ESTestCase {
         try (Directory d = newDirectory()) {
             try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
                 Document document = new Document();
-                KnnFloatVectorField vectorField = new KnnFloatVectorField(
+                KnnFloatVectorField vectorField = new XKnnFloatVectorField(
                     "float_vector",
                     new float[] { 1, 1, 1 },
                     VectorSimilarityFunction.COSINE
@@ -157,7 +158,7 @@ public class VectorSimilarityQueryTests extends ESTestCase {
         Supplier<float[]> vectorValue = () -> new float[] { randomFloat(), randomFloat(), randomFloat(), randomFloat() };
         try (Directory d = newDirectory()) {
             try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
-                KnnFloatVectorField vectorField = new KnnFloatVectorField(fieldName, vectorValue.get(), VectorSimilarityFunction.COSINE);
+                KnnFloatVectorField vectorField = new XKnnFloatVectorField(fieldName, vectorValue.get(), VectorSimilarityFunction.COSINE);
                 Document document = new Document();
                 document.add(vectorField);
                 for (int i = 0; i < n; i++) {
@@ -191,7 +192,7 @@ public class VectorSimilarityQueryTests extends ESTestCase {
         try (Directory d = newDirectory()) {
             try (IndexWriter w = new IndexWriter(d, new IndexWriterConfig())) {
                 Document document = new Document();
-                KnnFloatVectorField vectorField = new KnnFloatVectorField("float_vector", new float[] { 1, 1, 1 });
+                KnnFloatVectorField vectorField = new XKnnFloatVectorField("float_vector", new float[] { 1, 1, 1 });
                 document.add(vectorField);
                 w.addDocument(document);
                 vectorField.setVectorValue(new float[] { 2, 1, 1 });

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/FieldSubsetReaderTests.java
@@ -11,8 +11,6 @@ import org.apache.lucene.document.Document;
 import org.apache.lucene.document.Field;
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.IntPoint;
-import org.apache.lucene.document.KnnByteVectorField;
-import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.document.NumericDocValuesField;
 import org.apache.lucene.document.SortedDocValuesField;
 import org.apache.lucene.document.SortedNumericDocValuesField;
@@ -64,6 +62,8 @@ import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.index.mapper.FieldNamesFieldMapper;
 import org.elasticsearch.index.mapper.SourceFieldMapper;
+import org.elasticsearch.index.mapper.vectors.XKnnByteVectorField;
+import org.elasticsearch.index.mapper.vectors.XKnnFloatVectorField;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.security.authz.permission.FieldPermissions;
@@ -189,8 +189,8 @@ public class FieldSubsetReaderTests extends ESTestCase {
         IndexWriter iw = new IndexWriter(dir, iwc);
 
         Document doc = new Document();
-        doc.add(new KnnFloatVectorField("fieldA", new float[] { 0.1f, 0.2f, 0.3f }));
-        doc.add(new KnnFloatVectorField("fieldB", new float[] { 3.0f, 2.0f, 1.0f }));
+        doc.add(new XKnnFloatVectorField("fieldA", new float[] { 0.1f, 0.2f, 0.3f }));
+        doc.add(new XKnnFloatVectorField("fieldB", new float[] { 3.0f, 2.0f, 1.0f }));
         iw.addDocument(doc);
 
         DirectoryReader ir = FieldSubsetReader.wrap(DirectoryReader.open(iw), new CharacterRunAutomaton(Automata.makeString("fieldA")));
@@ -221,8 +221,8 @@ public class FieldSubsetReaderTests extends ESTestCase {
         IndexWriter iw = new IndexWriter(dir, iwc);
 
         Document doc = new Document();
-        doc.add(new KnnByteVectorField("fieldA", new byte[] { 1, 2, 3 }));
-        doc.add(new KnnByteVectorField("fieldB", new byte[] { 3, 2, 1 }));
+        doc.add(new XKnnByteVectorField("fieldA", new byte[] { 1, 2, 3 }));
+        doc.add(new XKnnByteVectorField("fieldB", new byte[] { 3, 2, 1 }));
         iw.addDocument(doc);
 
         DirectoryReader ir = FieldSubsetReader.wrap(DirectoryReader.open(iw), new CharacterRunAutomaton(Automata.makeString("fieldA")));


### PR DESCRIPTION
Currently Lucene limits the max number of vector dimensions to 1024. 
This commit overrides KnnFloatVectorField and KnnByteVectorField 
classes to increase the limit to 2048 for indexed vectors in ES.