### PR TITLE
[ML] Remove default model name from Text Expansion Query

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilder.java
@@ -41,8 +41,6 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
     public static final ParseField MODEL_TEXT = new ParseField("model_text");
     public static final ParseField MODEL_ID = new ParseField("model_id");
 
-    private static final String DEFAULT_MODEL_ID = "slim";
-
     private final String fieldName;
     private final String modelText;
     private final String modelId;
@@ -55,10 +53,13 @@ public class TextExpansionQueryBuilder extends AbstractQueryBuilder<TextExpansio
         if (modelText == null) {
             throw new IllegalArgumentException("[" + NAME + "] requires a " + MODEL_TEXT.getPreferredName() + " value");
         }
+        if (modelId == null) {
+            throw new IllegalArgumentException("[" + NAME + "] requires a " + MODEL_ID.getPreferredName() + " value");
+        }
 
         this.fieldName = fieldName;
         this.modelText = modelText;
-        this.modelId = modelId == null ? DEFAULT_MODEL_ID : modelId;
+        this.modelId = modelId;
     }
 
     public TextExpansionQueryBuilder(StreamInput in) throws IOException {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/queries/TextExpansionQueryBuilderTests.java
@@ -45,11 +45,7 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
 
     @Override
     protected TextExpansionQueryBuilder doCreateTestQueryBuilder() {
-        var builder = new TextExpansionQueryBuilder(
-            RANK_FEATURES_FIELD,
-            randomAlphaOfLength(4),
-            randomBoolean() ? null : randomAlphaOfLength(4)
-        );
+        var builder = new TextExpansionQueryBuilder(RANK_FEATURES_FIELD, randomAlphaOfLength(4), randomAlphaOfLength(4));
         if (randomBoolean()) {
             builder.boost((float) randomDoubleBetween(0.1, 10.0, true));
         }
@@ -129,27 +125,34 @@ public class TextExpansionQueryBuilderTests extends AbstractQueryTestCase<TextEx
         {
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> new TextExpansionQueryBuilder(null, "model text", null)
+                () -> new TextExpansionQueryBuilder(null, "model text", "model id")
             );
             assertEquals("[text_expansion] requires a fieldName", e.getMessage());
         }
         {
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> new TextExpansionQueryBuilder("field name", null, null)
+                () -> new TextExpansionQueryBuilder("field name", null, "model id")
             );
             assertEquals("[text_expansion] requires a model_text value", e.getMessage());
         }
+        {
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> new TextExpansionQueryBuilder("field name", "model text", null)
+            );
+            assertEquals("[text_expansion] requires a model_id value", e.getMessage());
+        }
     }
 
-    public void testToXContentWithDefaults() throws IOException {
-        QueryBuilder query = new TextExpansionQueryBuilder("foo", "bar", null);
+    public void testToXContent() throws IOException {
+        QueryBuilder query = new TextExpansionQueryBuilder("foo", "bar", "baz");
         checkGeneratedJson("""
             {
               "text_expansion": {
                 "foo": {
                   "model_text": "bar",
-                  "model_id": "slim"
+                  "model_id": "baz"
                 }
               }
             }""", query);


### PR DESCRIPTION
This change makes `model_id` is required field for the query