### PR TITLE
[ML] Increase timeout for stopping DFA in tests

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
+++ b/x-pack/qa/rolling-upgrade/src/test/resources/rest-api-spec/test/mixed_cluster/90_ml_data_frame_analytics_crud.yml
@@ -37,6 +37,7 @@
   - do:
       ml.stop_data_frame_analytics:
         id: "old_cluster_outlier_detection_job"
+        timeout: "60s"
   - match: { stopped: true }
 
   - do:
@@ -82,6 +83,7 @@
   - do:
       ml.stop_data_frame_analytics:
         id: "old_cluster_regression_job"
+        timeout: "60s"
   - match: { stopped: true }
 
   - do:
@@ -158,6 +160,7 @@
   - do:
       ml.stop_data_frame_analytics:
         id: "mixed_cluster_outlier_detection_job"
+        timeout: "60s"
   - match: { stopped: true }
 
   - do:


### PR DESCRIPTION
Fixes the timeout failure as reported in #95195.
The default timeout is 30 seconds, this increases it to 60.

Closes #95195