### PR TITLE
Use java.util.Objects index bounds checks in a few spots

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesReferenceStreamInput.java
@@ -15,6 +15,7 @@ import org.elasticsearch.common.io.stream.StreamInput;
 import java.io.EOFException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 /**
  * A StreamInput that reads off a {@link BytesRefIterator}. This is used to provide
@@ -201,17 +202,9 @@ class BytesReferenceStreamInput extends StreamInput {
 
     @Override
     public void readBytes(byte[] b, int bOffset, int len) throws IOException {
-        final int length = bytesReference.length();
-        final int offset = offset();
-        if (offset + len > length) {
-            throwIndexOutOfBounds(len, length, offset);
-        }
+        Objects.checkFromIndexSize(offset(), len, bytesReference.length());
         final int bytesRead = read(b, bOffset, len);
         assert bytesRead == len : bytesRead + " vs " + len;
-    }
-
-    private static void throwIndexOutOfBounds(int len, int length, int offset) {
-        throw new IndexOutOfBoundsException("Cannot read " + len + " bytes from stream with length " + length + " at offset " + offset);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/BytesStreamOutput.java
@@ -19,6 +19,7 @@ import org.elasticsearch.core.Nullable;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.util.Objects;
 
 /**
  * A @link {@link StreamOutput} that uses {@link BigArrays} to acquire pages of
@@ -77,10 +78,7 @@ public class BytesStreamOutput extends BytesStream {
             return;
         }
 
-        // illegal args: offset and/or length exceed array size
-        if (b.length < (offset + length)) {
-            throw new IllegalArgumentException("Illegal offset " + offset + "/length " + length + " for byte[] of length " + b.length);
-        }
+        Objects.checkFromIndexSize(offset, length, b.length);
 
         // get enough pages for new size
         ensureCapacity(((long) count) + length);

--- a/server/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/InputStreamStreamInput.java
@@ -13,6 +13,7 @@ import org.elasticsearch.core.Streams;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 public class InputStreamStreamInput extends StreamInput {
 
@@ -50,7 +51,7 @@ public class InputStreamStreamInput extends StreamInput {
 
     @Override
     public void readBytes(byte[] b, int offset, int len) throws IOException {
-        if (len < 0) throw new IndexOutOfBoundsException();
+        Objects.checkFromIndexSize(offset, len, b.length);
         final int read = Streams.readFully(is, b, offset, len);
         if (read != len) {
             throw new EOFException();

--- a/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutput.java
@@ -22,6 +22,7 @@ import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
+import java.util.Objects;
 
 /**
  * A @link {@link StreamOutput} that uses {@link Recycler.V<BytesRef>} to acquire pages of bytes, which
@@ -68,10 +69,7 @@ public class RecyclerBytesStreamOutput extends BytesStream implements Releasable
             return;
         }
 
-        // illegal args: offset and/or length exceed array size
-        if (b.length < (offset + length)) {
-            throw new IllegalArgumentException("Illegal offset " + offset + "/length " + length + " for byte[] of length " + b.length);
-        }
+        Objects.checkFromIndexSize(offset, length, b.length);
 
         // get enough pages for new size
         ensureCapacity(length);

--- a/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/Lucene.java
@@ -84,6 +84,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 public class Lucene {
     public static final String LATEST_CODEC = "Lucene95";
@@ -772,9 +773,7 @@ public class Lucene {
 
             @Override
             public boolean get(int index) {
-                if (index < 0 || index >= maxDoc) {
-                    throw new IndexOutOfBoundsException(index + " is out of bounds: [" + 0 + "-" + maxDoc + "[");
-                }
+                Objects.checkIndex(index, maxDoc);
                 if (index < previous) {
                     throw new IllegalArgumentException(
                         "This Bits instance can only be consumed in order. "

--- a/server/src/main/java/org/elasticsearch/common/lucene/store/InputStreamIndexInput.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/store/InputStreamIndexInput.java
@@ -12,6 +12,7 @@ import org.apache.lucene.store.IndexInput;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Objects;
 
 public class InputStreamIndexInput extends InputStream {
 
@@ -40,9 +41,8 @@ public class InputStreamIndexInput extends InputStream {
     public int read(byte[] b, int off, int len) throws IOException {
         if (b == null) {
             throw new NullPointerException();
-        } else if (off < 0 || len < 0 || len > b.length - off) {
-            throw new IndexOutOfBoundsException();
         }
+        Objects.checkFromIndexSize(off, len, b.length);
         if (len == 0) {
             return 0;
         }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -98,7 +98,7 @@ public class BytesStreamsTests extends ESTestCase {
         BytesStreamOutput out = new BytesStreamOutput();
 
         // bulk-write with wrong args
-        expectThrows(IllegalArgumentException.class, () -> out.writeBytes(new byte[] {}, 0, 1));
+        expectThrows(IndexOutOfBoundsException.class, () -> out.writeBytes(new byte[] {}, 0, 1));
         out.close();
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -107,7 +107,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
         RecyclerBytesStreamOutput out = new RecyclerBytesStreamOutput(recycler);
 
         // bulk-write with wrong args
-        expectThrows(IllegalArgumentException.class, () -> out.writeBytes(new byte[] {}, 0, 1));
+        expectThrows(IndexOutOfBoundsException.class, () -> out.writeBytes(new byte[] {}, 0, 1));
         out.close();
     }
 


### PR DESCRIPTION
Follow-up to the back and forth in https://github.com/elastic/elasticsearch/pull/95133 and friends to make debugging easier going forward ... just nice to have the negative offset check for free :)

Our home-brew checks in some of these spots are more lenient and likely also slower (due to code size and the fact that some of them are intrinsified) than those provided by `java.util.Objects`.