### PR TITLE
Dry up AbstractBytesReference.length implementations

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/AbstractBytesReference.java
@@ -18,8 +18,19 @@ import java.util.function.ToIntBiFunction;
 
 public abstract class AbstractBytesReference implements BytesReference {
 
+    protected final int length;
+
     private int hash;           // we cache the hash of this reference since it can be quite costly to re-calculated it
     private boolean hashIsZero; // if the calculated hash is actually zero
+
+    protected AbstractBytesReference(int length) {
+        this.length = length;
+    }
+
+    @Override
+    public final int length() {
+        return length;
+    }
 
     @Override
     public int getInt(int index) {

--- a/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/BytesArray.java
@@ -22,7 +22,6 @@ public final class BytesArray extends AbstractBytesReference {
     public static final BytesArray EMPTY = new BytesArray(BytesRef.EMPTY_BYTES, 0, 0);
     private final byte[] bytes;
     private final int offset;
-    private final int length;
 
     public BytesArray(String bytes) {
         this(new BytesRef(bytes));
@@ -33,12 +32,12 @@ public final class BytesArray extends AbstractBytesReference {
     }
 
     public BytesArray(BytesRef bytesRef, boolean deepCopy) {
+        super(bytesRef.length);
         if (deepCopy) {
             bytesRef = BytesRef.deepCopyOf(bytesRef);
         }
         bytes = bytesRef.bytes;
         offset = bytesRef.offset;
-        length = bytesRef.length;
     }
 
     public BytesArray(byte[] bytes) {
@@ -46,9 +45,9 @@ public final class BytesArray extends AbstractBytesReference {
     }
 
     public BytesArray(byte[] bytes, int offset, int length) {
+        super(length);
         this.bytes = bytes;
         this.offset = offset;
-        this.length = length;
     }
 
     @Override
@@ -64,11 +63,6 @@ public final class BytesArray extends AbstractBytesReference {
             }
         }
         return -1;
-    }
-
-    @Override
-    public int length() {
-        return length;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/CompositeBytesReference.java
@@ -29,7 +29,6 @@ public final class CompositeBytesReference extends AbstractBytesReference {
 
     private final BytesReference[] references;
     private final int[] offsets; // we use the offsets to seek into the right BytesReference for random access and slicing
-    private final int length;
     private final long ramBytesUsed;
 
     public static BytesReference of(BytesReference... references) {
@@ -87,6 +86,7 @@ public final class CompositeBytesReference extends AbstractBytesReference {
     }
 
     private CompositeBytesReference(BytesReference[] references, int[] offsets, int length, long ramBytesUsed) {
+        super(length);
         assert references != null && offsets != null;
         assert references.length > 1
             : "Should not build composite reference from less than two references but received [" + references.length + "]";
@@ -97,7 +97,6 @@ public final class CompositeBytesReference extends AbstractBytesReference {
         assert ramBytesUsed > Arrays.stream(references).mapToLong(BytesReference::ramBytesUsed).sum();
         this.references = Objects.requireNonNull(references, "references must not be null");
         this.offsets = offsets;
-        this.length = length;
         this.ramBytesUsed = ramBytesUsed;
     }
 
@@ -133,11 +132,6 @@ public final class CompositeBytesReference extends AbstractBytesReference {
             }
         }
         return result;
-    }
-
-    @Override
-    public int length() {
-        return length;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
+++ b/server/src/main/java/org/elasticsearch/common/bytes/PagedBytesReference.java
@@ -26,23 +26,17 @@ public class PagedBytesReference extends AbstractBytesReference {
 
     private final ByteArray byteArray;
     private final int offset;
-    private final int length;
 
     PagedBytesReference(ByteArray byteArray, int from, int length) {
+        super(length);
         assert byteArray.hasArray() == false : "use BytesReference#fromByteArray";
         this.byteArray = byteArray;
         this.offset = from;
-        this.length = length;
     }
 
     @Override
     public byte get(int index) {
         return byteArray.get(offset + index);
-    }
-
-    @Override
-    public int length() {
-        return length;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
+++ b/server/src/test/java/org/elasticsearch/common/bytes/ZeroBytesReference.java
@@ -17,11 +17,9 @@ import org.elasticsearch.common.util.PageCacheRecycler;
  */
 public class ZeroBytesReference extends AbstractBytesReference {
 
-    private final int length;
-
     public ZeroBytesReference(int length) {
+        super(length);
         assert 0 <= length : length;
-        this.length = length;
     }
 
     @Override
@@ -38,11 +36,6 @@ public class ZeroBytesReference extends AbstractBytesReference {
     public byte get(int index) {
         assert 0 <= index && index < length : index + " vs " + length;
         return 0;
-    }
-
-    @Override
-    public int length() {
-        return length;
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndicesRequestCacheTests.java
@@ -567,6 +567,7 @@ public class IndicesRequestCacheTests extends ESTestCase {
         int dummyValue;
 
         TestBytesReference(int dummyValue) {
+            super(0);
             this.dummyValue = dummyValue;
         }
 
@@ -584,11 +585,6 @@ public class IndicesRequestCacheTests extends ESTestCase {
 
         @Override
         public byte get(int index) {
-            return 0;
-        }
-
-        @Override
-        public int length() {
             return 0;
         }
 

--- a/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReference.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/main/java/org/elasticsearch/repositories/blobstore/testkit/RandomBlobContentBytesReference.java
@@ -17,7 +17,6 @@ import org.elasticsearch.common.bytes.BytesReference;
  */
 class RandomBlobContentBytesReference extends AbstractBytesReference {
 
-    private final int length;
     private final RandomBlobContent randomBlobContent;
 
     /**
@@ -25,19 +24,14 @@ class RandomBlobContentBytesReference extends AbstractBytesReference {
      * @param length            The length of this blob.
      */
     RandomBlobContentBytesReference(RandomBlobContent randomBlobContent, int length) {
+        super(length);
         assert 0 < length;
         this.randomBlobContent = randomBlobContent;
-        this.length = length;
     }
 
     @Override
     public byte get(int index) {
         return randomBlobContent.buffer[index % randomBlobContent.buffer.length];
-    }
-
-    @Override
-    public int length() {
-        return length;
     }
 
     @Override


### PR DESCRIPTION
All the length implementations are the same so we can dry this up which might provide a speedup here and there since it gets us down to only two possible implementations of `BytesReference.length()` (releasable and normal ref) which should inline in most places.
