### PR TITLE
Remove unused deprecation logger.

### DIFF
--- a/docs/changelog/95290.yaml
+++ b/docs/changelog/95290.yaml
@@ -1,5 +1,0 @@
-pr: 95290
-summary: Remove unused deprecation logger in rest multi search action.
-area: Search
-type: Non-Issue
-issues: []

--- a/docs/changelog/95290.yaml
+++ b/docs/changelog/95290.yaml
@@ -1,0 +1,5 @@
+pr: 95290
+summary: Remove unused deprecation logger in rest multi search action.
+area: Search
+type: Non-Issue
+issues: []

--- a/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/search/RestMultiSearchAction.java
@@ -18,7 +18,6 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
-import org.elasticsearch.common.logging.DeprecationLogger;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.core.Tuple;
@@ -43,7 +42,6 @@ import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestMultiSearchAction extends BaseRestHandler {
-    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(RestSearchAction.class);
     public static final String TYPES_DEPRECATION_MESSAGE = "[types removal]"
         + " Specifying types in multi search template requests is deprecated.";
 


### PR DESCRIPTION
It's introduced in https://github.com/elastic/elasticsearch/pull/72155.
And also the target logger class `RestSearchAction` is incorrect. So remove this unused deprecation logger directly.
