### PR TITLE
Better caching of parsers in `DateProcessor`

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateProcessor.java
@@ -81,11 +81,11 @@ public final class DateProcessor extends AbstractProcessor {
         for (String format : formats) {
             DateFormat dateFormat = DateFormat.fromString(format);
             dateParsers.add((params) -> {
-                var documentZoneId = newDateTimeZone(params);
-                var documentLocale = newLocale(params);
+                var documentTimezone = timezone == null ? null : timezone.newInstance(params).execute();
+                var documentLocale = locale == null ? null : locale.newInstance(params).execute();
                 return Cache.INSTANCE.getOrCompute(
-                    new Cache.Key(format, documentZoneId, documentLocale),
-                    () -> dateFormat.getFunction(format, documentZoneId, documentLocale)
+                    new Cache.Key(format, documentTimezone, documentLocale),
+                    () -> dateFormat.getFunction(format, newDateTimeZone(documentTimezone), newLocale(documentLocale))
                 );
             });
         }
@@ -93,12 +93,12 @@ public final class DateProcessor extends AbstractProcessor {
         formatter = DateFormatter.forPattern(this.outputFormat);
     }
 
-    private ZoneId newDateTimeZone(Map<String, Object> params) {
-        return timezone == null ? ZoneOffset.UTC : ZoneId.of(timezone.newInstance(params).execute());
+    private static ZoneId newDateTimeZone(String timezone) {
+        return timezone == null ? ZoneOffset.UTC : ZoneId.of(timezone);
     }
 
-    private Locale newLocale(Map<String, Object> params) {
-        return locale == null ? Locale.ROOT : LocaleUtils.parse(locale.newInstance(params).execute());
+    private static Locale newLocale(String locale) {
+        return locale == null ? Locale.ROOT : LocaleUtils.parse(locale);
     }
 
     @Override
@@ -255,6 +255,6 @@ public final class DateProcessor extends AbstractProcessor {
             return fn;
         }
 
-        record Key(String format, ZoneId zoneId, Locale locale) {}
+        record Key(String format, String zoneId, String locale) {}
     }
 }

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -349,8 +349,8 @@ public class DateProcessorTests extends ESTestCase {
         Function<String, ZonedDateTime> zonedDateTimeFunction1 = str -> ZonedDateTime.now();
         Function<String, ZonedDateTime> zonedDateTimeFunction2 = str -> ZonedDateTime.now();
         var cache = new DateProcessor.Cache(1);
-        var key1 = new DateProcessor.Cache.Key("format-1", ZoneId.systemDefault(), Locale.ROOT);
-        var key2 = new DateProcessor.Cache.Key("format-2", ZoneId.systemDefault(), Locale.ROOT);
+        var key1 = new DateProcessor.Cache.Key("format-1", ZoneId.systemDefault().toString(), Locale.ROOT.toString());
+        var key2 = new DateProcessor.Cache.Key("format-2", ZoneId.systemDefault().toString(), Locale.ROOT.toString());
 
         when(supplier1.get()).thenReturn(zonedDateTimeFunction1);
         when(supplier2.get()).thenReturn(zonedDateTimeFunction2);


### PR DESCRIPTION
Follow up to #92880, it introduced this caching, but actually we can do even better than that PR did.

The ZoneId and Locale are expensive to create -- they're better behind the cache rather than keying into it.

![Screen Shot 2023-04-17 at 11 25 43 AM](https://user-images.githubusercontent.com/187034/232534776-004f99bb-1667-44d2-b612-7b48923d7c04.png)

In the above screenshot, `DateProcessor.execute` is taking 3.86% of the profile, and `DateProcess.newLocale` is taking 0.53%, so better caching could give us a ~13% speedup on the `DateProcessor` in question. This caching would be faster for any `DateProcessor`s that have a `locale` or `timezone` configured.