### PR TITLE
Change rest status for TooManyBucketsException

### DIFF
--- a/docs/changelog/95304.yaml
+++ b/docs/changelog/95304.yaml
@@ -1,0 +1,6 @@
+pr: 95304
+summary: Change rest status for `TooManyBucketsException`
+area: Aggregations
+type: bug
+issues:
+ - 37957

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -75,7 +75,7 @@ public class MultiBucketConsumerService {
 
         @Override
         public RestStatus status() {
-            return RestStatus.SERVICE_UNAVAILABLE;
+            return RestStatus.BAD_REQUEST;
         }
 
         @Override


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/37957

Retrying will not resolve `TooManyBucketsException`, therefore we should not return a 5xx class error.  After some discussion, we decided `400 - Bad Request` was the most appropriate choice.