### PR TITLE
Speed up ParsedMediaType.parseMediaType

### DIFF
--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ParsedMediaType.java
@@ -62,7 +62,7 @@ public class ParsedMediaType {
             if (isMediaRange(headerValue) || "*/*".equals(headerValue)) {
                 return null;
             }
-            final String[] elements = headerValue.toLowerCase(Locale.ROOT).split("[\\s\\t]*;");
+            final String[] elements = headerValue.toLowerCase(Locale.ROOT).split(";");
 
             final String[] splitMediaType = elements[0].split("/");
             if ((splitMediaType.length == 2

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/content/ParsedMediaType.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/content/ParsedMediaType.java
@@ -59,7 +59,7 @@ class ParsedMediaType {
             if (isMediaRange(headerValue) || "*/*".equals(headerValue)) {
                 return null;
             }
-            final String[] elements = headerValue.toLowerCase(Locale.ROOT).split("[\\s\\t]*;");
+            final String[] elements = headerValue.toLowerCase(Locale.ROOT).split(";");
 
             final String[] splitMediaType = elements[0].split("/");
             if ((splitMediaType.length == 2


### PR DESCRIPTION
Just a really random find from an SDH, this showed with like a few percent CPU. Probably not too relevant but why waste cycles here when we don't have to :)

I saw this in some hot-threads: Splitting by a pattern that isn't a single char is expensive because it instantiates a `Pattern`. Seems like it's redundant to split the spaces+tabs away anyway since we trim values and keys later on in the logic.
-> lets use the split fast path and not have this on the transport thread + code is easier to read this way IMO.
