### PR TITLE
added cumulative sum reducer function for terms aggregations and added tests for cumulative sum aggregator #46225

### DIFF
--- a/modules/aggregations/src/test/java/org/elasticsearch/aggregations/pipeline/CumulativeSumAggregatorTests.java
+++ b/modules/aggregations/src/test/java/org/elasticsearch/aggregations/pipeline/CumulativeSumAggregatorTests.java
@@ -40,6 +40,14 @@ import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.CumulativeSumPipelineAggregationBuilder;
 import org.elasticsearch.search.aggregations.pipeline.InternalSimpleValue;
 import org.elasticsearch.search.aggregations.support.AggregationInspectionHelper;
+import org.apache.lucene.util.BytesRef;
+import org.elasticsearch.search.aggregations.bucket.terms.InternalTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
+import org.elasticsearhc.search.aggregations.support.ValueType;
+
+
+
+
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -329,5 +337,178 @@ public class CumulativeSumAggregatorTests extends AggregatorTestCase {
 
     private static long asLong(String dateTime) {
         return DateFormatters.from(DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.parse(dateTime)).toInstant().toEpochMilli();
+    }
+
+    public void testTermsHelper(ValueType vType, String bPath, Consumer<InternalAggregation> verify, CheckedConsumer<RandomIndexWriter, IOException> setup, String terms) throws IOException {
+        TermsAggregationBuilder termsAggResult = createTermsAggregation(vType, bPath, terms);
+
+        Query matchQuery = new MatchAllDocsQuery();
+
+        executeTestCase(matchQuery, termsAggResult, verify, setup);
+    }
+
+    public TermsAggregationBuilder createTermsAggregation(ValueType vType, String bPath, String terms) {
+        TermsAggregationBuilder termsAgg = new TermsAggregationBuilder("terms");
+        termsAgg.field(terms);
+        termsAgg.userValueTypeHint(vType);
+
+        SumAggregationBuilder sumAgg = new SumAggregationBuilder("sum");
+        sumAgg.field("value_field");
+        termsAgg.subAggregation(sumAgg);
+
+        CumulativeSumPipelineAggregationBuilder cusumAgg = new CumulativeSumPipelineAggregationBuilder("cusum", bPath);
+        termsAgg.subAggregation(cusumAgg);
+
+        return termsAgg;
+    }
+
+    public Consumer<InternalAggregation> createConsumer(List datasetTems) {
+        return terms -> {
+            Document currDoc = new Document();
+            for (int i : datasetTerms) {
+                int counterValue = datasetTerms.get(i);
+                SortedNumericDocValuesField sorted = new SortedNumericDocValuesField("value_field", new BytesRef((String) sorted));
+                currDoc.add(sorted.apply(counterValue));
+                currDoc.add(new NumericDocValuesField("value_field", datasetTerms.get(i).intValue()));
+
+                terms.addDocument(currDoc);
+                currDoc.clear();
+            }
+        };
+    }
+
+    public CheckedConsumer<RandomIndexWriter, IOException> createSetup(List expected) {
+        return checkedTerms -> {
+            List <? extends Terms.Bucket> buckets = ((InternalTerms) checkedTerms).getBuckets();
+            assertThat(buckets.size(), equalTo(expected.size()));
+            for (int i = 0; i < buckets.size(); i++) {
+                InternalSimpleValue value = (InternalSimpleValue) buckets.get(i).getAggregations().get("cusum");
+                assertThat(value.value(), equalTo(expected.get(i)));
+            }
+        };
+    }
+
+    public void testTermsAggSimple() {
+        List<String> simpleDataset = Array.asList("10", "20", "30", "40", "50");
+
+        List<Double> expectedCt = Array.asList(1.0, 2.0, 3.0, 4.0, 5.0);
+
+        List<Double> expectedSum = Array.asList(10.0, 30.0, 60.0, 100.0, 150.0);
+
+        verify = createConsumer(simpleDataset);
+
+        setup = createSetup(expectedCt);
+
+        testTermsHelper(ValueType.STRING, "_count", verify, setup, "keyword_field");
+
+        verify = createConsumer(simpleDataset);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.STRING, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggCheckCountVal() {
+        List<String> datasetTerms = Array.asList("10", "10", "20", "20", "30", "30", "30", "40", "40", "50");
+
+        List<Double> expectedCt = Array.asList(2.0, 4.0, 7.0, 9.0, 10.0);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedCt);
+
+        testTermsHelper(ValueType.STRING, "_count", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggDouble() {
+        List<Double> datasetTerms  = Array.asList(10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 10.0, 20.0, 20.0);
+
+        List<Double> expectedSum = Array.asList(80.0, 120.0);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.DOUBLE, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggString() {
+        List<String> datasetTerms = Array.asList("10", "20", "30", "40", "50", "60", "70", "80", "90", "100");
+
+        List<Double> expectedSum = Array.asList(10.0, 30.0, 60.0, 100.0, 150.0, 210.0, 280.0, 360.0, 450.0, 550.0);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.STRING, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggLong() {
+        List<Long> datasetTerms = Array.asList(1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L);
+
+        List<Double> expectedSum = Array.asList(1.0, 3.0, 6.0, 10.0, 15.0, 21.0, 28.0, 36.0, 45.0, 55.0);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.LONG, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggInteger() {
+        List<Integer> datasetTerms = Array.asList(100, 200, 300);
+
+        List<Double> expectedSum = Array.asList(100.0, 300.0, 600.0);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.INTEGER, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggShort() {
+        List<Short> datasetTerms = Array.asList(1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1);
+
+        List<Double> expectedSum = Array.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.SHORT, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsAggOneEntry() {
+        List<Double> datasetTerms = Array.asList(13.0);
+
+        List<Double> expectedSum = Array.asList(13.0);
+
+        verify = createConsumer(datasetTerms);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.DOUBLE, "sum", verify, setup, "keyword_field");
+    }
+
+    public void testTermsNoValues() {
+        List<String> datasetEmpty = Array.asList("");
+
+        List<String> expectedSum = Array.asList("");
+
+        List<Double> expectedCt = Array.asList(0.0);
+
+        vertify = createConsumer(datasetEmpty);
+
+        setup = createSetup(expectedSum);
+
+        testTermsHelper(ValueType.STRING, "sum", verify, setup, "keyword_field");
+
+        verify = createConsumer(datasetEmpty);
+
+        setup = createSetup(expectedCt);
+
+        testTermsHelper(ValueType.STRING, "_count", verify, setup, "keyword_field");
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/pipeline/CumulativeSumPipelineAggregator.java
@@ -16,11 +16,15 @@ import org.elasticsearch.search.aggregations.InternalMultiBucketAggregation;
 import org.elasticsearch.search.aggregations.bucket.MultiBucketsAggregation.Bucket;
 import org.elasticsearch.search.aggregations.bucket.histogram.HistogramFactory;
 import org.elasticsearch.search.aggregations.pipeline.BucketHelpers.GapPolicy;
+import org.elasticsearch.search.aggregations.bucket.terms.DoubleTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.LongTerms;
+import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import java.util.HashMap;
 import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.search.aggregations.pipeline.BucketHelpers.resolveBucketValue;
@@ -41,6 +45,11 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
             ? extends InternalMultiBucketAggregation.InternalBucket> histo = (InternalMultiBucketAggregation<
                 ? extends InternalMultiBucketAggregation,
                 ? extends InternalMultiBucketAggregation.InternalBucket>) aggregation;
+
+        if (aggregation instanceof LongTerms || aggregation instanceof DoubleTerms  || aggregation instanceof StringTerms) {
+            return reduceTermsAgg(histo, reduceContext);
+        }
+
         List<? extends InternalMultiBucketAggregation.InternalBucket> buckets = histo.getBuckets();
         HistogramFactory factory = (HistogramFactory) histo;
         List<Bucket> newBuckets = new ArrayList<>(buckets.size());
@@ -61,5 +70,67 @@ public class CumulativeSumPipelineAggregator extends PipelineAggregator {
             newBuckets.add(newBucket);
         }
         return factory.createAggregation(newBuckets);
+    }
+
+
+
+    public InternalAggregation createBucket(InternalAggregation aggregation, Map<Integer, List<InternalAggregation>> mapAggregations, List<? extends InternalMultiBucketAggregation.InternalBucket> allBuckets) {
+        List<Bucket> completeBuckets = new ArrayList<>();
+        Bucket longBucket = LongTerms.Bucket;
+        Bucket doubleBucket = DoubleTerms.Bucket;
+        Bucket stringBucket = StringTerms.Bucket;
+        var longFactory = (LongTerms) aggregation;
+        var doubleFactory = (DoubleTerms) aggregation;
+        var stringFactory = (StringTerms) aggregation;
+
+        if (aggregation instanceof LongTerms) {
+            longFactory = (LongTerms) aggregation;
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : mapAggregations.entrySet()) {
+                completeBuckets.add((Bucket) longFactory.createBucket(longBucket, entry.getValue(), allBuckets.get(entry.getKey())));
+            }
+            return longFactory.create(completeBuckets);
+        } else if (aggregation instanceof DoubleTerms) {
+            doubleFactory = (DoubleTerms) aggregation;
+            for (Map.Entry<Integer, List<InternalAggregation>> entry : mapAggregations.entrySet()) {
+                completeBuckets.add((Bucket) doubleFactory.createBucket(doubleBucket, entry.getValue(), allBuckets.get(entry.getKey())));
+            }
+            return doubleFactory.create(completeBuckets);
+        }
+        stringFactory = (StringTerms) aggregation;
+        for (Map.Entry<Integer, List<InternalAggregation>> entry : mapAggregations.entrySet()) {
+            completeBuckets.add((Bucket) stringFactory.createBucket(stringBucket, entry.getValue(), allBuckets.get(entry.getKey())));
+        }
+        return longFactory.create(completeBuckets);
+    }
+
+    public InternalAggregation reduceTermsAgg(InternalAggregation aggregation, AggregationReduceContext reduceContext) {
+        @SuppressWarnings("rawtypes")
+        InternalMultiBucketAggregation<
+            ? extends InternalMultiBucketAggregation,
+            ? extends InternalMultiBucketAggregation.InternalBucket> terms = (InternalMultiBucketAggregation< ? extends InternalMultiBucketAggregation, ? extends InternalMultiBucketAggregation.InternalBucket>) aggregation;
+        List<? extends InternalMultiBucketAggregation.InternalBucket> allBuckets = terms.getBuckets();
+
+        double sum = 0.0;
+
+        Map<Integer, List<InternalAggregation>> mapAggregations = new HashMap<Integer, List<InternalAggregation>>();
+
+        for (int i = 0; i < allBuckets.size(); ++i) {
+            InternalMultiBucketAggregation.InternalBucket bucket = allBuckets.get(i);
+            Double thisBucketValue = resolveBucketValue(terms, bucket, bucketsPaths()[0], GapPolicy.INSERT_ZEROS);
+            if (thisBucketValue != null && thisBucketValue.isInfinite() == false && thisBucketValue.isNaN() == false) {
+                sum += thisBucketValue;
+            }
+
+            List<InternalAggregation> aggs = StreamSupport.stream(bucket.getAggregations().spliterator(), false)
+                .map((p) -> (InternalAggregation) p)
+                .collect(Collectors.toList());
+
+            aggs.add(new InternalSimpleValue(name(), sum, formatter, metadata()));
+
+            mapAggregations.put(i, aggs);
+
+        }
+
+        createBucket(terms, mapAggregations, allBuckets);
     }
 }


### PR DESCRIPTION
I made this PR request that is same one I made several days ago because I accidentally deleted the files in that PR request. So I'm making another one with the same files.  I apologize for this.

Here is my attempt to add a cumulative sum aggregation to a bucket that is a terms aggregation for issue #46225 . I created another reducer function called 'reducerTermsAgg' that retrieves all the buckets of a terms aggregation and iterates through each bucket to calculate the sum of all the entries in the bucket and saving them in a map. I also created a helper function that takes that map and creates an aggregation that contains all sums of each bucket for each value type. The value types I used where Double, Long, and String.

I also added unit tests for this implementation. These tests cover whether the cumulative sum aggregation works on String, Double, and Long types, as well whether it works with no buckets provided and if it can also correctly find the total _count of each bucket.