### PR TITLE
Add specialized CCS API Keys for RCS 2.0

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -119,7 +119,7 @@ public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
     private static Map<String, Object> createCrossClusterAccessApiKey() throws IOException {
         assert fulfillingCluster != null;
-        final var createApiKeyRequest = new Request("POST", "/_security/api_key");
+        final var createApiKeyRequest = new Request("POST", "/_security/_ccs/api_key");
         createApiKeyRequest.setJsonEntity("""
             {
               "name": "cross_cluster_access_key",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyType.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+public enum ApiKeyType {
+
+    DEFAULT() {
+        @Override
+        public String getDocType() {
+            return "api_key";
+        }
+
+        @Override
+        public String getCredentialsPrefix() {
+            return "";
+        }
+    },
+    CCS() {
+        @Override
+        public String getDocType() {
+            return "api_key_ccs";
+        }
+
+        @Override
+        public String getCredentialsPrefix() {
+            return "ccs_";
+        }
+    };
+
+    public abstract String getDocType();
+
+    public abstract String getCredentialsPrefix();
+
+    public static ApiKeyType fromDocType(String docType) {
+        return switch (docType) {
+            case "api_key" -> DEFAULT;
+            case "api_key_ccs" -> CCS;
+            default -> throw new IllegalArgumentException("unknown doc type [" + docType + "]");
+        };
+    }
+
+    public static ApiKeyType fromCredentialsPrefix(String prefix) {
+        return switch (prefix) {
+            case "ccs_" -> CCS;
+            default -> throw new IllegalArgumentException("unknown credentials prefix [" + prefix + "]");
+        };
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/ApiKeyType.java
@@ -7,6 +7,8 @@
 
 package org.elasticsearch.xpack.core.security.action.apikey;
 
+import org.elasticsearch.core.Nullable;
+
 public enum ApiKeyType {
 
     DEFAULT() {
@@ -36,7 +38,10 @@ public enum ApiKeyType {
 
     public abstract String getCredentialsPrefix();
 
-    public static ApiKeyType fromDocType(String docType) {
+    public static ApiKeyType fromDocType(@Nullable String docType) {
+        if (docType == null) {
+            return DEFAULT;
+        }
         return switch (docType) {
             case "api_key" -> DEFAULT;
             case "api_key_ccs" -> CCS;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequest.java
@@ -42,6 +42,7 @@ public final class CreateApiKeyRequest extends ActionRequest {
     private Map<String, Object> metadata;
     private List<RoleDescriptor> roleDescriptors = Collections.emptyList();
     private WriteRequest.RefreshPolicy refreshPolicy = DEFAULT_REFRESH_POLICY;
+    private ApiKeyType type = ApiKeyType.DEFAULT;
 
     public CreateApiKeyRequest() {
         super();
@@ -140,6 +141,14 @@ public final class CreateApiKeyRequest extends ActionRequest {
 
     public void setMetadata(Map<String, Object> metadata) {
         this.metadata = metadata;
+    }
+
+    public ApiKeyType getType() {
+        return type;
+    }
+
+    public void setType(ApiKeyType type) {
+        this.type = type;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequestBuilder.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyRequestBuilder.java
@@ -85,6 +85,11 @@ public final class CreateApiKeyRequestBuilder extends ActionRequestBuilder<Creat
         return this;
     }
 
+    public CreateApiKeyRequestBuilder setType(ApiKeyType apiKeyType) {
+        request.setType(apiKeyType);
+        return this;
+    }
+
     public CreateApiKeyRequestBuilder source(BytesReference source, XContentType xContentType) throws IOException {
         final NamedXContentRegistry registry = NamedXContentRegistry.EMPTY;
         try (
@@ -96,7 +101,6 @@ public final class CreateApiKeyRequestBuilder extends ActionRequestBuilder<Creat
             setRoleDescriptors(createApiKeyRequest.getRoleDescriptors());
             setExpiration(createApiKeyRequest.getExpiration());
             setMetadata(createApiKeyRequest.getMetadata());
-
         }
         return this;
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateApiKeyResponse.java
@@ -111,6 +111,15 @@ public final class CreateApiKeyResponse extends ActionResponse implements ToXCon
         return expiration;
     }
 
+    public String getEncoded() {
+        final String encoded = Base64.getEncoder().encodeToString((id + ":" + key).getBytes(StandardCharsets.UTF_8));
+        if (type == ApiKeyType.DEFAULT) {
+            return encoded;
+        } else {
+            return type.getCredentialsPrefix() + encoded;
+        }
+    }
+
     @Override
     public int hashCode() {
         final int prime = 31;
@@ -175,13 +184,8 @@ public final class CreateApiKeyResponse extends ActionResponse implements ToXCon
             } finally {
                 Arrays.fill(charBytes, (byte) 0);
             }
-            builder.field("encoded", Base64.getEncoder().encodeToString((id + ":" + key).getBytes(StandardCharsets.UTF_8)));
-        } else {
-            builder.field(
-                "encoded",
-                type.getCredentialsPrefix() + Base64.getEncoder().encodeToString((id + ":" + key).getBytes(StandardCharsets.UTF_8))
-            );
         }
+        builder.field("encoded", getEncoded());
         return builder.endObject();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCcsApiKeyAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/CreateCcsApiKeyAction.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.action.ActionType;
+
+/**
+ * ActionType for the creation of an API key
+ */
+public final class CreateCcsApiKeyAction extends ActionType<CreateApiKeyResponse> {
+
+    public static final String NAME = "cluster:admin/xpack/security/ccs/api_key/create";
+    public static final CreateCcsApiKeyAction INSTANCE = new CreateCcsApiKeyAction();
+
+    private CreateCcsApiKeyAction() {
+        super(NAME, CreateApiKeyResponse::new);
+    }
+
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/AuthenticationField.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/AuthenticationField.java
@@ -20,6 +20,7 @@ public final class AuthenticationField {
     public static final String API_KEY_CREATOR_REALM_TYPE = "_security_api_key_creator_realm_type";
     public static final String API_KEY_ID_KEY = "_security_api_key_id";
     public static final String API_KEY_NAME_KEY = "_security_api_key_name";
+    public static final String API_KEY_TYPE_KEY = "_security_api_key_type";
     public static final String API_KEY_METADATA_KEY = "_security_api_key_metadata";
     public static final String API_KEY_ROLE_DESCRIPTORS_KEY = "_security_api_key_role_descriptors";
     public static final String API_KEY_LIMITED_ROLE_DESCRIPTORS_KEY = "_security_api_key_limited_by_role_descriptors";

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -129,7 +129,7 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
 
     static Map<String, Object> createCrossClusterAccessApiKey(RestClient targetClusterClient, String roleDescriptorsJson) {
         // Create API key on FC
-        final var createApiKeyRequest = new Request("POST", "/_security/api_key");
+        final var createApiKeyRequest = new Request("POST", "/_security/_ccs/api_key");
         createApiKeyRequest.setJsonEntity(Strings.format("""
             {
               "name": "cross_cluster_access_key",

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -193,6 +193,7 @@ public class Constants {
         "cluster:admin/xpack/security/api_key/update",
         "cluster:admin/xpack/security/api_key/bulk_update",
         "cluster:admin/xpack/security/cache/clear",
+        "cluster:admin/xpack/security/ccs/api_key/create",
         "cluster:admin/xpack/security/delegate_pki",
         "cluster:admin/xpack/security/enroll/node",
         "cluster:admin/xpack/security/enroll/kibana",

--- a/x-pack/plugin/security/qa/security-trial/build.gradle
+++ b/x-pack/plugin/security/qa/security-trial/build.gradle
@@ -24,10 +24,10 @@ testClusters.matching { it.name == 'javaRestTest' }.configureEach {
   setting 'xpack.security.authc.api_key.enabled', 'true'
   setting 'xpack.security.remote_cluster_client.ssl.enabled', 'false'
 
-  keystore 'cluster.remote.my_remote_cluster_a.credentials', 'cluster_a_credentials'
-  keystore 'cluster.remote.my_remote_cluster_b.credentials', 'cluster_b_credentials'
-  keystore 'cluster.remote.my_remote_cluster_a_1.credentials', 'cluster_a_credentials'
-  keystore 'cluster.remote.my_remote_cluster_a_2.credentials', 'cluster_a_credentials'
+  keystore 'cluster.remote.my_remote_cluster_a.credentials', 'ccs_cluster_a_credentials'
+  keystore 'cluster.remote.my_remote_cluster_b.credentials', 'ccs_cluster_b_credentials'
+  keystore 'cluster.remote.my_remote_cluster_a_1.credentials', 'ccs_cluster_a_credentials'
+  keystore 'cluster.remote.my_remote_cluster_a_2.credentials', 'ccs_cluster_a_credentials'
 
   rolesFile file('src/javaRestTest/resources/roles.yml')
   user username: "admin_user", password: "admin-password"

--- a/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
+++ b/x-pack/plugin/security/qa/security-trial/src/javaRestTest/java/org/elasticsearch/xpack/security/crossclusteraccess/CrossClusterAccessHeadersForCcsRestIT.java
@@ -95,8 +95,8 @@ public class CrossClusterAccessHeadersForCcsRestIT extends SecurityOnTrialLicens
 
     private static final String CLUSTER_A = "my_remote_cluster_a";
     private static final String CLUSTER_B = "my_remote_cluster_b";
-    private static final String CLUSTER_A_CREDENTIALS = "cluster_a_credentials";
-    private static final String CLUSTER_B_CREDENTIALS = "cluster_b_credentials";
+    private static final String CLUSTER_A_CREDENTIALS = "ccs_cluster_a_credentials";
+    private static final String CLUSTER_B_CREDENTIALS = "ccs_cluster_b_credentials";
     private static final String REMOTE_SEARCH_USER = "remote_search_user";
     private static final SecureString PASSWORD = new SecureString("super-secret-password".toCharArray());
     private static final String REMOTE_SEARCH_ROLE = "remote_search";

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -108,6 +108,7 @@ import org.elasticsearch.xpack.core.security.action.ClearSecurityCacheAction;
 import org.elasticsearch.xpack.core.security.action.DelegatePkiAuthenticationAction;
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCcsApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.GetApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.GrantApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.InvalidateApiKeyAction;
@@ -191,6 +192,7 @@ import org.elasticsearch.xpack.security.action.TransportClearSecurityCacheAction
 import org.elasticsearch.xpack.security.action.TransportDelegatePkiAuthenticationAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportBulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportCreateApiKeyAction;
+import org.elasticsearch.xpack.security.action.apikey.TransportCreateCcsApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportGetApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportGrantApiKeyAction;
 import org.elasticsearch.xpack.security.action.apikey.TransportInvalidateApiKeyAction;
@@ -294,6 +296,7 @@ import org.elasticsearch.xpack.security.rest.action.RestDelegatePkiAuthenticatio
 import org.elasticsearch.xpack.security.rest.action.apikey.RestBulkUpdateApiKeyAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestClearApiKeyCacheAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestCreateApiKeyAction;
+import org.elasticsearch.xpack.security.rest.action.apikey.RestCreateCcsApiKeyAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestGetApiKeyAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestGrantApiKeyAction;
 import org.elasticsearch.xpack.security.rest.action.apikey.RestInvalidateApiKeyAction;
@@ -1303,6 +1306,7 @@ public class Security extends Plugin
             new ActionHandler<>(PutPrivilegesAction.INSTANCE, TransportPutPrivilegesAction.class),
             new ActionHandler<>(DeletePrivilegesAction.INSTANCE, TransportDeletePrivilegesAction.class),
             new ActionHandler<>(CreateApiKeyAction.INSTANCE, TransportCreateApiKeyAction.class),
+            new ActionHandler<>(CreateCcsApiKeyAction.INSTANCE, TransportCreateCcsApiKeyAction.class),
             new ActionHandler<>(GrantApiKeyAction.INSTANCE, TransportGrantApiKeyAction.class),
             new ActionHandler<>(InvalidateApiKeyAction.INSTANCE, TransportInvalidateApiKeyAction.class),
             new ActionHandler<>(GetApiKeyAction.INSTANCE, TransportGetApiKeyAction.class),
@@ -1386,6 +1390,7 @@ public class Security extends Plugin
             new RestPutPrivilegesAction(settings, getLicenseState()),
             new RestDeletePrivilegesAction(settings, getLicenseState()),
             new RestCreateApiKeyAction(settings, getLicenseState()),
+            new RestCreateCcsApiKeyAction(settings, getLicenseState()),
             new RestUpdateApiKeyAction(settings, getLicenseState()),
             new RestBulkUpdateApiKeyAction(settings, getLicenseState()),
             new RestGrantApiKeyAction(settings, getLicenseState()),

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateCcsApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/apikey/TransportCreateCcsApiKeyAction.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.action.apikey;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.security.SecurityContext;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyResponse;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCcsApiKeyAction;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.security.authc.ApiKeyService;
+
+import java.util.Set;
+
+/**
+ * Implementation of the action needed to create an API key
+ */
+public final class TransportCreateCcsApiKeyAction extends HandledTransportAction<CreateApiKeyRequest, CreateApiKeyResponse> {
+
+    private final ApiKeyService apiKeyService;
+    private final SecurityContext securityContext;
+
+    @Inject
+    public TransportCreateCcsApiKeyAction(
+        TransportService transportService,
+        ActionFilters actionFilters,
+        ApiKeyService apiKeyService,
+        SecurityContext context
+    ) {
+        super(CreateCcsApiKeyAction.NAME, transportService, actionFilters, CreateApiKeyRequest::new);
+        this.apiKeyService = apiKeyService;
+        this.securityContext = context;
+    }
+
+    @Override
+    protected void doExecute(Task task, CreateApiKeyRequest request, ActionListener<CreateApiKeyResponse> listener) {
+        final Authentication authentication = securityContext.getAuthentication();
+        if (authentication == null) {
+            listener.onFailure(new IllegalStateException("authentication is required"));
+        } else {
+            apiKeyService.createApiKey(authentication, request, Set.copyOf(request.getRoleDescriptors()), listener);
+        }
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeaders.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeaders.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.security.authc;
 
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.xpack.core.security.action.apikey.ApiKeyType;
 import org.elasticsearch.xpack.core.security.authc.CrossClusterAccessSubjectInfo;
 
 import java.io.IOException;
@@ -48,8 +49,9 @@ public final class CrossClusterAccessHeaders {
     }
 
     private static ApiKeyService.ApiKeyCredentials parseCredentialsHeader(final String header) {
+        final ApiKeyService.ApiKeyCredentials apiKeyCredentials;
         try {
-            return Objects.requireNonNull(ApiKeyService.getCredentialsFromHeader(header));
+            apiKeyCredentials = Objects.requireNonNull(ApiKeyService.getCredentialsFromHeader(header));
         } catch (Exception ex) {
             throw new IllegalArgumentException(
                 "cross cluster access header ["
@@ -58,6 +60,10 @@ public final class CrossClusterAccessHeaders {
                 ex
             );
         }
+        if (apiKeyCredentials.getType() != ApiKeyType.CCS) {
+            throw new IllegalArgumentException("cross cluster access requires cross cluster specific API keys");
+        }
+        return apiKeyCredentials;
     }
 
     public CrossClusterAccessSubjectInfo getCleanAndValidatedSubjectInfo() {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InactiveApiKeysRemover.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InactiveApiKeysRemover.java
@@ -67,7 +67,7 @@ public final class InactiveApiKeysRemover extends AbstractRunnable {
         final long cutoffTimestamp = now.minusMillis(retentionPeriodInMs.get()).toEpochMilli();
         expiredDbq.setQuery(
             QueryBuilders.boolQuery()
-                .filter(QueryBuilders.termsQuery("doc_type", "api_key"))
+                .filter(QueryBuilders.prefixQuery("doc_type", "api_key"))
                 .should(QueryBuilders.rangeQuery("expiration_time").lte(cutoffTimestamp))
                 .should(
                     QueryBuilders.boolQuery()

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateCcsApiKeyAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/rest/action/apikey/RestCreateCcsApiKeyAction.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.rest.action.apikey;
+
+import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.license.XPackLicenseState;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestToXContentListener;
+import org.elasticsearch.xpack.core.security.action.apikey.ApiKeyType;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequestBuilder;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCcsApiKeyAction;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.POST;
+
+/**
+ * Rest action to create an API key for CCS
+ */
+public final class RestCreateCcsApiKeyAction extends ApiKeyBaseRestHandler {
+
+    /**
+     * @param settings the node's settings
+     * @param licenseState the license state that will be used to determine if
+     * security is licensed
+     */
+    public RestCreateCcsApiKeyAction(Settings settings, XPackLicenseState licenseState) {
+        super(settings, licenseState);
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(POST, "/_security/_ccs/api_key"));
+    }
+
+    @Override
+    public String getName() {
+        return "xpack_security_create_ccs_api_key";
+    }
+
+    @Override
+    protected RestChannelConsumer innerPrepareRequest(final RestRequest request, final NodeClient client) throws IOException {
+        String refresh = request.param("refresh");
+        CreateApiKeyRequestBuilder builder = new CreateApiKeyRequestBuilder(client).source(
+            request.requiredContent(),
+            request.getXContentType()
+        )
+            .setRefreshPolicy(
+                (refresh != null) ? WriteRequest.RefreshPolicy.parse(request.param("refresh")) : CreateApiKeyRequest.DEFAULT_REFRESH_POLICY
+            )
+            .setType(ApiKeyType.CCS);
+        return channel -> client.execute(CreateCcsApiKeyAction.INSTANCE, builder.request(), new RestToXContentListener<>(channel));
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilder.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/support/ApiKeyBoolQueryBuilder.java
@@ -65,7 +65,7 @@ public class ApiKeyBoolQueryBuilder extends BoolQueryBuilder {
             QueryBuilder processedQuery = doProcess(queryBuilder);
             finalQuery.must(processedQuery);
         }
-        finalQuery.filter(QueryBuilders.termQuery("doc_type", "api_key"));
+        finalQuery.filter(QueryBuilders.prefixQuery("doc_type", "api_key"));
 
         if (authentication != null) {
             if (authentication.isApiKey()) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyServiceTests.java
@@ -266,7 +266,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         String[] apiKeyIds = generateRandomStringArray(4, 4, true, true);
         PlainActionFuture<GetApiKeyResponse> getApiKeyResponsePlainActionFuture = new PlainActionFuture<>();
         service.getApiKeys(realmNames, username, apiKeyName, apiKeyIds, randomBoolean(), getApiKeyResponsePlainActionFuture);
-        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("doc_type", "api_key"));
+        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.prefixQuery("doc_type", "api_key"));
         if (realmNames != null && realmNames.length > 0) {
             if (realmNames.length == 1) {
                 boolQuery.filter(QueryBuilders.termQuery("creator.realm", realmNames[0]));
@@ -336,7 +336,7 @@ public class ApiKeyServiceTests extends ESTestCase {
         }
         PlainActionFuture<InvalidateApiKeyResponse> invalidateApiKeyResponseListener = new PlainActionFuture<>();
         service.invalidateApiKeys(realmNames, username, apiKeyName, apiKeyIds, invalidateApiKeyResponseListener);
-        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.termQuery("doc_type", "api_key"));
+        final BoolQueryBuilder boolQuery = QueryBuilders.boolQuery().filter(QueryBuilders.prefixQuery("doc_type", "api_key"));
         if (realmNames != null && realmNames.length > 0) {
             if (realmNames.length == 1) {
                 boolQuery.filter(QueryBuilders.termQuery("creator.realm", realmNames[0]));

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeadersTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/CrossClusterAccessHeadersTests.java
@@ -110,7 +110,7 @@ public class CrossClusterAccessHeadersTests extends ESTestCase {
     }
 
     private static String encodedApiKeyWithPrefix(String id, String key) {
-        return "ApiKey " + encodedApiKey(id, key);
+        return "ApiKey ccs_" + encodedApiKey(id, key);
     }
 
     private static String encodedApiKey(String id, String key) {


### PR DESCRIPTION
Add a new API to create specialized API keys for RCS 2 usages, e.g.

```
// Request
POST _security/_ccs/api_key
{
  "name": "k2",
  "role_descriptors": {
    "x": {
      "cluster": [ "cross_cluster_access" ],
      "indices": [
        {
          "names": [ "foo" ],
          "privileges": [ "read", "read_cross_cluster" ]
        }
      ]
    }
  }
}

// Response
{
  "id": "Qq9okocBu0QjU-Ce7i_l",
  "name": "k2",
  "encoded": "ccs_UXE5b2tvY0J1MFFqVS1DZTdpX2w6akIxSmpxZEFSR3E0SFRZek5yekJHZw=="
}
```

Note the `ccs_` prefix of the above `encoded` value. This serves as a visual indicator for the type of specialized API keys.