### PR TITLE
[Transform] Report validation failure if there are no aggregations in the test search query

### DIFF
--- a/docs/changelog/95318.yaml
+++ b/docs/changelog/95318.yaml
@@ -1,0 +1,6 @@
+pr: 95318
+summary: Report validation failure if there are no aggregations in the test search
+  query
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityTransformIT.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/RemoteClusterSecurityTransformIT.java
@@ -206,8 +206,7 @@ public class RemoteClusterSecurityTransformIT extends AbstractRemoteClusterSecur
             assertOK(performRequestWithRemoteTransformUser(new Request("DELETE", "/_transform/simple-remote-transform")));
 
             // Create a transform targeting an index without permission
-            final var putTransformRequest2 = new Request("PUT", "/_transform/invalid");
-            putTransformRequest2.setJsonEntity("""
+            String invalidTransformConfig = """
                 {
                   "source": { "index": "my_remote_cluster:private-transform-index" },
                   "dest": { "index": "simple-remote-transform" },
@@ -216,15 +215,26 @@ public class RemoteClusterSecurityTransformIT extends AbstractRemoteClusterSecur
                     "aggs": {"avg_stars": {"avg": {"field": "stars"}}}
                   }
                 }
-                """);
-            assertOK(performRequestWithRemoteTransformUser(putTransformRequest2));
-            // It errors when trying to preview it
+                """;
+            final var putInvalidTransformRequest = new Request("PUT", "/_transform/invalid");
+            putInvalidTransformRequest.setJsonEntity(invalidTransformConfig);
+            // It errors when trying to execute the PUT request
             final ResponseException e = expectThrows(
                 ResponseException.class,
-                () -> performRequestWithRemoteTransformUser(new Request("GET", "/_transform/invalid/_preview"))
+                () -> performRequestWithRemoteTransformUser(putInvalidTransformRequest)
             );
             assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
             assertThat(e.getMessage(), containsString("Source indices have been deleted or closed"));
+
+            final var previewInvalidTransformRequest = new Request("GET", "/_transform/_preview");
+            previewInvalidTransformRequest.setJsonEntity(invalidTransformConfig);
+            // It also errors when trying to execute _preview request
+            final ResponseException e2 = expectThrows(
+                ResponseException.class,
+                () -> performRequestWithRemoteTransformUser(previewInvalidTransformRequest)
+            );
+            assertThat(e2.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+            assertThat(e2.getMessage(), containsString("Source indices have been deleted or closed"));
         }
     }
 

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_unattended.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_unattended.yml
@@ -74,6 +74,7 @@ teardown:
   - do:
       transform.put_transform:
         transform_id: "transform-unattended"
+        defer_validation: true
         body: >
           {
             "source": { "index": "airline-data*" },

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -306,6 +306,7 @@ teardown:
 ---
 "Batch transform from remote cluster when the user is not authorized":
   - do:
+      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.put_transform:
         transform_id: "simple-remote-transform-3"
@@ -318,6 +319,37 @@ teardown:
               "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
             }
           }
+
+  - do:
+      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
+      transform.put_transform:
+        transform_id: "simple-remote-transform-3"
+        # With defer_validation set, the validation is not performed, so the transform can be created
+        defer_validation: true
+        body: >
+          {
+            "source": { "index": "my_remote_cluster:remote_test_index" },
+            "dest": { "index": "simple-remote-transform-3" },
+            "pivot": {
+              "group_by": { "user": {"terms": {"field": "user"}}},
+              "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
+            }
+          }
+  - match: { acknowledged: true }
+
+  - do:
+      # bob is unauthorized to access the remote index
+      catch: /Source indices have been deleted or closed./
+      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
+      transform.preview_transform:
+        transform_id: "simple-remote-transform-3"
+
+  - do:
+      # On start, we perform the validation regardless of the defer_validation flag specified on PUT, hence the failure
+      catch: /Source indices have been deleted or closed./
+      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
+      transform.start_transform:
+        transform_id: "simple-remote-transform-3"
 
 ---
 "Batch transform update from remote cluster when the user is not authorized":
@@ -336,6 +368,7 @@ teardown:
           }
   - match: { acknowledged: true }
   - do:
+      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.update_transform:
         transform_id: "simple-remote-transform-2"

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
@@ -421,9 +421,8 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
-        String queryValidationIssue = "org.elasticsearch.ElasticsearchStatusException: Source indices have been deleted or closed.";
-        // transform is red with two issues
-        assertBusy(() -> assertRed(transformId, authIssue, queryValidationIssue), 10, TimeUnit.SECONDS);
+        // transform is red with one issue
+        assertBusy(() -> assertRed(transformId, authIssue), 10, TimeUnit.SECONDS);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());
@@ -464,9 +463,8 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
-        String queryValidationIssue = "org.elasticsearch.ElasticsearchStatusException: Source indices have been deleted or closed.";
-        // transform is red with two issues
-        assertBusy(() -> assertRed(transformId, authIssue, queryValidationIssue), 10, TimeUnit.SECONDS);
+        // transform is red with one issue
+        assertBusy(() -> assertRed(transformId, authIssue), 10, TimeUnit.SECONDS);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
@@ -421,9 +421,9 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
+        String queryValidationIssue = "org.elasticsearch.ElasticsearchStatusException: Source indices have been deleted or closed.";
         // transform is red with two issues
-        String noSuchIndexIssue = Strings.format("org.elasticsearch.index.IndexNotFoundException: no such index [%s]", destIndexName);
-        assertBusy(() -> assertRed(transformId, authIssue, noSuchIndexIssue), 10, TimeUnit.SECONDS);
+        assertBusy(() -> assertRed(transformId, authIssue, queryValidationIssue), 10, TimeUnit.SECONDS);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());
@@ -464,8 +464,9 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
-        // transform's auth state status is still RED, but the health status is GREEN (because dest index exists)
-        assertRed(transformId, authIssue);
+        String queryValidationIssue = "org.elasticsearch.ElasticsearchStatusException: Source indices have been deleted or closed.";
+        // transform is red with two issues
+        assertBusy(() -> assertRed(transformId, authIssue, queryValidationIssue), 10, TimeUnit.SECONDS);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TransformUpdateIT extends TransformRestTestCase {
@@ -246,7 +247,8 @@ public class TransformUpdateIT extends TransformRestTestCase {
             }
             fail("request should have failed");
         } catch (ResponseException e) {
-            assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(500));
+            assertThat("Error was: " + e.getMessage(), e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
+            assertThat(e.getMessage(), containsString("Source indices have been deleted or closed."));
         }
         assertBusy(() -> {
             Map<?, ?> transformStatsAsMap = getTransformStateAndStats(transformId);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -69,7 +69,6 @@ import static org.elasticsearch.xpack.transform.utils.SecondaryAuthorizationUtil
 
 public class TransportPreviewTransformAction extends HandledTransportAction<Request, Response> {
 
-    private static final int NUMBER_OF_PREVIEW_BUCKETS = 100;
     private final SecurityContext securityContext;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final Client client;
@@ -279,15 +278,7 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
 
         ActionListener<Map<String, String>> deduceMappingsListener = ActionListener.wrap(deducedMappings -> {
             mappings.set(deducedMappings);
-            function.preview(
-                parentTaskAssigningClient,
-                timeout,
-                filteredHeaders,
-                source,
-                deducedMappings,
-                NUMBER_OF_PREVIEW_BUCKETS,
-                previewListener
-            );
+            function.preview(parentTaskAssigningClient, timeout, filteredHeaders, source, deducedMappings, previewListener);
         }, listener::onFailure);
 
         function.deduceMappings(parentTaskAssigningClient, filteredHeaders, source, deduceMappingsListener);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -196,6 +196,7 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             );
         }, e -> {
             if (Boolean.TRUE.equals(transformConfigHolder.get().getSettings().getUnattended())) {
+                logger.debug(() -> format("[%s] Validation failed: %s", transformConfigHolder.get().getId(), e.getMessage()));
                 logger.debug(
                     () -> format("[%s] Skip dest index creation as this is an unattended transform", transformConfigHolder.get().getId())
                 );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -274,12 +274,15 @@ class ClientTransformIndexer extends TransformIndexer {
         SchemaUtil.getDestinationFieldMappings(client, getConfig().getDestination().getIndex(), fieldMappingsListener);
     }
 
+    @Override
     void validate(ActionListener<Void> listener) {
+        assert Boolean.TRUE.equals(transformConfig.getSettings().getUnattended());
         ClientHelper.executeAsyncWithOrigin(
             client,
             ClientHelper.TRANSFORM_ORIGIN,
             ValidateTransformAction.INSTANCE,
-            new ValidateTransformAction.Request(transformConfig, false, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT),
+            // Since the transform is unattended, we defer the deferrable validations.
+            new ValidateTransformAction.Request(transformConfig, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT),
             ActionListener.wrap(response -> listener.onResponse(null), listener::onFailure)
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
@@ -136,7 +136,6 @@ public interface Function {
      * @param headers headers to be used to query only for what the caller is allowed to
      * @param sourceConfig the source configuration
      * @param fieldTypeMap mapping of field types
-     * @param numberOfRows number of rows to produce for the preview
      * @param listener listener that takes a list, where every entry corresponds to 1 row/doc in the preview
      */
     void preview(
@@ -145,7 +144,6 @@ public interface Function {
         Map<String, String> headers,
         SourceConfig sourceConfig,
         Map<String, String> fieldTypeMap,
-        int numberOfRows,
         ActionListener<List<Map<String, Object>>> listener
     );
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -55,6 +55,7 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -125,6 +126,13 @@ public class PivotTests extends ESTestCase {
 
     public void testValidateNonExistingIndex() throws Exception {
         SourceConfig source = new SourceConfig("non_existing_source_index");
+        Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT, Collections.emptySet());
+
+        assertInvalidTransform(client, source, pivot);
+    }
+
+    public void testValidateAggregationsBeingNullInSearchResponse() throws Exception {
+        SourceConfig source = new SourceConfig("no_permissions");
         Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT, Collections.emptySet());
 
         assertInvalidTransform(client, source, pivot);
@@ -298,9 +306,12 @@ public class PivotTests extends ESTestCase {
                     }
                 }
 
+                final Aggregations aggregations = Arrays.stream(searchRequest.indices()).anyMatch(index -> index.contains("no_permissions"))
+                    ? null
+                    : new Aggregations(List.of());
                 final SearchResponseSections sections = new SearchResponseSections(
                     new SearchHits(new SearchHit[0], new TotalHits(0L, TotalHits.Relation.EQUAL_TO), 0),
-                    null,
+                    aggregations,
                     null,
                     false,
                     null,


### PR DESCRIPTION
Currently, when the user configures remote index in their transform but does not have permissions to access it, `_preview` request will fail with error message: "Source indices have been deleted or closed.".
However, such a transform can be created via `PUT` and then started via `_start`.

This PR makes the behavior between `_preview` and `PUT` consistent.
When there are no aggregations returned in the validation search query (which is a manifestation of missing remote index privileges), the exception is thrown, similarly to what `_preview` already does.

Relates https://github.com/elastic/elasticsearch/issues/95367