### PR TITLE
[8.7] Change rest status for TooManyBucketsException (#95304)

### DIFF
--- a/docs/changelog/95304.yaml
+++ b/docs/changelog/95304.yaml
@@ -1,0 +1,6 @@
+pr: 95304
+summary: Change rest status for `TooManyBucketsException`
+area: Aggregations
+type: bug
+issues:
+ - 37957

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -75,7 +75,7 @@ public class MultiBucketConsumerService {
 
         @Override
         public RestStatus status() {
-            return RestStatus.SERVICE_UNAVAILABLE;
+            return RestStatus.BAD_REQUEST;
         }
 
         @Override


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Change rest status for TooManyBucketsException (#95304)