### PR TITLE
Fix redundant connection profile instantiations

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -37,7 +37,6 @@ import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
@@ -1156,7 +1155,6 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                         transportService.connectToNode(
                             // Note: This connection must be explicitly closed in the connectionListener
                             masterEligibleNode,
-                            ConnectionProfile.buildDefaultConnectionProfile(clusterService.getSettings()),
                             connectionListener
                         );
                     }

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/MasterHistoryService.java
@@ -22,7 +22,6 @@ import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.threadpool.ThreadPool;
-import org.elasticsearch.transport.ConnectionProfile;
 import org.elasticsearch.transport.TransportRequestOptions;
 import org.elasticsearch.transport.TransportService;
 
@@ -36,7 +35,6 @@ import java.util.function.LongSupplier;
 public class MasterHistoryService {
     private final TransportService transportService;
     private final MasterHistory localMasterHistory;
-    private final ClusterService clusterService;
     private final LongSupplier currentTimeMillisSupplier;
     private final TimeValue acceptableRemoteHistoryAge;
     /*
@@ -62,7 +60,6 @@ public class MasterHistoryService {
     public MasterHistoryService(TransportService transportService, ThreadPool threadPool, ClusterService clusterService) {
         this.transportService = transportService;
         this.localMasterHistory = new MasterHistory(threadPool, clusterService);
-        this.clusterService = clusterService;
         this.currentTimeMillisSupplier = threadPool::relativeTimeInMillis;
         this.acceptableRemoteHistoryAge = REMOTE_HISTORY_TIME_TO_LIVE_SETTING.get(clusterService.getSettings());
     }
@@ -128,7 +125,6 @@ public class MasterHistoryService {
         transportService.connectToNode(
             // Note: This connection must be explicitly closed below
             node,
-            ConnectionProfile.buildDefaultConnectionProfile(clusterService.getSettings()),
             new ActionListener<>() {
                 @Override
                 public void onResponse(Releasable releasable) {

--- a/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
+++ b/server/src/main/java/org/elasticsearch/transport/ConnectionManager.java
@@ -10,6 +10,7 @@ package org.elasticsearch.transport;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 
 import java.io.Closeable;
@@ -26,7 +27,7 @@ public interface ConnectionManager extends Closeable {
 
     void connectToNode(
         DiscoveryNode node,
-        ConnectionProfile connectionProfile,
+        @Nullable ConnectionProfile connectionProfile,
         ConnectionValidator connectionValidator,
         ActionListener<Releasable> listener
     ) throws ConnectTransportException;

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -465,7 +465,11 @@ public class TransportService extends AbstractLifecycleComponent
      * @param connectionProfile the connection profile to use when connecting to this node
      * @param listener the action listener to notify
      */
-    public void connectToNode(final DiscoveryNode node, ConnectionProfile connectionProfile, ActionListener<Releasable> listener) {
+    public void connectToNode(
+        final DiscoveryNode node,
+        @Nullable ConnectionProfile connectionProfile,
+        ActionListener<Releasable> listener
+    ) {
         if (isLocalNode(node)) {
             listener.onResponse(null);
             return;

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1313,7 +1313,6 @@ public class SnapshotResiliencyTests extends ESTestCase {
                     .forEach(
                         n -> n.transportService.connectToNode(
                             node.node,
-                            null,
                             ActionTestUtils.assertNoFailureListener(c -> logger.info("--> Connected [{}] to [{}]", n.node, node.node))
                         )
                     )


### PR DESCRIPTION
Creating the default connection profile is very expensive (takes ~100s of CPU time for the `server:internalClusterTests` goal alone). We can just use the default profile overload to avoid this cost without changing behavior.
