### PR TITLE
Align constructors for query phase and friends

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -9,7 +9,6 @@ package org.elasticsearch.search.aggregations;
 
 import org.apache.lucene.search.Collector;
 import org.elasticsearch.action.search.SearchShardTask;
-import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.search.aggregations.support.TimeSeriesIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
@@ -26,8 +25,7 @@ import java.util.List;
  */
 public class AggregationPhase {
 
-    @Inject
-    public AggregationPhase() {}
+    private AggregationPhase() {}
 
     public static void preProcess(SearchContext context) {
         if (context.aggregations() == null) {

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -56,7 +56,7 @@ import static org.elasticsearch.search.query.TopDocsCollectorContext.createTopDo
 public class QueryPhase {
     private static final Logger LOGGER = LogManager.getLogger(QueryPhase.class);
 
-    public QueryPhase() {}
+    private QueryPhase() {}
 
     public static void execute(SearchContext searchContext) throws QueryPhaseExecutionException {
         if (searchContext.hasOnlySuggest()) {

--- a/server/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
+++ b/server/src/main/java/org/elasticsearch/search/rescore/RescorePhase.java
@@ -21,6 +21,8 @@ import java.io.IOException;
  */
 public class RescorePhase {
 
+    private RescorePhase() {}
+
     public static void execute(SearchContext context) {
         if (context.size() == 0 || context.collapse() != null || context.rescore() == null || context.rescore().isEmpty()) {
             return;

--- a/server/src/main/java/org/elasticsearch/search/suggest/SuggestPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/suggest/SuggestPhase.java
@@ -25,6 +25,8 @@ import java.util.Map;
  */
 public class SuggestPhase {
 
+    private SuggestPhase() {}
+
     public static void execute(SearchContext context) {
         final SuggestionSearchContext suggest = context.suggest();
         if (suggest == null) {


### PR DESCRIPTION
AggregationPhase was still using an Inject annotation in its constructor which is certainly a leftover. At the same time, none of these classes (QueryPhase, AggregationPhase, RescorePhase, SuggestPhase) need to ever be instantiated so adding a private constructor makes that explicit.