### PR TITLE
Reduce contention on the PeerFinder mutex

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/PeersResponse.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/PeersResponse.java
@@ -32,7 +32,7 @@ public class PeersResponse extends TransportResponse {
 
     public PeersResponse(StreamInput in) throws IOException {
         masterNode = Optional.ofNullable(in.readOptionalWriteable(DiscoveryNode::new));
-        knownPeers = in.readList(DiscoveryNode::new);
+        knownPeers = in.readImmutableList(DiscoveryNode::new);
         term = in.readLong();
         assert masterNode.isPresent() == false || knownPeers.isEmpty();
     }

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -52,13 +52,19 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
     );
 
     private final TransportService transportService;
-    private final TimeValue probeConnectTimeout;
-    private final TimeValue probeHandshakeTimeout;
+
+    private final ConnectionProfile handshakeConnectionProfile;
 
     public HandshakingTransportAddressConnector(Settings settings, TransportService transportService) {
         this.transportService = transportService;
-        probeConnectTimeout = PROBE_CONNECT_TIMEOUT_SETTING.get(settings);
-        probeHandshakeTimeout = PROBE_HANDSHAKE_TIMEOUT_SETTING.get(settings);
+        handshakeConnectionProfile = ConnectionProfile.buildSingleChannelProfile(
+            Type.REG,
+            PROBE_CONNECT_TIMEOUT_SETTING.get(settings),
+            PROBE_HANDSHAKE_TIMEOUT_SETTING.get(settings),
+            TimeValue.MINUS_ONE,
+            null,
+            null
+        );
     }
 
     @Override
@@ -81,17 +87,10 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                     emptySet(),
                     Version.CURRENT.minimumCompatibilityVersion()
                 ),
-                ConnectionProfile.buildSingleChannelProfile(
-                    Type.REG,
-                    probeConnectTimeout,
-                    probeHandshakeTimeout,
-                    TimeValue.MINUS_ONE,
-                    null,
-                    null
-                ),
+                handshakeConnectionProfile,
                 listener.delegateFailure((l, connection) -> {
                     logger.trace("[{}] opened probe connection", transportAddress);
-
+                    final var probeHandshakeTimeout = handshakeConnectionProfile.getHandshakeTimeout();
                     // use NotifyOnceListener to make sure the following line does not result in onFailure being called when
                     // the connection is closed in the onResponse handler
                     transportService.handshake(connection, probeHandshakeTimeout, ActionListener.notifyOnce(new ActionListener<>() {
@@ -101,7 +100,6 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                             try {
                                 // success means (amongst other things) that the cluster names match
                                 logger.trace("[{}] handshake successful: {}", transportAddress, remoteNode);
-                                IOUtils.closeWhileHandlingException(connection);
 
                                 if (remoteNode.equals(transportService.getLocalNode())) {
                                     listener.onFailure(

--- a/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
+++ b/server/src/main/java/org/elasticsearch/discovery/HandshakingTransportAddressConnector.java
@@ -100,6 +100,7 @@ public class HandshakingTransportAddressConnector implements TransportAddressCon
                             try {
                                 // success means (amongst other things) that the cluster names match
                                 logger.trace("[{}] handshake successful: {}", transportAddress, remoteNode);
+                                IOUtils.closeWhileHandlingException(connection);
 
                                 if (remoteNode.equals(transportService.getLocalNode())) {
                                     listener.onFailure(

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -31,11 +32,13 @@ import org.elasticsearch.transport.TransportResponseHandler;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 import static java.util.Collections.emptyList;
 import static org.elasticsearch.core.Strings.format;
@@ -129,11 +132,13 @@ public abstract class PeerFinder {
 
     public void deactivate(DiscoveryNode leader) {
         final boolean peersRemoved;
-        final List<Releasable> connectionReferences;
+        final Collection<Releasable> connectionReferences = new ArrayList<>();
         synchronized (mutex) {
             logger.trace("deactivating and setting leader to {}", leader);
             active = false;
-            connectionReferences = peersByAddress.values().stream().map(Peer::getConnectionReference).toList();
+            for (Peer peer : peersByAddress.values()) {
+                connectionReferences.add(peer.getConnectionReference());
+            }
             peersRemoved = handleWakeUp();
             this.leader = Optional.of(leader);
             assert assertInactiveWithNoKnownPeers();
@@ -174,9 +179,13 @@ public abstract class PeerFinder {
     }
 
     PeersResponse handlePeersRequest(PeersRequest peersRequest) {
+        final Collection<DiscoveryNode> knownPeers;
+        final Optional<DiscoveryNode> leader;
+        final long currentTerm;
         synchronized (mutex) {
             assert peersRequest.getSourceNode().equals(getLocalNode()) == false;
-            final List<DiscoveryNode> knownPeers;
+            leader = this.leader;
+            currentTerm = this.currentTerm;
             if (active) {
                 assert leader.isPresent() == false : leader;
                 if (peersRequest.getSourceNode().isMasterNode()) {
@@ -188,8 +197,8 @@ public abstract class PeerFinder {
                 assert leader.isPresent() || lastAcceptedNodes == null;
                 knownPeers = emptyList();
             }
-            return new PeersResponse(leader, knownPeers, currentTerm);
         }
+        return new PeersResponse(leader, List.copyOf(knownPeers), currentTerm);
     }
 
     // exposed for checking invariant in o.e.c.c.Coordinator (public since this is a different package)
@@ -239,9 +248,16 @@ public abstract class PeerFinder {
         }
     }
 
-    private List<DiscoveryNode> getFoundPeersUnderLock() {
+    private Collection<DiscoveryNode> getFoundPeersUnderLock() {
         assert holdsLock() : "PeerFinder mutex not held";
-        return peersByAddress.values().stream().map(Peer::getDiscoveryNode).filter(Objects::nonNull).distinct().toList();
+        Set<DiscoveryNode> peers = Sets.newHashSetWithExpectedSize(peersByAddress.size());
+        for (Peer peer : peersByAddress.values()) {
+            DiscoveryNode discoveryNode = peer.getDiscoveryNode();
+            if (discoveryNode != null) {
+                peers.add(discoveryNode);
+            }
+        }
+        return peers;
     }
 
     /**
@@ -450,7 +466,7 @@ public abstract class PeerFinder {
             logger.trace("{} requesting peers", this);
             peersRequestInFlight = true;
 
-            final List<DiscoveryNode> knownNodes = getFoundPeersUnderLock();
+            final List<DiscoveryNode> knownNodes = List.copyOf(getFoundPeersUnderLock());
 
             final TransportResponseHandler<PeersResponse> peersResponseHandler = new TransportResponseHandler<PeersResponse>() {
 
@@ -469,8 +485,10 @@ public abstract class PeerFinder {
 
                         peersRequestInFlight = false;
 
-                        response.getMasterNode().map(DiscoveryNode::getAddress).ifPresent(PeerFinder.this::startProbe);
-                        response.getKnownPeers().stream().map(DiscoveryNode::getAddress).forEach(PeerFinder.this::startProbe);
+                        response.getMasterNode().ifPresent(node -> startProbe(node.getAddress()));
+                        for (DiscoveryNode node : response.getKnownPeers()) {
+                            startProbe(node.getAddress());
+                        }
                     }
 
                     if (response.getMasterNode().equals(Optional.of(discoveryNode))) {

--- a/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
+++ b/server/src/main/java/org/elasticsearch/discovery/PeerFinder.java
@@ -132,10 +132,11 @@ public abstract class PeerFinder {
 
     public void deactivate(DiscoveryNode leader) {
         final boolean peersRemoved;
-        final Collection<Releasable> connectionReferences = new ArrayList<>();
+        final Collection<Releasable> connectionReferences;
         synchronized (mutex) {
             logger.trace("deactivating and setting leader to {}", leader);
             active = false;
+            connectionReferences = new ArrayList<>(peersByAddress.size());
             for (Peer peer : peersByAddress.values()) {
                 connectionReferences.add(peer.getConnectionReference());
             }


### PR DESCRIPTION
We spend a lot of time contending this mutex on transport threads at least in tests and I would assume also in production in some cases. With a couple of simple fixes here the time spent conding the lock here goes down by an order of magnitude or more with this PR (from ~200s in server:internalClusterTests to ~10s). The biggest effect comes from not building a list from a stream in `getFoundPeersUnderLock` but the otehr allocation savings are helping a little here and there as well and make the code a bit nicer in the case of the HandshakingAddressConnector reusign the connection profile.
