### PR TITLE
[8.7] Fix stable plugin API backward compatibility checks (11d0d7ad)

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.stable-api.gradle
@@ -8,7 +8,9 @@ import org.elasticsearch.gradle.internal.info.BuildParams
 import static org.elasticsearch.gradle.internal.InternalDistributionBwcSetupPlugin.buildBwcTaskName
 
 configurations {
-  newJar
+  newJar {
+    transitive = false
+  }
 }
 
 dependencies {


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix stable plugin API backward compatibility checks (11d0d7ad)

Closes https://github.com/elastic/elasticsearch/issues/95300