### PR TITLE
[8.7] [docs] Clarify that index template settings take precedence over comp… (#87374)

### DIFF
--- a/docs/reference/indices/index-templates.asciidoc
+++ b/docs/reference/indices/index-templates.asciidoc
@@ -28,6 +28,8 @@ applied.
 template, the settings from the <<indices-create-index,create index>> request
 take precedence over settings specified in the index template and its component
 templates.
+* Settings specified in the index template itself take precedence over the settings 
+in its component templates.
 * If a new data stream or index matches more than one index template, the index
 template with the highest priority is used.
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.7`:
 - [[docs] Clarify that index template settings take precedence over comp… (#87374)](https://github.com/elastic/elasticsearch/pull/87374)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)