### PR TITLE
Fix NPE when the start time of the last successful snapshot run is unknown

### DIFF
--- a/docs/changelog/95356.yaml
+++ b/docs/changelog/95356.yaml
@@ -1,0 +1,5 @@
+pr: 95356
+summary: Fix NPE when the start time of the last successful snapshot run is unknown
+area: Health
+type: bug
+issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -153,9 +153,10 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                             + policy.getName()
                             + "] had ["
                             + policy.getInvocationsSinceLastSuccess()
-                            + "] repeated failures without successful execution since ["
-                            + FORMATTER.formatMillis(policy.getLastSuccess().getSnapshotStartTimestamp())
-                            + "]"
+                            + "] repeated failures without successful execution"
+                            + (policy.getLastSuccess().getSnapshotStartTimestamp() != null
+                                ? " since [" + FORMATTER.formatMillis(policy.getLastSuccess().getSnapshotStartTimestamp()) + "]"
+                                : "")
                     )
                     .collect(Collectors.joining("\n"));
                 String cause = (unhealthyPolicies.size() > 1

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicyMetadata;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                 .values()
                 .stream()
                 .filter(metadata -> snapshotFailuresExceedWarningCount(failedSnapshotWarnThreshold, metadata))
+                .sorted(Comparator.comparing(SnapshotLifecyclePolicyMetadata::getName))
                 .toList();
 
             if (unhealthyPolicies.size() > 0) {
@@ -154,7 +156,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                             + "] had ["
                             + policy.getInvocationsSinceLastSuccess()
                             + "] repeated failures without successful execution"
-                            + (policy.getLastSuccess().getSnapshotStartTimestamp() != null
+                            + (policy.getLastSuccess() != null && policy.getLastSuccess().getSnapshotStartTimestamp() != null
                                 ? " since [" + FORMATTER.formatMillis(policy.getLastSuccess().getSnapshotStartTimestamp()) + "]"
                                 : "")
                     )

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorServiceTests.java
@@ -173,14 +173,50 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
     public void testIsYellowWhenPoliciesHaveFailedForMoreThanWarningThreshold() {
         long execTime = System.currentTimeMillis();
         long window = TimeUnit.HOURS.toMillis(24) + 5000L; // 24 hours and some extra room.
-        long failedInvocations = randomLongBetween(5L, Long.MAX_VALUE);
-        Long startTime = randomBoolean() ? null : execTime;
+        long failedInvocations1 = randomLongBetween(5L, Long.MAX_VALUE);
+        long failedInvocations2 = randomLongBetween(5L, Long.MAX_VALUE);
+        long failedInvocations3 = randomLongBetween(5L, Long.MAX_VALUE);
         var clusterState = createClusterStateWith(
             new SnapshotLifecycleMetadata(
-                createSlmPolicyWithInvocations(
-                    snapshotInvocation(startTime, execTime + 1000L),
-                    snapshotInvocation(null, execTime + window + 1000L),
-                    failedInvocations
+                Map.of(
+                    "test-policy",
+                    SnapshotLifecyclePolicyMetadata.builder()
+                        .setPolicy(new SnapshotLifecyclePolicy("policy-id-1", "test-policy", "", "test-repository", null, null))
+                        .setVersion(1L)
+                        .setModifiedDate(System.currentTimeMillis())
+                        .setLastSuccess(snapshotInvocation(execTime, execTime + 1000L))
+                        .setLastFailure(snapshotInvocation(null, execTime + window + 1000L))
+                        .setInvocationsSinceLastSuccess(failedInvocations1)
+                        .build(),
+                    "test-policy-without-any-success",
+                    SnapshotLifecyclePolicyMetadata.builder()
+                        .setPolicy(
+                            new SnapshotLifecyclePolicy("policy-id-2", "test-policy-without-any-success", "", "test-repository", null, null)
+                        )
+                        .setVersion(1L)
+                        .setModifiedDate(System.currentTimeMillis())
+                        .setLastSuccess(null)
+                        .setLastFailure(snapshotInvocation(null, execTime + window + 1000L))
+                        .setInvocationsSinceLastSuccess(failedInvocations2)
+                        .build(),
+                    "test-policy-without-success-start-time",
+                    SnapshotLifecyclePolicyMetadata.builder()
+                        .setPolicy(
+                            new SnapshotLifecyclePolicy(
+                                "policy-id-3",
+                                "test-policy-without-success-start-time",
+                                "",
+                                "test-repository",
+                                null,
+                                null
+                            )
+                        )
+                        .setVersion(1L)
+                        .setModifiedDate(System.currentTimeMillis())
+                        .setLastSuccess(snapshotInvocation(null, execTime))
+                        .setLastFailure(snapshotInvocation(null, execTime + window + 1000L))
+                        .setInvocationsSinceLastSuccess(failedInvocations3)
+                        .build()
                 ),
                 RUNNING,
                 null
@@ -195,15 +231,27 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                 new HealthIndicatorResult(
                     NAME,
                     YELLOW,
-                    "Encountered [1] unhealthy snapshot lifecycle management policies.",
+                    "Encountered [3] unhealthy snapshot lifecycle management policies.",
                     new SimpleHealthIndicatorDetails(
                         Map.of(
                             "slm_status",
                             RUNNING,
                             "policies",
-                            1,
+                            3,
                             "unhealthy_policies",
-                            Map.of("count", 1, "invocations_since_last_success", Map.of("test-policy", failedInvocations))
+                            Map.of(
+                                "count",
+                                3,
+                                "invocations_since_last_success",
+                                Map.of(
+                                    "test-policy",
+                                    failedInvocations1,
+                                    "test-policy-without-any-success",
+                                    failedInvocations2,
+                                    "test-policy-without-success-start-time",
+                                    failedInvocations3
+                                )
+                            )
                         )
                     ),
                     Collections.singletonList(
@@ -219,20 +267,30 @@ public class SlmHealthIndicatorServiceTests extends ESTestCase {
                     List.of(
                         new Diagnosis(
                             SlmHealthIndicatorService.checkRecentlyFailedSnapshots(
-                                startTime != null
-                                    ? "An automated snapshot policy is unhealthy:\n"
-                                        + "- [test-policy] had ["
-                                        + failedInvocations
-                                        + "] repeated failures without successful execution since ["
-                                        + FORMATTER.formatMillis(execTime)
-                                        + "]"
-                                    : "An automated snapshot policy is unhealthy:\n"
-                                        + "- [test-policy] had ["
-                                        + failedInvocations
-                                        + "] repeated failures without successful execution",
-                                "Check the snapshot lifecycle policy for detailed failure info:\n- GET /_slm/policy/policy-id?human"
+                                "Several automated snapshot policies are unhealthy:\n"
+                                    + "- [test-policy] had ["
+                                    + failedInvocations1
+                                    + "] repeated failures without successful execution since ["
+                                    + FORMATTER.formatMillis(execTime)
+                                    + "]\n"
+                                    + "- [test-policy-without-any-success] had ["
+                                    + failedInvocations2
+                                    + "] repeated failures without successful execution\n"
+                                    + "- [test-policy-without-success-start-time] had ["
+                                    + failedInvocations3
+                                    + "] repeated failures without successful execution",
+                                "Check the snapshot lifecycle policies for detailed failure info:\n"
+                                    + "- GET /_slm/policy/policy-id-1?human\n"
+                                    + "- GET /_slm/policy/policy-id-2?human\n"
+                                    + "- GET /_slm/policy/policy-id-3?human"
+
                             ),
-                            List.of(new Diagnosis.Resource(Type.SLM_POLICY, List.of("test-policy")))
+                            List.of(
+                                new Diagnosis.Resource(
+                                    Type.SLM_POLICY,
+                                    List.of("test-policy", "test-policy-without-any-success", "test-policy-without-success-start-time")
+                                )
+                            )
                         )
                     )
                 )


### PR DESCRIPTION
It was reported that the health API returns status code `500` when SLM is running, there are unhealthy policies but the last successful start time is unknown:
```
{
  "error": {
    "root_cause": [
      {
        "type": "null_pointer_exception",
        "reason": "Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord.getSnapshotStartTimestamp()\" is null",
        "stack_trace": "org.elasticsearch.ElasticsearchException$1: Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord.getSnapshotStartTimestamp()\" is null\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.ElasticsearchException.guessRootCauses(ElasticsearchException.java:668)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.ElasticsearchException.generateFailureXContent(ElasticsearchException.java:596)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.rest.RestResponse.build(RestResponse.java:175)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.rest.RestResponse.<init>(RestResponse.java:123)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.rest.RestResponse.<init>(RestResponse.java:102)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.rest.action.RestActionListener.onFailure(RestActionListener.java:55)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.rest.action.RestCancellableNodeClient$1.onFailure(RestCancellableNodeClient.java:96)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.client.internal.node.NodeClient$SafelyWrappedActionListener.onFailure(NodeClient.java:170)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.tasks.TaskManager$1.onFailure(TaskManager.java:218)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.action.support.ContextPreservingActionListener.onFailure(ContextPreservingActionListener.java:38)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.action.ActionListener$Delegating.onFailure(ActionListener.java:97)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.action.ActionListener$Delegating.onFailure(ActionListener.java:97)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.action.ActionRunnable.onFailure(ActionRunnable.java:92)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:28)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:891)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)\n\tat java.base/java.lang.Thread.run(Thread.java:1589)\nCaused by: java.lang.NullPointerException: Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord.getSnapshotStartTimestamp()\" is null\n\tat org.elasticsearch.ilm@8.7.0/org.elasticsearch.xpack.slm.SlmHealthIndicatorService.lambda$calculate$1(SlmHealthIndicatorService.java:157)\n\tat java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)\n\tat java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)\n\tat java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)\n\tat java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)\n\tat org.elasticsearch.ilm@8.7.0/org.elasticsearch.xpack.slm.SlmHealthIndicatorService.calculate(SlmHealthIndicatorService.java:160)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.health.HealthService$1.lambda$calculateFilteredIndicatorsRunnable$0(HealthService.java:158)\n\tat java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)\n\tat java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)\n\tat java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)\n\tat java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)\n\tat java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)\n\tat java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)\n\tat java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)\n\tat java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.health.HealthService$1.lambda$calculateFilteredIndicatorsRunnable$1(HealthService.java:159)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:72)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)\n\t... 6 more\n"
      }
    ],
    "type": "null_pointer_exception",
    "reason": "Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord.getSnapshotStartTimestamp()\" is null",
    "stack_trace": "java.lang.NullPointerException: Cannot invoke \"java.lang.Long.longValue()\" because the return value of \"org.elasticsearch.xpack.core.slm.SnapshotInvocationRecord.getSnapshotStartTimestamp()\" is null\n\tat org.elasticsearch.ilm@8.7.0/org.elasticsearch.xpack.slm.SlmHealthIndicatorService.lambda$calculate$1(SlmHealthIndicatorService.java:157)\n\tat java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)\n\tat java.base/java.util.AbstractList$RandomAccessSpliterator.forEachRemaining(AbstractList.java:722)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)\n\tat java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)\n\tat java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)\n\tat org.elasticsearch.ilm@8.7.0/org.elasticsearch.xpack.slm.SlmHealthIndicatorService.calculate(SlmHealthIndicatorService.java:160)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.health.HealthService$1.lambda$calculateFilteredIndicatorsRunnable$0(HealthService.java:158)\n\tat java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)\n\tat java.base/java.util.stream.ReferencePipeline$2$1.accept(ReferencePipeline.java:179)\n\tat java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)\n\tat java.base/java.util.stream.StreamSpliterators$WrappingSpliterator.forEachRemaining(StreamSpliterators.java:310)\n\tat java.base/java.util.stream.Streams$ConcatSpliterator.forEachRemaining(Streams.java:735)\n\tat java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)\n\tat java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)\n\tat java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:575)\n\tat java.base/java.util.stream.AbstractPipeline.evaluateToArrayNode(AbstractPipeline.java:260)\n\tat java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:616)\n\tat java.base/java.util.stream.ReferencePipeline.toArray(ReferencePipeline.java:622)\n\tat java.base/java.util.stream.ReferencePipeline.toList(ReferencePipeline.java:627)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.health.HealthService$1.lambda$calculateFilteredIndicatorsRunnable$1(HealthService.java:159)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.action.ActionRunnable$3.doRun(ActionRunnable.java:72)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.common.util.concurrent.AbstractRunnable.run(AbstractRunnable.java:26)\n\tat java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:577)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:317)\n\tat org.elasticsearch.server@8.7.0/org.elasticsearch.common.util.concurrent.ThreadContext$ContextPreservingRunnable.run(ThreadContext.java:891)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)\n\tat java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)\n\tat java.base/java.lang.Thread.run(Thread.java:1589)\n"
  },
  "status": 500
}
```

We fix this by checking if the start time is not null and only then we add the start time related message.