### PR TITLE
Add WildcardLike/Pattern to QL

### DIFF
--- a/docs/changelog/95357.yaml
+++ b/docs/changelog/95357.yaml
@@ -1,0 +1,5 @@
+pr: 95357
+summary: Add `WildcardLike/Pattern` to QL
+area: SQL
+type: enhancement
+issues: []

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/AbstractStringPattern.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/AbstractStringPattern.java
@@ -12,11 +12,11 @@ import org.apache.lucene.util.UnicodeUtil;
 import org.apache.lucene.util.automaton.Automaton;
 import org.apache.lucene.util.automaton.Operations;
 
-abstract class AbstractStringPattern implements StringPattern {
+public abstract class AbstractStringPattern implements StringPattern {
 
     private Automaton automaton;
 
-    abstract Automaton createAutomaton();
+    public abstract Automaton createAutomaton();
 
     private Automaton automaton() {
         if (automaton == null) {

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/RLikePattern.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/RLikePattern.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.ql.expression.predicate.regex;
 import org.apache.lucene.util.automaton.Automaton;
 import org.elasticsearch.common.lucene.RegExp;
 
+import java.util.Objects;
+
 public class RLikePattern extends AbstractStringPattern {
 
     private final String regexpPattern;
@@ -18,12 +20,25 @@ public class RLikePattern extends AbstractStringPattern {
     }
 
     @Override
-    Automaton createAutomaton() {
+    public Automaton createAutomaton() {
         return new RegExp(regexpPattern).toAutomaton();
     }
 
     @Override
     public String asJavaRegex() {
         return regexpPattern;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RLikePattern that = (RLikePattern) o;
+        return Objects.equals(regexpPattern, that.regexpPattern);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(regexpPattern);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/WildcardLike.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/WildcardLike.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ql.expression.predicate.regex;
+
+import org.elasticsearch.xpack.ql.expression.Expression;
+import org.elasticsearch.xpack.ql.tree.NodeInfo;
+import org.elasticsearch.xpack.ql.tree.Source;
+
+public class WildcardLike extends RegexMatch<WildcardPattern> {
+
+    public WildcardLike(Source source, Expression left, WildcardPattern pattern) {
+        this(source, left, pattern, false);
+    }
+
+    public WildcardLike(Source source, Expression left, WildcardPattern pattern, boolean caseInsensitive) {
+        super(source, left, pattern, caseInsensitive);
+    }
+
+    @Override
+    protected NodeInfo<WildcardLike> info() {
+        return NodeInfo.create(this, WildcardLike::new, field(), pattern(), caseInsensitive());
+    }
+
+    @Override
+    protected WildcardLike replaceChild(Expression newLeft) {
+        return new WildcardLike(source(), newLeft, pattern(), caseInsensitive());
+    }
+
+}

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/WildcardPattern.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/expression/predicate/regex/WildcardPattern.java
@@ -16,37 +16,25 @@ import org.elasticsearch.xpack.ql.util.StringUtils;
 import java.util.Objects;
 
 /**
- * A SQL 'like' pattern.
- * Similar to basic regex, supporting '_' instead of '?' and '%' instead of '*'.
+ * Similar to basic regex, supporting '?' wildcard for single character (same as regex  ".")
+ * and '*' wildcard for multiple characters (same as regex ".*")
  * <p>
- * Allows escaping based on a regular char.
+ * Allows escaping based on a regular char
  *
- * To prevent conflicts with ES, the string and char must be validated to not contain '*'.
  */
-public class LikePattern extends AbstractStringPattern {
+public class WildcardPattern extends AbstractStringPattern {
 
-    private final String pattern;
-    private final char escape;
-
-    private final String regex;
     private final String wildcard;
-    private final String indexNameWildcard;
+    private final String regex;
 
-    public LikePattern(String pattern, char escape) {
-        this.pattern = pattern;
-        this.escape = escape;
+    public WildcardPattern(String pattern) {
+        this.wildcard = pattern;
         // early initialization to force string validation
-        this.regex = StringUtils.likeToJavaPattern(pattern, escape);
-        this.wildcard = StringUtils.likeToLuceneWildcard(pattern, escape);
-        this.indexNameWildcard = StringUtils.likeToIndexWildcard(pattern, escape);
+        this.regex = StringUtils.wildcardToJavaPattern(pattern, '\\');
     }
 
     public String pattern() {
-        return pattern;
-    }
-
-    public char escape() {
-        return escape;
+        return wildcard;
     }
 
     @Override
@@ -71,12 +59,12 @@ public class LikePattern extends AbstractStringPattern {
      * Returns the pattern in (IndexNameExpressionResolver) wildcard format.
      */
     public String asIndexNameWildcard() {
-        return indexNameWildcard;
+        return wildcard;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(pattern, escape);
+        return Objects.hash(wildcard);
     }
 
     @Override
@@ -89,7 +77,7 @@ public class LikePattern extends AbstractStringPattern {
             return false;
         }
 
-        LikePattern other = (LikePattern) obj;
-        return Objects.equals(pattern, other.pattern) && escape == other.escape;
+        WildcardPattern other = (WildcardPattern) obj;
+        return Objects.equals(wildcard, other.wildcard);
     }
 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -35,6 +35,7 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullE
 import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RLike;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RegexMatch;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.WildcardLike;
 import org.elasticsearch.xpack.ql.querydsl.query.BoolQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.ExistsQuery;
 import org.elasticsearch.xpack.ql.querydsl.query.MatchQuery;
@@ -123,7 +124,9 @@ public final class ExpressionTranslators {
                 if (e instanceof Like l) {
                     q = new WildcardQuery(e.source(), targetFieldName, l.pattern().asLuceneWildcard(), l.caseInsensitive());
                 }
-
+                if (e instanceof WildcardLike l) {
+                    q = new WildcardQuery(e.source(), targetFieldName, l.pattern().asLuceneWildcard(), l.caseInsensitive());
+                }
                 if (e instanceof RLike rl) {
                     q = new RegexQuery(e.source(), targetFieldName, rl.pattern().asJavaRegex(), rl.caseInsensitive());
                 }

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/util/StringUtils.java
@@ -136,6 +136,47 @@ public final class StringUtils {
         return regex.toString();
     }
 
+    // * -> .*
+    // ? -> .
+    // escape character - can be 0 (in which case no regex gets escaped) or
+    // should be followed by % or _ (otherwise an exception is thrown)
+    public static String wildcardToJavaPattern(String pattern, char escape) {
+        StringBuilder regex = new StringBuilder(pattern.length() + 4);
+
+        boolean escaped = false;
+        regex.append('^');
+        for (int i = 0; i < pattern.length(); i++) {
+            char curr = pattern.charAt(i);
+            if (escaped == false && (curr == escape) && escape != 0) {
+                escaped = true;
+                if (i + 1 == pattern.length()) {
+                    throw new QlIllegalArgumentException("Invalid sequence - escape character is not followed by special wildcard char");
+                }
+            } else {
+                switch (curr) {
+                    case '*' -> regex.append(escaped ? "\\*" : ".*");
+                    case '?' -> regex.append(escaped ? "\\?" : ".");
+                    default -> {
+                        if (escaped) {
+                            throw new QlIllegalArgumentException(
+                                "Invalid sequence - escape character is not followed by special wildcard char"
+                            );
+                        }
+                        // escape special regex characters
+                        switch (curr) {
+                            case '\\', '^', '$', '.', '*', '?', '+', '|', '(', ')', '[', ']', '{', '}' -> regex.append('\\');
+                        }
+                        regex.append(curr);
+                    }
+                }
+                escaped = false;
+            }
+        }
+        regex.append('$');
+
+        return regex.toString();
+    }
+
     /**
      * Translates a like pattern to a Lucene wildcard.
      * This methods pays attention to the custom escape char which gets converted into \ (used by Lucene).

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRulesTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/optimizer/OptimizerRulesTests.java
@@ -40,6 +40,8 @@ import org.elasticsearch.xpack.ql.expression.predicate.regex.Like;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.LikePattern;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RLike;
 import org.elasticsearch.xpack.ql.expression.predicate.regex.RLikePattern;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.WildcardLike;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BinaryComparisonSimplification;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanFunctionEqualsElimination;
 import org.elasticsearch.xpack.ql.optimizer.OptimizerRules.BooleanSimplification;
@@ -224,6 +226,7 @@ public class OptimizerRulesTests extends ESTestCase {
 
     public void testConstantFoldingLikes() {
         assertEquals(TRUE, new ConstantFolding().rule(new Like(EMPTY, of("test_emp"), new LikePattern("test%", (char) 0))).canonical());
+        assertEquals(TRUE, new ConstantFolding().rule(new WildcardLike(EMPTY, of("test_emp"), new WildcardPattern("test*"))).canonical());
         assertEquals(TRUE, new ConstantFolding().rule(new RLike(EMPTY, of("test_emp"), new RLikePattern("test.emp"))).canonical());
     }
 
@@ -1434,6 +1437,18 @@ public class OptimizerRulesTests extends ESTestCase {
         }
     }
 
+    public void testMatchAllWildcardLikeToExist() throws Exception {
+        for (String s : asList("*", "**", "***")) {
+            WildcardPattern pattern = new WildcardPattern(s);
+            FieldAttribute fa = getFieldAttribute();
+            WildcardLike l = new WildcardLike(EMPTY, fa, pattern);
+            Expression e = new ReplaceRegexMatch().rule(l);
+            assertEquals(IsNotNull.class, e.getClass());
+            IsNotNull inn = (IsNotNull) e;
+            assertEquals(fa, inn.field());
+        }
+    }
+
     public void testMatchAllRLikeToExist() throws Exception {
         RLikePattern pattern = new RLikePattern(".*");
         FieldAttribute fa = getFieldAttribute();
@@ -1455,6 +1470,18 @@ public class OptimizerRulesTests extends ESTestCase {
             assertEquals(fa, eq.left());
             assertEquals(s.replace("0", StringUtils.EMPTY), eq.right().fold());
         }
+    }
+
+    public void testExactMatchWildcardLike() throws Exception {
+        String s = "ab";
+        WildcardPattern pattern = new WildcardPattern(s);
+        FieldAttribute fa = getFieldAttribute();
+        WildcardLike l = new WildcardLike(EMPTY, fa, pattern);
+        Expression e = new ReplaceRegexMatch().rule(l);
+        assertEquals(Equals.class, e.getClass());
+        Equals eq = (Equals) e;
+        assertEquals(fa, eq.left());
+        assertEquals(s, eq.right().fold());
     }
 
     public void testExactMatchRLike() throws Exception {

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/util/StringUtilsTests.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ql.util;
+
+import org.elasticsearch.test.ESTestCase;
+
+import static org.elasticsearch.xpack.ql.util.StringUtils.wildcardToJavaPattern;
+
+public class StringUtilsTests extends ESTestCase {
+
+    public void testNoWildcard() {
+        assertEquals("^fooBar$", wildcardToJavaPattern("fooBar", '\\'));
+    }
+
+    public void testSimpleWildcard() {
+        assertEquals("^foo.bar$", wildcardToJavaPattern("foo?bar", '\\'));
+        assertEquals("^foo.*bar$", wildcardToJavaPattern("foo*bar", '\\'));
+    }
+
+    public void testMultipleWildcards() {
+        assertEquals("^.*foo.*bar.$", wildcardToJavaPattern("*foo*bar?", '\\'));
+        assertEquals("^foo.*bar.$", wildcardToJavaPattern("foo*bar?", '\\'));
+        assertEquals("^foo.*bar...$", wildcardToJavaPattern("foo*bar???", '\\'));
+        assertEquals("^foo.*bar..*.$", wildcardToJavaPattern("foo*bar?*?", '\\'));
+    }
+
+    public void testDot() {
+        assertEquals("^foo\\.$", wildcardToJavaPattern("foo.", '\\'));
+        assertEquals("^\\..*foobar$", wildcardToJavaPattern(".*foobar", '\\'));
+        assertEquals("^foo\\..*bar$", wildcardToJavaPattern("foo.*bar", '\\'));
+        assertEquals("^foobar\\..*$", wildcardToJavaPattern("foobar.*", '\\'));
+    }
+
+    public void testEscapedJavaRegex() {
+        assertEquals("^\\[a-zA-Z\\]$", wildcardToJavaPattern("[a-zA-Z]", '\\'));
+    }
+
+    public void testWildcard() {
+        assertEquals("^foo\\?$", wildcardToJavaPattern("foo\\?", '\\'));
+        assertEquals("^foo\\?bar$", wildcardToJavaPattern("foo\\?bar", '\\'));
+        assertEquals("^foo\\?.$", wildcardToJavaPattern("foo\\??", '\\'));
+        assertEquals("^foo\\*$", wildcardToJavaPattern("foo\\*", '\\'));
+        assertEquals("^foo\\*bar$", wildcardToJavaPattern("foo\\*bar", '\\'));
+        assertEquals("^foo\\*.*$", wildcardToJavaPattern("foo\\**", '\\'));
+
+        assertEquals("^foo\\?$", wildcardToJavaPattern("foox?", 'x'));
+        assertEquals("^foo\\*$", wildcardToJavaPattern("foox*", 'x'));
+    }
+
+}

--- a/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
+++ b/x-pack/plugin/ql/test-fixtures/src/main/java/org/elasticsearch/xpack/ql/TestUtils.java
@@ -32,6 +32,10 @@ import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessT
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.LessThanOrEqual;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NotEquals;
 import org.elasticsearch.xpack.ql.expression.predicate.operator.comparison.NullEquals;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.RLike;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.RLikePattern;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.WildcardLike;
+import org.elasticsearch.xpack.ql.expression.predicate.regex.WildcardPattern;
 import org.elasticsearch.xpack.ql.index.EsIndex;
 import org.elasticsearch.xpack.ql.plan.logical.EsRelation;
 import org.elasticsearch.xpack.ql.session.Configuration;
@@ -142,6 +146,14 @@ public final class TestUtils {
 
     public static Range rangeOf(Expression value, Expression lower, boolean includeLower, Expression upper, boolean includeUpper) {
         return new Range(EMPTY, value, lower, includeLower, upper, includeUpper, randomZone());
+    }
+
+    public static WildcardLike wildcardLike(Expression left, String exp) {
+        return new WildcardLike(EMPTY, left, new WildcardPattern(exp));
+    }
+
+    public static RLike rlike(Expression left, String exp) {
+        return new RLike(EMPTY, left, new RLikePattern(exp));
     }
 
     public static FieldAttribute fieldAttribute() {


### PR DESCRIPTION
Add basic components for a LIKE syntax that allows `*`/`?` wildcards instead of `%`/`_`