### PR TITLE
[ML] implement check for the minimum version for a packaged trained model

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TrainedModelValidator.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TrainedModelValidator.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.xpack.core.ml.inference.TrainedModelConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig;
+
+import static org.elasticsearch.core.Strings.format;
+
+/**
+ * {@TrainedModelValidator} analyzes a trained model config to find various issues w.r.t. the various combinations of model types,
+ * packages, etc.
+ */
+final class TrainedModelValidator {
+
+    static void validatePackage(
+        TrainedModelConfig.Builder trainedModelConfig,
+        ModelPackageConfig resolvedModelPackageConfig,
+        ClusterState state
+    ) {
+        validateMinimumVersion(resolvedModelPackageConfig, state);
+        // check that user doesn't try to override parts that are
+        trainedModelConfig.validateNoPackageOverrides();
+    }
+
+    static void validateMinimumVersion(ModelPackageConfig resolvedModelPackageConfig, ClusterState state) {
+        Version minimumVersion;
+
+        // {@link Version#fromString} interprets an empty string as current version, so we have to check ourselves
+        if (Strings.isNullOrEmpty(resolvedModelPackageConfig.getMinimumVersion())) {
+            throw new ActionRequestValidationException().addValidationError(
+                format(
+                    "Invalid model package configuration for [%s], missing minimum_version property",
+                    resolvedModelPackageConfig.getPackagedModelId()
+                )
+            );
+        }
+
+        try {
+            minimumVersion = Version.fromString(resolvedModelPackageConfig.getMinimumVersion());
+        } catch (IllegalArgumentException e) {
+            throw new ActionRequestValidationException().addValidationError(
+                format(
+                    "Invalid model package configuration for [%s], failed to parse the minimum_version property",
+                    resolvedModelPackageConfig.getPackagedModelId()
+                )
+            );
+        }
+
+        if (state.nodes().getMinNodeVersion().before(minimumVersion)) {
+            throw new ActionRequestValidationException().addValidationError(
+                format(
+                    "The model [%s] requires that all nodes are at least version [%s]",
+                    resolvedModelPackageConfig.getPackagedModelId(),
+                    resolvedModelPackageConfig.getMinimumVersion()
+                )
+            );
+        }
+    }
+
+    private TrainedModelValidator() {}
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -307,13 +307,13 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
         if (config.isPackagedModel()) {
             resolvePackageConfig(config.getModelId(), ActionListener.wrap(resolvedModelPackageConfig -> {
                 try {
-                    trainedModelConfig.validateNoPackageOverrides();
+                    TrainedModelValidator.validatePackage(trainedModelConfig, resolvedModelPackageConfig, state);
                 } catch (ValidationException e) {
                     listener.onFailure(e);
                     return;
                 }
                 modelPackageConfigHolder.set(resolvedModelPackageConfig);
-                setTrainedModelConfigFieldsFromPackagedModel(trainedModelConfig, resolvedModelPackageConfig);
+                setTrainedModelConfigFieldsFromPackagedModel(trainedModelConfig, resolvedModelPackageConfig, xContentRegistry);
 
                 checkModelIdAgainstTags(trainedModelConfig.getModelId(), modelIdTagCheckListener);
             }, listener::onFailure));

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportPutTrainedModelAction.java
@@ -313,7 +313,7 @@ public class TransportPutTrainedModelAction extends TransportMasterNodeAction<Re
                     return;
                 }
                 modelPackageConfigHolder.set(resolvedModelPackageConfig);
-                setTrainedModelConfigFieldsFromPackagedModel(trainedModelConfig, resolvedModelPackageConfig, xContentRegistry);
+                setTrainedModelConfigFieldsFromPackagedModel(trainedModelConfig, resolvedModelPackageConfig);
 
                 checkModelIdAgainstTags(trainedModelConfig.getModelId(), modelIdTagCheckListener);
             }, listener::onFailure));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TrainedModelValidatorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TrainedModelValidatorTests.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.action;
+
+import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfig;
+import org.elasticsearch.xpack.core.ml.inference.trainedmodel.ModelPackageConfigTests;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class TrainedModelValidatorTests extends ESTestCase {
+
+    public void testValidateMinimumVersion() {
+        final ModelPackageConfig packageConfig = new ModelPackageConfig.Builder(ModelPackageConfigTests.randomModulePackageConfig())
+            .setMinimumVersion("99.9.9")
+            .build();
+
+        ClusterState state = mock(ClusterState.class);
+        DiscoveryNodes nodes = mock(DiscoveryNodes.class);
+        when(state.nodes()).thenReturn(nodes);
+        when(nodes.getMinNodeVersion()).thenReturn(Version.CURRENT);
+
+        Exception e = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelValidator.validateMinimumVersion(packageConfig, state)
+        );
+
+        assertEquals(
+            "Validation Failed: 1: The model ["
+                + packageConfig.getPackagedModelId()
+                + "] requires that all nodes are at least version [99.9.9];",
+            e.getMessage()
+        );
+
+        final ModelPackageConfig packageConfigCurrent = new ModelPackageConfig.Builder(ModelPackageConfigTests.randomModulePackageConfig())
+            .setMinimumVersion(Version.CURRENT.toString())
+            .build();
+        TrainedModelValidator.validateMinimumVersion(packageConfigCurrent, state);
+
+        when(nodes.getMinNodeVersion()).thenReturn(Version.V_8_7_0);
+
+        e = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelValidator.validateMinimumVersion(packageConfigCurrent, state)
+        );
+
+        assertEquals(
+            "Validation Failed: 1: The model ["
+                + packageConfigCurrent.getPackagedModelId()
+                + "] requires that all nodes are at least version ["
+                + Version.CURRENT
+                + "];",
+            e.getMessage()
+        );
+
+        final ModelPackageConfig packageConfigBroken = new ModelPackageConfig.Builder(ModelPackageConfigTests.randomModulePackageConfig())
+            .setMinimumVersion("_broken_version_")
+            .build();
+
+        e = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelValidator.validateMinimumVersion(packageConfigBroken, state)
+        );
+
+        assertEquals(
+            "Validation Failed: 1: Invalid model package configuration for ["
+                + packageConfigBroken.getPackagedModelId()
+                + "], failed to parse the minimum_version property;",
+            e.getMessage()
+        );
+
+        final ModelPackageConfig packageConfigVersionMissing = new ModelPackageConfig.Builder(
+            ModelPackageConfigTests.randomModulePackageConfig()
+        ).setMinimumVersion("").build();
+
+        e = expectThrows(
+            ActionRequestValidationException.class,
+            () -> TrainedModelValidator.validateMinimumVersion(packageConfigVersionMissing, state)
+        );
+
+        assertEquals(
+            "Validation Failed: 1: Invalid model package configuration for ["
+                + packageConfigVersionMissing.getPackagedModelId()
+                + "], missing minimum_version property;",
+            e.getMessage()
+        );
+    }
+}


### PR DESCRIPTION
check the minimum_version field of a packaged model, only allow model install if all nodes fulfill the requirement