### PR TITLE
Refactor the new snapshot code in Engine

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -196,7 +196,6 @@ import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -7400,25 +7399,6 @@ public class InternalEngineTests extends EngineTestCase {
                 assertThat(userData.get(ES_VERSION), is(equalTo(Version.CURRENT.toString())));
             }
         }
-    }
-
-    public void testExtraUserDataIsCommitted() throws IOException {
-        engine.close();
-        engine = new InternalEngine(engine.config()) {
-            @Override
-            protected Map<String, String> getCommitExtraUserData() {
-                return Map.of("userkey", "userdata", ES_VERSION, Version.V_EMPTY.toString());
-            }
-        };
-        engine.skipTranslogRecovery();
-
-        ParsedDocument doc = testParsedDocument("1", null, testDocumentWithTextField(), SOURCE, null);
-        engine.index(indexForDoc(doc));
-        engine.flush();
-
-        Map<String, String> userData = engine.getLastCommittedSegmentInfos().getUserData();
-        assertThat(userData, hasEntry("userkey", "userdata"));
-        assertThat(userData, hasEntry(ES_VERSION, Version.CURRENT.toString()));
     }
 
     public void testTrimUnsafeCommitHasESVersionInUserData() throws IOException {


### PR DESCRIPTION
Relates ES-5058

Revert "Ability to add extra user data for lucene commits (#95073)" This reverts commit 192b4aacc3e4754782b10a623b7ade1b266c8268.

Relates ES-5849
