### PR TITLE
Move more work that blocks on PeerFinder mutex to coordinating thread

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1111,7 +1111,8 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
                     TransportRequestOptions.timeout(transportTimeout),
                     new ActionListenerResponseHandler<>(
                         ActionListener.runBefore(fetchRemoteResultListener, () -> Releasables.close(releasable)),
-                        transportActionType.getResponseReader()
+                        transportActionType.getResponseReader(),
+                        ThreadPool.Names.CLUSTER_COORDINATION
                     )
                 );
             }
@@ -1165,7 +1166,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
             public String toString() {
                 return "delayed retrieval of coordination diagnostics info from " + masterEligibleNode;
             }
-        }, remoteRequestInitialDelay, ThreadPool.Names.SAME);
+        }, remoteRequestInitialDelay, ThreadPool.Names.CLUSTER_COORDINATION);
     }
 
     void cancelPollingRemoteMasterStabilityDiagnostic() {

--- a/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
+++ b/server/src/main/java/org/elasticsearch/discovery/SeedHostsResolver.java
@@ -179,7 +179,7 @@ public class SeedHostsResolver extends AbstractLifecycleComponent implements Con
         }
 
         if (resolveInProgress.compareAndSet(false, true)) {
-            transportService.getThreadPool().generic().execute(new AbstractRunnable() {
+            transportService.getThreadPool().executor(ThreadPool.Names.CLUSTER_COORDINATION).execute(new AbstractRunnable() {
                 @Override
                 public void onFailure(Exception e) {
                     logger.debug("failure when resolving unicast hosts list", e);

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -515,7 +515,7 @@ public class TransportService extends AbstractLifecycleComponent
      * and returns the discovery node of the node the connection
      * was established with. The handshake will fail if the cluster
      * name on the target node mismatches the local cluster name.
-     * The ActionListener will be called on the calling thread or the generic thread pool.
+     * The ActionListener will be called on the calling thread or the cluster coordination thread pool.
      *
      * @param connection       the connection to a specific node
      * @param handshakeTimeout handshake timeout
@@ -536,7 +536,7 @@ public class TransportService extends AbstractLifecycleComponent
      * and returns the discovery node of the node the connection
      * was established with. The handshake will fail if the cluster
      * name on the target node doesn't match the local cluster name.
-     * The ActionListener will be called on the calling thread or the generic thread pool.
+     * The ActionListener will be called on the calling thread or the cluster coordination thread pool.
      *
      * @param connection       the connection to a specific node
      * @param handshakeTimeout handshake timeout
@@ -583,7 +583,7 @@ public class TransportService extends AbstractLifecycleComponent
                 } else {
                     l.onResponse(response);
                 }
-            }), HandshakeResponse::new, ThreadPool.Names.GENERIC)
+            }), HandshakeResponse::new, ThreadPool.Names.CLUSTER_COORDINATION)
         );
     }
 
@@ -1281,7 +1281,7 @@ public class TransportService extends AbstractLifecycleComponent
         // want handlers to worry about stack overflows.
         // Execute on the current thread in the special case of a node shut down to notify the listener even when the threadpool has
         // already been shut down.
-        final String executor = lifecycle.stoppedOrClosed() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC;
+        final String executor = lifecycle.stoppedOrClosed() ? ThreadPool.Names.SAME : ThreadPool.Names.CLUSTER_COORDINATION;
         threadPool.executor(executor).execute(new AbstractRunnable() {
             @Override
             public void doRun() {

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -515,7 +515,7 @@ public class TransportService extends AbstractLifecycleComponent
      * and returns the discovery node of the node the connection
      * was established with. The handshake will fail if the cluster
      * name on the target node mismatches the local cluster name.
-     * The ActionListener will be called on the calling thread or the cluster coordination thread pool.
+     * The ActionListener will be called on the calling thread or the generic thread pool.
      *
      * @param connection       the connection to a specific node
      * @param handshakeTimeout handshake timeout
@@ -536,7 +536,7 @@ public class TransportService extends AbstractLifecycleComponent
      * and returns the discovery node of the node the connection
      * was established with. The handshake will fail if the cluster
      * name on the target node doesn't match the local cluster name.
-     * The ActionListener will be called on the calling thread or the cluster coordination thread pool.
+     * The ActionListener will be called on the calling thread or the generic thread pool.
      *
      * @param connection       the connection to a specific node
      * @param handshakeTimeout handshake timeout

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -583,7 +583,7 @@ public class TransportService extends AbstractLifecycleComponent
                 } else {
                     l.onResponse(response);
                 }
-            }), HandshakeResponse::new, ThreadPool.Names.CLUSTER_COORDINATION)
+            }), HandshakeResponse::new, ThreadPool.Names.GENERIC)
         );
     }
 
@@ -1281,7 +1281,7 @@ public class TransportService extends AbstractLifecycleComponent
         // want handlers to worry about stack overflows.
         // Execute on the current thread in the special case of a node shut down to notify the listener even when the threadpool has
         // already been shut down.
-        final String executor = lifecycle.stoppedOrClosed() ? ThreadPool.Names.SAME : ThreadPool.Names.CLUSTER_COORDINATION;
+        final String executor = lifecycle.stoppedOrClosed() ? ThreadPool.Names.SAME : ThreadPool.Names.GENERIC;
         threadPool.executor(executor).execute(new AbstractRunnable() {
             @Override
             public void doRun() {


### PR DESCRIPTION
follow up to #95341 

Moving a couple of things that eventually use the peer finder and involve cluster coordination work to the coordinating thread. This avoids blocking on its mutex on the scheduler and transport threads and causing needless contention by running work on the generic pool that can very well wait for its turn on the cluster coordinating pool. Also this takes some more load off of the transport threads by moving response serializations to the coordinating pool.