### PR TITLE
Deduplicate Heavy CCR Repository CS Requests (#91398)

### DIFF
--- a/docs/changelog/91398.yaml
+++ b/docs/changelog/91398.yaml
@@ -1,0 +1,5 @@
+pr: 91398
+summary: Deduplicate Heavy CCR Repository CS Requests
+area: CCR
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/transport/SingleResultDeduplicatorTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SingleResultDeduplicatorTests.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.transport;
+
+import org.apache.lucene.util.SetOnce;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.SingleResultDeduplicator;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+
+public class SingleResultDeduplicatorTests extends ESTestCase {
+
+    public void testDeduplicatesWithoutShowingStaleData() {
+        final SetOnce<ActionListener<Object>> firstListenerRef = new SetOnce<>();
+        final SetOnce<ActionListener<Object>> secondListenerRef = new SetOnce<>();
+        final SingleResultDeduplicator<Object> deduplicator = new SingleResultDeduplicator<>(new ThreadContext(Settings.EMPTY), l -> {
+            if (firstListenerRef.trySet(l) == false) {
+                secondListenerRef.set(l);
+            }
+        });
+        final Object result1 = new Object();
+        final Object result2 = new Object();
+
+        final int totalListeners = randomIntBetween(2, 10);
+        final boolean[] called = new boolean[totalListeners];
+        deduplicator.execute(new ActionListener<Object>() {
+            @Override
+            public void onResponse(Object response) {
+                assertFalse(called[0]);
+                called[0] = true;
+                assertEquals(result1, response);
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                throw new AssertionError(e);
+            }
+        });
+
+        for (int i = 1; i < totalListeners; i++) {
+            final int index = i;
+            deduplicator.execute(new ActionListener<Object>() {
+
+                @Override
+                public void onResponse(Object response) {
+                    assertFalse(called[index]);
+                    called[index] = true;
+                    assertEquals(result2, response);
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError(e);
+                }
+            });
+        }
+        for (int i = 0; i < totalListeners; i++) {
+            assertFalse(called[i]);
+        }
+        firstListenerRef.get().onResponse(result1);
+        assertTrue(called[0]);
+        for (int i = 1; i < totalListeners; i++) {
+            assertFalse(called[i]);
+        }
+        secondListenerRef.get().onResponse(result2);
+        for (int i = 0; i < totalListeners; i++) {
+            assertTrue(called[i]);
+        }
+    }
+}


### PR DESCRIPTION
We run the same request back to back for each put-follower call during the restore. Also, concurrent put-follower calls will all run the same full CS request concurrently.
In older versions prior to https://github.com/elastic/elasticsearch/pull/87235 the concurrency was limited by the size of the snapshot pool. With that fix though, they are run at almost arbitry concurrency when many put-follow requests are executed concurrently.
-> fixed by using the existing deduplicator to only run a single remote CS request at a time for each CCR repository.
Also, this removes the needless forking in the put-follower action that is not necessary any longer now that we have the CCR repository non-blocking (we do the same for normal restores that can safely be started from a transport thread), which should fix some bad-ux situations where the snapshot threads are busy on master, making the put-follower requests not go through in time.

back port of #91398 