### PR TITLE
[8.7] Fix NPE when the start time of the last successful snapshot run is unknown (#95356)

### DIFF
--- a/docs/changelog/95356.yaml
+++ b/docs/changelog/95356.yaml
@@ -1,0 +1,5 @@
+pr: 95356
+summary: Fix NPE when the start time of the last successful snapshot run is unknown
+area: Health
+type: bug
+issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/slm/SlmHealthIndicatorService.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.slm.SnapshotLifecyclePolicyMetadata;
 import java.time.ZoneOffset;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -133,6 +134,7 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                 .values()
                 .stream()
                 .filter(metadata -> snapshotFailuresExceedWarningCount(failedSnapshotWarnThreshold, metadata))
+                .sorted(Comparator.comparing(SnapshotLifecyclePolicyMetadata::getName))
                 .toList();
 
             if (unhealthyPolicies.size() > 0) {
@@ -153,9 +155,10 @@ public class SlmHealthIndicatorService implements HealthIndicatorService {
                             + policy.getName()
                             + "] had ["
                             + policy.getInvocationsSinceLastSuccess()
-                            + "] repeated failures without successful execution since ["
-                            + FORMATTER.formatMillis(policy.getLastSuccess().getSnapshotStartTimestamp())
-                            + "]"
+                            + "] repeated failures without successful execution"
+                            + (policy.getLastSuccess() != null && policy.getLastSuccess().getSnapshotStartTimestamp() != null
+                                ? " since [" + FORMATTER.formatMillis(policy.getLastSuccess().getSnapshotStartTimestamp()) + "]"
+                                : "")
                     )
                     .collect(Collectors.joining("\n"));
                 String cause = (unhealthyPolicies.size() > 1


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix NPE when the start time of the last successful snapshot run is unknown (#95356)