### PR TITLE
Set Search Application API stability as "experimental"

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html",
       "description": "Deletes a search application."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.delete_behavioral_analytics.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
       "description": "Delete a behavioral analytics collection."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/get-search-application.html",
       "description": "Returns the details about a search application."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.get_behavioral_analytics.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html",
       "description": "Returns the existing behavioral analytics collections."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.list.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-search-applications.html",
       "description": "Returns the existing search applications."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-search-application.html",
       "description": "Creates or updates a search application."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.put_behavioral_analytics.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
       "description": "Creates a behavioral analytics collection."
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.search.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.search.json
@@ -4,7 +4,7 @@
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/search-application-search.html",
       "description": "Perform a search against a search application"
     },
-    "stability": "beta",
+    "stability": "experimental",
     "visibility": "public",
     "headers": {
       "accept": [


### PR DESCRIPTION
Set Search Applications API stability in REST API specs as "experimental" according to [this conversation](https://elastic.slack.com/archives/C0D8Y4ZJ9/p1681822180604019).