### PR TITLE
Add event_loop_utilization Kibana stats to the monitoring index templates

### DIFF
--- a/docs/changelog/95388.yaml
+++ b/docs/changelog/95388.yaml
@@ -1,0 +1,5 @@
+pr: 95388
+summary: Add `event_loop_utilization` Kibana stats to the monitoring index templates
+area: Monitoring
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/monitoring/exporter/MonitoringTemplateUtils.java
@@ -19,7 +19,7 @@ public final class MonitoringTemplateUtils {
      * <p>
      * It may be possible for this to diverge between templates and pipelines, but for now they're the same.
      */
-    public static final int LAST_UPDATED_VERSION = Version.V_8_7_0.id;
+    public static final int LAST_UPDATED_VERSION = Version.V_8_8_0.id;
 
     /**
      * Current version of templates used in their name to differentiate from breaking changes (separate from product version).

--- a/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
+++ b/x-pack/plugin/core/src/main/resources/monitoring-kibana-mb.json
@@ -122,6 +122,22 @@
                         }
                       }
                     },
+                    "event_loop_utilization": {
+                      "properties": {
+                        "active": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "idle": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        },
+                        "utilization": {
+                          "scaling_factor": 1000,
+                          "type": "scaled_float"
+                        }
+                      }
+                    },
                     "uptime": {
                       "properties": {
                         "ms": {

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -50,7 +50,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * continue to use the release version number in this registry, even though this is not standard practice for template
      * registries.
      */
-    public static final int REGISTRY_VERSION = Version.V_8_7_0.id;
+    public static final int REGISTRY_VERSION = Version.V_8_8_0.id;
     private static final String REGISTRY_VERSION_VARIABLE = "xpack.monitoring.template.release.version";
 
     /**

--- a/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
+++ b/x-pack/plugin/monitoring/src/main/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistry.java
@@ -78,7 +78,7 @@ public class MonitoringTemplateRegistry extends IndexTemplateRegistry {
      * writes monitoring data in ECS format as of 8.0. These templates define the ECS schema as well as alias fields for the old monitoring
      * mappings that point to the corresponding ECS fields.
      */
-    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 8;
+    public static final int STACK_MONITORING_REGISTRY_VERSION = Version.V_8_0_0.id + 9;
     private static final String STACK_MONITORING_REGISTRY_VERSION_VARIABLE = "xpack.stack.monitoring.template.release.version";
     private static final String STACK_TEMPLATE_VERSION = "8";
     private static final String STACK_TEMPLATE_VERSION_VARIABLE = "xpack.stack.monitoring.template.version";


### PR DESCRIPTION
Adds mappings for `kibana.stats.process.event_loop_utilization` to the monitoring templates.

Corresponding Beats PR: https://github.com/elastic/beats/pull/35020
