### PR TITLE
Use UID for dockerfile to allow runAsNonRoot to be used.

### DIFF
--- a/distribution/docker/src/docker/Dockerfile
+++ b/distribution/docker/src/docker/Dockerfile
@@ -289,7 +289,7 @@ ENTRYPOINT ["/bin/tini", "--", "/usr/local/bin/docker-entrypoint.sh"]
 CMD ["eswrapper"]
 <% } %>
 
-USER elasticsearch:root
+USER 1000:0
 
 <% if (docker_base == 'iron_bank') { %>
 HEALTHCHECK --interval=10s --timeout=5s --start-period=1m --retries=5 CMD curl -I -f --max-time 5 http://localhost:9200 || exit 1


### PR DESCRIPTION
See https://github.com/elastic/cloud-on-k8s/pull/6688#issuecomment-1514363649

This change will allow the Elasticsearch container in Kubernetes to be ran with `runAsNonRoot` as it checks against the numeric UID, and not a name.

Without this change you encounter the following error:

```
Warning  Failed     2m10s (x12 over 3m48s)  kubelet            Error: container has runAsNonRoot and image has non-numeric user (elasticsearch), cannot verify user is non-root
```