### PR TITLE
GA release of the JWT realm

### DIFF
--- a/docs/changelog/95398.yaml
+++ b/docs/changelog/95398.yaml
@@ -1,0 +1,9 @@
+pr: 95398
+summary: GA release of the JWT realm
+area: Authentication
+type: docs
+issues: []
+highlight:
+  title: GA release of the JWT realm
+  body: This PR removes the beta label for JWT realm feature to make it GA.
+  notable: true

--- a/docs/changelog/95398.yaml
+++ b/docs/changelog/95398.yaml
@@ -1,7 +1,7 @@
 pr: 95398
 summary: GA release of the JWT realm
 area: Authentication
-type: docs
+type: feature
 issues: []
 highlight:
   title: GA release of the JWT realm

--- a/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
@@ -2,8 +2,6 @@
 [[jwt-auth-realm]]
 === JWT authentication
 
-beta::[]
-
 {es} can be configured to trust JSON Web Tokens (JWTs) issued from an external service
 as bearer tokens for authentication.
 


### PR DESCRIPTION
This PR removes the beta label for JWT realm feature to make it GA.

