### PR TITLE
Revert "mute multiple tests (#95145)"

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/cluster.component_template/10_basic.yml
@@ -117,8 +117,8 @@
 ---
 "Add data lifecycle":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/95141"
+      version: " - 8.7.99"
+      reason: "Data Lifecycle template was added after 8.7"
 
   - do:
       cluster.put_component_template:
@@ -144,8 +144,8 @@
 ---
 "Get data lifecycle with default rollover":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/95141"
+      version: " - 8.7.99"
+      reason: "Data Lifecycle template was added after 8.7"
 
   - do:
       cluster.put_component_template:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.get_index_template/10_basic.yml
@@ -107,8 +107,9 @@ setup:
 ---
 "Add data lifecycle":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/95141"
+      version: " - 8.7.99"
+      reason: "Data lifecycle in index templates was added after 8.7"
+      features: allowed_warnings
 
   - do:
       allowed_warnings:
@@ -140,8 +141,9 @@ setup:
 ---
 "Get data lifecycle with default rollover":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/95141"
+      version: " - 8.7.99"
+      reason: "Data lifecycle in index templates was added after 8.7"
+      features: allowed_warnings
 
   - do:
       allowed_warnings:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_index_template/10_basic.yml
@@ -227,8 +227,9 @@
 ---
 "Simulate index template with lifecycle and include defaults":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/95141"
+      version: " - 8.7.99"
+      reason: "Lifecycle is only available in 8.8+"
+      features: ["default_shards"]
 
   - do:
       indices.put_index_template:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.simulate_template/10_basic.yml
@@ -202,8 +202,9 @@
 ---
 "Simulate template with lifecycle and include defaults":
   - skip:
-      version: "all"
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/95141"
+      version: " - 8.7.99"
+      reason: "Lifecycle is only available in 8.8+"
+      features: ["default_shards"]
 
   - do:
       indices.put_index_template:


### PR DESCRIPTION
It looks that the problem was that the feature flag was not properly enabled in combination with ` -Dtests.jvm.argline="-Dbuild.snapshot=false"`.

This issue was manifesting with other tests as well but appears to be fixed. Locally the test doesn't fail. For this reason I would like to unmute the tests and see if it is fixed here too.

Fixes: #95146