### PR TITLE
Add toString to AbstractBlobContainer

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/support/AbstractBlobContainer.java
@@ -39,4 +39,8 @@ public abstract class AbstractBlobContainer implements BlobContainer {
         return this.path;
     }
 
+    @Override
+    public String toString() {
+        return getClass() + "{" + path + "}";
+    }
 }


### PR DESCRIPTION
Just adding a default toString here to help with debugging. We don't really log these objects anywhere at the moment I think but it's immensely helpful to have the path shown in toString when working with a debugger.

