### PR TITLE
Mark Core/Infra Rest API for serverless

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -722,6 +722,7 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
             }
         }
     }
+
     @ServerlessScope(Scope.PUBLIC)
     public static class RestAction extends BaseRestHandler {
 

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/action/PainlessExecuteAction.java
@@ -60,6 +60,8 @@ import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.painless.spi.PainlessTestScript;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 import org.elasticsearch.script.BooleanFieldScript;
 import org.elasticsearch.script.CompositeFieldScript;
@@ -720,7 +722,7 @@ public class PainlessExecuteAction extends ActionType<PainlessExecuteAction.Resp
             }
         }
     }
-
+    @ServerlessScope(Scope.PUBLIC)
     public static class RestAction extends BaseRestHandler {
 
         @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/RestMainAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/RestMainAction.java
@@ -26,7 +26,7 @@ import java.util.List;
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.HEAD;
 
-@ServerlessScope(Scope.INTERNAL)
+@ServerlessScope(Scope.PUBLIC)
 public class RestMainAction extends BaseRestHandler {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetScriptContextAction extends BaseRestHandler {
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
@@ -13,13 +13,15 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetScriptContextRequ
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-
+@ServerlessScope(Scope.PUBLIC)
 public class RestGetScriptContextAction extends BaseRestHandler {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
@@ -13,13 +13,15 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetScriptLanguageReq
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
-
+@ServerlessScope(Scope.PUBLIC)
 public class RestGetScriptLanguageAction extends BaseRestHandler {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
+
 @ServerlessScope(Scope.PUBLIC)
 public class RestGetScriptLanguageAction extends BaseRestHandler {
 

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestNodesHotThreadsAction.java
@@ -20,6 +20,8 @@ import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestResponse;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestResponseListener;
 
 import java.io.IOException;
@@ -28,6 +30,7 @@ import java.util.Locale;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
+@ServerlessScope(Scope.INTERNAL)
 public class RestNodesHotThreadsAction extends BaseRestHandler {
 
     private static final String formatDeprecatedMessageWithoutNodeID = "[%s] is a deprecated endpoint. "

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeIndexDiskUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeIndexDiskUsageAction.java
@@ -17,6 +17,8 @@ import org.elasticsearch.core.Booleans;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
@@ -24,7 +26,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
-
+@ServerlessScope(Scope.PUBLIC)
 public class RestAnalyzeIndexDiskUsageAction extends BaseRestHandler {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeIndexDiskUsageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/indices/RestAnalyzeIndexDiskUsageAction.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.POST;
+
 @ServerlessScope(Scope.PUBLIC)
 public class RestAnalyzeIndexDiskUsageAction extends BaseRestHandler {
 


### PR DESCRIPTION
This commit exposes core/infra owned REST APIs for serverless deployment.
It uses @ServerlessScope(Scope.PUBLIC) to achieve this.

follows up on https://github.com/elastic/elasticsearch/pull/94037

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against main? Unless there is a good reason otherwise, we prefer pull requests against main and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS and architecture that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/main/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
