### PR TITLE
[ML] validate and restrict model package property for air-gapped environments

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
@@ -8,8 +8,10 @@ package org.elasticsearch.xpack.ml.packageloader;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Setting;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.plugins.ActionPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.xpack.core.ml.packageloader.action.GetTrainedModelPackageConfigAction;
@@ -17,12 +19,15 @@ import org.elasticsearch.xpack.core.ml.packageloader.action.LoadTrainedModelPack
 import org.elasticsearch.xpack.ml.packageloader.action.TransportGetTrainedModelPackageConfigAction;
 import org.elasticsearch.xpack.ml.packageloader.action.TransportLoadTrainedModelPackage;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
+import java.util.Set;
 
 public class MachineLearningPackageLoader extends Plugin implements ActionPlugin {
-
-    private final Settings settings;
 
     public static final String DEFAULT_ML_MODELS_REPOSITORY = "https://ml-models.elastic.co";
     public static final Setting<String> MODEL_REPOSITORY = Setting.simpleString(
@@ -35,9 +40,7 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
     // re-using thread pool setup by the ml plugin
     public static final String UTILITY_THREAD_POOL_NAME = "ml_utility";
 
-    public MachineLearningPackageLoader(Settings settings) {
-        this.settings = settings;
-    }
+    public MachineLearningPackageLoader() {}
 
     @Override
     public List<Setting<?>> getSettings() {
@@ -51,5 +54,53 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
             new ActionHandler<>(GetTrainedModelPackageConfigAction.INSTANCE, TransportGetTrainedModelPackageConfigAction.class),
             new ActionHandler<>(LoadTrainedModelPackageAction.INSTANCE, TransportLoadTrainedModelPackage.class)
         );
+    }
+
+    @Override
+    public List<BootstrapCheck> getBootstrapChecks() {
+        return List.of(new BootstrapCheck() {
+            @Override
+            public BootstrapCheckResult check(BootstrapContext context) {
+                try {
+                    validateModelRepository(MODEL_REPOSITORY.get(context.settings()), context.environment().configFile());
+                } catch (Exception e) {
+                    return BootstrapCheckResult.failure(
+                        "Found an invalid configuration for xpack.ml.model_repository. "
+                            + e.getMessage()
+                            + ". See <TODO: URL> for more information."
+                    );
+                }
+                return BootstrapCheckResult.success();
+            }
+
+            @Override
+            public boolean alwaysEnforce() {
+                return true;
+            }
+        });
+    }
+
+    static void validateModelRepository(String repository, Path configPath) throws URISyntaxException {
+        URI baseUri = new URI(repository.endsWith("/") ? repository : repository + "/").normalize();
+        String normalizedConfigPath = configPath.normalize().toAbsolutePath().toString();
+
+        if (Strings.isNullOrEmpty(baseUri.getScheme())) {
+            throw new IllegalArgumentException(
+                "xpack.ml.model_repository must contain a scheme, possible schemes are \"http\", \"https\", \"file\""
+            );
+        }
+
+        final String scheme = baseUri.getScheme().toLowerCase(Locale.ROOT);
+        if (Set.of("http", "https", "file").contains(scheme) == false) {
+            throw new IllegalArgumentException(
+                "xpack.ml.model_repository must be configured with one of the following schemes: \"http\", \"https\", \"file\""
+            );
+        }
+
+        if (scheme.equals("file") && (baseUri.getPath().startsWith(normalizedConfigPath) == false)) {
+            throw new IllegalArgumentException(
+                "If xpack.ml.model_repository is a file location, it must be placed below the configuration path: " + configPath
+            );
+        }
     }
 }

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
@@ -86,7 +86,7 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
 
         if (Strings.isNullOrEmpty(baseUri.getScheme())) {
             throw new IllegalArgumentException(
-                "xpack.ml.model_repository must contain a scheme, possible schemes are \"http\", \"https\", \"file\""
+                "xpack.ml.model_repository must contain a scheme, supported schemes are \"http\", \"https\", \"file\""
             );
         }
 

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
@@ -93,7 +93,7 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
 
     static void validateModelRepository(String repository, Path configPath) throws URISyntaxException {
         URI baseUri = new URI(repository.endsWith("/") ? repository : repository + "/").normalize();
-        URI normalizedConfigUri = new URI("file://" + configPath.toAbsolutePath().toString()).normalize();
+        URI normalizedConfigUri = configPath.toUri().normalize();
 
         if (Strings.isNullOrEmpty(baseUri.getScheme())) {
             throw new IllegalArgumentException(

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.ml.packageloader.action;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.SpecialPermission;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.hash.MessageDigests;
 import org.elasticsearch.common.io.Streams;
@@ -28,6 +29,7 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.HttpURLConnection;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.security.AccessController;
 import java.security.MessageDigest;
@@ -93,6 +95,8 @@ final class ModelLoaderUtils {
 
     static InputStream getInputStreamFromModelRepository(URI uri) throws IOException {
         String scheme = uri.getScheme().toLowerCase(Locale.ROOT);
+
+        // if you add a scheme here, also add it to the bootstrap check in {@link MachineLearningPackageLoader#validateModelRepository}
         switch (scheme) {
             case "http":
             case "https":
@@ -104,7 +108,7 @@ final class ModelLoaderUtils {
         }
     }
 
-    public static Tuple<List<String>, List<String>> loadVocabulary(URI uri) {
+    static Tuple<List<String>, List<String>> loadVocabulary(URI uri) {
         try {
             InputStream vocabInputStream = getInputStreamFromModelRepository(uri);
 
@@ -130,6 +134,25 @@ final class ModelLoaderUtils {
         } catch (Exception e) {
             throw new RuntimeException("Failed to load vocabulary file", e);
         }
+    }
+
+    static URI resolvePackageLocation(String repository, String artefact) throws URISyntaxException {
+        URI baseUri = new URI(repository.endsWith("/") ? repository : repository + "/").normalize();
+        URI resolvedUri = baseUri.resolve(artefact).normalize();
+
+        if (Strings.isNullOrEmpty(baseUri.getScheme())) {
+            throw new IllegalArgumentException("Repository must contain a scheme");
+        }
+
+        if (baseUri.getScheme().equals(resolvedUri.getScheme()) == false) {
+            throw new IllegalArgumentException("Illegal schema change in package location");
+        }
+
+        if (resolvedUri.getPath().startsWith(baseUri.getPath()) == false) {
+            throw new IllegalArgumentException("Illegal path in package location");
+        }
+
+        return baseUri.resolve(artefact);
     }
 
     private ModelLoaderUtils() {}

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportGetTrainedModelPackageConfigAction.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportGetTrainedModelPackageConfigAction.java
@@ -72,12 +72,13 @@ public class TransportGetTrainedModelPackageConfigAction extends TransportMaster
     @Override
     protected void masterOperation(Task task, Request request, ClusterState state, ActionListener<Response> listener) throws Exception {
         String repository = MachineLearningPackageLoader.MODEL_REPOSITORY.get(settings);
+
         String packagedModelId = request.getPackagedModelId();
         logger.trace(() -> format("Fetch package manifest for [%s] from [%s]", packagedModelId, repository));
 
         threadPool.executor(MachineLearningPackageLoader.UTILITY_THREAD_POOL_NAME).execute(() -> {
             try {
-                URI uri = new URI(repository).resolve(packagedModelId + ModelLoaderUtils.METADATA_FILE_EXTENSION);
+                URI uri = ModelLoaderUtils.resolvePackageLocation(repository, packagedModelId + ModelLoaderUtils.METADATA_FILE_EXTENSION);
                 InputStream inputStream = ModelLoaderUtils.getInputStreamFromModelRepository(uri);
 
                 try (

--- a/x-pack/plugin/ml-package-loader/src/main/plugin-metadata/plugin-security.policy
+++ b/x-pack/plugin/ml-package-loader/src/main/plugin-metadata/plugin-security.policy
@@ -8,6 +8,4 @@
 
 grant {
   permission java.net.SocketPermission "*", "connect";
-
-  permission java.io.FilePermission "<<ALL FILES>>", "read";
 };

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
@@ -19,7 +19,7 @@ public class MachineLearningPackageLoaderTests extends ESTestCase {
         );
 
         assertEquals(
-            "If xpack.ml.model_repository is a file location, it must be placed below the configuration path: /home/elk/elasticsearch",
+            "If xpack.ml.model_repository is a file location, it must be placed below the configuration: file:///home/elk/elasticsearch",
             e.getMessage()
         );
 
@@ -29,7 +29,7 @@ public class MachineLearningPackageLoaderTests extends ESTestCase {
         );
 
         assertEquals(
-            "If xpack.ml.model_repository is a file location, it must be placed below the configuration path: /home/elk/elasticsearch",
+            "If xpack.ml.model_repository is a file location, it must be placed below the configuration: file:///home/elk/elasticsearch",
             e.getMessage()
         );
 

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.packageloader;
+
+import org.elasticsearch.core.PathUtils;
+import org.elasticsearch.test.ESTestCase;
+
+public class MachineLearningPackageLoaderTests extends ESTestCase {
+
+    public void testValidateModelRepository() {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearningPackageLoader.validateModelRepository("file:///etc/passwd", PathUtils.get("/home/elk/elasticsearch"))
+        );
+
+        assertEquals(
+            "If xpack.ml.model_repository is a file location, it must be placed below the configuration path: /home/elk/elasticsearch",
+            e.getMessage()
+        );
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearningPackageLoader.validateModelRepository("file:///home/elk/", PathUtils.get("/home/elk/elasticsearch"))
+        );
+
+        assertEquals(
+            "If xpack.ml.model_repository is a file location, it must be placed below the configuration path: /home/elk/elasticsearch",
+            e.getMessage()
+        );
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearningPackageLoader.validateModelRepository("elk/", PathUtils.get("/home/elk/elasticsearch"))
+        );
+
+        assertEquals("xpack.ml.model_repository must contain a scheme, possible schemes are \"http\", \"https\", \"file\"", e.getMessage());
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearningPackageLoader.validateModelRepository("mqtt://elky/", PathUtils.get("/home/elk/elasticsearch"))
+        );
+
+        assertEquals(
+            "xpack.ml.model_repository must be configured with one of the following schemes: \"http\", \"https\", \"file\"",
+            e.getMessage()
+        );
+    }
+}

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
@@ -38,7 +38,10 @@ public class MachineLearningPackageLoaderTests extends ESTestCase {
             () -> MachineLearningPackageLoader.validateModelRepository("elk/", PathUtils.get("/home/elk/elasticsearch"))
         );
 
-        assertEquals("xpack.ml.model_repository must contain a scheme, supported schemes are \"http\", \"https\", \"file\"", e.getMessage());
+        assertEquals(
+            "xpack.ml.model_repository must contain a scheme, supported schemes are \"http\", \"https\", \"file\"",
+            e.getMessage()
+        );
 
         e = expectThrows(
             IllegalArgumentException.class,

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
@@ -38,7 +38,7 @@ public class MachineLearningPackageLoaderTests extends ESTestCase {
             () -> MachineLearningPackageLoader.validateModelRepository("elk/", PathUtils.get("/home/elk/elasticsearch"))
         );
 
-        assertEquals("xpack.ml.model_repository must contain a scheme, possible schemes are \"http\", \"https\", \"file\"", e.getMessage());
+        assertEquals("xpack.ml.model_repository must contain a scheme, supported schemes are \"http\", \"https\", \"file\"", e.getMessage());
 
         e = expectThrows(
             IllegalArgumentException.class,

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtilsTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtilsTests.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.packageloader.action;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+public class ModelLoaderUtilsTests extends ESTestCase {
+
+    public void testResolvePackageLocationTrailingSlash() throws URISyntaxException {
+        assertEquals(new URI("file:/home/ml/package.ext"), ModelLoaderUtils.resolvePackageLocation("file:///home/ml", "package.ext"));
+        assertEquals(new URI("file:/home/ml/package.ext"), ModelLoaderUtils.resolvePackageLocation("file:///home/ml/", "package.ext"));
+        assertEquals(
+            new URI("http://my-package.repo/package.ext"),
+            ModelLoaderUtils.resolvePackageLocation("http://my-package.repo", "package.ext")
+        );
+        assertEquals(
+            new URI("http://my-package.repo/package.ext"),
+            ModelLoaderUtils.resolvePackageLocation("http://my-package.repo/", "package.ext")
+        );
+        assertEquals(
+            new URI("http://my-package.repo/sub/package.ext"),
+            ModelLoaderUtils.resolvePackageLocation("http://my-package.repo/sub", "package.ext")
+        );
+        assertEquals(
+            new URI("http://my-package.repo/sub/package.ext"),
+            ModelLoaderUtils.resolvePackageLocation("http://my-package.repo/sub/", "package.ext")
+        );
+    }
+
+    public void testResolvePackageLocationBreakout() {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ModelLoaderUtils.resolvePackageLocation("file:///home/ml/", "../package.ext")
+        );
+
+        assertEquals("Illegal path in package location", e.getMessage());
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ModelLoaderUtils.resolvePackageLocation("file:///home/ml/", "http://foo.ba")
+        );
+        assertEquals("Illegal schema change in package location", e.getMessage());
+    }
+
+    public void testResolvePackageLocationNoSchemeInRepository() {
+        Exception e = expectThrows(
+            IllegalArgumentException.class,
+            () -> ModelLoaderUtils.resolvePackageLocation("/home/ml/", "package.ext")
+        );
+        assertEquals("Repository must contain a scheme", e.getMessage());
+    }
+}


### PR DESCRIPTION
add validation for xpack.ml.model_repository to contain a proper URI,
restrict xpack.ml.model_repository to only allow files located below the configuration path and ensure that it is not possible to break out of the specified base path

@szabosteve I like to add a URL to a message in that change, the URL should link some documentation about the introduced setting. I will contact you later for the details. Maybe we can add a placeholder, so that I can merge this with a working URL.