### PR TITLE
Replace list of collectors with array in profile collector

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -52,12 +52,12 @@ public class AggregationPhase {
             }
             Collector collector = context.getProfilers() == null
                 ? BucketCollector.NO_OP_COLLECTOR
-                : new InternalProfileCollector(BucketCollector.NO_OP_COLLECTOR, CollectorResult.REASON_AGGREGATION, List.of());
+                : new InternalProfileCollector(BucketCollector.NO_OP_COLLECTOR, CollectorResult.REASON_AGGREGATION);
             context.registerAggsCollector(collector);
         } else {
             Collector collector = context.getProfilers() == null
                 ? bucketCollector.asCollector()
-                : new InternalProfileCollector(bucketCollector.asCollector(), CollectorResult.REASON_AGGREGATION, List.of());
+                : new InternalProfileCollector(bucketCollector.asCollector(), CollectorResult.REASON_AGGREGATION);
             context.registerAggsCollector(collector);
         }
     }

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -178,11 +178,7 @@ public class DfsPhase {
             TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(knnSearch.get(i).k(), Integer.MAX_VALUE);
             Collector collector = topScoreDocCollector;
             if (context.getProfilers() != null) {
-                InternalProfileCollector ipc = new InternalProfileCollector(
-                    topScoreDocCollector,
-                    CollectorResult.REASON_SEARCH_TOP_HITS,
-                    List.of()
-                );
+                InternalProfileCollector ipc = new InternalProfileCollector(topScoreDocCollector, CollectorResult.REASON_SEARCH_TOP_HITS);
                 QueryProfiler knnProfiler = context.getProfilers().getDfsProfiler().addQueryProfiler(ipc);
                 collector = ipc;
                 // Set the current searcher profiler to gather query profiling information for gathering top K docs

--- a/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollector.java
@@ -42,11 +42,11 @@ public class InternalProfileCollector implements Collector {
     private final ProfileCollector collector;
 
     /**
-     * A list of "embedded" children collectors
+     * An array of "embedded" children collectors
      */
-    private final List<InternalProfileCollector> children;
+    private final InternalProfileCollector[] children;
 
-    public InternalProfileCollector(Collector collector, String reason, List<InternalProfileCollector> children) {
+    public InternalProfileCollector(Collector collector, String reason, InternalProfileCollector... children) {
         this.collector = new ProfileCollector(collector);
         this.reason = reason;
         this.collectorName = deriveCollectorName(collector);
@@ -115,7 +115,7 @@ public class InternalProfileCollector implements Collector {
     }
 
     private static CollectorResult doGetCollectorTree(InternalProfileCollector collector) {
-        List<CollectorResult> childResults = new ArrayList<>(collector.children.size());
+        List<CollectorResult> childResults = new ArrayList<>(collector.children.length);
         for (InternalProfileCollector child : collector.children) {
             CollectorResult result = doGetCollectorTree(child);
             childResults.add(result);

--- a/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollector.java
@@ -16,6 +16,7 @@ import org.apache.lucene.search.ScoreMode;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This class wraps a Lucene Collector and times the execution of:
@@ -50,6 +51,10 @@ public class InternalProfileCollector implements Collector {
         this.collector = new ProfileCollector(collector);
         this.reason = reason;
         this.collectorName = deriveCollectorName(collector);
+        Objects.requireNonNull(children, "children collectors cannot be null");
+        for (InternalProfileCollector child : children) {
+            Objects.requireNonNull(child, "child collector cannot be null");
+        }
         this.children = children;
     }
 

--- a/server/src/main/java/org/elasticsearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryCollectorContext.java
@@ -57,7 +57,10 @@ abstract class QueryCollectorContext {
      */
     protected InternalProfileCollector createWithProfiler(InternalProfileCollector in) throws IOException {
         final Collector collector = create(in);
-        return new InternalProfileCollector(collector, profilerName, in != null ? Collections.singletonList(in) : Collections.emptyList());
+        if (in == null) {
+            return new InternalProfileCollector(collector, profilerName);
+        }
+        return new InternalProfileCollector(collector, profilerName, in);
     }
 
     /**
@@ -132,14 +135,11 @@ abstract class QueryCollectorContext {
 
             @Override
             protected InternalProfileCollector createWithProfiler(InternalProfileCollector in) {
-                final List<InternalProfileCollector> subCollectors = new ArrayList<>();
-                subCollectors.add(in);
                 if (subCollector instanceof InternalProfileCollector == false) {
                     throw new IllegalArgumentException("non-profiling collector");
                 }
-                subCollectors.add((InternalProfileCollector) subCollector);
-                final Collector collector = MultiCollector.wrap(subCollectors);
-                return new InternalProfileCollector(collector, REASON_SEARCH_MULTI, subCollectors);
+                final Collector collector = MultiCollector.wrap(in, subCollector);
+                return new InternalProfileCollector(collector, REASON_SEARCH_MULTI, in, (InternalProfileCollector) subCollector);
             }
         };
     }

--- a/server/src/main/java/org/elasticsearch/search/query/QueryCollectorContext.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryCollectorContext.java
@@ -21,7 +21,6 @@ import org.elasticsearch.search.profile.query.InternalProfileCollector;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import static org.elasticsearch.search.profile.query.CollectorResult.REASON_SEARCH_MIN_SCORE;


### PR DESCRIPTION
It simplifies things if we can just use an array to hold the children collectors in InternalProfileCollector, and adjust its constructor to take a varargs argument of collectors