### PR TITLE
Remove rolling restart checks for x-pack

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartBasicClusterTask.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;
 import java.util.Map;
@@ -124,7 +123,6 @@ public class StartBasicClusterTask implements ClusterStateTaskListener {
         @Override
         public ClusterState execute(BatchExecutionContext<StartBasicClusterTask> batchExecutionContext) throws Exception {
             final var initialState = batchExecutionContext.initialState();
-            XPackPlugin.checkReadyForXPackCustomMetadata(initialState);
             final LicensesMetadata originalLicensesMetadata = initialState.metadata().custom(LicensesMetadata.TYPE);
             var currentLicensesMetadata = originalLicensesMetadata;
             for (final var taskContext : batchExecutionContext.taskContexts()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartTrialClusterTask.java
@@ -15,7 +15,6 @@ import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;
 import java.util.Collections;
@@ -110,7 +109,6 @@ public class StartTrialClusterTask implements ClusterStateTaskListener {
         @Override
         public ClusterState execute(BatchExecutionContext<StartTrialClusterTask> batchExecutionContext) throws Exception {
             final var initialState = batchExecutionContext.initialState();
-            XPackPlugin.checkReadyForXPackCustomMetadata(initialState);
             final LicensesMetadata originalLicensesMetadata = initialState.metadata().custom(LicensesMetadata.TYPE);
             var currentLicensesMetadata = originalLicensesMetadata;
             for (final var taskContext : batchExecutionContext.taskContexts()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/license/StartupSelfGeneratedLicenseTask.java
@@ -16,7 +16,6 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.xpack.core.XPackPlugin;
 
 import java.time.Clock;
 import java.util.UUID;
@@ -51,7 +50,6 @@ public class StartupSelfGeneratedLicenseTask extends ClusterStateUpdateTask {
 
     @Override
     public ClusterState execute(ClusterState currentState) throws Exception {
-        XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
         final Metadata metadata = currentState.metadata();
         final LicensesMetadata currentLicensesMetadata = metadata.custom(LicensesMetadata.TYPE);
         // do not generate a license if any license is present

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackPlugin.java
@@ -16,9 +16,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.TransportAction;
 import org.elasticsearch.client.internal.Client;
-import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
-import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -35,7 +33,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.common.ssl.SslConfiguration;
 import org.elasticsearch.common.util.BigArrays;
-import org.elasticsearch.core.Booleans;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.index.IndexSettingProvider;
@@ -48,7 +45,6 @@ import org.elasticsearch.license.License;
 import org.elasticsearch.license.LicenseService;
 import org.elasticsearch.license.LicenseSettings;
 import org.elasticsearch.license.LicenseUtils;
-import org.elasticsearch.license.LicensesMetadata;
 import org.elasticsearch.license.Licensing;
 import org.elasticsearch.license.XPackLicenseState;
 import org.elasticsearch.license.internal.MutableLicenseService;
@@ -87,18 +83,14 @@ import org.elasticsearch.xpack.core.action.XPackUsageFeatureAction;
 import org.elasticsearch.xpack.core.action.XPackUsageResponse;
 import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
 import org.elasticsearch.xpack.core.async.TransportDeleteAsyncResultAction;
-import org.elasticsearch.xpack.core.ml.MlMetadata;
 import org.elasticsearch.xpack.core.rest.action.RestReloadAnalyzersAction;
 import org.elasticsearch.xpack.core.rest.action.RestXPackInfoAction;
 import org.elasticsearch.xpack.core.rest.action.RestXPackUsageAction;
-import org.elasticsearch.xpack.core.security.authc.TokenMetadata;
 import org.elasticsearch.xpack.core.ssl.SSLConfigurationReloader;
 import org.elasticsearch.xpack.core.ssl.SSLService;
 import org.elasticsearch.xpack.core.termsenum.action.TermsEnumAction;
 import org.elasticsearch.xpack.core.termsenum.action.TransportTermsEnumAction;
 import org.elasticsearch.xpack.core.termsenum.rest.RestTermsEnumAction;
-import org.elasticsearch.xpack.core.transform.TransformMetadata;
-import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -113,7 +105,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
-import java.util.stream.Collectors;
 
 @SuppressWarnings("HiddenField")
 public class XPackPlugin extends XPackClientPlugin
@@ -126,7 +117,7 @@ public class XPackPlugin extends XPackClientPlugin
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(XPackPlugin.class);
 
     public static final String ASYNC_RESULTS_INDEX = ".async-search";
-    public static final String XPACK_INSTALLED_NODE_ATTR = "xpack.installed";
+    public static final String XPACK_INSTALLED_NODE_ATTR = "xpack.installed"; // TODO: remove in 9.0
     private static final Logger logger = LogManager.getLogger(XPackPlugin.class);
 
     // TODO: clean up this library to not ask for write access to all system properties!
@@ -237,57 +228,6 @@ public class XPackPlugin extends XPackClientPlugin
 
     public static LongSupplier getSharedEpochMillisSupplier() {
         return epochMillisSupplier.get();
-    }
-
-    /**
-     * Checks if the cluster state allows this node to add x-pack metadata to the cluster state,
-     * and throws an exception otherwise.
-     * This check should be called before installing any x-pack metadata to the cluster state,
-     * to ensure that the other nodes that are part of the cluster will be able to deserialize
-     * that metadata. Note that if the cluster state already contains x-pack metadata, this
-     * check assumes that the nodes are already ready to receive additional x-pack metadata.
-     * Having this check properly in place everywhere allows to install x-pack into a cluster
-     * using a rolling restart.
-     */
-    public static void checkReadyForXPackCustomMetadata(ClusterState clusterState) {
-        if (alreadyContainsXPackCustomMetadata(clusterState)) {
-            return;
-        }
-        List<DiscoveryNode> notReadyNodes = nodesNotReadyForXPackCustomMetadata(clusterState);
-        if (notReadyNodes.isEmpty() == false) {
-            throw new IllegalStateException("The following nodes are not ready yet for enabling x-pack custom metadata: " + notReadyNodes);
-        }
-    }
-
-    /**
-     * Checks if the cluster state allows this node to add x-pack metadata to the cluster state.
-     * See {@link #checkReadyForXPackCustomMetadata} for more details.
-     */
-    public static boolean isReadyForXPackCustomMetadata(ClusterState clusterState) {
-        return alreadyContainsXPackCustomMetadata(clusterState) || nodesNotReadyForXPackCustomMetadata(clusterState).isEmpty();
-    }
-
-    /**
-     * Returns the list of nodes that won't allow this node from adding x-pack metadata to the cluster state.
-     * See {@link #checkReadyForXPackCustomMetadata} for more details.
-     */
-    public static List<DiscoveryNode> nodesNotReadyForXPackCustomMetadata(ClusterState clusterState) {
-        // check that all nodes would be capable of deserializing newly added x-pack metadata
-        final List<DiscoveryNode> notReadyNodes = clusterState.nodes().stream().filter(node -> {
-            final String xpackInstalledAttr = node.getAttributes().getOrDefault(XPACK_INSTALLED_NODE_ATTR, "false");
-            return Booleans.parseBoolean(xpackInstalledAttr) == false;
-        }).collect(Collectors.toList());
-
-        return notReadyNodes;
-    }
-
-    private static boolean alreadyContainsXPackCustomMetadata(ClusterState clusterState) {
-        final Metadata metadata = clusterState.metadata();
-        return metadata.custom(LicensesMetadata.TYPE) != null
-            || metadata.custom(MlMetadata.TYPE) != null
-            || metadata.custom(WatcherMetadata.TYPE) != null
-            || clusterState.custom(TokenMetadata.TYPE) != null
-            || metadata.custom(TransformMetadata.TYPE) != null;
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportPutRollupJobAction.java
@@ -47,7 +47,6 @@ import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.rollup.RollupField;
 import org.elasticsearch.xpack.core.rollup.action.PutRollupJobAction;
 import org.elasticsearch.xpack.core.rollup.job.RollupJob;
@@ -100,7 +99,6 @@ public class TransportPutRollupJobAction extends AcknowledgedTransportMasterNode
         ClusterState clusterState,
         ActionListener<AcknowledgedResponse> listener
     ) {
-        XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
         checkForDeprecatedTZ(request);
 
         FieldCapabilitiesRequest fieldCapsRequest = new FieldCapabilitiesRequest().indices(request.indices())

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -79,7 +79,6 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentFactory;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.core.XPackField;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.ScrollHelper;
 import org.elasticsearch.xpack.core.security.SecurityContext;
@@ -2374,14 +2373,7 @@ public final class TokenService {
             }
 
             if (state.nodes().isLocalNodeElectedMaster()) {
-                if (XPackPlugin.isReadyForXPackCustomMetadata(state)) {
-                    installTokenMetadata(state);
-                } else {
-                    logger.debug(
-                        "cannot add token metadata to cluster as the following nodes might not understand the metadata: {}",
-                        () -> XPackPlugin.nodesNotReadyForXPackCustomMetadata(state)
-                    );
-                }
+                installTokenMetadata(state);
             }
 
             TokenMetadata custom = event.state().custom(TokenMetadata.TYPE);
@@ -2406,7 +2398,6 @@ public final class TokenService {
                 submitUnbatchedTask("install-token-metadata", new ClusterStateUpdateTask(Priority.URGENT) {
                     @Override
                     public ClusterState execute(ClusterState currentState) {
-                        XPackPlugin.checkReadyForXPackCustomMetadata(currentState);
 
                         if (currentState.custom(TokenMetadata.TYPE) == null) {
                             return ClusterState.builder(currentState).putCustom(TokenMetadata.TYPE, getTokenMetadata()).build();

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPutTransformAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 import org.elasticsearch.xpack.core.ClientHelper;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.transform.TransformMessages;
@@ -92,7 +91,6 @@ public class TransportPutTransformAction extends AcknowledgedTransportMasterNode
 
     @Override
     protected void masterOperation(Task task, Request request, ClusterState clusterState, ActionListener<AcknowledgedResponse> listener) {
-        XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         TransformConfig config = request.getConfig().setCreateTime(Instant.now()).setVersion(Version.CURRENT);
         config.setHeaders(getSecurityHeadersPreferringSecondary(threadPool, securityContext, clusterState));

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportScheduleNowTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportScheduleNowTransformAction.java
@@ -25,7 +25,6 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.ActionNotFoundTransportException;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.transform.action.ScheduleNowTransformAction;
@@ -80,7 +79,6 @@ public class TransportScheduleNowTransformAction extends TransportTasksAction<Tr
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final ClusterState clusterState = clusterService.state();
-        XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         ActionListener<TransformConfig> getTransformListener = ActionListener.wrap(unusedConfig -> {
             PersistentTasksCustomMetadata.PersistentTask<?> transformTask = TransformTask.getTransformTask(request.getId(), clusterState);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
 import org.elasticsearch.xpack.core.transform.action.UpdateTransformAction;
@@ -99,7 +98,6 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
     @Override
     protected void doExecute(Task task, Request request, ActionListener<Response> listener) {
         final ClusterState clusterState = clusterService.state();
-        XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
         final DiscoveryNodes nodes = clusterState.nodes();
 

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherServiceAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherServiceAction.java
@@ -28,7 +28,6 @@ import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
-import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.watcher.WatcherMetadata;
 import org.elasticsearch.xpack.core.watcher.transport.actions.service.WatcherServiceAction;
 import org.elasticsearch.xpack.core.watcher.transport.actions.service.WatcherServiceRequest;
@@ -84,7 +83,6 @@ public class TransportWatcherServiceAction extends AcknowledgedTransportMasterNo
         }, listener) {
             @Override
             public ClusterState execute(ClusterState clusterState) {
-                XPackPlugin.checkReadyForXPackCustomMetadata(clusterState);
 
                 WatcherMetadata newWatcherMetadata = new WatcherMetadata(manuallyStopped);
                 WatcherMetadata currentMetadata = clusterState.metadata().custom(WatcherMetadata.TYPE);


### PR DESCRIPTION
This commit removes the checks introduced in https://github.com/elastic/elasticsearch/pull/30743.
Those checks were to help enable rolling restarts from the
OSS distribution to the (now) default distribution that includes
x-pack by default. These checks are no longer needed since
we no longer ship an OSS version https://github.com/elastic/elasticsearch/issues/68797
that is the base (lowest) version during a rolling restart.
Any rolling restart to 8.x requires 7.17+ but the last official
OSS distribution that did not include x-pack was 7.11. This
change, when applied to 8.x, means that all supported rolling
restarts to 8.x will already have x-pack metadata and thus no
need for these checks.

Note - the node attribute remains to handle and edge case
for a new mixed cluster where there is elder 8.x (i.e. 8.6) node
that has the node attibute set to true. In that case, the value of
the attribute will always be true but removing the 
attribute could cause an error.

---
This PR replaces https://github.com/elastic/elasticsearch/pull/93843 since there were too many merge conflicts to sort it out there and didn't want to force push and risk loosing the comments in that PR.  