### PR TITLE
[Behavioral Analytics] Add geo ip and user agent to events

### DIFF
--- a/docs/changelog/95433.yaml
+++ b/docs/changelog/95433.yaml
@@ -1,0 +1,5 @@
+pr: 95433
+summary: "[Behavioral Analytics] Add geo ip and user agent to events"
+area: Application
+type: enhancement
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
@@ -35,9 +35,15 @@
         }
       ]
     },
-    "body":{
-      "description":"The event definition",
-      "required":true
+    "params": {
+      "debug": {
+        "type": "boolean",
+        "description": "If true, returns event information that will be stored"
+      }
+    },
+    "body": {
+      "description": "The event definition",
+      "required": true
     }
   }
 }

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
@@ -33,6 +33,42 @@
           }
         }
       }
+    },
+    {
+      "user_agent": {
+        "field": "session.user_agent",
+        "target_field": "session.user_agent",
+        "ignore_missing": true,
+        "properties": ["name", "version", "os", "device"],
+        "extract_device_type": true
+      }
+    },
+    {
+      "rename": {
+        "field": "session.user_agent.name",
+        "target_field": "session.user_agent.browser.name",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "session.user_agent.version",
+        "target_field": "session.user_agent.browser.version",
+        "ignore_missing": true
+      }
+    },
+    {
+      "geoip": {
+        "field": "session.ip",
+        "target_field": "session.location",
+        "ignore_missing": true
+      }
+    },
+    {
+      "remove": {
+        "field": "session.ip",
+        "ignore_missing": true
+      }
     }
   ],
   "_meta": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-mappings.json
@@ -48,6 +48,81 @@
             "id": {
               "ignore_above": 1024,
               "type": "keyword"
+            },
+            "location": {
+              "properties": {
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                }
+              }
+            },
+            "user_agent": {
+              "properties": {
+                "os": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "full": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "browser": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "device": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
             }
           }
         },

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
@@ -87,6 +87,48 @@ teardown:
             url: "https://www.elastic.co"
             referrer: "http://anotherdomain.com/homepage"
 
+---
+"Post page_view analytics event - debug and session information":
+  - skip:
+      features: headers
+
+  - do:
+      headers:
+        X-Forwarded-For: 192.23.12.12
+        User-Agent: Mozilla/5.0
+      search_application.post_behavioral_analytics_event:
+        collection_name: my-test-analytics-collection
+        event_type: "page_view"
+        debug: true
+        body:
+          session:
+            id: "123"
+          user:
+            id: "456"
+          page:
+            url: "https://www.elastic.co"
+            title: "Elastic - Homepage"
+            referrer: "http://anotherdomain.com/homepage"
+          document:
+            id: "doc-1"
+            index: "search-index"
+
+  - match: { accepted: true }
+  - match: { event.event.action: "page_view" }
+  - match: { event.data_stream.type: "behavioral_analytics" }
+  - match: { event.data_stream.dataset: "events" }
+  - match: { event.data_stream.namespace: "my-test-analytics-collection" }
+  - match: { event.session.id: "123" }
+  - match: { event.session.user_agent: "Mozilla/5.0" }
+  - match: { event.session.ip: "192.23.12.12" }
+  - match: { event.document.id: "doc-1" }
+  - match: { event.document.index: "search-index" }
+  - match: { event.page.url: "https://www.elastic.co" }
+  - match: { event.page.title: "Elastic - Homepage" }
+  - match: { event.page.referrer: "http://anotherdomain.com/homepage" }
+  - match: { event.user.id: "456" }
+  - gte: { event.@timestamp: 0 }
+
 # Search event tests ############################################
 ---
 "Post search analytics event":
@@ -225,8 +267,75 @@ teardown:
             query: "test-query"
             filters:
               brand: "elastic"
-              products: ["elasticsearch", "kibana"]
+              products: [ "elasticsearch", "kibana" ]
               rating: "[3-5]"
+
+---
+"Post search analytics event - debug and session information":
+  - skip:
+      features: headers
+
+  - do:
+      headers:
+        X-Forwarded-For: 192.23.12.12
+        User-Agent: Mozilla/5.0
+      search_application.post_behavioral_analytics_event:
+        collection_name: my-test-analytics-collection
+        event_type: "search"
+        debug: true
+        body:
+          session:
+            id: "123"
+          user:
+            id: "456"
+          search:
+            query: "test-query"
+            search_application: "my-search-application"
+            sort:
+              name: "price"
+              direction: "desc"
+            filters:
+              brand: "elastic"
+              products: [ "elasticsearch", "kibana" ]
+              rating: "[3-5]"
+            page:
+              current: 1
+              size: 10
+            results:
+              total_results: 150
+              items:
+                - document:
+                    id: doc-1
+                - document:
+                    id: doc-2
+                    index: my-search-index
+                - page:
+                    url: "https://www.elastic.co"
+                - page:
+                    url: "https://www.elastic.co/doc/getting-stared"
+                  document:
+                    id: "getting-started"
+                    index: elastic-documentation-en
+
+  - match: { accepted: true }
+  - match: { event.event.action: "search" }
+  - match: { event.data_stream.type: "behavioral_analytics" }
+  - match: { event.data_stream.dataset: "events" }
+  - match: { event.data_stream.namespace: "my-test-analytics-collection" }
+  - match: { event.session.id: "123" }
+  - match: { event.session.user_agent: "Mozilla/5.0" }
+  - match: { event.session.ip: "192.23.12.12" }
+  - match: { event.search.query: "test-query" }
+  - match: { event.search.search_application: "my-search-application" }
+  - match: { event.search.sort.name: "price" }
+  - match: { event.search.sort.direction: "desc" }
+  - match: { event.search.filters.brand: [ "elastic" ] }
+  - match: { event.search.filters.products: [ "elasticsearch", "kibana" ] }
+  - match: { event.search.filters.rating: [ "[3-5]" ] }
+  - match: { event.search.page.current: 1 }
+  - match: { event.search.page.size: 10 }
+  - match: { event.search.results.total_results: 150 }
+  - gte: { event.@timestamp: 0 }
 
 # Search click event tests #######################################
 ---
@@ -246,6 +355,45 @@ teardown:
             url: "https://www.elastic.co"
           search:
             query: "test-query"
+
+---
+"Post search_click analytics event - debug and session information":
+  - skip:
+      features: headers
+
+  - do:
+      headers:
+        X-Forwarded-For: 192.23.12.12
+        User-Agent: Mozilla/5.0
+      search_application.post_behavioral_analytics_event:
+        collection_name: my-test-analytics-collection
+        event_type: "search_click"
+        debug: true
+        body:
+          session:
+            id: "123"
+          user:
+            id: "456"
+          document:
+            id: "doc-1"
+          page:
+            url: "https://www.elastic.co"
+          search:
+            query: "test-query"
+
+  - match: { accepted: true }
+  - match: { event.event.action: "search_click" }
+  - match: { event.data_stream.type: "behavioral_analytics" }
+  - match: { event.data_stream.dataset: "events" }
+  - match: { event.data_stream.namespace: "my-test-analytics-collection" }
+  - match: { event.session.id: "123" }
+  - match: { event.session.user_agent: "Mozilla/5.0" }
+  - match: { event.session.ip: "192.23.12.12" }
+  - match: { event.document.id: "doc-1" }
+  - match: { event.page.url: "https://www.elastic.co" }
+  - match: { event.user.id: "456" }
+  - match: { event.search.query: "test-query" }
+  - gte: { event.@timestamp: 0 }
 
 ---
 "Post search_click analytics event - Page Only":

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -96,19 +96,6 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
             this.clientAddress = ipAddress;
         }
 
-        private static InetAddress readInetAddress(StreamInput in) throws IOException {
-            final String ipString = in.readOptionalString();
-            if (ipString != null) {
-                try {
-                    return InetAddresses.forString(ipString);
-                } catch (IllegalArgumentException e) {
-                    // Ignore invalid client IP
-                }
-            }
-
-            return null;
-        }
-
         public static RequestBuilder builder(
             String eventCollectionName,
             String eventType,
@@ -216,6 +203,19 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
         @Override
         public int hashCode() {
             return Objects.hash(eventCollectionName, eventType, debug, eventTime, xContentType, payload, headers, clientAddress);
+        }
+
+        private static InetAddress readInetAddress(StreamInput in) throws IOException {
+            final String ipString = in.readOptionalString();
+            if (ipString != null) {
+                try {
+                    return InetAddresses.forString(ipString);
+                } catch (IllegalArgumentException e) {
+                    // Ignore invalid client IP
+                }
+            }
+
+            return null;
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -53,11 +53,15 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
 
         private final XContentType xContentType;
 
-        public Request(String eventCollectionName, String eventType, boolean debug, XContentType xContentType, BytesReference payload) {
+        // TODO: Remove: default value for time can be set into the builder
+        Request(String eventCollectionName, String eventType, boolean debug, XContentType xContentType, BytesReference payload) {
             this(eventCollectionName, eventType, debug, System.currentTimeMillis(), xContentType, payload);
         }
 
-        public Request(
+        // TODO:
+        // 1. Create a builder class
+        // 2. Add optional params for ip and headers
+        Request(
             String eventCollectionName,
             String eventType,
             boolean debug,

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -169,7 +169,6 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
         }
     }
 
-    // TODO: Add tests.
     public static class RequestBuilder {
 
         private String eventCollectionName;

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -53,21 +53,15 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
 
         private final XContentType xContentType;
 
-        // TODO: Remove: default value for time can be set into the builder
-        Request(String eventCollectionName, String eventType, boolean debug, XContentType xContentType, BytesReference payload) {
-            this(eventCollectionName, eventType, debug, System.currentTimeMillis(), xContentType, payload);
-        }
-
         // TODO:
-        // 1. Create a builder class
-        // 2. Add optional params for ip and headers
-        Request(
+        // 1. Add optional params for ip and headers
+        private Request(
             String eventCollectionName,
             String eventType,
-            boolean debug,
             long eventTime,
             XContentType xContentType,
-            BytesReference payload
+            BytesReference payload,
+            boolean debug
         ) {
             this.eventCollectionName = eventCollectionName;
             this.eventType = eventType;
@@ -85,6 +79,15 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
             this.eventTime = in.readLong();
             this.xContentType = in.readEnum(XContentType.class);
             this.payload = in.readBytesReference();
+        }
+
+        public static RequestBuilder builder(
+            String eventCollectionName,
+            String eventType,
+            XContentType xContentType,
+            BytesReference payload
+        ) {
+            return new RequestBuilder(eventCollectionName, eventType, xContentType, payload);
         }
 
         public String eventCollectionName() {
@@ -163,6 +166,63 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
         @Override
         public int hashCode() {
             return Objects.hash(eventCollectionName, eventType, debug, eventTime, xContentType, payload);
+        }
+    }
+
+    // TODO: Add tests.
+    public static class RequestBuilder {
+
+        private String eventCollectionName;
+
+        private String eventType;
+
+        private long eventTime = System.currentTimeMillis();
+
+        private boolean debug = false;
+
+        private BytesReference payload;
+
+        private XContentType xContentType;
+
+        private RequestBuilder(String eventCollectionName, String eventType, XContentType xContentType, BytesReference payload) {
+            this.eventCollectionName = eventCollectionName;
+            this.eventType = eventType;
+            this.xContentType = xContentType;
+            this.payload = payload;
+        }
+
+        public Request request() {
+            return new Request(eventCollectionName, eventType, eventTime, xContentType, payload, debug);
+        }
+
+        public RequestBuilder eventCollectionName(String eventCollectionName) {
+            this.eventCollectionName = eventCollectionName;
+            return this;
+        }
+
+        public RequestBuilder eventType(String eventType) {
+            this.eventType = eventType;
+            return this;
+        }
+
+        public RequestBuilder eventTime(long eventTime) {
+            this.eventTime = eventTime;
+            return this;
+        }
+
+        public RequestBuilder debug(boolean debug) {
+            this.debug = debug;
+            return this;
+        }
+
+        public RequestBuilder payload(BytesReference payload) {
+            this.payload = payload;
+            return this;
+        }
+
+        public RequestBuilder xContentType(XContentType xContentType) {
+            this.xContentType = xContentType;
+            return this;
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
@@ -43,7 +43,7 @@ public class RestPostAnalyticsEventAction extends BaseRestHandler {
         return channel -> client.execute(PostAnalyticsEventAction.INSTANCE, request, new RestStatusToXContentListener<>(channel));
     }
 
-    private static InetAddress getClientAddress(RestRequest restRequest, Map<String, List<String>> headers) {
+    private InetAddress getClientAddress(RestRequest restRequest, Map<String, List<String>> headers) {
         InetAddress remoteAddress = restRequest.getHttpChannel().getRemoteAddress().getAddress();
         if (headers.containsKey(X_FORWARDED_FOR_HEADER)) {
             final List<String> addresses = headers.get(X_FORWARDED_FOR_HEADER);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
@@ -35,6 +35,12 @@ public class RestPostAnalyticsEventAction extends BaseRestHandler {
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
+
+        // TODO:
+        // 1. Use the builder class
+        // 2. Extract ip address (do not forget the X-Forwarded-For header) and pass it to the request.
+        // 3. Extract / sanitize headers (user agent)
+
         PostAnalyticsEventAction.Request request = new PostAnalyticsEventAction.Request(
             restRequest.param("collection_name"),
             restRequest.param("event_type"),

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/RestPostAnalyticsEventAction.java
@@ -34,21 +34,26 @@ public class RestPostAnalyticsEventAction extends BaseRestHandler {
 
     @Override
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) {
+        PostAnalyticsEventAction.Request request = buidRequest(restRequest);
+        return channel -> client.execute(PostAnalyticsEventAction.INSTANCE, request, new RestStatusToXContentListener<>(channel));
+    }
+
+    private PostAnalyticsEventAction.Request buidRequest(RestRequest restRequest) {
         Tuple<XContentType, BytesReference> sourceTuple = restRequest.contentOrSourceParam();
 
-        // TODO:
-        // 1. Use the builder class
-        // 2. Extract ip address (do not forget the X-Forwarded-For header) and pass it to the request.
-        // 3. Extract / sanitize headers (user agent)
-
-        PostAnalyticsEventAction.Request request = new PostAnalyticsEventAction.Request(
+        PostAnalyticsEventAction.RequestBuilder builder = PostAnalyticsEventAction.Request.builder(
             restRequest.param("collection_name"),
             restRequest.param("event_type"),
-            restRequest.paramAsBoolean("debug", false),
             sourceTuple.v1(),
             sourceTuple.v2()
         );
 
-        return channel -> client.execute(PostAnalyticsEventAction.INSTANCE, request, new RestStatusToXContentListener<>(channel));
+        builder.debug(restRequest.paramAsBoolean("debug", false));
+
+        // TODO:
+        // 1. Extract ip address (do not forget the X-Forwarded-For header) and pass it to the request.
+        // 2. Extract / sanitize headers (user agent)
+
+        return builder.request();
     }
 }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
@@ -53,8 +53,13 @@ public class AnalyticsEvent implements Writeable, ToXContentObject {
         String eventCollectionName();
 
         default AnalyticsCollection analyticsCollection() {
+            // TODO: remove. Only used in tests.
             return new AnalyticsCollection(eventCollectionName());
         }
+
+        // TODO: Add clientIp method
+        // TODO: Add headers method
+        // TODO: Move the interface to the package (renamed into AnalyticsContext)
     }
 
     /**

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEvent.java
@@ -57,29 +57,6 @@ public class AnalyticsEvent implements Writeable, ToXContentObject {
         }
     }
 
-    static class AnalyticsEventContext implements Context {
-        private final AnalyticsEvent event;
-
-        AnalyticsEventContext(AnalyticsEvent event) {
-            this.event = Objects.requireNonNull(event, "event cannot be null");
-        }
-
-        @Override
-        public long eventTime() {
-            return event.eventTime();
-        }
-
-        @Override
-        public Type eventType() {
-            return event.eventType();
-        }
-
-        @Override
-        public String eventCollectionName() {
-            return event.eventCollectionName();
-        }
-    }
-
     /**
      * Analytics event types.
      */
@@ -154,10 +131,6 @@ public class AnalyticsEvent implements Writeable, ToXContentObject {
 
     public Map<String, Object> payloadAsMap() {
         return XContentHelper.convertToMap(payload(), true, xContentType()).v2();
-    }
-
-    public Context context() {
-        return new AnalyticsEventContext(this);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactory.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactory.java
@@ -61,10 +61,9 @@ public class AnalyticsEventFactory {
     /**
      * Creates an {@link AnalyticsEvent} object from an Analytics context and a payload (e.g. HTTP POST request body).
      *
-     * @param context the analytics context
+     * @param context      the analytics context
      * @param xContentType the type of the payload
-     * @param payload the payload as a {@link BytesReference} object
-     *
+     * @param payload      the payload as a {@link BytesReference} object
      * @return Parsed event ({@link AnalyticsEvent})
      */
     public AnalyticsEvent fromPayload(AnalyticsEvent.Context context, XContentType xContentType, BytesReference payload)

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.xpack.application.analytics.event.parser.field;
 
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.xcontent.ObjectParser;
 import org.elasticsearch.xcontent.ParseField;
@@ -24,9 +25,25 @@ public class SessionAnalyticsEventField {
 
     public static ParseField SESSION_ID_FIELD = new ParseField("id");
 
-    private static final ObjectParser<MapBuilder<String, String>, AnalyticsEvent.Context> PARSER = new ObjectParser<>(
+    public static final ParseField CLIENT_ADDRESS_FIELD = new ParseField("ip");
+
+    public static final ParseField USER_AGENT_FIELD = new ParseField("user_agent");
+
+    private static final ObjectParser<MapBuilder<String, String>, AnalyticsEvent.Context> PARSER = ObjectParser.fromBuilder(
         SESSION_FIELD.getPreferredName(),
-        MapBuilder::newMapBuilder
+        (c) -> {
+            MapBuilder<String, String> mapBuilder = MapBuilder.newMapBuilder();
+
+            if (Strings.isNullOrBlank(c.clientAddress()) == false) {
+                mapBuilder.put(CLIENT_ADDRESS_FIELD.getPreferredName(), c.clientAddress());
+            }
+
+            if (Strings.isNullOrBlank(c.userAgent()) == false) {
+                mapBuilder.put(USER_AGENT_FIELD.getPreferredName(), c.userAgent());
+            }
+
+            return mapBuilder;
+        }
     );
 
     static {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
@@ -27,6 +27,7 @@ public class SessionAnalyticsEventField {
     private static final ObjectParser<MapBuilder<String, String>, AnalyticsEvent.Context> PARSER = new ObjectParser<>(
         SESSION_FIELD.getPreferredName(),
         MapBuilder::newMapBuilder
+        // TODO: use Context to build session.ip and session.user_agent fields
     );
 
     static {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/event/parser/field/SessionAnalyticsEventField.java
@@ -27,7 +27,6 @@ public class SessionAnalyticsEventField {
     private static final ObjectParser<MapBuilder<String, String>, AnalyticsEvent.Context> PARSER = new ObjectParser<>(
         SESSION_FIELD.getPreferredName(),
         MapBuilder::newMapBuilder
-        // TODO: use Context to build session.ip and session.user_agent fields
     );
 
     static {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventRequestSerializingTests.java
@@ -32,14 +32,12 @@ public class PostAnalyticsEventRequestSerializingTests extends AbstractWireSeria
         List<String> invalidEventTypes = List.of(randomIdentifier(), randomEventType().toUpperCase(Locale.ROOT));
 
         for (String eventType : invalidEventTypes) {
-            PostAnalyticsEventAction.Request request = new PostAnalyticsEventAction.Request(
+            PostAnalyticsEventAction.Request request = PostAnalyticsEventAction.Request.builder(
                 randomIdentifier(),
                 eventType,
-                randomBoolean(),
-                randomLong(),
                 randomFrom(XContentType.values()),
                 mock(BytesReference.class)
-            );
+            ).eventTime(randomLong()).debug(randomBoolean()).request();
 
             ValidationException e = request.validate();
             assertNotNull(e);
@@ -54,14 +52,12 @@ public class PostAnalyticsEventRequestSerializingTests extends AbstractWireSeria
 
     @Override
     protected PostAnalyticsEventAction.Request createTestInstance() {
-        return new PostAnalyticsEventAction.Request(
+        return PostAnalyticsEventAction.Request.builder(
             randomIdentifier(),
             randomEventType(),
-            randomBoolean(),
-            randomLong(),
             randomFrom(XContentType.values()),
             new BytesArray(randomByteArrayOfLength(20))
-        );
+        ).eventTime(randomLong()).debug(randomBoolean()).request();
     }
 
     @Override

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
@@ -57,13 +57,11 @@ public class AnalyticsEventFactoryTests extends ESTestCase {
     }
 
     private PostAnalyticsEventAction.Request toRequest(AnalyticsEvent event) {
-        return new PostAnalyticsEventAction.Request(
+        return PostAnalyticsEventAction.Request.builder(
             event.eventCollectionName(),
             event.eventType().toString(),
-            randomBoolean(),
-            event.eventTime(),
             XContentType.JSON,
             event.payload()
-        );
+        ).eventTime(event.eventTime()).debug(randomBoolean()).request();
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
@@ -7,19 +7,26 @@
 
 package org.elasticsearch.xpack.application.analytics.event;
 
-import org.elasticsearch.core.Tuple;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.analytics.action.PostAnalyticsEventAction;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.convertMapToJson;
 import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.createAnalyticsContextMockFromEvent;
 import static org.elasticsearch.xpack.application.analytics.event.parser.event.PageViewAnalyticsEventTests.randomPageViewEvent;
 import static org.elasticsearch.xpack.application.analytics.event.parser.event.SearchAnalyticsEventTests.randomSearchEvent;
 import static org.elasticsearch.xpack.application.analytics.event.parser.event.SearchClickAnalyticsEventTests.randomSearchClickEvent;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SessionAnalyticsEventField.CLIENT_ADDRESS_FIELD;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SessionAnalyticsEventField.SESSION_FIELD;
+import static org.elasticsearch.xpack.application.analytics.event.parser.field.SessionAnalyticsEventField.USER_AGENT_FIELD;
 
 public class AnalyticsEventFactoryTests extends ESTestCase {
 
@@ -47,23 +54,45 @@ public class AnalyticsEventFactoryTests extends ESTestCase {
         assertEquals(event, AnalyticsEventFactory.INSTANCE.fromPayload(context, XContentType.JSON, event.payload()));
     }
 
-    private static PostAnalyticsEventAction.Request toRequest(AnalyticsEvent event) {
+    private static PostAnalyticsEventAction.Request toRequest(AnalyticsEvent event) throws IOException {
         final PostAnalyticsEventAction.RequestBuilder requestBuilder = PostAnalyticsEventAction.Request.builder(
             event.eventCollectionName(),
             event.eventType().toString(),
             XContentType.JSON,
-            event.payload()
-        ).eventTime(event.eventTime()).debug(randomBoolean()).clientAddress(event.clientAddress());
-        Map<String, List<String>> headers = randomMap(
-            0,
-            5,
-            () -> new Tuple<>(randomIdentifier(), randomList(1, 5, ESTestCase::randomIdentifier))
+            toRequestPayload(event)
         );
-        if (event.userAgent() != null) {
-            headers.put("User-Agent", List.of(event.userAgent()));
+
+        requestBuilder.eventTime(event.eventTime()).debug(randomBoolean());
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> eventSessionData = (Map<String, String>) event.payloadAsMap().get(SESSION_FIELD.getPreferredName());
+
+        Map<String, List<String>> headers = new HashMap<>();
+        requestBuilder.clientAddress(eventSessionData.get(CLIENT_ADDRESS_FIELD.getPreferredName()));
+
+        if (eventSessionData.containsKey(USER_AGENT_FIELD.getPreferredName())) {
+            headers.put("User-Agent", List.of(eventSessionData.get(USER_AGENT_FIELD.getPreferredName())));
         }
+
         requestBuilder.headers(headers);
         return requestBuilder.request();
+    }
+
+    private static BytesReference toRequestPayload(AnalyticsEvent event) throws IOException {
+        MapBuilder<String, Object> requestPayloadBuilder = MapBuilder.newMapBuilder(event.payloadAsMap());
+
+        @SuppressWarnings("unchecked")
+        Map<String, String> eventSessionData = (Map<String, String>) event.payloadAsMap().get(SESSION_FIELD.getPreferredName());
+
+        Map<String, Object> requestSessionData = eventSessionData.entrySet()
+            .stream()
+            .filter(e -> e.getKey() != CLIENT_ADDRESS_FIELD.getPreferredName())
+            .filter(e -> e.getKey() != USER_AGENT_FIELD.getPreferredName())
+            .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, Map.Entry::getValue));
+
+        requestPayloadBuilder.put(SESSION_FIELD.getPreferredName(), requestSessionData);
+
+        return convertMapToJson(requestPayloadBuilder.map());
     }
 
     public void testFromPayloadSearchClickEvent() throws IOException {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
@@ -7,11 +7,14 @@
 
 package org.elasticsearch.xpack.application.analytics.event;
 
+import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.analytics.action.PostAnalyticsEventAction;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
 
 import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.createAnalyticsContextMockFromEvent;
 import static org.elasticsearch.xpack.application.analytics.event.parser.event.PageViewAnalyticsEventTests.randomPageViewEvent;
@@ -44,10 +47,23 @@ public class AnalyticsEventFactoryTests extends ESTestCase {
         assertEquals(event, AnalyticsEventFactory.INSTANCE.fromPayload(context, XContentType.JSON, event.payload()));
     }
 
-    public void testFromPayloadSearchEvent() throws IOException {
-        AnalyticsEvent event = randomSearchEvent();
-        AnalyticsEvent.Context context = createAnalyticsContextMockFromEvent(event);
-        assertEquals(event, AnalyticsEventFactory.INSTANCE.fromPayload(context, XContentType.JSON, event.payload()));
+    private static PostAnalyticsEventAction.Request toRequest(AnalyticsEvent event) {
+        final PostAnalyticsEventAction.RequestBuilder requestBuilder = PostAnalyticsEventAction.Request.builder(
+            event.eventCollectionName(),
+            event.eventType().toString(),
+            XContentType.JSON,
+            event.payload()
+        ).eventTime(event.eventTime()).debug(randomBoolean()).clientAddress(event.clientAddress());
+        Map<String, List<String>> headers = randomMap(
+            0,
+            5,
+            () -> new Tuple<>(randomIdentifier(), randomList(1, 5, ESTestCase::randomIdentifier))
+        );
+        if (event.userAgent() != null) {
+            headers.put("User-Agent", List.of(event.userAgent()));
+        }
+        requestBuilder.headers(headers);
+        return requestBuilder.request();
     }
 
     public void testFromPayloadSearchClickEvent() throws IOException {
@@ -56,12 +72,10 @@ public class AnalyticsEventFactoryTests extends ESTestCase {
         assertEquals(event, AnalyticsEventFactory.INSTANCE.fromPayload(context, XContentType.JSON, event.payload()));
     }
 
-    private PostAnalyticsEventAction.Request toRequest(AnalyticsEvent event) {
-        return PostAnalyticsEventAction.Request.builder(
-            event.eventCollectionName(),
-            event.eventType().toString(),
-            XContentType.JSON,
-            event.payload()
-        ).eventTime(event.eventTime()).debug(randomBoolean()).request();
+    public void testFromPayloadSearchEvent() throws IOException {
+        AnalyticsEvent event = randomSearchEvent();
+        AnalyticsEvent.Context context = createAnalyticsContextMockFromEvent(event);
+        final AnalyticsEvent actual = AnalyticsEventFactory.INSTANCE.fromPayload(context, XContentType.JSON, event.payload());
+        assertEquals(event, actual);
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventTestUtils.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventTestUtils.java
@@ -9,16 +9,22 @@ package org.elasticsearch.xpack.application.analytics.event;
 
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.net.InetAddress;
 import java.util.Map;
 
+import static org.elasticsearch.test.ESTestCase.randomAlphaOfLengthBetween;
+import static org.elasticsearch.test.ESTestCase.randomArray;
+import static org.elasticsearch.test.ESTestCase.randomBoolean;
 import static org.elasticsearch.test.ESTestCase.randomFrom;
 import static org.elasticsearch.test.ESTestCase.randomIdentifier;
 import static org.elasticsearch.test.ESTestCase.randomLong;
+import static org.elasticsearch.test.ESTestCase.randomNonNegativeByte;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -35,6 +41,8 @@ public class AnalyticsEventTestUtils {
         when(context.eventCollectionName()).thenReturn(event.eventCollectionName());
         when(context.eventTime()).thenReturn(event.eventTime());
         when(context.eventType()).thenReturn(event.eventType());
+        when(context.userAgent()).thenReturn(event.userAgent());
+        when(context.clientAddress()).thenReturn(event.clientAddress());
 
         return context;
     }
@@ -45,7 +53,23 @@ public class AnalyticsEventTestUtils {
             randomLong(),
             randomFrom(AnalyticsEvent.Type.values()),
             XContentType.JSON,
-            new BytesArray("{}")
+            new BytesArray("{}"),
+            randomUserAgent(),
+            randomInetAddress()
         );
+    }
+
+    public static String randomUserAgent() {
+        return randomBoolean() ? randomAlphaOfLengthBetween(10, 100) : null;
+    }
+
+    public static InetAddress randomInetAddress() {
+        if (randomBoolean()) {
+            return InetAddresses.forString(
+                String.join(".", randomArray(4, 4, String[]::new, () -> String.valueOf(randomNonNegativeByte())))
+            );
+        }
+
+        return null;
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/event/AnalyticsEventParserTestCase.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/parser/event/AnalyticsEventParserTestCase.java
@@ -26,6 +26,8 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.createAnalyticsContextMockFromEvent;
+import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.randomInetAddress;
+import static org.elasticsearch.xpack.application.analytics.event.AnalyticsEventTestUtils.randomUserAgent;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -128,6 +130,8 @@ public abstract class AnalyticsEventParserTestCase extends ESTestCase {
         when(context.eventType()).thenReturn(eventType);
         when(context.eventTime()).thenReturn(randomLong());
         when(context.eventCollectionName()).thenReturn(randomIdentifier());
+        when(context.userAgent()).thenReturn(randomUserAgent());
+        when(context.clientAddress()).thenReturn(randomInetAddress());
 
         return AnalyticsEvent.builder(context).with(payload).build();
     }

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/GeoIpUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/GeoIpUpgradeIT.java
@@ -26,8 +26,8 @@ public class GeoIpUpgradeIT extends AbstractUpgradeTestCase {
             assertBusy(() -> {
                 Response response = client().performRequest(new Request("GET", "_ingest/geoip/stats"));
                 String tasks = EntityUtils.toString(response.getEntity(), StandardCharsets.UTF_8);
-                // The geoip downloader doesn't actually do anything since there are no geoip processors:
-                assertThat(tasks, Matchers.containsString("failed_downloads\":0"));
+                // The geoip downloader should be executed since a geoip processors is present in behavioral analytics default pipeline:
+                assertThat(tasks, Matchers.containsString("failed_downloads\":1"));
                 assertThat(tasks, Matchers.containsString("successful_downloads\":0"));
             });
         }


### PR DESCRIPTION
Add Geo IP and User Agent to analytics session fields.

User Agent and IP are retrieved from the action `Request`, and added to the Analytics `Context` so they can populate the appropriate `session` fields.

A pipeline is added for analyzing the user agent and resolving the IP, dropping the original so we don't have privacy related issues.