### PR TITLE
[8.7] Enable downsampling of time series index without any metric field (#95353)

### DIFF
--- a/docs/changelog/95353.yaml
+++ b/docs/changelog/95353.yaml
@@ -1,0 +1,6 @@
+pr: 95353
+summary: Enable downsampling of time series index without any metric field
+area: Rollup
+type: bug
+issues:
+ - 95352

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/10_basic.yml
@@ -435,8 +435,8 @@ setup:
 ---
 "Downsample no metric index":
   - skip:
-      version: " - 8.4.99"
-      reason: "rollup renamed to downsample in 8.5.0"
+      version: " - 8.7.99"
+      reason: "Downsample of time series index without metric allowed from version 8.8.0"
 
   - do:
       indices.create:
@@ -458,6 +458,30 @@ setup:
               metricset:
                 type: keyword
                 time_series_dimension: true
+              label:
+                type: integer
+
+  - do:
+      bulk:
+        refresh: true
+        index: no-metric-index
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "metricset": "pod", "label": 10, "unmapped": 10 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:24.467Z", "metricset": "pod", "label": 20, "unmapped": 20 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T20:50:44.467Z", "metricset": "pod", "label": 30, "unmapped": 30 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T20:51:04.467Z", "metricset": "pod", "label": 40, "unmapped": 40 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:03.142Z", "metricset": "pod", "label": 100, "unmapped": 100 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:23.142Z", "metricset": "pod", "label": 200, "unampped": 200 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:50:53.142Z", "metricset": "pod", "label": 300, "unmapped": 300 }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:51:03.142Z", "metricset": "pod", "label": 400, "unmapped": 400 }'
 
   - do:
       indices.put_settings:
@@ -466,14 +490,127 @@ setup:
           index.blocks.write: true
 
   - do:
-      catch: /Index \[no-metric-index\] does not contain any metric fields;/
       indices.downsample:
         index: no-metric-index
-        target_index: rollup-test
+        target_index: rollup-test-no-metric
         body:  >
           {
             "fixed_interval": "1h"
           }
+
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: rollup-test-no-metric
+        body:
+          sort: [ "_tsid", "@timestamp" ]
+
+  - length: { hits.hits: 3 }
+
+  - match: { hits.hits.0._source._doc_count: 4 }
+  - match: { hits.hits.0._source.metricset: pod }
+  - match: { hits.hits.0._source.label: 20 }
+  - match: { hits.hits.0._source.unmapped: 20 }
+  - match: { hits.hits.0._source.@timestamp: 2021-04-28T18:00:00.000Z }
+
+  - match: { hits.hits.1._source._doc_count: 2 }
+  - match: { hits.hits.1._source.metricset: pod }
+  - match: { hits.hits.1._source.label: 400 }
+  - match: { hits.hits.1._source.unmapped: 400 }
+  - match: { hits.hits.1._source.@timestamp: 2021-04-28T19:00:00.000Z }
+
+  - match: { hits.hits.2._source._doc_count: 2 }
+  - match: { hits.hits.2._source.metricset: pod }
+  - match: { hits.hits.2._source.label: 40 }
+  - match: { hits.hits.2._source.unmapped: 40 }
+  - match: { hits.hits.2._source.@timestamp: 2021-04-28T20:00:00.000Z }
+
+---
+"Downsample no metric no label index":
+  - skip:
+      version: " - 8.7.99"
+      reason: "Downsample of time series index without metric allowed from version 8.8.0"
+
+  - do:
+      indices.create:
+        index: no-metric-no-label-index
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              mode: time_series
+              routing_path: [metricset]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+
+  - do:
+      bulk:
+        refresh: true
+        index: no-metric-no-label-index
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:24.467Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T20:50:44.467Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T20:51:04.467Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:03.142Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:23.142Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:50:53.142Z", "metricset": "pod" }'
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T19:51:03.142Z", "metricset": "pod" }'
+
+  - do:
+      indices.put_settings:
+        index: no-metric-no-label-index
+        body:
+          index.blocks.write: true
+
+  - do:
+      indices.downsample:
+        index: no-metric-no-label-index
+        target_index: rollup-test-no-metric-no-label
+        body:  >
+          {
+            "fixed_interval": "1h"
+          }
+
+  - is_true: acknowledged
+
+  - do:
+      search:
+        index: rollup-test-no-metric-no-label
+        body:
+          sort: [ "_tsid", "@timestamp" ]
+
+  - length: { hits.hits: 3 }
+
+  - match: { hits.hits.0._source._doc_count: 4 }
+  - match: { hits.hits.0._source.metricset: pod }
+  - match: { hits.hits.0._source.@timestamp: 2021-04-28T18:00:00.000Z }
+
+  - match: { hits.hits.1._source._doc_count: 2 }
+  - match: { hits.hits.1._source.metricset: pod }
+  - match: { hits.hits.1._source.@timestamp: 2021-04-28T19:00:00.000Z }
+
+  - match: { hits.hits.2._source._doc_count: 2 }
+  - match: { hits.hits.2._source.metricset: pod }
+  - match: { hits.hits.2._source.@timestamp: 2021-04-28T20:00:00.000Z }
 
 ---
 "Downsample a downsampled index":

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/downsample/TransportDownsampleAction.java
@@ -256,9 +256,6 @@ public class TransportDownsampleAction extends AcknowledgedTransportMasterNodeAc
             if (dimensionFields.isEmpty()) {
                 validationException.addValidationError("Index [" + sourceIndexName + "] does not contain any dimension fields");
             }
-            if (metricFields.isEmpty()) {
-                validationException.addValidationError("Index [" + sourceIndexName + "] does not contain any metric fields");
-            }
 
             if (validationException.validationErrors().isEmpty() == false) {
                 listener.onFailure(validationException);

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -457,7 +457,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         assertRollupIndex(sourceIndex, rollupIndex, config);
     }
 
-    public void testCannotRollupIndexWithNoMetrics() {
+    public void testRollupIndexWithNoMetrics() throws IOException {
         // Create a source index that contains no metric fields in its mapping
         String sourceIndex = "no-metrics-idx-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
         client().admin()
@@ -485,8 +485,8 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
 
         DownsampleConfig config = new DownsampleConfig(randomInterval());
         prepareSourceIndex(sourceIndex);
-        Exception exception = expectThrows(ActionRequestValidationException.class, () -> rollup(sourceIndex, rollupIndex, config));
-        assertThat(exception.getMessage(), containsString("does not contain any metric fields"));
+        rollup(sourceIndex, rollupIndex, config);
+        assertRollupIndex(sourceIndex, rollupIndex, config);
     }
 
     public void testCannotRollupWriteableIndex() {


### PR DESCRIPTION
# Backport

This is an automatic backport to `8.7` of:
 - #95353

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)