### PR TITLE
[ML] Get stats by deployment or model id

### DIFF
--- a/docs/changelog/95440.yaml
+++ b/docs/changelog/95440.yaml
@@ -1,0 +1,5 @@
+pr: 95440
+summary: "[ML} Get stats by deployment or model id"
+area: Machine Learning
+type: enhancement
+issues: []

--- a/docs/changelog/95440.yaml
+++ b/docs/changelog/95440.yaml
@@ -1,5 +1,5 @@
 pr: 95440
-summary: "[ML} Get stats by deployment or model id"
+summary: "[ML] Get trained model stats by deployment id or model id"
 area: Machine Learning
 type: enhancement
 issues: []

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MultipleDeploymentsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MultipleDeploymentsIT.java
@@ -8,18 +8,24 @@
 package org.elasticsearch.xpack.ml.integration;
 
 import org.elasticsearch.client.Response;
+import org.elasticsearch.common.xcontent.support.XContentMapValues;
+import org.elasticsearch.core.Tuple;
+import org.elasticsearch.xpack.core.ml.utils.MapHelper;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 
 public class MultipleDeploymentsIT extends PyTorchModelRestTestCase {
 
     @SuppressWarnings("unchecked")
     public void testDeployModelMultipleTimes() throws IOException {
         String baseModelId = "base-model";
-        createPassThroughModel(baseModelId);
-        putModelDefinition(baseModelId);
-        putVocabulary(List.of("these", "are", "my", "words"), baseModelId);
+        putAllModelParts(baseModelId);
 
         String forSearch = "for-search";
         startWithDeploymentId(baseModelId, forSearch);
@@ -35,12 +41,120 @@ public class MultipleDeploymentsIT extends PyTorchModelRestTestCase {
         inference = infer("my words", forIngest);
         assertOK(inference);
 
-        // TODO
-        // assertInferenceCount(1, forSearch);
-        // assertInferenceCount(2, forIngest);
+        assertInferenceCount(1, forSearch);
+        assertInferenceCount(2, forIngest);
 
         stopDeployment(forSearch);
         stopDeployment(forIngest);
+
+        Response statsResponse = getTrainedModelStats("_all");
+        Map<String, Object> stats = entityAsMap(statsResponse);
+        List<Map<String, Object>> trainedModelStats = (List<Map<String, Object>>) stats.get("trained_model_stats");
+        assertThat(stats.toString(), trainedModelStats, hasSize(2));
+
+        for (var statsMap : trainedModelStats) {
+            assertNull(stats.toString(), statsMap.get("deployment_stats"));
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    public void testGetStats() throws IOException {
+        String undeployedModel1 = "undeployed_1";
+        putAllModelParts(undeployedModel1);
+        String undeployedModel2 = "undeployed_2";
+        putAllModelParts(undeployedModel2);
+
+        String modelWith1Deployment = "model-with-1-deployment";
+        putAllModelParts(modelWith1Deployment);
+
+        String modelWith2Deployments = "model-with-2-deployments";
+        putAllModelParts(modelWith2Deployments);
+        String forSearchDeployment = "for-search";
+        startWithDeploymentId(modelWith2Deployments, forSearchDeployment);
+        String forIngestDeployment = "for-ingest";
+        startWithDeploymentId(modelWith2Deployments, forIngestDeployment);
+
+        // deployment Id is the same as model
+        startDeployment(modelWith1Deployment);
+
+        {
+            Map<String, Object> stats = entityAsMap(getTrainedModelStats("_all"));
+            List<Map<String, Object>> trainedModelStats = (List<Map<String, Object>>) stats.get("trained_model_stats");
+            checkExpectedStats(
+                List.of(
+                    new Tuple<>(undeployedModel1, null),
+                    new Tuple<>(undeployedModel2, null),
+                    new Tuple<>(modelWith1Deployment, modelWith1Deployment),
+                    new Tuple<>(modelWith2Deployments, forSearchDeployment),
+                    new Tuple<>(modelWith2Deployments, forIngestDeployment)
+                ),
+                trainedModelStats,
+                true
+            );
+
+            // check the sorted order
+            assertEquals(trainedModelStats.get(0).get("model_id"), "lang_ident_model_1");
+            assertEquals(trainedModelStats.get(1).get("model_id"), modelWith1Deployment);
+            assertEquals(MapHelper.dig("deployment_stats.deployment_id", trainedModelStats.get(1)), modelWith1Deployment);
+            assertEquals(trainedModelStats.get(2).get("model_id"), modelWith2Deployments);
+            assertEquals(MapHelper.dig("deployment_stats.deployment_id", trainedModelStats.get(2)), forIngestDeployment);
+            assertEquals(trainedModelStats.get(3).get("model_id"), modelWith2Deployments);
+            assertEquals(MapHelper.dig("deployment_stats.deployment_id", trainedModelStats.get(3)), forSearchDeployment);
+            assertEquals(trainedModelStats.get(4).get("model_id"), undeployedModel1);
+            assertEquals(trainedModelStats.get(5).get("model_id"), undeployedModel2);
+        }
+        {
+            Map<String, Object> stats = entityAsMap(getTrainedModelStats(modelWith1Deployment));
+            List<Map<String, Object>> trainedModelStats = (List<Map<String, Object>>) stats.get("trained_model_stats");
+            checkExpectedStats(List.of(new Tuple<>(modelWith1Deployment, modelWith1Deployment)), trainedModelStats);
+        }
+        {
+            Map<String, Object> stats = entityAsMap(getTrainedModelStats(modelWith2Deployments));
+            List<Map<String, Object>> trainedModelStats = (List<Map<String, Object>>) stats.get("trained_model_stats");
+            checkExpectedStats(
+                List.of(new Tuple<>(modelWith2Deployments, forSearchDeployment), new Tuple<>(modelWith2Deployments, forIngestDeployment)),
+                trainedModelStats
+            );
+        }
+        {
+            Map<String, Object> stats = entityAsMap(getTrainedModelStats(forIngestDeployment));
+            List<Map<String, Object>> trainedModelStats = (List<Map<String, Object>>) stats.get("trained_model_stats");
+            checkExpectedStats(List.of(new Tuple<>(modelWith2Deployments, forIngestDeployment)), trainedModelStats);
+        }
+
+        stopDeployment(modelWith2Deployments); // TODO should stop 2 deployments
+    }
+
+    private void checkExpectedStats(List<Tuple<String, String>> modelDeploymentPairs, List<Map<String, Object>> trainedModelStats) {
+        checkExpectedStats(modelDeploymentPairs, trainedModelStats, false);
+    }
+
+    private void checkExpectedStats(
+        List<Tuple<String, String>> modelDeploymentPairs,
+        List<Map<String, Object>> trainedModelStats,
+        boolean plusOneForLangIdent
+    ) {
+        var concatenatedIds = new HashSet<String>();
+        modelDeploymentPairs.forEach(t -> concatenatedIds.add(t.v1() + t.v2()));
+
+        int expectedSize = modelDeploymentPairs.size();
+        if (plusOneForLangIdent) {
+            expectedSize++;
+        }
+        assertEquals(trainedModelStats.toString(), trainedModelStats.size(), expectedSize);
+        for (var tmStats : trainedModelStats) {
+            String modelId = (String) tmStats.get("model_id");
+            String deploymentId = (String) XContentMapValues.extractValue("deployment_stats.deployment_id", tmStats);
+            concatenatedIds.remove(modelId + deploymentId);
+        }
+
+        assertThat("Missing stats for " + concatenatedIds, concatenatedIds, empty());
+    }
+
+    private void putAllModelParts(String modelId) throws IOException {
+        createPassThroughModel(modelId);
+        putModelDefinition(modelId);
+        putVocabulary(List.of("these", "are", "my", "words"), modelId);
     }
 
     private void putModelDefinition(String modelId) throws IOException {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -60,7 +60,8 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
                     "logger.org.elasticsearch.xpack.ml.inference.assignment" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.inference.deployment" : "DEBUG",
                     "logger.org.elasticsearch.xpack.ml.inference.pytorch" : "DEBUG",
-                    "logger.org.elasticsearch.xpack.ml.process.logging" : "DEBUG"
+                    "logger.org.elasticsearch.xpack.ml.process.logging" : "DEBUG",
+                    "logger.org.elasticsearch.xpack.ml.action" : "DEBUG"
                 }}""");
         client().performRequest(loggingSettings);
     }

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelRestTestCase.java
@@ -122,15 +122,24 @@ public abstract class PyTorchModelRestTestCase extends ESRestTestCase {
 
     @SuppressWarnings("unchecked")
     protected void assertInferenceCount(int expectedCount, String deploymentId) throws IOException {
-        Response noInferenceCallsStatsResponse = getTrainedModelStats(deploymentId);
-        Map<String, Object> stats = entityAsMap(noInferenceCallsStatsResponse);
+        Response statsResponse = getTrainedModelStats(deploymentId);
+        Map<String, Object> stats = entityAsMap(statsResponse);
+        List<Map<String, Object>> trainedModelStats = (List<Map<String, Object>>) stats.get("trained_model_stats");
 
-        List<Map<String, Object>> nodes = (List<Map<String, Object>>) XContentMapValues.extractValue(
-            "trained_model_stats.0.deployment_stats.nodes",
-            stats
-        );
-        int inferenceCount = sumInferenceCountOnNodes(nodes);
-        assertEquals(expectedCount, inferenceCount);
+        boolean deploymentFound = false;
+        for (var statsMap : trainedModelStats) {
+            var deploymentStats = (Map<String, Object>) XContentMapValues.extractValue("deployment_stats", statsMap);
+            // find the matching deployment
+            if (deploymentId.equals(deploymentStats.get("deployment_id"))) {
+                List<Map<String, Object>> nodes = (List<Map<String, Object>>) XContentMapValues.extractValue("nodes", deploymentStats);
+                int inferenceCount = sumInferenceCountOnNodes(nodes);
+                assertEquals(stats.toString(), expectedCount, inferenceCount);
+                deploymentFound = true;
+                break;
+            }
+        }
+
+        assertTrue("No deployment stats found for deployment [" + deploymentId + "]", deploymentFound);
     }
 
     protected int sumInferenceCountOnNodes(List<Map<String, Object>> nodes) {

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelPersisterIT.java
@@ -113,6 +113,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
             Collections.emptySet(),
             ModelAliasMetadata.EMPTY,
             null,
+            Collections.emptySet(),
             getIdsFuture
         );
         Tuple<Long, Map<String, Set<String>>> ids = getIdsFuture.actionGet();
@@ -184,6 +185,7 @@ public class ChunkedTrainedModelPersisterIT extends MlSingleNodeTestCase {
             Collections.emptySet(),
             ModelAliasMetadata.EMPTY,
             null,
+            Collections.emptySet(),
             getIdsFuture
         );
         Tuple<Long, Map<String, Set<String>>> ids = getIdsFuture.actionGet();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteTrainedModelAction.java
@@ -134,7 +134,7 @@ public class TransportDeleteTrainedModelAction extends AcknowledgedTransportMast
             }
         }
 
-        if (TrainedModelAssignmentMetadata.fromState(state).isAssigned(request.getId())) {
+        if (TrainedModelAssignmentMetadata.fromState(state).modelIsDeployed(request.getId())) {
             if (request.isForce()) {
                 forceStopDeployment(
                     request.getId(),

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsAction.java
@@ -144,6 +144,7 @@ public class TransportGetTrainedModelsAction extends HandledTransportAction<Requ
             new HashSet<>(request.getTags()),
             ModelAliasMetadata.fromState(clusterService.state()),
             parentTaskId,
+            Collections.emptySet(),
             idExpansionListener
         );
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -6,7 +6,10 @@
  */
 package org.elasticsearch.xpack.ml.action;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.StepListener;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsAction;
 import org.elasticsearch.action.admin.cluster.node.stats.NodesStatsRequest;
@@ -18,6 +21,7 @@ import org.elasticsearch.action.support.HandledTransportAction;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.metrics.CounterMetric;
@@ -32,6 +36,7 @@ import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xpack.core.action.util.ExpandedIdsMatcher;
 import org.elasticsearch.xpack.core.ml.action.GetDeploymentStatsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
 import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
@@ -43,12 +48,15 @@ import org.elasticsearch.xpack.core.ml.inference.persistence.InferenceIndexConst
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceStats;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TrainedModelSizeStats;
 import org.elasticsearch.xpack.ml.inference.ModelAliasMetadata;
+import org.elasticsearch.xpack.ml.inference.assignment.TrainedModelAssignmentMetadata;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelDefinitionDoc;
 import org.elasticsearch.xpack.ml.inference.persistence.TrainedModelProvider;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,11 +67,13 @@ import java.util.stream.Stream;
 
 import static org.elasticsearch.xpack.core.ClientHelper.ML_ORIGIN;
 import static org.elasticsearch.xpack.core.ClientHelper.executeAsyncWithOrigin;
-import static org.elasticsearch.xpack.ml.utils.InferenceProcessorInfoExtractor.pipelineIdsByModelIdsOrAliases;
+import static org.elasticsearch.xpack.ml.utils.InferenceProcessorInfoExtractor.pipelineIdsByResource;
 
 public class TransportGetTrainedModelsStatsAction extends HandledTransportAction<
     GetTrainedModelsStatsAction.Request,
     GetTrainedModelsStatsAction.Response> {
+
+    private static final Logger logger = LogManager.getLogger(TransportGetTrainedModelsStatsAction.class);
 
     private final Client client;
     private final ClusterService clusterService;
@@ -90,16 +100,25 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         ActionListener<GetTrainedModelsStatsAction.Response> listener
     ) {
         final TaskId parentTaskId = new TaskId(clusterService.localNode().getId(), task.getId());
-        final ModelAliasMetadata currentMetadata = ModelAliasMetadata.fromState(clusterService.state());
+        final ModelAliasMetadata modelAliasMetadata = ModelAliasMetadata.fromState(clusterService.state());
+        final TrainedModelAssignmentMetadata assignmentMetadata = TrainedModelAssignmentMetadata.fromState(clusterService.state());
+        final Set<String> matchedDeploymentIds = matchedDeploymentIds(request.getResourceId(), assignmentMetadata);
+
         GetTrainedModelsStatsAction.Response.Builder responseBuilder = new GetTrainedModelsStatsAction.Response.Builder();
 
-        ActionListener<Map<String, TrainedModelSizeStats>> modelSizeStatsListener = ActionListener.wrap(modelSizeStatsByModelId -> {
+        StepListener<Map<String, TrainedModelSizeStats>> modelSizeStatsListener = new StepListener<>();
+        modelSizeStatsListener.whenComplete(modelSizeStatsByModelId -> {
             responseBuilder.setModelSizeStatsByModelId(modelSizeStatsByModelId);
-            listener.onResponse(responseBuilder.build());
+            listener.onResponse(
+                responseBuilder.build(modelToDeployments(responseBuilder.getExpandedIdsWithAliases().keySet(), assignmentMetadata))
+            );
         }, listener::onFailure);
 
-        ActionListener<GetDeploymentStatsAction.Response> deploymentStatsListener = ActionListener.wrap(deploymentStats -> {
-            responseBuilder.setDeploymentStatsByModelId(
+        StepListener<GetDeploymentStatsAction.Response> deploymentStatsListener = new StepListener<>();
+        deploymentStatsListener.whenComplete(deploymentStats -> {
+            // deployment stats for each matching deployment
+            // not necessarily for all models
+            responseBuilder.setDeploymentStatsByDeploymentId(
                 deploymentStats.getStats()
                     .results()
                     .stream()
@@ -108,35 +127,32 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
             modelSizeStats(responseBuilder.getExpandedIdsWithAliases(), request.isAllowNoResources(), parentTaskId, modelSizeStatsListener);
         }, listener::onFailure);
 
-        ActionListener<List<InferenceStats>> inferenceStatsListener = ActionListener.wrap(inferenceStats -> {
+        StepListener<List<InferenceStats>> inferenceStatsListener = new StepListener<>();
+        // inference stats are per model and are only
+        // persisted for boosted tree models
+        inferenceStatsListener.whenComplete(inferenceStats -> {
             responseBuilder.setInferenceStatsByModelId(
                 inferenceStats.stream().collect(Collectors.toMap(InferenceStats::getModelId, Function.identity()))
             );
-            GetDeploymentStatsAction.Request getDeploymentStatsRequest = new GetDeploymentStatsAction.Request(request.getResourceId());
-            getDeploymentStatsRequest.setParentTask(parentTaskId);
-            executeAsyncWithOrigin(
-                client,
-                ML_ORIGIN,
-                GetDeploymentStatsAction.INSTANCE,
-                getDeploymentStatsRequest,
-                deploymentStatsListener
-            );
+            getDeploymentStats(client, request.getResourceId(), parentTaskId, assignmentMetadata, deploymentStatsListener);
         }, listener::onFailure);
 
-        ActionListener<NodesStatsResponse> nodesStatsListener = ActionListener.wrap(nodesStatsResponse -> {
+        StepListener<NodesStatsResponse> nodesStatsListener = new StepListener<>();
+        nodesStatsListener.whenComplete(nodesStatsResponse -> {
+            // find all pipelines whether using the model id,
+            // alias or deployment id.
             Set<String> allPossiblePipelineReferences = responseBuilder.getExpandedIdsWithAliases()
                 .entrySet()
                 .stream()
                 .flatMap(entry -> Stream.concat(entry.getValue().stream(), Stream.of(entry.getKey())))
                 .collect(Collectors.toSet());
-            Map<String, Set<String>> pipelineIdsByModelIdsOrAliases = pipelineIdsByModelIdsOrAliases(
-                clusterService.state(),
-                allPossiblePipelineReferences
-            );
+            allPossiblePipelineReferences.addAll(matchedDeploymentIds);
+
+            Map<String, Set<String>> pipelineIdsByResource = pipelineIdsByResource(clusterService.state(), allPossiblePipelineReferences);
             Map<String, IngestStats> modelIdIngestStats = inferenceIngestStatsByModelId(
                 nodesStatsResponse,
-                currentMetadata,
-                pipelineIdsByModelIdsOrAliases
+                modelAliasMetadata,
+                pipelineIdsByResource
             );
             responseBuilder.setIngestStatsByModelId(modelIdIngestStats);
             trainedModelProvider.getInferenceStats(
@@ -146,23 +162,102 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
             );
         }, listener::onFailure);
 
-        ActionListener<Tuple<Long, Map<String, Set<String>>>> idsListener = ActionListener.wrap(tuple -> {
+        StepListener<Tuple<Long, Map<String, Set<String>>>> idsListener = new StepListener<>();
+        idsListener.whenComplete(tuple -> {
             responseBuilder.setExpandedIdsWithAliases(tuple.v2()).setTotalModelCount(tuple.v1());
-            String[] ingestNodes = ingestNodes(clusterService.state());
-            NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(ingestNodes).clear()
-                .addMetric(NodesStatsRequest.Metric.INGEST.metricName());
-            nodesStatsRequest.setParentTask(parentTaskId);
-            executeAsyncWithOrigin(client, ML_ORIGIN, NodesStatsAction.INSTANCE, nodesStatsRequest, nodesStatsListener);
+            executeAsyncWithOrigin(
+                client,
+                ML_ORIGIN,
+                NodesStatsAction.INSTANCE,
+                nodeStatsRequest(clusterService.state(), parentTaskId),
+                nodesStatsListener
+            );
         }, listener::onFailure);
+
+        // When the request resource is a deployment find the
+        // model used in that deployment for the model stats
+        String idExpression = addModelsUsedInMatchingDeployments(request.getResourceId(), assignmentMetadata);
+        logger.debug("Expanded models/deployment Ids request [{}]", idExpression);
+
         trainedModelProvider.expandIds(
-            request.getResourceId(),
+            idExpression,
             request.isAllowNoResources(),
             request.getPageParams(),
             Collections.emptySet(),
-            currentMetadata,
+            modelAliasMetadata,
             parentTaskId,
+            matchedDeploymentIds,  // the request Id may contain deployment Ids
             idsListener
         );
+    }
+
+    static String addModelsUsedInMatchingDeployments(String idExpression, TrainedModelAssignmentMetadata assignmentMetadata) {
+        if (Strings.isAllOrWildcard(idExpression)) {
+            return idExpression;
+        } else {
+            var tokens = new HashSet<>(Arrays.asList(ExpandedIdsMatcher.tokenizeExpression(idExpression)));
+            var modelsUsedByMatchingDeployments = modelsUsedByMatchingDeploymentId(idExpression, assignmentMetadata);
+            tokens.addAll(modelsUsedByMatchingDeployments);
+            return String.join(",", tokens);
+        }
+    }
+
+    static Map<String, Set<String>> modelToDeployments(Set<String> modelIds, TrainedModelAssignmentMetadata assignments) {
+        var modelToDeploymentMap = new HashMap<String, Set<String>>();
+        for (var assignment : assignments.allAssignments().values()) {
+            if (modelIds.contains(assignment.getModelId())) {
+                modelToDeploymentMap.computeIfAbsent(assignment.getModelId(), k -> new HashSet<>()).add(assignment.getDeploymentId());
+            }
+        }
+        return modelToDeploymentMap;
+    }
+
+    static Set<String> matchedDeploymentIds(String resourceId, TrainedModelAssignmentMetadata assignments) {
+        var deploymentIds = new HashSet<String>();
+        var matcher = new ExpandedIdsMatcher.SimpleIdsMatcher(resourceId);
+        for (var assignment : assignments.allAssignments().values()) {
+            if (matcher.idMatches(assignment.getDeploymentId())) {
+                deploymentIds.add(assignment.getDeploymentId());
+            }
+        }
+        return deploymentIds;
+    }
+
+    static Set<String> modelsUsedByMatchingDeploymentId(String resourceId, TrainedModelAssignmentMetadata assignments) {
+        var modelIds = new HashSet<String>();
+        var matcher = new ExpandedIdsMatcher.SimpleIdsMatcher(resourceId);
+        for (var assignment : assignments.allAssignments().values()) {
+            if (matcher.idMatches(assignment.getDeploymentId())) {
+                modelIds.add(assignment.getModelId());
+            }
+        }
+        return modelIds;
+    }
+
+    static void getDeploymentStats(
+        Client client,
+        String resourceId,
+        TaskId parentTaskId,
+        TrainedModelAssignmentMetadata assignments,
+        ActionListener<GetDeploymentStatsAction.Response> deploymentStatsListener
+    ) {
+        // include all matched deployments and models
+        var matcher = new ExpandedIdsMatcher.SimpleIdsMatcher(resourceId);
+        var matchedDeployments = new HashSet<String>();
+        for (var assignment : assignments.allAssignments().values()) {
+            if (matcher.idMatches(assignment.getDeploymentId())) {
+                matchedDeployments.add(assignment.getDeploymentId());
+            } else if (matcher.idMatches(assignment.getModelId())) {
+                matchedDeployments.add(assignment.getDeploymentId());
+            }
+        }
+        String deployments = matchedDeployments.stream().collect(Collectors.joining(","));
+
+        logger.info("Fetching stats for deployments [{}]", deployments);
+
+        GetDeploymentStatsAction.Request getDeploymentStatsRequest = new GetDeploymentStatsAction.Request(deployments);
+        getDeploymentStatsRequest.setParentTask(parentTaskId);
+        executeAsyncWithOrigin(client, ML_ORIGIN, GetDeploymentStatsAction.INSTANCE, getDeploymentStatsRequest, deploymentStatsListener);
     }
 
     private void modelSizeStats(
@@ -260,8 +355,12 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         return ingestStatsMap;
     }
 
-    static String[] ingestNodes(final ClusterState clusterState) {
-        return clusterState.nodes().getIngestNodes().keySet().toArray(String[]::new);
+    static NodesStatsRequest nodeStatsRequest(ClusterState state, TaskId parentTaskId) {
+        String[] ingestNodes = state.nodes().getIngestNodes().keySet().toArray(String[]::new);
+        NodesStatsRequest nodesStatsRequest = new NodesStatsRequest(ingestNodes).clear()
+            .addMetric(NodesStatsRequest.Metric.INGEST.metricName());
+        nodesStatsRequest.setParentTask(parentTaskId);
+        return nodesStatsRequest;
     }
 
     static IngestStats ingestStatsForPipelineIds(NodeStats nodeStats, Set<String> pipelineIds) {
@@ -360,5 +459,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
             return new IngestStats.Stats(ingestCount.count(), ingestTimeInMillis.count(), ingestCurrent.count(), ingestFailedCount.count());
         }
     }
+
+    private record ModelAndDeployment(String modelId, String deploymentId) {}
 
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentMetadata.java
@@ -114,6 +114,17 @@ public class TrainedModelAssignmentMetadata implements Metadata.Custom {
         return deploymentRoutingEntries.containsKey(deploymentId);
     }
 
+    public boolean modelIsDeployed(String modelId) {
+        return deploymentRoutingEntries.values().stream().anyMatch(assignment -> modelId.equals(assignment.getModelId()));
+    }
+
+    public List<TrainedModelAssignment> getDeploymentsUsingModel(String modelId) {
+        return deploymentRoutingEntries.values()
+            .stream()
+            .filter(assignment -> modelId.equals(assignment.getModelId()))
+            .collect(Collectors.toList());
+    }
+
     public Map<String, TrainedModelAssignment> allAssignments() {
         return Collections.unmodifiableMap(deploymentRoutingEntries);
     }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/persistence/TrainedModelProvider.java
@@ -863,6 +863,23 @@ public class TrainedModelProvider {
         }));
     }
 
+    /**
+     * Returns a Tuple of
+     *  - hit count: the number of matching model Ids
+     *  - Map model id -> aliases: All matched model Ids and
+     *    the list of aliases that reference the model Id
+     *
+     * @param idExpression The expression to expand
+     * @param allowNoResources When wildcard expressions are used allow
+     *                         no matches (don't error)
+     * @param pageParams paging
+     * @param tags Tags the model must contain
+     * @param modelAliasMetadata Aliases
+     * @param parentTaskId Optional parent task Id
+     * @param previouslyMatchedIds Ids that have already been matched (e.g. deployment Id).
+     *                             It is not an error if these Ids are not matched in the query
+     * @param idsListener The listener
+     */
     public void expandIds(
         String idExpression,
         boolean allowNoResources,
@@ -870,6 +887,7 @@ public class TrainedModelProvider {
         Set<String> tags,
         ModelAliasMetadata modelAliasMetadata,
         @Nullable TaskId parentTaskId,
+        Set<String> previouslyMatchedIds,
         ActionListener<Tuple<Long, Map<String, Set<String>>>> idsListener
     ) {
         String[] tokens = Strings.tokenizeToStringArray(idExpression, ",");
@@ -973,6 +991,7 @@ public class TrainedModelProvider {
                 // Reverse lookup to see what model aliases were matched by their found trained model IDs
                 ExpandedIdsMatcher requiredMatches = new ExpandedIdsMatcher(tokens, allowNoResources);
                 requiredMatches.filterMatchedIds(matchedTokens);
+                requiredMatches.filterMatchedIds(previouslyMatchedIds);
                 if (requiredMatches.hasUnmatchedIds()) {
                     idsListener.onFailure(ExceptionsHelper.missingTrainedModel(requiredMatches.unmatchedIdsString()));
                 } else {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractor.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractor.java
@@ -71,10 +71,10 @@ public final class InferenceProcessorInfoExtractor {
 
     /**
      * @param state Current cluster state
-     * @return a map from Model IDs or Aliases to each pipeline referencing them.
+     * @return a map from Model or Deployment IDs or Aliases to each pipeline referencing them.
      */
     @SuppressWarnings("unchecked")
-    public static Map<String, Set<String>> pipelineIdsByModelIdsOrAliases(ClusterState state, Set<String> modelIds) {
+    public static Map<String, Set<String>> pipelineIdsByResource(ClusterState state, Set<String> ids) {
         Map<String, Set<String>> pipelineIdsByModelIds = new HashMap<>();
         Metadata metadata = state.metadata();
         if (metadata == null) {
@@ -90,7 +90,7 @@ public final class InferenceProcessorInfoExtractor {
             for (Map<String, Object> processorConfigWithKey : processorConfigs) {
                 for (Map.Entry<String, Object> entry : processorConfigWithKey.entrySet()) {
                     addModelsAndPipelines(entry.getKey(), pipelineId, (Map<String, Object>) entry.getValue(), pam -> {
-                        if (modelIds.contains(pam.modelIdOrAlias)) {
+                        if (ids.contains(pam.modelIdOrAlias)) {
                             pipelineIdsByModelIds.computeIfAbsent(pam.modelIdOrAlias, m -> new LinkedHashSet<>()).add(pipelineId);
                         }
                     }, 0);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractorTests.java
@@ -48,10 +48,7 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
 
         ClusterState clusterState = buildClusterStateWithModelReferences(2, modelId1, modelId2, modelId3);
 
-        Map<String, Set<String>> pipelineIdsByModelIds = InferenceProcessorInfoExtractor.pipelineIdsByModelIdsOrAliases(
-            clusterState,
-            modelIds
-        );
+        Map<String, Set<String>> pipelineIdsByModelIds = InferenceProcessorInfoExtractor.pipelineIdsByResource(clusterState, modelIds);
 
         assertThat(pipelineIdsByModelIds.keySet(), equalTo(modelIds));
         assertThat(

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -458,6 +458,14 @@ setup:
               { "input": "words" }
             ]
           }
+  - do:
+      ml.get_trained_models_stats:
+        model_id: test_model
+  - match: { count: 1 } # one model matched
+  - match: { trained_model_stats.0.model_id: test_model }
+  - match: { trained_model_stats.0.deployment_stats.deployment_id: test_model_for_ingest }
+  - match: { trained_model_stats.1.model_id: test_model }
+  - match: { trained_model_stats.1.deployment_stats.deployment_id: test_model_for_search }
 
   - do:
       ml.stop_trained_model_deployment:


### PR DESCRIPTION
With #95168 models may be deployed multiple times with a deployment Id. The `_stats` API should also respect retrieving stats.

There is one small change the the `deployment_stats` object which has a new `deployment_id` field, otherwise the change is in the number of stats objects returned in the response.

 1. If the request is by a single deployment Id (assuming it is deployed), the result is 1 object containing the model stats and deployment stats. 
 2. If the request is by a single model Id which is either undeployed or has 1 deployment then a single result object is returned.
3. If the request is by a single model Id and that model has multiple deployments a result object is returned for each deployment. 

Case 3. is the new feature, for 1. and 2. there is effectively no change to existing usages of the API.

Wildcards are expanded to match both deployment and model Ids then handled according to the rules above. 
