### PR TITLE
Add backing indices to kibana_system permissions for TI packages supporting IOC expiration

### DIFF
--- a/docs/changelog/95449.yaml
+++ b/docs/changelog/95449.yaml
@@ -1,0 +1,5 @@
+pr: 95449
+summary: Add backing indices to kibana_system permissions for TI packages supporting IOC expiration
+area: Authorization
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -883,12 +883,14 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".ds-logs-ti_*.*-*")
                     .privileges(
-//                        "all"
                         // Require "delete_index" to perform ILM policy actions
                         DeleteIndexAction.NAME,
                         // Require "read" and "view_index_metadata" for transform
                         "read",
-                        "view_index_metadata"
+                        "view_index_metadata",
+                        UpdateSettingsAction.NAME,
+                        PutMappingAction.NAME,
+                        RolloverAction.NAME
                     )
                     .build(),
                 // For src/dest indices of the example transform package

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -881,8 +881,9 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                     .build(),
                 // For source indices of the Threat Intel (ti_*) packages that ships a transform for supporting IOC expiration
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices("logs-ti_*.*-*")
+                    .indices(".ds-logs-ti_*.*-*")
                     .privileges(
+//                        "all"
                         // Require "delete_index" to perform ILM policy actions
                         DeleteIndexAction.NAME,
                         // Require "read" and "view_index_metadata" for transform

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1078,10 +1078,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
         // Test allow permissions on Threat Intel (ti*) source indices required by latest transform : "read", "view_index_metadata",
         // IndicesAliasesAction.NAME, PutMappingAction.NAME, UpdateSettingsAction.NAME, "delete_index"
         Arrays.asList(
-            "logs-ti_recordedfuture.threat-default",
-            "logs-ti_anomali.threatstream-default",
-            "logs-ti_recordedfuture.threat-default" + randomAlphaOfLength(randomIntBetween(0, 13)),
-            "logs-ti_anomali.threatstream-default" + randomAlphaOfLength(randomIntBetween(0, 13))
+            ".ds-logs-ti_recordedfuture.threat-default",
+            ".ds-logs-ti_anomali.threatstream-default",
+            ".ds-logs-ti_recordedfuture.threat-default" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            ".ds-logs-ti_anomali.threatstream-default" + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach(indexName -> {
             final IndexAbstraction indexAbstraction = mockIndexAbstraction(indexName);
             // Allow read-only


### PR DESCRIPTION
With earlier permissions https://github.com/elastic/elasticsearch/pull/94506 that were added, we were able to successfully install the package manually from the Kibana UI and also execute the transform. 
However, the [system tests for ti* packages](https://github.com/elastic/integrations/pull/5460) failing due to permission error on the source indices of the transform:

`
Error: error running package system tests: could not complete test run: could not add data stream config to policy: could not add package to policy; API status code = 403; response body = {"statusCode":403,"error":"Forbidden","message":"Error installing ti_recordedfuture 1.7.0: security_exception\n\tRoot causes:\n\t\tsecurity_exception: Cannot create transform [logs-ti_recordedfuture.latest_ioc-default-0.1.0] because user elastic/kibana lacks the required permissions [.ds-logs-ti_recordedfuture.threat-*:[read], logs-ti_recordedfuture_latest.threat-1.7.0:[]]"}
`

Adding backing indices directly using `.ds-` prefix into the existing privileges fixed the system tests locally. 

This PR adds a `.ds-` prefix into the existing privileges for the source indices of ti* packages so that backing indices are directly given permissions.