### PR TITLE
Fix basic health test failure

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/health/10_basic.yml
@@ -1,10 +1,12 @@
 ---
 "cluster health basic test":
   - skip:
-      version: all
-      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/90183"
-      # version: "- 8.3.99"
-      # reason: "health was only added in 8.2.0, and master_is_stable in 8.4.0"
+       version: "- 8.6.99"
+       reason: "the API path changed in 8.7"
+
+  - do:
+      cluster.health:
+        wait_for_status: green
 
   - do:
       health_report: { }


### PR DESCRIPTION
This test was silenced some months ago due to a different issue. 

Trying to fix it I've figured out that since the Health API endpoint has changed is no possible anymore to test for old versions. Also, I'm forcing the test to wait for the cluster to be green before checking the health report.

Closes #90183 