### PR TITLE
Fix 95147 and 95058

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/20_cartesian_centroid.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/20_cartesian_centroid.yml
@@ -6,6 +6,8 @@ setup:
       indices.create:
         index: locations
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               location:
@@ -43,6 +45,8 @@ setup:
       indices.create:
         index: shapes
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               shape:
@@ -114,9 +118,6 @@ setup:
 
 ---
 "Test cartesian_centroid aggregation on cartesian shape shapes":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/95147"
   - do:
       search:
         rest_total_hits_as_int: true

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/20_cartesian_centroid.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/20_cartesian_centroid.yml
@@ -209,9 +209,6 @@ setup:
 
 ---
 "Test cartesian_centroid aggregation on cartesian shape shapes with grouping":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/95147"
   - do:
       search:
         rest_total_hits_as_int: true

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/20_geo_centroid.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/spatial/20_geo_centroid.yml
@@ -45,6 +45,8 @@ setup:
       indices.create:
         index: shapes
         body:
+          settings:
+            number_of_shards: 1
           mappings:
             properties:
               shape:
@@ -116,9 +118,6 @@ setup:
 
 ---
 "Test geo_centroid aggregation on geo_shape shapes":
-  - skip:
-      version: "all"
-      reason: "Awaits fix: https://github.com/elastic/elasticsearch/issues/95147"
   - do:
       search:
         rest_total_hits_as_int: true


### PR DESCRIPTION
Due to occasionally using multiple shards, slight differences in the calculation can occur. While we could increase the error threshold to cope with this, since the purpose of these tests is regression detection on the REST API, we decided to reduce this variability by setting to only one shard always.

Fixes #95147 
Fixes #95058 
