### PR TITLE
Wait for events in sort segments YAML test

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.sort/10_basic.yml
@@ -7,7 +7,7 @@
         body:
           settings:
             number_of_shards: 1
-            number_of_replicas: 0
+            refresh_interval: -1
             index.sort.field: rank
             # ensure no relocation as tests rely on segments.
             routing.rebalance.enable: "none"
@@ -19,6 +19,7 @@
       cluster.health:
         index: test
         # ensure that all shards are ready before indexing/refresh as tests rely on segments.
+        wait_for_events: languid
         wait_for_no_initializing_shards: true
   - do:
       index:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/search/380_sort_segments_on_timestamp.yml
@@ -21,6 +21,7 @@
       cluster.health:
         index: test_index1
         # ensure that all shards are ready before indexing/refresh as we will verify segments.
+        wait_for_events: languid
         wait_for_no_initializing_shards: true
   # 1st segment
   - do:
@@ -49,7 +50,7 @@
 ---
 "Test that index segments are NOT sorted on timestamp field when @timestamp field is dynamically added":
   - skip:
-      version: " - " # Tracked at https://github.com/elastic/elasticsearch/issues/94357
+      version: " - 7.99.99"
       reason: "sorting segments was added in 7.16"
       features: allowed_warnings
 
@@ -65,6 +66,7 @@
       cluster.health:
         index: test_index2
         # ensure that all shards are ready before indexing/refresh as we will verify segments.
+        wait_for_events: languid
         wait_for_no_initializing_shards: true
   # 1st segment
   - do:
@@ -110,7 +112,7 @@
 ---
 "Test if segments are missing @timestamp field we don't get errors":
   - skip:
-      version: " - " # Tracked at https://github.com/elastic/elasticsearch/issues/94357
+      version: "- 7.99.99"
       reason: "sorting segments was added in 7.16"
       features: allowed_warnings
 
@@ -130,6 +132,7 @@
       cluster.health:
         index: test_index3
         # ensure that all shards are ready before indexing/refresh as we will verify segments.
+        wait_for_events: languid
         wait_for_no_initializing_shards: true
   # 1st segment missing @timestamp field
   - do:


### PR DESCRIPTION
This PR is similar to #46586.

When waiting for no initializing shards we also have to wait for events when we have more than one node in the cluster. When the primary is started, there is a short period of time, where neither the primary nor any of the replicas are initializing.