### PR TITLE
Export java.io when running tests from ide to fix noisy exceptions

### DIFF
--- a/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
+++ b/build-tools-internal/src/main/groovy/elasticsearch.ide.gradle
@@ -153,6 +153,7 @@ if (providers.systemProperty('idea.active').getOrNull() == 'true') {
               // TODO: only open these for mockito when it is modularized
               '--add-opens=java.base/java.security.cert=ALL-UNNAMED',
               '--add-opens=java.base/java.nio.channels=ALL-UNNAMED',
+              '--add-opens=java.base/java.io=ALL-UNNAMED',
               '--add-opens=java.base/java.net=ALL-UNNAMED',
               '--add-opens=java.base/javax.net.ssl=ALL-UNNAMED',
               '--add-opens=java.base/java.nio.file=ALL-UNNAMED',


### PR DESCRIPTION
The preallocate module raises endless exceptions since we fail to get the file descriptor from the file channel in `FileDescriptorFieldAction` without the export.

This quiets things down and makes pre-allocate work from the IDE as well.