### PR TITLE
Disable incompatible build check when running serverless

### DIFF
--- a/docs/changelog/95491.yaml
+++ b/docs/changelog/95491.yaml
@@ -1,6 +1,6 @@
 pr: 95491
 summary: Disable incompatible build check when running serverless
 area: "Cluster Coordination, Infra/Transport API"
-type: feature
+type: bug
 issues:
  - 95485

--- a/docs/changelog/95491.yaml
+++ b/docs/changelog/95491.yaml
@@ -1,6 +1,0 @@
-pr: 95491
-summary: Disable incompatible build check when running serverless
-area: "Cluster Coordination, Infra/Transport API"
-type: bug
-issues:
- - 95485

--- a/docs/changelog/95491.yaml
+++ b/docs/changelog/95491.yaml
@@ -1,0 +1,6 @@
+pr: 95491
+summary: Disable incompatible build check when running serverless
+area: "Cluster Coordination, Infra/Transport API"
+type: feature
+issues:
+ - 95485

--- a/server/src/main/java/org/elasticsearch/transport/TransportService.java
+++ b/server/src/main/java/org/elasticsearch/transport/TransportService.java
@@ -644,7 +644,7 @@ public class TransportService extends AbstractLifecycleComponent
         }
 
         private void maybeThrowOnIncompatibleBuild(@Nullable DiscoveryNode node, @Nullable Exception e) {
-            if (isIncompatibleBuild(version, buildHash)) {
+            if (DiscoveryNode.isServerless() == false && isIncompatibleBuild(version, buildHash)) {
                 throwOnIncompatibleBuild(node, e);
             }
         }

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.network.NetworkService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.PageCacheRecycler;
+import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.indices.breaker.NoneCircuitBreakerService;
 import org.elasticsearch.test.ESTestCase;
@@ -357,6 +358,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
     }
 
+    @SuppressForbidden(reason = "Sets property for testing")
     public void testAcceptsMismatchedServerlessBuildHash() {
         assumeTrue("Current build needs to be a snapshot", Build.CURRENT.isSnapshot());
         assumeTrue("Security manager needs to be disabled", System.getSecurityManager() == null);

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.transport;
 
+import org.elasticsearch.Build;
 import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
@@ -354,6 +355,41 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             containsString("which has an incompatible wire format")
         );
         assertFalse(transportServiceA.nodeConnected(discoveryNode));
+    }
+
+    public void testAcceptsMismatchedServerlessBuildHash() {
+        assumeTrue("Current build needs to be a snapshot", Build.CURRENT.isSnapshot());
+        assumeTrue("Security manager needs to be disabled", System.getSecurityManager() == null);
+        System.setProperty("es.serverless", Boolean.TRUE.toString());   // security manager blocks this
+        try {
+            final DisruptingTransportInterceptor transportInterceptorA = new DisruptingTransportInterceptor();
+            final DisruptingTransportInterceptor transportInterceptorB = new DisruptingTransportInterceptor();
+            transportInterceptorA.setModifyBuildHash(true);
+            transportInterceptorB.setModifyBuildHash(true);
+            final Settings settings = Settings.builder()
+                .put("cluster.name", "a")
+                .put(IGNORE_DESERIALIZATION_ERRORS_SETTING.getKey(), true) // suppress assertions to test production error-handling
+                .build();
+            final TransportService transportServiceA = startServices(
+                "TS_A",
+                settings,
+                TransportVersion.CURRENT,
+                Version.CURRENT,
+                transportInterceptorA
+            );
+            final TransportService transportServiceB = startServices(
+                "TS_B",
+                settings,
+                TransportVersion.CURRENT,
+                Version.CURRENT,
+                transportInterceptorB
+            );
+            AbstractSimpleTransportTestCase.connectToNode(transportServiceA, transportServiceB.getLocalNode(), TestProfiles.LIGHT_PROFILE);
+            assertTrue(transportServiceA.nodeConnected(transportServiceB.getLocalNode()));
+        }
+        finally {
+            System.clearProperty("es.serverless");
+        }
     }
 
     public void testAcceptsMismatchedBuildHashFromDifferentVersion() {

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -388,8 +388,7 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             );
             AbstractSimpleTransportTestCase.connectToNode(transportServiceA, transportServiceB.getLocalNode(), TestProfiles.LIGHT_PROFILE);
             assertTrue(transportServiceA.nodeConnected(transportServiceB.getLocalNode()));
-        }
-        finally {
+        } finally {
             System.clearProperty("es.serverless");
         }
     }


### PR DESCRIPTION
It is ok to run multiple builds together in a cluster on serverless clusters, so disable this check on serverless

This fixes #95485