### PR TITLE
Assert not null for databases field

### DIFF
--- a/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
+++ b/modules/ingest-geoip/src/yamlRestTest/java/org/elasticsearch/ingest/geoip/IngestGeoIpClientYamlTestSuiteIT.java
@@ -35,6 +35,7 @@ import java.util.stream.Collectors;
 
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.notNullValue;
 
 public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
 
@@ -79,10 +80,10 @@ public class IngestGeoIpClientYamlTestSuiteIT extends ESClientYamlSuiteTestCase 
             Map<?, ?> nodes = (Map<?, ?>) response.get("nodes");
             assertThat(nodes.size(), equalTo(1));
             Map<?, ?> node = (Map<?, ?>) nodes.values().iterator().next();
-            List<String> databases = ((List<?>) node.get("databases")).stream()
-                .map(o -> (String) ((Map<?, ?>) o).get("name"))
-                .collect(Collectors.toList());
-            assertThat(databases, containsInAnyOrder("GeoLite2-City.mmdb", "GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb"));
+            List<?> databases = ((List<?>) node.get("databases"));
+            assertThat(databases, notNullValue());
+            List<String> databaseNames = databases.stream().map(o -> (String) ((Map<?, ?>) o).get("name")).collect(Collectors.toList());
+            assertThat(databaseNames, containsInAnyOrder("GeoLite2-City.mmdb", "GeoLite2-Country.mmdb", "GeoLite2-ASN.mmdb"));
         });
     }
 


### PR DESCRIPTION
In this PR we try to fix #95496 by asserting that the field `databases` is not null. This will address the NPE which I believe is caused because it's not fully initialized yet. Changing the NPE to a assertion failure will trigger the `assertBusy` to retry until everything is properly initialized.

I cannot reproduce it locally, so I am not 100% that there is no other issue with the test, but I believe this is a step forward.

Closes: #95496 

