### PR TITLE
fix incorrect TESTRESPONSE definition

### DIFF
--- a/docs/reference/slm/apis/slm-stats.asciidoc
+++ b/docs/reference/slm/apis/slm-stats.asciidoc
@@ -44,4 +44,4 @@ The API returns the following response:
   "total_snapshot_deletion_failures": 0
 }
 --------------------------------------------------
-// TESTRESPONSE[s/runs": 13/runs": $body.retention_runs/ s/_failed": 0/_failed": $body.retention_failed/ s/_timed_out": 0/_timed_out": $body.retention_timed_out/ s/"1.4s"/$body.retention_deletion_time/ s/1404/$body.retention_deletion_time_millis/ s/total_snapshots_taken": 1/total_snapshots_taken": $body.total_snapshots_taken/ s/total_snapshots_failed": 1/total_snapshots_failed": $body.total_snapshots_failed/ s/"policy_stats": [.*]/"policy_stats": $body.policy_stats/]
+// TESTRESPONSE[s/runs": 13/runs": $body.retention_runs/ s/_failed": 0/_failed": $body.retention_failed/ s/_timed_out": 0/_timed_out": $body.retention_timed_out/ s/"1.4s"/$body.retention_deletion_time/ s/1404/$body.retention_deletion_time_millis/ s/total_snapshots_taken": 1/total_snapshots_taken": $body.total_snapshots_taken/ s/total_snapshots_failed": 1/total_snapshots_failed": $body.total_snapshots_failed/ s/"policy_stats": \[.*\]/"policy_stats": $body.policy_stats/]


### PR DESCRIPTION
`// TESTRESPONSE` definitions have to be escaped to properly override the value coming from the response.

---

According to the Gradle error, the stats endpoint has extra information:

```
0: <unexpected> but was <{policy=hourly-snapshots, snapshots_taken=0, snapshots_failed=1, snapshots_deleted=0, snapshot_deletion_failures=0}>
```

After some time, I was able to replicate the issue by adding the following change to the docs:


![Screenshot 2023-04-24 at 17 48 18](https://user-images.githubusercontent.com/284537/234049098-7c575081-d464-4944-92a1-d913534c8637.png)

Basically, forcing the execution of an SLM policy, which will fill up the stats with extra information (the `policy_stats` array!). After replicating the issue, the fix was obvious: to escape the `[ & ]` symbols.

### Why this test failed?

Within the [`take-snapshot` page](https://github.com/elastic/elasticsearch/blob/main/docs/reference/snapshot-restore/take-snapshot.asciidoc?plain=1#L558) a policy named `hourly-snapshots` was created. None of these policies are manually executed... but, as you can see in the following screenshot, the test ran 3 seconds after the 11 CEST: 

![Screenshot 2023-04-24 at 17 50 25](https://user-images.githubusercontent.com/284537/234049656-a3839cc4-06ed-4cfa-aa3d-27904f7993b8.png)

Due to this, the `hourly-snapshots` policy was automatically executed and "polluted" the `policy_stats` output.


Closes #94942 