### PR TITLE
Fix versioning for tests cases using a randomly generated rank builder

### DIFF
--- a/docs/changelog/95514.yaml
+++ b/docs/changelog/95514.yaml
@@ -1,0 +1,5 @@
+pr: 95514
+summary: Fix versioning for tests cases using a randomly generated rank builder
+area: Ranking
+type: bug
+issues: []

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -231,6 +231,9 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
             if (Optional.ofNullable(request.source()).map(SearchSourceBuilder::knnSearch).map(List::size).orElse(0) > 1) {
                 version = TransportVersionUtils.randomVersionBetween(random(), TransportVersion.V_8_7_0, TransportVersion.CURRENT);
             }
+            if (request.source() != null && request.source().rankBuilder() != null) {
+                version = TransportVersionUtils.randomVersionBetween(random(), TransportVersion.V_8_8_0, TransportVersion.CURRENT);
+            }
             request = copyWriteable(request, namedWriteableRegistry, ShardSearchRequest::new, version);
             channelVersion = TransportVersion.min(channelVersion, version);
             assertThat(request.getChannelVersion(), equalTo(channelVersion));
@@ -253,6 +256,9 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
 
     public void testForceSyntheticUnsupported() throws IOException {
         SearchRequest request = createSearchRequest();
+        if (request.source() != null) {
+            request.source().rankBuilder(null);
+        }
         request.setForceSyntheticSource(true);
         ShardSearchRequest shardRequest = createShardSearchReqest(request);
         StreamOutput out = new BytesStreamOutput();


### PR DESCRIPTION
Certain tests generate a random search request. These search requests aren't versioned, so in certain tests if a rank builder is set, the versions must be appropriately gated or the rank builder must be set to `null`. This change fixes the issues for `testForceUnsupportedSynthetic` and `testChannelVersion`.