### PR TITLE
Introduce interface to allow plugins to react to process termination

### DIFF
--- a/server/src/main/java/org/elasticsearch/plugins/NodeTerminationHandlerPlugin.java
+++ b/server/src/main/java/org/elasticsearch/plugins/NodeTerminationHandlerPlugin.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.plugins;
+
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.env.NodeEnvironment;
+
+/**
+ * A plugin that performs operations when the node is shut down, i.e. in response to a sigterm.
+ */
+public interface NodeTerminationHandlerPlugin {
+
+    void handleTerminationSignal(NodeClient client, NodeEnvironment nodeEnvironment);
+}

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/ShutdownPlugin.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/ShutdownPlugin.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
@@ -22,6 +23,7 @@ import org.elasticsearch.common.settings.SettingsFilter;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
 import org.elasticsearch.plugins.ActionPlugin;
+import org.elasticsearch.plugins.NodeTerminationHandlerPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.rest.RestController;
@@ -38,7 +40,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 
-public class ShutdownPlugin extends Plugin implements ActionPlugin {
+public class ShutdownPlugin extends Plugin implements ActionPlugin, NodeTerminationHandlerPlugin {
     @Override
     public Collection<Object> createComponents(
         Client client,
@@ -89,5 +91,10 @@ public class ShutdownPlugin extends Plugin implements ActionPlugin {
         Supplier<DiscoveryNodes> nodesInCluster
     ) {
         return Arrays.asList(new RestPutShutdownNodeAction(), new RestDeleteShutdownNodeAction(), new RestGetShutdownStatusAction());
+    }
+
+    @Override
+    public void handleTerminationSignal(NodeClient client, NodeEnvironment nodeEnvironment) {
+        // this space intentionally left blank
     }
 }


### PR DESCRIPTION
For the moment, this is for discussion. Open questions:

- Do we need to allow more than one of these plugins, or can we enforce just one? If we need to allow more than one, we need to consider ordering.
- I'm still working on how best to test this, and make sure that plugins won't break the test infrastructure (which uses sigterm and/or calls `Node#close`). It works in manual testing though, with a [quick hack to simulate what we eventually plan to do](https://gist.github.com/gwbrown/4d4c28f40f031563f35355b0bba68497)