### PR TITLE
[Transform] Fix failing test: Expect two error messages rather than just one

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
@@ -421,8 +421,9 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
-        // transform is red with one issue
-        assertBusy(() -> assertRed(transformId, authIssue), 10, TimeUnit.SECONDS);
+        // transform is red with two issues
+        String noSuchIndexIssue = Strings.format("org.elasticsearch.index.IndexNotFoundException: no such index [%s]", destIndexName);
+        assertBusy(() -> assertRed(transformId, authIssue, noSuchIndexIssue), 10, TimeUnit.SECONDS);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());


### PR DESCRIPTION
This PR fixes the `org.elasticsearch.xpack.transform.integration.TransformInsufficientPermissionsIT.testTransformPermissionsDeferUnattendedNoDest` test broken by https://github.com/elastic/elasticsearch/pull/95318.

Relates https://github.com/elastic/elasticsearch/issues/95367
Fixes https://github.com/elastic/elasticsearch/issues/95516