### PR TITLE
Tweak ReactiveStorageDeciderService logic

### DIFF
--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageDeciderService.java
@@ -595,10 +595,8 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
                 return this;
             }
             List<SingleForecast> singleForecasts = dataStreamMetadata.dataStreams()
-                .keySet()
+                .values()
                 .stream()
-                .map(state.metadata().getIndicesLookup()::get)
-                .map(DataStream.class::cast)
                 .map(ds -> forecast(state.metadata(), ds, forecastWindow, now))
                 .filter(Objects::nonNull)
                 .toList();
@@ -678,8 +676,11 @@ public class ReactiveStorageDeciderService implements AutoscalingDeciderService 
                 scaledTotalSize = totalSize;
             }
 
-            IndexMetadata writeIndex = metadata.index(stream.getWriteIndex());
+            if (numberNewIndices == 0) {
+                return null;
+            }
 
+            IndexMetadata writeIndex = metadata.index(stream.getWriteIndex());
             Map<IndexMetadata, Long> newIndices = new HashMap<>();
             for (int i = 0; i < numberNewIndices; ++i) {
                 final String uuid = UUIDs.randomBase64UUID();


### PR DESCRIPTION
* Don't return an empty `SingleForecast`, this can happen if `numberNewIndices` is zero.
* Iterate data streams from data stream map values instead from keys (this avoids casting and using indices lookup).