### PR TITLE
fix get-lifecycle doc test

### DIFF
--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -1,4 +1,14 @@
 [[downsampling]]
+
+/////
+[source,console]
+--------------------------------------------------
+DELETE _ilm/policy/my_policy
+--------------------------------------------------
+// TEST
+// TEARDOWN
+/////
+
 === Downsampling a time series data stream
 
 Downsampling provides a method to reduce the footprint of your <<tsds,time
@@ -120,8 +130,8 @@ There are a few things to note when querying downsampled indices:
 * When you run queries in {kib} and through Elastic solutions, a normal
 response is returned without notification that some of the queried indices are
 downsampled.
-* For 
-<<search-aggregations-bucket-datehistogram-aggregation,date histogram aggregations>>, 
+* For
+<<search-aggregations-bucket-datehistogram-aggregation,date histogram aggregations>>,
 only `fixed_intervals` (and not calendar-aware intervals) are supported.
 * Only Coordinated Universal Time (UTC) date-times are supported.
 
@@ -131,13 +141,13 @@ only `fixed_intervals` (and not calendar-aware intervals) are supported.
 
 The following restrictions and limitations apply for downsampling:
 
-* Only indices in a <<tsds,time series data stream>> are supported. 
+* Only indices in a <<tsds,time series data stream>> are supported.
 
 * Data is downsampled based on the time dimension only. All other dimensions are
 copied to the new index without any modification.
 
 * Within a data stream, a downsampled index replaces the original index and the
-original index is deleted. Only one index can exist for a given time period. 
+original index is deleted. Only one index can exist for a given time period.
 
 * A source index must be in read-only mode for the downsampling process to
 succeed. Check the <<downsampling-manual,Run downsampling manually>> example for

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -115,7 +115,7 @@ If the request succeeds, the body of the response contains the policy definition
   }
 }
 --------------------------------------------------
-// TESTRESPONSE[skip:"AwaitsFix https://github.com/elastic/elasticsearch/issues/95128"]
+// TESTRESPONSE[s/"modified_date": 82392349/"modified_date": $body.my_policy.modified_date/]
 
 <1> The policy version is incremented whenever the policy is updated
 <2> When this policy was last modified


### PR DESCRIPTION
The `data-streams/downsampling.asciidoc` test was missing a teardown clean of the ILM policies created. Due to this tests *do not have* the string `ilm` in its name, the automatic teardown process that cleans up the resources (check [`ESRestTestCase.java#L815`](https://github.com/elastic/elasticsearch/blob/main/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java#L815) & [`DocsClientYamlTestSuiteIT.java`](https://github.com/elastic/elasticsearch/blob/main/docs/src/yamlRestTest/java/org/elasticsearch/smoketest/DocsClientYamlTestSuiteIT.java) lines 177 & 195) is not executed for this specific test. In the case this test runs right before the `get-lifecycle` test, the policy won't be automatically deleted hence the test checking the version will fail. Finally, the order of execution of the test is not guaranteed by the suite.

I was able to replicate the failure by doing the following: 

1. In `ESRestTestCase.java#addSuite` I filtered out all the tests but `downsampling.yml` and `ilm's get-lifecycle.yml`:

<img width="810" alt="Screenshot 2023-04-26 at 10 43 31" src="https://user-images.githubusercontent.com/284537/234520689-c9bdd8e7-9fae-47c9-aa65-dd8ec66a22d1.png">

2. Executed the whole suite
<img width="1279" alt="Screenshot 2023-04-26 at 10 39 09" src="https://user-images.githubusercontent.com/284537/234520568-8ca66763-2a26-4490-85cb-f10029676ae4.png">


Closes #95128 