### PR TITLE
[ML] Infer by model or deployment Id

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/InferTrainedModelDeploymentAction.java
@@ -85,10 +85,10 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             );
         }
 
-        public static Request.Builder parseRequest(String modelId, XContentParser parser) {
+        public static Request.Builder parseRequest(String id, XContentParser parser) {
             Request.Builder builder = PARSER.apply(parser, null);
-            if (modelId != null) {
-                builder.setId(modelId);
+            if (id != null) {
+                builder.setId(id);
             }
             return builder;
         }
@@ -103,14 +103,9 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
         // input and so cannot construct a document.
         private final List<String> textInput;
 
-        public static Request forDocs(
-            String modelId,
-            InferenceConfigUpdate update,
-            List<Map<String, Object>> docs,
-            TimeValue inferenceTimeout
-        ) {
+        public static Request forDocs(String id, InferenceConfigUpdate update, List<Map<String, Object>> docs, TimeValue inferenceTimeout) {
             return new Request(
-                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID),
+                ExceptionsHelper.requireNonNull(id, InferModelAction.Request.DEPLOYMENT_ID),
                 update,
                 ExceptionsHelper.requireNonNull(Collections.unmodifiableList(docs), DOCS),
                 null,
@@ -119,14 +114,9 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
             );
         }
 
-        public static Request forTextInput(
-            String modelId,
-            InferenceConfigUpdate update,
-            List<String> textInput,
-            TimeValue inferenceTimeout
-        ) {
+        public static Request forTextInput(String id, InferenceConfigUpdate update, List<String> textInput, TimeValue inferenceTimeout) {
             return new Request(
-                ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID),
+                ExceptionsHelper.requireNonNull(id, InferModelAction.Request.DEPLOYMENT_ID),
                 update,
                 List.of(),
                 ExceptionsHelper.requireNonNull(textInput, "inference text input"),
@@ -137,14 +127,14 @@ public class InferTrainedModelDeploymentAction extends ActionType<InferTrainedMo
 
         // for tests
         Request(
-            String modelId,
+            String id,
             InferenceConfigUpdate update,
             List<Map<String, Object>> docs,
             List<String> textInput,
             boolean highPriority,
             TimeValue inferenceTimeout
         ) {
-            this.id = ExceptionsHelper.requireNonNull(modelId, InferModelAction.Request.DEPLOYMENT_ID);
+            this.id = ExceptionsHelper.requireNonNull(id, InferModelAction.Request.DEPLOYMENT_ID);
             this.docs = docs;
             this.textInput = textInput;
             this.update = update;

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelActionRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/PutTrainedModelActionRequestTests.java
@@ -22,7 +22,7 @@ public class PutTrainedModelActionRequestTests extends AbstractWireSerializingTe
         String modelId = randomAlphaOfLength(10);
         return new Request(
             TrainedModelConfigTests.createTestInstance(modelId, false)
-                .setParsedDefinition(TrainedModelDefinitionTests.createRandomBuilder())
+                .setParsedDefinition(TrainedModelDefinitionTests.createSmallRandomBuilder())
                 .build(),
             randomBoolean(),
             randomBoolean()

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MultipleDeploymentsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MultipleDeploymentsIT.java
@@ -43,8 +43,17 @@ public class MultipleDeploymentsIT extends PyTorchModelRestTestCase {
         inference = infer("my words", forIngest);
         assertOK(inference);
 
-        assertInferenceCount(1, forSearch);
-        assertInferenceCount(2, forIngest);
+        assertInferenceCountOnDeployment(1, forSearch);
+        assertInferenceCountOnDeployment(2, forIngest);
+
+        // infer by model Id
+        inference = infer("my words", baseModelId);
+        assertOK(inference);
+        assertInferenceCountOnModel(4, baseModelId);
+
+        inference = infer("my words", baseModelId);
+        assertOK(inference);
+        assertInferenceCountOnModel(5, baseModelId);
 
         stopDeployment(forSearch);
         stopDeployment(forIngest);

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/PyTorchModelIT.java
@@ -968,7 +968,7 @@ public class PyTorchModelIT extends PyTorchModelRestTestCase {
     public void testUpdateDeployment_GivenMissingModel() throws IOException {
         ResponseException ex = expectThrows(ResponseException.class, () -> updateDeployment("missing", 4));
         assertThat(ex.getResponse().getStatusLine().getStatusCode(), equalTo(404));
-        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("deployment with id [missing] not found"));
+        assertThat(EntityUtils.toString(ex.getResponse().getEntity()), containsString("No known model deployment with id [missing]"));
     }
 
     public void testUpdateDeployment_GivenAllocationsAreIncreased() throws Exception {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.ml.action;
 
-import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.action.TaskOperationFailure;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportClearDeploymentCacheAction.java
@@ -71,7 +71,7 @@ public class TransportClearDeploymentCacheAction extends TransportTasksAction<Tr
         final TrainedModelAssignmentMetadata assignment = TrainedModelAssignmentMetadata.fromState(clusterState);
         TrainedModelAssignment trainedModelAssignment = assignment.getDeploymentAssignment(request.getDeploymentId());
         if (trainedModelAssignment == null) {
-            listener.onFailure(new ResourceNotFoundException("assignment for model with id [{}] not found", request.getDeploymentId()));
+            listener.onFailure(ExceptionsHelper.missingModelDeployment(request.getDeploymentId()));
             return;
         }
         String[] nodes = trainedModelAssignment.getNodeRoutingTable()

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/assignment/TrainedModelAssignmentClusterService.java
@@ -42,6 +42,7 @@ import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingInfo;
 import org.elasticsearch.xpack.core.ml.inference.assignment.RoutingState;
 import org.elasticsearch.xpack.core.ml.inference.assignment.TrainedModelAssignment;
 import org.elasticsearch.xpack.core.ml.job.messages.Messages;
+import org.elasticsearch.xpack.core.ml.utils.ExceptionsHelper;
 import org.elasticsearch.xpack.ml.MachineLearning;
 import org.elasticsearch.xpack.ml.autoscaling.NodeAvailabilityZoneMapper;
 import org.elasticsearch.xpack.ml.inference.assignment.planning.AllocationReducer;
@@ -571,7 +572,8 @@ public class TrainedModelAssignmentClusterService implements ClusterStateListene
         TrainedModelAssignmentMetadata metadata = TrainedModelAssignmentMetadata.fromState(clusterState);
         final TrainedModelAssignment existingAssignment = metadata.getDeploymentAssignment(deploymentId);
         if (existingAssignment == null) {
-            throw new ResourceNotFoundException("deployment with id [{}] not found", deploymentId);
+            listener.onFailure(ExceptionsHelper.missingModelDeployment(deploymentId));
+            return;
         }
         if (existingAssignment.getTaskParams().getNumberOfAllocations() == numberOfAllocations) {
             listener.onResponse(existingAssignment);

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/ml/3rd_party_deployment.yml
@@ -230,6 +230,26 @@ setup:
       ml.stop_trained_model_deployment:
         model_id: test_model
   - match: { stopped: true }
+
+  - do:
+      ml.start_trained_model_deployment:
+        model_id: test_model
+        deployment_id: test_model_deployment
+        wait_for: started
+  - match: { assignment.assignment_state: started }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.number_of_allocations: 1 }
+
+  - do:
+      # We update to the same value of 1 as if the test runs on a node with just 1 processor it would fail otherwise
+      ml.update_trained_model_deployment:
+        model_id: test_model_deployment
+        body: >
+          {
+            "number_of_allocations": 1
+          }
+  - match: { assignment.task_parameters.model_id: test_model }
+  - match: { assignment.task_parameters.number_of_allocations: 1 }
 ---
 "Test clear deployment cache":
   - skip:
@@ -238,6 +258,7 @@ setup:
   - do:
       ml.start_trained_model_deployment:
         model_id: test_model
+        deployment_id: test_model_deployment_cache_test
         cache_size: 10kb
         wait_for: started
   - match: {assignment.assignment_state: started}
@@ -290,7 +311,7 @@ setup:
 
   - do:
       ml.clear_trained_model_deployment_cache:
-        model_id: test_model
+        model_id: test_model_deployment_cache_test
   - match: { cleared: true }
 
   - do:


### PR DESCRIPTION
If the _infer API is called with a model Id and that model has multiple deployments a random deployment is used.

Also adds tests for _update and _clear_cache APIs using deployment Ids.


non-issue as part of a series of PRs to support multiple deployments. 