### PR TITLE
Turn TopDocsCollectorFactory into a collector manager factory

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollectorManager.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollectorManager.java
@@ -20,11 +20,6 @@ public final class InternalProfileCollectorManager extends SingleThreadCollector
         super(collector);
     }
 
-    @Override
-    public InternalProfileCollector newCollector() {
-        return (InternalProfileCollector) super.newCollector();
-    }
-
     public CollectorResult getCollectorTree() {
         return ((InternalProfileCollector) collector).getCollectorTree();
     }

--- a/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollectorManager.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/InternalProfileCollectorManager.java
@@ -20,6 +20,11 @@ public final class InternalProfileCollectorManager extends SingleThreadCollector
         super(collector);
     }
 
+    @Override
+    public InternalProfileCollector newCollector() {
+        return (InternalProfileCollector) super.newCollector();
+    }
+
     public CollectorResult getCollectorTree() {
         return ((InternalProfileCollector) collector).getCollectorTree();
     }

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -313,9 +313,10 @@ public class QueryPhase {
         }
         // to keep it simple, we rely on the fact that profile collector manager is single-threaded
         // hence its newCollector always returns the same collector instance
-        InternalProfileCollector[] childProfileCollectors = Arrays.stream(children)
-            .map(manager -> ((InternalProfileCollectorManager) manager).newCollector())
-            .toArray(InternalProfileCollector[]::new);
+        InternalProfileCollector[] childProfileCollectors = new InternalProfileCollector[children.length];
+        for (int i = 0; i < children.length; i++) {
+            childProfileCollectors[i] = ((InternalProfileCollectorManager)children[i]).newCollector();
+        }
         return new InternalProfileCollectorManager(
             new InternalProfileCollector(collectorManager.newCollector(), profilerName, childProfileCollectors)
         );

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.search.profile.query.CollectorResult.REASON_SEAR
 import static org.elasticsearch.search.profile.query.CollectorResult.REASON_SEARCH_MULTI;
 import static org.elasticsearch.search.profile.query.CollectorResult.REASON_SEARCH_POST_FILTER;
 import static org.elasticsearch.search.profile.query.CollectorResult.REASON_SEARCH_TERMINATE_AFTER_COUNT;
-import static org.elasticsearch.search.query.TopDocsCollectorFactory.createTopDocsCollectorFactory;
+import static org.elasticsearch.search.query.TopDocsCollectorManagerFactory.createTopDocsCollectorFactory;
 
 /**
  * Query phase of a search request, used to run the query and get back from each shard information about the matching documents
@@ -194,14 +194,14 @@ public class QueryPhase {
             }
 
             // create the top docs collector last when the other collectors are known
-            final TopDocsCollectorFactory topDocsFactory = createTopDocsCollectorFactory(
+            final TopDocsCollectorManagerFactory topDocsFactory = createTopDocsCollectorFactory(
                 searchContext,
                 searchContext.parsedPostFilter() != null || searchContext.minimumScore() != null
             );
 
             CollectorManager<Collector, Void> collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                 searchContext.getProfilers(),
-                topDocsFactory.collector(),
+                topDocsFactory.collectorManager(),
                 topDocsFactory.profilerName
             );
 
@@ -216,9 +216,9 @@ public class QueryPhase {
                 final Collector collector = collectorManager.newCollector();
                 collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                     searchContext.getProfilers(),
-                    MultiCollector.wrap(earlyTerminatingCollector, collector),
+                    new SingleThreadCollectorManager(MultiCollector.wrap(earlyTerminatingCollector, collector)),
                     REASON_SEARCH_TERMINATE_AFTER_COUNT,
-                    collector
+                    collectorManager
                 );
             }
             if (searchContext.parsedPostFilter() != null) {
@@ -232,9 +232,9 @@ public class QueryPhase {
                 final Collector collector = collectorManager.newCollector();
                 collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                     searchContext.getProfilers(),
-                    new FilteredCollector(collector, filterWeight),
+                    new SingleThreadCollectorManager(new FilteredCollector(collector, filterWeight)),
                     REASON_SEARCH_POST_FILTER,
-                    collector
+                    collectorManager
                 );
             }
             if (searchContext.getAggsCollectorManager() != null) {
@@ -242,10 +242,10 @@ public class QueryPhase {
                 final Collector aggsCollector = searchContext.getAggsCollectorManager().newCollector();
                 collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                     searchContext.getProfilers(),
-                    MultiCollector.wrap(collector, aggsCollector),
+                    new SingleThreadCollectorManager(MultiCollector.wrap(collector, aggsCollector)),
                     REASON_SEARCH_MULTI,
-                    collector,
-                    aggsCollector
+                    collectorManager,
+                    searchContext.getAggsCollectorManager()
                 );
             }
             if (searchContext.minimumScore() != null) {
@@ -253,9 +253,9 @@ public class QueryPhase {
                 // apply the minimum score after multi collector so we filter aggs as well
                 collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                     searchContext.getProfilers(),
-                    new MinimumScoreCollector(collector, searchContext.minimumScore()),
+                    new SingleThreadCollectorManager(new MinimumScoreCollector(collector, searchContext.minimumScore())),
                     REASON_SEARCH_MIN_SCORE,
-                    collector
+                    collectorManager
                 );
             }
 
@@ -301,19 +301,24 @@ public class QueryPhase {
         }
     }
 
+    @SafeVarargs
     private static CollectorManager<Collector, Void> wrapWithProfilerCollectorManagerIfNeeded(
         Profilers profilers,
-        Collector collector,
+        CollectorManager<Collector, Void> collectorManager,
         String profilerName,
-        Collector... children
-    ) {
+        CollectorManager<Collector, Void>... children
+    ) throws IOException {
         if (profilers == null) {
-            return new SingleThreadCollectorManager(collector);
+            return collectorManager;
         }
+        // to keep it simple, we rely on the fact that profile collector manager is single-threaded
+        // hence its newCollector always returns the same collector instance
         InternalProfileCollector[] childProfileCollectors = Arrays.stream(children)
-            .map(c -> (InternalProfileCollector) c)
+            .map(manager -> ((InternalProfileCollectorManager) manager).newCollector())
             .toArray(InternalProfileCollector[]::new);
-        return new InternalProfileCollectorManager(new InternalProfileCollector(collector, profilerName, childProfileCollectors));
+        return new InternalProfileCollectorManager(
+            new InternalProfileCollector(collectorManager.newCollector(), profilerName, childProfileCollectors)
+        );
     }
 
     private static void searchWithCollectorManager(

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -315,7 +315,7 @@ public class QueryPhase {
         // hence its newCollector always returns the same collector instance
         InternalProfileCollector[] childProfileCollectors = new InternalProfileCollector[children.length];
         for (int i = 0; i < children.length; i++) {
-            childProfileCollectors[i] = ((InternalProfileCollectorManager)children[i]).newCollector();
+            childProfileCollectors[i] = (InternalProfileCollector) children[i].newCollector();
         }
         return new InternalProfileCollectorManager(
             new InternalProfileCollector(collectorManager.newCollector(), profilerName, childProfileCollectors)

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -91,7 +91,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.IntUnaryOperator;
 
-import static org.elasticsearch.search.query.TopDocsCollectorFactory.hasInfMaxScore;
+import static org.elasticsearch.search.query.TopDocsCollectorManagerFactory.hasInfMaxScore;
 import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
@@ -689,7 +689,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         context.parsedQuery(new ParsedQuery(q));
         context.setSize(3);
         context.trackTotalHitsUpTo(3);
-        TopDocsCollectorFactory topDocsContext = TopDocsCollectorFactory.createTopDocsCollectorFactory(context, false);
+        TopDocsCollectorManagerFactory topDocsContext = TopDocsCollectorManagerFactory.createTopDocsCollectorFactory(context, false);
         assertEquals(topDocsContext.collector().scoreMode(), org.apache.lucene.search.ScoreMode.COMPLETE);
         QueryPhase.executeQuery(context);
         assertEquals(5, context.queryResult().topDocs().topDocs.totalHits.value);
@@ -697,7 +697,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
 
         context.sort(new SortAndFormats(new Sort(new SortField("other", SortField.Type.INT)), new DocValueFormat[] { DocValueFormat.RAW }));
-        topDocsContext = TopDocsCollectorFactory.createTopDocsCollectorFactory(context, false);
+        topDocsContext = TopDocsCollectorManagerFactory.createTopDocsCollectorFactory(context, false);
         assertEquals(topDocsContext.collector().scoreMode(), org.apache.lucene.search.ScoreMode.TOP_DOCS);
         QueryPhase.executeQuery(context);
         assertEquals(5, context.queryResult().topDocs().topDocs.totalHits.value);

--- a/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorManagerFactoryTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/TopDocsCollectorManagerFactoryTests.java
@@ -25,7 +25,7 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
 
-public class TopDocsCollectorFactoryTests extends ESTestCase {
+public class TopDocsCollectorManagerFactoryTests extends ESTestCase {
 
     public void testShortcutTotalHitCountTextField() throws IOException {
         try (Directory dir = newDirectory(); RandomIndexWriter iw = new RandomIndexWriter(random(), dir)) {
@@ -39,7 +39,7 @@ public class TopDocsCollectorFactoryTests extends ESTestCase {
             iw.commit();
             try (IndexReader reader = iw.getReader()) {
                 final Query testQuery = new FieldExistsQuery("text");
-                int hitCount = TopDocsCollectorFactory.shortcutTotalHitCount(reader, testQuery);
+                int hitCount = TopDocsCollectorManagerFactory.shortcutTotalHitCount(reader, testQuery);
                 assertEquals(-1, hitCount);
             }
         }
@@ -59,7 +59,7 @@ public class TopDocsCollectorFactoryTests extends ESTestCase {
             iw.commit();
             try (IndexReader reader = iw.getReader()) {
                 final Query testQuery = new FieldExistsQuery("string");
-                int hitCount = TopDocsCollectorFactory.shortcutTotalHitCount(reader, testQuery);
+                int hitCount = TopDocsCollectorManagerFactory.shortcutTotalHitCount(reader, testQuery);
                 assertEquals(2, hitCount);
             }
         }
@@ -75,7 +75,7 @@ public class TopDocsCollectorFactoryTests extends ESTestCase {
             iw.commit();
             try (IndexReader reader = iw.getReader()) {
                 final Query testQuery = new FieldExistsQuery("int");
-                int hitCount = TopDocsCollectorFactory.shortcutTotalHitCount(reader, testQuery);
+                int hitCount = TopDocsCollectorManagerFactory.shortcutTotalHitCount(reader, testQuery);
                 assertEquals(1, hitCount);
             }
         }


### PR DESCRIPTION
TopDocsCollectorFactory is used to create the appropriate top docs collector depending on the requested functionalities. In order to later enable concurrent segment search we need to have it expose a collector manager instead of a collector.
