### PR TITLE
Align enterprise search enabled setting name

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/search_application.post_behavioral_analytics_event.json
@@ -5,8 +5,7 @@
       "description": "Creates a behavioral analytics event for existing collection."
     },
     "stability": "experimental",
-    "visibility": "feature_flag",
-    "feature_flag": "xpack.ent-search.enabled",
+    "visibility": "public",
     "headers": {
       "accept": [
         "application/json"

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/XPackSettings.java
@@ -95,7 +95,7 @@ public class XPackSettings {
 
     /** Setting for enabling or disabling enterprise search. Defaults to true. */
     public static final Setting<Boolean> ENTERPRISE_SEARCH_ENABLED = Setting.boolSetting(
-        "xpack.ent-search.enabled",
+        "xpack.ent_search.enabled",
         true,
         Setting.Property.NodeScope
     );

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/build.gradle
@@ -53,7 +53,7 @@ testClusters.configureEach {
   setting 'indices.lifecycle.history_index_enabled', 'false'
   setting 'slm.history_index_enabled', 'false'
   setting 'stack.templates.enabled', 'false'
-  setting 'xpack.ent-search.enabled', 'false'
+  setting 'xpack.ent_search.enabled', 'false'
   // To spice things up a bit, one of the nodes is not an ML node
   nodes.'javaRestTest-0'.setting 'node.roles', '["master","data","ingest"]'
   nodes.'javaRestTest-1'.setting 'node.roles', '["master","data","ingest","ml"]'


### PR DESCRIPTION
This commit aligns the name of the setting to enable enterprise search with similar settings (use underscore to separate words).