### PR TITLE
[DOCS]Nodes need access to storage.googleapis.com for geoip

### DIFF
--- a/docs/reference/ingest/processors/geoip.asciidoc
+++ b/docs/reference/ingest/processors/geoip.asciidoc
@@ -9,13 +9,13 @@ IPv4 or IPv6 address.
 
 [[geoip-automatic-updates]]
 By default, the processor uses the GeoLite2 City, GeoLite2 Country, and GeoLite2
-ASN GeoIP2 databases from
-http://dev.maxmind.com/geoip/geoip2/geolite2/[MaxMind], shared under the
-CC BY-SA 4.0 license. It automatically downloads these databases if either
-`ingest.geoip.downloader.eager.download` is set to true, or your cluster
-has at least one pipeline with a `geoip` processor. {es}
-automatically downloads updates for
-these databases from the Elastic GeoIP endpoint:
+ASN GeoIP2 databases from http://dev.maxmind.com/geoip/geoip2/geolite2/[MaxMind], shared under the
+CC BY-SA 4.0 license. It automatically downloads these databases if your nodes can connect to `storage.googleapis.com` domain and either:
+
+* `ingest.geoip.downloader.eager.download` is set to true
+* your cluster has at least one pipeline with a `geoip` processor
+ 
+{es} automatically downloads updates for these databases from the Elastic GeoIP endpoint:
 https://geoip.elastic.co/v1/database. To get download statistics for these
 updates, use the <<geoip-stats-api,GeoIP stats API>>.
 


### PR DESCRIPTION
Clarify that nodes need access to the storage.googleapis.com domain for GeoIP.

Related: #95532 
