### PR TITLE
Revert usage of SafeMustacheFactory in CustomMustacheFactory

### DIFF
--- a/docs/changelog/95557.yaml
+++ b/docs/changelog/95557.yaml
@@ -1,0 +1,5 @@
+pr: 95557
+summary: Revert usage of `SafeMustacheFactory` in `CustomMustacheFactory`
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -14,9 +14,7 @@ import com.github.mustachejava.DefaultMustacheVisitor;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheVisitor;
-import com.github.mustachejava.SafeMustacheFactory;
 import com.github.mustachejava.TemplateContext;
-import com.github.mustachejava.TemplateFunction;
 import com.github.mustachejava.codes.DefaultMustache;
 import com.github.mustachejava.codes.IterableCode;
 import com.github.mustachejava.codes.WriteCode;
@@ -36,11 +34,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CustomMustacheFactory extends SafeMustacheFactory {
+public class CustomMustacheFactory extends DefaultMustacheFactory {
     static final String V7_JSON_MEDIA_TYPE_WITH_CHARSET = "application/json; charset=UTF-8";
     static final String JSON_MEDIA_TYPE_WITH_CHARSET = "application/json;charset=utf-8";
     static final String JSON_MEDIA_TYPE = "application/json";
@@ -65,7 +64,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
     private final Encoder encoder;
 
     public CustomMustacheFactory(String mediaType) {
-        super(Collections.emptySet(), ".");
+        super();
         setObjectHandler(new CustomReflectionObjectHandler());
         this.encoder = createEncoder(mediaType);
     }
@@ -146,7 +145,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
             writer.write(tc.endChars());
         }
 
-        protected abstract TemplateFunction createFunction(Object resolved);
+        protected abstract Function<String, String> createFunction(Object resolved);
 
         /**
          * At compile time, this function extracts the name of the variable:
@@ -189,7 +188,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
 
         @Override
         @SuppressWarnings("unchecked")
-        protected TemplateFunction createFunction(Object resolved) {
+        protected Function<String, String> createFunction(Object resolved) {
             return s -> {
                 if (resolved == null) {
                     return null;
@@ -239,7 +238,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
         }
 
         @Override
-        protected TemplateFunction createFunction(Object resolved) {
+        protected Function<String, String> createFunction(Object resolved) {
             return s -> {
                 if (s == null) {
                     return null;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -10,6 +10,7 @@ package org.elasticsearch.script.mustache;
 
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
 
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.iterable.Iterables;
 
@@ -161,5 +162,11 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
         public Iterator<Object> iterator() {
             return col.iterator();
         }
+    }
+
+    @Override
+    public String stringify(Object object) {
+        CollectionUtils.ensureNoSelfReferences(object, "CustomReflectionObjectHandler stringify");
+        return super.stringify(object);
     }
 }

--- a/x-pack/plugin/watcher/qa/rest/build.gradle
+++ b/x-pack/plugin/watcher/qa/rest/build.gradle
@@ -40,6 +40,7 @@ tasks.named("yamlRestTestV7CompatTransform").configure{ task ->
   task.skipTest("mustache/30_search_input/Test search input mustache integration (using request body and rest_total_hits_as_int)", "remove JodaCompatibleDateTime -- ZonedDateTime doesn't output millis/nanos if they're 0 (#78417)")
   task.skipTest("mustache/30_search_input/Test search input mustache integration (using request body)", "remove JodaCompatibleDateTime -- ZonedDateTime doesn't output millis/nanos if they're 0 (#78417)")
   task.skipTest("mustache/40_search_transform/Test search transform mustache integration (using request body)", "remove JodaCompatibleDateTime -- ZonedDateTime doesn't output millis/nanos if they're 0 (#78417)")
+  task.skipTest("painless/40_exception/Test painless exceptions are returned when logging a broken response", "Exceptions are no longer thrown from Mustache, but from the transform action itself")
   task.replaceKeyInDo("watcher.ack_watch", "xpack-watcher.ack_watch")
   task.replaceKeyInDo("watcher.activate_watch", "xpack-watcher.activate_watch")
   task.replaceKeyInDo("watcher.deactivate_watch", "xpack-watcher.deactivate_watch")

--- a/x-pack/plugin/watcher/qa/rest/build.gradle
+++ b/x-pack/plugin/watcher/qa/rest/build.gradle
@@ -40,7 +40,6 @@ tasks.named("yamlRestTestV7CompatTransform").configure{ task ->
   task.skipTest("mustache/30_search_input/Test search input mustache integration (using request body and rest_total_hits_as_int)", "remove JodaCompatibleDateTime -- ZonedDateTime doesn't output millis/nanos if they're 0 (#78417)")
   task.skipTest("mustache/30_search_input/Test search input mustache integration (using request body)", "remove JodaCompatibleDateTime -- ZonedDateTime doesn't output millis/nanos if they're 0 (#78417)")
   task.skipTest("mustache/40_search_transform/Test search transform mustache integration (using request body)", "remove JodaCompatibleDateTime -- ZonedDateTime doesn't output millis/nanos if they're 0 (#78417)")
-  task.skipTest("painless/40_exception/Test painless exceptions are returned when logging a broken response", "Exceptions are no longer thrown from Mustache, but from the transform action itself")
   task.replaceKeyInDo("watcher.ack_watch", "xpack-watcher.ack_watch")
   task.replaceKeyInDo("watcher.activate_watch", "xpack-watcher.activate_watch")
   task.replaceKeyInDo("watcher.deactivate_watch", "xpack-watcher.deactivate_watch")

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
@@ -78,6 +78,6 @@
   - match: { watch_record.watch_id: "_inlined_" }
   - match: { watch_record.trigger_event.type: "manual" }
   - match: { watch_record.state: "executed" }
-  - match: { watch_record.result.actions.0.status: "failure" }
-  - match: { watch_record.result.actions.0.error.caused_by.caused_by.type: "illegal_argument_exception" }
-  - match: { watch_record.result.actions.0.error.caused_by.caused_by.reason: "Iterable object is self-referencing itself (CustomReflectionObjectHandler stringify)" }
+  - match: { watch_record.result.actions.0.transform.status: "failure" }
+  - match: { watch_record.result.actions.0.transform.error.type: "illegal_argument_exception" }
+  - match: { watch_record.result.actions.0.transform.error.reason: "Iterable object is self-referencing itself (watcher action payload)" }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
@@ -37,6 +37,10 @@
 
 ---
 "Test painless exceptions are returned when logging a broken response":
+  - skip:
+      version: "8.7.0 - 8.7.1"
+      reason:  "self-referencing objects were in Painless instead of Mustache in 8.7.0 to 8.7.1"
+
   - do:
       cluster.health:
           wait_for_status: green
@@ -75,5 +79,5 @@
   - match: { watch_record.trigger_event.type: "manual" }
   - match: { watch_record.state: "executed" }
   - match: { watch_record.result.actions.0.status: "failure" }
-  - match: { watch_record.result.actions.0.reason: "Failed to transform payload" }
-  - match: { watch_record.result.actions.0.transform.error.reason: "Iterable object is self-referencing itself (watcher action payload)" }
+  - match: { watch_record.result.actions.0.error.caused_by.caused_by.type: "illegal_argument_exception" }
+  - match: { watch_record.result.actions.0.error.caused_by.caused_by.reason: "Iterable object is self-referencing itself (CustomReflectionObjectHandler stringify)" }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
@@ -37,10 +37,6 @@
 
 ---
 "Test painless exceptions are returned when logging a broken response":
-  - skip:
-      version: " - 8.6.99"
-      reason:  "self-referencing objects were fixed to be in Painless instead of Mustache in 8.7"
-
   - do:
       cluster.health:
           wait_for_status: green


### PR DESCRIPTION
`SafeMustacheFactory` does not allow changing the default delimiter, triggering "Disallowed: changing defaul delimiters" MustacheExceptions when attempted.

This is a partial revert of #92211.

Fixes: #95421