### PR TITLE
Revert "[Transform] Report validation failure if there are no aggregations in the test search query"

### DIFF
--- a/docs/changelog/95318.yaml
+++ b/docs/changelog/95318.yaml
@@ -1,6 +1,0 @@
-pr: 95318
-summary: Report validation failure if there are no aggregations in the test search
-  query
-area: Transform
-type: bug
-issues: []

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_unattended.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/transform/transforms_unattended.yml
@@ -74,7 +74,6 @@ teardown:
   - do:
       transform.put_transform:
         transform_id: "transform-unattended"
-        defer_validation: true
         body: >
           {
             "source": { "index": "airline-data*" },

--- a/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
+++ b/x-pack/plugin/transform/qa/multi-cluster-tests-with-security/src/test/resources/rest-api-spec/test/multi_cluster/80_transform.yml
@@ -306,7 +306,6 @@ teardown:
 ---
 "Batch transform from remote cluster when the user is not authorized":
   - do:
-      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.put_transform:
         transform_id: "simple-remote-transform-3"
@@ -319,37 +318,6 @@ teardown:
               "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
             }
           }
-
-  - do:
-      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
-      transform.put_transform:
-        transform_id: "simple-remote-transform-3"
-        # With defer_validation set, the validation is not performed, so the transform can be created
-        defer_validation: true
-        body: >
-          {
-            "source": { "index": "my_remote_cluster:remote_test_index" },
-            "dest": { "index": "simple-remote-transform-3" },
-            "pivot": {
-              "group_by": { "user": {"terms": {"field": "user"}}},
-              "aggs": { "avg_stars": {"avg": {"field": "stars"}}}
-            }
-          }
-  - match: { acknowledged: true }
-
-  - do:
-      # bob is unauthorized to access the remote index
-      catch: /Source indices have been deleted or closed./
-      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
-      transform.preview_transform:
-        transform_id: "simple-remote-transform-3"
-
-  - do:
-      # On start, we perform the validation regardless of the defer_validation flag specified on PUT, hence the failure
-      catch: /Source indices have been deleted or closed./
-      headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
-      transform.start_transform:
-        transform_id: "simple-remote-transform-3"
 
 ---
 "Batch transform update from remote cluster when the user is not authorized":
@@ -368,7 +336,6 @@ teardown:
           }
   - match: { acknowledged: true }
   - do:
-      catch: /Source indices have been deleted or closed./
       headers: { Authorization: "Basic Ym9iOnRyYW5zZm9ybS1wYXNzd29yZA==" }  # This is bob
       transform.update_transform:
         transform_id: "simple-remote-transform-2"

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformInsufficientPermissionsIT.java
@@ -464,8 +464,8 @@ public class TransformInsufficientPermissionsIT extends TransformRestTestCase {
 
         startTransform(config.getId(), RequestOptions.DEFAULT);
 
-        // transform is red with one issue
-        assertBusy(() -> assertRed(transformId, authIssue), 10, TimeUnit.SECONDS);
+        // transform's auth state status is still RED, but the health status is GREEN (because dest index exists)
+        assertRed(transformId, authIssue);
 
         // update transform's credentials so that the transform has permission to access source/dest indices
         updateConfig(transformId, "{}", RequestOptions.DEFAULT.toBuilder().addHeader(AUTH_KEY, Users.SENIOR.header).build());

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -22,7 +22,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class TransformUpdateIT extends TransformRestTestCase {
@@ -247,8 +246,7 @@ public class TransformUpdateIT extends TransformRestTestCase {
             }
             fail("request should have failed");
         } catch (ResponseException e) {
-            assertThat("Error was: " + e.getMessage(), e.getResponse().getStatusLine().getStatusCode(), equalTo(400));
-            assertThat(e.getMessage(), containsString("Source indices have been deleted or closed."));
+            assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(500));
         }
         assertBusy(() -> {
             Map<?, ?> transformStatsAsMap = getTransformStateAndStats(transformId);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportPreviewTransformAction.java
@@ -69,6 +69,7 @@ import static org.elasticsearch.xpack.transform.utils.SecondaryAuthorizationUtil
 
 public class TransportPreviewTransformAction extends HandledTransportAction<Request, Response> {
 
+    private static final int NUMBER_OF_PREVIEW_BUCKETS = 100;
     private final SecurityContext securityContext;
     private final IndexNameExpressionResolver indexNameExpressionResolver;
     private final Client client;
@@ -278,7 +279,15 @@ public class TransportPreviewTransformAction extends HandledTransportAction<Requ
 
         ActionListener<Map<String, String>> deduceMappingsListener = ActionListener.wrap(deducedMappings -> {
             mappings.set(deducedMappings);
-            function.preview(parentTaskAssigningClient, timeout, filteredHeaders, source, deducedMappings, previewListener);
+            function.preview(
+                parentTaskAssigningClient,
+                timeout,
+                filteredHeaders,
+                source,
+                deducedMappings,
+                NUMBER_OF_PREVIEW_BUCKETS,
+                previewListener
+            );
         }, listener::onFailure);
 
         function.deduceMappings(parentTaskAssigningClient, filteredHeaders, source, deduceMappingsListener);

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportStartTransformAction.java
@@ -196,7 +196,6 @@ public class TransportStartTransformAction extends TransportMasterNodeAction<Sta
             );
         }, e -> {
             if (Boolean.TRUE.equals(transformConfigHolder.get().getSettings().getUnattended())) {
-                logger.debug(() -> format("[%s] Validation failed: %s", transformConfigHolder.get().getId(), e.getMessage()));
                 logger.debug(
                     () -> format("[%s] Skip dest index creation as this is an unattended transform", transformConfigHolder.get().getId())
                 );

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexer.java
@@ -274,15 +274,12 @@ class ClientTransformIndexer extends TransformIndexer {
         SchemaUtil.getDestinationFieldMappings(client, getConfig().getDestination().getIndex(), fieldMappingsListener);
     }
 
-    @Override
     void validate(ActionListener<Void> listener) {
-        assert Boolean.TRUE.equals(transformConfig.getSettings().getUnattended());
         ClientHelper.executeAsyncWithOrigin(
             client,
             ClientHelper.TRANSFORM_ORIGIN,
             ValidateTransformAction.INSTANCE,
-            // Since the transform is unattended, we defer the deferrable validations.
-            new ValidateTransformAction.Request(transformConfig, true, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT),
+            new ValidateTransformAction.Request(transformConfig, false, AcknowledgedRequest.DEFAULT_ACK_TIMEOUT),
             ActionListener.wrap(response -> listener.onResponse(null), listener::onFailure)
         );
     }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/Function.java
@@ -136,6 +136,7 @@ public interface Function {
      * @param headers headers to be used to query only for what the caller is allowed to
      * @param sourceConfig the source configuration
      * @param fieldTypeMap mapping of field types
+     * @param numberOfRows number of rows to produce for the preview
      * @param listener listener that takes a list, where every entry corresponds to 1 row/doc in the preview
      */
     void preview(
@@ -144,6 +145,7 @@ public interface Function {
         Map<String, String> headers,
         SourceConfig sourceConfig,
         Map<String, String> fieldTypeMap,
+        int numberOfRows,
         ActionListener<List<Map<String, Object>>> listener
     );
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/PivotTests.java
@@ -55,7 +55,6 @@ import org.junit.Before;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -126,13 +125,6 @@ public class PivotTests extends ESTestCase {
 
     public void testValidateNonExistingIndex() throws Exception {
         SourceConfig source = new SourceConfig("non_existing_source_index");
-        Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT, Collections.emptySet());
-
-        assertInvalidTransform(client, source, pivot);
-    }
-
-    public void testValidateAggregationsBeingNullInSearchResponse() throws Exception {
-        SourceConfig source = new SourceConfig("no_permissions");
         Function pivot = new Pivot(getValidPivotConfig(), new SettingsConfig(), Version.CURRENT, Collections.emptySet());
 
         assertInvalidTransform(client, source, pivot);
@@ -306,12 +298,9 @@ public class PivotTests extends ESTestCase {
                     }
                 }
 
-                final Aggregations aggregations = Arrays.stream(searchRequest.indices()).anyMatch(index -> index.contains("no_permissions"))
-                    ? null
-                    : new Aggregations(List.of());
                 final SearchResponseSections sections = new SearchResponseSections(
                     new SearchHits(new SearchHit[0], new TotalHits(0L, TotalHits.Relation.EQUAL_TO), 0),
-                    aggregations,
+                    null,
                     null,
                     false,
                     null,


### PR DESCRIPTION
elastic/elasticsearch#95318 turned out to be a braking change for some integrations.
Reverting it for now.

Reverts elastic/elasticsearch#95318

Relates https://github.com/elastic/elasticsearch/issues/95367