### PR TITLE
Remove remaining tsdb tech preview labels

### DIFF
--- a/docs/reference/data-streams/tsds-index-settings.asciidoc
+++ b/docs/reference/data-streams/tsds-index-settings.asciidoc
@@ -6,34 +6,34 @@ following index settings.
 
 [[index-mode]]
 `index.mode`::
-preview:[] (<<_static_index_settings,Static>>, string) Mode for the index.
+(<<_static_index_settings,Static>>, string) Mode for the index.
 Valid values are <<time-series-mode,`time_series`>> and `null` (no mode).
 Defaults to `null`.
 
 [[index-time-series-start-time]]
 `index.time_series.start_time`::
-preview:[] (<<_static_index_settings,Static>>, string) Earliest `@timestamp`
+(<<_static_index_settings,Static>>, string) Earliest `@timestamp`
 value (inclusive) accepted by the index. Only indices with an `index.mode` of
 <<time-series-mode,`time_series`>> support this setting. For more information,
 refer to <<time-bound-indices>>.
 
 [[index-time-series-end-time]]
 `index.time_series.end_time`::
-preview:[] (<<dynamic-index-settings,Dynamic>>, string) Latest `@timestamp`
+(<<dynamic-index-settings,Dynamic>>, string) Latest `@timestamp`
 value (exclusive) accepted by the index. Only indices with an `index.mode` of
 `time_series` support this setting. For more information, refer to
 <<time-bound-indices>>.
 
 [[index-look-ahead-time]]
 `index.look_ahead_time`::
-preview:[] (<<_static_index_settings,Static>>, <<time-units,time units>>)
+(<<_static_index_settings,Static>>, <<time-units,time units>>)
 Interval used to calculate the `index.time_series.end_time` for a TSDS's write
 index. Defaults to `2h` (2 hours). Accepts `1m` (one minute) to `7d` (seven
 days). Only indices with an `index.mode` of `time_series` support this setting.
 For more information, refer to <<tsds-look-ahead-time>>. Additionally this setting
 can not be less than `time_series.poll_interval` cluster setting.
 
-[[index-routing-path]] `index.routing_path`:: preview:[]
+[[index-routing-path]] `index.routing_path`::
 (<<_static_index_settings,Static>>, string or array of strings) Plain `keyword`
 fields used to route documents in a TSDS to index shards. Supports wildcards
 (`*`). Only indices with an `index.mode` of `time_series` support this setting.
@@ -44,7 +44,7 @@ more information, refer to <<dimension-based-routing>>.
 [[index-mapping-dimension-fields-limit]]
 // tag::dimensions-limit[]
 `index.mapping.dimension_fields.limit`::
-preview:[] (<<dynamic-index-settings,Dynamic>>, integer)
+(<<dynamic-index-settings,Dynamic>>, integer)
 Maximum number of <<time-series-dimension,time series dimensions>> for the
 index. Defaults to `16`.
 // end::dimensions-limit[]

--- a/docs/reference/indices/put-index-template.asciidoc
+++ b/docs/reference/indices/put-index-template.asciidoc
@@ -112,7 +112,7 @@ See <<create-index-template,create an index template>>.
 `false`.
 
 `index_mode`::
-preview:[] (Optional, string) Type of data stream to create. Valid values are `null`
+(Optional, string) Type of data stream to create. Valid values are `null`
 (regular data stream) and `time_series` (<<tsds,time series data stream>>).
 +
 If `time_series`, each backing index has an `index.mode` index setting of

--- a/docs/reference/mapping/types/aggregate-metric-double.asciidoc
+++ b/docs/reference/mapping/types/aggregate-metric-double.asciidoc
@@ -58,7 +58,7 @@ Default metric sub-field to use for queries, scripts, and aggregations that
 don't use a sub-field. Must be a value from the `metrics` array.
 
 `time_series_metric`::
-preview:[] (Optional, string)
+(Optional, string)
 include::numeric.asciidoc[tag=time_series_metric]
 +
 .Valid `time_series_metric` values for `aggregate_metric_double` fields

--- a/docs/reference/mapping/types/ip.asciidoc
+++ b/docs/reference/mapping/types/ip.asciidoc
@@ -95,7 +95,7 @@ The following parameters are accepted by `ip` fields:
     (default).
 
 `time_series_dimension`::
-preview:[] (Optional, Boolean)
+    (Optional, Boolean)
 +
 --
 include::keyword.asciidoc[tag=dimension]

--- a/docs/reference/mapping/types/keyword.asciidoc
+++ b/docs/reference/mapping/types/keyword.asciidoc
@@ -149,7 +149,7 @@ The following parameters are accepted by `keyword` fields:
     Accepts `true` or `false` (default).
 
 `time_series_dimension`::
-preview:[] (Optional, Boolean)
+    (Optional, Boolean)
 +
 --
 // tag::dimension[]

--- a/docs/reference/mapping/types/numeric.asciidoc
+++ b/docs/reference/mapping/types/numeric.asciidoc
@@ -179,7 +179,7 @@ The following parameters are accepted by numeric types:
     (default).
 
 `time_series_dimension`::
-preview:[] (Optional, Boolean)
+(Optional, Boolean)
 +
 --
 include::keyword.asciidoc[tag=dimension]
@@ -191,7 +191,7 @@ A numeric field can't be both a time series dimension and a time series metric.
 --
 
 `time_series_metric`::
-preview:[] (Optional, string)
+(Optional, string)
 // tag::time_series_metric[]
 Marks the field as a <<time-series-metric,time series metric>>. The value is the
 metric type. You can't update this parameter for existing fields.

--- a/docs/reference/search/field-caps.asciidoc
+++ b/docs/reference/search/field-caps.asciidoc
@@ -75,7 +75,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=index-ignore-unavailab
 
 `include_unmapped`::
   (Optional, Boolean) If `true`, unmapped fields that are mapped in one index but not in another are included in the response. Fields that don't have any mapping are never included.
-  Defaults to `false`. 
+  Defaults to `false`.
 
 `filters`::
 (Optional, string) Comma-separated list of filters to apply to the response.
@@ -136,12 +136,10 @@ field types are all described as the `keyword` type family.
   Whether this field can be aggregated on all indices.
 
 `time_series_dimension`::
-  preview:[]
   Whether this field is used as a time series dimension on all indices.
   For non-time-series indices this field is not present.
 
 `time_series_metric`::
-  preview:[]
   Contains the metric type if the field is used as a time series metric on all indices, absent if the field is
   not used as a metric. For non-time-series indices this field is not included.
 


### PR DESCRIPTION
Remove tech preview label from a number of tsdb settings and mapping attributes.