### PR TITLE
Fix _xpack/usage for enterprise_search in docs tests

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -129,6 +129,13 @@ GET /_xpack/usage
         }
       }
     },
+    "enterprise_search" : {
+      "available": true,
+      "enabled": true,
+      "search_applications" : {
+        "count": 0
+      }
+    },
     "inference" : {
       "ingest_processors" : {
         "_all" : {


### PR DESCRIPTION
Fixes https://github.com/elastic/elasticsearch/issues/95564