### PR TITLE
fix flaky docs tests `get-lifecycle` (#95529)

### DIFF
--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -1,4 +1,14 @@
 [[downsampling]]
+
+/////
+[source,console]
+--------------------------------------------------
+DELETE _ilm/policy/my_policy
+--------------------------------------------------
+// TEST
+// TEARDOWN
+/////
+
 === Downsampling a time series data stream
 
 Downsampling provides a method to reduce the footprint of your <<tsds,time
@@ -120,8 +130,8 @@ There are a few things to note when querying downsampled indices:
 * When you run queries in {kib} and through Elastic solutions, a normal
 response is returned without notification that some of the queried indices are
 downsampled.
-* For 
-<<search-aggregations-bucket-datehistogram-aggregation,date histogram aggregations>>, 
+* For
+<<search-aggregations-bucket-datehistogram-aggregation,date histogram aggregations>>,
 only `fixed_intervals` (and not calendar-aware intervals) are supported.
 * Only Coordinated Universal Time (UTC) date-times are supported.
 
@@ -131,13 +141,13 @@ only `fixed_intervals` (and not calendar-aware intervals) are supported.
 
 The following restrictions and limitations apply for downsampling:
 
-* Only indices in a <<tsds,time series data stream>> are supported. 
+* Only indices in a <<tsds,time series data stream>> are supported.
 
 * Data is downsampled based on the time dimension only. All other dimensions are
 copied to the new index without any modification.
 
 * Within a data stream, a downsampled index replaces the original index and the
-original index is deleted. Only one index can exist for a given time period. 
+original index is deleted. Only one index can exist for a given time period.
 
 * A source index must be in read-only mode for the downsampling process to
 succeed. Check the <<downsampling-manual,Run downsampling manually>> example for

--- a/docs/reference/ilm/apis/get-lifecycle.asciidoc
+++ b/docs/reference/ilm/apis/get-lifecycle.asciidoc
@@ -115,7 +115,6 @@ If the request succeeds, the body of the response contains the policy definition
   }
 }
 --------------------------------------------------
-// TEST[skip:https://github.com/elastic/elasticsearch/issues/89623]
 // TESTRESPONSE[s/"modified_date": 82392349/"modified_date": $body.my_policy.modified_date/]
 
 <1> The policy version is incremented whenever the policy is updated


### PR DESCRIPTION
The `data-streams/downsampling.asciidoc` test was missing a teardown clean of the ILM policies created. Due to this tests *do not have* the string `ilm` in its name, the automatic teardown process that cleans up the resources (check `ESRestTestCase.java#L815` & `DocsClientYamlTestSuiteIT.java` lines 177 & 195) is not executed for this specific test. In the case this test runs right before the `get-lifecycle` test, the policy won't be automatically deleted hence the test checking the version will fail. Finally, the order of execution of the test is not guaranteed by the suite.
