### PR TITLE
Fork ClusterFormationInfoAction and CoordinationDiagsticsAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoAction.java
@@ -21,6 +21,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -124,7 +125,13 @@ public class ClusterFormationInfoAction extends ActionType<ClusterFormationInfoA
 
         @Inject
         public TransportAction(TransportService transportService, ActionFilters actionFilters, Coordinator coordinator) {
-            super(ClusterFormationInfoAction.NAME, transportService, actionFilters, ClusterFormationInfoAction.Request::new);
+            super(
+                ClusterFormationInfoAction.NAME,
+                transportService,
+                actionFilters,
+                ClusterFormationInfoAction.Request::new,
+                ThreadPool.Names.CLUSTER_COORDINATION
+            );
             this.coordinator = coordinator;
         }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/CoordinationDiagnosticsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/coordination/CoordinationDiagnosticsAction.java
@@ -20,6 +20,7 @@ import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.tasks.Task;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
 
 import java.io.IOException;
@@ -125,7 +126,13 @@ public class CoordinationDiagnosticsAction extends ActionType<CoordinationDiagno
             ActionFilters actionFilters,
             CoordinationDiagnosticsService coordinationDiagnosticsService
         ) {
-            super(CoordinationDiagnosticsAction.NAME, transportService, actionFilters, CoordinationDiagnosticsAction.Request::new);
+            super(
+                CoordinationDiagnosticsAction.NAME,
+                transportService,
+                actionFilters,
+                CoordinationDiagnosticsAction.Request::new,
+                ThreadPool.Names.CLUSTER_COORDINATION
+            );
             this.coordinationDiagnosticsService = coordinationDiagnosticsService;
         }
 


### PR DESCRIPTION
Both of these actions take together take up the majority of transport thread time in tests. I expect them to be fairly heavy weight if not even more so in production. The reason for this is mainly in the inefficient implementation of how the cluster formation state is built. The adjustment of the blocks is O(N) in index count and quite heavy with lots of object creation.
We already fork the response handlers for this kind of request to the cluster coordination pool, lets fix this by also forking request handlers for now. We could however look into a follow-up to optimize the building of the formation state.
