### PR TITLE
Add more tests for rate aggregation

### DIFF
--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
@@ -1,5 +1,5 @@
 ---
-setup:
+"value rate":
   - do:
       bulk:
         index: test
@@ -13,12 +13,10 @@ setup:
           - '{"timestamp": "2020-02-11T10:00:00Z", "val": 6}'
           - '{"index": {}}'
           - '{"timestamp": "2020-02-12T10:00:00Z", "val": 8}'
----
-"value rate":
   - do:
       search:
         size: 0
-        index: "test"
+        index: test
         body:
           aggs:
             by_date:
@@ -57,7 +55,7 @@ setup:
   - do:
       search:
         size: 0
-        index: "test2"
+        index: test2
         body:
           aggs:
             by_date:
@@ -75,3 +73,135 @@ setup:
   - match: { aggregations.by_date.buckets.2.rate.value: 6.0 }
   - match: { aggregations.by_date.buckets.3.rate.value: 1.0 }
 
+
+---
+"composite buckets":
+  - do:
+      bulk:
+        index: test3
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-03T10:00:00Z", "dept": 1003, "val": 7}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-04T10:00:00Z", "dept": 1003, "val": 14}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-05T10:00:00Z", "dept": 1005, "val": 7}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-11T10:00:00Z", "dept": 1003, "val": 28}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-12T10:00:00Z", "dept": 1005, "val": 7}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-12T10:00:00Z", "dept": 1005, "val": 70}'
+  - do:
+      search:
+        size: 0
+        index: test3
+        body:
+          aggs:
+            by_date:
+              composite:
+                sources:
+                  - week:
+                      date_histogram:
+                        field: timestamp
+                        calendar_interval: week
+                  - department:
+                      terms:
+                        field: dept
+              aggs:
+                rate:
+                  rate:
+                    field: val
+                    unit: day
+
+  - length: { aggregations.by_date.buckets: 4 }
+  - match: { aggregations.by_date.buckets.0.rate.value: 3.0 }
+  - match: { aggregations.by_date.buckets.1.rate.value: 1.0 }
+  - match: { aggregations.by_date.buckets.2.rate.value: 4.0 }
+  - match: { aggregations.by_date.buckets.3.rate.value: 11.0 }
+
+
+---
+"value count mode":
+  - do:
+      bulk:
+        index: test4
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-01T10:00:00Z", "val": 1}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-01T11:00:00Z", "val": 20}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-01T12:00:00Z", "val": 300}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-02T10:00:00Z", "val": 4}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-02T11:00:00Z", "val": 50}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-04T10:00:00Z", "val": 6}'
+  - do:
+      search:
+        size: 0
+        index: test4
+        body:
+          aggs:
+            by_date:
+              date_histogram:
+                field: timestamp
+                calendar_interval: day
+              aggs:
+                rate:
+                  rate:
+                    field: val
+                    unit: week
+                    mode: value_count
+
+  - length: { aggregations.by_date.buckets: 4 }
+  - match: { aggregations.by_date.buckets.0.rate.value: 21.0 }
+  - match: { aggregations.by_date.buckets.1.rate.value: 14.0 }
+  - match: { aggregations.by_date.buckets.2.rate.value: 0.0 }
+  - match: { aggregations.by_date.buckets.3.rate.value: 7.0 }
+
+
+---
+"runtime field with script":
+  - do:
+      bulk:
+        index: test2
+        refresh: true
+        body:
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-03T10:00:00Z", "val": 1}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-04T10:00:00Z", "val": 2}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-11T10:00:00Z", "val": 4}'
+          - '{"index": {}}'
+          - '{"timestamp": "2020-02-12T10:00:00Z", "val": 5}'
+  - do:
+      search:
+        size: 0
+        index: test2
+        body:
+          runtime_mappings:
+            val.adjusted:
+              type: double
+              script:
+                source: "emit(doc['val'].value * params.adjustment)"
+                params:
+                  adjustment: 2.0
+          aggs:
+            by_date:
+              date_histogram:
+                field: timestamp
+                calendar_interval: week
+              aggs:
+                rate:
+                  rate:
+                    field: val.adjusted
+
+  - length: { aggregations.by_date.buckets: 2 }
+  - match: { aggregations.by_date.buckets.0.rate.value: 6.0 }
+  - match: { aggregations.by_date.buckets.1.rate.value: 18.0 }

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/rate.yml
@@ -75,7 +75,7 @@
 
 
 ---
-"composite buckets":
+"composite aggregation":
   - do:
       bulk:
         index: test3
@@ -169,7 +169,7 @@
 "runtime field with script":
   - do:
       bulk:
-        index: test2
+        index: test5
         refresh: true
         body:
           - '{"index": {}}'
@@ -183,7 +183,7 @@
   - do:
       search:
         size: 0
-        index: test2
+        index: test5
         body:
           runtime_mappings:
             val.adjusted:


### PR DESCRIPTION
The missing tests were derived from [rate aggregation documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-rate-aggregation.html):

- Composite aggregation
- Rate with mode set to `value_count`
- Aggregation on a runtime field using script

Related to #26220
