### PR TITLE
Mute ContextIndexSearcherTests testContextIndexSearcherDenseWithDeletions

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ContextIndexSearcherTests.java
@@ -174,6 +174,7 @@ public class ContextIndexSearcherTests extends ESTestCase {
         doTestContextIndexSearcher(true, true);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/94615")
     public void testContextIndexSearcherDenseWithDeletions() throws IOException {
         doTestContextIndexSearcher(false, true);
     }


### PR DESCRIPTION
Mute ContextIndexSearcherTests testContextIndexSearcherDenseWithDeletions

Relates https://github.com/elastic/elasticsearch/issues/94615
