### PR TITLE
[DOCS] Remove 8.8 release highlights link to fix docs build

### DIFF
--- a/docs/reference/release-notes/highlights.asciidoc
+++ b/docs/reference/release-notes/highlights.asciidoc
@@ -12,8 +12,8 @@ endif::[]
 // Add previous release to the list
 Other versions:
 
-{ref-bare}/8.8/release-highlights.html[8.8]
-| {ref-bare}/8.7/release-highlights.html[8.7]
+//{ref-bare}/8.8/release-highlights.html[8.8]
+{ref-bare}/8.7/release-highlights.html[8.7]
 | {ref-bare}/8.6/release-highlights.html[8.6]
 | {ref-bare}/8.5/release-highlights.html[8.5]
 | {ref-bare}/8.4/release-highlights.html[8.4]


### PR DESCRIPTION
This is to fix a [broken docs build](https://elasticsearch-ci.elastic.co/job/elastic+docs+master+build/39148/):

```
14:43:41 INFO:build_docs:Bad cross-document links:
14:43:41 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/reference/master/release-highlights.html contains broken links to:
14:43:41 INFO:build_docs:   - en/elasticsearch/reference/8.8/release-highlights.html
```