### PR TITLE
[8.8] Fix _xpack/usage for enterprise_search in docs tests (#95565)

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -129,6 +129,13 @@ GET /_xpack/usage
         }
       }
     },
+    "enterprise_search" : {
+      "available": true,
+      "enabled": true,
+      "search_applications" : {
+        "count": 0
+      }
+    },
     "inference" : {
       "ingest_processors" : {
         "_all" : {


### PR DESCRIPTION
Fixes _xpack/usage docs test which reports enterprise_search usage.

Backport of #95565