### PR TITLE
Add more info on EnrichAdvancedSecurityIT failures

### DIFF
--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -347,6 +347,14 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             maxExecutedSearchesTotal = Math.max(maxExecutedSearchesTotal, foundExecutedSearchesTotal);
         }
 
+        // the asserts after this if block keep failing randomly,
+        // so here we're going to pre-check early and fail with more useful information for debugging purposes
+        // that is, given that the search result didn't have a positive value for these, but it does have a non-zero number
+        // of hits, what's in it!? and maybe the size of search result is the interesting thing (since we only get 10 hits by default...)?
+        if (maxRemoteRequestsTotal == 0 || maxExecutedSearchesTotal == 0) {
+            assertThat(response.toString(), equalTo(""));
+        }
+
         assertThat(maxRemoteRequestsTotal, greaterThanOrEqualTo(1));
         assertThat(maxExecutedSearchesTotal, greaterThanOrEqualTo(1));
     }

--- a/x-pack/plugin/enrich/qa/rest-with-advanced-security/src/javaRestTest/java/org/elasticsearch/xpack/enrich/EnrichAdvancedSecurityIT.java
+++ b/x-pack/plugin/enrich/qa/rest-with-advanced-security/src/javaRestTest/java/org/elasticsearch/xpack/enrich/EnrichAdvancedSecurityIT.java
@@ -32,12 +32,6 @@ public class EnrichAdvancedSecurityIT extends CommonEnrichRestTestCase {
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", token).build();
     }
 
-    @Override
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86061")
-    public void testBasicFlowLong() throws Exception {
-        super.testBasicFlowLong();
-    }
-
     public void testEnrichEnforcesDLS() throws IOException {
         // Create the index and policy using the admin client
         final String sourceIndexName = "dls-source-index";


### PR DESCRIPTION
Related to #86061 #94920 #95129 #95589

These are all the same thing, or approximately the same, and they keep failing ([every day!](https://gradle-enterprise.elastic.co/scans/tests?search.timeZoneId=America/New_York&tests.container=org.elasticsearch.xpack.enrich.EnrichAdvancedSecurityIT)) and we still don't know why. This adds some new info for the next failures so that we can poke and learn a little more.