### PR TITLE
[8.8] disable http authentication to set expectations right. We have to pass and (#95582)

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoader.java
@@ -113,5 +113,9 @@ public class MachineLearningPackageLoader extends Plugin implements ActionPlugin
                 "If xpack.ml.model_repository is a file location, it must be placed below the configuration: " + normalizedConfigUri
             );
         }
+
+        if (baseUri.getUserInfo() != null) {
+            throw new IllegalArgumentException("xpack.ml.model_repository does not support authentication");
+        }
     }
 }

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
@@ -161,6 +161,8 @@ final class ModelLoaderUtils {
     @SuppressForbidden(reason = "we need socket connection to download")
     private static InputStream getHttpOrHttpsInputStream(URI uri) throws IOException {
 
+        assert uri.getUserInfo() == null : "URI's with credentials are not supported";
+
         SecurityManager sm = System.getSecurityManager();
         if (sm != null) {
             sm.checkPermission(new SpecialPermission());

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/MachineLearningPackageLoaderTests.java
@@ -69,5 +69,15 @@ public class MachineLearningPackageLoaderTests extends ESTestCase {
             "xpack.ml.model_repository must be configured with one of the following schemes: \"http\", \"https\", \"file\"",
             e.getMessage()
         );
+
+        e = expectThrows(
+            IllegalArgumentException.class,
+            () -> MachineLearningPackageLoader.validateModelRepository(
+                "http://user:pass@localhost",
+                PathUtils.get("/home/elk/elasticsearch")
+            )
+        );
+
+        assertEquals("xpack.ml.model_repository does not support authentication", e.getMessage());
     }
 }


### PR DESCRIPTION
Backports the following commits to 8.8:
 - disable http authentication to set expectations right. We have to pass and (#95582)