### PR TITLE
[ML] Check model size after model download

### DIFF
--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtils.java
@@ -65,6 +65,8 @@ final class ModelLoaderUtils {
         private final MessageDigest digestSha256 = MessageDigests.sha256();
         private final int chunkSize;
 
+        private int totalBytesRead = 0;
+
         InputStreamChunker(InputStream inputStream, int chunkSize) {
             this.inputStream = inputStream;
             this.chunkSize = chunkSize;
@@ -83,6 +85,7 @@ final class ModelLoaderUtils {
                 bytesRead += read;
             }
             digestSha256.update(buf, 0, bytesRead);
+            totalBytesRead += bytesRead;
 
             return new BytesArray(buf, 0, bytesRead);
         }
@@ -91,6 +94,9 @@ final class ModelLoaderUtils {
             return MessageDigests.toHexString(digestSha256.digest());
         }
 
+        public int getTotalBytesRead() {
+            return totalBytesRead;
+        }
     }
 
     static InputStream getInputStreamFromModelRepository(URI uri) throws IOException {

--- a/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportGetTrainedModelPackageConfigAction.java
+++ b/x-pack/plugin/ml-package-loader/src/main/java/org/elasticsearch/xpack/ml/packageloader/action/TransportGetTrainedModelPackageConfigAction.java
@@ -74,7 +74,7 @@ public class TransportGetTrainedModelPackageConfigAction extends TransportMaster
         String repository = MachineLearningPackageLoader.MODEL_REPOSITORY.get(settings);
 
         String packagedModelId = request.getPackagedModelId();
-        logger.trace(() -> format("Fetch package manifest for [%s] from [%s]", packagedModelId, repository));
+        logger.debug(() -> format("Fetch package manifest for [%s] from [%s]", packagedModelId, repository));
 
         threadPool.executor(MachineLearningPackageLoader.UTILITY_THREAD_POOL_NAME).execute(() -> {
             try {

--- a/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtilsTests.java
+++ b/x-pack/plugin/ml-package-loader/src/test/java/org/elasticsearch/xpack/ml/packageloader/action/ModelLoaderUtilsTests.java
@@ -61,7 +61,7 @@ public class ModelLoaderUtilsTests extends ESTestCase {
         assertEquals("Repository must contain a scheme", e.getMessage());
     }
 
-    public void testSha256() throws IOException {
+    public void testSha256AndSize() throws IOException {
         byte[] bytes = randomByteArrayOfLength(randomIntBetween(10, 1_000_000));
         String expectedDigest = MessageDigests.toHexString(MessageDigests.sha256().digest(bytes));
         assertEquals(64, expectedDigest.length());
@@ -80,7 +80,7 @@ public class ModelLoaderUtilsTests extends ESTestCase {
         }
 
         assertEquals(bytes.length - (chunkSize * (totalParts - 1)), inputStreamChunker.next().length());
-
+        assertEquals(bytes.length, inputStreamChunker.getTotalBytesRead());
         assertEquals(expectedDigest, inputStreamChunker.getSha256());
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -262,7 +262,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
         }
         String deployments = matchedDeployments.stream().collect(Collectors.joining(","));
 
-        logger.info("Fetching stats for deployments [{}]", deployments);
+        logger.debug("Fetching stats for deployments [{}]", deployments);
 
         GetDeploymentStatsAction.Request getDeploymentStatsRequest = new GetDeploymentStatsAction.Request(deployments);
         getDeploymentStatsRequest.setParentTask(parentTaskId);


### PR DESCRIPTION
After downloading the model package the size parameter wasn't checked and caused a late error on deployment of the model. This change adds a size check as part of the download to error earlier. In addition this change improves logging.