### PR TITLE
Mute tsdb mixed cluster rest IT

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -57,6 +57,8 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
         nonInputProperties.systemProperty('tests.clustername', baseName)
       }
       systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      systemProperty 'tests.rest.blacklist', ['tsdb/140_routing_path/missing routing path field',
+                                              'tsdb/140_routing_path/multi-value routing path field'].join(',')
       onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
     }
 


### PR DESCRIPTION
MixedClusterClientYamlTestSuiteIT » test {p0=tsdb/140_routing_path/missing routing path field}
MixedClusterClientYamlTestSuiteIT » test {p0=tsdb/140_routing_path/multi-value routing path field}

Relates https://github.com/elastic/elasticsearch/issues/95382