### PR TITLE
[8.8] Mute tsdb mixed cluster rest IT(#95609)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -57,6 +57,8 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
         nonInputProperties.systemProperty('tests.clustername', baseName)
       }
       systemProperty 'tests.path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
+      systemProperty 'tests.rest.blacklist', ['tsdb/140_routing_path/missing routing path field',
+                                              'tsdb/140_routing_path/multi-value routing path field'].join(',')
       onlyIf("BWC tests disabled") { project.bwc_tests_enabled }
     }
 


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Mute tsdb mixed cluster rest IT(#95609) (#95609)