### PR TITLE
[Behavioral Analytics] Use a a client with ent-search origin in the BulkProcessorFactory.

### DIFF
--- a/docs/changelog/95614.yaml
+++ b/docs/changelog/95614.yaml
@@ -1,0 +1,5 @@
+pr: 95614
+summary: "[Behavioral Analytics] Use a a client with ent-search origin in the `BulkProcessorFactory`"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
@@ -50,7 +50,7 @@ public class AnalyticsEventEmitter extends AbstractLifecycleComponent {
 
     @Inject
     public AnalyticsEventEmitter(Client client, BulkProcessorFactory bulkProcessorFactory, AnalyticsCollectionResolver collectionResolver) {
-        this(client, bulkProcessorFactory.create(client), collectionResolver, AnalyticsEventFactory.INSTANCE);
+        this(client, bulkProcessorFactory.create(), collectionResolver, AnalyticsEventFactory.INSTANCE);
     }
 
     AnalyticsEventEmitter(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactory.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactory.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -19,6 +20,8 @@ import org.elasticsearch.logging.Logger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
 /**
  * Event ingest is done through a {@link BulkProcessor2}. This class is responsible for instantiating the bulk processor.
@@ -28,12 +31,15 @@ public class BulkProcessorFactory {
 
     private final AnalyticsEventIngestConfig config;
 
+    private final Client client;
+
     @Inject
-    public BulkProcessorFactory(AnalyticsEventIngestConfig config) {
+    public BulkProcessorFactory(Client client, AnalyticsEventIngestConfig config) {
+        this.client = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
         this.config = config;
     }
 
-    public BulkProcessor2 create(Client client) {
+    public BulkProcessor2 create() {
         return BulkProcessor2.builder(client::bulk, new BulkProcessorListener(), client.threadPool())
             .setMaxNumberOfRetries(config.maxNumberOfRetries())
             .setBulkActions(config.maxNumberOfEventsPerBulk())

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactoryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactoryTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.application.analytics.ingest;
 
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.bulk.BulkAction;
 import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.index.IndexRequest;
@@ -57,11 +58,11 @@ public class BulkProcessorFactoryTests extends ESTestCase {
         Client client = mock(Client.class);
 
         doReturn(testThreadPool).when(client).threadPool();
-        BulkProcessor2 bulkProcessor = new BulkProcessorFactory(config).create(client);
+        BulkProcessor2 bulkProcessor = new BulkProcessorFactory(client, config).create();
         IndexRequest indexRequest = mock(IndexRequest.class);
         bulkProcessor.add(indexRequest);
 
-        assertBusy(() -> verify(client).bulk(argThat((BulkRequest bulkRequest) -> {
+        assertBusy(() -> verify(client).execute(any(BulkAction.class), argThat((BulkRequest bulkRequest) -> {
             assertThat(bulkRequest.numberOfActions(), equalTo(1));
             assertThat(bulkRequest.requests().stream().findFirst().get(), equalTo(indexRequest));
             return true;
@@ -80,13 +81,13 @@ public class BulkProcessorFactoryTests extends ESTestCase {
         InOrder inOrder = Mockito.inOrder(client);
 
         doReturn(testThreadPool).when(client).threadPool();
-        BulkProcessor2 bulkProcessor = new BulkProcessorFactory(config).create(client);
+        BulkProcessor2 bulkProcessor = new BulkProcessorFactory(client, config).create();
 
         for (int i = 0; i < totalEvents; i++) {
             bulkProcessor.add(mock(IndexRequest.class));
         }
 
-        inOrder.verify(client, times(totalEvents / maxBulkActions)).bulk(argThat((BulkRequest bulkRequest) -> {
+        inOrder.verify(client, times(totalEvents / maxBulkActions)).execute(any(BulkAction.class), argThat((BulkRequest bulkRequest) -> {
             // Verify a bulk is executed immediately with maxNumberOfEventsPerBulk is reached.
             assertThat(bulkRequest.numberOfActions(), equalTo(maxBulkActions));
             return true;
@@ -95,7 +96,7 @@ public class BulkProcessorFactoryTests extends ESTestCase {
         bulkProcessor.awaitClose(1, TimeUnit.SECONDS);
 
         if (totalEvents % maxBulkActions > 0) {
-            inOrder.verify(client).bulk(argThat((BulkRequest bulkRequest) -> {
+            inOrder.verify(client).execute(any(BulkAction.class),argThat((BulkRequest bulkRequest) -> {
                 // Verify another bulk with only 1 event (the remaining) is executed when closing the processor.
                 assertThat(bulkRequest.numberOfActions(), equalTo(totalEvents % maxBulkActions));
                 return true;
@@ -112,16 +113,16 @@ public class BulkProcessorFactoryTests extends ESTestCase {
 
         Client client = mock(Client.class);
         doAnswer(i -> {
-            i.getArgument(1, ActionListener.class).onFailure(new ElasticsearchStatusException("", RestStatus.TOO_MANY_REQUESTS));
+            i.getArgument(2, ActionListener.class).onFailure(new ElasticsearchStatusException("", RestStatus.TOO_MANY_REQUESTS));
             return null;
-        }).when(client).bulk(any(), any());
+        }).when(client).execute(any(), any(), any());
         doReturn(testThreadPool).when(client).threadPool();
-        BulkProcessor2 bulkProcessor = new BulkProcessorFactory(config).create(client);
+        BulkProcessor2 bulkProcessor = new BulkProcessorFactory(client, config).create();
 
         IndexRequest indexRequest = mock(IndexRequest.class);
         bulkProcessor.add(indexRequest);
 
-        verify(client, times(numberOfRetries + 1)).bulk(argThat((BulkRequest bulkRequest) -> {
+        verify(client, times(numberOfRetries + 1)).execute(any(BulkAction.class), argThat((BulkRequest bulkRequest) -> {
             assertThat(bulkRequest.numberOfActions(), equalTo(1));
             assertThat(bulkRequest.requests().stream().findFirst().get(), equalTo(indexRequest));
             return true;

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactoryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactoryTests.java
@@ -96,7 +96,7 @@ public class BulkProcessorFactoryTests extends ESTestCase {
         bulkProcessor.awaitClose(1, TimeUnit.SECONDS);
 
         if (totalEvents % maxBulkActions > 0) {
-            inOrder.verify(client).execute(any(BulkAction.class),argThat((BulkRequest bulkRequest) -> {
+            inOrder.verify(client).execute(any(BulkAction.class), argThat((BulkRequest bulkRequest) -> {
                 // Verify another bulk with only 1 event (the remaining) is executed when closing the processor.
                 assertThat(bulkRequest.numberOfActions(), equalTo(totalEvents % maxBulkActions));
                 return true;


### PR DESCRIPTION
Fix a bug when using an API Key with only the `post_behavioral_analytics_event ` cluster privilege.
The event is accepted but never ingested to the data stream.
This is caused by a wrong instantiation of the client used by the bulk processor.

More context here: post_behavioral_analytics_event