### PR TITLE
Remove MultiBucketConsumer from AggregationContext

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -43,7 +43,6 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.SearchModule;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
-import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.bucket.terms.TermsAggregationBuilder;
 import org.elasticsearch.search.aggregations.metrics.SumAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
@@ -152,7 +151,6 @@ public class AggConstructionContentionBenchmark {
 
         private final CircuitBreaker breaker;
         private final PreallocatedCircuitBreakerService preallocated;
-        private final MultiBucketConsumer multiBucketConsumer;
 
         DummyAggregationContext(long bytesToPreallocate) {
             CircuitBreakerService breakerService;
@@ -168,7 +166,6 @@ public class AggConstructionContentionBenchmark {
                 preallocated = null;
             }
             breaker = breakerService.getBreaker(CircuitBreaker.REQUEST);
-            multiBucketConsumer = new MultiBucketConsumer(Integer.MAX_VALUE, breaker);
         }
 
         @Override
@@ -298,8 +295,8 @@ public class AggConstructionContentionBenchmark {
         }
 
         @Override
-        public MultiBucketConsumer multiBucketConsumer() {
-            return multiBucketConsumer;
+        public int maxBuckets() {
+            return Integer.MAX_VALUE;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1255,7 +1255,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
                  */
                 () -> context.rewrittenQuery() == null ? new MatchAllDocsQuery() : context.rewrittenQuery(),
                 context.getProfilers() == null ? null : context.getProfilers().getAggregationProfiler(),
-                multiBucketConsumerService.create(),
+                multiBucketConsumerService.getLimit(),
                 () -> new SubSearchContext(context).parsedQuery(context.parsedQuery()).fetchFieldsContext(context.fetchFieldsContext()),
                 context.bitsetFilterCache(),
                 context.indexShard().shardId().hashCode(),

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -107,10 +107,6 @@ public class AggregationPhase {
         Aggregator[] aggregators = context.aggregations().aggregators();
 
         List<InternalAggregation> aggregations = new ArrayList<>(aggregators.length);
-        if (context.aggregations().factories().context() != null) {
-            // Rollup can end up here with a null context but not null factories.....
-            context.aggregations().factories().context().multiBucketConsumer().reset();
-        }
         for (Aggregator aggregator : context.aggregations().aggregators()) {
             try {
                 aggregator.postCollection();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/MultiBucketConsumerService.java
@@ -125,20 +125,16 @@ public class MultiBucketConsumerService {
             }
         }
 
-        public void reset() {
-            this.count = 0;
-        }
-
         public int getCount() {
             return count;
-        }
-
-        public int getLimit() {
-            return limit;
         }
     }
 
     public MultiBucketConsumer create() {
         return new MultiBucketConsumer(maxBucket, breaker);
+    }
+
+    public int getLimit() {
+        return maxBucket;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BucketsAggregator.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.search.aggregations.bucket;
 
 import org.apache.lucene.index.LeafReaderContext;
+import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.util.LongArray;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.search.aggregations.AggregationExecutionException;
@@ -34,14 +35,14 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
-import java.util.function.IntConsumer;
 import java.util.function.LongUnaryOperator;
 import java.util.function.ToLongFunction;
 
 public abstract class BucketsAggregator extends AggregatorBase {
-    private final IntConsumer multiBucketConsumer;
+    private final CircuitBreaker breaker;
     private LongArray docCounts;
     protected final DocCountProvider docCountProvider;
+    private int callCount;
 
     public BucketsAggregator(
         String name,
@@ -52,7 +53,7 @@ public abstract class BucketsAggregator extends AggregatorBase {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, factories, aggCtx, parent, bucketCardinality, metadata);
-        multiBucketConsumer = aggCtx.multiBucketConsumer();
+        breaker = aggCtx.breaker();
         docCounts = bigArrays().newLongArray(1, true);
         docCountProvider = new DocCountProvider();
     }
@@ -85,10 +86,12 @@ public abstract class BucketsAggregator extends AggregatorBase {
     public final void collectExistingBucket(LeafBucketCollector subCollector, int doc, long bucketOrd) throws IOException {
         int docCount = docCountProvider.getDocCount(doc);
         if (docCounts.increment(bucketOrd, docCount) == docCount) {
-            // We calculate the final number of buckets only during the reduce phase. But we still need to
-            // trigger bucket consumer from time to time in order to give it a chance to check available memory and break
-            // the execution if we are running out. To achieve that we are passing 0 as a bucket count.
-            multiBucketConsumer.accept(0);
+            // We call the circuit breaker the time to time in order to give it a chance to check available
+            // memory in the parent breaker and break the execution if we are running out. To achieve that we
+            // are passing 0 as the estimated bytes every 1024 calls
+            if ((++callCount & 0x3FF) == 0) {
+                breaker.addEstimateBytesAndMaybeBreak(0, "allocated_buckets");
+            }
         }
         subCollector.collect(doc, bucketOrd);
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -105,7 +105,7 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
         this.formats = Arrays.stream(sourceConfigs).map(CompositeValuesSourceConfig::format).toList();
         this.sources = new SingleDimensionValuesSource<?>[sourceConfigs.length];
         // check that the provided size is not greater than the search.max_buckets setting
-        int bucketLimit = aggCtx.multiBucketConsumer().getLimit();
+        int bucketLimit = aggCtx.maxBuckets();
         if (size > bucketLimit) {
             throw new MultiBucketConsumerService.TooManyBucketsException(
                 "Trying to create too many buckets. Must be less than or equal"

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -37,7 +37,6 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.BucketCollector;
-import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.bucket.filter.FilterByFilterAggregator;
 import org.elasticsearch.search.internal.SubSearchContext;
 import org.elasticsearch.search.lookup.SearchLookup;
@@ -230,7 +229,10 @@ public abstract class AggregationContext implements Releasable {
      */
     public abstract void addReleasable(Aggregator aggregator);
 
-    public abstract MultiBucketConsumer multiBucketConsumer();
+    /**
+     * Max buckets provided by the search.max_buckets setting
+     */
+    public abstract int maxBuckets();
 
     /**
      * Get the filter cache.
@@ -330,7 +332,7 @@ public abstract class AggregationContext implements Releasable {
         private final BigArrays bigArrays;
         private final Supplier<Query> topLevelQuery;
         private final AggregationProfiler profiler;
-        private final MultiBucketConsumer multiBucketConsumer;
+        private final int maxBuckets;
         private final Supplier<SubSearchContext> subSearchContextBuilder;
         private final BitsetFilterCache bitsetFilterCache;
         private final int randomSeed;
@@ -350,7 +352,7 @@ public abstract class AggregationContext implements Releasable {
             long bytesToPreallocate,
             Supplier<Query> topLevelQuery,
             @Nullable AggregationProfiler profiler,
-            MultiBucketConsumer multiBucketConsumer,
+            int maxBuckets,
             Supplier<SubSearchContext> subSearchContextBuilder,
             BitsetFilterCache bitsetFilterCache,
             int randomSeed,
@@ -383,7 +385,7 @@ public abstract class AggregationContext implements Releasable {
             }
             this.topLevelQuery = topLevelQuery;
             this.profiler = profiler;
-            this.multiBucketConsumer = multiBucketConsumer;
+            this.maxBuckets = maxBuckets;
             this.subSearchContextBuilder = subSearchContextBuilder;
             this.bitsetFilterCache = bitsetFilterCache;
             this.randomSeed = randomSeed;
@@ -519,8 +521,8 @@ public abstract class AggregationContext implements Releasable {
         }
 
         @Override
-        public MultiBucketConsumer multiBucketConsumer() {
-            return multiBucketConsumer;
+        public int maxBuckets() {
+            return maxBuckets;
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/histogram/DateHistogramAggregatorTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.search.aggregations.AggregationBuilder;
 import org.elasticsearch.search.aggregations.AggregationReduceContext;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.BucketOrder;
+import org.elasticsearch.search.aggregations.MultiBucketConsumerService;
 import org.elasticsearch.search.aggregations.bucket.DateHistogramAggregatorTestCase;
 import org.elasticsearch.search.aggregations.bucket.range.RangeAggregator;
 import org.elasticsearch.search.aggregations.bucket.terms.StringTerms;
@@ -1069,7 +1070,7 @@ public class DateHistogramAggregatorTests extends DateHistogramAggregatorTestCas
                         null,
                         () -> false,
                         builder,
-                        context.multiBucketConsumer(),
+                        new MultiBucketConsumerService.MultiBucketConsumer(context.maxBuckets(), context.breaker()),
                         PipelineTree.EMPTY
                     )
                 );

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -58,7 +58,6 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.Script;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.search.aggregations.Aggregator;
-import org.elasticsearch.search.aggregations.MultiBucketConsumerService.MultiBucketConsumer;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import org.elasticsearch.search.internal.SubSearchContext;
@@ -371,7 +370,6 @@ public abstract class MapperServiceTestCase extends ESTestCase {
     ) {
         return new AggregationContext() {
             private final CircuitBreaker breaker = mock(CircuitBreaker.class);
-            private final MultiBucketConsumer multiBucketConsumer = new MultiBucketConsumer(Integer.MAX_VALUE, breaker);
 
             @Override
             public IndexSearcher searcher() {
@@ -497,8 +495,8 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             }
 
             @Override
-            public MultiBucketConsumer multiBucketConsumer() {
-                return multiBucketConsumer;
+            public int maxBuckets() {
+                return Integer.MAX_VALUE;
             }
 
             @Override

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -345,7 +345,6 @@ public abstract class AggregatorTestCase extends ESTestCase {
             emptyMap()
         );
 
-        MultiBucketConsumer consumer = new MultiBucketConsumer(maxBucket, breakerService.getBreaker(CircuitBreaker.REQUEST));
         AggregationContext context = new ProductionAggregationContext(
             Optional.ofNullable(analysisModule).map(AnalysisModule::getAnalysisRegistry).orElse(null),
             searchExecutionContext,
@@ -353,7 +352,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             bytesToPreallocate,
             () -> query,
             null,
-            consumer,
+            maxBucket,
             () -> buildSubSearchContext(indexSettings, searchExecutionContext, bitsetFilterCache),
             bitsetFilterCache,
             randomInt(),
@@ -792,7 +791,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     getMockScriptService(),
                     () -> false,
                     builder,
-                    context.multiBucketConsumer(),
+                    new MultiBucketConsumer(context.maxBuckets(), context.breaker()),
                     builder.buildPipelineTree()
                 )
             );


### PR DESCRIPTION
We currently don't circuit break in number of buckets during the aggregation phase, therefore it makes no sense to have a MultiBucketConsumer in the AggregationContext. 