### PR TITLE
[8.8] [Behavioral Analytics] Use a client with ent-search origin in the BulkProcessorFactory. (#95614)

### DIFF
--- a/docs/changelog/95614.yaml
+++ b/docs/changelog/95614.yaml
@@ -1,0 +1,5 @@
+pr: 95614
+summary: "[Behavioral Analytics] Use a a client with ent-search origin in the `BulkProcessorFactory`"
+area: Application
+type: bug
+issues: []

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
@@ -50,7 +50,7 @@ public class AnalyticsEventEmitter extends AbstractLifecycleComponent {
 
     @Inject
     public AnalyticsEventEmitter(Client client, BulkProcessorFactory bulkProcessorFactory, AnalyticsCollectionResolver collectionResolver) {
-        this(client, bulkProcessorFactory.create(client), collectionResolver, AnalyticsEventFactory.INSTANCE);
+        this(client, bulkProcessorFactory.create(), collectionResolver, AnalyticsEventFactory.INSTANCE);
     }
 
     AnalyticsEventEmitter(

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactory.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/BulkProcessorFactory.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.bulk.BulkProcessor2;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.bulk.BulkResponse;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.OriginSettingClient;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.logging.LogManager;
 import org.elasticsearch.logging.Logger;
@@ -19,6 +20,8 @@ import org.elasticsearch.logging.Logger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import static org.elasticsearch.xpack.core.ClientHelper.ENT_SEARCH_ORIGIN;
 
 /**
  * Event ingest is done through a {@link BulkProcessor2}. This class is responsible for instantiating the bulk processor.
@@ -28,12 +31,15 @@ public class BulkProcessorFactory {
 
     private final AnalyticsEventIngestConfig config;
 
+    private final Client client;
+
     @Inject
-    public BulkProcessorFactory(AnalyticsEventIngestConfig config) {
+    public BulkProcessorFactory(Client client, AnalyticsEventIngestConfig config) {
+        this.client = new OriginSettingClient(client, ENT_SEARCH_ORIGIN);
         this.config = config;
     }
 
-    public BulkProcessor2 create(Client client) {
+    public BulkProcessor2 create() {
         return BulkProcessor2.builder(client::bulk, new BulkProcessorListener(), client.threadPool())
             .setMaxNumberOfRetries(config.maxNumberOfRetries())
             .setBulkActions(config.maxNumberOfEventsPerBulk())


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Behavioral Analytics] Use a client with ent-search origin in the BulkProcessorFactory. (#95614)](https://github.com/elastic/elasticsearch/pull/95614)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)