### PR TITLE
[8.8] Add template information to search application API docs (#95591)

### DIFF
--- a/docs/reference/search-application/apis/get-search-application.asciidoc
+++ b/docs/reference/search-application/apis/get-search-application.asciidoc
@@ -53,6 +53,22 @@ A sample response:
 {
     "name": "my-app",
     "indices": [ "index1", "index2" ],
-    "analytics_collection_name": "my-analytics"
+    "updated_at_millis": 1682105622204,
+    "template": {
+      "script": {
+        "source": {
+          "query": {
+            "query_string": {
+              "query": "{{query_string}}",
+              "default_field": "{{default_field}}"
+            }
+          }
+        },
+        "params": {
+          "query_string": "*",
+          "default_field": "*"
+        }
+      }
+  }
 }
 ----

--- a/docs/reference/search-application/apis/index.asciidoc
+++ b/docs/reference/search-application/apis/index.asciidoc
@@ -15,10 +15,12 @@ Use Search Application APIs to manage tasks and resources related to Search Appl
 * <<get-search-application>>
 * <<list-search-applications>>
 * <<delete-search-application>>
+* <<search-application-search>>
 
 
 include::put-search-application.asciidoc[]
 include::get-search-application.asciidoc[]
 include::list-search-applications.asciidoc[]
 include::delete-search-application.asciidoc[]
+include::search-application-search.asciidoc[]
 

--- a/docs/reference/search-application/apis/list-search-applications.asciidoc
+++ b/docs/reference/search-application/apis/list-search-applications.asciidoc
@@ -24,7 +24,7 @@ Requires the `manage_search_application` cluster privilege.
 ==== {api-path-parms-title}
 
 `q`::
-(Optional, string) Query in the Lucene query string syntax, to return only Search Applications matching the query.
+(Optional, string) Query in the Lucene query string syntax, to return only search applications matching the query.
 
 `size`::
 (Optional, integer) Maximum number of results to retrieve.
@@ -38,7 +38,7 @@ Requires the `manage_search_application` cluster privilege.
 [[list-search-applications-example]]
 ==== {api-examples-title}
 
-The following example lists all configured Search Applications:
+The following example lists all configured search applications:
 
 [source,console]
 ----
@@ -46,7 +46,7 @@ GET _application/search_application/
 ----
 // TEST[skip:TBD]
 
-The following example lists the first three Search Applications whose names match the query string `app`:
+The following example lists the first three search applications whose names match the query string `app`:
 
 [source,console]
 ----
@@ -69,6 +69,7 @@ A sample response:
       "name": "app-2",
       "indices": [ "index3", "index4" ]
     }
-  ]
+  ],
+  "updated_at_millis": 1682105622204
 }
 ----

--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -24,9 +24,33 @@ Also requires <<privileges-list-indices,manage privileges>> on all indices that 
 [[put-search-application-path-params]]
 ==== {api-path-parms-title}
 
+
 `create`::
 (Optional, Boolean) If `true`, this request cannot replace or update existing Search Applications.
 Defaults to `false`.
+
+`<body>`::
+(Required, object)
+Contains parameters for a search application:
++
+.Properties of `<body>` objects
+[%collapsible%open]
+====
+`indices`::
+(Required, array of strings)
+The <<indices,indices>> associated with this search application. All indices need to exist in order to be added to a search application.
+
+`template`::
+(Optional, object)
+The <<search-template,search template>> associated with this search application. The search application's template is only stored and accessible through the search application.
+
+- This search template must be a Mustache template.
+- The template must contain a Mustache script and script source.
+- The template may be modified with subsequent <<put-search-application,put search application>> requests.
+- If no template is specified when creating a search application, or if a template is removed from a search application, we use the <<query-string-query-ex-request,query_string>> defined in the template examples as a default.
+- This template will be used by the <<search-application-search,search application search>> API to execute searches.
+====
+
 
 [[put-search-application-response-codes]]
 ==== {api-response-codes-title}
@@ -47,7 +71,22 @@ The following example creates a new Search Application called `my-app`:
 PUT _application/search_application/my-app?create
 {
   "indices": [ "index1", "index2" ],
-  "analytics_collection_name": "my-analytics-collection"
+  "template": {
+    "script": {
+      "source": {
+        "query": {
+          "query_string": {
+            "query": "{{query_string}}",
+            "default_field": "{{default_field}}"
+          }
+        }
+      },
+      "params": {
+        "query_string": "*",
+        "default_field": "*"
+      }
+    }
+  }
 }
 ----
 // TEST[skip:TBD]
@@ -59,7 +98,22 @@ The following example creates or updates an existing Search Application called `
 PUT _application/search_application/my-app
 {
   "indices": [ "index1", "index2", "index3" ],
-  "analytics_collection_name": "my-analytics-collection"
+  "template": {
+    "script": {
+      "source": {
+        "query": {
+          "query_string": {
+            "query": "{{query_string}}",
+            "default_field": "{{default_field}}"
+          }
+        }
+      },
+      "params": {
+        "query_string": "*",
+        "default_field": "*"
+      }
+    }
+  }
 }
 ----
 // TEST[skip:TBD]


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Add template information to search application API docs (#95591)