### PR TITLE
Add a sort and size for EnrichAdvancedSecurityIT failures

### DIFF
--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -166,37 +166,37 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
 
     public void testBasicFlowKeyword() throws Exception {
         setupGenericLifecycleTest("host", "match", "elastic.co");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowDate() throws Exception {
         setupGenericLifecycleTest("date", "range", "2021-09-06");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowInteger() throws Exception {
         setupGenericLifecycleTest("integer", "range", "41");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowLong() throws Exception {
         setupGenericLifecycleTest("long", "range", "8411017");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowDouble() throws Exception {
         setupGenericLifecycleTest("double", "range", "15.15");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowFloat() throws Exception {
         setupGenericLifecycleTest("float", "range", "10000.66666");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowIp() throws Exception {
         setupGenericLifecycleTest("ip", "range", "100.120.140.160");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
     }
 
     public void testImmutablePolicy() throws IOException {

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -318,7 +318,11 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
     private static void verifyEnrichMonitoring() throws IOException {
         Request request = new Request("GET", "/.monitoring-*/_search");
         request.setJsonEntity("""
-            {"query": {"term": {"type": "enrich_coordinator_stats"}}}""");
+            {
+              "query": {"term": {"type": "enrich_coordinator_stats"}},
+              "size": 5
+            }
+            """);
         Map<String, ?> response;
         try {
             response = toMap(adminClient().performRequest(request));

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -166,37 +166,37 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
 
     public void testBasicFlowKeyword() throws Exception {
         setupGenericLifecycleTest("host", "match", "elastic.co");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowDate() throws Exception {
         setupGenericLifecycleTest("date", "range", "2021-09-06");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowInteger() throws Exception {
         setupGenericLifecycleTest("integer", "range", "41");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowLong() throws Exception {
         setupGenericLifecycleTest("long", "range", "8411017");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowDouble() throws Exception {
         setupGenericLifecycleTest("double", "range", "15.15");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowFloat() throws Exception {
         setupGenericLifecycleTest("float", "range", "10000.66666");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testBasicFlowIp() throws Exception {
         setupGenericLifecycleTest("ip", "range", "100.120.140.160");
-        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 1, TimeUnit.MINUTES);
+        assertBusy(CommonEnrichRestTestCase::verifyEnrichMonitoring, 3, TimeUnit.MINUTES);
     }
 
     public void testImmutablePolicy() throws IOException {

--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -320,6 +320,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
         request.setJsonEntity("""
             {
               "query": {"term": {"type": "enrich_coordinator_stats"}},
+              "sort": [{"timestamp": "desc"}],
               "size": 5
             }
             """);


### PR DESCRIPTION
Related to #86061 #94920 #95129 #95589, follow up to #95592

These are all the same thing, or approximately the same, and they keep failing ([every day!](https://gradle-enterprise.elastic.co/scans/tests?search.timeZoneId=America/New_York&tests.container=org.elasticsearch.xpack.enrich.EnrichAdvancedSecurityIT)) and we still don't know why.

The additional information we added in #95592 ([link to test failure with valuable new data](https://gradle-enterprise.elastic.co/s/2u7d5x3uxhdzu/tests/:x-pack:plugin:enrich:qa:rest-with-advanced-security:javaRestTest/org.elasticsearch.xpack.enrich.EnrichAdvancedSecurityIT/testBasicFlowKeyword?top-execution=1)) points to the possibility that we're exceeding the default limit on the hits size (10), which combined with the document order in the index results in us never seeing the documents that would satisfy the assertions of the test. This PR introduces a smaller size so that the toString we'll see on failures is more complete, and a sort-by-timestamp-descending so that we always see the newest results, rather than getting stuck with the oldest.