### PR TITLE
[8.8] Revert usage of SafeMustacheFactory in CustomMustacheFactory (#95557)

### DIFF
--- a/docs/changelog/95557.yaml
+++ b/docs/changelog/95557.yaml
@@ -1,0 +1,5 @@
+pr: 95557
+summary: Revert usage of `SafeMustacheFactory` in `CustomMustacheFactory`
+area: Infra/Scripting
+type: bug
+issues: []

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomMustacheFactory.java
@@ -14,9 +14,7 @@ import com.github.mustachejava.DefaultMustacheVisitor;
 import com.github.mustachejava.Mustache;
 import com.github.mustachejava.MustacheException;
 import com.github.mustachejava.MustacheVisitor;
-import com.github.mustachejava.SafeMustacheFactory;
 import com.github.mustachejava.TemplateContext;
-import com.github.mustachejava.TemplateFunction;
 import com.github.mustachejava.codes.DefaultMustache;
 import com.github.mustachejava.codes.IterableCode;
 import com.github.mustachejava.codes.WriteCode;
@@ -36,11 +34,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.StringJoiner;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class CustomMustacheFactory extends SafeMustacheFactory {
+public class CustomMustacheFactory extends DefaultMustacheFactory {
     static final String V7_JSON_MEDIA_TYPE_WITH_CHARSET = "application/json; charset=UTF-8";
     static final String JSON_MEDIA_TYPE_WITH_CHARSET = "application/json;charset=utf-8";
     static final String JSON_MEDIA_TYPE = "application/json";
@@ -65,7 +64,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
     private final Encoder encoder;
 
     public CustomMustacheFactory(String mediaType) {
-        super(Collections.emptySet(), ".");
+        super();
         setObjectHandler(new CustomReflectionObjectHandler());
         this.encoder = createEncoder(mediaType);
     }
@@ -146,7 +145,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
             writer.write(tc.endChars());
         }
 
-        protected abstract TemplateFunction createFunction(Object resolved);
+        protected abstract Function<String, String> createFunction(Object resolved);
 
         /**
          * At compile time, this function extracts the name of the variable:
@@ -189,7 +188,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
 
         @Override
         @SuppressWarnings("unchecked")
-        protected TemplateFunction createFunction(Object resolved) {
+        protected Function<String, String> createFunction(Object resolved) {
             return s -> {
                 if (resolved == null) {
                     return null;
@@ -239,7 +238,7 @@ public class CustomMustacheFactory extends SafeMustacheFactory {
         }
 
         @Override
-        protected TemplateFunction createFunction(Object resolved) {
+        protected Function<String, String> createFunction(Object resolved) {
             return s -> {
                 if (s == null) {
                     return null;

--- a/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
+++ b/modules/lang-mustache/src/main/java/org/elasticsearch/script/mustache/CustomReflectionObjectHandler.java
@@ -10,6 +10,7 @@ package org.elasticsearch.script.mustache;
 
 import com.github.mustachejava.reflect.ReflectionObjectHandler;
 
+import org.elasticsearch.common.util.CollectionUtils;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.iterable.Iterables;
 
@@ -161,5 +162,11 @@ final class CustomReflectionObjectHandler extends ReflectionObjectHandler {
         public Iterator<Object> iterator() {
             return col.iterator();
         }
+    }
+
+    @Override
+    public String stringify(Object object) {
+        CollectionUtils.ensureNoSelfReferences(object, "CustomReflectionObjectHandler stringify");
+        return super.stringify(object);
     }
 }

--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/painless/40_exception.yml
@@ -38,8 +38,8 @@
 ---
 "Test painless exceptions are returned when logging a broken response":
   - skip:
-      version: " - 8.6.99"
-      reason:  "self-referencing objects were fixed to be in Painless instead of Mustache in 8.7"
+      version: "8.7.0 - 8.7.1"
+      reason:  "self-referencing objects were in Painless instead of Mustache in 8.7.0 to 8.7.1"
 
   - do:
       cluster.health:
@@ -78,6 +78,6 @@
   - match: { watch_record.watch_id: "_inlined_" }
   - match: { watch_record.trigger_event.type: "manual" }
   - match: { watch_record.state: "executed" }
-  - match: { watch_record.result.actions.0.status: "failure" }
-  - match: { watch_record.result.actions.0.reason: "Failed to transform payload" }
+  - match: { watch_record.result.actions.0.transform.status: "failure" }
+  - match: { watch_record.result.actions.0.transform.error.type: "illegal_argument_exception" }
   - match: { watch_record.result.actions.0.transform.error.reason: "Iterable object is self-referencing itself (watcher action payload)" }


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Revert usage of SafeMustacheFactory in CustomMustacheFactory (#95557)