### PR TITLE
Optimize indexing for disabled keyword field

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/KeywordFieldMapperTests.java
@@ -627,7 +627,7 @@ public class KeywordFieldMapperTests extends MapperTestCase {
     }
 
     /**
-     * Test that we don't error on exceeding field size if field is neither indexed nor has doc values
+     * Test that we don't error on exceeding field size if field is neither indexed nor has doc values nor stored
      */
     public void testKeywordFieldUtf8LongerThan32766SourceOnly() throws Exception {
         DocumentMapper mapper = createDocumentMapper(fieldMapping(b -> {


### PR DESCRIPTION
Small optimization for indexing disabled keyword field. 
If a keyword field is disabled (no indexing, no docvalues, no store) 
return earlier without unnecessary processing (e.g. creating BytesRef).

This is useful if keyword field is used just as Key/Value store, where
we don't want ES to do any processing of Value except storing it
in source.
