### PR TITLE
[Transform] Fix failing `testTransformDestIndexAliases` test

### DIFF
--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformDestIndexIT.java
@@ -92,6 +92,10 @@ public class TransformDestIndexIT extends TransformRestTestCase {
         // Verify that the search results are the same, regardless whether we use index or alias
         assertHitsAreTheSame(destIndex1, destAliasAll, destAliasLatest);
 
+        // Stop the transform so that the transform task is properly removed before calling DELETE.
+        // TODO: Remove this step once the underlying issue (race condition is fixed).
+        stopTransform(transformId, false);
+
         // Delete the transform
         deleteTransform(transformId);
         assertAliases(destIndex1, destAliasAll, destAliasLatest);


### PR DESCRIPTION
This PR fixes the immediate CI test failure only.
It does it by adding an additional step (stopping the transform) before deleting the transform. This additional step in general should not be needed.
However, the root cause fix is outside of scope of this PR.

Fixes https://github.com/elastic/elasticsearch/issues/95327