### PR TITLE
[DLM] Fix the new endpoint rest-api specification

### DIFF
--- a/docs/changelog/95665.yaml
+++ b/docs/changelog/95665.yaml
@@ -1,0 +1,5 @@
+pr: 95665
+summary: "[DLM] Fix the new endpoint rest-api specification"
+area: DLM
+type: bug
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.delete_data_lifecycle.json
@@ -4,19 +4,13 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-delete-lifecycle.html",
       "description":"Deletes the data lifecycle of the selected data streams."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },
     "url":{
       "paths":[
-        {
-          "path":"/_data_stream/_lifecycle",
-          "methods":[
-            "DELETE"
-          ]
-        },
         {
           "path":"/_data_stream/{name}/_lifecycle",
           "methods":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.get_data_lifecycle.json
@@ -4,19 +4,13 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-get-lifecycle.html",
       "description":"Returns the data lifecycle of the selected data streams."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },
     "url":{
       "paths":[
-        {
-          "path":"/_data_stream/_lifecycle",
-          "methods":[
-            "GET"
-          ]
-        },
         {
           "path":"/_data_stream/{name}/_lifecycle",
           "methods":[

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.put_data_lifecycle.json
@@ -4,19 +4,13 @@
       "url":"https://www.elastic.co/guide/en/elasticsearch/reference/master/dlm-put-lifecycle.html",
       "description":"Updates the data lifecycle of the selected data streams."
     },
-    "stability":"stable",
+    "stability":"experimental",
     "visibility":"public",
     "headers":{
       "accept": [ "application/json"]
     },
-    "url":{
-      "paths":[
-        {
-          "path":"/_data_stream/_lifecycle",
-          "methods":[
-            "PUT"
-          ]
-        },
+    "url": {
+      "paths": [
         {
           "path":"/_data_stream/{name}/_lifecycle",
           "methods":[


### PR DESCRIPTION
Fix the following mistakes in the rest-api specification for the new endpoints.

- Changed the stability of the endpoints from stable to experimental.
- Removed the following paths that we decided we do not support.

Relates to: #93596