### PR TITLE
Update TransportVersion javadoc and static checks

### DIFF
--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -12,11 +12,13 @@ import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.TransportVersionUtils;
 
 import java.lang.reflect.Modifier;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.is;
@@ -54,30 +56,50 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public static class CorrectFakeVersion {
-        public static final TransportVersion V1 = new TransportVersion(1, "1");
-        public static final TransportVersion V2 = new TransportVersion(2, "2");
-        public static final TransportVersion V3 = new TransportVersion(3, "3");
+        public static final TransportVersion V_0_00_01 = new TransportVersion(199, "1");
+        public static final TransportVersion V_0_000_002 = new TransportVersion(2, "2");
+        public static final TransportVersion V_0_000_003 = new TransportVersion(3, "3");
+        public static final TransportVersion V_0_000_004 = new TransportVersion(4, "4");
+    }
+
+    public static class IncorrectFormatVersion {
+        public static final TransportVersion V_1 = new TransportVersion(1, "1");
     }
 
     public static class DuplicatedIdFakeVersion {
-        public static final TransportVersion V1 = new TransportVersion(1, "1");
-        public static final TransportVersion V2 = new TransportVersion(2, "2");
-        public static final TransportVersion V3 = new TransportVersion(2, "3");
+        public static final TransportVersion V_0_000_001 = new TransportVersion(1, "1");
+        public static final TransportVersion V_0_000_002 = new TransportVersion(2, "2");
+        public static final TransportVersion V_0_000_003 = new TransportVersion(2, "3");
     }
 
     public static class DuplicatedStringIdFakeVersion {
-        public static final TransportVersion V1 = new TransportVersion(1, "1");
-        public static final TransportVersion V2 = new TransportVersion(2, "2");
-        public static final TransportVersion V3 = new TransportVersion(3, "2");
+        public static final TransportVersion V_0_000_001 = new TransportVersion(1, "1");
+        public static final TransportVersion V_0_000_002 = new TransportVersion(2, "2");
+        public static final TransportVersion V_0_000_003 = new TransportVersion(3, "2");
     }
 
     public void testStaticTransportVersionChecks() {
         assertThat(
             TransportVersion.getAllVersionIds(CorrectFakeVersion.class),
-            equalTo(Map.of(1, CorrectFakeVersion.V1, 2, CorrectFakeVersion.V2, 3, CorrectFakeVersion.V3))
+            equalTo(
+                Map.of(
+                    199,
+                    CorrectFakeVersion.V_0_00_01,
+                    2,
+                    CorrectFakeVersion.V_0_000_002,
+                    3,
+                    CorrectFakeVersion.V_0_000_003,
+                    4,
+                    CorrectFakeVersion.V_0_000_004
+                )
+            )
         );
-        expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(DuplicatedIdFakeVersion.class));
-        expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(DuplicatedStringIdFakeVersion.class));
+        AssertionError e = expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(IncorrectFormatVersion.class));
+        assertThat(e.getMessage(), containsString("does not have the correct name format"));
+        e = expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(DuplicatedIdFakeVersion.class));
+        assertThat(e.getMessage(), containsString("have the same version number"));
+        e = expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(DuplicatedStringIdFakeVersion.class));
+        assertThat(e.getMessage(), containsString("have the same unique id"));
     }
 
     public void testDefinedConstants() throws IllegalAccessException {
@@ -144,7 +166,6 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testVersionConstantPresent() {
-        // TODO those versions are not cached at the moment, perhaps we should add them to idToVersion set too?
         Set<TransportVersion> ignore = Set.of(TransportVersion.ZERO, TransportVersion.CURRENT, TransportVersion.MINIMUM_COMPATIBLE);
         assertThat(TransportVersion.CURRENT, sameInstance(TransportVersion.fromId(TransportVersion.CURRENT.id)));
         final int iters = scaledRandomIntBetween(20, 100);
@@ -156,17 +177,7 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testCURRENTIsLatest() {
-        final int iters = scaledRandomIntBetween(100, 1000);
-        for (int i = 0; i < iters; i++) {
-            TransportVersion version = TransportVersionUtils.randomVersion();
-            if (version != TransportVersion.CURRENT) {
-                assertThat(
-                    "Version: " + version + " should be before: " + Version.CURRENT + " but wasn't",
-                    version.before(TransportVersion.CURRENT),
-                    is(true)
-                );
-            }
-        }
+        assertThat(Collections.max(TransportVersion.getAllVersions()), is(TransportVersion.CURRENT));
     }
 
     public void testToString() {


### PR DESCRIPTION
Rewrite the javadoc to represent how the class will be used in the future, along with some explanations.

Update the static checks to be more robust & catch erroneous versions being added.