### PR TITLE
Update CCS compatibility version to the next minor version

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -161,7 +161,7 @@ public class TransportVersion implements Comparable<TransportVersion> {
      * Reference to the minimum transport version that can be used with CCS.
      * This should be the transport version used by the previous minor release.
      */
-    public static final TransportVersion MINIMUM_CCS_VERSION = V_8_7_0;
+    public static final TransportVersion MINIMUM_CCS_VERSION = V_8_8_0;
 
     static NavigableMap<Integer, TransportVersion> getAllVersionIds(Class<?> cls) {
         NavigableMap<Integer, TransportVersion> builder = new TreeMap<>();


### PR DESCRIPTION
Update the hardcoded CCS compatibility version, now 8.8.0 is released.