### PR TITLE
[Transform] Improve reporting status of the transform that is about to finish

### DIFF
--- a/docs/changelog/95672.yaml
+++ b/docs/changelog/95672.yaml
@@ -1,0 +1,5 @@
+pr: 95672
+summary: Improve reporting status of the transform that is about to finish
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRobustnessIT.java
@@ -113,6 +113,27 @@ public class TransformRobustnessIT extends TransformRestTestCase {
         deleteTransform(transformId);
     }
 
+    public void testCreateAndDeleteTransformInALoop() throws IOException {
+        createReviewsIndex();
+
+        String transformId = "test_create_and_delete_in_a_loop";
+        String destIndex = transformId + "-dest";
+        for (int i = 0; i < 100; ++i) {
+            try {
+                // Create the batch transform
+                createPivotReviewsTransform(transformId, destIndex, null);
+                // Wait until the transform finishes
+                startAndWaitForTransform(transformId, destIndex);
+                // After the transform finishes, there should be no transform task left
+                assertEquals(0, getNumberOfTransformTasks());
+                // Delete the transform
+                deleteTransform(transformId);
+            } catch (AssertionError | Exception e) {
+                fail("Failure at iteration " + i + ": " + e.getMessage());
+            }
+        }
+    }
+
     @SuppressWarnings("unchecked")
     private int getNumberOfTransformTasks() throws IOException {
         final Request tasksRequest = new Request("GET", "/_tasks");

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -365,8 +365,10 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                             )
                         );
                     } else {
-                        final boolean transformPersistentTaskIsStillRunning =
-                            TransformTask.getTransformTask(stat.getId(), clusterState) != null;
+                        final boolean transformPersistentTaskIsStillRunning = TransformTask.getTransformTask(
+                            stat.getId(),
+                            clusterState
+                        ) != null;
                         allStateAndStats.add(
                             new TransformStats(
                                 stat.getId(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -365,11 +365,12 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                             )
                         );
                     } else {
-                        final boolean transformTaskIsStillRunning = TransformTask.getTransformTask(stat.getId(), clusterState) != null;
+                        final boolean transformPersistentTaskIsStillRunning =
+                            TransformTask.getTransformTask(stat.getId(), clusterState) != null;
                         allStateAndStats.add(
                             new TransformStats(
                                 stat.getId(),
-                                transformTaskIsStillRunning ? TransformStats.State.STOPPING : TransformStats.State.STOPPED,
+                                transformPersistentTaskIsStillRunning ? TransformStats.State.STOPPING : TransformStats.State.STOPPED,
                                 null,
                                 null,
                                 stat.getTransformStats(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportGetTransformStatsAction.java
@@ -335,7 +335,6 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
         ClusterState clusterState,
         ActionListener<Void> listener
     ) {
-
         if (statsForTransformsWithoutTasks.isEmpty()) {
             // No work to do, but we must respond to the listener
             listener.onResponse(null);
@@ -366,10 +365,11 @@ public class TransportGetTransformStatsAction extends TransportTasksAction<Trans
                             )
                         );
                     } else {
+                        final boolean transformTaskIsStillRunning = TransformTask.getTransformTask(stat.getId(), clusterState) != null;
                         allStateAndStats.add(
                             new TransformStats(
                                 stat.getId(),
-                                TransformStats.State.STOPPED,
+                                transformTaskIsStillRunning ? TransformStats.State.STOPPING : TransformStats.State.STOPPED,
                                 null,
                                 null,
                                 stat.getTransformStats(),

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/transforms/TransformTask.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.regex.Regex;
 import org.elasticsearch.persistent.AllocatedPersistentTask;
+import org.elasticsearch.persistent.PersistentTaskParams;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata.PersistentTask;
 import org.elasticsearch.persistent.PersistentTasksService;
@@ -47,6 +48,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -464,6 +466,17 @@ public class TransformTask extends AllocatedPersistentTask implements TransformS
         logger.debug("[{}] shutdown of transform requested", transform.getId());
         transformScheduler.deregisterTransform(getTransformId());
         markAsCompleted();
+        waitForPersistentTask(Objects::isNull, null, new PersistentTasksService.WaitForPersistentTaskListener<>() {
+            @Override
+            public void onResponse(PersistentTask<PersistentTaskParams> persistentTask) {
+                logger.trace("[{}] successfully finished waiting for persistent task to disappear.", transform.getId());
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                logger.error(() -> "[" + transform.getId() + "] failure while waiting for persistent task to disappear.", e);
+            }
+        });
     }
 
     void persistStateToClusterState(TransformState state, ActionListener<PersistentTask<?>> listener) {


### PR DESCRIPTION
This PR fixes 2 places that may yield issues with status reporting when the transform finishes:
1. it makes the `TransformTask.shutdown` method wait until the persistent task disappears.
2. It makes the `_stats` action report `stopping` rather than `stopped` state if there is no persistent task seen by the `TaskManager` but there still is a task in the `ClusterState`.

Additionally, this PR adds a test (`TransformRobustnessIT.testCreateAndDeleteTransformInALoop`) which shows that every time we are about to delete the transform, the persistent task is already gone.

Relates https://github.com/elastic/elasticsearch/issues/95327