### PR TITLE
Create a TestDiscoveryNode class to create test instances of DiscoveryNode

### DIFF
--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/DatabaseNodeServiceTests.java
@@ -26,6 +26,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -220,10 +221,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
 
         ClusterState state = ClusterState.builder(new ClusterName("name"))
             .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).build())
-            .nodes(
-                new DiscoveryNodes.Builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT))
-                    .localNodeId("_id1")
-            )
+            .nodes(new DiscoveryNodes.Builder().add(TestDiscoveryNode.create("_id1")).localNodeId("_id1"))
             .build();
 
         databaseNodeService.checkDatabases(state);
@@ -387,9 +385,7 @@ public class DatabaseNodeServiceTests extends ESTestCase {
         }
         return ClusterState.builder(new ClusterName("name"))
             .metadata(Metadata.builder().putCustom(TYPE, tasksCustomMetadata).put(idxMeta))
-            .nodes(
-                DiscoveryNodes.builder().add(new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT)).localNodeId("_id1")
-            )
+            .nodes(DiscoveryNodes.builder().add(TestDiscoveryNode.create("_id1")).localNodeId("_id1"))
             .routingTable(
                 RoutingTable.builder()
                     .add(

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsActionNodeResponseSerializingTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsActionNodeResponseSerializingTests.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.ingest.geoip.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
@@ -34,7 +34,7 @@ public class GeoIpDownloaderStatsActionNodeResponseSerializingTests extends Abst
     }
 
     static GeoIpDownloaderStatsAction.NodeResponse createRandomInstance() {
-        DiscoveryNode node = new DiscoveryNode("id", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("id");
         Set<String> databases = Set.copyOf(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
         Set<String> files = Set.copyOf(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
         Set<String> configDatabases = Set.copyOf(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNode.java
@@ -163,23 +163,6 @@ public class DiscoveryNode implements Writeable, ToXContentFragment {
      *
      * @param id               the nodes unique (persistent) node id. This constructor will auto generate a random ephemeral id.
      * @param address          the nodes transport address
-     * @param version          the version of the node
-     */
-    public DiscoveryNode(final String id, TransportAddress address, Version version) {
-        this(id, address, Collections.emptyMap(), DiscoveryNodeRole.roles(), version);
-    }
-
-    /**
-     * Creates a new {@link DiscoveryNode}
-     * <p>
-     * <b>Note:</b> if the version of the node is unknown {@link Version#minimumCompatibilityVersion()} should be used for the current
-     * version. it corresponds to the minimum version this elasticsearch version can communicate with. If a higher version is used
-     * the node might not be able to communicate with the remote node. After initial handshakes node versions will be discovered
-     * and updated.
-     * </p>
-     *
-     * @param id               the nodes unique (persistent) node id. This constructor will auto generate a random ephemeral id.
-     * @param address          the nodes transport address
      * @param attributes       node attributes
      * @param roles            node roles
      * @param version          the version of the node

--- a/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
+++ b/server/src/main/java/org/elasticsearch/transport/SniffConnectionStrategy.java
@@ -498,8 +498,10 @@ public class SniffConnectionStrategy extends RemoteConnectionStrategy {
         if (proxyAddress == null || proxyAddress.isEmpty()) {
             TransportAddress transportAddress = new TransportAddress(parseConfiguredAddress(address));
             return new DiscoveryNode(
-                clusterAlias + "#" + transportAddress.toString(),
+                clusterAlias + "#" + transportAddress,
                 transportAddress,
+                Collections.emptyMap(),
+                DiscoveryNodeRole.roles(),
                 Version.CURRENT.minimumCompatibilityVersion()
             );
         } else {

--- a/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
+++ b/server/src/test/java/org/elasticsearch/ElasticsearchExceptionTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.client.internal.transport.NoNodeAvailableException;
 import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -1071,7 +1072,7 @@ public class ElasticsearchExceptionTests extends ESTestCase {
                 expected.addSuppressed(suppressed);
             }
             case 6 -> { // SearchPhaseExecutionException with cause and multiple failures
-                DiscoveryNode node = new DiscoveryNode("node_g", buildNewFakeTransportAddress(), Version.CURRENT);
+                DiscoveryNode node = TestDiscoveryNode.create("node_g");
                 failureCause = new NodeClosedException(node);
                 failureCause = new NoShardAvailableActionException(new ShardId("_index_g", "_uuid_g", 6), "node_g", failureCause);
                 ShardSearchFailure[] shardFailures = new ShardSearchFailure[] {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/configuration/TransportClearVotingConfigExclusionsActionTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.DiscoveryNodes.Builder;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
@@ -62,7 +63,7 @@ public class TransportClearVotingConfigExclusionsActionTests extends ESTestCase 
     @BeforeClass
     public static void createThreadPoolAndClusterService() {
         threadPool = new TestThreadPool("test", Settings.EMPTY);
-        localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+        localNode = TestDiscoveryNode.create("local");
         otherNode1 = new DiscoveryNode("other1", "other1", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         otherNode1Exclusion = new VotingConfigExclusion(otherNode1);
         otherNode2 = new DiscoveryNode("other2", "other2", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/ClusterFormationInfoActionTests.java
@@ -8,13 +8,13 @@
 
 package org.elasticsearch.action.admin.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.coordination.ClusterFormationFailureHelper;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.coordination.Coordinator;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.monitor.StatusInfo;
@@ -125,7 +125,7 @@ public class ClusterFormationInfoActionTests extends ESTestCase {
         int numberOfMasterEligibleNodes = randomIntBetween(1, 7);
         for (int i = 0; i < numberOfMasterEligibleNodes; i++) {
             String id = "_id" + i;
-            DiscoveryNode masterNode = new DiscoveryNode(id, buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode masterNode = TestDiscoveryNode.create(id);
             masterEligibleNodes.put(id, masterNode);
         }
         return masterEligibleNodes;

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/coordination/MasterHistoryActionTests.java
@@ -8,12 +8,12 @@
 
 package org.elasticsearch.action.admin.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.coordination.MasterHistory;
 import org.elasticsearch.cluster.coordination.MasterHistoryService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
@@ -29,10 +29,7 @@ import static org.mockito.Mockito.when;
 
 public class MasterHistoryActionTests extends ESTestCase {
     public void testSerialization() {
-        List<DiscoveryNode> masterHistory = List.of(
-            new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT),
-            new DiscoveryNode("_id2", buildNewFakeTransportAddress(), Version.CURRENT)
-        );
+        List<DiscoveryNode> masterHistory = List.of(TestDiscoveryNode.create("_id1"), TestDiscoveryNode.create("_id2"));
         MasterHistoryAction.Response response = new MasterHistoryAction.Response(masterHistory);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             response,
@@ -52,7 +49,7 @@ public class MasterHistoryActionTests extends ESTestCase {
         switch (randomIntBetween(1, 4)) {
             case 1 -> {
                 List<DiscoveryNode> newNodes = new ArrayList<>(nodes);
-                newNodes.add(new DiscoveryNode("_id3", buildNewFakeTransportAddress(), Version.CURRENT));
+                newNodes.add(TestDiscoveryNode.create("_id3"));
                 return new MasterHistoryAction.Response(newNodes);
             }
             case 2 -> {
@@ -63,7 +60,7 @@ public class MasterHistoryActionTests extends ESTestCase {
             case 3 -> {
                 List<DiscoveryNode> newNodes = new ArrayList<>(nodes);
                 newNodes.remove(0);
-                newNodes.add(0, new DiscoveryNode("_id1", buildNewFakeTransportAddress(), Version.CURRENT));
+                newNodes.add(0, TestDiscoveryNode.create("_id1"));
                 return new MasterHistoryAction.Response(newNodes);
             }
             case 4 -> {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathResponseSerializationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/shutdown/NodePrevalidateShardPathResponseSerializationTests.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.action.admin.cluster.node.shutdown;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
@@ -35,7 +35,7 @@ public class NodePrevalidateShardPathResponseSerializationTests extends Abstract
     }
 
     public static DiscoveryNode getRandomNode() {
-        return new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT);
+        return TestDiscoveryNode.create(randomAlphaOfLength(10));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteResponseTests.java
@@ -14,8 +14,8 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.RerouteExplanation;
 import org.elasticsearch.cluster.routing.allocation.RoutingExplanations;
 import org.elasticsearch.cluster.routing.allocation.command.AllocateReplicaAllocationCommand;
@@ -300,7 +300,7 @@ public class ClusterRerouteResponseTests extends ESTestCase {
     }
 
     private static ClusterState createClusterState() {
-        var node0 = new DiscoveryNode("node0", new TransportAddress(TransportAddress.META_ADDRESS, 9000), Version.CURRENT);
+        var node0 = TestDiscoveryNode.create("node0", new TransportAddress(TransportAddress.META_ADDRESS, 9000));
         return ClusterState.builder(new ClusterName("test"))
             .nodes(new DiscoveryNodes.Builder().add(node0).masterNodeId(node0.getId()).build())
             .putTransportVersion(node0.getId(), TransportVersion.V_8_0_0)

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponseTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.admin.cluster.shards;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
@@ -48,7 +49,7 @@ public class ClusterSearchShardsResponseTests extends ESTestCase {
             String nodeId = randomAlphaOfLength(10);
             ShardRouting shardRouting = TestShardRouting.newShardRouting(shardId, nodeId, randomBoolean(), ShardRoutingState.STARTED);
             clusterSearchShardsGroups[i] = new ClusterSearchShardsGroup(shardId, new ShardRouting[] { shardRouting });
-            DiscoveryNode node = new DiscoveryNode(
+            DiscoveryNode node = TestDiscoveryNode.create(
                 shardRouting.currentNodeId(),
                 new TransportAddress(TransportAddress.META_ADDRESS, randomInt(0xFFFF)),
                 VersionUtils.randomVersion(random())

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsNodesTests.java
@@ -14,7 +14,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStats;
 import org.elasticsearch.action.admin.cluster.node.stats.NodeStatsTests;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.network.InetAddresses;
 import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
@@ -324,7 +324,7 @@ public class ClusterStatsNodesTests extends ESTestCase {
             Version.CURRENT,
             TransportVersion.CURRENT,
             Build.CURRENT,
-            new DiscoveryNode(nodeId, buildNewFakeTransportAddress(), null),
+            TestDiscoveryNode.create(nodeId, buildNewFakeTransportAddress()),
             settings.build(),
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -15,7 +15,7 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.cluster.health.ClusterHealthStatus;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.UnassignedInfo;
@@ -120,7 +120,7 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
             null
         );
         ClusterStatsNodeResponse nodeResponse = new ClusterStatsNodeResponse(
-            new DiscoveryNode("id", buildNewFakeTransportAddress(), Version.CURRENT),
+            TestDiscoveryNode.create("id"),
             ClusterHealthStatus.GREEN,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/shards/TransportIndicesShardStoresActionTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -179,7 +180,7 @@ public class TransportIndicesShardStoresActionTests extends ESTestCase {
 
         TestHarness() {
             this.deterministicTaskQueue = new DeterministicTaskQueue();
-            this.localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+            this.localNode = TestDiscoveryNode.create("local");
 
             final var threadPool = deterministicTaskQueue.getThreadPool();
 

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.metadata.DataStreamTestHelper;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -98,8 +99,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         );
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = randomBoolean() ? null : new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = randomBoolean() ? null : TestDiscoveryNode.create("node_2");
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
         final boolean shard1 = randomBoolean();
@@ -182,8 +183,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             System::nanoTime
         );
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
         final boolean shard1 = randomBoolean();
@@ -273,8 +274,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         );
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
 
@@ -371,8 +372,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         );
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
 
@@ -704,8 +705,8 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
         BiConsumer<List<SearchShardIterator>, List<ShardSearchRequest>> canMatchResultsConsumer
     ) throws Exception {
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
 

--- a/server/src/test/java/org/elasticsearch/action/search/ClearScrollControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/ClearScrollControllerTests.java
@@ -7,11 +7,11 @@
  */
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.shard.ShardId;
@@ -35,9 +35,9 @@ import java.util.concurrent.atomic.AtomicInteger;
 public class ClearScrollControllerTests extends ESTestCase {
 
     public void testClearAll() throws InterruptedException {
-        DiscoveryNode node1 = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node2 = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node3 = new DiscoveryNode("node_3", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node_1");
+        DiscoveryNode node2 = TestDiscoveryNode.create("node_2");
+        DiscoveryNode node3 = TestDiscoveryNode.create("node_3");
         DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).add(node2).add(node3).build();
         CountDownLatch latch = new CountDownLatch(1);
         ActionListener<ClearScrollResponse> listener = new LatchedActionListener<>(new ActionListener<ClearScrollResponse>() {
@@ -77,9 +77,9 @@ public class ClearScrollControllerTests extends ESTestCase {
     }
 
     public void testClearScrollIds() throws IOException, InterruptedException {
-        DiscoveryNode node1 = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node2 = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node3 = new DiscoveryNode("node_3", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node_1");
+        DiscoveryNode node2 = TestDiscoveryNode.create("node_2");
+        DiscoveryNode node3 = TestDiscoveryNode.create("node_3");
         AtomicArray<SearchPhaseResult> array = new AtomicArray<>(3);
         SearchAsyncActionTests.TestSearchPhaseResult testSearchPhaseResult1 = new SearchAsyncActionTests.TestSearchPhaseResult(
             new ShardSearchContextId(UUIDs.randomBase64UUID(), 1),
@@ -149,9 +149,9 @@ public class ClearScrollControllerTests extends ESTestCase {
     }
 
     public void testClearScrollIdsWithFailure() throws IOException, InterruptedException {
-        DiscoveryNode node1 = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node2 = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node3 = new DiscoveryNode("node_3", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node_1");
+        DiscoveryNode node2 = TestDiscoveryNode.create("node_2");
+        DiscoveryNode node3 = TestDiscoveryNode.create("node_3");
         AtomicArray<SearchPhaseResult> array = new AtomicArray<>(3);
         SearchAsyncActionTests.TestSearchPhaseResult testSearchPhaseResult1 = new SearchAsyncActionTests.TestSearchPhaseResult(
             new ShardSearchContextId(UUIDs.randomBase64UUID(), 1),

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -8,11 +8,11 @@
 package org.elasticsearch.action.search;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -66,8 +66,8 @@ public class SearchAsyncActionTests extends ESTestCase {
         ActionListener<SearchResponse> responseListener = ActionListener.wrap(searchResponse::set, (e) -> {
             throw new AssertionError("unexpected", e);
         });
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
 
         AtomicInteger contextIdGenerator = new AtomicInteger(0);
         GroupShardsIterator<SearchShardIterator> shardsIter = getShardsIter(
@@ -184,9 +184,9 @@ public class SearchAsyncActionTests extends ESTestCase {
             response -> {},
             (e) -> { throw new AssertionError("unexpected", e); }
         );
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
         // for the sake of this test we place the replica on the same node. ie. this is not a mistake since we limit per node now
-        DiscoveryNode replicaNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_1");
 
         AtomicInteger contextIdGenerator = new AtomicInteger(0);
         GroupShardsIterator<SearchShardIterator> shardsIter = getShardsIter(
@@ -287,8 +287,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 throw new AssertionError("unexpected", e);
             }
         );
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
 
         Map<DiscoveryNode, Set<ShardSearchContextId>> nodeToContextMap = newConcurrentMap();
         AtomicInteger contextIdGenerator = new AtomicInteger(0);
@@ -408,8 +408,8 @@ public class SearchAsyncActionTests extends ESTestCase {
                 latch.countDown();
             }
         );
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_2");
 
         Map<DiscoveryNode, Set<ShardSearchContextId>> nodeToContextMap = newConcurrentMap();
         AtomicInteger contextIdGenerator = new AtomicInteger(0);
@@ -523,9 +523,9 @@ public class SearchAsyncActionTests extends ESTestCase {
             response -> {},
             (e) -> { throw new AssertionError("unexpected", e); }
         );
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
         // for the sake of this test we place the replica on the same node. ie. this is not a mistake since we limit per node now
-        DiscoveryNode replicaNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node_1");
 
         AtomicInteger contextIdGenerator = new AtomicInteger(0);
         GroupShardsIterator<SearchShardIterator> shardsIter = getShardsIter(
@@ -619,7 +619,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         ActionListener<SearchResponse> responseListener = ActionListener.wrap(searchResponse::set, (e) -> {
             throw new AssertionError("unexpected", e);
         });
-        DiscoveryNode primaryNode = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node_1");
 
         final int numUnavailableSkippedShards = randomIntBetween(1, 10);
         List<SearchShardIterator> searchShardIterators = new ArrayList<>(numUnavailableSkippedShards);

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -260,8 +260,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         int numConcurrent = randomIntBetween(1, 4);
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode newVersionNode = new DiscoveryNode("node1", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode oldVersionNode = new DiscoveryNode("node2", buildNewFakeTransportAddress(), oldVersion);
+        DiscoveryNode newVersionNode = TestDiscoveryNode.create("node1", buildNewFakeTransportAddress(), newVersion);
+        DiscoveryNode oldVersionNode = TestDiscoveryNode.create("node2", buildNewFakeTransportAddress(), oldVersion);
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(newVersionNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(oldVersionNode));
 
@@ -360,8 +360,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         AtomicInteger successfulOps = new AtomicInteger();
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode newVersionNode = new DiscoveryNode("node1", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode oldVersionNode = new DiscoveryNode("node2", buildNewFakeTransportAddress(), oldVersion);
+        DiscoveryNode newVersionNode = TestDiscoveryNode.create("node1", buildNewFakeTransportAddress(), newVersion);
+        DiscoveryNode oldVersionNode = TestDiscoveryNode.create("node2", buildNewFakeTransportAddress(), oldVersion);
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(newVersionNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(oldVersionNode));
 
@@ -502,9 +502,9 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         AtomicInteger successfulOps = new AtomicInteger();
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode newVersionNode1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode newVersionNode2 = new DiscoveryNode("node2", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode oldVersionNode = new DiscoveryNode("node3", buildNewFakeTransportAddress(), oldVersion);
+        DiscoveryNode newVersionNode1 = TestDiscoveryNode.create("node1", buildNewFakeTransportAddress(), newVersion);
+        DiscoveryNode newVersionNode2 = TestDiscoveryNode.create("node2", buildNewFakeTransportAddress(), newVersion);
+        DiscoveryNode oldVersionNode = TestDiscoveryNode.create("node3", buildNewFakeTransportAddress(), oldVersion);
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(newVersionNode1));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(newVersionNode2));
         lookup.put("node3", new SearchAsyncActionTests.MockConnection(oldVersionNode));

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -79,8 +80,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         );
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode primaryNode = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode replicaNode = new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode primaryNode = TestDiscoveryNode.create("node1");
+        DiscoveryNode replicaNode = TestDiscoveryNode.create("node2");
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(primaryNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(replicaNode));
 

--- a/server/src/test/java/org/elasticsearch/action/search/SearchScrollAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchScrollAsyncActionTests.java
@@ -7,10 +7,10 @@
  */
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.TimeValue;
@@ -45,9 +45,9 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             new SearchContextIdForNode(null, "node3", new ShardSearchContextId(UUIDs.randomBase64UUID(), 0))
         );
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
+            .add(TestDiscoveryNode.create("node2"))
+            .add(TestDiscoveryNode.create("node3"))
             .build();
 
         AtomicArray<SearchAsyncActionTests.TestSearchPhaseResult> results = new AtomicArray<>(scrollId.getContext().length);
@@ -119,9 +119,9 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             new SearchContextIdForNode(null, "node3", new ShardSearchContextId("d", 0))
         );
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
+            .add(TestDiscoveryNode.create("node2"))
+            .add(TestDiscoveryNode.create("node3"))
             .build();
 
         AtomicArray<SearchAsyncActionTests.TestSearchPhaseResult> results = new AtomicArray<>(scrollId.getContext().length);
@@ -216,8 +216,8 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
         );
         // node2 is not available
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
+            .add(TestDiscoveryNode.create("node3"))
             .build();
 
         AtomicArray<SearchAsyncActionTests.TestSearchPhaseResult> results = new AtomicArray<>(scrollId.getContext().length);
@@ -300,9 +300,9 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             new SearchContextIdForNode(null, "node3", new ShardSearchContextId("", 0))
         );
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
+            .add(TestDiscoveryNode.create("node2"))
+            .add(TestDiscoveryNode.create("node3"))
             .build();
 
         AtomicArray<SearchAsyncActionTests.TestSearchPhaseResult> results = new AtomicArray<>(scrollId.getContext().length);
@@ -381,9 +381,9 @@ public class SearchScrollAsyncActionTests extends ESTestCase {
             new SearchContextIdForNode(null, "node3", new ShardSearchContextId("", 0))
         );
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
+            .add(TestDiscoveryNode.create("node2"))
+            .add(TestDiscoveryNode.create("node3"))
             .build();
 
         AtomicArray<SearchAsyncActionTests.TestSearchPhaseResult> results = new AtomicArray<>(scrollId.getContext().length);

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.GroupShardsIterator;
 import org.elasticsearch.cluster.routing.GroupShardsIteratorTests;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
@@ -256,9 +257,7 @@ public class TransportSearchActionTests extends ESTestCase {
             RemoteClusterService service = transportService.getRemoteClusterService();
             assertFalse(service.isCrossClusterSearchEnabled());
             Map<String, ClusterSearchShardsResponse> searchShardsResponseMap = new HashMap<>();
-            DiscoveryNode[] nodes = new DiscoveryNode[] {
-                new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT),
-                new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT) };
+            DiscoveryNode[] nodes = new DiscoveryNode[] { TestDiscoveryNode.create("node1"), TestDiscoveryNode.create("node2") };
             Map<String, AliasFilter> indicesAndAliases = new HashMap<>();
             indicesAndAliases.put("foo", AliasFilter.of(new TermsQueryBuilder("foo", "bar"), "some_alias_for_foo", "some_other_foo_alias"));
             indicesAndAliases.put("bar", AliasFilter.of(new MatchAllQueryBuilder(), Strings.EMPTY_ARRAY));
@@ -282,7 +281,7 @@ public class TransportSearchActionTests extends ESTestCase {
                         TestShardRouting.newShardRouting("bar", 0, "node1", false, ShardRoutingState.STARTED) }
                 ) };
             searchShardsResponseMap.put("test_cluster_1", new ClusterSearchShardsResponse(groups, nodes, indicesAndAliases));
-            DiscoveryNode[] nodes2 = new DiscoveryNode[] { new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT) };
+            DiscoveryNode[] nodes2 = new DiscoveryNode[] { TestDiscoveryNode.create("node3") };
             ClusterSearchShardsGroup[] groups2 = new ClusterSearchShardsGroup[] {
                 new ClusterSearchShardsGroup(
                     new ShardId("xyz", "xyz_id", 0),

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -354,15 +354,13 @@ public class TransportSearchActionTests extends ESTestCase {
     }
 
     public void testBuildConnectionLookup() {
-        Function<String, DiscoveryNode> localNodes = (nodeId) -> new DiscoveryNode(
+        Function<String, DiscoveryNode> localNodes = (nodeId) -> TestDiscoveryNode.create(
             "local-" + nodeId,
-            new TransportAddress(TransportAddress.META_ADDRESS, 1024),
-            Version.CURRENT
+            new TransportAddress(TransportAddress.META_ADDRESS, 1024)
         );
-        BiFunction<String, String, DiscoveryNode> remoteNodes = (clusterAlias, nodeId) -> new DiscoveryNode(
+        BiFunction<String, String, DiscoveryNode> remoteNodes = (clusterAlias, nodeId) -> TestDiscoveryNode.create(
             "remote-" + nodeId,
-            new TransportAddress(TransportAddress.META_ADDRESS, 2048),
-            Version.CURRENT
+            new TransportAddress(TransportAddress.META_ADDRESS, 2048)
         );
         BiFunction<String, DiscoveryNode, Transport.Connection> nodeToConnection = (clusterAlias, node) -> new Transport.Connection() {
             @Override

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchHelperTests.java
@@ -7,8 +7,8 @@
  */
 package org.elasticsearch.action.search;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.search.SearchPhaseResult;
@@ -22,9 +22,9 @@ public class TransportSearchHelperTests extends ESTestCase {
 
     public static AtomicArray<SearchPhaseResult> generateQueryResults() {
         AtomicArray<SearchPhaseResult> array = new AtomicArray<>(3);
-        DiscoveryNode node1 = new DiscoveryNode("node_1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node2 = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node3 = new DiscoveryNode("node_3", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node_1");
+        DiscoveryNode node2 = TestDiscoveryNode.create("node_2");
+        DiscoveryNode node3 = TestDiscoveryNode.create("node_3");
         SearchAsyncActionTests.TestSearchPhaseResult testSearchPhaseResult1 = new SearchAsyncActionTests.TestSearchPhaseResult(
             new ShardSearchContextId("a", 1),
             node1

--- a/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/master/TransportMasterNodeActionTests.java
@@ -36,6 +36,7 @@ import org.elasticsearch.cluster.metadata.ReservedStateMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
@@ -529,7 +530,7 @@ public class TransportMasterNodeActionTests extends ESTestCase {
                 // simulate master restart followed by a state recovery - this will reset the cluster state version
                 final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder(clusterService.state().nodes());
                 nodesBuilder.remove(masterNode);
-                masterNode = new DiscoveryNode(masterNode.getId(), masterNode.getAddress(), masterNode.getVersion());
+                masterNode = TestDiscoveryNode.create(masterNode.getId(), masterNode.getAddress(), masterNode.getVersion());
                 nodesBuilder.add(masterNode);
                 nodesBuilder.masterNodeId(masterNode.getId());
                 final ClusterState.Builder builder = ClusterState.builder(clusterService.state()).nodes(nodesBuilder);

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -10,7 +10,6 @@ package org.elasticsearch.action.support.replication;
 import org.apache.logging.log4j.Logger;
 import org.apache.lucene.index.CorruptIndexException;
 import org.apache.lucene.store.AlreadyClosedException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.UnavailableShardsException;
 import org.elasticsearch.action.support.ActiveShardCount;
@@ -202,7 +201,7 @@ public class ReplicationOperationTests extends ESTestCase {
                 exception = new RemoteTransportException("remote", cause);
             } else {
                 TransportAddress address = new TransportAddress(InetAddress.getLoopbackAddress(), 9300);
-                DiscoveryNode node = new DiscoveryNode("replica", address, Version.CURRENT);
+                DiscoveryNode node = TestDiscoveryNode.create("replica", address);
                 cause = new ConnectTransportException(node, "broken");
                 exception = cause;
             }

--- a/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/replication/ReplicationOperationTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.action.shard.ShardStateAction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -309,9 +310,9 @@ public class ReplicationOperationTests extends ESTestCase {
         final boolean testPrimaryDemotedOnStaleShardCopies = randomBoolean();
         final Exception shardActionFailure;
         if (randomBoolean()) {
-            shardActionFailure = new NodeClosedException(new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT));
+            shardActionFailure = new NodeClosedException(TestDiscoveryNode.create("foo"));
         } else if (randomBoolean()) {
-            DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode node = TestDiscoveryNode.create("foo");
             shardActionFailure = new SendRequestTransportException(
                 node,
                 ShardStateAction.SHARD_FAILED_ACTION_NAME,

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -1021,7 +1022,7 @@ public class ClusterStateTests extends ESTestCase {
             .nodes(
                 DiscoveryNodes.builder()
                     .masterNodeId("nodeId1")
-                    .add(new DiscoveryNode("nodeId1", new TransportAddress(InetAddress.getByName("127.0.0.1"), 111), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("nodeId1", new TransportAddress(InetAddress.getByName("127.0.0.1"), 111)))
                     .build()
             )
             .putTransportVersion("nodeId1", TransportVersion.CURRENT)

--- a/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/InternalClusterInfoServiceSchedulingTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.cluster;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -19,6 +18,7 @@ import org.elasticsearch.cluster.block.ClusterBlockException;
 import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.FakeThreadPoolMasterService;
@@ -42,7 +42,7 @@ import static org.hamcrest.Matchers.equalTo;
 public class InternalClusterInfoServiceSchedulingTests extends ESTestCase {
 
     public void testScheduling() {
-        final DiscoveryNode discoveryNode = new DiscoveryNode("test", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode discoveryNode = TestDiscoveryNode.create("test");
         final DiscoveryNodes noMaster = DiscoveryNodes.builder().add(discoveryNode).localNodeId(discoveryNode.getId()).build();
         final DiscoveryNodes localMaster = DiscoveryNodes.builder(noMaster).masterNodeId(discoveryNode.getId()).build();
 

--- a/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/NodeConnectionsServiceTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.component.LifecycleListener;
@@ -260,7 +261,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
         });
 
         // connect to one node
-        final DiscoveryNode node0 = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode node0 = TestDiscoveryNode.create("node0");
         final DiscoveryNodes nodes0 = DiscoveryNodes.builder().add(node0).build();
         connectToNodes(service, nodes0);
         assertConnectedExactlyToNodes(nodes0);
@@ -272,7 +273,7 @@ public class NodeConnectionsServiceTests extends ESTestCase {
             transportService.disconnectFromNode(node0);
 
             // can still connect to another node without blocking
-            final DiscoveryNode node1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
+            final DiscoveryNode node1 = TestDiscoveryNode.create("node1");
             final DiscoveryNodes nodes1 = DiscoveryNodes.builder().add(node1).build();
             final DiscoveryNodes nodes01 = DiscoveryNodes.builder(nodes0).add(node1).build();
             connectToNodes(service, nodes01);

--- a/server/src/test/java/org/elasticsearch/cluster/action/index/MappingUpdatedActionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/index/MappingUpdatedActionTests.java
@@ -16,8 +16,8 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.IndicesAdminClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -129,7 +129,7 @@ public class MappingUpdatedActionTests extends ESTestCase {
 
     public void testSendUpdateMappingUsingAutoPutMappingAction() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.V_7_9_0))
+            .add(TestDiscoveryNode.create("first", buildNewFakeTransportAddress(), Version.V_7_9_0))
             .build();
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
         ClusterService clusterService = mock(ClusterService.class);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelperTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -992,13 +993,13 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
         final DiscoveryNode localNode = makeDiscoveryNode("local");
         List<TransportAddress> resolvedAddresses = List.of(buildNewFakeTransportAddress(), buildNewFakeTransportAddress());
         List<DiscoveryNode> foundPeers = List.of(
-            new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT),
-            new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT),
-            new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT)
+            TestDiscoveryNode.create(UUID.randomUUID().toString()),
+            TestDiscoveryNode.create(UUID.randomUUID().toString()),
+            TestDiscoveryNode.create(UUID.randomUUID().toString())
         );
         List<JoinStatus> joinStatuses = List.of(
             new JoinStatus(
-                new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT),
+                TestDiscoveryNode.create(UUID.randomUUID().toString()),
                 1,
                 "join status message",
                 new TimeValue(500, TimeUnit.SECONDS)
@@ -1067,7 +1068,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
             }
             case 2 -> {
                 List<DiscoveryNode> newFoundPeers = new ArrayList<>(foundPeers);
-                newFoundPeers.add(new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT));
+                newFoundPeers.add(TestDiscoveryNode.create(UUID.randomUUID().toString()));
                 return new ClusterFormationState(
                     settings,
                     clusterState,
@@ -1083,7 +1084,7 @@ public class ClusterFormationFailureHelperTests extends ESTestCase {
                 List<JoinStatus> newJoinStatuses = new ArrayList<>(joinStatuses);
                 newJoinStatuses.add(
                     new JoinStatus(
-                        new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT),
+                        TestDiscoveryNode.create(UUID.randomUUID().toString()),
                         1,
                         "join status message",
                         new TimeValue(500, TimeUnit.SECONDS)

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinationStateTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -854,9 +855,7 @@ public class CoordinationStateTests extends ESTestCase {
 
     public void testSafety() {
         new CoordinationStateTestCluster(
-            IntStream.range(0, randomIntBetween(1, 5))
-                .mapToObj(i -> new DiscoveryNode("node_" + i, buildNewFakeTransportAddress(), Version.CURRENT))
-                .toList(),
+            IntStream.range(0, randomIntBetween(1, 5)).mapToObj(i -> TestDiscoveryNode.create("node_" + i)).toList(),
             ElectionStrategy.DEFAULT_INSTANCE
         ).runRandomly();
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinHelperTests.java
@@ -11,11 +11,11 @@ import org.apache.logging.log4j.Level;
 import org.elasticsearch.Build;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.NotMasterException;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.MasterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -60,7 +60,7 @@ public class JoinHelperTests extends ESTestCase {
     public void testJoinDeduplication() {
         DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
         CapturingTransport capturingTransport = new HandshakingCapturingTransport();
-        DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node0");
         final var threadPool = deterministicTaskQueue.getThreadPool();
         final var clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final var taskManger = new TaskManager(Settings.EMPTY, threadPool, Set.of());
@@ -94,8 +94,8 @@ public class JoinHelperTests extends ESTestCase {
         );
         transportService.start();
 
-        DiscoveryNode node1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node2 = new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node1");
+        DiscoveryNode node2 = TestDiscoveryNode.create("node2");
         final boolean mightSucceed = randomBoolean();
 
         assertFalse(joinHelper.isJoinPending());
@@ -225,7 +225,7 @@ public class JoinHelperTests extends ESTestCase {
     public void testJoinFailureOnUnhealthyNodes() {
         DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
         CapturingTransport capturingTransport = new HandshakingCapturingTransport();
-        DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node0");
         ThreadPool threadPool = deterministicTaskQueue.getThreadPool();
         final var clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final var taskManger = new TaskManager(Settings.EMPTY, threadPool, Set.of());
@@ -260,8 +260,8 @@ public class JoinHelperTests extends ESTestCase {
         );
         transportService.start();
 
-        DiscoveryNode node1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode node2 = new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node1");
+        DiscoveryNode node2 = TestDiscoveryNode.create("node2");
 
         assertFalse(joinHelper.isJoinPending());
 
@@ -301,7 +301,7 @@ public class JoinHelperTests extends ESTestCase {
     public void testLatestStoredStateFailure() {
         DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
         CapturingTransport capturingTransport = new HandshakingCapturingTransport();
-        DiscoveryNode localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node0");
         final var threadPool = deterministicTaskQueue.getThreadPool();
         final var clusterSettings = new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS);
         final var taskManger = new TaskManager(Settings.EMPTY, threadPool, Set.of());

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinStatusTests.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
@@ -21,7 +21,7 @@ public class JoinStatusTests extends ESTestCase {
 
     public void testSerialization() throws Exception {
         JoinStatus joinStatus = new JoinStatus(
-            new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT),
+            TestDiscoveryNode.create(UUID.randomUUID().toString()),
             randomLongBetween(0, 1000),
             randomAlphaOfLengthBetween(0, 100),
             randomNonNegativeTimeValue()
@@ -60,7 +60,7 @@ public class JoinStatusTests extends ESTestCase {
                 );
             }
             case 4 -> {
-                DiscoveryNode newNode = new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT);
+                DiscoveryNode newNode = TestDiscoveryNode.create(UUID.randomUUID().toString());
                 return new JoinStatus(newNode, originalJoinStatus.term(), originalJoinStatus.message(), originalJoinStatus.age());
             }
             default -> throw new IllegalStateException();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/JoinValidationServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.SimpleDiffable;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.component.Lifecycle;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -130,7 +131,7 @@ public class JoinValidationServiceTests extends ESTestCase {
                 }
             };
 
-            final var localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+            final var localNode = TestDiscoveryNode.create("local");
 
             final var transportService = new TransportService(
                 settings,
@@ -158,7 +159,7 @@ public class JoinValidationServiceTests extends ESTestCase {
 
             final var otherNodes = new DiscoveryNode[between(1, 10)];
             for (int i = 0; i < otherNodes.length; i++) {
-                otherNodes[i] = new DiscoveryNode("other-" + i, buildNewFakeTransportAddress(), Version.CURRENT);
+                otherNodes[i] = TestDiscoveryNode.create("other-" + i);
                 final var connectionListener = new PlainActionFuture<Releasable>();
                 transportService.connectToNode(otherNodes[i], connectionListener);
                 releasables.add(connectionListener.get(10, TimeUnit.SECONDS));
@@ -260,7 +261,7 @@ public class JoinValidationServiceTests extends ESTestCase {
         final var deterministicTaskQueue = new DeterministicTaskQueue();
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT).putCustom("test", new BadCustom()).build();
 
-        final var joiningNode = new DiscoveryNode("joining", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var joiningNode = TestDiscoveryNode.create("joining");
         final var joiningNodeTransport = new MockTransport();
         final var joiningNodeTransportService = joiningNodeTransport.createTransportService(
             Settings.EMPTY,
@@ -274,7 +275,7 @@ public class JoinValidationServiceTests extends ESTestCase {
         joiningNodeTransportService.start();
         joiningNodeTransportService.acceptIncomingRequests();
 
-        final var masterNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create("node0");
         final var masterTransport = new MockTransport() {
             @Override
             protected void onSendRequest(long requestId, String action, TransportRequest request, DiscoveryNode node) {
@@ -338,7 +339,7 @@ public class JoinValidationServiceTests extends ESTestCase {
     public void testJoinValidationRejectsMismatchedClusterUUID() {
         final var deterministicTaskQueue = new DeterministicTaskQueue();
         final var mockTransport = new MockTransport();
-        final var localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var localNode = TestDiscoveryNode.create("node0");
 
         final var localClusterState = ClusterState.builder(ClusterName.DEFAULT)
             .metadata(Metadata.builder().generateClusterUuidIfNeeded().clusterUUIDCommitted(true))
@@ -387,7 +388,7 @@ public class JoinValidationServiceTests extends ESTestCase {
     public void testJoinValidationRunsJoinValidators() {
         final var deterministicTaskQueue = new DeterministicTaskQueue();
         final var mockTransport = new MockTransport();
-        final var localNode = new DiscoveryNode("node0", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var localNode = TestDiscoveryNode.create("node0");
         final var localClusterState = ClusterState.builder(ClusterName.DEFAULT).build();
 
         final var transportService = mockTransport.createTransportService(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LagDetectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LagDetectorTests.java
@@ -9,8 +9,8 @@ package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.ReferenceDocs;
 import org.elasticsearch.common.logging.ChunkedLoggingStreamTests;
 import org.elasticsearch.common.settings.Settings;
@@ -255,7 +255,7 @@ public class LagDetectorTests extends ESTestCase {
 
     @TestLogging(reason = "testing LagDetector logging", value = LOGGER_NAME + ":DEBUG")
     public void testHotThreadsChunkedLoggingEncoding() {
-        final var node = new DiscoveryNode("test", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var node = TestDiscoveryNode.create("test");
         final var expectedBody = randomUnicodeOfLengthBetween(1, 20000);
         assertEquals(
             expectedBody,

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.coordination.LeaderChecker.LeaderCheckRequest;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -64,12 +65,10 @@ import static org.hamcrest.Matchers.startsWith;
 public class LeaderCheckerTests extends ESTestCase {
 
     public void testFollowerBehaviour() {
-        final DiscoveryNode leader1 = new DiscoveryNode("leader-1", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode leader2 = randomBoolean()
-            ? leader1
-            : new DiscoveryNode("leader-2", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode leader1 = TestDiscoveryNode.create("leader-1");
+        final DiscoveryNode leader2 = randomBoolean() ? leader1 : TestDiscoveryNode.create("leader-2");
 
-        final DiscoveryNode localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("local-node");
         Settings.Builder settingsBuilder = Settings.builder().put(NODE_NAME_SETTING.getKey(), localNode.getId());
 
         final long leaderCheckIntervalMillis;
@@ -244,8 +243,8 @@ public class LeaderCheckerTests extends ESTestCase {
     }
 
     public void testFollowerFailsImmediatelyOnDisconnection() {
-        final DiscoveryNode localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode leader = new DiscoveryNode("leader", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("local-node");
+        final DiscoveryNode leader = TestDiscoveryNode.create("leader");
 
         final Response[] responseHolder = new Response[] { Response.SUCCESS };
 
@@ -380,8 +379,8 @@ public class LeaderCheckerTests extends ESTestCase {
     }
 
     public void testFollowerFailsImmediatelyOnHealthCheckFailure() {
-        final DiscoveryNode localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode leader = new DiscoveryNode("leader", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("local-node");
+        final DiscoveryNode leader = TestDiscoveryNode.create("leader");
 
         final Response[] responseHolder = new Response[] { Response.SUCCESS };
 
@@ -465,8 +464,8 @@ public class LeaderCheckerTests extends ESTestCase {
     }
 
     public void testLeaderBehaviour() {
-        final DiscoveryNode localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("local-node");
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         final Settings settings = Settings.builder().put(NODE_NAME_SETTING.getKey(), localNode.getId()).build();
         final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
         final CapturingTransport capturingTransport = new CapturingTransport();
@@ -576,14 +575,12 @@ public class LeaderCheckerTests extends ESTestCase {
     }
 
     public void testLeaderCheckRequestEqualsHashcodeSerialization() {
-        LeaderCheckRequest request = new LeaderCheckRequest(
-            new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT)
-        );
+        LeaderCheckRequest request = new LeaderCheckRequest(TestDiscoveryNode.create(randomAlphaOfLength(10)));
         // noinspection RedundantCast since it is needed for some IDEs (specifically Eclipse 4.8.0) to infer the right type
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             request,
             (CopyFunction<LeaderCheckRequest>) rq -> copyWriteable(rq, writableRegistry(), LeaderCheckRequest::new),
-            rq -> new LeaderCheckRequest(new DiscoveryNode(randomAlphaOfLength(10), buildNewFakeTransportAddress(), Version.CURRENT))
+            rq -> new LeaderCheckRequest(TestDiscoveryNode.create(randomAlphaOfLength(10)))
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryServiceTests.java
@@ -8,8 +8,8 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -33,7 +33,7 @@ public class MasterHistoryServiceTests extends ESTestCase {
         MasterHistoryService masterHistoryService = createMasterHistoryService();
         List<DiscoveryNode> remoteHistory = masterHistoryService.getRemoteMasterHistory();
         assertNull(remoteHistory);
-        DiscoveryNode masterNode = new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode masterNode = TestDiscoveryNode.create(UUID.randomUUID().toString());
         List<DiscoveryNode> masterHistory = new ArrayList<>();
         masterHistory.add(masterNode);
         masterHistory.add(null);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MasterHistoryTests.java
@@ -8,13 +8,13 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
@@ -237,7 +237,7 @@ public class MasterHistoryTests extends ESTestCase {
         Metadata.Builder metadataBuilder = Metadata.builder();
         DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
         if (masterNodeId != null) {
-            DiscoveryNode node = new DiscoveryNode(masterNodeId, buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode node = TestDiscoveryNode.create(masterNodeId);
             nodesBuilder.masterNodeId(masterNodeId);
             nodesBuilder.add(node);
         }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/MessagesTests.java
@@ -7,9 +7,9 @@
  */
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
@@ -22,7 +22,7 @@ import java.util.Set;
 public class MessagesTests extends ESTestCase {
 
     private DiscoveryNode createNode(String id) {
-        return new DiscoveryNode(id, buildNewFakeTransportAddress(), Version.CURRENT);
+        return TestDiscoveryNode.create(id);
     }
 
     public void testJoinEqualsHashCodeSerialization() {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
@@ -214,9 +215,9 @@ public class NodeJoinExecutorTests extends ESTestCase {
 
         final NodeJoinExecutor executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final DiscoveryNode masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode masterNode = TestDiscoveryNode.create(UUIDs.base64UUID());
 
-        final DiscoveryNode actualNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode actualNode = TestDiscoveryNode.create(UUIDs.base64UUID());
         final DiscoveryNode bwcNode = new DiscoveryNode(
             actualNode.getName(),
             actualNode.getId(),
@@ -248,7 +249,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final long executorTerm = randomLongBetween(0L, Long.MAX_VALUE - 1);
         final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).masterNodeId(masterNode.getId()).build())
             .metadata(
@@ -291,8 +292,8 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final long executorTerm = randomNonNegativeLong();
         final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
-        final var localNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
+        final var localNode = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(
                 DiscoveryNodes.builder()
@@ -342,7 +343,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final long executorTerm = randomNonNegativeLong();
         final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final var masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create(UUIDs.base64UUID());
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).build())
             .metadata(
@@ -374,8 +375,8 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final long executorTerm = randomLongBetween(1, Long.MAX_VALUE);
         final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
-        final var otherNodeOld = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
+        final var otherNodeOld = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
         final var otherNodeNew = new DiscoveryNode(
             otherNodeOld.getName(),
             otherNodeOld.getId(),
@@ -439,7 +440,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final long executorTerm = randomLongBetween(1, Long.MAX_VALUE);
         final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
         final var otherNode = new DiscoveryNode(
             UUIDs.randomBase64UUID(random()),
             UUIDs.randomBase64UUID(random()),
@@ -519,7 +520,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
         final long currentTerm = randomLongBetween(100, 1000);
         final var executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final var masterNode = new DiscoveryNode(UUIDs.randomBase64UUID(random()), buildNewFakeTransportAddress(), Version.CURRENT);
+        final var masterNode = TestDiscoveryNode.create(UUIDs.randomBase64UUID(random()));
         final var clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).masterNodeId(masterNode.getId()).build())
             .metadata(Metadata.builder().coordinationMetadata(CoordinationMetadata.builder().term(currentTerm).build()).build())
@@ -629,7 +630,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
 
         final NodeJoinExecutor executor = new NodeJoinExecutor(allocationService, rerouteService);
 
-        final DiscoveryNode masterNode = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode masterNode = TestDiscoveryNode.create(UUIDs.base64UUID());
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(masterNode).localNodeId(masterNode.getId()).masterNodeId(masterNode.getId()))
             .build();
@@ -640,7 +641,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
             var ignored = appender.capturing(NodeJoinExecutor.class);
             var clusterService = ClusterServiceUtils.createClusterService(clusterState, threadPool)
         ) {
-            final var node1 = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+            final var node1 = TestDiscoveryNode.create(UUIDs.base64UUID());
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(
                     "info message",
@@ -660,7 +661,7 @@ public class NodeJoinExecutorTests extends ESTestCase {
             );
             appender.assertAllExpectationsMatched();
 
-            final var node2 = new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), Version.CURRENT);
+            final var node2 = TestDiscoveryNode.create(UUIDs.base64UUID());
             final var testReasonWithLink = new JoinReason("test", ReferenceDocs.UNSTABLE_CLUSTER_TROUBLESHOOTING);
             appender.addExpectation(
                 new MockLogAppender.SeenEventExpectation(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -107,8 +107,10 @@ public class NodeJoinExecutorTests extends ESTestCase {
     public void testPreventJoinClusterWithUnsupportedNodeVersions() {
         DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
         final Version version = randomCompatibleVersion(random(), Version.CURRENT);
-        builder.add(new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), version));
-        builder.add(new DiscoveryNode(UUIDs.base64UUID(), buildNewFakeTransportAddress(), randomCompatibleVersion(random(), version)));
+        builder.add(TestDiscoveryNode.create(UUIDs.base64UUID(), buildNewFakeTransportAddress(), version));
+        builder.add(
+            TestDiscoveryNode.create(UUIDs.base64UUID(), buildNewFakeTransportAddress(), randomCompatibleVersion(random(), version))
+        );
         DiscoveryNodes nodes = builder.build();
 
         final Version maxNodeVersion = nodes.getMaxNodeVersion();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeLeftExecutorTests.java
@@ -10,12 +10,12 @@ package org.elasticsearch.cluster.coordination;
 
 import org.apache.logging.log4j.Level;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.AllocationService;
 import org.elasticsearch.cluster.service.ClusterStateTaskExecutorUtils;
 import org.elasticsearch.common.Priority;
@@ -110,14 +110,10 @@ public class NodeLeftExecutorTests extends ESTestCase {
         );
         final var executor = new NodeLeftExecutor(allocationService);
 
-        final DiscoveryNode masterNode = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode masterNode = TestDiscoveryNode.create("master");
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(
-                DiscoveryNodes.builder()
-                    .add(masterNode)
-                    .localNodeId("master")
-                    .masterNodeId("master")
-                    .add(new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT))
+                DiscoveryNodes.builder().add(masterNode).localNodeId("master").masterNodeId("master").add(TestDiscoveryNode.create("other"))
             )
             .build();
 
@@ -150,7 +146,7 @@ public class NodeLeftExecutorTests extends ESTestCase {
     }
 
     private static DiscoveryNode node(final int id) {
-        return new DiscoveryNode(Integer.toString(id), buildNewFakeTransportAddress(), Version.CURRENT);
+        return TestDiscoveryNode.create(Integer.toString(id));
     }
 
     // Hard-coding the class name here because it is also mentioned in the troubleshooting docs, so should not be renamed without care.

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -228,7 +228,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
 
             final List<DiscoveryNode> allNodes = new ArrayList<>();
             while (allNodes.size() < 10) {
-                var node = new DiscoveryNode(
+                var node = TestDiscoveryNode.create(
                     "node-" + allNodes.size(),
                     buildNewFakeTransportAddress(),
                     VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
@@ -361,7 +361,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         final var completed = new AtomicBoolean();
 
         final var localNode = TestDiscoveryNode.create("localNode");
-        final var otherNode = new DiscoveryNode(
+        final var otherNode = TestDiscoveryNode.create(
             "otherNode",
             buildNewFakeTransportAddress(),
             VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.BatchSummary;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.compress.Compressor;
@@ -77,7 +78,7 @@ import static org.mockito.Mockito.when;
 public class PublicationTransportHandlerTests extends ESTestCase {
 
     public void testDiffSerializationFailure() {
-        final DiscoveryNode localNode = new DiscoveryNode("localNode", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("localNode");
 
         final TransportService transportService = mock(TransportService.class);
         final BytesRefRecycler recycler = new BytesRefRecycler(new MockPageCacheRecycler(Settings.EMPTY));
@@ -88,7 +89,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
 
         final PublicationTransportHandler handler = new PublicationTransportHandler(transportService, writableRegistry(), pu -> null);
 
-        final DiscoveryNode otherNode = new DiscoveryNode("otherNode", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("otherNode");
         final ClusterState clusterState = CoordinationStateTests.clusterState(
             2L,
             1L,
@@ -359,7 +360,7 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         final var receivedStateRef = new AtomicReference<ClusterState>();
         final var completed = new AtomicBoolean();
 
-        final var localNode = new DiscoveryNode("localNode", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var localNode = TestDiscoveryNode.create("localNode");
         final var otherNode = new DiscoveryNode(
             "otherNode",
             buildNewFakeTransportAddress(),

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ReconfiguratorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ReconfiguratorTests.java
@@ -8,9 +8,9 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.settings.Settings.Builder;
@@ -174,7 +174,7 @@ public class ReconfiguratorTests extends ESTestCase {
     private Set<DiscoveryNode> nodes(String... nodes) {
         final Set<DiscoveryNode> liveNodes = new HashSet<>();
         for (String id : nodes) {
-            liveNodes.add(new DiscoveryNode(id, buildNewFakeTransportAddress(), Version.CURRENT));
+            liveNodes.add(TestDiscoveryNode.create(id));
         }
         return liveNodes;
     }

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/StatefulPreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/StatefulPreVoteCollectorTests.java
@@ -8,10 +8,10 @@
 
 package org.elasticsearch.cluster.coordination;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata.VotingConfiguration;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -102,7 +102,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
         currentTerm = randomLongBetween(lastAcceptedTerm, Long.MAX_VALUE);
         lastAcceptedVersion = randomNonNegativeLong();
 
-        localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        localNode = TestDiscoveryNode.create("local-node");
         responsesByNode.put(localNode, new PreVoteResponse(currentTerm, lastAcceptedTerm, lastAcceptedVersion));
         healthStatus = new StatusInfo(HEALTHY, "healthy-info");
         transportService = mockTransport.createTransportService(
@@ -168,21 +168,21 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
     }
 
     public void testStartsElectionIfLocalNodeIsQuorum() {
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(otherNode, getLocalPreVoteResponse());
         startAndRunCollector(otherNode);
         assertTrue(electionOccurred);
     }
 
     public void testStartsElectionIfOtherNodeIsQuorum() {
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(otherNode, getLocalPreVoteResponse());
         startAndRunCollector(otherNode);
         assertTrue(electionOccurred);
     }
 
     public void testDoesNotStartsElectionIfOtherNodeIsQuorumAndDoesNotRespond() {
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(otherNode, null);
         startAndRunCollector(otherNode);
         assertFalse(electionOccurred);
@@ -191,7 +191,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
     public void testUnhealthyNodeDoesNotOfferPreVote() {
         final long term = randomNonNegativeLong();
         healthStatus = new StatusInfo(UNHEALTHY, "unhealthy-info");
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         RemoteTransportException remoteTransportException = expectThrows(
             RemoteTransportException.class,
             () -> handlePreVoteRequestViaTransportService(new PreVoteRequest(otherNode, term))
@@ -200,7 +200,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
     }
 
     public void testDoesNotStartElectionIfStopped() {
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(otherNode, getLocalPreVoteResponse());
         startCollector(otherNode).close();
         runCollector();
@@ -210,7 +210,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
     public void testIgnoresPreVotesFromLaterTerms() {
         assumeTrue("unluckily chose lastAcceptedTerm too close to currentTerm, no later terms", lastAcceptedTerm < currentTerm - 1);
 
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(
             otherNode,
             new PreVoteResponse(currentTerm, randomLongBetween(lastAcceptedTerm + 1, currentTerm - 1), randomNonNegativeLong())
@@ -222,7 +222,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
     public void testIgnoresPreVotesFromLaterVersionInSameTerm() {
         assumeTrue("unluckily hit Long.MAX_VALUE for lastAcceptedVersion, cannot increment", lastAcceptedVersion < Long.MAX_VALUE);
 
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(
             otherNode,
             new PreVoteResponse(currentTerm, lastAcceptedTerm, randomLongBetween(lastAcceptedVersion + 1, Long.MAX_VALUE))
@@ -234,7 +234,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
     public void testAcceptsPreVotesFromAnyVersionInEarlierTerms() {
         assumeTrue("unluckily hit 0 for lastAcceptedTerm, cannot decrement", 0 < lastAcceptedTerm);
 
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
         responsesByNode.put(
             otherNode,
             new PreVoteResponse(currentTerm, randomLongBetween(0, lastAcceptedTerm - 1), randomNonNegativeLong())
@@ -254,7 +254,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
         final Set<DiscoveryNode> votingNodesSet = new HashSet<>();
         final int nodeCount = randomIntBetween(0, 5);
         for (int i = 0; i < nodeCount; i++) {
-            final DiscoveryNode otherNode = new DiscoveryNode("other-node-" + i, buildNewFakeTransportAddress(), Version.CURRENT);
+            final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node-" + i);
             responsesByNode.put(otherNode, randomBoolean() ? null : randomPreVoteResponse());
             PreVoteResponse newPreVoteResponse = new PreVoteResponse(currentTerm, lastAcceptedTerm, lastAcceptedVersion);
             preVoteCollector.update(newPreVoteResponse, null);
@@ -340,7 +340,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
 
     public void testResponseIfCandidate() {
         final long term = randomNonNegativeLong();
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
 
         PreVoteResponse newPreVoteResponse = new PreVoteResponse(currentTerm, lastAcceptedTerm, lastAcceptedVersion);
         preVoteCollector.update(newPreVoteResponse, null);
@@ -350,8 +350,8 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
 
     public void testResponseToNonLeaderIfNotCandidate() {
         final long term = randomNonNegativeLong();
-        final DiscoveryNode leaderNode = new DiscoveryNode("leader-node", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode otherNode = new DiscoveryNode("other-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode leaderNode = TestDiscoveryNode.create("leader-node");
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other-node");
 
         PreVoteResponse newPreVoteResponse = new PreVoteResponse(currentTerm, lastAcceptedTerm, lastAcceptedVersion);
         preVoteCollector.update(newPreVoteResponse, leaderNode);
@@ -371,7 +371,7 @@ public class StatefulPreVoteCollectorTests extends ESTestCase {
         // detect its failure.
 
         final long term = randomNonNegativeLong();
-        final DiscoveryNode leaderNode = new DiscoveryNode("leader-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode leaderNode = TestDiscoveryNode.create("leader-node");
 
         PreVoteResponse newPreVoteResponse = new PreVoteResponse(currentTerm, lastAcceptedTerm, lastAcceptedVersion);
         preVoteCollector.update(newPreVoteResponse, leaderNode);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/AtomicRegisterPreVoteCollectorTests.java
@@ -8,11 +8,10 @@
 
 package org.elasticsearch.cluster.coordination.stateless;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -46,7 +45,7 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
         final var currentTermProvider = new AtomicLong(1);
         final var heartbeatFrequency = TimeValue.timeValueSeconds(randomIntBetween(15, 30));
         final var maxTimeSinceLastHeartbeat = TimeValue.timeValueSeconds(2 * heartbeatFrequency.seconds());
-        final var leaderNode = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var leaderNode = TestDiscoveryNode.create("master");
 
         final var fakeClock = new AtomicLong();
         final var heartbeatStore = new InMemoryHeartbeatStore();
@@ -81,7 +80,7 @@ public class AtomicRegisterPreVoteCollectorTests extends ESTestCase {
         final var currentTermProvider = new AtomicLong(1);
         final var heartbeatFrequency = TimeValue.timeValueSeconds(randomIntBetween(15, 30));
         final var maxTimeSinceLastHeartbeat = TimeValue.timeValueSeconds(2 * heartbeatFrequency.seconds());
-        final var leaderNode = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var leaderNode = TestDiscoveryNode.create("master");
 
         final var fakeClock = new AtomicLong();
         final var heartbeatStore = new InMemoryHeartbeatStore();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/SingleNodeReconfiguratorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/SingleNodeReconfiguratorTests.java
@@ -8,13 +8,12 @@
 
 package org.elasticsearch.cluster.coordination.stateless;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.coordination.CoordinationMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.test.ESTestCase;
@@ -32,7 +31,7 @@ public class SingleNodeReconfiguratorTests extends ESTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
 
-        final var currentLeader = new DiscoveryNode("current-leader", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var currentLeader = TestDiscoveryNode.create("current-leader");
         final var currentVotingConfig = new CoordinationMetadata.VotingConfiguration(Set.of(currentLeader.getId()));
 
         assertThat(
@@ -47,8 +46,8 @@ public class SingleNodeReconfiguratorTests extends ESTestCase {
             new ClusterSettings(Settings.EMPTY, ClusterSettings.BUILT_IN_CLUSTER_SETTINGS)
         );
 
-        final var oldLeader = new DiscoveryNode("old-leader", buildNewFakeTransportAddress(), Version.CURRENT);
-        final var currentLeader = new DiscoveryNode("current-leader", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var oldLeader = TestDiscoveryNode.create("old-leader");
+        final var currentLeader = TestDiscoveryNode.create("current-leader");
         final var currentVotingConfig = new CoordinationMetadata.VotingConfiguration(Set.of(oldLeader.getId()));
 
         final var updatedState = reconfigurator.maybeReconfigureAfterNewMasterIsElected(

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/stateless/StoreHeartbeatServiceTests.java
@@ -9,10 +9,9 @@
 package org.elasticsearch.cluster.coordination.stateless;
 
 import org.apache.logging.log4j.Level;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.MockLogAppender;
@@ -64,7 +63,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         );
 
         PlainActionFuture<Long> completionListener = PlainActionFuture.newFuture();
-        final var currentLeader = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var currentLeader = TestDiscoveryNode.create("master");
         heartbeatService.start(currentLeader, currentTermProvider.get(), completionListener);
 
         Heartbeat firstHeartbeat = PlainActionFuture.get(heartbeatStore::readLatestHeartbeat);
@@ -127,7 +126,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         );
 
         PlainActionFuture<Long> completionListener = PlainActionFuture.newFuture();
-        final var currentLeader = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var currentLeader = TestDiscoveryNode.create("master");
 
         final boolean failFirstHeartBeat = randomBoolean();
         injectWriteHeartBeatFailure.set(failFirstHeartBeat);
@@ -169,7 +168,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
         );
 
         PlainActionFuture<Long> completionListener = PlainActionFuture.newFuture();
-        final var currentLeader = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var currentLeader = TestDiscoveryNode.create("master");
 
         final long currentTerm = currentTermProvider.get();
         boolean termBumpBeforeStart = randomBoolean();
@@ -283,7 +282,7 @@ public class StoreHeartbeatServiceTests extends ESTestCase {
     public void testRetriesEarlyAfterGettingAnEmptyTerm() {
         final var heartbeatFrequency = TimeValue.timeValueSeconds(randomIntBetween(15, 30));
         final var maxTimeSinceLastHeartbeat = TimeValue.timeValueSeconds(2 * heartbeatFrequency.seconds());
-        final var currentLeader = new DiscoveryNode("master", buildNewFakeTransportAddress(), Version.CURRENT);
+        final var currentLeader = TestDiscoveryNode.create("master");
 
         final var currentTermSupplier = new AtomicReference<>(OptionalLong.empty());
         final var fakeClock = new AtomicLong();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadataTests.java
@@ -9,12 +9,12 @@
 package org.elasticsearch.cluster.metadata;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.settings.Settings;
@@ -92,11 +92,7 @@ public class NodesShutdownMetadataTests extends ChunkedToXContentDiffableSeriali
 
             state = ClusterState.builder(state)
                 .metadata(Metadata.builder(state.metadata()).putCustom(NodesShutdownMetadata.TYPE, nodesShutdownMetadata).build())
-                .nodes(
-                    DiscoveryNodes.builder(state.nodes())
-                        .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
-                        .build()
-                )
+                .nodes(DiscoveryNodes.builder(state.nodes()).add(TestDiscoveryNode.create("_node_1")).build())
                 .build();
 
             assertThat(NodesShutdownMetadata.isNodeShuttingDown(state, "this_node"), equalTo(true));

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/AllocationServiceTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodes;
@@ -141,9 +142,9 @@ public class AllocationServiceTests extends ESTestCase {
         allocationService.setExistingShardsAllocators(allocatorMap);
 
         final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
-        nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT));
-        nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT));
-        nodesBuilder.add(new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT));
+        nodesBuilder.add(TestDiscoveryNode.create("node1"));
+        nodesBuilder.add(TestDiscoveryNode.create("node2"));
+        nodesBuilder.add(TestDiscoveryNode.create("node3"));
 
         final Metadata.Builder metadata = Metadata.builder()
             // create 3 indices with different priorities. The high and low priority indices use the default allocator which (in this test)
@@ -241,8 +242,8 @@ public class AllocationServiceTests extends ESTestCase {
         );
 
         final DiscoveryNodes.Builder nodesBuilder = DiscoveryNodes.builder();
-        nodesBuilder.add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT));
-        nodesBuilder.add(new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT));
+        nodesBuilder.add(TestDiscoveryNode.create("node1"));
+        nodesBuilder.add(TestDiscoveryNode.create("node2"));
 
         final Metadata.Builder metadata = Metadata.builder()
             .put(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorServiceTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingTable;
@@ -837,7 +838,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                     null,
                     List.of(
                         new NodeAllocationResult(
-                            new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                            TestDiscoveryNode.create(randomNodeId()),
                             new Decision.Multi().add(Decision.single(Decision.Type.YES, EnableAllocationDecider.NAME, null))
                                 .add(Decision.single(Decision.Type.YES, "data_tier", null))
                                 .add(Decision.single(Decision.Type.YES, ShardsLimitAllocationDecider.NAME, null))
@@ -882,7 +883,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             List.of(
                 new NodeAllocationResult(
                     // Shard allocation is disabled on index
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.NO, EnableAllocationDecider.NAME, null)),
                     1
                 )
@@ -914,7 +915,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             List.of(
                 new NodeAllocationResult(
                     // Shard allocation is disabled on index
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new NodeAllocationResult.ShardStoreInfo(10),
                     null
                 )
@@ -945,7 +946,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             List.of(
                 new NodeAllocationResult(
                     // Shard allocation is disabled on index
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.NO, EnableAllocationDecider.NAME, null)),
                     1
                 )
@@ -982,7 +983,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             List.of(
                 new NodeAllocationResult(
                     // Shard allocation is disabled on index
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.NO, EnableAllocationDecider.NAME, null)),
                     1
                 )
@@ -1015,7 +1016,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
             List.of(
                 // Shard is not allowed due to data tier filter
                 new NodeAllocationResult(
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.NO, "data_tier", null)),
                     1
                 )
@@ -1300,7 +1301,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 // Shard is allowed on data tier, but disallowed because of allocation filters
                 new NodeAllocationResult(
                     // Node has no data attributes on it
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.YES, "data_tier", null))
                         .add(Decision.single(Decision.Type.NO, FilterAllocationDecider.NAME, null)),
                     1
@@ -1336,7 +1337,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 // Shard is allowed on data tier, but disallowed because of allocation filters
                 new NodeAllocationResult(
                     // Node has no data attributes on it
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.YES, "data_tier", null))
                         .add(Decision.single(Decision.Type.NO, FilterAllocationDecider.NAME, null)),
                     1
@@ -1371,7 +1372,7 @@ public class ShardsAvailabilityHealthIndicatorServiceTests extends ESTestCase {
                 // Shard is allowed on data tier, but disallowed because of allocation filters
                 new NodeAllocationResult(
                     // Node does not have data attribute on it
-                    new DiscoveryNode(randomNodeId(), buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create(randomNodeId()),
                     new Decision.Multi().add(Decision.single(Decision.Type.YES, "data_tier", null))
                         .add(Decision.single(Decision.Type.NO, FilterAllocationDecider.NAME, null)),
                     1

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceReconcilerTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.IndexRoutingTable;
 import org.elasticsearch.cluster.routing.IndexShardRoutingTable;
 import org.elasticsearch.cluster.routing.RecoverySource;
@@ -1022,7 +1023,7 @@ public class DesiredBalanceReconcilerTests extends ESTestCase {
                     // data-node-1 left the cluster
                     .localNodeId("data-node-2")
                     .masterNodeId("data-node-2")
-                    .add(new DiscoveryNode("data-node-2", buildNewFakeTransportAddress(), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("data-node-2"))
             )
             .metadata(Metadata.builder().put(indexMetadata, true))
             .routingTable(

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/decider/AllocationDecidersTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.RoutingNode;
 import org.elasticsearch.cluster.routing.RoutingNodesHelper;
@@ -137,7 +138,7 @@ public class AllocationDecidersTests extends ESTestCase {
             .build();
         ShardRouting shardRouting = createShardRouting(index.getIndex());
         RoutingNode routingNode = RoutingNodesHelper.routingNode("node", null);
-        DiscoveryNode discoveryNode = new DiscoveryNode("node", new TransportAddress(TransportAddress.META_ADDRESS, 0), Version.CURRENT);
+        DiscoveryNode discoveryNode = TestDiscoveryNode.create("node", new TransportAddress(TransportAddress.META_ADDRESS, 0));
 
         List.<BiFunction<RoutingAllocation, AllocationDeciders, Decision>>of(
             (allocation, deciders) -> deciders.canAllocate(shardRouting, allocation),

--- a/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/service/TransportVersionsFixupListenerTests.java
@@ -18,8 +18,8 @@ import org.elasticsearch.client.internal.ClusterAdminClient;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.TransportVersionsFixupListener.NodeTransportVersionTask;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
@@ -56,7 +56,7 @@ public class TransportVersionsFixupListenerTests extends ESTestCase {
     private static DiscoveryNodes node(Version... versions) {
         var builder = DiscoveryNodes.builder();
         for (int i = 0; i < versions.length; i++) {
-            builder.add(new DiscoveryNode("node" + i, new TransportAddress(TransportAddress.META_ADDRESS, 9200 + i), versions[i]));
+            builder.add(TestDiscoveryNode.create("node" + i, new TransportAddress(TransportAddress.META_ADDRESS, 9200 + i), versions[i]));
         }
         builder.localNodeId("node0").masterNodeId("node0");
         return builder.build();
@@ -81,7 +81,7 @@ public class TransportVersionsFixupListenerTests extends ESTestCase {
                         null,
                         e.getValue(),
                         null,
-                        new DiscoveryNode(e.getKey(), new TransportAddress(TransportAddress.META_ADDRESS, 9200), null),
+                        TestDiscoveryNode.create(e.getKey(), new TransportAddress(TransportAddress.META_ADDRESS, 9200)),
                         null,
                         null,
                         null,

--- a/server/src/test/java/org/elasticsearch/common/file/AbstractFileWatchingServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/common/file/AbstractFileWatchingServiceTests.java
@@ -8,12 +8,12 @@
 
 package org.elasticsearch.common.file;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -89,7 +89,7 @@ public class AbstractFileWatchingServiceTests extends ESTestCase {
         clusterService = mock(ClusterService.class);
         when(clusterService.getSettings()).thenReturn(Settings.builder().put(NODE_NAME_SETTING.getKey(), "test").build());
 
-        final DiscoveryNode localNode = new DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("node");
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
             .build();

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -150,7 +150,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
     public void testLogsFullConnectionFailureAfterSuccessfulHandshake() throws Exception {
 
         final var remoteNodeAddress = buildNewFakeTransportAddress();
-        remoteNode = new DiscoveryNode("remote-node", remoteNodeAddress, Version.CURRENT);
+        remoteNode = TestDiscoveryNode.create("remote-node", remoteNodeAddress);
         remoteClusterName = "local-cluster";
         discoveryAddress = buildNewFakeTransportAddress();
 

--- a/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/HandshakingTransportAddressConnectorTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.Nullable;
@@ -65,7 +66,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
 
     @Before
     public void startServices() {
-        localNode = new DiscoveryNode("local-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        localNode = TestDiscoveryNode.create("local-node");
         final Settings settings = Settings.builder()
             .put(NODE_NAME_SETTING.getKey(), "node")
             .put(CLUSTER_NAME_SETTING.getKey(), "local-cluster")
@@ -124,7 +125,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
         final CountDownLatch completionLatch = new CountDownLatch(1);
         final SetOnce<DiscoveryNode> receivedNode = new SetOnce<>();
 
-        remoteNode = new DiscoveryNode("remote-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        remoteNode = TestDiscoveryNode.create("remote-node");
         remoteClusterName = "local-cluster";
         discoveryAddress = getDiscoveryAddress();
 
@@ -209,7 +210,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
     }
 
     public void testDoesNotConnectToDifferentCluster() throws InterruptedException {
-        remoteNode = new DiscoveryNode("remote-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        remoteNode = TestDiscoveryNode.create("remote-node");
         discoveryAddress = getDiscoveryAddress();
         remoteClusterName = "another-cluster";
 
@@ -227,7 +228,7 @@ public class HandshakingTransportAddressConnectorTests extends ESTestCase {
     }
 
     public void testHandshakeTimesOut() throws InterruptedException {
-        remoteNode = new DiscoveryNode("remote-node", buildNewFakeTransportAddress(), Version.CURRENT);
+        remoteNode = TestDiscoveryNode.create("remote-node");
         discoveryAddress = getDiscoveryAddress();
         remoteClusterName = "local-cluster";
         dropHandshake = true;

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderMessagesTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderMessagesTests.java
@@ -8,9 +8,9 @@
 
 package org.elasticsearch.discovery;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.coordination.PeersResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.EqualsHashCodeTestUtils;
 import org.elasticsearch.test.EqualsHashCodeTestUtils.CopyFunction;
@@ -26,7 +26,7 @@ import static java.util.Collections.singletonList;
 
 public class PeerFinderMessagesTests extends ESTestCase {
     private DiscoveryNode createNode(String id) {
-        return new DiscoveryNode(id, buildNewFakeTransportAddress(), Version.CURRENT);
+        return TestDiscoveryNode.create(id);
     }
 
     public void testPeersRequestEqualsHashCodeSerialization() {

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.coordination.PeersResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.DiscoveryNodes.Builder;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -911,7 +912,7 @@ public class PeerFinderTests extends ESTestCase {
     }
 
     private DiscoveryNode newDiscoveryNode(String nodeId) {
-        return new DiscoveryNode(nodeId, buildNewFakeTransportAddress(), Version.CURRENT);
+        return TestDiscoveryNode.create(nodeId);
     }
 
     private void runAllRunnableTasks() {

--- a/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
+++ b/server/src/test/java/org/elasticsearch/discovery/PeerFinderTests.java
@@ -873,7 +873,7 @@ public class PeerFinderTests extends ESTestCase {
         assertFoundPeers(otherNode);
 
         transportAddressConnector.reachableNodes.clear();
-        final DiscoveryNode rebootedOtherNode = new DiscoveryNode("rebooted-node", otherNode.getAddress(), Version.CURRENT);
+        final DiscoveryNode rebootedOtherNode = TestDiscoveryNode.create("rebooted-node", otherNode.getAddress());
         transportAddressConnector.addReachableNode(rebootedOtherNode);
 
         connectedNodes.remove(otherNode);

--- a/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/PersistedClusterStateServiceTests.java
@@ -44,6 +44,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.Randomness;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -1158,7 +1159,7 @@ public class PersistedClusterStateServiceTests extends ESTestCase {
                 .build();
         }
 
-        final DiscoveryNode localNode = new DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("node");
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()))
             .build();

--- a/server/src/test/java/org/elasticsearch/health/stats/HealthApiStatsActionResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/health/stats/HealthApiStatsActionResponseTests.java
@@ -8,9 +8,8 @@
 
 package org.elasticsearch.health.stats;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.metrics.Counters;
 import org.elasticsearch.test.ESTestCase;
 
@@ -22,22 +21,16 @@ public class HealthApiStatsActionResponseTests extends ESTestCase {
 
     public void testMerging() {
 
-        HealthApiStatsAction.Response.Node nodeResponse1 = new HealthApiStatsAction.Response.Node(
-            new DiscoveryNode("remote_node", buildNewFakeTransportAddress(), Version.CURRENT)
-        );
+        HealthApiStatsAction.Response.Node nodeResponse1 = new HealthApiStatsAction.Response.Node(TestDiscoveryNode.create("remote_node"));
         {
             Counters counters = new Counters();
             counters.inc("merged.metric", randomIntBetween(1, 10));
             counters.inc("only.one.metric", randomIntBetween(1, 10));
             nodeResponse1.setStats(counters);
         }
-        HealthApiStatsAction.Response.Node nodeResponse2 = new HealthApiStatsAction.Response.Node(
-            new DiscoveryNode("remote_node", buildNewFakeTransportAddress(), Version.CURRENT)
-        );
+        HealthApiStatsAction.Response.Node nodeResponse2 = new HealthApiStatsAction.Response.Node(TestDiscoveryNode.create("remote_node"));
 
-        HealthApiStatsAction.Response.Node nodeResponse3 = new HealthApiStatsAction.Response.Node(
-            new DiscoveryNode("remote_node", buildNewFakeTransportAddress(), Version.CURRENT)
-        );
+        HealthApiStatsAction.Response.Node nodeResponse3 = new HealthApiStatsAction.Response.Node(TestDiscoveryNode.create("remote_node"));
         {
             Counters counters = new Counters();
             counters.inc("merged.metric", randomIntBetween(1, 10));

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksClusterServiceTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
@@ -139,7 +140,7 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
         EnableAssignmentDecider.Allocation allocation = randomFrom(EnableAssignmentDecider.Allocation.values());
 
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("_node"))
             .localNodeId("_node")
             .masterNodeId("_node")
             .build();
@@ -320,9 +321,7 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
     }
 
     public void testPersistentTasksChangedNoTasks() {
-        DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .build();
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(TestDiscoveryNode.create("_node_1")).build();
 
         ClusterState previous = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
         ClusterState current = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
@@ -331,9 +330,7 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
     }
 
     public void testPersistentTasksChangedTaskAdded() {
-        DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .build();
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(TestDiscoveryNode.create("_node_1")).build();
 
         ClusterState previous = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
 
@@ -351,8 +348,8 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
 
     public void testPersistentTasksChangedTaskRemoved() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("_node_1"))
+            .add(TestDiscoveryNode.create("_node_2"))
             .build();
 
         PersistentTasksCustomMetadata previousTasks = PersistentTasksCustomMetadata.builder()
@@ -381,8 +378,8 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
 
     public void testPersistentTasksAssigned() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("_node_1"))
+            .add(TestDiscoveryNode.create("_node_2"))
             .build();
 
         PersistentTasksCustomMetadata previousTasks = PersistentTasksCustomMetadata.builder()
@@ -410,8 +407,8 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
 
     public void testNeedsReassignment() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
-            .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("_node_1"))
+            .add(TestDiscoveryNode.create("_node_2"))
             .build();
 
         assertTrue(needsReassignment(new Assignment(null, "unassigned"), nodes));
@@ -537,10 +534,10 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
             clusterState.metadata().custom(PersistentTasksCustomMetadata.TYPE)
         );
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("_node_1"))
             .localNodeId("_node_1")
             .masterNodeId("_node_1")
-            .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT));
+            .add(TestDiscoveryNode.create("_node_2"));
 
         String unassignedId = addTask(tasks, "unassign", "_node_2");
 
@@ -566,10 +563,10 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
             clusterState.metadata().custom(PersistentTasksCustomMetadata.TYPE)
         );
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("_node_1", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("_node_1"))
             .localNodeId("_node_1")
             .masterNodeId("_node_1")
-            .add(new DiscoveryNode("_node_2", buildNewFakeTransportAddress(), Version.CURRENT));
+            .add(TestDiscoveryNode.create("_node_2"));
 
         Metadata.Builder metadata = Metadata.builder(clusterState.metadata()).putCustom(PersistentTasksCustomMetadata.TYPE, tasks.build());
         clusterState = builder.metadata(metadata).nodes(nodes).build();
@@ -743,7 +740,7 @@ public class PersistentTasksClusterServiceTests extends ESTestCase {
 
     private void addTestNodes(DiscoveryNodes.Builder nodes, int nonLocalNodesCount) {
         for (int i = 0; i < nonLocalNodesCount; i++) {
-            nodes.add(new DiscoveryNode("other_node_" + i, buildNewFakeTransportAddress(), Version.CURRENT));
+            nodes.add(TestDiscoveryNode.create("other_node_" + i));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksCustomMetadataTests.java
@@ -9,15 +9,14 @@ package org.elasticsearch.persistent;
 
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.NamedDiff;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.Metadata.Custom;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
@@ -303,7 +302,7 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
 
     public void testDisassociateDeadNodes_givenAssignedPersistentTask() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
             .localNodeId("node1")
             .masterNodeId("node1")
             .build();
@@ -331,7 +330,7 @@ public class PersistentTasksCustomMetadataTests extends ChunkedToXContentDiffabl
 
     public void testDisassociateDeadNodes() {
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node1"))
             .localNodeId("node1")
             .masterNodeId("node1")
             .build();

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksDecidersTestCase.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksDecidersTestCase.java
@@ -7,12 +7,11 @@
  */
 package org.elasticsearch.persistent;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -91,7 +90,7 @@ public abstract class PersistentTasksDecidersTestCase extends ESTestCase {
     protected static ClusterState createClusterStateWithTasks(final int nbNodes, final int nbTasks) {
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
         for (int i = 0; i < nbNodes; i++) {
-            nodes.add(new DiscoveryNode("_node_" + i, buildNewFakeTransportAddress(), Version.CURRENT));
+            nodes.add(TestDiscoveryNode.create("_node_" + i));
         }
 
         PersistentTasksCustomMetadata.Builder tasks = PersistentTasksCustomMetadata.builder();

--- a/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/persistent/PersistentTasksNodeServiceTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.persistent;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
 import org.elasticsearch.client.internal.Client;
@@ -18,6 +17,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.Settings;
@@ -84,7 +84,7 @@ public class PersistentTasksNodeServiceTests extends ESTestCase {
         DiscoveryNodes.Builder nodes = DiscoveryNodes.builder();
         nodes.add(DiscoveryNode.createLocal(settings, buildNewFakeTransportAddress(), "this_node"));
         for (int i = 0; i < nonLocalNodesCount; i++) {
-            nodes.add(new DiscoveryNode("other_node_" + i, buildNewFakeTransportAddress(), Version.CURRENT));
+            nodes.add(TestDiscoveryNode.create("other_node_" + i));
         }
         nodes.localNodeId("this_node");
         state.nodes(nodes);

--- a/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/reservedstate/service/FileSettingsServiceTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.NodeConnectionsService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RerouteService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -76,7 +77,7 @@ public class FileSettingsServiceTests extends ESTestCase {
             )
         );
 
-        final DiscoveryNode localNode = new DiscoveryNode("node", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("node");
         final ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(DiscoveryNodes.builder().add(localNode).localNodeId(localNode.getId()).masterNodeId(localNode.getId()))
             .build();

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.rest.action.cat;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
 import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.IndexStats;
@@ -17,6 +16,7 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RoutingTable;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -41,7 +41,7 @@ public class RestShardsActionTests extends ESTestCase {
 
     public void testBuildTable() {
         final int numShards = randomIntBetween(1, 5);
-        DiscoveryNode localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("local");
 
         List<ShardRouting> shardRoutings = new ArrayList<>(numShards);
         Map<ShardRouting, ShardStats> shardStatsMap = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -15,8 +15,8 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.index.shard.ShardId;
@@ -86,7 +86,11 @@ public class RestIndexActionTests extends RestActionTestCase {
             .build();
         clusterStateSupplier.set(
             ClusterState.builder(ClusterName.DEFAULT)
-                .nodes(DiscoveryNodes.builder().add(new DiscoveryNode("test", buildNewFakeTransportAddress(), minClusterVersion)).build())
+                .nodes(
+                    DiscoveryNodes.builder()
+                        .add(TestDiscoveryNode.create("test", buildNewFakeTransportAddress(), minClusterVersion))
+                        .build()
+                )
                 .build()
         );
         dispatchRequest(autoIdRequest);

--- a/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/ClusterConnectionManagerTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
@@ -103,7 +104,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
             }
         });
 
-        DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
         Transport.Connection connection = new TestConnect(node);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -212,7 +213,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
     public void testConcurrentConnects() throws Exception {
         Set<Transport.Connection> connections = Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-        DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
@@ -379,7 +380,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
 
             @Override
             protected void doRun() throws Exception {
-                final var discoveryNode = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+                final var discoveryNode = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
                 final var listener = new ActionListener<Releasable>() {
                     @Override
                     public void onResponse(Releasable releasable) {
@@ -435,7 +436,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
         Releasables.closeExpectNoException(
             PlainActionFuture.<Releasable, RuntimeException>get(
                 fut -> connectionManager.connectToNode(
-                    new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT),
+                    TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0)),
                     connectionProfile,
                     validator,
                     fut
@@ -458,7 +459,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
     }
 
     public void testConcurrentConnectsAndDisconnects() throws Exception {
-        final DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        final DiscoveryNode node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
@@ -536,7 +537,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
 
     @TestLogging(reason = "ignore copious 'closed by remote' messages", value = "org.elasticsearch.transport.ClusterConnectionManager:WARN")
     public void testConcurrentConnectsAndCloses() throws Exception {
-        final DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        final DiscoveryNode node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
@@ -658,7 +659,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
             }
         });
 
-        DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
         Transport.Connection connection = new TestConnect(node);
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
@@ -698,7 +699,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
             }
         });
 
-        DiscoveryNode node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
         doAnswer(invocationOnMock -> {
             @SuppressWarnings("unchecked")
             ActionListener<Transport.Connection> listener = (ActionListener<Transport.Connection>) invocationOnMock.getArguments()[2];
@@ -723,7 +724,7 @@ public class ClusterConnectionManagerTests extends ESTestCase {
 
     public void testConnectAfterClose() {
         connectionManager.close();
-        final var node = new DiscoveryNode("", new TransportAddress(InetAddress.getLoopbackAddress(), 0), Version.CURRENT);
+        final var node = TestDiscoveryNode.create("", new TransportAddress(InetAddress.getLoopbackAddress(), 0));
 
         final var openConnectionFuture = new PlainActionFuture<Transport.Connection>();
         connectionManager.openConnection(node, connectionProfile, openConnectionFuture);

--- a/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/OutboundHandlerTests.java
@@ -13,10 +13,10 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -70,7 +70,7 @@ public class OutboundHandlerTests extends ESTestCase {
         super.setUp();
         channel = new FakeTcpChannel(randomBoolean(), buildNewFakeTransportAddress().address(), buildNewFakeTransportAddress().address());
         TransportAddress transportAddress = buildNewFakeTransportAddress();
-        node = new DiscoveryNode("", transportAddress, Version.CURRENT);
+        node = TestDiscoveryNode.create("", transportAddress);
         StatsTracker statsTracker = new StatsTracker();
         compressionScheme = randomFrom(Compression.Scheme.DEFLATE, Compression.Scheme.LZ4);
         handler = new OutboundHandler(

--- a/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteConnectionManagerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -59,7 +60,7 @@ public class RemoteConnectionManagerTests extends ESTestCase {
     }
 
     public void testGetConnection() {
-        DiscoveryNode node1 = new DiscoveryNode("node-1", address, Version.CURRENT);
+        DiscoveryNode node1 = TestDiscoveryNode.create("node-1", address);
         PlainActionFuture<Void> future1 = PlainActionFuture.newFuture();
         remoteConnectionManager.connectToRemoteClusterNode(node1, validator, future1);
         assertTrue(future1.isDone());
@@ -67,7 +68,7 @@ public class RemoteConnectionManagerTests extends ESTestCase {
         // Add duplicate connect attempt to ensure that we do not get duplicate connections in the round robin
         remoteConnectionManager.connectToRemoteClusterNode(node1, validator, PlainActionFuture.newFuture());
 
-        DiscoveryNode node2 = new DiscoveryNode("node-2", address, Version.CURRENT.minimumCompatibilityVersion());
+        DiscoveryNode node2 = TestDiscoveryNode.create("node-2", address, Version.CURRENT.minimumCompatibilityVersion());
         PlainActionFuture<Void> future2 = PlainActionFuture.newFuture();
         remoteConnectionManager.connectToRemoteClusterNode(node2, validator, future2);
         assertTrue(future2.isDone());
@@ -75,7 +76,7 @@ public class RemoteConnectionManagerTests extends ESTestCase {
         assertEquals(node1, remoteConnectionManager.getConnection(node1).getNode());
         assertEquals(node2, remoteConnectionManager.getConnection(node2).getNode());
 
-        DiscoveryNode node4 = new DiscoveryNode("node-4", address, Version.CURRENT);
+        DiscoveryNode node4 = TestDiscoveryNode.create("node-4", address);
         assertThat(remoteConnectionManager.getConnection(node4), instanceOf(RemoteConnectionManager.ProxyConnection.class));
 
         // Test round robin
@@ -97,7 +98,7 @@ public class RemoteConnectionManagerTests extends ESTestCase {
     }
 
     public void testResolveRemoteClusterAlias() throws ExecutionException, InterruptedException {
-        DiscoveryNode remoteNode1 = new DiscoveryNode("remote-node-1", address, Version.CURRENT);
+        DiscoveryNode remoteNode1 = TestDiscoveryNode.create("remote-node-1", address);
         PlainActionFuture<Void> future = PlainActionFuture.newFuture();
         remoteConnectionManager.connectToRemoteClusterNode(remoteNode1, validator, future);
         assertTrue(future.isDone());
@@ -108,7 +109,7 @@ public class RemoteConnectionManagerTests extends ESTestCase {
         Transport.Connection localConnection = mock(Transport.Connection.class);
         assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(localConnection).isPresent(), equalTo(false));
 
-        DiscoveryNode remoteNode2 = new DiscoveryNode("remote-node-2", address, Version.CURRENT);
+        DiscoveryNode remoteNode2 = TestDiscoveryNode.create("remote-node-2", address);
         Transport.Connection proxyConnection = remoteConnectionManager.getConnection(remoteNode2);
         assertThat(proxyConnection, instanceOf(RemoteConnectionManager.ProxyConnection.class));
         assertThat(RemoteConnectionManager.resolveRemoteClusterAlias(proxyConnection).get(), equalTo("remote-cluster"));

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceDeserializationFailureTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.DeterministicTaskQueue;
@@ -37,8 +38,8 @@ import static org.hamcrest.Matchers.hasToString;
 public class TransportServiceDeserializationFailureTests extends ESTestCase {
 
     public void testDeserializationFailureLogIdentifiesListener() {
-        final DiscoveryNode localNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
-        final DiscoveryNode otherNode = new DiscoveryNode("other", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("local");
+        final DiscoveryNode otherNode = TestDiscoveryNode.create("other");
 
         final DeterministicTaskQueue deterministicTaskQueue = new DeterministicTaskQueue();
 

--- a/test/framework/src/main/java/org/elasticsearch/cluster/node/TestDiscoveryNode.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/node/TestDiscoveryNode.java
@@ -8,18 +8,23 @@
 
 package org.elasticsearch.cluster.node;
 
+import org.elasticsearch.Version;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
 
 public class TestDiscoveryNode {
 
-    /**
-     * Creates a new {@link DiscoveryNode} with the specified id, using a fake transport address
-     *
-     * @param id               the nodes unique (persistent) node id. This constructor will auto generate a random ephemeral id.
-     */
     public static DiscoveryNode create(String id) {
         return new DiscoveryNode(id, ESTestCase.buildNewFakeTransportAddress(), Collections.emptyMap(), DiscoveryNodeRole.roles(), null);
+    }
+
+    public static DiscoveryNode create(String id, TransportAddress address) {
+        return new DiscoveryNode(id, address, Collections.emptyMap(), DiscoveryNodeRole.roles(), null);
+    }
+
+    public static DiscoveryNode create(String id, TransportAddress address, Version version) {
+        return new DiscoveryNode(id, address, Collections.emptyMap(), DiscoveryNodeRole.roles(), version);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/cluster/node/TestDiscoveryNode.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/node/TestDiscoveryNode.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.cluster.node;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Collections;
+
+public class TestDiscoveryNode {
+
+    /**
+     * Creates a new {@link DiscoveryNode} with the specified id, using a fake transport address
+     *
+     * @param id               the nodes unique (persistent) node id. This constructor will auto generate a random ephemeral id.
+     */
+    public static DiscoveryNode create(String id) {
+        return new DiscoveryNode(id, ESTestCase.buildNewFakeTransportAddress(), Collections.emptyMap(), DiscoveryNodeRole.roles(), null);
+    }
+}

--- a/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
+++ b/test/framework/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreTestUtil.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.repositories.blobstore;
 
 import org.apache.lucene.util.SameThreadExecutorService;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRunnable;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -22,6 +21,7 @@ import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
@@ -64,7 +64,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 
 import static org.apache.lucene.tests.util.LuceneTestCase.random;
-import static org.elasticsearch.test.ESTestCase.buildNewFakeTransportAddress;
 import static org.elasticsearch.test.ESTestCase.randomIntBetween;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
@@ -432,7 +431,7 @@ public final class BlobStoreTestUtil {
         final ClusterApplierService clusterApplierService = mock(ClusterApplierService.class);
         when(clusterService.getClusterApplierService()).thenReturn(clusterApplierService);
         // Setting local node as master so it may update the repository metadata in the cluster state
-        final DiscoveryNode localNode = new DiscoveryNode("", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode localNode = TestDiscoveryNode.create("");
         when(clusterService.localNode()).thenReturn(localNode);
         final AtomicReference<ClusterState> currentState = new AtomicReference<>(
             ClusterState.builder(initialState)

--- a/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
+++ b/test/framework/src/test/java/org/elasticsearch/transport/DisruptableMockTransportTests.java
@@ -9,11 +9,11 @@
 package org.elasticsearch.transport;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.coordination.CleanableResponseHandler;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -87,8 +87,8 @@ public class DisruptableMockTransportTests extends ESTestCase {
 
     @Before
     public void initTransports() {
-        node1 = new DiscoveryNode("node1", buildNewFakeTransportAddress(), Version.CURRENT);
-        node2 = new DiscoveryNode("node2", buildNewFakeTransportAddress(), Version.CURRENT);
+        node1 = TestDiscoveryNode.create("node1");
+        node2 = TestDiscoveryNode.create("node2");
 
         disconnectedLinks = new HashSet<>();
         blackholedLinks = new HashSet<>();
@@ -584,7 +584,7 @@ public class DisruptableMockTransportTests extends ESTestCase {
         );
         blackholedRequestLinks.clear();
 
-        final DiscoveryNode node3 = new DiscoveryNode("node3", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode node3 = TestDiscoveryNode.create("node3");
         assertThat(
             expectThrows(ConnectTransportException.class, () -> AbstractSimpleTransportTestCase.connectToNode(service1, node3))
                 .getMessage(),

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsStatsActionNodeResponseTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/AnalyticsStatsActionNodeResponseTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.analytics.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xpack.core.analytics.action.AnalyticsStatsAction;
@@ -26,7 +26,7 @@ public class AnalyticsStatsActionNodeResponseTests extends AbstractWireSerializi
     @Override
     protected AnalyticsStatsAction.NodeResponse createTestInstance() {
         String nodeName = randomAlphaOfLength(10);
-        DiscoveryNode node = new DiscoveryNode(nodeName, buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create(nodeName);
         EnumCounters<AnalyticsStatsAction.Item> counters = new EnumCounters<>(AnalyticsStatsAction.Item.class);
         for (AnalyticsStatsAction.Item item : AnalyticsStatsAction.Item.values()) {
             if (randomBoolean()) {

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/action/TransportAnalyticsStatsActionTests.java
@@ -6,12 +6,12 @@
  */
 package org.elasticsearch.xpack.analytics.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.test.ESTestCase;
@@ -45,7 +45,7 @@ public class TransportAnalyticsStatsActionTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
 
         ClusterService clusterService = mock(ClusterService.class);
-        DiscoveryNode discoveryNode = new DiscoveryNode("nodeId", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode discoveryNode = TestDiscoveryNode.create("nodeId");
         when(clusterService.localNode()).thenReturn(discoveryNode);
         ClusterName clusterName = new ClusterName("cluster_name");
         when(clusterService.getClusterName()).thenReturn(clusterName);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -30,6 +30,7 @@ import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -372,7 +373,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
             () -> {},
             RetentionLeaseSyncer.EMPTY
         );
-        DiscoveryNode discoveryNode = new DiscoveryNode("node_g", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode discoveryNode = TestDiscoveryNode.create("node_g");
         restoredShard.markAsRecovering("test from snap", new RecoveryState(restoredShard.routingEntry(), discoveryNode, null));
         runAsSnapshot(shard.getThreadPool(), () -> {
             final PlainActionFuture<Boolean> future = PlainActionFuture.newFuture();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/MlTasksTests.java
@@ -8,8 +8,8 @@
 package org.elasticsearch.xpack.core.ml;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
 import org.elasticsearch.test.ESTestCase;
@@ -210,7 +210,7 @@ public class MlTasksTests extends ESTestCase {
         );
 
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node-1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node-1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)))
             .localNodeId("node-1")
             .masterNodeId("node-1")
             .build();
@@ -240,7 +240,7 @@ public class MlTasksTests extends ESTestCase {
         );
 
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("node-1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
+            .add(TestDiscoveryNode.create("node-1", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)))
             .localNodeId("node-1")
             .masterNodeId("node-1")
             .build();

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CacheInfoTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/CacheInfoTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -26,10 +26,9 @@ public class CacheInfoTests extends AbstractWireSerializingTestCase<CacheInfo> {
 
     @Override
     protected CacheInfo createTestInstance() {
-        DiscoveryNode node = new DiscoveryNode(
+        DiscoveryNode node = TestDiscoveryNode.create(
             randomAlphaOfLength(20),
-            new TransportAddress(InetAddress.getLoopbackAddress(), randomIntBetween(1024, 65535)),
-            Version.CURRENT
+            new TransportAddress(InetAddress.getLoopbackAddress(), randomIntBetween(1024, 65535))
         );
         return createTestInstance(node);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedStatsActionResponseTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -51,7 +52,7 @@ public class GetDatafeedStatsActionResponseTests extends AbstractWireSerializing
             DatafeedState datafeedState = randomFrom(DatafeedState.values());
             DiscoveryNode node = randomBoolean()
                 ? null
-                : new DiscoveryNode("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT);
+                : TestDiscoveryNode.create("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300));
             String explanation = randomBoolean() ? null : randomAlphaOfLength(3);
             DatafeedTimingStats timingStats = randomBoolean() ? null : DatafeedTimingStatsTests.createRandom();
             Response.DatafeedStats datafeedStats = new Response.DatafeedStats(

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobModelSnapshotsUpgradeStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobModelSnapshotsUpgradeStatsActionResponseTests.java
@@ -7,8 +7,7 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -50,7 +49,7 @@ public class GetJobModelSnapshotsUpgradeStatsActionResponseTests extends Abstrac
             randomAlphaOfLengthBetween(1, 20)
         ).setUpgradeState(randomFrom(SnapshotUpgradeState.values()));
         if (randomBoolean()) {
-            builder.setNode(new DiscoveryNode("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT));
+            builder.setNode(TestDiscoveryNode.create("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)));
         } else {
             builder.setAssignmentExplanation(randomAlphaOfLengthBetween(20, 50));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobStatsActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/GetJobStatsActionResponseTests.java
@@ -6,8 +6,8 @@
  */
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.core.TimeValue;
@@ -47,7 +47,7 @@ public class GetJobStatsActionResponseTests extends AbstractWireSerializingTestC
             JobState jobState = randomFrom(EnumSet.allOf(JobState.class));
             DiscoveryNode node = randomBoolean()
                 ? null
-                : new DiscoveryNode("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT);
+                : TestDiscoveryNode.create("_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300));
             String explanation = randomBoolean() ? null : randomAlphaOfLength(3);
             TimeValue openTime = randomBoolean() ? null : parseTimeValue(randomPositiveTimeValue(), "open_time-Test");
             TimingStats timingStats = randomBoolean() ? null : TimingStatsTests.createTestInstance("foo");

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/MlMemoryActionResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/MlMemoryActionResponseTests.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -32,10 +32,9 @@ public class MlMemoryActionResponseTests extends AbstractWireSerializingTestCase
         int numNodes = randomIntBetween(1, 20);
         List<MlMemoryAction.Response.MlMemoryStats> nodes = new ArrayList<>(numNodes);
         for (int i = 0; i < numNodes; ++i) {
-            DiscoveryNode node = new DiscoveryNode(
+            DiscoveryNode node = TestDiscoveryNode.create(
                 randomAlphaOfLength(20),
-                new TransportAddress(InetAddress.getLoopbackAddress(), 9200 + i),
-                Version.CURRENT
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9200 + i)
             );
             nodes.add(MlMemoryStatsTests.createTestInstance(node));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/MlMemoryStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/MlMemoryStatsTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
@@ -26,10 +26,9 @@ public class MlMemoryStatsTests extends AbstractWireSerializingTestCase<MlMemory
 
     @Override
     protected MlMemoryStats createTestInstance() {
-        DiscoveryNode node = new DiscoveryNode(
+        DiscoveryNode node = TestDiscoveryNode.create(
             randomAlphaOfLength(20),
-            new TransportAddress(InetAddress.getLoopbackAddress(), randomIntBetween(1024, 65535)),
-            Version.CURRENT
+            new TransportAddress(InetAddress.getLoopbackAddress(), randomIntBetween(1024, 65535))
         );
         return createTestInstance(node);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoRequestTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoRequestTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.ml.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -27,11 +27,7 @@ public class TrainedModelCacheInfoRequestTests extends AbstractWireSerializingTe
         int numNodes = randomIntBetween(1, 20);
         DiscoveryNode[] nodes = new DiscoveryNode[numNodes];
         for (int i = 0; i < numNodes; ++i) {
-            nodes[i] = new DiscoveryNode(
-                randomAlphaOfLength(20),
-                new TransportAddress(InetAddress.getLoopbackAddress(), 9200 + i),
-                Version.CURRENT
-            );
+            nodes[i] = TestDiscoveryNode.create(randomAlphaOfLength(20), new TransportAddress(InetAddress.getLoopbackAddress(), 9200 + i));
         }
         return new TrainedModelCacheInfoAction.Request(nodes);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/action/TrainedModelCacheInfoResponseTests.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.xpack.core.ml.action;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -33,10 +33,9 @@ public class TrainedModelCacheInfoResponseTests extends AbstractWireSerializingT
         int numNodes = randomIntBetween(1, 20);
         List<CacheInfo> nodes = new ArrayList<>(numNodes);
         for (int i = 0; i < numNodes; ++i) {
-            DiscoveryNode node = new DiscoveryNode(
+            DiscoveryNode node = TestDiscoveryNode.create(
                 randomAlphaOfLength(20),
-                new TransportAddress(InetAddress.getLoopbackAddress(), 9200 + i),
-                Version.CURRENT
+                new TransportAddress(InetAddress.getLoopbackAddress(), 9200 + i)
             );
             nodes.add(CacheInfoTests.createTestInstance(node));
         }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStatsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/inference/assignment/AssignmentStatsTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.core.ml.inference.assignment;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -27,7 +27,7 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
         List<AssignmentStats.NodeStats> nodeStatsList = new ArrayList<>();
         int numNodes = randomIntBetween(1, 4);
         for (int i = 0; i < numNodes; i++) {
-            var node = new DiscoveryNode("node_" + i, buildNewFakeTransportAddress(), Version.CURRENT);
+            var node = TestDiscoveryNode.create("node_" + i);
             if (randomBoolean()) {
                 nodeStatsList.add(randomNodeStats(node));
             } else {
@@ -107,7 +107,7 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
             Instant.now(),
             List.of(
                 AssignmentStats.NodeStats.forStartedState(
-                    new DiscoveryNode("node_started_1", buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create("node_started_1"),
                     10L,
                     randomDoubleBetween(0.0, 100.0, true),
                     randomDoubleBetween(0.0, 100.0, true),
@@ -126,7 +126,7 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
                     1L
                 ),
                 AssignmentStats.NodeStats.forStartedState(
-                    new DiscoveryNode("node_started_2", buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create("node_started_2"),
                     12L,
                     randomDoubleBetween(0.0, 100.0, true),
                     randomDoubleBetween(0.0, 100.0, true),
@@ -145,7 +145,7 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
                     1L
                 ),
                 AssignmentStats.NodeStats.forNotStartedState(
-                    new DiscoveryNode("node_not_started_3", buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create("node_not_started_3"),
                     randomFrom(RoutingState.values()),
                     randomBoolean() ? null : "a good reason"
                 )
@@ -192,12 +192,12 @@ public class AssignmentStatsTests extends AbstractWireSerializingTestCase<Assign
             Instant.now(),
             List.of(
                 AssignmentStats.NodeStats.forNotStartedState(
-                    new DiscoveryNode("node_not_started_1", buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create("node_not_started_1"),
                     randomFrom(RoutingState.values()),
                     randomBoolean() ? null : "a good reason"
                 ),
                 AssignmentStats.NodeStats.forNotStartedState(
-                    new DiscoveryNode("node_not_started_2", buildNewFakeTransportAddress(), Version.CURRENT),
+                    TestDiscoveryNode.create("node_not_started_2"),
                     randomFrom(RoutingState.values()),
                     randomBoolean() ? null : "a good reason"
                 )

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/utils/MlIndexAndAliasTests.java
@@ -33,8 +33,8 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -406,8 +406,8 @@ public class MlIndexAndAliasTests extends ESTestCase {
         return ClusterState.builder(ClusterName.DEFAULT)
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("foo", new TransportAddress(inetAddress1, 9201), Version.CURRENT))
-                    .add(new DiscoveryNode("bar", new TransportAddress(inetAddress2, 9202), minNodeVersion))
+                    .add(TestDiscoveryNode.create("foo", new TransportAddress(inetAddress1, 9201)))
+                    .add(TestDiscoveryNode.create("bar", new TransportAddress(inetAddress2, 9202), minNodeVersion))
                     .build()
             )
             .metadata(Metadata.builder().indices(indices).templates(legacyTemplates).indexTemplates(composableTemplates).build())

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsResponseTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/action/service/GetServiceAccountCredentialsResponseTests.java
@@ -7,10 +7,10 @@
 
 package org.elasticsearch.xpack.core.security.action.service;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.transport.TransportAddress;
@@ -117,10 +117,9 @@ public class GetServiceAccountCredentialsResponseTests extends ESTestCase {
     }
 
     private GetServiceAccountCredentialsNodesResponse.Node randomNodeResponse(String[] tokenNames, int i) {
-        final DiscoveryNode discoveryNode = new DiscoveryNode(
+        final DiscoveryNode discoveryNode = TestDiscoveryNode.create(
             randomAlphaOfLength(8) + i,
-            new TransportAddress(TransportAddress.META_ADDRESS, 9300),
-            Version.CURRENT
+            new TransportAddress(TransportAddress.META_ADDRESS, 9300)
         );
         return new GetServiceAccountCredentialsNodesResponse.Node(
             discoveryNode,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsageTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/spatial/SpatialFeatureSetUsageTests.java
@@ -6,9 +6,9 @@
  */
 package org.elasticsearch.xpack.core.spatial;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
@@ -39,7 +39,7 @@ public class SpatialFeatureSetUsageTests extends AbstractWireSerializingTestCase
     }
 
     private SpatialStatsAction.Response randomStatsResponse() {
-        DiscoveryNode node = new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300));
         EnumCounters<SpatialStatsAction.Item> counters = new EnumCounters<>(SpatialStatsAction.Item.class);
         SpatialStatsAction.NodeResponse nodeResponse = new SpatialStatsAction.NodeResponse(node, counters);
         return new SpatialStatsAction.Response(new ClusterName("cluster_name"), List.of(nodeResponse), emptyList());

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/ClusterDeprecationChecksTests.java
@@ -12,8 +12,8 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.allocation.DataTier;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.ShardLimitValidator;
@@ -42,8 +42,8 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             )
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT))
-                    .add(new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT))
+                    .add(TestDiscoveryNode.create(UUID.randomUUID().toString()))
+                    .add(TestDiscoveryNode.create(UUID.randomUUID().toString()))
             )
             .build();
         List<DeprecationIssue> issues = DeprecationChecks.filterChecks(CLUSTER_SETTINGS_CHECKS, c -> c.apply(state));
@@ -65,8 +65,8 @@ public class ClusterDeprecationChecksTests extends ESTestCase {
             )
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT))
-                    .add(new DiscoveryNode(UUID.randomUUID().toString(), buildNewFakeTransportAddress(), Version.CURRENT))
+                    .add(TestDiscoveryNode.create(UUID.randomUUID().toString()))
+                    .add(TestDiscoveryNode.create(UUID.randomUUID().toString()))
             )
             .build();
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.application.analytics;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -22,6 +21,7 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.bytes.BytesReference;
@@ -75,7 +75,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingPipelinesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
@@ -87,7 +87,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
     }
 
     public void testIngestPipelinesAlreadyExists() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         client.setVerifier((action, request, listener) -> {
@@ -108,7 +108,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
     }
 
     public void testThatVersionedOldPipelinesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs()
@@ -124,7 +124,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
     }
 
     public void testThatNewerPipelinesAreNotUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, Integer> existingPipelines = registry.getIngestPipelineConfigs()
@@ -146,7 +146,7 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
 
         client.setVerifier((a, r, l) -> {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.application.analytics;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -24,6 +23,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -86,7 +86,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingComposableTemplatesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
         Map<String, Integer> existingComponentTemplates = Map.of(
             AnalyticsTemplateRegistry.EVENT_DATA_STREAM_SETTINGS_COMPONENT_NAME,
@@ -117,7 +117,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingComponentTemplatesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
@@ -142,7 +142,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingPoliciesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         AtomicInteger calledTimes = new AtomicInteger(0);
@@ -173,7 +173,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExists() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -198,7 +198,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExistsButDiffers() throws IOException {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -244,7 +244,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatVersionedOldComponentTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(
@@ -262,7 +262,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatUnversionedOldComponentTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(
@@ -278,7 +278,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
 
     @TestLogging(value = "org.elasticsearch.xpack.core.template:DEBUG", reason = "test")
     public void testSameOrHigherVersionComponentTemplateNotUpgraded() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, Integer> versions = new HashMap<>();
@@ -316,7 +316,7 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
 
         client.setVerifier((a, r, l) -> {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlInfoTransportActionTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/EqlInfoTransportActionTests.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.eql;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -69,7 +69,7 @@ public class EqlInfoTransportActionTests extends ESTestCase {
             ActionListener<EqlStatsResponse> listener = (ActionListener<EqlStatsResponse>) mock.getArguments()[2];
 
             List<EqlStatsResponse.NodeStatsResponse> nodes = new ArrayList<>();
-            DiscoveryNode first = new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode first = TestDiscoveryNode.create("first");
             EqlStatsResponse.NodeStatsResponse firstNode = new EqlStatsResponse.NodeStatsResponse(first);
             Counters firstCounters = new Counters();
             firstCounters.inc("foo.foo", 1);
@@ -77,7 +77,7 @@ public class EqlInfoTransportActionTests extends ESTestCase {
             firstNode.setStats(firstCounters);
             nodes.add(firstNode);
 
-            DiscoveryNode second = new DiscoveryNode("second", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode second = TestDiscoveryNode.create("second");
             EqlStatsResponse.NodeStatsResponse secondNode = new EqlStatsResponse.NodeStatsResponse(second);
             Counters secondCounters = new Counters();
             secondCounters.inc("spam", 1);

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/SnapshotLifecycleServiceTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.slm;
 
 import org.apache.lucene.util.SetOnce;
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -18,6 +17,7 @@ import org.elasticsearch.cluster.metadata.RepositoriesMetadata;
 import org.elasticsearch.cluster.metadata.RepositoryMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -504,7 +504,7 @@ public class SnapshotLifecycleServiceTests extends ESTestCase {
         Metadata metadata = Metadata.builder().putCustom(SnapshotLifecycleMetadata.TYPE, snapMeta).build();
         final DiscoveryNodes.Builder discoveryNodesBuilder = DiscoveryNodes.builder()
             .add(DiscoveryNode.createLocal(Settings.EMPTY, new TransportAddress(TransportAddress.META_ADDRESS, 9300), "local"))
-            .add(new DiscoveryNode("remote", new TransportAddress(TransportAddress.META_ADDRESS, 9301), Version.CURRENT))
+            .add(TestDiscoveryNode.create("remote", new TransportAddress(TransportAddress.META_ADDRESS, 9301)))
             .localNodeId("local")
             .masterNodeId(localNodeMaster ? "local" : "remote");
         return ClusterState.builder(new ClusterName("cluster")).nodes(discoveryNodesBuilder).metadata(metadata).build();

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistryTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/slm/history/SnapshotLifecycleTemplateRegistryTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.slm.history;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -23,6 +22,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -121,7 +121,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingTemplatesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
@@ -146,7 +146,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingPoliciesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         AtomicInteger calledTimes = new AtomicInteger(0);
@@ -174,7 +174,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExists() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -200,7 +200,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExistsButDiffers() throws IOException {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -233,7 +233,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatVersionedOldTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(
@@ -247,7 +247,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatUnversionedOldTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.singletonMap(SLM_TEMPLATE_NAME, null), nodes);
@@ -258,7 +258,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testSameOrHigherVersionTemplateNotUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent sameVersionEvent = createClusterChangedEvent(
@@ -288,7 +288,7 @@ public class SnapshotLifecycleTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
 
         client.setVerifier((a, r, l) -> {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningInfoTransportActionTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -388,42 +389,42 @@ public class MachineLearningInfoTransportActionTests extends ESTestCase {
                                 Instant.now(),
                                 List.of(
                                     AssignmentStats.NodeStats.forStartedState(
-                                        new DiscoveryNode("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2), Version.CURRENT),
-                                        5,
-                                        42.0,
-                                        42.0,
-                                        0,
-                                        1,
-                                        3L,
-                                        2,
-                                        3,
-                                        Instant.now(),
-                                        Instant.now(),
-                                        randomIntBetween(1, 16),
-                                        randomIntBetween(1, 16),
-                                        1L,
-                                        2L,
-                                        33.0,
-                                        1L
+                                            TestDiscoveryNode.create("foo", new TransportAddress(TransportAddress.META_ADDRESS, 2)),
+                                            5,
+                                            42.0,
+                                            42.0,
+                                            0,
+                                            1,
+                                            3L,
+                                            2,
+                                            3,
+                                            Instant.now(),
+                                            Instant.now(),
+                                            randomIntBetween(1, 16),
+                                            randomIntBetween(1, 16),
+                                            1L,
+                                            2L,
+                                            33.0,
+                                            1L
                                     ),
                                     AssignmentStats.NodeStats.forStartedState(
-                                        new DiscoveryNode("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3), Version.CURRENT),
-                                        4,
-                                        50.0,
-                                        50.0,
-                                        0,
-                                        1,
-                                        1L,
-                                        2,
-                                        3,
-                                        Instant.now(),
-                                        Instant.now(),
-                                        randomIntBetween(1, 16),
-                                        randomIntBetween(1, 16),
-                                        2L,
-                                        4L,
-                                        34.0,
-                                        1L
+                                            TestDiscoveryNode.create("bar", new TransportAddress(TransportAddress.META_ADDRESS, 3)),
+                                            4,
+                                            50.0,
+                                            50.0,
+                                            0,
+                                            1,
+                                            1L,
+                                            2,
+                                            3,
+                                            Instant.now(),
+                                            Instant.now(),
+                                            randomIntBetween(1, 16),
+                                            randomIntBetween(1, 16),
+                                            2L,
+                                            4L,
+                                            34.0,
+                                            1L
                                     )
                                 ),
                                 Priority.NORMAL

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAssignmentNotifierTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlAssignmentNotifierTests.java
@@ -6,13 +6,12 @@
  */
 package org.elasticsearch.xpack.ml;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -81,7 +80,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             // set local node master
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )
@@ -98,7 +97,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             .metadata(metadata)
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)))
                     .localNodeId("_node_id")
             )
             .build();
@@ -124,7 +123,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             // set local node master
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )
@@ -138,7 +137,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             // set local node master
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )
@@ -157,7 +156,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             .metadata(metadata)
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200)))
                     .localNodeId("_node_id")
             )
             .build();
@@ -184,7 +183,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             // set local node master
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )
@@ -198,7 +197,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             .metadata(metadata)
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200)))
                     .localNodeId("_node_id")
             )
             .build();
@@ -221,7 +220,7 @@ public class MlAssignmentNotifierTests extends ESTestCase {
             // set local node master
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9200)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MlIndexTemplateRegistryTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.ml;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
@@ -20,6 +19,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.CollectionUtils;
@@ -49,7 +49,7 @@ import static org.mockito.Mockito.when;
 
 public class MlIndexTemplateRegistryTests extends ESTestCase {
 
-    private final DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+    private final DiscoveryNode node = TestDiscoveryNode.create("node");
     private final DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
     private NamedXContentRegistry xContentRegistry;

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportGetDeploymentStatsActionTests.java
@@ -7,9 +7,8 @@
 
 package org.elasticsearch.xpack.ml.action;
 
-import org.elasticsearch.Version;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.test.ESTestCase;
@@ -152,7 +151,7 @@ public class TransportGetDeploymentStatsActionTests extends ESTestCase {
         DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
         int port = 9200;
         for (String nodeId : nodeIds) {
-            builder.add(new DiscoveryNode(nodeId, new TransportAddress(inetAddress, port++), Version.CURRENT));
+            builder.add(TestDiscoveryNode.create(nodeId, new TransportAddress(inetAddress, port++)));
         }
         return builder.build();
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/ingest/InferenceProcessorFactoryTests.java
@@ -13,8 +13,8 @@ import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.OperationRouting;
 import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -464,9 +464,9 @@ public class InferenceProcessorFactoryTests extends ESTestCase {
             .metadata(Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata))
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), minNodeVersion))
-                    .add(new DiscoveryNode("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302), Version.CURRENT))
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), minNodeVersion))
+                    .add(TestDiscoveryNode.create("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302)))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractorTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/utils/InferenceProcessorInfoExtractorTests.java
@@ -7,12 +7,11 @@
 
 package org.elasticsearch.xpack.ml.utils;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.common.util.Maps;
@@ -107,9 +106,9 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
             .metadata(Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata))
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
-                    .add(new DiscoveryNode("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302), Version.CURRENT))
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)))
+                    .add(TestDiscoveryNode.create("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302)))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )
@@ -157,9 +156,9 @@ public class InferenceProcessorInfoExtractorTests extends ESTestCase {
             .metadata(Metadata.builder().putCustom(IngestMetadata.TYPE, ingestMetadata))
             .nodes(
                 DiscoveryNodes.builder()
-                    .add(new DiscoveryNode("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300), Version.CURRENT))
-                    .add(new DiscoveryNode("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302), Version.CURRENT))
-                    .add(new DiscoveryNode("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304), Version.CURRENT))
+                    .add(TestDiscoveryNode.create("min_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9300)))
+                    .add(TestDiscoveryNode.create("current_node", new TransportAddress(InetAddress.getLoopbackAddress(), 9302)))
+                    .add(TestDiscoveryNode.create("_node_id", new TransportAddress(InetAddress.getLoopbackAddress(), 9304)))
                     .localNodeId("_node_id")
                     .masterNodeId("_node_id")
             )

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/BaseCollectorTestCase.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/BaseCollectorTestCase.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.monitoring;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Setting;
@@ -101,6 +101,6 @@ public abstract class BaseCollectorTestCase extends ESTestCase {
     }
 
     protected static DiscoveryNode localNode(final String uuid) {
-        return new DiscoveryNode(uuid, new TransportAddress(TransportAddress.META_ADDRESS, 9300), Version.CURRENT);
+        return TestDiscoveryNode.create(uuid, new TransportAddress(TransportAddress.META_ADDRESS, 9300));
     }
 }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistryTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringTemplateRegistryTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.monitoring;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -24,6 +23,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Setting;
@@ -91,7 +91,7 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
 
         client.setVerifier((a, r, l) -> {
@@ -121,7 +121,7 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingTemplatesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
@@ -146,7 +146,7 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingPoliciesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         boolean historyDurationPresent = randomBoolean();
@@ -208,7 +208,7 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExists() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -239,7 +239,7 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExistsButDiffers() throws IOException {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -291,7 +291,7 @@ public class MonitoringTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatVersionedOldTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/action/TransportMonitoringBulkActionTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.block.ClusterBlocks;
 import org.elasticsearch.cluster.coordination.NoMasterBlockService;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesArray;
@@ -53,7 +54,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
-import static org.elasticsearch.Version.CURRENT;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasToString;
@@ -182,7 +182,7 @@ public class TransportMonitoringBulkActionTests extends ESTestCase {
     public void testExecuteRequest() {
         when(monitoringService.isMonitoringActive()).thenReturn(true);
 
-        final DiscoveryNode discoveryNode = new DiscoveryNode("_id", new TransportAddress(TransportAddress.META_ADDRESS, 9300), CURRENT);
+        final DiscoveryNode discoveryNode = TestDiscoveryNode.create("_id", new TransportAddress(TransportAddress.META_ADDRESS, 9300));
         when(clusterService.localNode()).thenReturn(discoveryNode);
 
         final String clusterUUID = UUIDs.randomBase64UUID();

--- a/x-pack/plugin/repositories-metering-api/src/test/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesMeteringResponseTests.java
+++ b/x-pack/plugin/repositories-metering-api/src/test/java/org/elasticsearch/xpack/repositories/metering/action/RepositoriesMeteringResponseTests.java
@@ -8,10 +8,10 @@
 package org.elasticsearch.xpack.repositories.metering.action;
 
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.FailedNodeException;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.repositories.RepositoryInfo;
 import org.elasticsearch.repositories.RepositoryStats;
 import org.elasticsearch.repositories.RepositoryStatsSnapshot;
@@ -62,7 +62,7 @@ public class RepositoriesMeteringResponseTests extends ESTestCase {
         int nodes = randomIntBetween(1, 10);
         List<RepositoriesNodeMeteringResponse> nodeResponses = new ArrayList<>(nodes);
         for (int nodeId = 0; nodeId < nodes; nodeId++) {
-            DiscoveryNode node = new DiscoveryNode("nodeId" + nodeId, buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode node = TestDiscoveryNode.create("nodeId" + nodeId);
             int numberOfRepos = randomInt(10);
             List<RepositoryStatsSnapshot> nodeRepoStats = new ArrayList<>(numberOfRepos);
 

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -18,6 +18,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -233,7 +234,7 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
                 new IndexId("some_index", UUIDs.randomBase64UUID(random()))
             )
         );
-        DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode targetNode = TestDiscoveryNode.create("local");
         SearchableSnapshotRecoveryState recoveryState = new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
 
         recoveryState.setStage(RecoveryState.Stage.INIT)

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotsRecoveryStateTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotsRecoveryStateTests.java
@@ -7,8 +7,8 @@
 
 package org.elasticsearch.xpack.searchablesnapshots.recovery;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
 import org.elasticsearch.cluster.routing.TestShardRouting;
@@ -150,7 +150,7 @@ public class SearchableSnapshotsRecoveryStateTests extends ESTestCase {
             true,
             ShardRoutingState.INITIALIZING
         );
-        DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode targetNode = TestDiscoveryNode.create("local");
         return new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.blobcache.BlobCacheTestUtils;
 import org.elasticsearch.blobcache.shared.SharedBlobCacheService;
 import org.elasticsearch.blobcache.shared.SharedBytes;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.ShardRoutingState;
@@ -691,7 +692,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
                     new IndexId("some_index", UUIDs.randomBase64UUID(random()))
                 )
             );
-            DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode targetNode = TestDiscoveryNode.create("local");
             RecoveryState recoveryState = new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
             final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
             final boolean loaded = directory.loadSnapshot(recoveryState, future);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.logging.Loggers;
@@ -427,14 +428,14 @@ public class SecurityTests extends ESTestCase {
         createComponents(Settings.EMPTY);
         BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
         assertNotNull(joinValidator);
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
         int indexFormat = randomBoolean() ? INTERNAL_MAIN_INDEX_FORMAT : INTERNAL_MAIN_INDEX_FORMAT - 1;
         IndexMetadata indexMetadata = IndexMetadata.builder(SECURITY_MAIN_ALIAS)
             .settings(settings(VersionUtils.randomIndexCompatibleVersion(random())).put(INDEX_FORMAT_SETTING.getKey(), indexFormat))
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        DiscoveryNode existingOtherNode = new DiscoveryNode("bar", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode existingOtherNode = TestDiscoveryNode.create("bar");
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder().add(existingOtherNode).build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(discoveryNodes)
@@ -448,7 +449,7 @@ public class SecurityTests extends ESTestCase {
         BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
         assertNotNull(joinValidator);
         Version version = VersionUtils.randomIndexCompatibleVersion(random());
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
         IndexMetadata indexMetadata = IndexMetadata.builder(SECURITY_MAIN_ALIAS)
             .settings(settings(version).put(INDEX_FORMAT_SETTING.getKey(), INTERNAL_MAIN_INDEX_FORMAT))
             .numberOfShards(1)
@@ -467,7 +468,7 @@ public class SecurityTests extends ESTestCase {
         createComponents(Settings.EMPTY);
         BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
         assertNotNull(joinValidator);
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
         DiscoveryNode existingOtherNode = new DiscoveryNode(
             "bar",
             buildNewFakeTransportAddress(),

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -370,7 +370,7 @@ public class SecurityTests extends ESTestCase {
     }
 
     public void testJoinValidatorForFIPSOnAllowedLicense() throws Exception {
-        DiscoveryNode node = new DiscoveryNode(
+        DiscoveryNode node = TestDiscoveryNode.create(
             "foo",
             buildNewFakeTransportAddress(),
             VersionUtils.randomVersionBetween(random(), null, Version.CURRENT)
@@ -397,7 +397,7 @@ public class SecurityTests extends ESTestCase {
     }
 
     public void testJoinValidatorForFIPSOnForbiddenLicense() throws Exception {
-        DiscoveryNode node = new DiscoveryNode(
+        DiscoveryNode node = TestDiscoveryNode.create(
             "foo",
             buildNewFakeTransportAddress(),
             VersionUtils.randomVersionBetween(random(), null, Version.CURRENT)
@@ -455,7 +455,7 @@ public class SecurityTests extends ESTestCase {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        DiscoveryNode existingOtherNode = new DiscoveryNode("bar", buildNewFakeTransportAddress(), version);
+        DiscoveryNode existingOtherNode = TestDiscoveryNode.create("bar", buildNewFakeTransportAddress(), version);
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder().add(existingOtherNode).build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(discoveryNodes)
@@ -469,7 +469,7 @@ public class SecurityTests extends ESTestCase {
         BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
         assertNotNull(joinValidator);
         DiscoveryNode node = TestDiscoveryNode.create("foo");
-        DiscoveryNode existingOtherNode = new DiscoveryNode(
+        DiscoveryNode existingOtherNode = TestDiscoveryNode.create(
             "bar",
             buildNewFakeTransportAddress(),
             VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
@@ -19,7 +19,6 @@ import org.elasticsearch.action.support.ActionFilterChain;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
-import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
@@ -97,7 +96,7 @@ public class SecurityActionFilterTests extends ESTestCase {
         ClusterState state = mock(ClusterState.class);
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(TestDiscoveryNode.create("id1"))
-            .add(new DiscoveryNode("id2", buildNewFakeTransportAddress(), Version.CURRENT.minimumCompatibilityVersion()))
+            .add(TestDiscoveryNode.create("id2", buildNewFakeTransportAddress(), Version.CURRENT.minimumCompatibilityVersion()))
             .build();
         when(state.nodes()).thenReturn(nodes);
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
@@ -21,6 +21,7 @@ import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
@@ -95,7 +96,7 @@ public class SecurityActionFilterTests extends ESTestCase {
         );
         ClusterState state = mock(ClusterState.class);
         DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(new DiscoveryNode("id1", buildNewFakeTransportAddress(), Version.CURRENT))
+            .add(TestDiscoveryNode.create("id1"))
             .add(new DiscoveryNode("id2", buildNewFakeTransportAddress(), Version.CURRENT.minimumCompatibilityVersion()))
             .build();
         when(state.nodes()).thenReturn(nodes);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -88,6 +88,7 @@ import org.elasticsearch.cluster.metadata.IndexAbstraction;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
@@ -2629,7 +2630,7 @@ public class AuthorizationServiceTests extends ESTestCase {
 
     public void testProxyRequestFailsOnNonProxyAction() {
         TransportRequest request = TransportRequest.Empty.INSTANCE;
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
         TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, request);
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
         User user = new User("test user", "role");
@@ -2668,7 +2669,7 @@ public class AuthorizationServiceTests extends ESTestCase {
 
     public void testProxyRequestAuthenticationDenied() {
         final TransportRequest proxiedRequest = new SearchRequest();
-        final DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        final DiscoveryNode node = TestDiscoveryNode.create("foo");
         final TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, proxiedRequest);
         final String action = TransportActionProxy.getProxyAction(SearchTransportService.QUERY_ACTION_NAME);
         final Authentication authentication = createAuthentication(new User("test user", "no_indices"));
@@ -2699,7 +2700,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         mockEmptyMetadata();
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
 
         final ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
         final TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, clearScrollRequest);
@@ -2724,7 +2725,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         final Authentication authentication = createAuthentication(new User("test user", "a_all"));
         roleMap.put("a_all", role);
         mockEmptyMetadata();
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
 
         final ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
@@ -2751,7 +2752,7 @@ public class AuthorizationServiceTests extends ESTestCase {
         roleMap.put("a_all", role);
         final String requestId = AuditUtil.getOrGenerateRequestId(threadContext);
         mockEmptyMetadata();
-        DiscoveryNode node = new DiscoveryNode("foo", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("foo");
         ClearScrollRequest clearScrollRequest = new ClearScrollRequest();
         TransportRequest transportRequest = TransportActionProxy.wrapRequest(node, clearScrollRequest);
         String action = TransportActionProxy.getProxyAction(SearchTransportService.CLEAR_SCROLL_CONTEXTS_ACTION_NAME);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.io.stream.OutputStreamStreamOutput;
 import org.elasticsearch.common.network.NetworkService;
@@ -443,7 +444,11 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             TransportAddress clientAddress = originalTransport.profileBoundAddresses().get("client").publishAddress();
-            DiscoveryNode node = new DiscoveryNode(service.getLocalNode().getId(), clientAddress, service.getLocalNode().getVersion());
+            DiscoveryNode node = TestDiscoveryNode.create(
+                service.getLocalNode().getId(),
+                clientAddress,
+                service.getLocalNode().getVersion()
+            );
             try (Transport.Connection connection2 = openConnection(serviceA, node, TestProfiles.LIGHT_PROFILE)) {
                 sslEngine = getEngineFromAcceptedChannel(originalTransport, connection2);
                 assertEquals("client", getAcceptedChannel(originalTransport, connection2).getProfile());
@@ -466,7 +471,11 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             TransportAddress clientAddress = originalTransport.profileBoundAddresses().get("client").publishAddress();
-            DiscoveryNode node = new DiscoveryNode(service.getLocalNode().getId(), clientAddress, service.getLocalNode().getVersion());
+            DiscoveryNode node = TestDiscoveryNode.create(
+                service.getLocalNode().getId(),
+                clientAddress,
+                service.getLocalNode().getVersion()
+            );
             try (Transport.Connection connection2 = openConnection(serviceA, node, TestProfiles.LIGHT_PROFILE)) {
                 sslEngine = getEngineFromAcceptedChannel(originalTransport, connection2);
                 assertEquals("client", getAcceptedChannel(originalTransport, connection2).getProfile());
@@ -494,7 +503,11 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         ) {
             TcpTransport originalTransport = (TcpTransport) service.getOriginalTransport();
             TransportAddress clientAddress = originalTransport.profileBoundAddresses().get("client").publishAddress();
-            DiscoveryNode node = new DiscoveryNode(service.getLocalNode().getId(), clientAddress, service.getLocalNode().getVersion());
+            DiscoveryNode node = TestDiscoveryNode.create(
+                service.getLocalNode().getId(),
+                clientAddress,
+                service.getLocalNode().getVersion()
+            );
             try (Transport.Connection connection2 = openConnection(serviceA, node, TestProfiles.LIGHT_PROFILE)) {
                 sslEngine = getEngineFromAcceptedChannel(originalTransport, connection2);
                 assertEquals("client", getAcceptedChannel(originalTransport, connection2).getProfile());
@@ -534,7 +547,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         try (MockTransportService fcService = buildService("FC", Version.CURRENT, TransportVersion.CURRENT, fcSettings)) {
             final TcpTransport originalTransport = (TcpTransport) fcService.getOriginalTransport();
             final TransportAddress remoteAccessAddress = originalTransport.profileBoundAddresses().get("_remote_cluster").publishAddress();
-            final DiscoveryNode node = new DiscoveryNode(
+            final DiscoveryNode node = TestDiscoveryNode.create(
                 fcService.getLocalNode().getId(),
                 remoteAccessAddress,
                 fcService.getLocalNode().getVersion()
@@ -654,7 +667,7 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         try (MockTransportService fcService = buildService("FC", Version.CURRENT, TransportVersion.CURRENT, fcSettings)) {
             final TcpTransport originalTransport = (TcpTransport) fcService.getOriginalTransport();
             final TransportAddress remoteAccessAddress = originalTransport.profileBoundAddresses().get("_remote_cluster").publishAddress();
-            final DiscoveryNode node = new DiscoveryNode(
+            final DiscoveryNode node = TestDiscoveryNode.create(
                 fcService.getLocalNode().getId(),
                 remoteAccessAddress,
                 fcService.getLocalNode().getVersion()

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialInfoTransportActionTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialInfoTransportActionTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.spatial.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -15,6 +14,7 @@ import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.tasks.Task;
@@ -44,7 +44,7 @@ public class SpatialInfoTransportActionTests extends ESTestCase {
     public void init() {
         clusterService = mock(ClusterService.class);
 
-        DiscoveryNode discoveryNode = new DiscoveryNode("nodeId", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode discoveryNode = TestDiscoveryNode.create("nodeId");
         when(clusterService.localNode()).thenReturn(discoveryNode);
         ClusterName clusterName = new ClusterName("cluster_name");
         when(clusterService.getClusterName()).thenReturn(clusterName);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportActionTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/action/SpatialStatsTransportActionTests.java
@@ -6,12 +6,12 @@
  */
 package org.elasticsearch.xpack.spatial.action;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.test.ESTestCase;
@@ -51,7 +51,7 @@ public class SpatialStatsTransportActionTests extends ESTestCase {
         threadPool = mock(ThreadPool.class);
         clusterService = mock(ClusterService.class);
 
-        DiscoveryNode discoveryNode = new DiscoveryNode("nodeId", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode discoveryNode = TestDiscoveryNode.create("nodeId");
         when(clusterService.localNode()).thenReturn(discoveryNode);
         ClusterName clusterName = new ClusterName("cluster_name");
         when(clusterService.getClusterName()).thenReturn(clusterName);

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlInfoTransportActionTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/SqlInfoTransportActionTests.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.sql;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -71,7 +71,7 @@ public class SqlInfoTransportActionTests extends ESTestCase {
             ActionListener<SqlStatsResponse> listener = (ActionListener<SqlStatsResponse>) mock.getArguments()[2];
 
             List<SqlStatsResponse.NodeStatsResponse> nodes = new ArrayList<>();
-            DiscoveryNode first = new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode first = TestDiscoveryNode.create("first");
             SqlStatsResponse.NodeStatsResponse firstNode = new SqlStatsResponse.NodeStatsResponse(first);
             Counters firstCounters = new Counters();
             firstCounters.inc("foo.foo", 1);
@@ -79,7 +79,7 @@ public class SqlInfoTransportActionTests extends ESTestCase {
             firstNode.setStats(firstCounters);
             nodes.add(firstNode);
 
-            DiscoveryNode second = new DiscoveryNode("second", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode second = TestDiscoveryNode.create("second");
             SqlStatsResponse.NodeStatsResponse secondNode = new SqlStatsResponse.NodeStatsResponse(second);
             Counters secondCounters = new Counters();
             secondCounters.inc("spam", 1);

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -7,7 +7,6 @@
 
 package org.elasticsearch.xpack.stack;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -24,6 +23,7 @@ import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.TriFunction;
 import org.elasticsearch.common.settings.Settings;
@@ -102,7 +102,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingTemplatesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
@@ -127,7 +127,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingPoliciesAreAddedImmediately() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         AtomicInteger calledTimes = new AtomicInteger(0);
@@ -170,7 +170,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExists() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -195,7 +195,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExistsButDiffers() throws IOException {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -241,7 +241,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatVersionedOldTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(
@@ -258,7 +258,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatUnversionedOldTemplatesAreUpgraded() throws Exception {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(
@@ -280,7 +280,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
             NamedXContentRegistry.EMPTY
         );
 
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(
@@ -320,7 +320,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
 
     @TestLogging(value = "org.elasticsearch.xpack.core.template:DEBUG", reason = "test")
     public void testSameOrHigherVersionTemplateNotUpgraded() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, Integer> versions = new HashMap<>();
@@ -383,7 +383,7 @@ public class StackTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
 
         client.setVerifier((a, r, l) -> {

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherInfoTransportActionTests.java
@@ -6,13 +6,13 @@
  */
 package org.elasticsearch.xpack.watcher;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.settings.Settings;
@@ -103,7 +103,7 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
             ActionListener<WatcherStatsResponse> listener = (ActionListener<WatcherStatsResponse>) mock.getArguments()[2];
 
             List<WatcherStatsResponse.Node> nodes = new ArrayList<>();
-            DiscoveryNode first = new DiscoveryNode("first", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode first = TestDiscoveryNode.create("first");
             WatcherStatsResponse.Node firstNode = new WatcherStatsResponse.Node(first);
             Counters firstCounters = new Counters();
             firstCounters.inc("foo.foo", 1);
@@ -111,7 +111,7 @@ public class WatcherInfoTransportActionTests extends ESTestCase {
             firstNode.setStats(firstCounters);
             nodes.add(firstNode);
 
-            DiscoveryNode second = new DiscoveryNode("second", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode second = TestDiscoveryNode.create("second");
             WatcherStatsResponse.Node secondNode = new WatcherStatsResponse.Node(second);
             Counters secondCounters = new Counters();
             secondCounters.inc("spam", 1);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/support/WatcherIndexTemplateRegistryTests.java
@@ -6,7 +6,6 @@
  */
 package org.elasticsearch.xpack.watcher.support;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.template.put.PutComposableIndexTemplateAction;
 import org.elasticsearch.action.admin.indices.template.put.PutIndexTemplateRequest;
@@ -24,6 +23,7 @@ import org.elasticsearch.cluster.metadata.IndexTemplateMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
@@ -117,7 +117,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingTemplatesAreAddedImmediately() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
@@ -143,7 +143,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingTemplatesAreAddedEvenWithILMUsageDisabled() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         registry = new WatcherIndexTemplateRegistry(
@@ -172,7 +172,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatNonExistingPoliciesAreAddedImmediately() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
@@ -181,7 +181,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExists() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -195,7 +195,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testNoPolicyButILMDisabled() {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         registry = new WatcherIndexTemplateRegistry(
@@ -211,7 +211,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testPolicyAlreadyExistsButDiffers() throws IOException {
-        DiscoveryNode node = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode node = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("node").add(node).build();
 
         Map<String, LifecyclePolicy> policyMap = new HashMap<>();
@@ -283,8 +283,8 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatTemplatesAreNotAppliedOnSameVersionNodes() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
-        DiscoveryNode masterNode = new DiscoveryNode("master", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
+        DiscoveryNode masterNode = TestDiscoveryNode.create("master");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").masterNodeId("master").add(localNode).add(masterNode).build();
 
         Map<String, Integer> existingTemplates = new HashMap<>();
@@ -296,7 +296,7 @@ public class WatcherIndexTemplateRegistryTests extends ESTestCase {
     }
 
     public void testThatMissingMasterNodeDoesNothing() {
-        DiscoveryNode localNode = new DiscoveryNode("node", ESTestCase.buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode localNode = TestDiscoveryNode.create("node");
         DiscoveryNodes nodes = DiscoveryNodes.builder().localNodeId("node").add(localNode).build();
 
         Map<String, Integer> existingTemplates = new HashMap<>();

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportAckWatchActionTests.java
@@ -7,7 +7,6 @@
 package org.elasticsearch.xpack.watcher.transport.actions;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.action.support.ActionFilters;
@@ -16,6 +15,7 @@ import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -122,7 +122,7 @@ public class TransportAckWatchActionTests extends ESTestCase {
 
         doAnswer(invocation -> {
             ContextPreservingActionListener listener = (ContextPreservingActionListener) invocation.getArguments()[2];
-            DiscoveryNode discoveryNode = new DiscoveryNode("node_2", buildNewFakeTransportAddress(), Version.CURRENT);
+            DiscoveryNode discoveryNode = TestDiscoveryNode.create("node_2");
             WatcherStatsResponse.Node node = new WatcherStatsResponse.Node(discoveryNode);
             WatchExecutionSnapshot snapshot = mock(WatchExecutionSnapshot.class);
             when(snapshot.watchId()).thenReturn(watchId);

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportWatcherStatsActionTests.java
@@ -6,12 +6,12 @@
  */
 package org.elasticsearch.xpack.watcher.transport.actions;
 
-import org.elasticsearch.Version;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.TestDiscoveryNode;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.test.ESTestCase;
@@ -48,7 +48,7 @@ public class TransportWatcherStatsActionTests extends ESTestCase {
         ThreadPool threadPool = mock(ThreadPool.class);
 
         ClusterService clusterService = mock(ClusterService.class);
-        DiscoveryNode discoveryNode = new DiscoveryNode("nodeId", buildNewFakeTransportAddress(), Version.CURRENT);
+        DiscoveryNode discoveryNode = TestDiscoveryNode.create("nodeId");
         when(clusterService.localNode()).thenReturn(discoveryNode);
 
         ClusterName clusterName = new ClusterName("cluster_name");


### PR DESCRIPTION
Create a TestDiscoveryNode class to help create instances of DiscoveryNode for tests, and refactor uses of the smallest constructor to use it.

This is the first of a series of PRs to simplify the constructors in `DiscoveryNode`, in preparation for future work to change the constructor signature to allow for index versions to be specified.

These changes have all been done mechanically, using structural find-and-replace.