### PR TITLE
[8.8] Fix behavioural analytics tests (#95680)

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
@@ -14,6 +14,11 @@ teardown:
         name: my-test-analytics-collection
         ignore: 404
 
+  - do:
+      search_application.delete_behavioral_analytics:
+        name: my-test-analytics-collection2
+        ignore: 404
+
 ---
 "Get Analytics Collection for a particular collection":
   - do:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/80_behavioral_analytics_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/80_behavioral_analytics_delete.yml
@@ -7,7 +7,7 @@ setup:
 teardown:
   - do:
       search_application.delete_behavioral_analytics:
-        name: test-analytics-collection-to-delete
+        name: my-test-analytics-collection
         ignore: 404
 
 ---

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
@@ -2,6 +2,7 @@ setup:
   - do:
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
+        ignore: 400 # Sometimes teardown does not delete the collection and tests get flaky - this fixes it
 
 ---
 teardown:
@@ -413,9 +414,6 @@ teardown:
 
 ---
 "Post search_click analytics event - Document Only":
-  - skip:
-      version: all
-      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/95629"
   - do:
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
@@ -481,9 +479,6 @@ teardown:
 
 ---
 "Post analytics event - Event type does not exist":
-  - skip:
-      version: all
-      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/95629"
   - do:
       catch: "bad_request"
       search_application.post_behavioral_analytics_event:
@@ -501,9 +496,6 @@ teardown:
 
 ---
 "Post page_view analytics event - Missing session.id":
-  - skip:
-      version: all
-      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/95629"
   - do:
       catch: "bad_request"
       search_application.post_behavioral_analytics_event:


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix behavioural analytics tests (#95680)