### PR TITLE
Change some double comparisons in matrix stats tests to be approximate

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
@@ -125,7 +125,8 @@ setup:
 
 ---
 "Multi value field Max":
-
+  - skip:
+      features: close_to
   - do:
       search:
         rest_total_hits_as_int: true
@@ -135,10 +136,12 @@ setup:
   - match: {hits.total: 15}
   - match: {aggregations.mfs.doc_count: 14}
   - match: {aggregations.mfs.fields.0.count: 14}
-  - match: {aggregations.mfs.fields.0.correlation.val1: 0.06838646533369998}
+  - close_to: {aggregations.mfs.fields.0.correlation.val1: {value: 0.06838646533369998, error: 0.00000000001}}
 
 ---
 "Multi value field Min":
+  - skip:
+      features: close_to
 
   - do:
       search:
@@ -149,10 +152,12 @@ setup:
   - match: {hits.total: 15}
   - match: {aggregations.mfs.doc_count: 14}
   - match: {aggregations.mfs.fields.0.count: 14}
-  - match: {aggregations.mfs.fields.0.correlation.val1: -0.09777682707831963}
+  - close_to: {aggregations.mfs.fields.0.correlation.val1: {value: -0.09777682707831963, error: 0.00000000001}}
 
 ---
 "Partially unmapped":
+  - skip:
+      features: close_to
 
   - do:
       search:
@@ -163,10 +168,12 @@ setup:
   - match: {hits.total: 15}
   - match: {aggregations.mfs.doc_count: 13}
   - match: {aggregations.mfs.fields.0.count: 13}
-  - match: {aggregations.mfs.fields.0.correlation.val1: -0.044997535185684244}
+  - close_to: {aggregations.mfs.fields.0.correlation.val1: {value: -0.044997535185684244, error: 0.00000000001}}
 
 ---
 "Partially unmapped with missing defaults":
+  - skip:
+      features: close_to
 
   - do:
       search:
@@ -177,7 +184,7 @@ setup:
   - match: {hits.total: 15}
   - match: {aggregations.mfs.doc_count: 15}
   - match: {aggregations.mfs.fields.0.count: 15}
-  - match: {aggregations.mfs.fields.0.correlation.val2: 0.04028024709708195}
+  - close_to: {aggregations.mfs.fields.0.correlation.val2: {value: 0.04028024709708195, error: 0.00000000001}}
 
 ---
 "With script":

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_single_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_single_value_field.yml
@@ -135,7 +135,8 @@ setup:
 
 ---
 "Partially unmapped":
-
+  - skip:
+      features: close_to
   - do:
       search:
         rest_total_hits_as_int: true
@@ -145,11 +146,12 @@ setup:
   - match: {hits.total: 15}
   - match: {aggregations.mfs.doc_count: 14}
   - match: {aggregations.mfs.fields.0.count: 14}
-  - match: {aggregations.mfs.fields.2.correlation.val2: 0.9569513137793205}
+  - close_to: {aggregations.mfs.fields.2.correlation.val2: {value: 0.9569513137793205, error: 0.00000000001}}
 
 ---
 "Partially unmapped with missing default":
-
+  - skip:
+      features: close_to
   - do:
       search:
         rest_total_hits_as_int: true
@@ -159,7 +161,7 @@ setup:
   - match: {hits.total: 15}
   - match: {aggregations.mfs.doc_count: 15}
   - match: {aggregations.mfs.fields.0.count: 15}
-  - match: {aggregations.mfs.fields.2.correlation.val2: 0.9567970467908384}
+  - close_to: {aggregations.mfs.fields.2.correlation.val2: {value: 0.9567970467908384, error: 0.00000000001}}
 
 ---
 "With script":


### PR DESCRIPTION
resolves https://github.com/elastic/elasticsearch/issues/94631

The test in question is failing occasionally with a difference somewhere around 2.2e-16 on an exact match double comparison.  I think we can just set it to use a close enough match and move on.  I made the same change in a few related places too, although I didn't go looking for everywhere we might be doing an exact match on a double value.