### PR TITLE
[8.8] [DOCS] Fix 'shards_size' typo (#95696)

### DIFF
--- a/docs/reference/search/suggesters/phrase-suggest.asciidoc
+++ b/docs/reference/search/suggesters/phrase-suggest.asciidoc
@@ -366,7 +366,7 @@ The direct generators support the following parameters:
 
 `max_inspections`::
     A factor that is used to multiply with the
-    `shards_size` in order to inspect more candidate spelling corrections on
+    `shard_size` in order to inspect more candidate spelling corrections on
     the shard level. Can improve accuracy at the cost of performance.
     Defaults to 5.
 

--- a/docs/reference/search/suggesters/term-suggest.asciidoc
+++ b/docs/reference/search/suggesters/term-suggest.asciidoc
@@ -79,7 +79,7 @@ doesn't take the query into account that is part of request.
 
 `max_inspections`::
     A factor that is used to multiply with the
-    `shards_size` in order to inspect more candidate spelling corrections on
+    `shard_size` in order to inspect more candidate spelling corrections on
     the shard level. Can improve accuracy at the cost of performance.
     Defaults to 5.
 


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Fix 'shards_size' typo (#95696)