### PR TITLE
Use test admin client shortcuts in more spots

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/IndicesRequestIT.java
@@ -386,7 +386,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
         clearInterceptedActions();
         String[] concreteIndexNames = TestIndexNameExpressionResolver.newInstance()
-            .concreteIndexNames(client().admin().cluster().prepareState().get().getState(), flushRequest);
+            .concreteIndexNames(clusterAdmin().prepareState().get().getState(), flushRequest);
         assertIndicesSubset(Arrays.asList(concreteIndexNames), indexShardActions);
     }
 
@@ -413,7 +413,7 @@ public class IndicesRequestIT extends ESIntegTestCase {
 
         clearInterceptedActions();
         String[] concreteIndexNames = TestIndexNameExpressionResolver.newInstance()
-            .concreteIndexNames(client().admin().cluster().prepareState().get().getState(), refreshRequest);
+            .concreteIndexNames(clusterAdmin().prepareState().get().getState(), refreshRequest);
         assertIndicesSubset(Arrays.asList(concreteIndexNames), indexShardActions);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/HotThreadsIT.java
@@ -45,7 +45,7 @@ public class HotThreadsIT extends ESIntegTestCase {
         final AtomicBoolean hasErrors = new AtomicBoolean(false);
         for (int i = 0; i < iters; i++) {
             final String type;
-            NodesHotThreadsRequestBuilder nodesHotThreadsRequestBuilder = client().admin().cluster().prepareNodesHotThreads();
+            NodesHotThreadsRequestBuilder nodesHotThreadsRequestBuilder = clusterAdmin().prepareNodesHotThreads();
             if (randomBoolean()) {
                 TimeValue timeValue = new TimeValue(rarely() ? randomIntBetween(500, 5000) : randomIntBetween(20, 500));
                 nodesHotThreadsRequestBuilder.setInterval(timeValue);
@@ -126,7 +126,7 @@ public class HotThreadsIT extends ESIntegTestCase {
         assumeTrue("no support for hot_threads on FreeBSD", Constants.FREE_BSD == false);
 
         // First time, don't ignore idle threads:
-        NodesHotThreadsRequestBuilder builder = client().admin().cluster().prepareNodesHotThreads();
+        NodesHotThreadsRequestBuilder builder = clusterAdmin().prepareNodesHotThreads();
         builder.setIgnoreIdleThreads(false);
         builder.setThreads(Integer.MAX_VALUE);
         NodesHotThreadsResponse response = builder.execute().get();
@@ -142,7 +142,7 @@ public class HotThreadsIT extends ESIntegTestCase {
         }
 
         // Second time, do ignore idle threads:
-        builder = client().admin().cluster().prepareNodesHotThreads();
+        builder = clusterAdmin().prepareNodesHotThreads();
         builder.setThreads(Integer.MAX_VALUE);
 
         // Make sure default is true:
@@ -161,7 +161,7 @@ public class HotThreadsIT extends ESIntegTestCase {
 
     public void testTimestampAndParams() throws ExecutionException, InterruptedException {
 
-        NodesHotThreadsResponse response = client().admin().cluster().prepareNodesHotThreads().execute().get();
+        NodesHotThreadsResponse response = clusterAdmin().prepareNodesHotThreads().execute().get();
 
         if (Constants.FREE_BSD) {
             for (NodeHotThreads node : response.getNodesMap().values()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/ReloadSecureSettingsIT.java
@@ -66,9 +66,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         final int initialReloadCount = mockReloadablePlugin.getReloadCount();
         final CountDownLatch latch = new CountDownLatch(1);
         final SecureString emptyPassword = randomBoolean() ? new SecureString(new char[0]) : null;
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             .setSecureStorePassword(emptyPassword)
             .setNodesIds(Strings.EMPTY_ARRAY)
             .execute(new ActionListener<NodesReloadSecureSettingsResponse>() {
@@ -122,9 +120,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         }
         final CountDownLatch latch = new CountDownLatch(1);
         final SecureString emptyPassword = randomBoolean() ? new SecureString(new char[0]) : null;
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             .setSecureStorePassword(emptyPassword)
             .setNodesIds(Strings.EMPTY_ARRAY)
             .execute(new ActionListener<NodesReloadSecureSettingsResponse>() {
@@ -170,9 +166,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         final char[] password = randomAlphaOfLength(12).toCharArray();
         writeEmptyKeystore(environment, password);
         final CountDownLatch latch = new CountDownLatch(1);
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             // No filter should try to hit all nodes
             .setNodesIds(Strings.EMPTY_ARRAY)
             .setSecureStorePassword(new SecureString(password))
@@ -210,9 +204,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         final char[] password = randomAlphaOfLength(12).toCharArray();
         writeEmptyKeystore(environment, password);
         final CountDownLatch latch = new CountDownLatch(1);
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             .setNodesIds("_local")
             .setSecureStorePassword(new SecureString(password))
             .execute(new ActionListener<NodesReloadSecureSettingsResponse>() {
@@ -256,9 +248,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         // "some" keystore should be present in this case
         writeEmptyKeystore(environment, new char[0]);
         final CountDownLatch latch = new CountDownLatch(1);
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             .setNodesIds("_local")
             .setSecureStorePassword(new SecureString(new char[] { 'W', 'r', 'o', 'n', 'g' }))
             .execute(new ActionListener<NodesReloadSecureSettingsResponse>() {
@@ -319,9 +309,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         ).toString();
         final CountDownLatch latch = new CountDownLatch(1);
         final SecureString emptyPassword = randomBoolean() ? new SecureString(new char[0]) : null;
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             .setSecureStorePassword(emptyPassword)
             .setNodesIds(Strings.EMPTY_ARRAY)
             .execute(new ActionListener<NodesReloadSecureSettingsResponse>() {
@@ -393,9 +381,7 @@ public class ReloadSecureSettingsIT extends ESIntegTestCase {
         final AtomicReference<AssertionError> reloadSettingsError = new AtomicReference<>();
         final CountDownLatch latch = new CountDownLatch(1);
         final SecureString emptyPassword = randomBoolean() ? new SecureString(new char[0]) : null;
-        client().admin()
-            .cluster()
-            .prepareReloadSecureSettings()
+        clusterAdmin().prepareReloadSecureSettings()
             .setSecureStorePassword(emptyPassword)
             .setNodesIds(Strings.EMPTY_ARRAY)
             .execute(new ActionListener<NodesReloadSecureSettingsResponse>() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetDesiredBalanceActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/TransportGetDesiredBalanceActionIT.java
@@ -37,10 +37,7 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
 
         indexData(index);
 
-        var clusterHealthResponse = client().admin()
-            .cluster()
-            .health(new ClusterHealthRequest().waitForStatus(ClusterHealthStatus.GREEN))
-            .get();
+        var clusterHealthResponse = clusterAdmin().health(new ClusterHealthRequest().waitForStatus(ClusterHealthStatus.GREEN)).get();
         assertEquals(RestStatus.OK, clusterHealthResponse.status());
 
         DesiredBalanceResponse desiredBalanceResponse = client().execute(GetDesiredBalanceAction.INSTANCE, new DesiredBalanceRequest())
@@ -52,9 +49,7 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
         for (var entry : shardsMap.entrySet()) {
             Integer shardId = entry.getKey();
             DesiredBalanceResponse.DesiredShards desiredShards = entry.getValue();
-            IndexShardRoutingTable shardRoutingTable = client().admin()
-                .cluster()
-                .prepareState()
+            IndexShardRoutingTable shardRoutingTable = clusterAdmin().prepareState()
                 .get()
                 .getState()
                 .routingTable()
@@ -77,10 +72,7 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
         int numberOfReplicas = 1;
         createIndex(index, numberOfShards, numberOfReplicas);
         indexData(index);
-        var clusterHealthResponse = client().admin()
-            .cluster()
-            .health(new ClusterHealthRequest(index).waitForStatus(ClusterHealthStatus.YELLOW))
-            .get();
+        var clusterHealthResponse = clusterAdmin().health(new ClusterHealthRequest(index).waitForStatus(ClusterHealthStatus.YELLOW)).get();
         assertEquals(RestStatus.OK, clusterHealthResponse.status());
 
         DesiredBalanceResponse desiredBalanceResponse = client().execute(GetDesiredBalanceAction.INSTANCE, new DesiredBalanceRequest())
@@ -92,9 +84,7 @@ public class TransportGetDesiredBalanceActionIT extends ESIntegTestCase {
         for (var entry : shardsMap.entrySet()) {
             Integer shardId = entry.getKey();
             DesiredBalanceResponse.DesiredShards desiredShards = entry.getValue();
-            IndexShardRoutingTable shardRoutingTable = client().admin()
-                .cluster()
-                .prepareState()
+            IndexShardRoutingTable shardRoutingTable = clusterAdmin().prepareState()
                 .get()
                 .getState()
                 .routingTable()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDesiredNodesActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/desirednodes/TransportDesiredNodesActionsIT.java
@@ -371,7 +371,7 @@ public class TransportDesiredNodesActionsIT extends ESIntegTestCase {
             future.actionGet();
         }
 
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final DesiredNodes latestDesiredNodes = DesiredNodes.latestFromClusterState(state);
         assertThat(latestDesiredNodes, is(nullValue()));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/node/tasks/CancellableTasksIT.java
@@ -165,22 +165,18 @@ public class CancellableTasksIT extends ESIntegTestCase {
         ActionFuture<TestResponse> rootTaskFuture = client().execute(TransportTestAction.ACTION, rootRequest);
         Set<TestRequest> pendingRequests = allowPartialRequest(rootRequest);
         TaskId rootTaskId = getRootTaskId(rootRequest);
-        ActionFuture<CancelTasksResponse> cancelFuture = client().admin()
-            .cluster()
-            .prepareCancelTasks()
+        ActionFuture<CancelTasksResponse> cancelFuture = clusterAdmin().prepareCancelTasks()
             .setTargetTaskId(rootTaskId)
             .waitForCompletion(true)
             .execute();
         if (randomBoolean()) {
-            List<TaskInfo> runningTasks = client().admin()
-                .cluster()
-                .prepareListTasks()
+            List<TaskInfo> runningTasks = clusterAdmin().prepareListTasks()
                 .setActions(TransportTestAction.ACTION.name())
                 .setDetailed(true)
                 .get()
                 .getTasks();
             for (TaskInfo subTask : randomSubsetOf(runningTasks)) {
-                client().admin().cluster().prepareCancelTasks().setTargetTaskId(subTask.taskId()).waitForCompletion(false).get();
+                clusterAdmin().prepareCancelTasks().setTargetTaskId(subTask.taskId()).waitForCompletion(false).get();
             }
         }
         try {
@@ -218,12 +214,10 @@ public class CancellableTasksIT extends ESIntegTestCase {
         ActionFuture<TestResponse> mainTaskFuture = client().execute(TransportTestAction.ACTION, rootRequest);
         TaskId taskId = getRootTaskId(rootRequest);
         allowPartialRequest(rootRequest);
-        CancelTasksResponse resp = client().admin().cluster().prepareCancelTasks().setTargetTaskId(taskId).waitForCompletion(false).get();
+        CancelTasksResponse resp = clusterAdmin().prepareCancelTasks().setTargetTaskId(taskId).waitForCompletion(false).get();
         assertThat(resp.getTaskFailures(), empty());
         assertThat(resp.getNodeFailures(), empty());
-        ActionFuture<CancelTasksResponse> cancelFuture = client().admin()
-            .cluster()
-            .prepareCancelTasks()
+        ActionFuture<CancelTasksResponse> cancelFuture = clusterAdmin().prepareCancelTasks()
             .setTargetTaskId(taskId)
             .waitForCompletion(true)
             .execute();
@@ -232,9 +226,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
         assertThat(cancelFuture.actionGet().getTaskFailures(), empty());
         assertThat(cancelFuture.actionGet().getTaskFailures(), empty());
         waitForRootTask(mainTaskFuture, false);
-        CancelTasksResponse cancelError = client().admin()
-            .cluster()
-            .prepareCancelTasks()
+        CancelTasksResponse cancelError = clusterAdmin().prepareCancelTasks()
             .setTargetTaskId(taskId)
             .waitForCompletion(randomBoolean())
             .get();
@@ -253,9 +245,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
             allowPartialRequest(rootRequest);
         }
         boolean waitForCompletion = randomBoolean();
-        ActionFuture<CancelTasksResponse> cancelFuture = client().admin()
-            .cluster()
-            .prepareCancelTasks()
+        ActionFuture<CancelTasksResponse> cancelFuture = clusterAdmin().prepareCancelTasks()
             .setTargetTaskId(taskId)
             .waitForCompletion(waitForCompletion)
             .execute();
@@ -275,7 +265,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
         TestRequest rootRequest = generateTestRequest(nodes, 0, between(1, 3), false);
         ActionFuture<TestResponse> rootTaskFuture = client().execute(TransportTestAction.ACTION, rootRequest);
         TaskId taskId = getRootTaskId(rootRequest);
-        client().admin().cluster().prepareCancelTasks().setTargetTaskId(taskId).waitForCompletion(false).get();
+        clusterAdmin().prepareCancelTasks().setTargetTaskId(taskId).waitForCompletion(false).get();
         DiscoveryNode nodeWithParentTask = nodes.stream().filter(n -> n.getId().equals(taskId.getNodeId())).findFirst().get();
         TransportTestAction mainAction = internalCluster().getInstance(TransportTestAction.class, nodeWithParentTask.getName());
         PlainActionFuture<TestResponse> future = new PlainActionFuture<>();
@@ -321,9 +311,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
         client().execute(TransportTestAction.ACTION, rootRequest);
         Set<TestRequest> pendingRequests = allowPartialRequest(rootRequest);
         TaskId rootTaskId = getRootTaskId(rootRequest);
-        ActionFuture<CancelTasksResponse> cancelFuture = client().admin()
-            .cluster()
-            .prepareCancelTasks()
+        ActionFuture<CancelTasksResponse> cancelFuture = clusterAdmin().prepareCancelTasks()
             .setTargetTaskId(rootTaskId)
             .waitForCompletion(true)
             .execute();
@@ -392,9 +380,7 @@ public class CancellableTasksIT extends ESIntegTestCase {
     static TaskId getRootTaskId(TestRequest request) throws Exception {
         SetOnce<TaskId> taskId = new SetOnce<>();
         assertBusy(() -> {
-            ListTasksResponse listTasksResponse = client().admin()
-                .cluster()
-                .prepareListTasks()
+            ListTasksResponse listTasksResponse = clusterAdmin().prepareListTasks()
                 .setActions(TransportTestAction.ACTION.name())
                 .setDetailed(true)
                 .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/repositories/RepositoryBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/repositories/RepositoryBlocksIT.java
@@ -32,9 +32,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
         try {
             setClusterReadOnly(true);
             assertBlocked(
-                client().admin()
-                    .cluster()
-                    .preparePutRepository("test-repo-blocks")
+                clusterAdmin().preparePutRepository("test-repo-blocks")
                     .setType("fs")
                     .setVerify(false)
                     .setSettings(Settings.builder().put("location", randomRepoPath())),
@@ -46,9 +44,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
 
         logger.info("-->  registering a repository is allowed when the cluster is not read only");
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutRepository("test-repo-blocks")
+            clusterAdmin().preparePutRepository("test-repo-blocks")
                 .setType("fs")
                 .setVerify(false)
                 .setSettings(Settings.builder().put("location", randomRepoPath()))
@@ -57,9 +53,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
 
     public void testVerifyRepositoryWithBlocks() {
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutRepository("test-repo-blocks")
+            clusterAdmin().preparePutRepository("test-repo-blocks")
                 .setType("fs")
                 .setVerify(false)
                 .setSettings(Settings.builder().put("location", randomRepoPath()))
@@ -68,11 +62,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
         // This test checks that the Get Repository operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            VerifyRepositoryResponse response = client().admin()
-                .cluster()
-                .prepareVerifyRepository("test-repo-blocks")
-                .execute()
-                .actionGet();
+            VerifyRepositoryResponse response = clusterAdmin().prepareVerifyRepository("test-repo-blocks").execute().actionGet();
             assertThat(response.getNodes().size(), equalTo(cluster().numDataAndMasterNodes()));
         } finally {
             setClusterReadOnly(false);
@@ -81,9 +71,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
 
     public void testDeleteRepositoryWithBlocks() {
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutRepository("test-repo-blocks")
+            clusterAdmin().preparePutRepository("test-repo-blocks")
                 .setType("fs")
                 .setVerify(false)
                 .setSettings(Settings.builder().put("location", randomRepoPath()))
@@ -92,20 +80,18 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
         logger.info("-->  deleting a repository is blocked when the cluster is read only");
         try {
             setClusterReadOnly(true);
-            assertBlocked(client().admin().cluster().prepareDeleteRepository("test-repo-blocks"), Metadata.CLUSTER_READ_ONLY_BLOCK);
+            assertBlocked(clusterAdmin().prepareDeleteRepository("test-repo-blocks"), Metadata.CLUSTER_READ_ONLY_BLOCK);
         } finally {
             setClusterReadOnly(false);
         }
 
         logger.info("-->  deleting a repository is allowed when the cluster is not read only");
-        assertAcked(client().admin().cluster().prepareDeleteRepository("test-repo-blocks"));
+        assertAcked(clusterAdmin().prepareDeleteRepository("test-repo-blocks"));
     }
 
     public void testGetRepositoryWithBlocks() {
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutRepository("test-repo-blocks")
+            clusterAdmin().preparePutRepository("test-repo-blocks")
                 .setType("fs")
                 .setVerify(false)
                 .setSettings(Settings.builder().put("location", randomRepoPath()))
@@ -114,7 +100,7 @@ public class RepositoryBlocksIT extends ESIntegTestCase {
         // This test checks that the Get Repository operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            GetRepositoriesResponse response = client().admin().cluster().prepareGetRepositories("test-repo-blocks").execute().actionGet();
+            GetRepositoriesResponse response = clusterAdmin().prepareGetRepositories("test-repo-blocks").execute().actionGet();
             assertThat(response.repositories(), hasSize(1));
         } finally {
             setClusterReadOnly(false);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/snapshots/SnapshotBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/snapshots/SnapshotBlocksIT.java
@@ -56,21 +56,17 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         logger.info("--> register a repository");
 
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutRepository(REPOSITORY_NAME)
+            clusterAdmin().preparePutRepository(REPOSITORY_NAME)
                 .setType("fs")
                 .setSettings(Settings.builder().put("location", randomRepoPath()))
         );
 
         logger.info("--> verify the repository");
-        VerifyRepositoryResponse verifyResponse = client().admin().cluster().prepareVerifyRepository(REPOSITORY_NAME).get();
+        VerifyRepositoryResponse verifyResponse = clusterAdmin().prepareVerifyRepository(REPOSITORY_NAME).get();
         assertThat(verifyResponse.getNodes().size(), equalTo(cluster().numDataAndMasterNodes()));
 
         logger.info("--> create a snapshot");
-        CreateSnapshotResponse snapshotResponse = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
+        CreateSnapshotResponse snapshotResponse = clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
             .setIncludeGlobalState(true)
             .setWaitForCompletion(true)
             .execute()
@@ -84,7 +80,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         try {
             setClusterReadOnly(true);
             assertThat(
-                client().admin().cluster().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1").setWaitForCompletion(true).get().status(),
+                clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1").setWaitForCompletion(true).get().status(),
                 equalTo(RestStatus.OK)
             );
         } finally {
@@ -92,9 +88,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         }
 
         logger.info("-->  creating a snapshot is allowed when the cluster is not read only");
-        CreateSnapshotResponse response = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-2")
+        CreateSnapshotResponse response = clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-2")
             .setWaitForCompletion(true)
             .execute()
             .actionGet();
@@ -106,9 +100,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         try {
             enableIndexBlock(INDEX_NAME, SETTING_READ_ONLY);
             assertThat(
-                client().admin()
-                    .cluster()
-                    .prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1")
+                clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-1")
                     .setIndices(COMMON_INDEX_NAME_MASK)
                     .setWaitForCompletion(true)
                     .get()
@@ -123,9 +115,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         try {
             enableIndexBlock(INDEX_NAME, SETTING_BLOCKS_READ);
             assertThat(
-                client().admin()
-                    .cluster()
-                    .prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-2")
+                clusterAdmin().prepareCreateSnapshot(REPOSITORY_NAME, "snapshot-2")
                     .setIndices(COMMON_INDEX_NAME_MASK)
                     .setWaitForCompletion(true)
                     .get()
@@ -141,7 +131,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         logger.info("-->  deleting a snapshot is allowed when the cluster is read only");
         try {
             setClusterReadOnly(true);
-            assertTrue(client().admin().cluster().prepareDeleteSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME).get().isAcknowledged());
+            assertTrue(clusterAdmin().prepareDeleteSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME).get().isAcknowledged());
         } finally {
             setClusterReadOnly(false);
         }
@@ -155,18 +145,13 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         logger.info("-->  restoring a snapshot is blocked when the cluster is read only");
         try {
             setClusterReadOnly(true);
-            assertBlocked(
-                client().admin().cluster().prepareRestoreSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME),
-                Metadata.CLUSTER_READ_ONLY_BLOCK
-            );
+            assertBlocked(clusterAdmin().prepareRestoreSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME), Metadata.CLUSTER_READ_ONLY_BLOCK);
         } finally {
             setClusterReadOnly(false);
         }
 
         logger.info("-->  creating a snapshot is allowed when the cluster is not read only");
-        RestoreSnapshotResponse response = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
+        RestoreSnapshotResponse response = clusterAdmin().prepareRestoreSnapshot(REPOSITORY_NAME, SNAPSHOT_NAME)
             .setWaitForCompletion(true)
             .execute()
             .actionGet();
@@ -179,7 +164,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         // This test checks that the Get Snapshot operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            GetSnapshotsResponse response = client().admin().cluster().prepareGetSnapshots(REPOSITORY_NAME).execute().actionGet();
+            GetSnapshotsResponse response = clusterAdmin().prepareGetSnapshots(REPOSITORY_NAME).execute().actionGet();
             assertThat(response.getSnapshots(), hasSize(1));
             assertThat(response.getSnapshots().get(0).snapshotId().getName(), equalTo(SNAPSHOT_NAME));
         } finally {
@@ -191,9 +176,7 @@ public class SnapshotBlocksIT extends ESIntegTestCase {
         // This test checks that the Snapshot Status operation is never blocked, even if the cluster is read only.
         try {
             setClusterReadOnly(true);
-            SnapshotsStatusResponse response = client().admin()
-                .cluster()
-                .prepareSnapshotStatus(REPOSITORY_NAME)
+            SnapshotsStatusResponse response = clusterAdmin().prepareSnapshotStatus(REPOSITORY_NAME)
                 .setSnapshots(SNAPSHOT_NAME)
                 .execute()
                 .actionGet();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/state/TransportClusterStateActionDisruptionIT.java
@@ -45,9 +45,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
 
     public void testNonLocalRequestAlwaysFindsMaster() throws Exception {
         runRepeatedlyWhileChangingMaster(() -> {
-            final ClusterStateRequestBuilder clusterStateRequestBuilder = client().admin()
-                .cluster()
-                .prepareState()
+            final ClusterStateRequestBuilder clusterStateRequestBuilder = clusterAdmin().prepareState()
                 .clear()
                 .setNodes(true)
                 .setMasterNodeTimeout("100ms");
@@ -150,9 +148,7 @@ public class TransportClusterStateActionDisruptionIT extends ESIntegTestCase {
 
         assertBusy(
             () -> assertThat(
-                client().admin()
-                    .cluster()
-                    .prepareState()
+                clusterAdmin().prepareState()
                     .clear()
                     .setMetadata(true)
                     .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/stats/ClusterStatsIT.java
@@ -58,10 +58,9 @@ public class ClusterStatsIT extends ESIntegTestCase {
     }
 
     private void waitForNodes(int numNodes) {
-        ClusterHealthResponse actionGet = client().admin()
-            .cluster()
-            .health(new ClusterHealthRequest(new String[] {}).waitForEvents(Priority.LANGUID).waitForNodes(Integer.toString(numNodes)))
-            .actionGet();
+        ClusterHealthResponse actionGet = clusterAdmin().health(
+            new ClusterHealthRequest(new String[] {}).waitForEvents(Priority.LANGUID).waitForNodes(Integer.toString(numNodes))
+        ).actionGet();
         assertThat(actionGet.isTimedOut(), is(false));
     }
 
@@ -86,7 +85,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         expectedCounts.put(ClusterStatsNodes.Counts.COORDINATING_ONLY, 0);
         int numNodes = randomIntBetween(1, 5);
 
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertCounts(response.getNodesStats().getCounts(), total, expectedCounts);
 
         for (int i = 0; i < numNodes; i++) {
@@ -130,7 +129,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
                 incrementCountForRole(ClusterStatsNodes.Counts.COORDINATING_ONLY, expectedCounts);
             }
 
-            response = client().admin().cluster().prepareClusterStats().get();
+            response = clusterAdmin().prepareClusterStats().get();
             assertCounts(response.getNodesStats().getCounts(), total, expectedCounts);
         }
     }
@@ -154,12 +153,12 @@ public class ClusterStatsIT extends ESIntegTestCase {
     public void testIndicesShardStats() throws ExecutionException, InterruptedException {
         internalCluster().startNode();
         ensureGreen();
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
 
         prepareCreate("test1").setSettings(Settings.builder().put("number_of_shards", 2).put("number_of_replicas", 1)).get();
 
-        response = client().admin().cluster().prepareClusterStats().get();
+        response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.YELLOW));
         assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(0L));
         assertThat(response.indicesStats.getIndexCount(), Matchers.equalTo(1));
@@ -170,14 +169,14 @@ public class ClusterStatsIT extends ESIntegTestCase {
         ensureGreen();
         indexDoc("test1", "1", "f", "f");
         refresh(); // make the doc visible
-        response = client().admin().cluster().prepareClusterStats().get();
+        response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
         assertThat(response.indicesStats.getDocs().getCount(), Matchers.equalTo(1L));
         assertShardStats(response.getIndicesStats().getShards(), 1, 4, 2, 1.0);
 
         prepareCreate("test2").setSettings(Settings.builder().put("number_of_shards", 3).put("number_of_replicas", 0)).get();
         ensureGreen();
-        response = client().admin().cluster().prepareClusterStats().get();
+        response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
         assertThat(response.indicesStats.getIndexCount(), Matchers.equalTo(2));
         assertShardStats(response.getIndicesStats().getShards(), 2, 7, 5, 2.0 / 5);
@@ -200,7 +199,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         internalCluster().startNodes(randomIntBetween(1, 3));
         indexDoc("test1", "1", "f", "f");
 
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         String msg = response.toString();
         assertThat(msg, response.getTimestamp(), Matchers.greaterThan(946681200000L)); // 1 Jan 2000
         assertThat(msg, response.indicesStats.getStore().getSizeInBytes(), Matchers.greaterThan(0L));
@@ -219,7 +218,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         assertThat(msg, response.nodesStats.getProcess().getMinOpenFileDescriptors(), Matchers.greaterThanOrEqualTo(-1L));
         assertThat(msg, response.nodesStats.getProcess().getMaxOpenFileDescriptors(), Matchers.greaterThanOrEqualTo(-1L));
 
-        NodesStatsResponse nodesStatsResponse = client().admin().cluster().prepareNodesStats().setOs(true).get();
+        NodesStatsResponse nodesStatsResponse = clusterAdmin().prepareNodesStats().setOs(true).get();
         long total = 0;
         long free = 0;
         long used = 0;
@@ -241,26 +240,26 @@ public class ClusterStatsIT extends ESIntegTestCase {
         internalCluster().startNode(Settings.builder().put(EsExecutors.NODE_PROCESSORS_SETTING.getKey(), nodeProcessors).build());
         waitForNodes(1);
 
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getNodesStats().getOs().getAllocatedProcessors(), equalTo(nodeProcessors));
     }
 
     public void testClusterStatusWhenStateNotRecovered() {
         internalCluster().startMasterOnlyNode(Settings.builder().put(GatewayService.RECOVER_AFTER_DATA_NODES_SETTING.getKey(), 1).build());
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), equalTo(ClusterHealthStatus.RED));
 
         internalCluster().startDataOnlyNode();
         // wait for the cluster status to settle
         ensureGreen();
-        response = client().admin().cluster().prepareClusterStats().get();
+        response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
     }
 
     public void testFieldTypes() {
         internalCluster().startNode();
         ensureGreen();
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getStatus(), Matchers.equalTo(ClusterHealthStatus.GREEN));
         assertTrue(response.getIndicesStats().getMappings().getFieldTypeStats().isEmpty());
 
@@ -284,7 +283,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
                 }
               }
             }""").get();
-        response = client().admin().cluster().prepareClusterStats().get();
+        response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getIndicesStats().getMappings().getFieldTypeStats().size(), equalTo(3));
         List<FieldStats> stats = response.getIndicesStats().getMappings().getFieldTypeStats();
         for (FieldStats stat : stats) {
@@ -302,7 +301,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
         internalCluster().startNode();
         ensureStableCluster(1);
         {
-            SearchUsageStats stats = client().admin().cluster().prepareClusterStats().get().getIndicesStats().getSearchUsageStats();
+            SearchUsageStats stats = clusterAdmin().prepareClusterStats().get().getIndicesStats().getSearchUsageStats();
             assertEquals(0, stats.getTotalSearchCount());
             assertEquals(0, stats.getQueryUsage().size());
             assertEquals(0, stats.getSectionsUsage().size());
@@ -350,7 +349,7 @@ public class ClusterStatsIT extends ESIntegTestCase {
             getRestClient().performRequest(request);
         }
 
-        SearchUsageStats stats = client().admin().cluster().prepareClusterStats().get().getIndicesStats().getSearchUsageStats();
+        SearchUsageStats stats = clusterAdmin().prepareClusterStats().get().getIndicesStats().getSearchUsageStats();
         assertEquals(5, stats.getTotalSearchCount());
         assertEquals(4, stats.getQueryUsage().size());
         assertEquals(1, stats.getQueryUsage().get("match").longValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/PendingTasksBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/tasks/PendingTasksBlocksIT.java
@@ -37,7 +37,7 @@ public class PendingTasksBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test", blockSetting);
-                PendingClusterTasksResponse response = client().admin().cluster().preparePendingClusterTasks().get();
+                PendingClusterTasksResponse response = clusterAdmin().preparePendingClusterTasks().get();
                 assertNotNull(response.pendingTasks());
             } finally {
                 disableIndexBlock("test", blockSetting);
@@ -53,7 +53,7 @@ public class PendingTasksBlocksIT extends ESIntegTestCase {
 
         try {
             setClusterReadOnly(true);
-            PendingClusterTasksResponse response = client().admin().cluster().preparePendingClusterTasks().get();
+            PendingClusterTasksResponse response = clusterAdmin().preparePendingClusterTasks().get();
             assertNotNull(response.pendingTasks());
         } finally {
             setClusterReadOnly(false);
@@ -67,7 +67,7 @@ public class PendingTasksBlocksIT extends ESIntegTestCase {
         }
 
         // restart the cluster but prevent it from performing state recovery
-        final int nodeCount = client().admin().cluster().prepareNodesInfo("data:true").get().getNodes().size();
+        final int nodeCount = clusterAdmin().prepareNodesInfo("data:true").get().getNodes().size();
         internalCluster().fullRestart(new InternalTestCluster.RestartCallback() {
             @Override
             public Settings onNodeStopped(String nodeName) {
@@ -80,7 +80,7 @@ public class PendingTasksBlocksIT extends ESIntegTestCase {
             }
         });
 
-        assertNotNull(client().admin().cluster().preparePendingClusterTasks().get().pendingTasks());
+        assertNotNull(clusterAdmin().preparePendingClusterTasks().get().pendingTasks());
 
         // starting one more node allows the cluster to recover
         internalCluster().startNode();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/CreateIndexIT.java
@@ -70,7 +70,7 @@ public class CreateIndexIT extends ESIntegTestCase {
         long timeBeforeRequest = System.currentTimeMillis();
         prepareCreate("test").get();
         long timeAfterRequest = System.currentTimeMillis();
-        ClusterStateResponse response = client().admin().cluster().prepareState().get();
+        ClusterStateResponse response = clusterAdmin().prepareState().get();
         ClusterState state = response.getState();
         assertThat(state, notNullValue());
         Metadata metadata = state.getMetadata();
@@ -279,9 +279,7 @@ public class CreateIndexIT extends ESIntegTestCase {
     }
 
     public void testRestartIndexCreationAfterFullClusterRestart() throws Exception {
-        client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(Settings.builder().put("cluster.routing.allocation.enable", "none"))
             .get();
         client().admin().indices().prepareCreate("test").setWaitForActiveShards(ActiveShardCount.NONE).setSettings(indexSettings()).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/create/SplitIndexIT.java
@@ -391,7 +391,7 @@ public class SplitIndexIT extends ESIntegTestCase {
             ensureGreen();
             assertNoResizeSourceIndexSettings("target");
 
-            final ClusterState state = client().admin().cluster().prepareState().get().getState();
+            final ClusterState state = clusterAdmin().prepareState().get().getState();
             DiscoveryNode mergeNode = state.nodes().get(state.getRoutingTable().index("target").shard(0).primaryShard().currentNodeId());
             logger.info("split node {}", mergeNode);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/rollover/RolloverIT.java
@@ -83,7 +83,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-1");
         if (explicitWriteIndex) {
             assertTrue(oldIndex.getAliases().containsKey("test_alias"));
@@ -106,7 +106,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         assertFalse(oldIndex.getAliases().containsKey("test_alias"));
         final IndexMetadata newIndex = state.metadata().index("test_index-000003");
@@ -131,7 +131,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
         assertFalse(oldIndex.getAliases().get("test_alias").writeIndex());
@@ -181,7 +181,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         final IndexMetadata newIndex = state.metadata().index("test_index-000003");
         assertThat(newIndex.getNumberOfShards(), equalTo(1));
@@ -217,7 +217,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-2");
         final IndexMetadata newIndex = state.metadata().index("test_index-000003");
         assertThat(newIndex.getNumberOfShards(), equalTo(1));
@@ -271,7 +271,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(true));
         assertThat(response.isRolledOver(), equalTo(false));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-1");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
         final IndexMetadata newIndex = state.metadata().index("test_index-000002");
@@ -311,7 +311,7 @@ public class RolloverIT extends ESIntegTestCase {
             )
         );
 
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index-0");
         assertTrue(oldIndex.getAliases().containsKey("test_alias"));
         if (explicitWriteIndex) {
@@ -342,7 +342,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index("test_index");
         final IndexMetadata newIndex = state.metadata().index("test_new_index");
         assertTrue(newIndex.getAliases().containsKey("test_alias"));
@@ -438,7 +438,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("No rollover with a large max_size condition", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
@@ -454,7 +454,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("Should rollover with a small max_size condition", response.isRolledOver(), equalTo(true));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(metConditions.get(0).toString(), equalTo(new MaxSizeCondition(maxSizeValue).toString()));
@@ -478,7 +478,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));
             assertThat("No rollover with an empty index", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-000002");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-000002");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
     }
@@ -505,7 +505,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("No rollover with a large max_primary_shard_size condition", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
@@ -521,7 +521,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("Should rollover with a small max_primary_shard_size condition", response.isRolledOver(), equalTo(true));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(metConditions.get(0).toString(), equalTo(new MaxPrimaryShardSizeCondition(maxPrimaryShardSizeCondition).toString()));
@@ -545,7 +545,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));
             assertThat("No rollover with an empty index", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-000002");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-000002");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
     }
@@ -571,7 +571,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("No rollover with a large max_primary_shard_docs condition", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
 
@@ -587,7 +587,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-1"));
             assertThat(response.getNewIndex(), equalTo("test-000002"));
             assertThat("Should rollover with a small max_primary_shard_docs condition", response.isRolledOver(), equalTo(true));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-1");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-1");
             List<Condition<?>> metConditions = oldIndex.getRolloverInfos().get("test_alias").getMetConditions();
             assertThat(metConditions.size(), equalTo(1));
             assertThat(
@@ -612,7 +612,7 @@ public class RolloverIT extends ESIntegTestCase {
             assertThat(response.getOldIndex(), equalTo("test-000002"));
             assertThat(response.getNewIndex(), equalTo("test-000003"));
             assertThat("No rollover with an empty index", response.isRolledOver(), equalTo(false));
-            final IndexMetadata oldIndex = client().admin().cluster().prepareState().get().getState().metadata().index("test-000002");
+            final IndexMetadata oldIndex = clusterAdmin().prepareState().get().getState().metadata().index("test-000002");
             assertThat(oldIndex.getRolloverInfos().size(), equalTo(0));
         }
     }
@@ -709,7 +709,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index(firstIndexName);
         assertTrue(oldIndex.getAliases().containsKey(aliasName));
         assertTrue(oldIndex.getAliases().get(aliasName).isHidden());
@@ -743,7 +743,7 @@ public class RolloverIT extends ESIntegTestCase {
         assertThat(response.isDryRun(), equalTo(false));
         assertThat(response.isRolledOver(), equalTo(true));
         assertThat(response.getConditionStatus().size(), equalTo(0));
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final IndexMetadata oldIndex = state.metadata().index(firstIndexName);
         assertFalse(oldIndex.getAliases().containsKey(aliasName));
         final IndexMetadata newIndex = state.metadata().index(secondIndexName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoreRequestIT.java
@@ -84,10 +84,10 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         logger.info("--> disable allocation");
         disableAllocation(index);
         logger.info("--> stop random node");
-        int num = client().admin().cluster().prepareState().get().getState().nodes().getSize();
+        int num = clusterAdmin().prepareState().get().getState().nodes().getSize();
         internalCluster().stopNode(internalCluster().getNodeNameThat(new IndexNodePredicate(index)));
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes("" + (num - 1)));
-        ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        assertNoTimeout(clusterAdmin().prepareHealth().setWaitForNodes("" + (num - 1)));
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         List<ShardRouting> unassignedShards = clusterState.routingTable().index(index).shardsWithState(ShardRoutingState.UNASSIGNED);
         response = client().admin().indices().shardStores(new IndicesShardStoresRequest(index)).get();
         assertThat(response.getStoreStatuses().containsKey(index), equalTo(true));
@@ -221,7 +221,7 @@ public class IndicesShardStoreRequestIT extends ESIntegTestCase {
         }
 
         private Set<String> findNodesWithShard(String index) {
-            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState().get().getState();
             IndexRoutingTable indexRoutingTable = state.routingTable().index(index);
             List<ShardRouting> startedShards = indexRoutingTable.shardsWithState(ShardRoutingState.STARTED);
             Set<String> nodesNamesWithShard = new HashSet<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -154,10 +154,9 @@ public class BulkIntegrationIT extends ESIntegTestCase {
             .endArray()
             .endObject();
 
-        AcknowledgedResponse acknowledgedResponse = client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest(pipelineId, BytesReference.bytes(pipeline), XContentType.JSON))
-            .get();
+        AcknowledgedResponse acknowledgedResponse = clusterAdmin().putPipeline(
+            new PutPipelineRequest(pipelineId, BytesReference.bytes(pipeline), XContentType.JSON)
+        ).get();
 
         assertTrue(acknowledgedResponse.isAcknowledged());
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorClusterSettingsIT.java
@@ -28,7 +28,7 @@ public class BulkProcessorClusterSettingsIT extends ESIntegTestCase {
         internalCluster().startNode(settings);
 
         createIndex("willwork");
-        client().admin().cluster().prepareHealth("willwork").setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth("willwork").setWaitForGreenStatus().execute().actionGet();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
         bulkRequestBuilder.add(client().prepareIndex("willwork").setId("1").setSource("{\"foo\":1}", XContentType.JSON));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -426,7 +426,7 @@ public class PointInTimeIT extends ESIntegTestCase {
 
     public void testCloseInvalidPointInTime() {
         expectThrows(Exception.class, () -> client().execute(ClosePointInTimeAction.INSTANCE, new ClosePointInTimeRequest("")).actionGet());
-        List<TaskInfo> tasks = client().admin().cluster().prepareListTasks().setActions(ClosePointInTimeAction.NAME).get().getTasks();
+        List<TaskInfo> tasks = clusterAdmin().prepareListTasks().setActions(ClosePointInTimeAction.NAME).get().getTasks();
         assertThat(tasks, empty());
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -558,7 +558,7 @@ public class TransportSearchIT extends ESIntegTestCase {
     }
 
     private long requestBreakerUsed() {
-        NodesStatsResponse stats = client().admin().cluster().prepareNodesStats().setBreaker(true).get();
+        NodesStatsResponse stats = clusterAdmin().prepareNodesStats().setBreaker(true).get();
         long estimated = 0;
         for (NodeStats nodeStats : stats.getNodes()) {
             estimated += nodeStats.getBreaker().getStats(CircuitBreaker.REQUEST).getEstimated();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
@@ -136,7 +136,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
             .execute();
 
         logger.info("--> wait until the cluster state contains the new index");
-        assertBusy(() -> assertTrue(client().admin().cluster().prepareState().get().getState().metadata().hasIndex(indexName)));
+        assertBusy(() -> assertTrue(clusterAdmin().prepareState().get().getState().metadata().hasIndex(indexName)));
 
         logger.info("--> delete the index");
         assertAcked(client().admin().indices().prepareDelete(indexName));
@@ -150,7 +150,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
     // only after the test cleanup does the index creation manifest in the cluster state. To take care of this problem
     // and its potential ramifications, we wait here for the index creation cluster state update task to finish
     private void waitForIndexCreationToComplete(final String indexName) {
-        client().admin().cluster().prepareHealth(indexName).setWaitForEvents(Priority.URGENT).get();
+        clusterAdmin().prepareHealth(indexName).setWaitForEvents(Priority.URGENT).get();
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/WaitActiveShardCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/WaitActiveShardCountIT.java
@@ -55,9 +55,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
 
         allowNodes("test", 2);
 
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForActiveShards(2)
             .setWaitForYellowStatus()
@@ -99,9 +97,7 @@ public class WaitActiveShardCountIT extends ESIntegTestCase {
         }
 
         allowNodes("test", 3);
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForActiveShards(3)
             .setWaitForGreenStatus()

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
@@ -1013,7 +1013,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         indexRandom(true, client().prepareIndex("test").setId("1").setSource("field1", "random permutation"));
 
         // Get search shards
-        ClusterSearchShardsResponse searchShardsResponse = client().admin().cluster().prepareSearchShards("test").get();
+        ClusterSearchShardsResponse searchShardsResponse = clusterAdmin().prepareSearchShards("test").get();
         List<Integer> shardIds = Arrays.stream(searchShardsResponse.getGroups()).map(s -> s.getShardId().id()).toList();
 
         // request termvectors of artificial document from each shard

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -305,7 +305,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("index.routing.allocation.include._name", "nothing").build())
         );
 
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         assertThat(clusterState.metadata().indices().get(indexName).getState(), is(IndexMetadata.State.OPEN));
         assertThat(clusterState.routingTable().allShards().allMatch(ShardRouting::unassigned), is(true));
 
@@ -418,7 +418,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
             }
             indices[i] = indexName;
         }
-        assertThat(client().admin().cluster().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
+        assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
 
         final List<Thread> threads = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -484,7 +484,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
     }
 
     static void assertIndexHasBlock(APIBlock block, final String... indices) {
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         for (String index : indices) {
             final IndexMetadata indexMetadata = clusterState.metadata().indices().get(index);
             final Settings indexSettings = indexMetadata.getSettings();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -56,9 +56,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
     public void testHealth() {
         logger.info("--> running cluster health on an index that does not exists");
-        ClusterHealthResponse healthResponse = client().admin()
-            .cluster()
-            .prepareHealth("test1")
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test1")
             .setWaitForYellowStatus()
             .setTimeout("1s")
             .execute()
@@ -68,7 +66,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
 
         logger.info("--> running cluster wide health");
-        healthResponse = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().isEmpty(), equalTo(true));
@@ -77,19 +75,13 @@ public class ClusterHealthIT extends ESIntegTestCase {
         createIndex("test1");
 
         logger.info("--> running cluster health on an index that does exists");
-        healthResponse = client().admin().cluster().prepareHealth("test1").setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth("test1").setWaitForGreenStatus().setTimeout("10s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
 
         logger.info("--> running cluster health on an index that does exists and an index that doesn't exists");
-        healthResponse = client().admin()
-            .cluster()
-            .prepareHealth("test1", "test2")
-            .setWaitForYellowStatus()
-            .setTimeout("1s")
-            .execute()
-            .actionGet();
+        healthResponse = clusterAdmin().prepareHealth("test1", "test2").setWaitForYellowStatus().setTimeout("1s").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(true));
         assertThat(healthResponse.getStatus(), equalTo(ClusterHealthStatus.RED));
         assertThat(healthResponse.getIndices().get("test1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -99,7 +91,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
     public void testHealthWithClosedIndices() {
         createIndex("index-1");
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().get("index-1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -109,7 +101,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().prepareClose("index-2"));
 
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(2));
@@ -117,21 +109,21 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-1").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-1").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-2").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-2").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-*").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(2));
@@ -139,9 +131,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = client().admin()
-                .cluster()
-                .prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -151,9 +141,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-2"), nullValue());
         }
         {
-            ClusterHealthResponse response = client().admin()
-                .cluster()
-                .prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
                 .setIndicesOptions(IndicesOptions.fromOptions(true, true, false, true))
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -167,9 +155,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         assertAcked(client().admin().indices().prepareClose("index-3"));
 
         {
-            ClusterHealthResponse response = client().admin()
-                .cluster()
-                .prepareHealth()
+            ClusterHealthResponse response = clusterAdmin().prepareHealth()
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForNoInitializingShards(true)
                 .setWaitForYellowStatus()
@@ -182,28 +168,28 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-3").getStatus(), equalTo(ClusterHealthStatus.YELLOW));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-1").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-1").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-1").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-2").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-2").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-2").getStatus(), equalTo(ClusterHealthStatus.GREEN));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-3").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-3").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(1));
             assertThat(response.getIndices().get("index-3").getStatus(), equalTo(ClusterHealthStatus.YELLOW));
         }
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth("index-*").get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*").get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(3));
@@ -212,9 +198,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-3").getStatus(), equalTo(ClusterHealthStatus.YELLOW));
         }
         {
-            ClusterHealthResponse response = client().admin()
-                .cluster()
-                .prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
                 .setIndicesOptions(IndicesOptions.lenientExpandOpen())
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
@@ -225,9 +209,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             assertThat(response.getIndices().get("index-3"), nullValue());
         }
         {
-            ClusterHealthResponse response = client().admin()
-                .cluster()
-                .prepareHealth("index-*")
+            ClusterHealthResponse response = clusterAdmin().prepareHealth("index-*")
                 .setIndicesOptions(IndicesOptions.fromOptions(true, true, false, true))
                 .get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.YELLOW));
@@ -240,7 +222,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
         setReplicaCount(numberOfReplicas(), "index-3");
         {
-            ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForGreenStatus().get();
+            ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
             assertThat(response.getStatus(), equalTo(ClusterHealthStatus.GREEN));
             assertThat(response.isTimedOut(), equalTo(false));
             assertThat(response.getIndices().size(), equalTo(3));
@@ -256,7 +238,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
             @Override
             public void run() {
                 while (finished.get() == false) {
-                    ClusterHealthResponse health = client().admin().cluster().prepareHealth().get();
+                    ClusterHealthResponse health = clusterAdmin().prepareHealth().get();
                     assertThat(health.getStatus(), not(equalTo(ClusterHealthStatus.RED)));
                 }
             }
@@ -270,9 +252,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
     }
 
     public void testWaitForEventsRetriesIfOtherConditionsNotMet() {
-        final ActionFuture<ClusterHealthResponse> healthResponseFuture = client().admin()
-            .cluster()
-            .prepareHealth("index")
+        final ActionFuture<ClusterHealthResponse> healthResponseFuture = clusterAdmin().prepareHealth("index")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .execute();
@@ -304,7 +284,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
 
         try {
             createIndex("index");
-            assertFalse(client().admin().cluster().prepareHealth("index").setWaitForGreenStatus().get().isTimedOut());
+            assertFalse(clusterAdmin().prepareHealth("index").setWaitForGreenStatus().get().isTimedOut());
 
             // at this point the original health response should not have returned: there was never a point where the index was green AND
             // the master had processed all pending tasks above LANGUID priority.
@@ -387,9 +367,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         });
 
         try {
-            final ClusterHealthResponse clusterHealthResponse = client().admin()
-                .cluster()
-                .prepareHealth()
+            final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueSeconds(1))
                 .get(TimeValue.timeValueSeconds(30));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -205,9 +205,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
         prepareCreate("test").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1)).get();
         ensureGreen("test");
 
-        final IndexShardRoutingTable indexShardRoutingTable = client().admin()
-            .cluster()
-            .prepareState()
+        final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
             .clear()
             .setRoutingTable(true)
             .get()
@@ -324,7 +322,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             assertThat("size for shard " + shardRouting + " found", originalInfo.getShardSize(shardRouting), notNullValue());
         }
 
-        RoutingTable routingTable = client().admin().cluster().prepareState().clear().setRoutingTable(true).get().getState().routingTable();
+        RoutingTable routingTable = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState().routingTable();
         for (ShardRouting shard : routingTable.allShardsIterator()) {
             assertTrue(
                 infoAfterRecovery.getReservedSpace(shard.currentNodeId(), infoAfterRecovery.getDataPath(shard))

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesSnapshotsIT.java
@@ -44,7 +44,7 @@ public class DesiredNodesSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final var desiredNodesAfterSnapshot = getLatestDesiredNodes();
 
-        client().admin().cluster().prepareRestoreSnapshot(repositoryName, snapshotName).setRestoreGlobalState(true).get();
+        clusterAdmin().prepareRestoreSnapshot(repositoryName, snapshotName).setRestoreGlobalState(true).get();
 
         final var desiredNodesAfterRestore = getLatestDesiredNodes();
         assertThat(desiredNodesAfterRestore.historyID(), is(equalTo(desiredNodesAfterSnapshot.historyID())));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesStatusIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesStatusIT.java
@@ -43,7 +43,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         updateDesiredNodes(updateDesiredNodesRequest);
 
         {
-            final var clusterState = client().admin().cluster().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState().get().getState();
             assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
 
@@ -56,7 +56,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         updateDesiredNodes(newVersionUpdateDesiredNodesRequest);
 
         {
-            final var clusterState = client().admin().cluster().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState().get().getState();
             assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
     }
@@ -78,14 +78,14 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         updateDesiredNodes(updateDesiredNodesRequest);
 
         {
-            final var clusterState = client().admin().cluster().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState().get().getState();
             DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
 
         updateDesiredNodes(updateDesiredNodesRequest);
 
         {
-            final var clusterState = client().admin().cluster().prepareState().get().getState();
+            final var clusterState = clusterAdmin().prepareState().get().getState();
             DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
         }
     }
@@ -106,7 +106,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         );
         updateDesiredNodes(updateDesiredNodesRequest);
 
-        final var clusterState = client().admin().cluster().prepareState().get().getState();
+        final var clusterState = clusterAdmin().prepareState().get().getState();
         DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
 
         final var leavingNodeNames = randomSubsetOf(nodeNames);
@@ -114,7 +114,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
             internalCluster().stopNode(leavingNodeName);
         }
 
-        final var newClusterState = client().admin().cluster().prepareState().get().getState();
+        final var newClusterState = clusterAdmin().prepareState().get().getState();
         final var latestDesiredNodes = DesiredNodes.latestFromClusterState(newClusterState);
 
         for (String leavingNodeName : leavingNodeNames) {
@@ -139,7 +139,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         );
         updateDesiredNodes(updateDesiredNodesRequest);
 
-        final var clusterState = client().admin().cluster().prepareState().get().getState();
+        final var clusterState = clusterAdmin().prepareState().get().getState();
         DesiredNodesTestCase.assertDesiredNodesStatusIsCorrect(clusterState, actualizedDesiredNodes, pendingDesiredNodes);
 
         // Stop some nodes, these shouldn't be actualized within the new desired node's history until they join back
@@ -157,7 +157,7 @@ public class DesiredNodesStatusIT extends ESIntegTestCase {
         final var response = updateDesiredNodes(updateDesiredNodesWithNewHistoryRequest);
         assertThat(response.hasReplacedExistingHistoryId(), is(equalTo(true)));
 
-        final var updatedClusterState = client().admin().cluster().prepareState().get().getState();
+        final var updatedClusterState = clusterAdmin().prepareState().get().getState();
         final var latestDesiredNodes = DesiredNodes.latestFromClusterState(updatedClusterState);
 
         for (String clusterNodeName : clusterNodeNames) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -67,28 +67,26 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         String node1Name = internalCluster().startNode(settings);
 
         logger.info("--> should be blocked, no master...");
-        ClusterState state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         assertThat(state.nodes().getSize(), equalTo(1)); // verify that we still see the local node in the cluster state
 
         logger.info("--> start second node, cluster should be formed");
         String node2Name = internalCluster().startNode(settings);
 
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .execute()
             .actionGet();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(false));
 
@@ -135,11 +133,11 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopNode(masterNode);
 
         assertBusy(() -> {
-            ClusterState clusterState = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState clusterState = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
             assertTrue(clusterState.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID));
         });
 
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         // verify that both nodes are still in the cluster state but there is no master
         assertThat(state.nodes().getSize(), equalTo(2));
@@ -148,9 +146,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.info("--> starting the previous master node again...");
         node2Name = internalCluster().startNode(Settings.builder().put(settings).put(masterDataPathSettings).build());
 
-        clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForNodes("2")
@@ -158,12 +154,12 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             .actionGet();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(true));
 
@@ -188,7 +184,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().stopNode(otherNode);
 
         assertBusy(() -> {
-            ClusterState state1 = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState state1 = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
             assertThat(state1.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         });
 
@@ -196,9 +192,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().startNode(Settings.builder().put(settings).put(otherNodeDataPathSettings).build());
 
         ensureGreen();
-        clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .setWaitForGreenStatus()
@@ -206,12 +200,12 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             .actionGet();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
-        state = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+        state = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
         assertThat(state.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(false));
 
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(2));
         assertThat(state.metadata().indices().containsKey("test"), equalTo(true));
 
@@ -245,16 +239,14 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().startNode(settings);
 
         ensureGreen();
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("3")
             .execute()
             .actionGet();
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(3));
 
         createIndex("test");
@@ -266,13 +258,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         ensureGreen();
         // make sure that all shards recovered before trying to flush
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareHealth("test")
-                .setWaitForActiveShards(numShards.totalNumShards)
-                .execute()
-                .actionGet()
-                .isTimedOut(),
+            clusterAdmin().prepareHealth("test").setWaitForActiveShards(numShards.totalNumShards).execute().actionGet().isTimedOut(),
             equalTo(false)
         );
         // flush for simpler debugging
@@ -295,7 +281,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         logger.info("--> verify that there is no master anymore on remaining node");
         // spin here to wait till the state is set
         assertBusy(() -> {
-            ClusterState st = client().admin().cluster().prepareState().setLocal(true).execute().actionGet().getState();
+            ClusterState st = clusterAdmin().prepareState().setLocal(true).execute().actionGet().getState();
             assertThat(st.blocks().hasGlobalBlockWithId(NoMasterBlockService.NO_MASTER_BLOCK_ID), equalTo(true));
         });
 
@@ -305,7 +291,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         internalCluster().validateClusterFormed();
         ensureGreen();
 
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.nodes().getSize(), equalTo(3));
 
         logger.info("--> verify we the data back");
@@ -384,7 +370,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
         partition.stopDisrupting();
 
         logger.debug("--> waiting for cluster to heal");
-        assertNoTimeout(client().admin().cluster().prepareHealth().setWaitForNodes("3").setWaitForEvents(Priority.LANGUID));
+        assertNoTimeout(clusterAdmin().prepareHealth().setWaitForNodes("3").setWaitForEvents(Priority.LANGUID));
 
         for (String node : internalCluster().getNodeNames()) {
             Settings nodeSetting = internalCluster().clusterService(node).state().metadata().settings();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateNodeRemovalIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/PrevalidateNodeRemovalIT.java
@@ -207,9 +207,7 @@ public class PrevalidateNodeRemovalIT extends ESIntegTestCase {
 
     private void ensureRed(String indexName) throws Exception {
         assertBusy(() -> {
-            ClusterHealthResponse healthResponse = client().admin()
-                .cluster()
-                .prepareHealth(indexName)
+            ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(indexName)
                 .setWaitForStatus(ClusterHealthStatus.RED)
                 .setWaitForEvents(Priority.LANGUID)
                 .execute()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -211,9 +211,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
      * that the cluster state returns coherent data for both routing table and metadata.
      */
     private void testFilteringByIndexWorks(String[] indices, String[] expected) {
-        ClusterStateResponse clusterState = client().admin()
-            .cluster()
-            .prepareState()
+        ClusterStateResponse clusterState = clusterAdmin().prepareState()
             .clear()
             .setMetadata(true)
             .setRoutingTable(true)
@@ -280,13 +278,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
     }
 
     public void testIndicesOptions() throws Exception {
-        ClusterStateResponse clusterStateResponse = client().admin()
-            .cluster()
-            .prepareState()
-            .clear()
-            .setMetadata(true)
-            .setIndices("f*")
-            .get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().setMetadata(true).setIndices("f*").get();
         assertThat(clusterStateResponse.getState().metadata().indices().size(), is(2));
         ensureGreen("fuu");
 
@@ -298,9 +290,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
 
         // expand_wildcards_closed should toggle return only closed index fuu
         IndicesOptions expandCloseOptions = IndicesOptions.fromOptions(false, true, false, true);
-        clusterStateResponse = client().admin()
-            .cluster()
-            .prepareState()
+        clusterStateResponse = clusterAdmin().prepareState()
             .clear()
             .setMetadata(true)
             .setIndices("f*")
@@ -311,9 +301,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
 
         // ignore_unavailable set to true should not raise exception on fzzbzz
         IndicesOptions ignoreUnavailabe = IndicesOptions.fromOptions(true, true, true, false);
-        clusterStateResponse = client().admin()
-            .cluster()
-            .prepareState()
+        clusterStateResponse = clusterAdmin().prepareState()
             .clear()
             .setMetadata(true)
             .setIndices("fzzbzz")
@@ -324,9 +312,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         // empty wildcard expansion result should work when allowNoIndices is
         // turned on
         IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, true, true, false);
-        clusterStateResponse = client().admin()
-            .cluster()
-            .prepareState()
+        clusterStateResponse = clusterAdmin().prepareState()
             .clear()
             .setMetadata(true)
             .setIndices("a*")
@@ -350,14 +336,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         // ignore_unavailable set to false throws exception when allowNoIndices is turned off
         IndicesOptions allowNoIndices = IndicesOptions.fromOptions(false, true, true, false);
         try {
-            client().admin()
-                .cluster()
-                .prepareState()
-                .clear()
-                .setMetadata(true)
-                .setIndices("fzzbzz")
-                .setIndicesOptions(allowNoIndices)
-                .get();
+            clusterAdmin().prepareState().clear().setMetadata(true).setIndices("fzzbzz").setIndicesOptions(allowNoIndices).get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
             assertThat(e.getMessage(), is("no such index [fzzbzz]"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
@@ -46,9 +46,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
 
         internalCluster().startNode(nonDataNode());
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes("2")
                 .setLocal(true)
@@ -69,9 +67,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         // now, start a node data, and see that it gets with shards
         internalCluster().startNode(dataNode());
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes("3")
                 .setLocal(true)
@@ -94,9 +90,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
                     .waitForActiveShards(ActiveShardCount.NONE)
             )
             .actionGet();
-        final ClusterHealthResponse healthResponse1 = client().admin()
-            .cluster()
-            .prepareHealth()
+        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .execute()
             .actionGet();
@@ -107,9 +101,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
         internalCluster().startNode(dataNode());
 
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNodes("2")
                 .setWaitForGreenStatus()
@@ -129,9 +121,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
                     .waitForActiveShards(ActiveShardCount.NONE)
             )
             .actionGet();
-        final ClusterHealthResponse healthResponse1 = client().admin()
-            .cluster()
-            .prepareHealth()
+        final ClusterHealthResponse healthResponse1 = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .execute()
             .actionGet();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/UpdateSettingsValidationIT.java
@@ -27,9 +27,7 @@ public class UpdateSettingsValidationIT extends ESIntegTestCase {
         createIndex("test");
         NumShards test = getNumShards("test");
 
-        ClusterHealthResponse healthResponse = client().admin()
-            .cluster()
-            .prepareHealth("test")
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("3")
             .setWaitForGreenStatus()
@@ -39,9 +37,7 @@ public class UpdateSettingsValidationIT extends ESIntegTestCase {
         assertThat(healthResponse.getIndices().get("test").getActiveShards(), equalTo(test.totalNumShards));
 
         setReplicaCount(0, "test");
-        healthResponse = client().admin()
-            .cluster()
-            .prepareHealth("test")
+        healthResponse = clusterAdmin().prepareHealth("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .execute()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/AwarenessAllocationIT.java
@@ -70,9 +70,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         // On slow machines the initial relocation might be delayed
         assertBusy(() -> {
             logger.info("--> waiting for no relocation");
-            ClusterHealthResponse clusterHealth = client().admin()
-                .cluster()
-                .prepareHealth()
+            ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
                 .setIndices("test1", "test2")
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForGreenStatus()
@@ -83,7 +81,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertThat("Cluster health request timed out", clusterHealth.isTimedOut(), equalTo(false));
 
             logger.info("--> checking current state");
-            ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+            ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
 
             // check that closed indices are effectively closed
             final List<String> notClosedIndices = indicesToClose.stream()
@@ -116,7 +114,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         String A_1 = nodes.get(3);
 
         logger.info("--> waiting for nodes to form a cluster");
-        ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForNodes("4").execute().actionGet();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForNodes("4").execute().actionGet();
         assertThat(health.isTimedOut(), equalTo(false));
 
         createIndex("test", 5, 1);
@@ -126,9 +124,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         }
 
         logger.info("--> waiting for shards to be allocated");
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -137,7 +133,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .actionGet();
         assertThat(health.isTimedOut(), equalTo(false));
 
-        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         Map<String, Integer> counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_1), anyOf(equalTo(2), equalTo(3)));
@@ -166,9 +162,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             assertAcked(client().admin().indices().prepareClose("test"));
         }
 
-        ClusterHealthResponse health = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -177,7 +171,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .execute()
             .actionGet();
         assertThat(health.isTimedOut(), equalTo(false));
-        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         Map<String, Integer> counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -185,9 +179,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         logger.info("--> starting another node in zone 'b'");
 
         String B_1 = internalCluster().startNode(Settings.builder().put(commonSettings).put("node.attr.zone", "b").build());
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -195,10 +187,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .execute()
             .actionGet();
         assertThat(health.isTimedOut(), equalTo(false));
-        client().admin().cluster().prepareReroute().get();
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterAdmin().prepareReroute().get();
+        health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -209,7 +199,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .actionGet();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -217,9 +207,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(counts.get(B_1), equalTo(2));
 
         String noZoneNode = internalCluster().startNode();
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -227,10 +215,8 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .execute()
             .actionGet();
         assertThat(health.isTimedOut(), equalTo(false));
-        client().admin().cluster().prepareReroute().get();
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterAdmin().prepareReroute().get();
+        health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -241,7 +227,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .actionGet();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(5));
@@ -249,9 +235,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(counts.get(B_1), equalTo(2));
         assertThat(counts.containsKey(noZoneNode), equalTo(false));
         updateClusterSettings(Settings.builder().put("cluster.routing.allocation.awareness.attributes", ""));
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        health = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -262,7 +246,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
             .actionGet();
 
         assertThat(health.isTimedOut(), equalTo(false));
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         counts = computeShardCounts(clusterState);
 
         assertThat(counts.get(A_0), equalTo(3));
@@ -276,11 +260,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
 
         final IllegalArgumentException illegalArgumentException = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
-                .setPersistentSettings(Settings.builder().put(prefix + "nonsense", "foo"))
-                .get()
+            () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put(prefix + "nonsense", "foo")).get()
         );
         assertThat(illegalArgumentException.getMessage(), containsString("[cluster.routing.allocation.awareness.force.]"));
         assertThat(illegalArgumentException.getCause(), instanceOf(SettingsException.class));
@@ -289,9 +269,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
+                () -> clusterAdmin().prepareUpdateSettings()
                     .setPersistentSettings(Settings.builder().put(prefix + "attr.not_values", "foo"))
                     .get()
             ).getMessage(),
@@ -301,9 +279,7 @@ public class AwarenessAllocationIT extends ESIntegTestCase {
         assertThat(
             expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
+                () -> clusterAdmin().prepareUpdateSettings()
                     .setPersistentSettings(Settings.builder().put(prefix + "attr.values.junk", "foo"))
                     .get()
             ).getMessage(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/ClusterRerouteIT.java
@@ -101,13 +101,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
-        ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, *under dry_run*");
-        state = client().admin()
-            .cluster()
-            .prepareReroute()
+        state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
             .setDryRun(true)
@@ -121,13 +119,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         );
 
         logger.info("--> get the state, verify nothing changed because of the dry run");
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, actually allocating, no dry run");
-        state = client().admin()
-            .cluster()
-            .prepareReroute()
+        state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
             .execute()
@@ -139,9 +135,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             equalTo(ShardRoutingState.INITIALIZING)
         );
 
-        ClusterHealthResponse healthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
@@ -150,7 +144,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary allocated");
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_1).getId()).iterator().next().state(),
@@ -158,9 +152,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         );
 
         logger.info("--> move shard 1 primary from node1 to node2");
-        state = client().admin()
-            .cluster()
-            .prepareReroute()
+        state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new MoveAllocationCommand("test", 0, node_1, node_2))
             .execute()
@@ -176,9 +168,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             equalTo(ShardRoutingState.INITIALIZING)
         );
 
-        healthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        healthResponse = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
@@ -188,7 +178,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary moved from node1 to node2");
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_2).getId()).iterator().next().state(),
@@ -223,7 +213,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         internalCluster().startNode(commonSettings);
 
         assertThat(cluster().size(), equalTo(4));
-        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("4").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("4").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create indices");
@@ -253,7 +243,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         String node_1 = internalCluster().startNode(commonSettings);
         internalCluster().startNode(commonSettings);
         assertThat(cluster().size(), equalTo(2));
-        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create an index with 1 shard, 1 replica, nothing should allocate");
@@ -270,13 +260,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.NONE).get();
         }
 
-        ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(2));
 
         logger.info("--> explicitly allocate shard 1, actually allocating, no dry run");
-        state = client().admin()
-            .cluster()
-            .prepareReroute()
+        state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
             .execute()
@@ -288,9 +276,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             equalTo(ShardRoutingState.INITIALIZING)
         );
 
-        healthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        healthResponse = clusterAdmin().prepareHealth()
             .setIndices("test")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
@@ -299,7 +285,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> get the state, verify shard 1 primary allocated");
-        state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.getRoutingNodes().unassigned().size(), equalTo(1));
         assertThat(
             state.getRoutingNodes().node(state.nodes().resolveNode(node_1).getId()).iterator().next().state(),
@@ -325,15 +311,13 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         internalCluster().startNode(commonSettings);
         // wait a bit for the cluster to realize that the shard is not there...
         // TODO can we get around this? the cluster is RED, so what do we wait for?
-        client().admin().cluster().prepareReroute().get();
+        clusterAdmin().prepareReroute().get();
         assertThat(
-            client().admin().cluster().prepareHealth().setIndices("test").setWaitForNodes("2").execute().actionGet().getStatus(),
+            clusterAdmin().prepareHealth().setIndices("test").setWaitForNodes("2").execute().actionGet().getStatus(),
             equalTo(ClusterHealthStatus.RED)
         );
         logger.info("--> explicitly allocate primary");
-        state = client().admin()
-            .cluster()
-            .prepareReroute()
+        state = clusterAdmin().prepareReroute()
             .setExplain(randomBoolean())
             .add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node_1, true))
             .execute()
@@ -348,7 +332,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         logger.info("--> get the state, verify shard 1 primary allocated");
         final String nodeToCheck = node_1;
         assertBusy(() -> {
-            ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+            ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
             String nodeId = clusterState.nodes().resolveNode(nodeToCheck).getId();
             assertThat(clusterState.getRoutingNodes().node(nodeId).iterator().next().state(), equalTo(ShardRoutingState.STARTED));
         });
@@ -361,7 +345,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         String node_1 = internalCluster().startNode(commonSettings);
 
         assertThat(cluster().size(), equalTo(1));
-        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("1").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> create an index with 1 shard");
@@ -378,12 +362,12 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         logger.info("--> starting a second node");
         String node_2 = internalCluster().startNode(commonSettings);
         assertThat(cluster().size(), equalTo(2));
-        healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> try to move the shard from node1 to node2");
         MoveAllocationCommand cmd = new MoveAllocationCommand("test", 0, node_1, node_2);
-        ClusterRerouteResponse resp = client().admin().cluster().prepareReroute().add(cmd).setExplain(true).execute().actionGet();
+        ClusterRerouteResponse resp = clusterAdmin().prepareReroute().add(cmd).setExplain(true).execute().actionGet();
         RoutingExplanations e = resp.getExplanations();
         assertThat(e.explanations().size(), equalTo(1));
         RerouteExplanation explanation = e.explanations().get(0);
@@ -402,12 +386,12 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         final String nodeName1 = internalCluster().startNode(settings);
         assertThat(cluster().size(), equalTo(1));
-        ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("1").execute().actionGet();
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("1").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         final String nodeName2 = internalCluster().startNode(settings);
         assertThat(cluster().size(), equalTo(2));
-        healthResponse = client().admin().cluster().prepareHealth().setWaitForNodes("2").execute().actionGet();
+        healthResponse = clusterAdmin().prepareHealth().setWaitForNodes("2").execute().actionGet();
         assertThat(healthResponse.isTimedOut(), equalTo(false));
 
         final String indexName = "test_index";
@@ -435,9 +419,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
         try (var ignored = dryRunMockLog.capturing(TransportClusterRerouteAction.class)) {
             AllocationCommand dryRunAllocation = new AllocateEmptyPrimaryAllocationCommand(indexName, 0, nodeName1, true);
-            ClusterRerouteResponse dryRunResponse = client().admin()
-                .cluster()
-                .prepareReroute()
+            ClusterRerouteResponse dryRunResponse = clusterAdmin().prepareReroute()
                 .setExplain(randomBoolean())
                 .setDryRun(true)
                 .add(dryRunAllocation)
@@ -472,9 +454,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
 
             AllocationCommand yesDecisionAllocation = new AllocateEmptyPrimaryAllocationCommand(indexName, 0, nodeName1, true);
             AllocationCommand noDecisionAllocation = new AllocateEmptyPrimaryAllocationCommand("noexist", 1, nodeName2, true);
-            ClusterRerouteResponse response = client().admin()
-                .cluster()
-                .prepareReroute()
+            ClusterRerouteResponse response = clusterAdmin().prepareReroute()
                 .setExplain(true) // so we get a NO decision back rather than an exception
                 .add(yesDecisionAllocation)
                 .add(noDecisionAllocation)
@@ -501,7 +481,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         ensureGreen("test-blocks");
 
         logger.info("--> check that the index has 1 shard");
-        ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
         List<ShardRouting> shards = state.routingTable().allShards("test-blocks");
         assertThat(shards, hasSize(1));
 
@@ -527,15 +507,11 @@ public class ClusterRerouteIT extends ESIntegTestCase {
             try {
                 enableIndexBlock("test-blocks", blockSetting);
                 assertAcked(
-                    client().admin()
-                        .cluster()
-                        .prepareReroute()
+                    clusterAdmin().prepareReroute()
                         .add(new MoveAllocationCommand("test-blocks", 0, nodesIds.get(toggle % 2), nodesIds.get(++toggle % 2)))
                 );
 
-                ClusterHealthResponse healthResponse = client().admin()
-                    .cluster()
-                    .prepareHealth()
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
                     .setIndices("test-blocks")
                     .setWaitForYellowStatus()
                     .setWaitForNoRelocatingShards(true)
@@ -551,9 +527,7 @@ public class ClusterRerouteIT extends ESIntegTestCase {
         try {
             setClusterReadOnly(true);
             assertBlocked(
-                client().admin()
-                    .cluster()
-                    .prepareReroute()
+                clusterAdmin().prepareReroute()
                     .add(new MoveAllocationCommand("test-blocks", 1, nodesIds.get(toggle % 2), nodesIds.get(++toggle % 2)))
             );
         } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/allocation/FilteringAllocationIT.java
@@ -73,7 +73,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all are allocated on node1 now");
-        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
                 final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
@@ -109,7 +109,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> creating an index with auto-expand replicas");
         createIndex("test", Settings.builder().put(AutoExpandReplicas.SETTING.getKey(), "0-all").build());
-        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(1));
         ensureGreen("test");
 
@@ -122,7 +122,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         logger.info("--> verify all are allocated on node1 now");
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(clusterState.metadata().index("test").getNumberOfReplicas(), equalTo(0));
         for (IndexRoutingTable indexRoutingTable : clusterState.routingTable()) {
             for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
@@ -167,7 +167,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             ensureGreen("test");
         }
 
-        ClusterState clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         IndexRoutingTable indexRoutingTable = clusterState.routingTable().index("test");
         int numShardsOnNode1 = 0;
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
@@ -186,11 +186,11 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         }
         logger.info("--> remove index from the first node");
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", node_0), "test");
-        client().admin().cluster().prepareReroute().get();
+        clusterAdmin().prepareReroute().get();
         ensureGreen("test");
 
         logger.info("--> verify all shards are allocated on node_1 now");
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         indexRoutingTable = clusterState.routingTable().index("test");
         for (int shardId = 0; shardId < indexRoutingTable.size(); shardId++) {
             final IndexShardRoutingTable indexShardRoutingTable = indexRoutingTable.shard(shardId);
@@ -201,11 +201,11 @@ public class FilteringAllocationIT extends ESIntegTestCase {
 
         logger.info("--> disable allocation filtering ");
         updateIndexSettings(Settings.builder().put("index.routing.allocation.exclude._name", ""), "test");
-        client().admin().cluster().prepareReroute().get();
+        clusterAdmin().prepareReroute().get();
         ensureGreen("test");
 
         logger.info("--> verify that there are shards allocated on both nodes now");
-        clusterState = client().admin().cluster().prepareState().execute().actionGet().getState();
+        clusterState = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(clusterState.routingTable().index("test").numberOfNodesShardsAreAllocatedOn(), equalTo(2));
     }
 
@@ -218,9 +218,7 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         );
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            () -> clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().put(filterSetting.getKey() + ipKey, "192.168.1.1."))
                 .execute()
                 .actionGet()
@@ -250,12 +248,12 @@ public class FilteringAllocationIT extends ESIntegTestCase {
             .build();
 
         logger.info("--> updating settings");
-        client().admin().cluster().prepareUpdateSettings().setTransientSettings(exclude).get();
+        clusterAdmin().prepareUpdateSettings().setTransientSettings(exclude).get();
 
         logger.info("--> waiting for relocation");
         waitForRelocation(ClusterHealthStatus.GREEN);
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
 
         for (ShardRouting shard : RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED)) {
             String node = state.getRoutingNodes().node(shard.currentNodeId()).node().getName();
@@ -272,12 +270,12 @@ public class FilteringAllocationIT extends ESIntegTestCase {
         Settings other = Settings.builder().put("cluster.info.update.interval", "45s").build();
 
         logger.info("--> updating settings with random persistent setting");
-        client().admin().cluster().prepareUpdateSettings().setPersistentSettings(other).setTransientSettings(exclude).get();
+        clusterAdmin().prepareUpdateSettings().setPersistentSettings(other).setTransientSettings(exclude).get();
 
         logger.info("--> waiting for relocation");
         waitForRelocation(ClusterHealthStatus.GREEN);
 
-        state = client().admin().cluster().prepareState().get().getState();
+        state = clusterAdmin().prepareState().get().getState();
 
         // The transient settings still exist in the state
         assertThat(state.metadata().transientSettings(), equalTo(exclude));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveSettingsCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveSettingsCommandIT.java
@@ -58,7 +58,7 @@ public class RemoveSettingsCommandIT extends ESIntegTestCase {
             Settings.builder().put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), false)
         );
         assertThat(
-            client().admin().cluster().prepareState().get().getState().metadata().persistentSettings().keySet(),
+            clusterAdmin().prepareState().get().getState().metadata().persistentSettings().keySet(),
             contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey())
         );
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
@@ -84,7 +84,7 @@ public class RemoveSettingsCommandIT extends ESIntegTestCase {
 
         internalCluster().startNode(dataPathSettings);
         assertThat(
-            client().admin().cluster().prepareState().get().getState().metadata().persistentSettings().keySet(),
+            clusterAdmin().prepareState().get().getState().metadata().persistentSettings().keySet(),
             not(contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey()))
         );
     }
@@ -96,7 +96,7 @@ public class RemoveSettingsCommandIT extends ESIntegTestCase {
             Settings.builder().put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), false)
         );
         assertThat(
-            client().admin().cluster().prepareState().get().getState().metadata().persistentSettings().keySet(),
+            clusterAdmin().prepareState().get().getState().metadata().persistentSettings().keySet(),
             contains(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey())
         );
         Settings dataPathSettings = internalCluster().dataPathSettings(node);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
@@ -35,9 +35,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         internalCluster().startNodes(2, masterNodeSettings);
         Settings dateNodeSettings = dataNode();
         internalCluster().startNodes(2, dateNodeSettings);
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("4")
             .setWaitForNoRelocatingShards(true)
@@ -74,7 +72,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         ); // see https://github.com/elastic/elasticsearch/issues/24388
 
         logger.info("--> request node discovery stats");
-        NodesStatsResponse statsResponse = client().admin().cluster().prepareNodesStats().clear().setDiscovery(true).get();
+        NodesStatsResponse statsResponse = clusterAdmin().prepareNodesStats().clear().setDiscovery(true).get();
         assertThat(statsResponse.getNodes().size(), equalTo(1));
 
         DiscoveryStats stats = statsResponse.getNodes().get(0).getDiscoveryStats();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/AllocationIdIT.java
@@ -143,11 +143,7 @@ public class AllocationIdIT extends ESIntegTestCase {
     }
 
     public void checkHealthStatus(String indexName, ClusterHealthStatus healthStatus) {
-        final ClusterHealthStatus indexHealthStatus = client().admin()
-            .cluster()
-            .health(new ClusterHealthRequest(indexName))
-            .actionGet()
-            .getStatus();
+        final ClusterHealthStatus indexHealthStatus = clusterAdmin().health(new ClusterHealthRequest(indexName)).actionGet().getStatus();
         assertThat(indexHealthStatus, is(healthStatus));
     }
 
@@ -173,9 +169,8 @@ public class AllocationIdIT extends ESIntegTestCase {
     }
 
     private Set<String> getAllocationIds(String indexName) {
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
-        final Set<String> allocationIds = state.metadata().index(indexName).inSyncAllocationIds(0);
-        return allocationIds;
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
+        return state.metadata().index(indexName).inSyncAllocationIds(0);
     }
 
     private IndexSettings getIndexSettings(String indexName, String nodeName) {
@@ -204,9 +199,7 @@ public class AllocationIdIT extends ESIntegTestCase {
 
     private void checkNoValidShardCopy(String indexName, ShardId shardId) throws Exception {
         assertBusy(() -> {
-            final ClusterAllocationExplanation explanation = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplanation explanation = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(shardId.id())
                 .setPrimary(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/DelayedAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/DelayedAllocationIT.java
@@ -33,7 +33,7 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         ensureGreen("test");
         indexRandomData();
         internalCluster().stopNode(findNodeWithShard());
-        assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
         ensureGreen("test");
     }
 
@@ -54,12 +54,9 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         Settings nodeWithShardDataPathSettings = internalCluster().dataPathSettings(nodeWithShard);
         internalCluster().stopNode(nodeWithShard);
         assertBusy(
-            () -> assertThat(
-                client().admin().cluster().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0,
-                equalTo(true)
-            )
+            () -> assertThat(clusterAdmin().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0, equalTo(true))
         );
-        assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
         internalCluster().startNode(nodeWithShardDataPathSettings); // this will use the same data location as the stopped node
         ensureGreen("test");
     }
@@ -105,19 +102,16 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         indexRandomData();
         internalCluster().stopNode(findNodeWithShard());
         assertBusy(
-            () -> assertThat(
-                client().admin().cluster().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0,
-                equalTo(true)
-            )
+            () -> assertThat(clusterAdmin().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0, equalTo(true))
         );
-        assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
         logger.info("Setting shorter allocation delay");
         updateIndexSettings(
             Settings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(100)),
             "test"
         );
         ensureGreen("test");
-        assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
     }
 
     /**
@@ -134,18 +128,15 @@ public class DelayedAllocationIT extends ESIntegTestCase {
         indexRandomData();
         internalCluster().stopNode(findNodeWithShard());
         assertBusy(
-            () -> assertThat(
-                client().admin().cluster().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0,
-                equalTo(true)
-            )
+            () -> assertThat(clusterAdmin().prepareState().all().get().getState().getRoutingNodes().unassigned().size() > 0, equalTo(true))
         );
-        assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
+        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(1));
         updateIndexSettings(
             Settings.builder().put(UnassignedInfo.INDEX_DELAYED_NODE_LEFT_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMillis(0)),
             "test"
         );
         ensureGreen("test");
-        assertThat(client().admin().cluster().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
+        assertThat(clusterAdmin().prepareHealth().get().getDelayedUnassignedShards(), equalTo(0));
     }
 
     private void indexRandomData() throws Exception {
@@ -161,7 +152,7 @@ public class DelayedAllocationIT extends ESIntegTestCase {
     }
 
     private String findNodeWithShard() {
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         List<ShardRouting> startedShards = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.STARTED);
         return state.nodes().get(randomFrom(startedShards).currentNodeId()).getName();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/PrimaryAllocationIT.java
@@ -120,7 +120,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
     private Settings createStaleReplicaScenario(String master) throws Exception {
         client().prepareIndex("test").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
         refresh();
-        ClusterState state = client().admin().cluster().prepareState().all().get().getState();
+        ClusterState state = clusterAdmin().prepareState().all().get().getState();
         List<ShardRouting> shards = state.routingTable().allShards("test");
         assertThat(shards.size(), equalTo(2));
 
@@ -198,9 +198,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         internalCluster().stopNode(dataNodeWithShardCopy);
         ensureStableCluster(1);
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareState()
+            clusterAdmin().prepareState()
                 .get()
                 .getState()
                 .getRoutingTable()
@@ -215,9 +213,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         logger.info("--> force allocation of stale copy to node that does not have shard copy");
         Throwable iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareReroute()
+            () -> clusterAdmin().prepareReroute()
                 .add(new AllocateStalePrimaryAllocationCommand("test", 0, dataNodeWithNoShardCopy, true))
                 .get()
         );
@@ -225,13 +221,11 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
 
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertTrue(
-            client().admin().cluster().prepareState().get().getState().toString(),
-            client().admin().cluster().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
+            clusterAdmin().prepareState().get().getState().toString(),
+            clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
         );
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareState()
+            clusterAdmin().prepareState()
                 .get()
                 .getState()
                 .getRoutingTable()
@@ -266,7 +260,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             .get()
             .getStoreStatuses()
             .get(idxName);
-        ClusterRerouteRequestBuilder rerouteBuilder = client().admin().cluster().prepareReroute();
+        ClusterRerouteRequestBuilder rerouteBuilder = clusterAdmin().prepareReroute();
         for (Map.Entry<Integer, List<IndicesShardStoresResponse.StoreStatus>> shardStoreStatuses : storeStatuses.entrySet()) {
             int shardId = shardStoreStatuses.getKey();
             IndicesShardStoresResponse.StoreStatus storeStatus = randomFrom(shardStoreStatuses.getValue());
@@ -308,9 +302,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             // search can throw an "all shards failed" exception. We will wait until the shard initialization has completed before
             // verifying the search hit count.
             assertBusy(
-                () -> assertTrue(
-                    client().admin().cluster().prepareState().get().getState().routingTable().index(idxName).allPrimaryShardsActive()
-                )
+                () -> assertTrue(clusterAdmin().prepareState().get().getState().routingTable().index(idxName).allPrimaryShardsActive())
             );
         }
         ShardStats[] shardStats = client().admin()
@@ -323,7 +315,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             assertThat(shardStat.getCommitStats().getNumDocs(), equalTo(useStaleReplica ? 1 : 0));
         }
         // allocation id of old primary was cleaned from the in-sync set
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
 
         assertEquals(
             Collections.singleton(state.routingTable().index(idxName).shard(0).primary.allocationId().getId()),
@@ -363,9 +355,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final String nodeWithoutData = nodeNames.get(0);
         Throwable iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareReroute()
+            () -> clusterAdmin().prepareReroute()
                 .add(new AllocateStalePrimaryAllocationCommand(idxName, shardId, nodeWithoutData, true))
                 .get()
         );
@@ -385,9 +375,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final int shardId = 0;
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareReroute()
+            () -> clusterAdmin().prepareReroute()
                 .add(new AllocateStalePrimaryAllocationCommand(idxName, shardId, nodeWithoutData, true))
                 .get()
         );
@@ -400,11 +388,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final String idxName = "test";
         IndexNotFoundException ex = expectThrows(
             IndexNotFoundException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareReroute()
-                .add(new AllocateStalePrimaryAllocationCommand(idxName, 0, dataNode, true))
-                .get()
+            () -> clusterAdmin().prepareReroute().add(new AllocateStalePrimaryAllocationCommand(idxName, 0, dataNode, true)).get()
         );
         assertThat(ex.getIndex().getName(), equalTo(idxName));
     }
@@ -418,12 +402,9 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
             .setSettings(indexSettings(1, 0).put("index.routing.allocation.exclude._name", node))
             .get();
 
-        assertThat(
-            client().admin().cluster().prepareState().get().getState().getRoutingTable().shardRoutingTable("test", 0).assignedShards(),
-            empty()
-        );
+        assertThat(clusterAdmin().prepareState().get().getState().getRoutingTable().shardRoutingTable("test", 0).assignedShards(), empty());
 
-        client().admin().cluster().prepareReroute().add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node, true)).get();
+        clusterAdmin().prepareReroute().add(new AllocateEmptyPrimaryAllocationCommand("test", 0, node, true)).get();
         ensureGreen("test");
     }
 
@@ -442,7 +423,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final Settings inSyncDataPathSettings = internalCluster().dataPathSettings(replicaNode);
         internalCluster().stopNode(replicaNode);
         ensureYellow("test");
-        assertEquals(2, client().admin().cluster().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(2, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
         internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
             @Override
             public boolean clearData(String nodeName) {
@@ -451,11 +432,9 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         });
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertBusy(
-            () -> assertTrue(
-                client().admin().cluster().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
-            )
+            () -> assertTrue(clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned())
         );
-        assertEquals(2, client().admin().cluster().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(2, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
 
         logger.info("--> starting node that reuses data folder with the up-to-date shard");
         internalCluster().startDataOnlyNode(inSyncDataPathSettings);
@@ -477,10 +456,10 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         final Settings inSyncDataPathSettings = internalCluster().dataPathSettings(replicaNode);
         internalCluster().stopNode(replicaNode);
         ensureYellow("test");
-        assertEquals(2, client().admin().cluster().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(2, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
         logger.info("--> indexing...");
         client().prepareIndex("test").setSource(jsonBuilder().startObject().field("field", "value1").endObject()).get();
-        assertEquals(1, client().admin().cluster().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(1, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
         internalCluster().restartRandomDataNode(new InternalTestCluster.RestartCallback() {
             @Override
             public boolean clearData(String nodeName) {
@@ -489,18 +468,14 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         });
         logger.info("--> wait until shard is failed and becomes unassigned again");
         assertBusy(
-            () -> assertTrue(
-                client().admin().cluster().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
-            )
+            () -> assertTrue(clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned())
         );
-        assertEquals(1, client().admin().cluster().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
+        assertEquals(1, clusterAdmin().prepareState().get().getState().metadata().index("test").inSyncAllocationIds(0).size());
 
         logger.info("--> starting node that reuses data folder with the up-to-date shard");
         internalCluster().startDataOnlyNode(inSyncDataPathSettings);
         assertBusy(
-            () -> assertTrue(
-                client().admin().cluster().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned()
-            )
+            () -> assertTrue(clusterAdmin().prepareState().get().getState().getRoutingTable().index("test").allPrimaryShardsUnassigned())
         );
     }
 
@@ -539,15 +514,7 @@ public class PrimaryAllocationIT extends ESIntegTestCase {
         ensureGreen(indexName);
         assertEquals(
             1,
-            client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .routingTable()
-                .index(indexName)
-                .shardsWithState(ShardRoutingState.STARTED)
-                .size()
+            clusterAdmin().prepareState().get().getState().routingTable().index(indexName).shardsWithState(ShardRoutingState.STARTED).size()
         );
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/RemoveReplicaPriorityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/RemoveReplicaPriorityIT.java
@@ -52,9 +52,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             });
         }
 
-        final String dataNodeIdFilter = client().admin()
-            .cluster()
-            .prepareState()
+        final String dataNodeIdFilter = clusterAdmin().prepareState()
             .clear()
             .setNodes(true)
             .get()
@@ -76,9 +74,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
         );
 
         assertBusy(() -> {
-            final IndexShardRoutingTable indexShardRoutingTable = client().admin()
-                .cluster()
-                .prepareState()
+            final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
                 .clear()
                 .setRoutingTable(true)
                 .get()
@@ -94,9 +90,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
         updateIndexSettings(Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._id"), INDEX_NAME);
 
         assertBusy(() -> {
-            final IndexShardRoutingTable indexShardRoutingTable = client().admin()
-                .cluster()
-                .prepareState()
+            final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
                 .clear()
                 .setRoutingTable(true)
                 .get()
@@ -113,9 +107,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             setReplicaCount(2, INDEX_NAME);
 
             assertBusy(() -> {
-                final IndexShardRoutingTable indexShardRoutingTable = client().admin()
-                    .cluster()
-                    .prepareState()
+                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
                     .clear()
                     .setRoutingTable(true)
                     .get()
@@ -133,9 +125,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             setReplicaCount(1, INDEX_NAME);
 
             assertBusy(() -> {
-                final IndexShardRoutingTable indexShardRoutingTable = client().admin()
-                    .cluster()
-                    .prepareState()
+                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
                     .clear()
                     .setRoutingTable(true)
                     .get()
@@ -153,9 +143,7 @@ public class RemoveReplicaPriorityIT extends ESIntegTestCase {
             setReplicaCount(0, INDEX_NAME);
 
             assertBusy(() -> {
-                final IndexShardRoutingTable indexShardRoutingTable = client().admin()
-                    .cluster()
-                    .prepareState()
+                final IndexShardRoutingTable indexShardRoutingTable = clusterAdmin().prepareState()
                     .clear()
                     .setRoutingTable(true)
                     .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/ShardRoutingRoleIT.java
@@ -292,7 +292,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
             createIndex(INDEX_NAME, routingTableWatcher.getIndexSettings());
 
-            final var clusterState = client().admin().cluster().prepareState().clear().setRoutingTable(true).get().getState();
+            final var clusterState = clusterAdmin().prepareState().clear().setRoutingTable(true).get().getState();
 
             // verify non-DEFAULT roles reported in cluster state XContent
             assertRolesInRoutingTableXContent(clusterState);
@@ -325,16 +325,12 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
             // restoring the index from a snapshot may change the number of indexing replicas because the routing table is created afresh
             var repoPath = randomRepoPath();
             assertAcked(
-                client().admin()
-                    .cluster()
-                    .preparePutRepository("repo")
-                    .setType("fs")
-                    .setSettings(Settings.builder().put("location", repoPath))
+                clusterAdmin().preparePutRepository("repo").setType("fs").setSettings(Settings.builder().put("location", repoPath))
             );
 
             assertEquals(
                 SnapshotState.SUCCESS,
-                client().admin().cluster().prepareCreateSnapshot("repo", "snap").setWaitForCompletion(true).get().getSnapshotInfo().state()
+                clusterAdmin().prepareCreateSnapshot("repo", "snap").setWaitForCompletion(true).get().getSnapshotInfo().state()
             );
 
             if (randomBoolean()) {
@@ -350,9 +346,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
             assertEquals(
                 0,
-                client().admin()
-                    .cluster()
-                    .prepareRestoreSnapshot("repo", "snap")
+                clusterAdmin().prepareRestoreSnapshot("repo", "snap")
                     .setIndices(INDEX_NAME)
                     .setIndexSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, routingTableWatcher.numReplicas))
                     .setWaitForCompletion(true)
@@ -428,7 +422,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
             updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_REQUIRE_GROUP_PREFIX + "._name", "not-a-node"), "test");
             AllocationCommand cancelPrimaryCommand;
             while ((cancelPrimaryCommand = getCancelPrimaryCommand()) != null) {
-                client().admin().cluster().prepareReroute().add(cancelPrimaryCommand).get();
+                clusterAdmin().prepareReroute().add(cancelPrimaryCommand).get();
             }
         } finally {
             masterClusterService.removeListener(routingTableWatcher);
@@ -437,9 +431,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
 
     @Nullable
     public AllocationCommand getCancelPrimaryCommand() {
-        final var indexRoutingTable = client().admin()
-            .cluster()
-            .prepareState()
+        final var indexRoutingTable = clusterAdmin().prepareState()
             .clear()
             .setRoutingTable(true)
             .get()
@@ -487,9 +479,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
             assertEngineTypes();
 
             final var searchShardProfileKeys = new HashSet<String>();
-            final var indexRoutingTable = client().admin()
-                .cluster()
-                .prepareState()
+            final var indexRoutingTable = clusterAdmin().prepareState()
                 .clear()
                 .setRoutingTable(true)
                 .get()
@@ -551,7 +541,7 @@ public class ShardRoutingRoleIT extends ESIntegTestCase {
             }
             // search-shards API
             for (int i = 0; i < 10; i++) {
-                final var search = client().admin().cluster().prepareSearchShards(INDEX_NAME);
+                final var search = clusterAdmin().prepareSearchShards(INDEX_NAME);
                 switch (randomIntBetween(0, 2)) {
                     case 0 -> search.setRouting(randomAlphaOfLength(10));
                     case 1 -> search.setRouting(randomSearchPreference(routingTableWatcher.numShards, internalCluster().getNodeNames()));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -75,11 +75,9 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
         // Verify that we can still move shards around even while blocked
         final String newDataNodeName = internalCluster().startDataOnlyNode();
-        final String newDataNodeId = client().admin().cluster().prepareNodesInfo(newDataNodeName).get().getNodes().get(0).getNode().getId();
+        final String newDataNodeId = clusterAdmin().prepareNodesInfo(newDataNodeName).get().getNodes().get(0).getNode().getId();
         assertBusy(() -> {
-            final ShardRouting primaryShard = client().admin()
-                .cluster()
-                .prepareState()
+            final ShardRouting primaryShard = clusterAdmin().prepareState()
                 .clear()
                 .setRoutingTable(true)
                 .setNodes(true)
@@ -96,7 +94,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
         // Verify that the block is removed once the shard migration is complete
         refreshClusterInfo();
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertNull(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE));
     }
 
@@ -131,7 +129,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
         // Verify that the block is removed
         refreshClusterInfo();
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertNull(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE));
 
         // Re-enable and the blocks should be back!
@@ -139,7 +137,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
             Settings.builder().put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_THRESHOLD_ENABLED_SETTING.getKey(), true)
         );
         refreshClusterInfo();
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).get().isTimedOut());
         assertThat(getIndexBlock(indexName, IndexMetadata.SETTING_READ_ONLY_ALLOW_DELETE), equalTo("true"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/DiskThresholdDeciderIT.java
@@ -103,9 +103,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
         ensureStableCluster(3);
 
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutRepository("repo")
+            clusterAdmin().preparePutRepository("repo")
                 .setType(FsRepository.TYPE)
                 .setSettings(Settings.builder().put("location", randomRepoPath()).put("compress", randomBoolean()))
         );
@@ -141,9 +139,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_REBALANCE_ENABLE_SETTING.getKey(), Rebalance.NONE.toString())
         );
 
-        final RestoreSnapshotResponse restoreSnapshotResponse = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot("repo", "snap")
+        final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repo", "snap")
             .setWaitForCompletion(true)
             .get();
         final RestoreInfo restoreInfo = restoreSnapshotResponse.getRestoreInfo();
@@ -161,9 +157,7 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
 
     private Set<ShardId> getShardIds(final String nodeId, final String indexName) {
         final Set<ShardId> shardIds = new HashSet<>();
-        final IndexRoutingTable indexRoutingTable = client().admin()
-            .cluster()
-            .prepareState()
+        final IndexRoutingTable indexRoutingTable = clusterAdmin().prepareState()
             .clear()
             .setRoutingTable(true)
             .get()
@@ -243,13 +237,11 @@ public class DiskThresholdDeciderIT extends DiskUsageIntegTestCase {
             .values()
             .stream()
             .allMatch(e -> e.getFreeBytes() > WATERMARK_BYTES)) {
-            assertAcked(client().admin().cluster().prepareReroute());
+            assertAcked(clusterAdmin().prepareReroute());
         }
 
         assertFalse(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForNoInitializingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -75,9 +75,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             internalCluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
         }
 
-        final List<String> nodeIds = client().admin()
-            .cluster()
-            .prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState()
             .get()
             .getState()
             .getRoutingNodes()
@@ -155,9 +153,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             internalCluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
         }
 
-        final List<String> nodeIds = client().admin()
-            .cluster()
-            .prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState()
             .get()
             .getState()
             .getRoutingNodes()
@@ -218,7 +214,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             )
         );
 
-        assertFalse(client().admin().cluster().prepareHealth("test").setWaitForEvents(Priority.LANGUID).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth("test").setWaitForEvents(Priority.LANGUID).get().isTimedOut());
 
         // Cannot add further documents
         assertBlocked(
@@ -275,9 +271,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
                 .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms")
         );
 
-        final List<String> nodeIds = client().admin()
-            .cluster()
-            .prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState()
             .get()
             .getState()
             .getRoutingNodes()
@@ -334,9 +328,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
 
         final MockInternalClusterInfoService clusterInfoService = getMockInternalClusterInfoService();
 
-        final List<String> nodeIds = client().admin()
-            .cluster()
-            .prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState()
             .get()
             .getState()
             .getRoutingNodes()
@@ -410,7 +402,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             twoPathSettings.putList(Environment.PATH_DATA_SETTING.getKey(), pathOverWatermark.toString(), createTempDir().toString());
         }
         internalCluster().startNode(twoPathSettings);
-        final String nodeWithTwoPaths = client().admin().cluster().prepareNodesInfo().get().getNodes().get(0).getNode().getId();
+        final String nodeWithTwoPaths = clusterAdmin().prepareNodesInfo().get().getNodes().get(0).getNode().getId();
 
         // other two nodes have one data path each
         internalCluster().startNode(Settings.builder().put(Environment.PATH_DATA_SETTING.getKey(), createTempDir()));
@@ -432,9 +424,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
                 .put(CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING.getKey(), "0ms")
         );
 
-        final List<String> nodeIds = client().admin()
-            .cluster()
-            .prepareState()
+        final List<String> nodeIds = clusterAdmin().prepareState()
             .get()
             .getState()
             .getRoutingNodes()
@@ -503,7 +493,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
 
     private Map<String, Integer> getShardCountByNodeId() {
         final Map<String, Integer> shardCountByNodeId = new HashMap<>();
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         for (final RoutingNode node : clusterState.getRoutingNodes()) {
             logger.info(
                 "----> node {} has {} shards",

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/settings/ClusterSettingsIT.java
@@ -43,9 +43,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
     @After
     public void cleanup() throws Exception {
         assertAcked(
-            client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().putNull("*"))
                 .setTransientSettings(Settings.builder().putNull("*"))
         );
@@ -66,7 +64,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         String key1 = "no_idea_what_you_are_talking_about";
         int value1 = 10;
         try {
-            ClusterUpdateSettingsRequestBuilder builder = client().admin().cluster().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
             consumer.accept(Settings.builder().put(key1, value1), builder);
 
             builder.get();
@@ -97,7 +95,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
         final Setting<TimeValue> REROUTE_INTERVAL = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
 
-        ClusterUpdateSettingsRequestBuilder builder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 7).put(REROUTE_INTERVAL.getKey(), "42s"), builder);
 
         ClusterUpdateSettingsResponse response = builder.get();
@@ -108,7 +106,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(REROUTE_INTERVAL.get(settingsFunction.apply(response)), equalTo(TimeValue.timeValueSeconds(42)));
         assertThat(clusterService().getClusterSettings().get(REROUTE_INTERVAL), equalTo(TimeValue.timeValueSeconds(42)));
 
-        ClusterUpdateSettingsRequestBuilder undoBuilder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(
             Settings.builder().putNull((randomBoolean() ? "cluster.routing.*" : "*")).put(REROUTE_INTERVAL.getKey(), "43s"),
             undoBuilder
@@ -126,9 +124,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
         final Setting<TimeValue> REROUTE_INTERVAL = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
 
-        ClusterUpdateSettingsResponse response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 7).build())
             .get();
 
@@ -136,9 +132,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(INITIAL_RECOVERIES.get(response.getTransientSettings()), equalTo(7));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(7));
 
-        response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(Settings.builder().putNull(INITIAL_RECOVERIES.getKey()))
             .get();
 
@@ -146,9 +140,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertNull(response.getTransientSettings().get(INITIAL_RECOVERIES.getKey()));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(INITIAL_RECOVERIES.get(Settings.EMPTY)));
 
-        response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 8).put(REROUTE_INTERVAL.getKey(), "43s").build())
             .get();
 
@@ -157,9 +149,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(8));
         assertThat(REROUTE_INTERVAL.get(response.getTransientSettings()), equalTo(TimeValue.timeValueSeconds(43)));
         assertThat(clusterService().getClusterSettings().get(REROUTE_INTERVAL), equalTo(TimeValue.timeValueSeconds(43)));
-        response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(Settings.builder().putNull((randomBoolean() ? "cluster.routing.*" : "*")))
             .get();
 
@@ -174,9 +164,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
         final Setting<TimeValue> REROUTE_INTERVAL = CLUSTER_ROUTING_ALLOCATION_REROUTE_INTERVAL_SETTING;
 
-        ClusterUpdateSettingsResponse response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 9).build())
             .get();
 
@@ -184,9 +172,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(INITIAL_RECOVERIES.get(response.getPersistentSettings()), equalTo(9));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(9));
 
-        response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().putNull(INITIAL_RECOVERIES.getKey()))
             .get();
 
@@ -194,9 +180,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(INITIAL_RECOVERIES.get(response.getPersistentSettings()), equalTo(INITIAL_RECOVERIES.get(Settings.EMPTY)));
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(INITIAL_RECOVERIES.get(Settings.EMPTY)));
 
-        response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 10).put(REROUTE_INTERVAL.getKey(), "44s").build())
             .get();
 
@@ -205,9 +189,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(10));
         assertThat(REROUTE_INTERVAL.get(response.getPersistentSettings()), equalTo(TimeValue.timeValueSeconds(44)));
         assertThat(clusterService().getClusterSettings().get(REROUTE_INTERVAL), equalTo(TimeValue.timeValueSeconds(44)));
-        response = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        response = clusterAdmin().prepareUpdateSettings()
             .setPersistentSettings(Settings.builder().putNull((randomBoolean() ? "cluster.routing.*" : "*")))
             .get();
 
@@ -227,9 +209,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings transientSettings1 = Settings.builder().put(key1, value1, ByteSizeUnit.BYTES).build();
         Settings persistentSettings1 = Settings.builder().put(key2, value2).build();
 
-        ClusterUpdateSettingsResponse response1 = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings1)
             .setPersistentSettings(persistentSettings1)
             .execute()
@@ -244,9 +224,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings transientSettings2 = Settings.builder().put(key1, value1, ByteSizeUnit.BYTES).put(key2, value2).build();
         Settings persistentSettings2 = Settings.EMPTY;
 
-        ClusterUpdateSettingsResponse response2 = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response2 = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings2)
             .setPersistentSettings(persistentSettings2)
             .execute()
@@ -261,9 +239,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings transientSettings3 = Settings.EMPTY;
         Settings persistentSettings3 = Settings.builder().put(key1, value1, ByteSizeUnit.BYTES).put(key2, value2).build();
 
-        ClusterUpdateSettingsResponse response3 = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        ClusterUpdateSettingsResponse response3 = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings3)
             .setPersistentSettings(persistentSettings3)
             .execute()
@@ -294,7 +270,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         final BiConsumer<Settings.Builder, ClusterUpdateSettingsRequestBuilder> consumer,
         final Function<ClusterUpdateSettingsResponse, Settings> settingsFunction
     ) {
-        ClusterUpdateSettingsRequestBuilder builder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(
             Settings.builder().putList("transport.tracer.include", "internal:index/shard/recovery/*", "internal:gateway/local*"),
             builder
@@ -327,7 +303,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
     ) {
         final Setting<Integer> INITIAL_RECOVERIES = CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING;
 
-        ClusterUpdateSettingsRequestBuilder initialBuilder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder initialBuilder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), 42), initialBuilder);
 
         ClusterUpdateSettingsResponse response = initialBuilder.get();
@@ -337,7 +313,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(42));
 
         try {
-            ClusterUpdateSettingsRequestBuilder badBuilder = client().admin().cluster().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder badBuilder = clusterAdmin().prepareUpdateSettings();
             consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), "whatever"), badBuilder);
             badBuilder.get();
             fail("bogus value");
@@ -348,7 +324,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         assertThat(clusterService().getClusterSettings().get(INITIAL_RECOVERIES), equalTo(42));
 
         try {
-            ClusterUpdateSettingsRequestBuilder badBuilder = client().admin().cluster().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder badBuilder = clusterAdmin().prepareUpdateSettings();
             consumer.accept(Settings.builder().put(INITIAL_RECOVERIES.getKey(), -1), badBuilder);
             badBuilder.get();
             fail("bogus value");
@@ -374,15 +350,10 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             settingsBuilder.put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), "true");
         }
         assertAcked(
-            client().admin()
-                .cluster()
-                .prepareUpdateSettings()
-                .setPersistentSettings(settingsBuilder)
-                .setTransientSettings(settingsBuilder)
-                .get()
+            clusterAdmin().prepareUpdateSettings().setPersistentSettings(settingsBuilder).setTransientSettings(settingsBuilder).get()
         );
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         if (readOnly) {
             assertTrue(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().transientSettings()));
             assertTrue(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().persistentSettings()));
@@ -399,7 +370,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             .build();
         restartNodesOnBrokenClusterState(ClusterState.builder(state).metadata(brokenMeta));
         ensureGreen(); // wait for state recovery
-        state = client().admin().cluster().prepareState().get().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertTrue(state.getMetadata().persistentSettings().getAsBoolean("archived.this.is.unknown", false));
 
         // cannot remove read only block due to archived settings
@@ -407,16 +378,14 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             Settings.Builder builder = Settings.builder();
             clearOrSetFalse(builder, readOnly, Metadata.SETTING_READ_ONLY_SETTING);
             clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
-            client().admin().cluster().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder).get();
+            clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder).get();
         });
         assertTrue(e1.getMessage().contains("unknown setting [archived.this.is.unknown]"));
 
         // fail to clear archived settings with non-archived settings
         final ClusterBlockException e2 = expectThrows(
             ClusterBlockException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            () -> clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().putNull("cluster.routing.allocation.enable"))
                 .setTransientSettings(Settings.builder().putNull("archived.*"))
                 .get()
@@ -431,7 +400,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         // fail to clear archived settings due to cluster read only block
         final ClusterBlockException e3 = expectThrows(
             ClusterBlockException.class,
-            () -> client().admin().cluster().prepareUpdateSettings().setPersistentSettings(Settings.builder().putNull("archived.*")).get()
+            () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().putNull("archived.*")).get()
         );
         if (readOnly) {
             assertTrue(e3.getMessage().contains("cluster read-only (api)"));
@@ -451,7 +420,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             } else {
                 builder.put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), "true");
             }
-            client().admin().cluster().prepareUpdateSettings().setPersistentSettings(builder).get();
+            clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder).get();
         });
         if (readOnly) {
             assertTrue(e4.getMessage().contains("cluster read-only (api)"));
@@ -465,7 +434,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
             Settings.Builder builder = Settings.builder().put("archived.this.is.unknown", "false");
             clearOrSetFalse(builder, readOnly, Metadata.SETTING_READ_ONLY_SETTING);
             clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
-            client().admin().cluster().prepareUpdateSettings().setPersistentSettings(builder).get();
+            clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder).get();
         });
         if (readOnly) {
             assertTrue(e5.getMessage().contains("cluster read-only (api)"));
@@ -478,9 +447,9 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         Settings.Builder builder = Settings.builder().putNull("archived.*");
         clearOrSetFalse(builder, readOnly, Metadata.SETTING_READ_ONLY_SETTING);
         clearOrSetFalse(builder, readOnlyAllowDelete, Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING);
-        assertAcked(client().admin().cluster().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder).get());
+        assertAcked(clusterAdmin().prepareUpdateSettings().setPersistentSettings(builder).setTransientSettings(builder).get());
 
-        state = client().admin().cluster().prepareState().get().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertFalse(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().transientSettings()));
         assertFalse(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.get(state.getMetadata().transientSettings()));
         assertFalse(Metadata.SETTING_READ_ONLY_SETTING.get(state.getMetadata().persistentSettings()));
@@ -505,9 +474,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         String key2 = "cluster.routing.allocation.node_concurrent_recoveries";
         Settings persistentSettings = Settings.builder().put(key2, "5").build();
 
-        ClusterUpdateSettingsRequestBuilder request = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
+        ClusterUpdateSettingsRequestBuilder request = clusterAdmin().prepareUpdateSettings()
             .setTransientSettings(transientSettings)
             .setPersistentSettings(persistentSettings);
 
@@ -518,7 +485,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
             // But it's possible to update the settings to update the "cluster.blocks.read_only" setting
             Settings settings = Settings.builder().putNull(Metadata.SETTING_READ_ONLY_SETTING.getKey()).build();
-            assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings).get());
+            assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings).get());
 
         } finally {
             setClusterReadOnly(false);
@@ -528,12 +495,12 @@ public class ClusterSettingsIT extends ESIntegTestCase {
         try {
             // But it's possible to update the settings to update the "cluster.blocks.read_only" setting
             Settings settings = Settings.builder().put(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey(), true).build();
-            assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(settings).get());
+            assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(settings).get());
             assertBlocked(request, Metadata.CLUSTER_READ_ONLY_ALLOW_DELETE_BLOCK);
         } finally {
             // But it's possible to update the settings to update the "cluster.blocks.read_only" setting
             Settings s = Settings.builder().putNull(Metadata.SETTING_READ_ONLY_ALLOW_DELETE_SETTING.getKey()).build();
-            assertAcked(client().admin().cluster().prepareUpdateSettings().setTransientSettings(s).get());
+            assertAcked(clusterAdmin().prepareUpdateSettings().setTransientSettings(s).get());
         }
 
         // It should work now
@@ -576,7 +543,7 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         final Level level = LogManager.getRootLogger().getLevel();
 
-        ClusterUpdateSettingsRequestBuilder throwBuilder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder throwBuilder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(Settings.builder().put("logger._root", "BOOM"), throwBuilder);
 
         final IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> throwBuilder.execute().actionGet());
@@ -584,14 +551,14 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         try {
             final Settings.Builder testSettings = Settings.builder().put("logger.test", "TRACE").put("logger._root", "trace");
-            ClusterUpdateSettingsRequestBuilder updateBuilder = client().admin().cluster().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings();
             consumer.accept(testSettings, updateBuilder);
 
             updateBuilder.execute().actionGet();
             assertEquals(Level.TRACE, LogManager.getLogger("test").getLevel());
             assertEquals(Level.TRACE, LogManager.getRootLogger().getLevel());
         } finally {
-            ClusterUpdateSettingsRequestBuilder undoBuilder = client().admin().cluster().prepareUpdateSettings();
+            ClusterUpdateSettingsRequestBuilder undoBuilder = clusterAdmin().prepareUpdateSettings();
 
             if (randomBoolean()) {
                 final Settings.Builder defaultSettings = Settings.builder().putNull("logger.test").putNull("logger._root");
@@ -627,18 +594,18 @@ public class ClusterSettingsIT extends ESIntegTestCase {
 
         logger.info("Using " + ((persistent) ? "persistent" : "transient") + " settings");
 
-        ClusterUpdateSettingsRequestBuilder builder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder builder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(settings, builder);
 
         builder.execute().actionGet();
-        ClusterStateResponse state = client().admin().cluster().prepareState().execute().actionGet();
+        ClusterStateResponse state = clusterAdmin().prepareState().execute().actionGet();
         assertEquals(value, getter.apply(state.getState().getMetadata()).get(key));
 
-        ClusterUpdateSettingsRequestBuilder updateBuilder = client().admin().cluster().prepareUpdateSettings();
+        ClusterUpdateSettingsRequestBuilder updateBuilder = clusterAdmin().prepareUpdateSettings();
         consumer.accept(updatedSettings, updateBuilder);
         updateBuilder.execute().actionGet();
 
-        ClusterStateResponse updatedState = client().admin().cluster().prepareState().execute().actionGet();
+        ClusterStateResponse updatedState = clusterAdmin().prepareState().execute().actionGet();
         assertEquals(updatedValue, getter.apply(updatedState.getState().getMetadata()).get(key));
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterSearchShardsIT.java
@@ -46,7 +46,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
             .execute()
             .actionGet();
         ensureGreen();
-        ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test").execute().actionGet();
+        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
         assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getGroups()[0].getShardId().getId(), equalTo(0));
@@ -54,7 +54,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
 
-        response = client().admin().cluster().prepareSearchShards("test").setRouting("A").execute().actionGet();
+        response = clusterAdmin().prepareSearchShards("test").setRouting("A").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
         assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getGroups()[0].getShardId().getId(), equalTo(0));
@@ -73,16 +73,16 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
             .actionGet();
         ensureGreen();
 
-        ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test").execute().actionGet();
+        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(4));
         assertThat(response.getGroups()[0].getShardId().getIndexName(), equalTo("test"));
         assertThat(response.getNodes().length, equalTo(1));
         assertThat(response.getGroups()[0].getShards()[0].currentNodeId(), equalTo(response.getNodes()[0].getId()));
 
-        response = client().admin().cluster().prepareSearchShards("test").setRouting("ABC").execute().actionGet();
+        response = clusterAdmin().prepareSearchShards("test").setRouting("ABC").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
 
-        response = client().admin().cluster().prepareSearchShards("test").setPreference("_shards:2").execute().actionGet();
+        response = clusterAdmin().prepareSearchShards("test").setPreference("_shards:2").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(1));
         assertThat(response.getGroups()[0].getShardId().getId(), equalTo(2));
     }
@@ -96,9 +96,9 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
             .addAliasAction(AliasActions.add().index("test1").alias("routing_alias").routing("ABC"))
             .addAliasAction(AliasActions.add().index("test2").alias("routing_alias").routing("EFG"))
             .get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
 
-        ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("routing_alias").execute().actionGet();
+        ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("routing_alias").execute().actionGet();
         assertThat(response.getGroups().length, equalTo(2));
         assertThat(response.getGroups()[0].getShards().length, equalTo(2));
         assertThat(response.getGroups()[1].getShards().length, equalTo(2));
@@ -140,7 +140,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test-blocks", blockSetting);
-                ClusterSearchShardsResponse response = client().admin().cluster().prepareSearchShards("test-blocks").execute().actionGet();
+                ClusterSearchShardsResponse response = clusterAdmin().prepareSearchShards("test-blocks").execute().actionGet();
                 assertThat(response.getGroups().length, equalTo(numShards.numPrimaries));
             } finally {
                 disableIndexBlock("test-blocks", blockSetting);
@@ -150,7 +150,7 @@ public class ClusterSearchShardsIT extends ESIntegTestCase {
         // Request is blocked
         try {
             enableIndexBlock("test-blocks", SETTING_BLOCKS_METADATA);
-            assertBlocked(client().admin().cluster().prepareSearchShards("test-blocks"));
+            assertBlocked(clusterAdmin().prepareSearchShards("test-blocks"));
         } finally {
             disableIndexBlock("test-blocks", SETTING_BLOCKS_METADATA);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
@@ -48,15 +48,11 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         int negativeShardsPerNode = between(-50_000, 0);
         try {
             if (frequently()) {
-                client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
+                clusterAdmin().prepareUpdateSettings()
                     .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, negativeShardsPerNode).build())
                     .get();
             } else {
-                client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
+                clusterAdmin().prepareUpdateSettings()
                     .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, negativeShardsPerNode).build())
                     .get();
             }
@@ -70,7 +66,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
     }
 
     public void testIndexCreationOverLimit() {
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
 
         ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
 
@@ -98,12 +94,12 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         } catch (IllegalArgumentException e) {
             verifyException(dataNodes, counts, e);
         }
-        ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         assertFalse(clusterState.getMetadata().hasIndex("should-fail"));
     }
 
     public void testIndexCreationOverLimitFromTemplate() {
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
 
         final ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
 
@@ -135,12 +131,12 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
             () -> client().admin().indices().prepareCreate("should-fail").get()
         );
         verifyException(dataNodes, counts, e);
-        ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         assertFalse(clusterState.getMetadata().hasIndex("should-fail"));
     }
 
     public void testIncreaseReplicasOverLimit() {
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
 
         dataNodes = ensureMultipleDataNodes(dataNodes);
 
@@ -167,12 +163,12 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 + "] maximum normal shards open;";
             assertEquals(expectedError, e.getMessage());
         }
-        Metadata clusterState = client().admin().cluster().prepareState().get().getState().metadata();
+        Metadata clusterState = clusterAdmin().prepareState().get().getState().metadata();
         assertEquals(0, clusterState.index("growing-should-fail").getNumberOfReplicas());
     }
 
     public void testChangingMultipleIndicesOverLimit() {
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
 
         dataNodes = ensureMultipleDataNodes(dataNodes);
 
@@ -228,13 +224,13 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 + "] maximum normal shards open;";
             assertEquals(expectedError, e.getMessage());
         }
-        Metadata clusterState = client().admin().cluster().prepareState().get().getState().metadata();
+        Metadata clusterState = clusterAdmin().prepareState().get().getState().metadata();
         assertEquals(firstIndexReplicas, clusterState.index("test-1-index").getNumberOfReplicas());
         assertEquals(secondIndexReplicas, clusterState.index("test-2-index").getNumberOfReplicas());
     }
 
     public void testPreserveExistingSkipsCheck() {
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
 
         dataNodes = ensureMultipleDataNodes(dataNodes);
 
@@ -257,7 +253,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("number_of_replicas", dataNodes))
                 .get()
         );
-        ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         assertEquals(0, clusterState.getMetadata().index("test-index").getNumberOfReplicas());
     }
 
@@ -272,7 +268,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
 
         assertAcked(client.admin().cluster().preparePutRepository("test-repo").setType("fs").setSettings(repoSettings.build()));
 
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
         ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
         createIndex(
             "snapshot-index",
@@ -343,7 +339,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
 
     public void testOpenIndexOverLimit() {
         Client client = client();
-        int dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+        int dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
         ShardCounts counts = ShardCounts.forDataNodeCount(dataNodes);
 
         createIndex(
@@ -386,9 +382,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
         if (dataNodes == 1) {
             internalCluster().startNode(dataNode());
             assertThat(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
+                clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(">=2")
                     .setLocal(true)
@@ -397,29 +391,17 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
                     .isTimedOut(),
                 equalTo(false)
             );
-            dataNodes = client().admin().cluster().prepareState().get().getState().getNodes().getDataNodes().size();
+            dataNodes = clusterAdmin().prepareState().get().getState().getNodes().getDataNodes().size();
         }
         return dataNodes;
     }
 
     private void setShardsPerNode(int shardsPerNode) {
         try {
-            ClusterUpdateSettingsResponse response;
-            if (frequently()) {
-                response = client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
-                    .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, shardsPerNode).build())
-                    .get();
-                assertEquals(shardsPerNode, response.getPersistentSettings().getAsInt(shardsPerNodeKey, -1).intValue());
-            } else {
-                response = client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
-                    .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, shardsPerNode).build())
-                    .get();
-                assertEquals(shardsPerNode, response.getPersistentSettings().getAsInt(shardsPerNodeKey, -1).intValue());
-            }
+            ClusterUpdateSettingsResponse response = clusterAdmin().prepareUpdateSettings()
+                .setPersistentSettings(Settings.builder().put(shardsPerNodeKey, shardsPerNode).build())
+                .get();
+            assertEquals(shardsPerNode, response.getPersistentSettings().getAsInt(shardsPerNodeKey, -1).intValue());
         } catch (IllegalArgumentException ex) {
             fail(ex.getMessage());
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/ClusterDisruptionIT.java
@@ -232,7 +232,7 @@ public class ClusterDisruptionIT extends AbstractDisruptionTestCase {
                 // is the super-connected node and recovery source and target are on opposite sides of the bridge
                 if (disruptionScheme instanceof NetworkDisruption networkDisruption
                     && networkDisruption.getDisruptedLinks() instanceof Bridge) {
-                    assertBusy(() -> assertAcked(client().admin().cluster().prepareReroute().setRetryFailed(true)));
+                    assertBusy(() -> assertAcked(clusterAdmin().prepareReroute().setRetryFailed(true)));
                 }
                 ensureGreen("test");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiscoveryDisruptionIT.java
@@ -164,7 +164,7 @@ public class DiscoveryDisruptionIT extends AbstractDisruptionTestCase {
 
         isolateAllNodes.stopDisrupting();
 
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         if (state.metadata().hasIndex("test") == false) {
             fail("index 'test' was lost. current cluster state: " + state);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
@@ -114,12 +114,12 @@ public class ShardInfoIT extends ESIntegTestCase {
 
     private void ensureActiveShardCopies(final int shardId, final int copyCount) throws Exception {
         assertBusy(() -> {
-            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState().get().getState();
             assertThat(state.routingTable().index("idx"), not(nullValue()));
             assertThat(state.routingTable().index("idx").shard(shardId), not(nullValue()));
             assertThat(state.routingTable().index("idx").shard(shardId).activeShards().size(), equalTo(copyCount));
 
-            ClusterHealthResponse healthResponse = client().admin().cluster().prepareHealth("idx").setWaitForNoRelocatingShards(true).get();
+            ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("idx").setWaitForNoRelocatingShards(true).get();
             assertThat(healthResponse.isTimedOut(), equalTo(false));
 
             RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("idx").setActiveOnly(true).get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/env/NodeEnvironmentIT.java
@@ -153,7 +153,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         String node = internalCluster().startNode();
         prepareCreate("test").get();
         indexRandom(true, client().prepareIndex("test").setId("1").setSource("{}", XContentType.JSON));
-        String nodeId = client().admin().cluster().prepareState().get().getState().nodes().getMasterNodeId();
+        String nodeId = clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId();
 
         final Settings dataPathSettings = internalCluster().dataPathSettings(node);
         internalCluster().stopRandomDataNode();
@@ -235,7 +235,7 @@ public class NodeEnvironmentIT extends ESIntegTestCase {
         dataPaths.forEach(path -> assertTrue(Files.isDirectory(path.resolve("nodes"))));
         internalCluster().startNode(dataPathSettings);
         dataPaths.forEach(path -> assertTrue(Files.isRegularFile(path.resolve("nodes"))));
-        assertEquals(nodeId, client().admin().cluster().prepareState().get().getState().nodes().getMasterNodeId());
+        assertEquals(nodeId, clusterAdmin().prepareState().get().getState().nodes().getMasterNodeId());
         assertTrue(indexExists("test"));
         ensureYellow("test");
         assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 1L);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/GatewayIndexStateIT.java
@@ -98,15 +98,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
             .actionGet();
 
         logger.info("--> verify meta _routing required exists");
-        MappingMetadata mappingMd = client().admin()
-            .cluster()
-            .prepareState()
-            .execute()
-            .actionGet()
-            .getState()
-            .metadata()
-            .index("test")
-            .mapping();
+        MappingMetadata mappingMd = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test").mapping();
         assertThat(mappingMd.routingRequired(), equalTo(true));
 
         logger.info("--> restarting nodes...");
@@ -116,7 +108,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         ensureYellow();
 
         logger.info("--> verify meta _routing required exists");
-        mappingMd = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test").mapping();
+        mappingMd = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test").mapping();
         assertThat(mappingMd.routingRequired(), equalTo(true));
     }
 
@@ -132,7 +124,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        ClusterStateResponse stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -146,7 +138,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(client().admin().indices().prepareClose("test"));
 
-        stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -172,7 +164,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> verifying that the state is green");
         ensureGreen();
 
-        stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -186,7 +178,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         logger.info("--> closing test index...");
         assertAcked(client().admin().indices().prepareClose("test"));
-        stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -195,7 +187,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for two nodes and green status");
         ensureGreen();
 
-        stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -213,7 +205,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(test.numPrimaries));
         assertThat(
@@ -247,9 +239,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         });
 
         logger.info("--> waiting for test index to be created");
-        ClusterHealthResponse health = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse health = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setIndices("test")
             .execute()
@@ -257,7 +247,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         assertThat(health.isTimedOut(), equalTo(false));
 
         logger.info("--> verify we have an index");
-        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().setIndices("test").execute().actionGet();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().setIndices("test").execute().actionGet();
         assertThat(clusterStateResponse.getState().metadata().hasIndex("test"), equalTo(true));
     }
 
@@ -284,9 +274,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
 
         logger.info("--> waiting for green status");
-        ClusterHealthResponse health = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse health = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
@@ -302,7 +290,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(client().admin().indices().prepareClose("test"));
 
-        ClusterStateResponse stateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().execute().actionGet();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -310,9 +298,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         client().admin().indices().prepareOpen("test").execute().actionGet();
 
         logger.info("--> waiting for green status");
-        health = client().admin()
-            .cluster()
-            .prepareHealth()
+        health = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
@@ -366,10 +352,9 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         });
 
         logger.info("--> wait until all nodes are back online");
-        client().admin()
-            .cluster()
-            .health(new ClusterHealthRequest(new String[] {}).waitForEvents(Priority.LANGUID).waitForNodes(Integer.toString(numNodes)))
-            .actionGet();
+        clusterAdmin().health(
+            new ClusterHealthRequest(new String[] {}).waitForEvents(Priority.LANGUID).waitForNodes(Integer.toString(numNodes))
+        ).actionGet();
 
         logger.info("--> waiting for green status");
         ensureGreen();
@@ -402,17 +387,14 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
             ensureYellow();
         } else {
             internalCluster().startNode();
-            client().admin()
-                .cluster()
-                .health(
-                    new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
-                        .waitForEvents(Priority.LANGUID)
-                        .waitForNoRelocatingShards(true)
-                        .waitForNodes("2")
-                )
-                .actionGet();
+            clusterAdmin().health(
+                new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
+                    .waitForEvents(Priority.LANGUID)
+                    .waitForNoRelocatingShards(true)
+                    .waitForNodes("2")
+            ).actionGet();
         }
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
 
         final IndexMetadata metadata = state.getMetadata().index("test");
         final IndexMetadata.Builder brokenMeta = IndexMetadata.builder(metadata)
@@ -429,7 +411,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         // check that the cluster does not keep reallocating shards
         assertBusy(() -> {
-            final RoutingTable routingTable = client().admin().cluster().prepareState().get().getState().routingTable();
+            final RoutingTable routingTable = clusterAdmin().prepareState().get().getState().routingTable();
             final IndexRoutingTable indexRoutingTable = routingTable.index("test");
             assertNotNull(indexRoutingTable);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
@@ -444,7 +426,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         }, 60, TimeUnit.SECONDS);
         client().admin().indices().prepareClose("test").get();
 
-        state = client().admin().cluster().prepareState().get().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertEquals(IndexMetadata.State.CLOSE, state.getMetadata().index(metadata.getIndex()).getState());
         assertEquals("boolean", state.getMetadata().index(metadata.getIndex()).getSettings().get("archived.index.similarity.BM25.type"));
         // try to open it with the broken setting - fail again!
@@ -482,17 +464,14 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
             ensureYellow();
         } else {
             internalCluster().startNode();
-            client().admin()
-                .cluster()
-                .health(
-                    new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
-                        .waitForEvents(Priority.LANGUID)
-                        .waitForNoRelocatingShards(true)
-                        .waitForNodes("2")
-                )
-                .actionGet();
+            clusterAdmin().health(
+                new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
+                    .waitForEvents(Priority.LANGUID)
+                    .waitForNoRelocatingShards(true)
+                    .waitForNodes("2")
+            ).actionGet();
         }
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
 
         final IndexMetadata metadata = state.getMetadata().index("test");
         final IndexMetadata.Builder brokenMeta = IndexMetadata.builder(metadata)
@@ -501,7 +480,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         // check that the cluster does not keep reallocating shards
         assertBusy(() -> {
-            final RoutingTable routingTable = client().admin().cluster().prepareState().get().getState().routingTable();
+            final RoutingTable routingTable = clusterAdmin().prepareState().get().getState().routingTable();
             final IndexRoutingTable indexRoutingTable = routingTable.index("test");
             assertNotNull(indexRoutingTable);
             for (int i = 0; i < indexRoutingTable.size(); i++) {
@@ -533,17 +512,14 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
             ensureYellow();
         } else {
             internalCluster().startNode();
-            client().admin()
-                .cluster()
-                .health(
-                    new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
-                        .waitForEvents(Priority.LANGUID)
-                        .waitForNoRelocatingShards(true)
-                        .waitForNodes("2")
-                )
-                .actionGet();
+            clusterAdmin().health(
+                new ClusterHealthRequest(new String[] {}).waitForGreenStatus()
+                    .waitForEvents(Priority.LANGUID)
+                    .waitForNoRelocatingShards(true)
+                    .waitForNodes("2")
+            ).actionGet();
         }
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
 
         final Metadata metadata = state.getMetadata();
         final Metadata brokenMeta = Metadata.builder(metadata)
@@ -558,7 +534,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         restartNodesOnBrokenClusterState(ClusterState.builder(state).metadata(brokenMeta));
 
         ensureYellow("test"); // wait for state recovery
-        state = client().admin().cluster().prepareState().get().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertEquals("true", state.metadata().persistentSettings().get("archived.this.is.unknown"));
         assertEquals(
             "broken",
@@ -568,7 +544,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
         // delete these settings
         updateClusterSettings(Settings.builder().putNull("archived.*"));
 
-        state = client().admin().cluster().prepareState().get().getState();
+        state = clusterAdmin().prepareState().get().getState();
         assertNull(state.metadata().persistentSettings().get("archived.this.is.unknown"));
         assertNull(
             state.metadata().persistentSettings().get("archived." + ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE.getKey())
@@ -587,7 +563,7 @@ public class GatewayIndexStateIT extends ESIntegTestCase {
 
         final Metadata metadata = internalCluster().getInstance(ClusterService.class).state().metadata();
         final Path[] paths = internalCluster().getInstance(NodeEnvironment.class).nodeDataPaths();
-        final String nodeId = client().admin().cluster().prepareNodesInfo(nodeName).clear().get().getNodes().get(0).getNode().getId();
+        final String nodeId = clusterAdmin().prepareNodesInfo(nodeName).clear().get().getNodes().get(0).getNode().getId();
 
         writeBrokenMeta(nodeEnvironment -> {
             for (final Path path : paths) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
@@ -69,7 +69,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
 
         logger.debug("relocating index...");
         updateIndexSettings(Settings.builder().put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "_name", node2), index);
-        client().admin().cluster().prepareHealth().setWaitForNoRelocatingShards(true).get();
+        clusterAdmin().prepareHealth().setWaitForNoRelocatingShards(true).get();
         ensureGreen();
         assertIndexDirectoryDeleted(node1, resolveIndex);
         assertIndexInMetaState(node2, index);
@@ -98,7 +98,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
         logger.info("--> close index");
         client().admin().indices().prepareClose(index).get();
         // close the index
-        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
         assertThat(clusterStateResponse.getState().getMetadata().index(index).getState().name(), equalTo(IndexMetadata.State.CLOSE.name()));
 
         // update the mapping. this should cause the new meta data to be written although index is closed

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/RecoveryFromGatewayIT.java
@@ -152,7 +152,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             previousTerms = new HashMap<>();
         }
         final Map<String, long[]> result = new HashMap<>();
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         for (IndexMetadata indexMetadata : state.metadata().indices().values()) {
             final String index = indexMetadata.getIndex().getName();
             final long[] previous = previousTerms.get(index);
@@ -398,7 +398,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 2);
         }
 
-        String metadataUuid = client().admin().cluster().prepareState().execute().get().getState().getMetadata().clusterUUID();
+        String metadataUuid = clusterAdmin().prepareState().execute().get().getState().getMetadata().clusterUUID();
         assertThat(metadataUuid, not(equalTo("_na_")));
 
         logger.info("--> closing first node, and indexing more data to the second node");
@@ -412,7 +412,7 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
             .actionGet();
         // TODO: remove once refresh doesn't fail immediately if there a master block:
         // https://github.com/elastic/elasticsearch/issues/9997
-        // client().admin().cluster().prepareHealth("test").setWaitForYellowStatus().get();
+        // clusterAdmin().prepareHealth("test").setWaitForYellowStatus().get();
         logger.info("--> refreshing all indices after indexing is complete");
         client().admin().indices().prepareRefresh().execute().actionGet();
 
@@ -466,13 +466,13 @@ public class RecoveryFromGatewayIT extends ESIntegTestCase {
         logger.info("--> running cluster_health (wait for the shards to startup)");
         ensureGreen();
 
-        assertThat(client().admin().cluster().prepareState().execute().get().getState().getMetadata().clusterUUID(), equalTo(metadataUuid));
+        assertThat(clusterAdmin().prepareState().execute().get().getState().getMetadata().clusterUUID(), equalTo(metadataUuid));
 
         for (int i = 0; i < 10; i++) {
             assertHitCount(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).execute().actionGet(), 3);
         }
 
-        ClusterState state = client().admin().cluster().prepareState().execute().actionGet().getState();
+        ClusterState state = clusterAdmin().prepareState().execute().actionGet().getState();
         assertThat(state.metadata().templates().get("template_1").patterns(), equalTo(Collections.singletonList("te*")));
         assertThat(state.metadata().index("test").getAliases().get("test_alias"), notNullValue());
         assertThat(state.metadata().index("test").getAliases().get("test_alias").filter(), notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorIT.java
@@ -220,7 +220,7 @@ public class ReplicaShardAllocatorIT extends ESIntegTestCase {
         );
         internalCluster().startDataOnlyNode(nodeWithReplicaSettings);
         // need to wait for events to ensure the reroute has happened since we perform it async when a new node joins.
-        client().admin().cluster().prepareHealth(indexName).setWaitForYellowStatus().setWaitForEvents(Priority.LANGUID).get();
+        clusterAdmin().prepareHealth(indexName).setWaitForYellowStatus().setWaitForEvents(Priority.LANGUID).get();
         blockRecovery.countDown();
         ensureGreen(indexName);
         assertThat(internalCluster().nodesInclude(indexName), hasItem(newNode));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
@@ -70,12 +70,10 @@ public class FinalPipelineIT extends ESIntegTestCase {
     public void cleanUpPipelines() {
         client().admin().indices().prepareDelete("*").get();
 
-        final GetPipelineResponse response = client().admin()
-            .cluster()
-            .prepareGetPipeline("default_pipeline", "final_pipeline", "request_pipeline")
+        final GetPipelineResponse response = clusterAdmin().prepareGetPipeline("default_pipeline", "final_pipeline", "request_pipeline")
             .get();
         for (final PipelineConfiguration pipeline : response.pipelines()) {
-            client().admin().cluster().deletePipeline(new DeletePipelineRequest(pipeline.getId())).actionGet();
+            clusterAdmin().deletePipeline(new DeletePipelineRequest(pipeline.getId())).actionGet();
         }
     }
 
@@ -85,7 +83,7 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         final BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"changing_dest": {}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
 
         final IllegalStateException e = expectThrows(
             IllegalStateException.class,
@@ -105,7 +103,7 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         final BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"reroute": {}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
 
         final IllegalStateException e = expectThrows(
             IllegalStateException.class,
@@ -128,14 +126,11 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"changing_dest": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
 
         BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"final": {"exists":"no_such_field"}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
 
         IndexResponse indexResponse = client().prepareIndex("index")
             .setId("1")
@@ -157,14 +152,11 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"changing_dest": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
 
         BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"final": {}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
 
         IndexResponse indexResponse = client().prepareIndex("index")
             .setId("1")
@@ -186,17 +178,11 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"changing_dest": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
 
         BytesReference targetPipeline = new BytesArray("""
             {"processors": [{"final": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("target_default_pipeline", targetPipeline, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("target_default_pipeline", targetPipeline, XContentType.JSON)).actionGet();
 
         IndexResponse indexResponse = client().prepareIndex("index")
             .setId("1")
@@ -218,17 +204,11 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"reroute": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
 
         BytesReference targetPipeline = new BytesArray("""
             {"processors": [{"final": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("target_default_pipeline", targetPipeline, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("target_default_pipeline", targetPipeline, XContentType.JSON)).actionGet();
 
         IndexResponse indexResponse = client().prepareIndex("index")
             .setId("1")
@@ -250,17 +230,11 @@ public class FinalPipelineIT extends ESIntegTestCase {
 
         BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"reroute": {"dest": "target"}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
 
         BytesReference targetPipeline = new BytesArray("""
             {"processors": [{"reroute": {"dest": "index"}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("target_default_pipeline", targetPipeline, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("target_default_pipeline", targetPipeline, XContentType.JSON)).actionGet();
 
         IllegalStateException exception = expectThrows(
             IllegalStateException.class,
@@ -291,13 +265,10 @@ public class FinalPipelineIT extends ESIntegTestCase {
     public void testRequestPipelineAndFinalPipeline() {
         final BytesReference requestPipelineBody = new BytesArray("""
             {"processors": [{"request": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("request_pipeline", requestPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("request_pipeline", requestPipelineBody, XContentType.JSON)).actionGet();
         final BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"final": {"exists":"request"}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
         final Settings settings = Settings.builder().put(IndexSettings.FINAL_PIPELINE.getKey(), "final_pipeline").build();
         createIndex("index", settings);
         final IndexRequestBuilder index = client().prepareIndex("index").setId("1");
@@ -319,13 +290,10 @@ public class FinalPipelineIT extends ESIntegTestCase {
     public void testDefaultAndFinalPipeline() {
         final BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"default": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
         final BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"final": {"exists":"default"}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
         final Settings settings = Settings.builder()
             .put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default_pipeline")
             .put(IndexSettings.FINAL_PIPELINE.getKey(), "final_pipeline")
@@ -349,13 +317,10 @@ public class FinalPipelineIT extends ESIntegTestCase {
     public void testDefaultAndFinalPipelineFromTemplates() {
         final BytesReference defaultPipelineBody = new BytesArray("""
             {"processors": [{"default": {}}]}""");
-        client().admin()
-            .cluster()
-            .putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON))
-            .actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("default_pipeline", defaultPipelineBody, XContentType.JSON)).actionGet();
         final BytesReference finalPipelineBody = new BytesArray("""
             {"processors": [{"final": {"exists":"default"}}]}""");
-        client().admin().cluster().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
+        clusterAdmin().putPipeline(new PutPipelineRequest("final_pipeline", finalPipelineBody, XContentType.JSON)).actionGet();
         final int lowOrder = randomIntBetween(0, Integer.MAX_VALUE - 1);
         final int highOrder = randomIntBetween(lowOrder + 1, Integer.MAX_VALUE);
         final int finalPipelineOrder;

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
@@ -395,17 +395,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
     }
 
     private String getCoordinatingOnlyNode() {
-        return client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .nodes()
-            .getCoordinatingOnlyNodes()
-            .values()
-            .iterator()
-            .next()
-            .getName();
+        return clusterAdmin().prepareState().get().getState().nodes().getCoordinatingOnlyNodes().values().iterator().next().getName();
     }
 
     private Tuple<String, String> getPrimaryReplicaNodeNames() {
@@ -422,7 +412,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
             .findAny()
             .get()
             .currentNodeId();
-        DiscoveryNodes nodes = client().admin().cluster().prepareState().get().getState().nodes();
+        DiscoveryNodes nodes = clusterAdmin().prepareState().get().getState().nodes();
         String primaryName = nodes.get(primaryId).getName();
         String replicaName = nodes.get(replicaId).getName();
         return new Tuple<>(primaryName, replicaName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/fielddata/FieldDataLoadingIT.java
@@ -38,7 +38,7 @@ public class FieldDataLoadingIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("name", "name").get();
         client().admin().indices().prepareRefresh("test").get();
 
-        ClusterStatsResponse response = client().admin().cluster().prepareClusterStats().get();
+        ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseCreationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseCreationIT.java
@@ -75,7 +75,7 @@ public class PeerRecoveryRetentionLeaseCreationIT extends ESIntegTestCase {
 
         ensureGreen(INDEX_NAME);
         final RetentionLeases retentionLeases = getRetentionLeases();
-        final String nodeId = client().admin().cluster().prepareNodesInfo(dataNode).clear().get().getNodes().get(0).getNode().getId();
+        final String nodeId = clusterAdmin().prepareNodesInfo(dataNode).clear().get().getNodes().get(0).getNode().getId();
         assertTrue(
             "expected lease for [" + nodeId + "] in " + retentionLeases,
             retentionLeases.contains(ReplicationTracker.getPeerRecoveryRetentionLeaseId(nodeId))

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -560,7 +560,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
             .build();
         assertAcked(prepareCreate("index").setSettings(settings));
         ensureYellowAndNoInitializingShards("index");
-        assertFalse(client().admin().cluster().prepareHealth("index").setWaitForActiveShards(numDataNodes).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth("index").setWaitForActiveShards(numDataNodes).get().isTimedOut());
 
         final String primaryShardNodeId = clusterService().state().routingTable().index("index").shard(0).primaryShard().currentNodeId();
         final String primaryShardNodeName = clusterService().state().nodes().get(primaryShardNodeId).getName();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -173,9 +173,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
 
         // shard should be failed due to a corrupted index
         assertBusy(() -> {
-            final ClusterAllocationExplanation explanation = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplanation explanation = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(0)
                 .setPrimary(true)
@@ -221,9 +219,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
 
         // there is only _stale_ primary (due to new allocation id)
         assertBusy(() -> {
-            final ClusterAllocationExplanation explanation = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplanation explanation = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(0)
                 .setPrimary(true)
@@ -241,9 +237,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         client().admin().cluster().prepareReroute().add(new AllocateStalePrimaryAllocationCommand(indexName, 0, nodeId, true)).get();
 
         assertBusy(() -> {
-            final ClusterAllocationExplanation explanation = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplanation explanation = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(0)
                 .setPrimary(true)
@@ -337,9 +331,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
 
         // all shards should be failed due to a corrupted translog
         assertBusy(() -> {
-            final UnassignedInfo unassignedInfo = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final UnassignedInfo unassignedInfo = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(0)
                 .setPrimary(true)
@@ -400,9 +392,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
 
         // there is only _stale_ primary (due to new allocation id)
         assertBusy(() -> {
-            final ClusterAllocationExplanation explanation = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplanation explanation = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(0)
                 .setPrimary(true)
@@ -420,9 +410,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         client().admin().cluster().prepareReroute().add(new AllocateStalePrimaryAllocationCommand(indexName, 0, primaryNodeId, true)).get();
 
         assertBusy(() -> {
-            final ClusterAllocationExplanation explanation = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplanation explanation = clusterAdmin().prepareAllocationExplain()
                 .setIndex(indexName)
                 .setShard(0)
                 .setPrimary(true)
@@ -578,7 +566,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
         ensureGreen(indexName);
 
         final Map<String, String> nodeNameToNodeId = new HashMap<>();
-        final ClusterState state = client().admin().cluster().prepareState().get().getState();
+        final ClusterState state = clusterAdmin().prepareState().get().getState();
         final DiscoveryNodes nodes = state.nodes();
         for (Map.Entry<String, DiscoveryNode> cursor : nodes.getNodes().entrySet()) {
             nodeNameToNodeId.put(cursor.getValue().getName(), cursor.getKey());
@@ -638,7 +626,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
     }
 
     public static Path getPathToShardData(String nodeId, ShardId shardId, String shardPathSubdirectory) {
-        final NodesStatsResponse nodeStatsResponse = client().admin().cluster().prepareNodesStats(nodeId).setFs(true).get();
+        final NodesStatsResponse nodeStatsResponse = clusterAdmin().prepareNodesStats(nodeId).setFs(true).get();
         final Set<Path> paths = StreamSupport.stream(nodeStatsResponse.getNodes().get(0).getFs().spliterator(), false)
             .map(
                 dataPath -> PathUtils.get(dataPath.getPath())

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedTranslogIT.java
@@ -79,9 +79,7 @@ public class CorruptedTranslogIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             // assertBusy since the shard starts out unassigned with reason CLUSTER_RECOVERED, then it's assigned, and then it fails.
-            final ClusterAllocationExplainResponse allocationExplainResponse = client().admin()
-                .cluster()
-                .prepareAllocationExplain()
+            final ClusterAllocationExplainResponse allocationExplainResponse = clusterAdmin().prepareAllocationExplain()
                 .setIndex("test")
                 .setShard(0)
                 .setPrimary(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
@@ -70,9 +70,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         // first wait for 2 nodes in the cluster
         logger.info("Waiting for replicas to be assigned");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -86,10 +84,9 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         // explicitly call reroute, so shards will get relocated to the new node (we delay it in ES in case other nodes join)
         client().admin().cluster().prepareReroute().execute().actionGet();
 
-        clusterHealth = client().admin()
-            .cluster()
-            .health(new ClusterHealthRequest(new String[] {}).waitForGreenStatus().waitForNodes("2").waitForNoRelocatingShards(true))
-            .actionGet();
+        clusterHealth = clusterAdmin().health(
+            new ClusterHealthRequest(new String[] {}).waitForGreenStatus().waitForNodes("2").waitForNoRelocatingShards(true)
+        ).actionGet();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), equalTo(ClusterHealthStatus.GREEN));
         assertThat(clusterHealth.getNumberOfDataNodes(), equalTo(2));
@@ -114,9 +111,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         // first wait for 3 nodes in the cluster
         logger.info("Waiting for replicas to be assigned");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNodes("3")
             .setWaitForNoRelocatingShards(true)
@@ -130,9 +125,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         // explicitly call reroute, so shards will get relocated to the new node (we delay it in ES in case other nodes join)
         client().admin().cluster().prepareReroute().execute().actionGet();
 
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNodes("3")
             .setWaitForNoRelocatingShards(true)
@@ -174,9 +167,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
         internalCluster().stopNode(server_1);
         // verify health
         logger.info("Running Cluster Health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -188,9 +179,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         client().admin().cluster().prepareReroute().get();
 
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesOptionsIntegrationIT.java
@@ -248,9 +248,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         ensureGreen("test1");
         waitForRelocation();
 
-        AcknowledgedResponse putRepositoryResponse = client().admin()
-            .cluster()
-            .preparePutRepository("dummy-repo")
+        AcknowledgedResponse putRepositoryResponse = clusterAdmin().preparePutRepository("dummy-repo")
             .setType("fs")
             .setSettings(Settings.builder().put("location", randomRepoPath()))
             .get();
@@ -367,9 +365,7 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
         ensureGreen("foobar");
         waitForRelocation();
 
-        AcknowledgedResponse putRepositoryResponse = client().admin()
-            .cluster()
-            .preparePutRepository("dummy-repo")
+        AcknowledgedResponse putRepositoryResponse = clusterAdmin().preparePutRepository("dummy-repo")
             .setType("fs")
             .setSettings(Settings.builder().put("location", randomRepoPath()))
             .get();
@@ -681,13 +677,11 @@ public class IndicesOptionsIntegrationIT extends ESIntegTestCase {
     }
 
     private static CreateSnapshotRequestBuilder snapshot(String name, String... indices) {
-        return client().admin().cluster().prepareCreateSnapshot("dummy-repo", name).setWaitForCompletion(true).setIndices(indices);
+        return clusterAdmin().prepareCreateSnapshot("dummy-repo", name).setWaitForCompletion(true).setIndices(indices);
     }
 
     private static RestoreSnapshotRequestBuilder restore(String name, String... indices) {
-        return client().admin()
-            .cluster()
-            .prepareRestoreSnapshot("dummy-repo", name)
+        return clusterAdmin().prepareRestoreSnapshot("dummy-repo", name)
             .setRenamePattern("(.+)")
             .setRenameReplacement("$1-copy-" + name)
             .setWaitForCompletion(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/cluster/ShardLockFailureIT.java
@@ -156,9 +156,7 @@ public class ShardLockFailureIT extends ESIntegTestCase {
 
             updateIndexSettings(Settings.builder().putNull(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name"), indexName);
             assertBusy(mockLogAppender::assertAllExpectationsMatched);
-            final var clusterHealthResponse = client().admin()
-                .cluster()
-                .prepareHealth(indexName)
+            final var clusterHealthResponse = clusterAdmin().prepareHealth(indexName)
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(TimeValue.timeValueSeconds(10))
                 .setWaitForNoInitializingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetMappingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/SimpleGetMappingsIT.java
@@ -62,9 +62,7 @@ public class SimpleGetMappingsIT extends ESIntegTestCase {
         client().admin().indices().prepareCreate("indexa").setMapping(getMappingForType()).execute().actionGet();
         client().admin().indices().prepareCreate("indexb").setMapping(getMappingForType()).execute().actionGet();
 
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .execute()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/UpdateMappingIntegrationIT.java
@@ -66,7 +66,7 @@ public class UpdateMappingIntegrationIT extends ESIntegTestCase {
             .setSettings(indexSettings(1, 0).put(MapperService.INDEX_MAPPING_TOTAL_FIELDS_LIMIT_SETTING.getKey(), Long.MAX_VALUE))
             .execute()
             .actionGet();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().execute().actionGet();
         updateClusterSettings(
             Settings.builder().put(MappingUpdatedAction.INDICES_MAPPING_DYNAMIC_TIMEOUT_SETTING.getKey(), TimeValue.timeValueMinutes(5))
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -295,12 +295,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     public void clearFieldData() throws Exception {
         client().admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
         assertBusy(() -> {
-            NodesStatsResponse resp = client().admin()
-                .cluster()
-                .prepareNodesStats()
-                .clear()
-                .setBreaker(true)
-                .get(new TimeValue(15, TimeUnit.SECONDS));
+            NodesStatsResponse resp = clusterAdmin().prepareNodesStats().clear().setBreaker(true).get(new TimeValue(15, TimeUnit.SECONDS));
             for (NodeStats nStats : resp.getNodes()) {
                 assertThat(
                     "fielddata breaker never reset back to 0",
@@ -325,9 +320,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         reset();
 
         assertThat(
-            client().admin()
-                .cluster()
-                .prepareState()
+            clusterAdmin().prepareState()
                 .get()
                 .getState()
                 .metadata()
@@ -347,7 +340,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
 
         internalCluster().ensureAtLeastNumDataNodes(2);
 
-        NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().get();
+        NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().get();
         List<NodeStats> dataNodeStats = new ArrayList<>();
         for (NodeStats stat : nodeStats.getNodes()) {
             if (stat.getNode().canContainData()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -127,7 +127,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
         final String danglingIndexUUID = findDanglingIndexForNode(stoppedNodeName, INDEX_NAME);
 
         final ImportDanglingIndexRequest request = new ImportDanglingIndexRequest(danglingIndexUUID, true);
-        client().admin().cluster().importDanglingIndex(request).get();
+        clusterAdmin().importDanglingIndex(request).get();
 
         assertTrue("Expected dangling index " + INDEX_NAME + " to be recovered", indexExists(INDEX_NAME));
     }
@@ -143,7 +143,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
 
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin().cluster().importDanglingIndex(request).actionGet()
+            () -> clusterAdmin().importDanglingIndex(request).actionGet()
         );
 
         assertThat(e.getMessage(), containsString("No dangling index found for UUID [NonExistentUUID]"));
@@ -160,7 +160,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
 
         final ImportDanglingIndexRequest request = new ImportDanglingIndexRequest(danglingIndexUUID, false);
 
-        Exception e = expectThrows(Exception.class, () -> client().admin().cluster().importDanglingIndex(request).actionGet());
+        Exception e = expectThrows(Exception.class, () -> clusterAdmin().importDanglingIndex(request).actionGet());
 
         assertThat(e.getMessage(), containsString("accept_data_loss must be set to true"));
     }
@@ -183,7 +183,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
         final String stoppedNodeName = createDanglingIndices(INDEX_NAME, OTHER_INDEX_NAME);
         final String danglingIndexUUID = findDanglingIndexForNode(stoppedNodeName, INDEX_NAME);
 
-        client().admin().cluster().deleteDanglingIndex(new DeleteDanglingIndexRequest(danglingIndexUUID, true)).actionGet();
+        clusterAdmin().deleteDanglingIndex(new DeleteDanglingIndexRequest(danglingIndexUUID, true)).actionGet();
 
         // The dangling index that we deleted ought to have been removed from disk. Check by
         // creating and deleting another index, which creates a new tombstone entry, which should
@@ -260,7 +260,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
 
         Exception e = expectThrows(
             Exception.class,
-            () -> client().admin().cluster().deleteDanglingIndex(new DeleteDanglingIndexRequest(danglingIndexUUID, false)).actionGet()
+            () -> clusterAdmin().deleteDanglingIndex(new DeleteDanglingIndexRequest(danglingIndexUUID, false)).actionGet()
         );
 
         assertThat(e.getMessage(), containsString("accept_data_loss must be set to true"));
@@ -290,7 +290,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
 
                 while (isImporting.get()) {
                     try {
-                        client().admin().cluster().importDanglingIndex(new ImportDanglingIndexRequest(danglingIndexUUID, true)).get();
+                        clusterAdmin().importDanglingIndex(new ImportDanglingIndexRequest(danglingIndexUUID, true)).get();
                     } catch (Exception e) {
                         // failures are expected
                     }
@@ -328,7 +328,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
             }
         }
 
-        final Metadata metadata = client().admin().cluster().prepareState().clear().setMetadata(true).get().getState().metadata();
+        final Metadata metadata = clusterAdmin().prepareState().clear().setMetadata(true).get().getState().metadata();
         assertTrue(metadata.indexGraveyard().toString(), metadata.indexGraveyard().containsIndex(new Index(INDEX_NAME, danglingIndexUUID)));
         assertNull(Strings.toString(metadata, true, true), metadata.index(INDEX_NAME));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -38,9 +38,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         logger.info("Creating index test");
         assertAcked(prepareCreate("test", 2));
         logger.info("Running Cluster Health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .execute()
@@ -69,20 +67,11 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertHitCount(countResponse, 10L);
         }
 
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         logger.info("Increasing the number of replicas from 1 to 2");
         setReplicaCount(2, "test");
         logger.info("Running Cluster Health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -96,9 +85,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         // only 2 copies allocated (1 replica) across 2 nodes
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
-        final long afterReplicaIncreaseSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterReplicaIncreaseSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -109,9 +96,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         logger.info("starting another node to new replicas will be allocated to it");
         allowNodes("test", 3);
 
-        final long afterStartingAnotherNodeVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterStartingAnotherNodeVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -119,9 +104,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             .getSettingsVersion();
 
         logger.info("Running Cluster Health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
@@ -145,9 +128,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         setReplicaCount(0, "test");
 
         logger.info("Running Cluster Health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNoRelocatingShards(true)
@@ -166,9 +147,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertHitCount(client().prepareSearch().setQuery(matchAllQuery()).get(), 10);
         }
 
-        final long afterReplicaDecreaseSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterReplicaDecreaseSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -185,9 +164,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("--> running cluster health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -219,22 +196,13 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
         }
 
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
 
         logger.info("--> add another node, should increase the number of replicas");
         allowNodes("test", 3);
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
@@ -248,9 +216,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(2));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
-        final long afterAddingOneNodeSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterAddingOneNodeSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -263,9 +229,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 2);
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -279,9 +243,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
-        final long afterClosingOneNodeSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterClosingOneNodeSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -294,9 +256,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 1);
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes(">=1")
@@ -310,9 +270,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(0));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries));
 
-        final long afterClosingAnotherNodeSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterClosingAnotherNodeSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -329,9 +287,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("--> running cluster health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 2)
@@ -363,21 +319,12 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
             assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
         }
 
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         logger.info("--> add another node, should increase the number of replicas");
         allowNodes("test", 3);
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
@@ -390,9 +337,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(2));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 3));
 
-        final long afterAddingOneNodeSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterAddingOneNodeSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -405,9 +350,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 2);
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForNodes(">=2")
@@ -421,9 +364,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getNumberOfReplicas(), equalTo(1));
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
-        final long afterClosingOneNodeSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
+        final long afterClosingOneNodeSettingsVersion = clusterAdmin().prepareState()
             .get()
             .getState()
             .metadata()
@@ -436,9 +377,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 1);
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForYellowStatus()
             .setWaitForNodes(">=1")
@@ -460,9 +399,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         logger.info("--> running cluster health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 3)
@@ -479,21 +416,12 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         allowNodes("test", 4);
         allowNodes("test", 5);
 
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         logger.info("--> update the auto expand replicas to 0-3");
         updateIndexSettings(Settings.builder().put("auto_expand_replicas", "0-3"), "test");
 
         logger.info("--> running cluster health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
             .setWaitForActiveShards(numShards.numPrimaries * 4)
@@ -518,14 +446,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
 
     public void testUpdateWithInvalidNumberOfReplicas() {
         createIndex("test");
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         final int value = randomIntBetween(-10, -1);
         try {
             client().admin()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -72,7 +72,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 .actionGet()
         );
         assertEquals(exception.getCause().getMessage(), "this setting goes boom");
-        IndexMetadata indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertNotEquals(indexMetadata.getSettings().get("index.dummy"), "invalid dynamic value");
     }
 
@@ -152,29 +152,19 @@ public class UpdateSettingsIT extends ESIntegTestCase {
     public void testUpdateDependentClusterSettings() {
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
-                .setPersistentSettings(Settings.builder().put("cluster.acc.test.pw", "asdf"))
-                .get()
+            () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put("cluster.acc.test.pw", "asdf")).get()
         );
         assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
         iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
-                .setTransientSettings(Settings.builder().put("cluster.acc.test.pw", "asdf"))
-                .get()
+            () -> clusterAdmin().prepareUpdateSettings().setTransientSettings(Settings.builder().put("cluster.acc.test.pw", "asdf")).get()
         );
         assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
         iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            () -> clusterAdmin().prepareUpdateSettings()
                 .setTransientSettings(Settings.builder().put("cluster.acc.test.pw", "asdf"))
                 .setPersistentSettings(Settings.builder().put("cluster.acc.test.user", "asdf"))
                 .get()
@@ -182,37 +172,25 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
 
         if (randomBoolean()) {
-            client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings()
                 .setTransientSettings(Settings.builder().put("cluster.acc.test.pw", "asdf").put("cluster.acc.test.user", "asdf"))
                 .get();
             iae = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
-                    .setTransientSettings(Settings.builder().putNull("cluster.acc.test.user"))
-                    .get()
+                () -> clusterAdmin().prepareUpdateSettings().setTransientSettings(Settings.builder().putNull("cluster.acc.test.user")).get()
             );
             assertEquals("missing required setting [cluster.acc.test.user] for setting [cluster.acc.test.pw]", iae.getMessage());
-            client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings()
                 .setTransientSettings(Settings.builder().putNull("cluster.acc.test.pw").putNull("cluster.acc.test.user"))
                 .get();
         } else {
-            client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().put("cluster.acc.test.pw", "asdf").put("cluster.acc.test.user", "asdf"))
                 .get();
 
             iae = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin()
-                    .cluster()
-                    .prepareUpdateSettings()
+                () -> clusterAdmin().prepareUpdateSettings()
                     .setPersistentSettings(Settings.builder().putNull("cluster.acc.test.user"))
                     .get()
             );
@@ -294,7 +272,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .setSettings(Settings.builder().put("index.refresh_interval", -1))
             .execute()
             .actionGet();
-        IndexMetadata indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertEquals(indexMetadata.getSettings().get("index.refresh_interval"), "-1");
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -308,7 +286,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .setSettings(Settings.builder().putNull("index.ref*"))
             .execute()
             .actionGet();
-        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertNull(indexMetadata.getSettings().get("index.refresh_interval"));
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -331,7 +309,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             )
             .execute()
             .actionGet();
-        IndexMetadata indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertEquals(indexMetadata.getSettings().get("index.refresh_interval"), "-1");
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -347,7 +325,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .setSettings(Settings.builder().putNull("index.refresh_interval"))
             .execute()
             .actionGet();
-        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertNull(indexMetadata.getSettings().get("index.refresh_interval"));
         for (IndicesService service : internalCluster().getInstances(IndicesService.class)) {
             IndexService indexService = service.indexService(resolveIndex("test"));
@@ -387,7 +365,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 .execute()
                 .actionGet()
         );
-        IndexMetadata indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        IndexMetadata indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), nullValue());
         assertThat(indexMetadata.getSettings().get("index.fielddata.cache"), nullValue());
         assertThat(indexMetadata.getSettings().get("index.final"), nullValue());
@@ -405,7 +383,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .execute()
             .actionGet();
 
-        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), equalTo("-1"));
         // Now verify via dedicated get settings api:
         getSettingsResponse = client().admin().indices().prepareGetSettings("test").get();
@@ -414,9 +392,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         // now close the index, change the non dynamic setting, and see that it applies
 
         // Wait for the index to turn green before attempting to close it
-        ClusterHealthResponse health = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse health = clusterAdmin().prepareHealth()
             .setTimeout("30s")
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForGreenStatus()
@@ -433,7 +409,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .execute()
             .actionGet();
 
-        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertThat(indexMetadata.getNumberOfReplicas(), equalTo(1));
 
         client().admin()
@@ -447,7 +423,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
             .execute()
             .actionGet();
 
-        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), equalTo("1s"));
         assertThat(indexMetadata.getSettings().get("index.fielddata.cache"), equalTo("none"));
 
@@ -465,7 +441,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 .actionGet()
         );
         assertThat(ex.getMessage(), containsString("final test setting [index.final], not updateable"));
-        indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
+        indexMetadata = clusterAdmin().prepareState().execute().actionGet().getState().metadata().index("test");
         assertThat(indexMetadata.getSettings().get("index.refresh_interval"), equalTo("1s"));
         assertThat(indexMetadata.getSettings().get("index.final"), nullValue());
 
@@ -530,14 +506,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         ensureGreen("test");
 
         {
-            final long settingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertAcked(
                 client().admin()
                     .indices()
@@ -545,14 +514,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .setSettings(Settings.builder().put("index.refresh_interval", "500ms"))
                     .get()
             );
-            final long newSettingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long newSettingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertThat(newSettingsVersion, equalTo(1 + settingsVersion));
         }
 
@@ -565,14 +527,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .setSettings(Settings.builder().put("index.blocks.read_only", block))
                     .get()
             );
-            final long settingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertAcked(
                 client().admin()
                     .indices()
@@ -580,14 +535,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .setSettings(Settings.builder().put("index.blocks.read_only", block == false))
                     .get()
             );
-            final long newSettingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long newSettingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertThat(newSettingsVersion, equalTo(1 + settingsVersion));
 
             // if the read-only block is present, remove it
@@ -608,14 +556,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         ensureGreen("test");
 
         {
-            final long settingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             final String refreshInterval = client().admin()
                 .indices()
                 .prepareGetSettings("test")
@@ -628,14 +569,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .setSettings(Settings.builder().put("index.refresh_interval", refreshInterval))
                     .get()
             );
-            final long newSettingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long newSettingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertThat(newSettingsVersion, equalTo(settingsVersion));
         }
 
@@ -649,14 +583,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .get()
             );
             // now put the same block again
-            final long settingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertAcked(
                 client().admin()
                     .indices()
@@ -664,14 +591,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                     .setSettings(Settings.builder().put("index.blocks.read_only", block))
                     .get()
             );
-            final long newSettingsVersion = client().admin()
-                .cluster()
-                .prepareState()
-                .get()
-                .getState()
-                .metadata()
-                .index("test")
-                .getSettingsVersion();
+            final long newSettingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
             assertThat(newSettingsVersion, equalTo(settingsVersion));
 
             // if the read-only block is present, remove it
@@ -695,14 +615,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
     public void testNumberOfReplicasSettingsVersionUnchanged() {
         createIndex("test");
 
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         final int numberOfReplicas = Integer.valueOf(
             client().admin().indices().prepareGetSettings("test").get().getSetting("test", "index.number_of_replicas")
         );
@@ -713,14 +626,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("index.number_of_replicas", numberOfReplicas))
                 .get()
         );
-        final long newSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long newSettingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         assertThat(newSettingsVersion, equalTo(settingsVersion));
     }
 
@@ -732,14 +638,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
     public void testNumberOfReplicasSettingsVersion() {
         createIndex("test");
 
-        final long settingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long settingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         final int numberOfReplicas = Integer.valueOf(
             client().admin().indices().prepareGetSettings("test").get().getSetting("test", "index.number_of_replicas")
         );
@@ -750,14 +649,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("index.number_of_replicas", 1 + numberOfReplicas))
                 .get()
         );
-        final long newSettingsVersion = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .metadata()
-            .index("test")
-            .getSettingsVersion();
+        final long newSettingsVersion = clusterAdmin().prepareState().get().getState().metadata().index("test").getSettingsVersion();
         assertThat(newSettingsVersion, equalTo(1 + settingsVersion));
     }
 
@@ -824,9 +716,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1))
         );
         assertNotSame(currentState, clusterService.state());
-        client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNoInitializingShards(true)
             .setWaitForNoRelocatingShards(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
@@ -47,7 +47,7 @@ public class CloseIndexDisableCloseAllIT extends ESIntegTestCase {
     }
 
     private void assertIndexIsClosed(String... indices) {
-        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().execute().actionGet();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().execute().actionGet();
         for (String index : indices) {
             IndexMetadata indexMetadata = clusterStateResponse.getState().metadata().indices().get(index);
             assertNotNull(indexMetadata);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -170,7 +170,7 @@ public class CloseIndexIT extends ESIntegTestCase {
                 .setSettings(Settings.builder().put("index.routing.allocation.include._name", "nothing").build())
         );
 
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         assertThat(clusterState.metadata().indices().get(indexName).getState(), is(IndexMetadata.State.OPEN));
         assertThat(clusterState.routingTable().allShards().allMatch(ShardRouting::unassigned), is(true));
 
@@ -192,9 +192,7 @@ public class CloseIndexIT extends ESIntegTestCase {
                 .collect(toList())
         );
 
-        ClusterHealthResponse healthResponse = client().admin()
-            .cluster()
-            .prepareHealth(indexName)
+        ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth(indexName)
             .setWaitForYellowStatus()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
@@ -270,7 +268,7 @@ public class CloseIndexIT extends ESIntegTestCase {
             }
             indices[i] = indexName;
         }
-        assertThat(client().admin().cluster().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
+        assertThat(clusterAdmin().prepareState().get().getState().metadata().indices().size(), equalTo(indices.length));
 
         final List<Thread> threads = new ArrayList<>();
         final CountDownLatch latch = new CountDownLatch(1);
@@ -362,7 +360,7 @@ public class CloseIndexIT extends ESIntegTestCase {
 
         indexer.stopAndAwaitStopped();
 
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         if (clusterState.metadata().indices().get(indexName).getState() == IndexMetadata.State.CLOSE) {
             assertIndexIsClosed(indexName);
             assertAcked(client().admin().indices().prepareOpen(indexName));
@@ -392,7 +390,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         ensureGreen(indexName);
 
         final CloseIndexResponse closeIndexResponse = client().admin().indices().prepareClose(indexName).get();
-        assertThat(client().admin().cluster().prepareHealth(indexName).get().getStatus(), is(ClusterHealthStatus.GREEN));
+        assertThat(clusterAdmin().prepareHealth(indexName).get().getStatus(), is(ClusterHealthStatus.GREEN));
         assertTrue(closeIndexResponse.isAcknowledged());
         assertTrue(closeIndexResponse.isShardsAcknowledged());
         assertThat(closeIndexResponse.getIndices().get(0), notNullValue());
@@ -624,7 +622,7 @@ public class CloseIndexIT extends ESIntegTestCase {
     }
 
     static void assertIndexIsClosed(final String... indices) {
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         for (String index : indices) {
             final IndexMetadata indexMetadata = clusterState.metadata().indices().get(index);
             assertThat(indexMetadata.getState(), is(IndexMetadata.State.CLOSE));
@@ -647,7 +645,7 @@ public class CloseIndexIT extends ESIntegTestCase {
     }
 
     static void assertIndexIsOpened(final String... indices) {
-        final ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
+        final ClusterState clusterState = clusterAdmin().prepareState().get().getState();
         for (String index : indices) {
             final IndexMetadata indexMetadata = clusterState.metadata().indices().get(index);
             assertThat(indexMetadata.getState(), is(IndexMetadata.State.OPEN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -189,7 +189,7 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
                 }
             }
 
-            assertAcked(client().admin().cluster().reroute(new ClusterRerouteRequest().commands(commands)).get());
+            assertAcked(clusterAdmin().reroute(new ClusterRerouteRequest().commands(commands)).get());
 
             // start index closing threads
             final List<Thread> threads = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/SimpleIndexStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/SimpleIndexStateIT.java
@@ -40,7 +40,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
 
         NumShards numShards = getNumShards("test");
 
-        ClusterStateResponse stateResponse = client().admin().cluster().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(numShards.numPrimaries));
         assertEquals(
@@ -54,7 +54,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
         logger.info("--> closing test index...");
         assertAcked(client().admin().indices().prepareClose("test"));
 
-        stateResponse = client().admin().cluster().prepareState().get();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.CLOSE));
         assertThat(stateResponse.getState().routingTable().index("test"), notNullValue());
 
@@ -73,7 +73,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
         logger.info("--> waiting for green status");
         ensureGreen();
 
-        stateResponse = client().admin().cluster().prepareState().get();
+        stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
 
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(numShards.numPrimaries));
@@ -95,7 +95,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
             .setSettings(Settings.builder().put("index.routing.allocation.include.tag", "no_such_node").build())
             .get();
 
-        ClusterHealthResponse health = client().admin().cluster().prepareHealth("test").setWaitForNodes(">=2").get();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth("test").setWaitForNodes(">=2").get();
         assertThat(health.isTimedOut(), equalTo(false));
         assertThat(health.getStatus(), equalTo(ClusterHealthStatus.RED));
 
@@ -111,7 +111,7 @@ public class SimpleIndexStateIT extends ESIntegTestCase {
 
         NumShards numShards = getNumShards("test");
 
-        ClusterStateResponse stateResponse = client().admin().cluster().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
         assertThat(stateResponse.getState().metadata().index("test").getState(), equalTo(IndexMetadata.State.OPEN));
         assertThat(stateResponse.getState().routingTable().index("test").size(), equalTo(numShards.numPrimaries));
         assertEquals(

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/stats/IndexStatsIT.java
@@ -141,7 +141,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("2").setSource("field", "value2", "field2", "value2").execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
-        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        NodesStatsResponse nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -163,7 +163,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         client().prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
         client().prepareSearch().addSort("field", SortOrder.ASC).execute().actionGet();
 
-        nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -180,9 +180,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         client().prepareSearch().addSort("field2", SortOrder.ASC).execute().actionGet();
 
         // now check the per field stats
-        nodesStats = client().admin()
-            .cluster()
-            .prepareNodesStats("data:true")
+        nodesStats = clusterAdmin().prepareNodesStats("data:true")
             .setIndices(new CommonStatsFlags().set(CommonStatsFlags.Flag.FieldData, true).fieldDataFields("*"))
             .execute()
             .actionGet();
@@ -235,7 +233,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         );
 
         client().admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
-        nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -259,12 +257,12 @@ public class IndexStatsIT extends ESIntegTestCase {
                 .get()
         );
         ensureGreen();
-        client().admin().cluster().prepareHealth().setWaitForGreenStatus().execute().actionGet();
+        clusterAdmin().prepareHealth().setWaitForGreenStatus().execute().actionGet();
         client().prepareIndex("test").setId("1").setSource("field", "value1").execute().actionGet();
         client().prepareIndex("test").setId("2").setSource("field", "value2").execute().actionGet();
         client().admin().indices().prepareRefresh().execute().actionGet();
 
-        NodesStatsResponse nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        NodesStatsResponse nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -305,7 +303,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             .execute()
             .actionGet();
 
-        nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -329,7 +327,7 @@ public class IndexStatsIT extends ESIntegTestCase {
 
         client().admin().indices().prepareClearCache().execute().actionGet();
         Thread.sleep(100); // Make sure the filter cache entries have been removed...
-        nodesStats = client().admin().cluster().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
+        nodesStats = clusterAdmin().prepareNodesStats("data:true").setIndices(true).execute().actionGet();
         assertThat(
             nodesStats.getNodes().get(0).getIndices().getFieldData().getMemorySizeInBytes() + nodesStats.getNodes()
                 .get(1)
@@ -563,7 +561,7 @@ public class IndexStatsIT extends ESIntegTestCase {
         }
         refresh();
         stats = client().admin().indices().prepareStats().execute().actionGet();
-        // nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
+        // nodesStats = clusterAdmin().prepareNodesStats().setIndices(true).get();
 
         stats = client().admin().indices().prepareStats().execute().actionGet();
         assertThat(stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis(), equalTo(0L));
@@ -602,7 +600,7 @@ public class IndexStatsIT extends ESIntegTestCase {
             }
             refresh();
             stats = client().admin().indices().prepareStats().execute().actionGet();
-            // nodesStats = client().admin().cluster().prepareNodesStats().setIndices(true).get();
+            // nodesStats = clusterAdmin().prepareNodesStats().setIndices(true).get();
             done = stats.getPrimaries().getIndexing().getTotal().getThrottleTime().millis() > 0;
             if (System.currentTimeMillis() - start > 300 * 1000) { // Wait 5 minutes for throttling to kick in
                 fail("index throttling didn't kick in after 5 minutes of intense merging");

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -98,7 +98,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             )
         );
         ensureGreen("test");
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         Index index = state.metadata().index("test").getIndex();
 
         logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
@@ -110,12 +110,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logger.info("--> starting node server3");
         final String node_3 = internalCluster().startNode(nonMasterNode());
         logger.info("--> running cluster_health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
-            .setWaitForNodes("4")
-            .setWaitForNoRelocatingShards(true)
-            .get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForNodes("4").setWaitForNoRelocatingShards(true).get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
@@ -136,7 +131,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         } else {
             internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_3)).get();
         }
-        clusterHealth = client().admin().cluster().prepareHealth().setWaitForNoRelocatingShards(true).get();
+        clusterHealth = clusterAdmin().prepareHealth().setWaitForNoRelocatingShards(true).get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         assertShardDeleted(node_1, index, 0);
@@ -203,13 +198,13 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             )
         );
         ensureGreen("test");
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         Index index = state.metadata().index("test").getIndex();
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
         assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
 
         final String node_2 = internalCluster().startDataOnlyNode(Settings.builder().build());
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("2").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("2").get().isTimedOut());
 
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
         assertThat(Files.exists(indexDirectory(node_1, index)), equalTo(true));
@@ -233,7 +228,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logger.info("--> move shard from {} to {}, and wait for relocation to finish", node_1, node_2);
         internalCluster().client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_2)).get();
         shardActiveRequestSent.await();
-        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForNoRelocatingShards(true).get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForNoRelocatingShards(true).get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         logClusterState();
         // delete the index. node_1 that still waits for the next cluster state update will then get the delete index next.
@@ -265,7 +260,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         );
         ensureGreen("test");
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         Index index = state.metadata().index("test").getIndex();
         logger.info("--> making sure that shard and its replica are allocated on node_1 and node_2");
         assertThat(Files.exists(shardDirectory(node_1, index, 0)), equalTo(true));
@@ -274,12 +269,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logger.info("--> starting node server3");
         String node_3 = internalCluster().startNode();
         logger.info("--> running cluster_health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
-            .setWaitForNodes("3")
-            .setWaitForNoRelocatingShards(true)
-            .get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForNodes("3").setWaitForNoRelocatingShards(true).get();
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
 
         logger.info("--> making sure that shard is not allocated on server3");
@@ -290,9 +280,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         internalCluster().stopNode(node_2);
 
         logger.info("--> running cluster_health");
-        clusterHealth = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealth = clusterAdmin().prepareHealth()
             .setWaitForGreenStatus()
             .setWaitForNodes("2")
             .setWaitForNoRelocatingShards(true)
@@ -339,9 +327,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
             )
         );
         assertFalse(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForGreenStatus()
                 .setWaitForNodes("5")
@@ -360,7 +346,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         internalCluster().stopNode(nodesToShutDown.get(1));
 
         logger.debug("--> verifying index is red");
-        ClusterHealthResponse health = client().admin().cluster().prepareHealth().setWaitForNodes("3").get();
+        ClusterHealthResponse health = clusterAdmin().prepareHealth().setWaitForNodes("3").get();
         if (health.getStatus() != ClusterHealthStatus.RED) {
             logClusterState();
             fail("cluster didn't become red, despite of shutting 2 of 3 nodes");
@@ -378,7 +364,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         assertBusy(() -> assertTrue(internalCluster().getInstance(IndicesService.class, node4).hasIndex(index)));
 
         // wait for 4 active shards - we should have lost one shard
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForActiveShards(4).get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForActiveShards(4).get().isTimedOut());
 
         // disable allocation again to control concurrency a bit and allow shard active to kick in before allocation
         updateClusterSettings(Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "none"));
@@ -387,7 +373,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
 
         internalCluster().startNodes(node1DataPathSettings, node2DataPathSettings);
 
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("5").get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("5").get().isTimedOut());
 
         updateClusterSettings(Settings.builder().put(EnableAllocationDecider.CLUSTER_ROUTING_ALLOCATION_ENABLE_SETTING.getKey(), "all"));
 
@@ -411,7 +397,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         ensureGreen("test");
 
         waitNoPendingTasksOnAll();
-        ClusterStateResponse stateResponse = client().admin().cluster().prepareState().get();
+        ClusterStateResponse stateResponse = clusterAdmin().prepareState().get();
         final Index index = stateResponse.getState().metadata().index("test").getIndex();
         RoutingNode routingNode = stateResponse.getState().getRoutingNodes().node(nonMasterId);
         final int[] node2Shards = new int[routingNode.numberOfOwningShards()];

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestClientIT.java
@@ -74,8 +74,8 @@ public class IngestClientIT extends ESIntegTestCase {
                 .endArray()
                 .endObject()
         );
-        client().admin().cluster().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
-        GetPipelineResponse getResponse = client().admin().cluster().prepareGetPipeline("_id").get();
+        clusterAdmin().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
+        GetPipelineResponse getResponse = clusterAdmin().prepareGetPipeline("_id").get();
         assertThat(getResponse.isFound(), is(true));
         assertThat(getResponse.pipelines().size(), equalTo(1));
         assertThat(getResponse.pipelines().get(0).getId(), equalTo("_id"));
@@ -97,11 +97,11 @@ public class IngestClientIT extends ESIntegTestCase {
         );
         SimulatePipelineResponse response;
         if (randomBoolean()) {
-            response = client().admin().cluster().prepareSimulatePipeline(bytes, XContentType.JSON).setId("_id").get();
+            response = clusterAdmin().prepareSimulatePipeline(bytes, XContentType.JSON).setId("_id").get();
         } else {
             SimulatePipelineRequest request = new SimulatePipelineRequest(bytes, XContentType.JSON);
             request.setId("_id");
-            response = client().admin().cluster().simulatePipeline(request).get();
+            response = clusterAdmin().simulatePipeline(request).get();
         }
         assertThat(response.isVerbose(), equalTo(false));
         assertThat(response.getPipelineId(), equalTo("_id"));
@@ -118,7 +118,7 @@ public class IngestClientIT extends ESIntegTestCase {
         assertThat(simulateDocumentBaseResult.getFailure(), nullValue());
 
         // cleanup
-        AcknowledgedResponse deletePipelineResponse = client().admin().cluster().prepareDeletePipeline("_id").get();
+        AcknowledgedResponse deletePipelineResponse = clusterAdmin().prepareDeletePipeline("_id").get();
         assertTrue(deletePipelineResponse.isAcknowledged());
     }
 
@@ -137,7 +137,7 @@ public class IngestClientIT extends ESIntegTestCase {
                 .endObject()
         );
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, XContentType.JSON);
-        client().admin().cluster().putPipeline(putPipelineRequest).get();
+        clusterAdmin().putPipeline(putPipelineRequest).get();
 
         int numRequests = scaledRandomIntBetween(32, 128);
         BulkRequest bulkRequest = new BulkRequest();
@@ -169,7 +169,7 @@ public class IngestClientIT extends ESIntegTestCase {
         }
 
         // cleanup
-        AcknowledgedResponse deletePipelineResponse = client().admin().cluster().prepareDeletePipeline("_id").get();
+        AcknowledgedResponse deletePipelineResponse = clusterAdmin().prepareDeletePipeline("_id").get();
         assertTrue(deletePipelineResponse.isAcknowledged());
     }
 
@@ -188,7 +188,7 @@ public class IngestClientIT extends ESIntegTestCase {
                 .endObject()
         );
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, XContentType.JSON);
-        client().admin().cluster().putPipeline(putPipelineRequest).get();
+        clusterAdmin().putPipeline(putPipelineRequest).get();
 
         BulkRequest bulkRequest = new BulkRequest();
         IndexRequest indexRequest = new IndexRequest("index").id("1").setPipeline("_id");
@@ -223,9 +223,9 @@ public class IngestClientIT extends ESIntegTestCase {
                 .endObject()
         );
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, XContentType.JSON);
-        client().admin().cluster().putPipeline(putPipelineRequest).get();
+        clusterAdmin().putPipeline(putPipelineRequest).get();
 
-        GetPipelineResponse getResponse = client().admin().cluster().prepareGetPipeline("_id").get();
+        GetPipelineResponse getResponse = clusterAdmin().prepareGetPipeline("_id").get();
         assertThat(getResponse.isFound(), is(true));
         assertThat(getResponse.pipelines().size(), equalTo(1));
         assertThat(getResponse.pipelines().get(0).getId(), equalTo("_id"));
@@ -244,10 +244,10 @@ public class IngestClientIT extends ESIntegTestCase {
         assertThat(doc.get("processed"), equalTo(true));
 
         DeletePipelineRequest deletePipelineRequest = new DeletePipelineRequest("_id");
-        AcknowledgedResponse response = client().admin().cluster().deletePipeline(deletePipelineRequest).get();
+        AcknowledgedResponse response = clusterAdmin().deletePipeline(deletePipelineRequest).get();
         assertThat(response.isAcknowledged(), is(true));
 
-        getResponse = client().admin().cluster().prepareGetPipeline("_id").get();
+        getResponse = clusterAdmin().prepareGetPipeline("_id").get();
         assertThat(getResponse.isFound(), is(false));
         assertThat(getResponse.pipelines().size(), equalTo(0));
     }
@@ -266,13 +266,10 @@ public class IngestClientIT extends ESIntegTestCase {
                 .endObject()
         );
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id2", source, XContentType.JSON);
-        Exception e = expectThrows(
-            ElasticsearchParseException.class,
-            () -> client().admin().cluster().putPipeline(putPipelineRequest).actionGet()
-        );
+        Exception e = expectThrows(ElasticsearchParseException.class, () -> clusterAdmin().putPipeline(putPipelineRequest).actionGet());
         assertThat(e.getMessage(), equalTo("processor [test] doesn't support one or more provided configuration parameters [unused]"));
 
-        GetPipelineResponse response = client().admin().cluster().prepareGetPipeline("_id2").get();
+        GetPipelineResponse response = clusterAdmin().prepareGetPipeline("_id2").get();
         assertFalse(response.isFound());
     }
 
@@ -290,7 +287,7 @@ public class IngestClientIT extends ESIntegTestCase {
                 .endObject()
         );
         PutPipelineRequest putPipelineRequest = new PutPipelineRequest("_id", source, XContentType.JSON);
-        client().admin().cluster().putPipeline(putPipelineRequest).get();
+        clusterAdmin().putPipeline(putPipelineRequest).get();
 
         BulkItemResponse item = client(masterOnlyNode).prepareBulk()
             .add(client().prepareIndex("test").setSource("field", "value2", "drop", true).setPipeline("_id"))
@@ -316,7 +313,7 @@ public class IngestClientIT extends ESIntegTestCase {
             }
             source.endObject();
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest("1", BytesReference.bytes(source), XContentType.JSON);
-            client().admin().cluster().putPipeline(putPipelineRequest).get();
+            clusterAdmin().putPipeline(putPipelineRequest).get();
         }
         {
             XContentBuilder source = jsonBuilder().startObject();
@@ -333,7 +330,7 @@ public class IngestClientIT extends ESIntegTestCase {
             }
             source.endObject();
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest("2", BytesReference.bytes(source), XContentType.JSON);
-            client().admin().cluster().putPipeline(putPipelineRequest).get();
+            clusterAdmin().putPipeline(putPipelineRequest).get();
         }
         {
             XContentBuilder source = jsonBuilder().startObject();
@@ -349,7 +346,7 @@ public class IngestClientIT extends ESIntegTestCase {
             }
             source.endObject();
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest("3", BytesReference.bytes(source), XContentType.JSON);
-            client().admin().cluster().putPipeline(putPipelineRequest).get();
+            clusterAdmin().putPipeline(putPipelineRequest).get();
         }
 
         Exception e = expectThrows(Exception.class, () -> {
@@ -389,7 +386,7 @@ public class IngestClientIT extends ESIntegTestCase {
             }
             source.endObject();
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest("1", BytesReference.bytes(source), XContentType.JSON);
-            client().admin().cluster().putPipeline(putPipelineRequest).get();
+            clusterAdmin().putPipeline(putPipelineRequest).get();
         }
         {
             XContentBuilder source = jsonBuilder().startObject();
@@ -406,7 +403,7 @@ public class IngestClientIT extends ESIntegTestCase {
             }
             source.endObject();
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest("2", BytesReference.bytes(source), XContentType.JSON);
-            client().admin().cluster().putPipeline(putPipelineRequest).get();
+            clusterAdmin().putPipeline(putPipelineRequest).get();
         }
         {
             XContentBuilder source = jsonBuilder().startObject();
@@ -422,7 +419,7 @@ public class IngestClientIT extends ESIntegTestCase {
             }
             source.endObject();
             PutPipelineRequest putPipelineRequest = new PutPipelineRequest("3", BytesReference.bytes(source), XContentType.JSON);
-            client().admin().cluster().putPipeline(putPipelineRequest).get();
+            clusterAdmin().putPipeline(putPipelineRequest).get();
         }
 
         client().prepareIndex("test").setId("1").setSource("{}", XContentType.JSON).setPipeline("1").get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestFileSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestFileSettingsIT.java
@@ -157,10 +157,9 @@ public class IngestFileSettingsIT extends ESIntegTestCase {
         boolean awaitSuccessful = savedClusterState.await(20, TimeUnit.SECONDS);
         assertTrue(awaitSuccessful);
 
-        final ClusterStateResponse clusterStateResponse = client().admin()
-            .cluster()
-            .state(new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get()))
-            .get();
+        final ClusterStateResponse clusterStateResponse = clusterAdmin().state(
+            new ClusterStateRequest().waitForMetadataVersion(metadataVersion.get())
+        ).get();
 
         ReservedStateMetadata reservedState = clusterStateResponse.getState()
             .metadata()

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestProcessorNotInstalledOnAllNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestProcessorNotInstalledOnAllNodesIT.java
@@ -60,7 +60,7 @@ public class IngestProcessorNotInstalledOnAllNodesIT extends ESIntegTestCase {
         ensureStableCluster(2, node2);
 
         try {
-            client().admin().cluster().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
+            clusterAdmin().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
             fail("exception expected");
         } catch (ElasticsearchParseException e) {
             assertThat(e.getMessage(), containsString("Processor type [test] is not installed on node"));
@@ -73,7 +73,7 @@ public class IngestProcessorNotInstalledOnAllNodesIT extends ESIntegTestCase {
         internalCluster().startNode();
 
         try {
-            client().admin().cluster().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
+            clusterAdmin().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
             fail("exception expected");
         } catch (ElasticsearchParseException e) {
             assertThat(e.getMessage(), equalTo("No processor type exists with name [test]"));
@@ -86,7 +86,7 @@ public class IngestProcessorNotInstalledOnAllNodesIT extends ESIntegTestCase {
         installPlugin = true;
         String node1 = internalCluster().startNode();
 
-        AcknowledgedResponse response = client().admin().cluster().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
+        AcknowledgedResponse response = clusterAdmin().preparePutPipeline("_id", pipelineSource, XContentType.JSON).get();
         assertThat(response.isAcknowledged(), is(true));
         Pipeline pipeline = internalCluster().getInstance(NodeService.class, node1).getIngestService().getPipeline("_id");
         assertThat(pipeline, notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestStatsNamesAndTypesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/ingest/IngestStatsNamesAndTypesIT.java
@@ -105,10 +105,7 @@ public class IngestStatsNamesAndTypesIT extends ESIntegTestCase {
         client().bulk(bulkRequest).actionGet();
 
         {
-            NodesStatsResponse nodesStatsResponse = client().admin()
-                .cluster()
-                .nodesStats(new NodesStatsRequest().addMetric("ingest"))
-                .actionGet();
+            NodesStatsResponse nodesStatsResponse = clusterAdmin().nodesStats(new NodesStatsRequest().addMetric("ingest")).actionGet();
             assertThat(nodesStatsResponse.getNodes().size(), equalTo(1));
 
             NodeStats stats = nodesStatsResponse.getNodes().get(0);

--- a/server/src/internalClusterTest/java/org/elasticsearch/nodesinfo/SimpleNodesInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/nodesinfo/SimpleNodesInfoIT.java
@@ -34,36 +34,36 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         final String node_1 = nodesIds.get(0);
         final String node_2 = nodesIds.get(1);
 
-        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = internalCluster().getInstance(ClusterService.class, node_1).state().nodes().getLocalNodeId();
         String server2NodeId = internalCluster().getInstance(ClusterService.class, node_2).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {} and {}", server1NodeId, server2NodeId);
 
-        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
         assertThat(response.getNodes().size(), is(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertThat(response.getNodesMap().get(server2NodeId), notNullValue());
 
-        response = client().admin().cluster().nodesInfo(new NodesInfoRequest()).actionGet();
+        response = clusterAdmin().nodesInfo(new NodesInfoRequest()).actionGet();
         assertThat(response.getNodes().size(), is(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertThat(response.getNodesMap().get(server2NodeId), notNullValue());
 
-        response = client().admin().cluster().nodesInfo(new NodesInfoRequest(server1NodeId)).actionGet();
+        response = clusterAdmin().nodesInfo(new NodesInfoRequest(server1NodeId)).actionGet();
         assertThat(response.getNodes().size(), is(1));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
 
-        response = client().admin().cluster().nodesInfo(new NodesInfoRequest(server1NodeId)).actionGet();
+        response = clusterAdmin().nodesInfo(new NodesInfoRequest(server1NodeId)).actionGet();
         assertThat(response.getNodes().size(), is(1));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
 
-        response = client().admin().cluster().nodesInfo(new NodesInfoRequest(server2NodeId)).actionGet();
+        response = clusterAdmin().nodesInfo(new NodesInfoRequest(server2NodeId)).actionGet();
         assertThat(response.getNodes().size(), is(1));
         assertThat(response.getNodesMap().get(server2NodeId), notNullValue());
 
-        response = client().admin().cluster().nodesInfo(new NodesInfoRequest(server2NodeId)).actionGet();
+        response = clusterAdmin().nodesInfo(new NodesInfoRequest(server2NodeId)).actionGet();
         assertThat(response.getNodes().size(), is(1));
         assertThat(response.getNodesMap().get(server2NodeId), notNullValue());
     }
@@ -73,14 +73,14 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         final String node_1 = nodesIds.get(0);
         final String node_2 = nodesIds.get(1);
 
-        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = internalCluster().getInstance(ClusterService.class, node_1).state().nodes().getLocalNodeId();
         String server2NodeId = internalCluster().getInstance(ClusterService.class, node_2).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {} and {}", server1NodeId, server2NodeId);
 
-        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
         assertThat(response.getNodes().size(), is(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertNotNull(response.getNodesMap().get(server1NodeId).getTotalIndexingBuffer());
@@ -91,7 +91,7 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         assertThat(response.getNodesMap().get(server2NodeId).getTotalIndexingBuffer().getBytes(), greaterThan(0L));
 
         // again, using only the indices flag
-        response = client().admin().cluster().prepareNodesInfo().clear().setIndices(true).execute().actionGet();
+        response = clusterAdmin().prepareNodesInfo().clear().setIndices(true).execute().actionGet();
         assertThat(response.getNodes().size(), is(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());
         assertNotNull(response.getNodesMap().get(server1NodeId).getTotalIndexingBuffer());
@@ -111,14 +111,14 @@ public class SimpleNodesInfoIT extends ESIntegTestCase {
         final String node_1 = nodesIds.get(0);
         final String node_2 = nodesIds.get(1);
 
-        ClusterHealthResponse clusterHealth = client().admin().cluster().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
+        ClusterHealthResponse clusterHealth = clusterAdmin().prepareHealth().setWaitForGreenStatus().setWaitForNodes("2").get();
         logger.info("--> done cluster_health, status {}", clusterHealth.getStatus());
 
         String server1NodeId = internalCluster().getInstance(ClusterService.class, node_1).state().nodes().getLocalNodeId();
         String server2NodeId = internalCluster().getInstance(ClusterService.class, node_2).state().nodes().getLocalNodeId();
         logger.info("--> started nodes: {} and {}", server1NodeId, server2NodeId);
 
-        NodesInfoResponse response = client().admin().cluster().prepareNodesInfo().execute().actionGet();
+        NodesInfoResponse response = clusterAdmin().prepareNodesInfo().execute().actionGet();
 
         assertThat(response.getNodes().size(), is(2));
         assertThat(response.getNodesMap().get(server1NodeId), notNullValue());

--- a/server/src/internalClusterTest/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIT.java
@@ -84,7 +84,7 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
             assertAcked(client().admin().indices().prepareClose("*").get());
         }
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         for (Map.Entry<String, IndexMetadata> indexMetadataEntry : state.getMetadata().indices().entrySet()) {
             assertEquals(IndexMetadata.State.CLOSE, indexMetadataEntry.getValue().getState());
         }
@@ -117,7 +117,7 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
             assertAcked(client().admin().indices().prepareOpen("*").get());
         }
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         for (Map.Entry<String, IndexMetadata> indexMetadataEntry : state.getMetadata().indices().entrySet()) {
             assertEquals(IndexMetadata.State.OPEN, indexMetadataEntry.getValue().getState());
         }
@@ -150,7 +150,7 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
             assertAcked(client().admin().indices().prepareAddBlock(WRITE, "*").get());
         }
 
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         assertTrue("write block is set on index1", state.getBlocks().hasIndexBlock("index1", IndexMetadata.INDEX_WRITE_BLOCK));
         assertTrue("write block is set on 1index", state.getBlocks().hasIndexBlock("1index", IndexMetadata.INDEX_WRITE_BLOCK));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTasksExecutorFullRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTasksExecutorFullRestartIT.java
@@ -62,7 +62,7 @@ public class PersistentTasksExecutorFullRestartIT extends ESIntegTestCase {
         assertBusy(() -> {
             // Wait for the task to start
             assertThat(
-                client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().size(),
+                clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().size(),
                 greaterThan(0)
             );
         });
@@ -83,7 +83,7 @@ public class PersistentTasksExecutorFullRestartIT extends ESIntegTestCase {
         assertBusy(() -> {
             // Wait for all tasks to start
             assertThat(
-                client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().size(),
+                clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().size(),
                 equalTo(numberOfTasks)
             );
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTasksExecutorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/PersistentTasksExecutorIT.java
@@ -75,9 +75,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         persistentTasksService.sendStartRequest(UUIDs.base64UUID(), TestPersistentTasksExecutor.NAME, new TestParams("Blah"), future);
         long allocationId = future.get().getAllocationId();
         waitForTaskToStart();
-        TaskInfo firstRunningTask = client().admin()
-            .cluster()
-            .prepareListTasks()
+        TaskInfo firstRunningTask = clusterAdmin().prepareListTasks()
             .setActions(TestPersistentTasksExecutor.NAME + "[c]")
             .get()
             .getTasks()
@@ -97,10 +95,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         logger.info("Waiting for persistent task with id {} to disappear", firstRunningTask.id());
         assertBusy(() -> {
             // Wait for the task to disappear completely
-            assertThat(
-                client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(),
-                empty()
-            );
+            assertThat(clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(), empty());
         });
     }
 
@@ -111,9 +106,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         persistentTasksService.sendStartRequest(taskId, TestPersistentTasksExecutor.NAME, new TestParams("Blah"), future);
         long allocationId = future.get().getAllocationId();
         waitForTaskToStart();
-        TaskInfo firstRunningTask = client().admin()
-            .cluster()
-            .prepareListTasks()
+        TaskInfo firstRunningTask = clusterAdmin().prepareListTasks()
             .setActions(TestPersistentTasksExecutor.NAME + "[c]")
             .setDetailed(true)
             .get()
@@ -133,9 +126,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
             assertFutureThrows(failedCompletionNotificationFuture, ResourceNotFoundException.class);
             // Make sure that the task is still running
             assertThat(
-                client().admin()
-                    .cluster()
-                    .prepareListTasks()
+                clusterAdmin().prepareListTasks()
                     .setActions(TestPersistentTasksExecutor.NAME + "[c]")
                     .setDetailed(true)
                     .get()
@@ -161,13 +152,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         String newNodeId = internalCluster().clusterService(newNode).localNode().getId();
         waitForTaskToStart();
 
-        TaskInfo taskInfo = client().admin()
-            .cluster()
-            .prepareListTasks()
-            .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-            .get()
-            .getTasks()
-            .get(0);
+        TaskInfo taskInfo = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().get(0);
 
         // Verifying the task runs on the new node
         assertThat(taskInfo.taskId().getNodeId(), equalTo(newNodeId));
@@ -178,10 +163,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             // Wait for the task to disappear completely
-            assertThat(
-                client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(),
-                empty()
-            );
+            assertThat(clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(), empty());
         });
 
         // Remove the persistent task
@@ -206,21 +188,12 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         persistentTasksService.sendStartRequest(UUIDs.base64UUID(), TestPersistentTasksExecutor.NAME, testParams, future);
         String taskId = future.get().getId();
 
-        assertThat(
-            client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(),
-            empty()
-        );
+        assertThat(clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(), empty());
 
         TestPersistentTasksExecutor.setNonClusterStateCondition(true);
 
         waitForTaskToStart();
-        TaskInfo taskInfo = client().admin()
-            .cluster()
-            .prepareListTasks()
-            .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-            .get()
-            .getTasks()
-            .get(0);
+        TaskInfo taskInfo = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().get(0);
 
         // Verifying the task can now be assigned
         assertThat(taskInfo.taskId().getNodeId(), notNullValue());
@@ -237,9 +210,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         persistentTasksService.sendStartRequest(UUIDs.base64UUID(), TestPersistentTasksExecutor.NAME, new TestParams("Blah"), future);
         String taskId = future.get().getId();
         waitForTaskToStart();
-        TaskInfo firstRunningTask = client().admin()
-            .cluster()
-            .prepareListTasks()
+        TaskInfo firstRunningTask = clusterAdmin().prepareListTasks()
             .setActions(TestPersistentTasksExecutor.NAME + "[c]")
             .get()
             .getTasks()
@@ -316,9 +287,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
 
         waitForTaskToStart();
 
-        TaskInfo firstRunningTask = client().admin()
-            .cluster()
-            .prepareListTasks()
+        TaskInfo firstRunningTask = clusterAdmin().prepareListTasks()
             .setActions(TestPersistentTasksExecutor.NAME + "[c]")
             .get()
             .getTasks()
@@ -334,10 +303,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         logger.info("Waiting for persistent task with id {} to disappear", firstRunningTask.id());
         assertBusy(() -> {
             // Wait for the task to disappear completely
-            assertThat(
-                client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(),
-                empty()
-            );
+            assertThat(clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks(), empty());
         });
     }
 
@@ -374,12 +340,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             // Verify that the task is NOT running on the node
-            List<TaskInfo> tasks = client().admin()
-                .cluster()
-                .prepareListTasks()
-                .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-                .get()
-                .getTasks();
+            List<TaskInfo> tasks = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks();
             assertThat(tasks.size(), equalTo(0));
 
             // Verify that the task is STILL in internal cluster state
@@ -395,13 +356,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         assertClusterStateHasTask(taskId);
 
         // Complete or cancel the running task
-        TaskInfo taskInfo = client().admin()
-            .cluster()
-            .prepareListTasks()
-            .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-            .get()
-            .getTasks()
-            .get(0);
+        TaskInfo taskInfo = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().get(0);
         stopOrCancelTask(taskInfo.taskId());
     }
 
@@ -418,9 +373,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         String taskId = future.get().getId();
         long allocationId = future.get().getAllocationId();
         waitForTaskToStart();
-        TaskInfo firstRunningTask = client().admin()
-            .cluster()
-            .prepareListTasks()
+        TaskInfo firstRunningTask = clusterAdmin().prepareListTasks()
             .setActions(TestPersistentTasksExecutor.NAME + "[c]")
             .get()
             .getTasks()
@@ -444,12 +397,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
 
         assertBusy(() -> {
             // Verify that the task is NOT running on any node
-            List<TaskInfo> tasks = client().admin()
-                .cluster()
-                .prepareListTasks()
-                .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-                .get()
-                .getTasks();
+            List<TaskInfo> tasks = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks();
             assertThat(tasks.size(), equalTo(0));
 
             // Verify that the task is STILL in internal cluster state, unassigned, with a reason indicating local abort
@@ -480,13 +428,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         });
 
         // Complete or cancel the running task
-        TaskInfo taskInfo = client().admin()
-            .cluster()
-            .prepareListTasks()
-            .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-            .get()
-            .getTasks()
-            .get(0);
+        TaskInfo taskInfo = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().get(0);
         stopOrCancelTask(taskInfo.taskId());
     }
 
@@ -502,7 +444,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         } else {
             logger.info("Cancelling the running task");
             // Cancel the running task and make sure it finishes properly
-            assertThat(client().admin().cluster().prepareCancelTasks().setTargetTaskId(taskId).get().getTasks().size(), equalTo(1));
+            assertThat(clusterAdmin().prepareCancelTasks().setTargetTaskId(taskId).get().getTasks().size(), equalTo(1));
         }
     }
 
@@ -510,7 +452,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
         assertBusy(() -> {
             // Wait for the task to start
             assertThat(
-                client().admin().cluster().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().size(),
+                clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks().size(),
                 equalTo(1)
             );
         });
@@ -528,12 +470,7 @@ public class PersistentTasksExecutorIT extends ESIntegTestCase {
     private void assertNoRunningTasks() throws Exception {
         assertBusy(() -> {
             // Wait for the task to finish
-            List<TaskInfo> tasks = client().admin()
-                .cluster()
-                .prepareListTasks()
-                .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-                .get()
-                .getTasks();
+            List<TaskInfo> tasks = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get().getTasks();
             logger.info("Found {} tasks", tasks.size());
             assertThat(tasks.size(), equalTo(0));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/persistent/decider/EnableAssignmentDeciderIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/persistent/decider/EnableAssignmentDeciderIT.java
@@ -67,11 +67,7 @@ public class EnableAssignmentDeciderIT extends ESIntegTestCase {
 
         logger.trace("waiting for the tasks to be running");
         assertBusy(() -> {
-            ListTasksResponse listTasks = client().admin()
-                .cluster()
-                .prepareListTasks()
-                .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-                .get();
+            ListTasksResponse listTasks = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get();
             assertThat(listTasks.getTasks().size(), equalTo(numberOfTasks));
         });
 
@@ -97,11 +93,7 @@ public class EnableAssignmentDeciderIT extends ESIntegTestCase {
                     .count()
             );
 
-            ListTasksResponse runningTasks = client().admin()
-                .cluster()
-                .prepareListTasks()
-                .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-                .get();
+            ListTasksResponse runningTasks = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get();
             assertThat(runningTasks.getTasks().size(), equalTo(0));
 
             logger.trace("enable persistent tasks assignment");
@@ -112,11 +104,7 @@ public class EnableAssignmentDeciderIT extends ESIntegTestCase {
             }
 
             assertBusy(() -> {
-                ListTasksResponse listTasks = client().admin()
-                    .cluster()
-                    .prepareListTasks()
-                    .setActions(TestPersistentTasksExecutor.NAME + "[c]")
-                    .get();
+                ListTasksResponse listTasks = clusterAdmin().prepareListTasks().setActions(TestPersistentTasksExecutor.NAME + "[c]").get();
                 assertThat(listTasks.getTasks().size(), equalTo(numberOfTasks));
             });
 
@@ -126,7 +114,7 @@ public class EnableAssignmentDeciderIT extends ESIntegTestCase {
     }
 
     private void assertEnableAssignmentSetting(final Allocation expected) {
-        ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().clear().setMetadata(true).get();
+        ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().clear().setMetadata(true).get();
         Settings settings = clusterStateResponse.getState().getMetadata().settings();
 
         String value = settings.get(CLUSTER_TASKS_ALLOCATION_ENABLE_SETTING.getKey());

--- a/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/readiness/ReadinessClusterIT.java
@@ -96,15 +96,7 @@ public class ReadinessClusterIT extends ESIntegTestCase implements ReadinessClie
     private void expectMasterNotFound() {
         expectThrows(
             MasterNotDiscoveredException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareState()
-                .setMasterNodeTimeout("100ms")
-                .execute()
-                .actionGet()
-                .getState()
-                .nodes()
-                .getMasterNodeId()
+            () -> clusterAdmin().prepareState().setMasterNodeTimeout("100ms").execute().actionGet().getState().nodes().getMasterNodeId()
         );
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -70,9 +70,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
 
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -86,9 +84,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
 
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -106,9 +102,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -119,9 +113,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -139,9 +131,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         internalCluster().stopRandomDataNode();
         // make sure the cluster state is green, and all has been recovered
         assertTimeout(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForGreenStatus()
@@ -153,9 +143,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
 
         // make sure the cluster state is yellow, and all has been recovered
         assertTimeout(
-            client().admin()
-                .cluster()
-                .prepareHealth()
+            clusterAdmin().prepareHealth()
                 .setWaitForEvents(Priority.LANGUID)
                 .setTimeout(healthTimeout)
                 .setWaitForYellowStatus()
@@ -192,7 +180,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
                 .actionGet();
         }
         ensureGreen();
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
             assertNotEquals(
@@ -210,7 +198,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         }
         internalCluster().restartRandomDataNode();
         ensureGreen();
-        client().admin().cluster().prepareState().get();
+        clusterAdmin().prepareState().get();
 
         recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -104,9 +104,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
             logger.info("--> waiting for GREEN health status ...");
             // make sure the cluster state is green, and all has been recovered
-            assertNoTimeout(
-                client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForGreenStatus()
-            );
+            assertNoTimeout(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForGreenStatus());
 
             logger.info("--> waiting for {} docs to be indexed ...", totalNumDocs);
             waitForDocs(totalNumDocs, indexer);
@@ -162,9 +160,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 4);
 
             logger.info("--> waiting for GREEN health status ...");
-            assertNoTimeout(
-                client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForGreenStatus()
-            );
+            assertNoTimeout(clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForGreenStatus());
 
             logger.info("--> waiting for {} docs to be indexed ...", totalNumDocs);
             waitForDocs(totalNumDocs, indexer);
@@ -222,9 +218,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
             logger.info("--> waiting for GREEN health status ...");
             assertNoTimeout(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
+                clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout("5m")
                     .setWaitForGreenStatus()
@@ -241,36 +235,21 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             allowNodes("test", 3);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
-                    .setWaitForEvents(Priority.LANGUID)
-                    .setTimeout("5m")
-                    .setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> allow 2 nodes for index [test] ...");
             allowNodes("test", 2);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
-                    .setWaitForEvents(Priority.LANGUID)
-                    .setTimeout("5m")
-                    .setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> allow 1 nodes for index [test] ...");
             allowNodes("test", 1);
             logger.info("--> waiting for relocations ...");
             assertNoTimeout(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
-                    .setWaitForEvents(Priority.LANGUID)
-                    .setTimeout("5m")
-                    .setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> marking and waiting for indexing threads to stop ...");
@@ -278,12 +257,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             logger.info("--> indexing threads stopped");
 
             assertNoTimeout(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
-                    .setWaitForEvents(Priority.LANGUID)
-                    .setTimeout("5m")
-                    .setWaitForNoRelocatingShards(true)
+                clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setTimeout("5m").setWaitForNoRelocatingShards(true)
             );
 
             logger.info("--> refreshing the index");

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -136,9 +136,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> start another node");
         final String node_2 = internalCluster().startNode();
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .execute()
@@ -146,11 +144,9 @@ public class RelocationIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> relocate the shard from node1 to node2");
-        client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_2)).execute().actionGet();
+        clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, node_1, node_2)).execute().actionGet();
 
-        clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -186,9 +182,7 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> starting [node{}] ...", i);
             nodes[i - 1] = internalCluster().startNode();
             if (i != numberOfNodes) {
-                ClusterHealthResponse healthResponse = client().admin()
-                    .cluster()
-                    .prepareHealth()
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(Integer.toString(i))
                     .setWaitForGreenStatus()
@@ -215,14 +209,12 @@ public class RelocationIT extends ESIntegTestCase {
                 logger.debug("--> Allow indexer to index [{}] documents", numDocs);
                 indexer.continueIndexing(numDocs);
                 logger.info("--> START relocate the shard from {} to {}", nodes[fromNode], nodes[toNode]);
-                client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode])).get();
+                clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode])).get();
                 if (rarely()) {
                     logger.debug("--> flushing");
                     client().admin().indices().prepareFlush().get();
                 }
-                ClusterHealthResponse clusterHealthResponse = client().admin()
-                    .cluster()
-                    .prepareHealth()
+                ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNoRelocatingShards(true)
                     .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -302,9 +294,7 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> starting [node_{}] ...", i);
             nodes[i] = internalCluster().startNode();
             if (i != numberOfNodes - 1) {
-                ClusterHealthResponse healthResponse = client().admin()
-                    .cluster()
-                    .prepareHealth()
+                ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
                     .setWaitForNodes(Integer.toString(i + 1))
                     .setWaitForGreenStatus()
@@ -354,7 +344,7 @@ public class RelocationIT extends ESIntegTestCase {
 
             logger.info("--> START relocate the shard from {} to {}", nodes[fromNode], nodes[toNode]);
 
-            client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode])).get();
+            clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode])).get();
 
             logger.debug("--> index [{}] documents", builders1.size());
             indexRandom(false, true, builders1);
@@ -366,9 +356,7 @@ public class RelocationIT extends ESIntegTestCase {
 
             // verify cluster was finished.
             assertFalse(
-                client().admin()
-                    .cluster()
-                    .prepareHealth()
+                clusterAdmin().prepareHealth()
                     .setWaitForNoRelocatingShards(true)
                     .setWaitForEvents(Priority.LANGUID)
                     .setTimeout("30s")
@@ -409,7 +397,7 @@ public class RelocationIT extends ESIntegTestCase {
             requests.add(client().prepareIndex(indexName).setSource("{}", XContentType.JSON));
         }
         indexRandom(true, requests);
-        assertFalse(client().admin().cluster().prepareHealth().setWaitForNodes("3").setWaitForGreenStatus().get().isTimedOut());
+        assertFalse(clusterAdmin().prepareHealth().setWaitForNodes("3").setWaitForGreenStatus().get().isTimedOut());
         flush();
 
         int allowedFailures = randomIntBetween(3, 5); // the default of the `index.allocation.max_retries` is 5.
@@ -574,9 +562,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> start another node");
         final String node2 = internalCluster().startNode();
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .execute()
@@ -584,11 +570,9 @@ public class RelocationIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> relocate the shard from node1 to node2");
-        client().admin().cluster().prepareReroute().add(new MoveAllocationCommand("test", 0, node1, node2)).execute().actionGet();
+        clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, node1, node2)).execute().actionGet();
 
-        clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -632,9 +616,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> start another node");
         final String node2 = internalCluster().startNode();
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNodes("2")
             .execute()
@@ -642,9 +624,7 @@ public class RelocationIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> relocate the shard from node1 to node2");
-        ActionFuture<ClusterRerouteResponse> relocationListener = client().admin()
-            .cluster()
-            .prepareReroute()
+        ActionFuture<ClusterRerouteResponse> relocationListener = clusterAdmin().prepareReroute()
             .add(new MoveAllocationCommand("test", 0, node1, node2))
             .execute();
         logger.info("--> index 100 docs while relocating");
@@ -658,9 +638,7 @@ public class RelocationIT extends ESIntegTestCase {
             );
         }
         relocationListener.actionGet();
-        clusterHealthResponse = client().admin()
-            .cluster()
-            .prepareHealth()
+        clusterHealthResponse = clusterAdmin().prepareHealth()
             .setWaitForEvents(Priority.LANGUID)
             .setWaitForNoRelocatingShards(true)
             .setTimeout(ACCEPTABLE_RELOCATION_TIME)
@@ -710,7 +688,7 @@ public class RelocationIT extends ESIntegTestCase {
 
     private void assertActiveCopiesEstablishedPeerRecoveryRetentionLeases() throws Exception {
         assertBusy(() -> {
-            for (String index : client().admin().cluster().prepareState().get().getState().metadata().indices().keySet()) {
+            for (String index : clusterAdmin().prepareState().get().getState().metadata().indices().keySet()) {
                 Map<ShardId, List<ShardStats>> byShardId = Stream.of(client().admin().indices().prepareStats(index).get().getShards())
                     .collect(Collectors.groupingBy(l -> l.getShardRouting().shardId()));
                 for (List<ShardStats> shardStats : byShardId.values()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/IndexSnapshotsServiceIT.java
@@ -175,9 +175,7 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
         blockAllDataNodes(fsRepoName);
 
         final String snapshotName = "snap-1";
-        final ActionFuture<CreateSnapshotResponse> snapshotFuture = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(fsRepoName, snapshotName)
+        final ActionFuture<CreateSnapshotResponse> snapshotFuture = clusterAdmin().prepareCreateSnapshot(fsRepoName, snapshotName)
             .setIndices(indexName)
             .setWaitForCompletion(true)
             .execute();
@@ -293,9 +291,7 @@ public class IndexSnapshotsServiceIT extends AbstractSnapshotIntegTestCase {
             ((MockRepository) repositoriesService.repository(repoName)).setBlockAndFailOnWriteSnapFiles();
         }
 
-        client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, "snap")
+        clusterAdmin().prepareCreateSnapshot(repoName, "snap")
             .setIndices(indexName)
             .setWaitForCompletion(false)
             .setFeatureStates(NO_FEATURE_STATES_VALUE)

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/InvalidRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/InvalidRepositoryIT.java
@@ -105,7 +105,7 @@ public class InvalidRepositoryIT extends ESIntegTestCase {
         // verification should fail with some node has InvalidRepository
         final var expectedException = expectThrows(
             RepositoryVerificationException.class,
-            () -> client().admin().cluster().prepareVerifyRepository(repositoryName).get()
+            () -> clusterAdmin().prepareVerifyRepository(repositoryName).get()
         );
         for (Throwable suppressed : expectedException.getSuppressed()) {
             Throwable outerCause = suppressed.getCause();
@@ -129,16 +129,16 @@ public class InvalidRepositoryIT extends ESIntegTestCase {
         // put repository again: let all node can create repository successfully
         createRepository(repositoryName, UnstableRepository.TYPE, Settings.builder().put("location", randomRepoPath()));
         // verification should succeed with all node create repository successfully
-        VerifyRepositoryResponse verifyRepositoryResponse = client().admin().cluster().prepareVerifyRepository(repositoryName).get();
+        VerifyRepositoryResponse verifyRepositoryResponse = clusterAdmin().prepareVerifyRepository(repositoryName).get();
         assertEquals(verifyRepositoryResponse.getNodes().size(), internalCluster().numDataAndMasterNodes());
 
     }
 
     private void createRepository(String name, String type, Settings.Builder settings) {
         // create
-        assertAcked(client().admin().cluster().preparePutRepository(name).setType(type).setVerify(false).setSettings(settings).get());
+        assertAcked(clusterAdmin().preparePutRepository(name).setType(type).setVerify(false).setSettings(settings).get());
         // get
-        final GetRepositoriesResponse updatedGetRepositoriesResponse = client().admin().cluster().prepareGetRepositories(name).get();
+        final GetRepositoriesResponse updatedGetRepositoriesResponse = clusterAdmin().prepareGetRepositories(name).get();
         // assert
         assertThat(updatedGetRepositoriesResponse.repositories(), hasSize(1));
         final RepositoryMetadata updatedRepositoryMetadata = updatedGetRepositoriesResponse.repositories().get(0);

--- a/server/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryCleanupIT.java
@@ -60,15 +60,10 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
         final ActionFuture<CleanupRepositoryResponse> cleanupFuture = startBlockedCleanup("test-repo");
 
         logger.info("-->  sending another cleanup");
-        assertFutureThrows(client().admin().cluster().prepareCleanupRepository("test-repo").execute(), IllegalStateException.class);
+        assertFutureThrows(clusterAdmin().prepareCleanupRepository("test-repo").execute(), IllegalStateException.class);
 
         logger.info("-->  ensure cleanup is still in progress");
-        final RepositoryCleanupInProgress cleanup = client().admin()
-            .cluster()
-            .prepareState()
-            .get()
-            .getState()
-            .custom(RepositoryCleanupInProgress.TYPE);
+        final RepositoryCleanupInProgress cleanup = clusterAdmin().prepareState().get().getState().custom(RepositoryCleanupInProgress.TYPE);
         assertTrue(cleanup.hasCleanupInProgress());
 
         logger.info("-->  unblocking master node");
@@ -93,7 +88,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
         createRepository(repoName, "mock");
 
         logger.info("-->  snapshot");
-        client().admin().cluster().prepareCreateSnapshot(repoName, "test-snap").setWaitForCompletion(true).get();
+        clusterAdmin().prepareCreateSnapshot(repoName, "test-snap").setWaitForCompletion(true).get();
 
         final BlobStoreRepository repository = getRepositoryOnMaster(repoName);
 
@@ -138,9 +133,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
 
         logger.info("--> create three snapshots");
         for (int i = 0; i < 3; ++i) {
-            CreateSnapshotResponse createSnapshotResponse = client().admin()
-                .cluster()
-                .prepareCreateSnapshot(repoName, "test-snap-" + i)
+            CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(repoName, "test-snap-" + i)
                 .setWaitForCompletion(true)
                 .get();
             assertThat(createSnapshotResponse.getSnapshotInfo().state(), is(SnapshotState.SUCCESS));
@@ -165,7 +158,7 @@ public class BlobStoreRepositoryCleanupIT extends AbstractSnapshotIntegTestCase 
         }
 
         logger.info("--> cleanup repository");
-        client().admin().cluster().prepareCleanupRepository(repoName).get();
+        clusterAdmin().prepareCleanupRepository(repoName).get();
 
         BlobStoreTestUtil.assertConsistency(repository);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
@@ -99,15 +99,8 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
                 Settings.builder()
                     .put(
                         "index.routing.allocation.require._name",
-                        client().admin()
-                            .cluster()
-                            .prepareState()
-                            .get()
-                            .getState()
-                            .nodes()
-                            .getDataNodes()
-                            .values()
-                            .toArray(DiscoveryNode[]::new)[0].getName()
+                        clusterAdmin().prepareState().get().getState().nodes().getDataNodes().values().toArray(DiscoveryNode[]::new)[0]
+                            .getName()
                     )
                     .put("index.blocks.write", true),
                 index

--- a/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/script/StoredScriptsIT.java
@@ -41,20 +41,20 @@ public class StoredScriptsIT extends ESIntegTestCase {
     }
 
     public void testBasics() {
-        assertAcked(client().admin().cluster().preparePutStoredScript().setId("foobar").setContent(new BytesArray(Strings.format("""
+        assertAcked(clusterAdmin().preparePutStoredScript().setId("foobar").setContent(new BytesArray(Strings.format("""
             {"script": {"lang": "%s", "source": "1"} }
             """, LANG)), XContentType.JSON));
-        String script = client().admin().cluster().prepareGetStoredScript("foobar").get().getSource().getSource();
+        String script = clusterAdmin().prepareGetStoredScript("foobar").get().getSource().getSource();
         assertNotNull(script);
         assertEquals("1", script);
 
-        assertAcked(client().admin().cluster().prepareDeleteStoredScript("foobar"));
-        StoredScriptSource source = client().admin().cluster().prepareGetStoredScript("foobar").get().getSource();
+        assertAcked(clusterAdmin().prepareDeleteStoredScript("foobar"));
+        StoredScriptSource source = clusterAdmin().prepareGetStoredScript("foobar").get().getSource();
         assertNull(source);
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> { client().admin().cluster().preparePutStoredScript().setId("id#").setContent(new BytesArray(Strings.format("""
+            () -> { clusterAdmin().preparePutStoredScript().setId("id#").setContent(new BytesArray(Strings.format("""
                 {"script": {"lang": "%s", "source": "1"} }
                 """, LANG)), XContentType.JSON).get(); }
         );
@@ -64,7 +64,7 @@ public class StoredScriptsIT extends ESIntegTestCase {
     public void testMaxScriptSize() {
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> { client().admin().cluster().preparePutStoredScript().setId("foobar").setContent(new BytesArray(Strings.format("""
+            () -> { clusterAdmin().preparePutStoredScript().setId("foobar").setContent(new BytesArray(Strings.format("""
                 {"script": { "lang": "%s", "source":"0123456789abcdef"} }\
                 """, LANG)), XContentType.JSON).get(); }
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/ScriptedMetricIT.java
@@ -304,29 +304,21 @@ public class ScriptedMetricIT extends ESIntegTestCase {
         // When using the MockScriptPlugin we can map Stored scripts to inline scripts:
         // the id of the stored script is used in test method while the source of the stored script
         // must match a predefined script from CustomScriptPlugin.pluginScripts() method
-        assertAcked(
-            client().admin().cluster().preparePutStoredScript().setId("initScript_stored").setContent(new BytesArray(Strings.format("""
-                {"script": {"lang": "%s", "source": "vars.multiplier = 3"} }
-                """, MockScriptPlugin.NAME)), XContentType.JSON)
-        );
+        assertAcked(clusterAdmin().preparePutStoredScript().setId("initScript_stored").setContent(new BytesArray(Strings.format("""
+            {"script": {"lang": "%s", "source": "vars.multiplier = 3"} }
+            """, MockScriptPlugin.NAME)), XContentType.JSON));
 
-        assertAcked(
-            client().admin().cluster().preparePutStoredScript().setId("mapScript_stored").setContent(new BytesArray(Strings.format("""
-                {"script": {"lang": "%s", "source": "state.list.add(vars.multiplier)"} }
-                """, MockScriptPlugin.NAME)), XContentType.JSON)
-        );
+        assertAcked(clusterAdmin().preparePutStoredScript().setId("mapScript_stored").setContent(new BytesArray(Strings.format("""
+            {"script": {"lang": "%s", "source": "state.list.add(vars.multiplier)"} }
+            """, MockScriptPlugin.NAME)), XContentType.JSON));
 
-        assertAcked(
-            client().admin().cluster().preparePutStoredScript().setId("combineScript_stored").setContent(new BytesArray(Strings.format("""
-                {"script": {"lang": "%s", "source": "sum state values as a new aggregation"} }
-                """, MockScriptPlugin.NAME)), XContentType.JSON)
-        );
+        assertAcked(clusterAdmin().preparePutStoredScript().setId("combineScript_stored").setContent(new BytesArray(Strings.format("""
+            {"script": {"lang": "%s", "source": "sum state values as a new aggregation"} }
+            """, MockScriptPlugin.NAME)), XContentType.JSON));
 
-        assertAcked(
-            client().admin().cluster().preparePutStoredScript().setId("reduceScript_stored").setContent(new BytesArray(Strings.format("""
-                {"script": {"lang": "%s", "source": "sum all states (lists) values as a new aggregation"} }
-                """, MockScriptPlugin.NAME)), XContentType.JSON)
-        );
+        assertAcked(clusterAdmin().preparePutStoredScript().setId("reduceScript_stored").setContent(new BytesArray(Strings.format("""
+            {"script": {"lang": "%s", "source": "sum all states (lists) values as a new aggregation"} }
+            """, MockScriptPlugin.NAME)), XContentType.JSON));
 
         indexRandom(true, builders);
         ensureSearchable();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketScriptIT.java
@@ -525,9 +525,7 @@ public class BucketScriptIT extends ESIntegTestCase {
 
     public void testStoredScript() {
         assertAcked(
-            client().admin()
-                .cluster()
-                .preparePutStoredScript()
+            clusterAdmin().preparePutStoredScript()
                 .setId("my_script")
                 // Script source is not interpreted but it references a pre-defined script from CustomScriptPlugin
                 .setContent(

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchRedStateIndexIT.java
@@ -100,11 +100,7 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
 
         Settings persistentSettings = Settings.builder().put(key, allowPartialResults).build();
 
-        ClusterUpdateSettingsResponse response1 = client().admin()
-            .cluster()
-            .prepareUpdateSettings()
-            .setPersistentSettings(persistentSettings)
-            .get();
+        ClusterUpdateSettingsResponse response1 = clusterAdmin().prepareUpdateSettings().setPersistentSettings(persistentSettings).get();
 
         assertAcked(response1);
         assertEquals(response1.getPersistentSettings().getAsBoolean(key, null), allowPartialResults);
@@ -120,10 +116,10 @@ public class SearchRedStateIndexIT extends ESIntegTestCase {
 
         internalCluster().stopRandomDataNode();
 
-        client().admin().cluster().prepareHealth().setWaitForStatus(ClusterHealthStatus.RED).get();
+        clusterAdmin().prepareHealth().setWaitForStatus(ClusterHealthStatus.RED).get();
 
         assertBusy(() -> {
-            ClusterState state = client().admin().cluster().prepareState().get().getState();
+            ClusterState state = clusterAdmin().prepareState().get().getState();
             List<ShardRouting> unassigneds = RoutingNodesHelper.shardsWithState(state.getRoutingNodes(), ShardRoutingState.UNASSIGNED);
             assertThat(unassigneds.size(), greaterThan(0));
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWhileRelocatingIT.java
@@ -125,9 +125,7 @@ public class SearchWhileRelocatingIT extends ESIntegTestCase {
                 threads[j].join();
             }
             // this might time out on some machines if they are really busy and you hit lots of throttling
-            ClusterHealthResponse resp = client().admin()
-                .cluster()
-                .prepareHealth()
+            ClusterHealthResponse resp = clusterAdmin().prepareHealth()
                 .setWaitForYellowStatus()
                 .setWaitForNoRelocatingShards(true)
                 .setWaitForEvents(Priority.LANGUID)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomIOExceptionsIT.java
@@ -100,8 +100,7 @@ public class SearchWithRandomIOExceptionsIT extends ESIntegTestCase {
             logger.info("creating index: [test] using settings: [{}]", settings.build());
             client().admin().indices().prepareCreate("test").setSettings(settings).setMapping(mapping).get();
         }
-        ClusterHealthResponse clusterHealthResponse = client().admin()
-            .cluster()
+        ClusterHealthResponse clusterHealthResponse = clusterAdmin()
             // it's OK to timeout here
             .health(new ClusterHealthRequest(new String[] {}).waitForYellowStatus().timeout(TimeValue.timeValueSeconds(5)))
             .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
@@ -69,20 +69,17 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
 
         allowNodes("test", 2);
         assertThat(
-            client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").get().isTimedOut(),
+            clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForNodes(">=2").get().isTimedOut(),
             equalTo(false)
         );
 
         logger.info("Running Cluster Health");
-        ClusterHealthResponse clusterHealth = client().admin()
-            .cluster()
-            .health(
-                new ClusterHealthRequest("test").waitForYellowStatus()
-                    .waitForNoRelocatingShards(true)
-                    .waitForEvents(Priority.LANGUID)
-                    .waitForActiveShards(test.totalNumShards)
-            )
-            .actionGet();
+        ClusterHealthResponse clusterHealth = clusterAdmin().health(
+            new ClusterHealthRequest("test").waitForYellowStatus()
+                .waitForNoRelocatingShards(true)
+                .waitForEvents(Priority.LANGUID)
+                .waitForActiveShards(test.totalNumShards)
+        ).actionGet();
         logger.info("Done Cluster Health, status {}", clusterHealth.getStatus());
         assertThat(clusterHealth.isTimedOut(), equalTo(false));
         assertThat(clusterHealth.getStatus(), anyOf(equalTo(ClusterHealthStatus.YELLOW), equalTo(ClusterHealthStatus.GREEN)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -557,9 +557,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
                     }
                     assertNotNull(fromNode);
                     assertNotNull(toNode);
-                    client().admin()
-                        .cluster()
-                        .prepareReroute()
+                    clusterAdmin().prepareReroute()
                         .add(new MoveAllocationCommand(shardId.getIndexName(), shardId.id(), fromNode.getId(), toNode.getId()))
                         .execute()
                         .actionGet();
@@ -692,9 +690,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             Cancellable cancellable = getRestClient().performRequestAsync(restRequest, wrapAsRestResponseListener(future));
             logger.info("--> waiting for field-caps tasks to be started");
             assertBusy(() -> {
-                List<TaskInfo> tasks = client().admin()
-                    .cluster()
-                    .prepareListTasks()
+                List<TaskInfo> tasks = clusterAdmin().prepareListTasks()
                     .setActions("indices:data/read/field_caps", "indices:data/read/field_caps[n]")
                     .get()
                     .getTasks();
@@ -708,9 +704,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             assertBusy(logAppender::assertAllExpectationsMatched);
             logger.info("--> waiting for field-caps tasks to be cancelled");
             assertBusy(() -> {
-                List<TaskInfo> tasks = client().admin()
-                    .cluster()
-                    .prepareListTasks()
+                List<TaskInfo> tasks = clusterAdmin().prepareListTasks()
                     .setActions("indices:data/read/field_caps", "indices:data/read/field_caps[n]")
                     .get()
                     .getTasks();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -69,9 +69,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetch() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test")
@@ -119,9 +119,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetchSmallSizeUnevenDistribution() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             String routing = "0";
@@ -186,7 +186,7 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testScrollAndUpdateIndex() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 5)).get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 500; i++) {
             client().prepareIndex("test")
@@ -262,9 +262,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetch_clearScrollIds() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test")
@@ -382,9 +382,9 @@ public class SearchScrollIT extends ESIntegTestCase {
 
     public void testSimpleScrollQueryThenFetchClearAllScrollIds() throws Exception {
         client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
-        client().admin().cluster().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
+        clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 100; i++) {
             client().prepareIndex("test")
@@ -564,9 +564,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     public void testScrollInvalidDefaultKeepAlive() throws IOException {
         IllegalArgumentException exc = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            () -> clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().put("search.max_keep_alive", "1m").put("search.default_keep_alive", "2m"))
                 .get()
         );
@@ -578,9 +576,7 @@ public class SearchScrollIT extends ESIntegTestCase {
 
         exc = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
+            () -> clusterAdmin().prepareUpdateSettings()
                 .setPersistentSettings(Settings.builder().put("search.default_keep_alive", "3m"))
                 .get()
         );
@@ -590,11 +586,7 @@ public class SearchScrollIT extends ESIntegTestCase {
 
         exc = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .cluster()
-                .prepareUpdateSettings()
-                .setPersistentSettings(Settings.builder().put("search.max_keep_alive", "30s"))
-                .get()
+            () -> clusterAdmin().prepareUpdateSettings().setPersistentSettings(Settings.builder().put("search.max_keep_alive", "30s")).get()
         );
         assertThat(exc.getMessage(), containsString("was (1m > 30s)"));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/SearchStatsIT.java
@@ -129,7 +129,7 @@ public class SearchStatsIT extends ESIntegTestCase {
         assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getQueryTimeInMillis(), greaterThan(0L));
         assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getFetchCount(), greaterThan(0L));
         assertThat(indicesStats.getTotal().getSearch().getGroupStats().get("group1").getFetchTimeInMillis(), greaterThan(0L));
-        NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().get();
+        NodesStatsResponse nodeStats = clusterAdmin().prepareNodesStats().get();
 
         Set<String> nodeIdsWithIndex = nodeIdsWithIndex("test1", "test2");
         int num = 0;
@@ -150,7 +150,7 @@ public class SearchStatsIT extends ESIntegTestCase {
     }
 
     private Set<String> nodeIdsWithIndex(String... indices) {
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         GroupShardsIterator<ShardIterator> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         Set<String> nodes = new HashSet<>();
         for (ShardIterator shardIterator : allAssignedShardsGrouped) {
@@ -231,7 +231,7 @@ public class SearchStatsIT extends ESIntegTestCase {
     }
 
     protected int numAssignedShards(String... indices) {
-        ClusterState state = client().admin().cluster().prepareState().get().getState();
+        ClusterState state = clusterAdmin().prepareState().get().getState();
         GroupShardsIterator<?> allAssignedShardsGrouped = state.routingTable().allAssignedShardsGrouped(indices, true);
         return allAssignedShardsGrouped.size();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -53,9 +53,7 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
         failReadsAllDataNodes(repositoryName);
 
         logger.info("--> starting restore");
-        final ActionFuture<RestoreSnapshotResponse> future = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot(repositoryName, snapshotName)
+        final ActionFuture<RestoreSnapshotResponse> future = clusterAdmin().prepareRestoreSnapshot(repositoryName, snapshotName)
             .setWaitForCompletion(true)
             .setIndices(indexName)
             .execute();

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -112,7 +112,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshot3 = "snap-3";
         logger.info("--> creating snapshot 3");
-        client().admin().cluster().prepareCreateSnapshot(repo, snapshot3).setIndices(indexName).setWaitForCompletion(true).get();
+        clusterAdmin().prepareCreateSnapshot(repo, snapshot3).setIndices(indexName).setWaitForCompletion(true).get();
 
         logger.info("--> Shutting down new primary node [{}]", newPrimary);
         stopNode(newPrimary);
@@ -120,7 +120,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshot4 = "snap-4";
         logger.info("--> creating snapshot 4");
-        client().admin().cluster().prepareCreateSnapshot(repo, snapshot4).setIndices(indexName).setWaitForCompletion(true).get();
+        clusterAdmin().prepareCreateSnapshot(repo, snapshot4).setIndices(indexName).setWaitForCompletion(true).get();
 
         assertTwoIdenticalShardSnapshots(repo, indexName, snapshot3, snapshot4);
 
@@ -156,7 +156,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         createRepository(repo, "fs");
 
         logger.info("--> creating snapshot 1");
-        client().admin().cluster().prepareCreateSnapshot(repo, snapshot1).setIndices(indexName).setWaitForCompletion(true).get();
+        clusterAdmin().prepareCreateSnapshot(repo, snapshot1).setIndices(indexName).setWaitForCompletion(true).get();
 
         logger.info("--> force merging down to a single segment");
         final ForceMergeResponse forceMergeResponse = client().admin()
@@ -169,7 +169,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshot2 = "snap-2";
         logger.info("--> creating snapshot 2");
-        client().admin().cluster().prepareCreateSnapshot(repo, snapshot2).setIndices(indexName).setWaitForCompletion(true).get();
+        clusterAdmin().prepareCreateSnapshot(repo, snapshot2).setIndices(indexName).setWaitForCompletion(true).get();
 
         logger.info("--> asserting that the two snapshots refer to different files in the repository");
         final SnapshotStats secondSnapshotShardStatus = getStats(repo, snapshot2).getIndices().get(indexName).getShards().get(0).getStats();
@@ -257,14 +257,12 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
     }
 
     private SnapshotStatus getStats(String repository, String snapshot) {
-        return client().admin().cluster().prepareSnapshotStatus(repository).setSnapshots(snapshot).get().getSnapshots().get(0);
+        return clusterAdmin().prepareSnapshotStatus(repository).setSnapshots(snapshot).get().getSnapshots().get(0);
     }
 
     private void ensureRestoreSingleShardSuccessfully(String repo, String indexName, String snapshot, String indexSuffix) {
         logger.info("--> restoring [{}]", snapshot);
-        final RestoreSnapshotResponse restoreSnapshotResponse = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot(repo, snapshot)
+        final RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(repo, snapshot)
             .setIndices(indexName)
             .setRenamePattern("(.+)")
             .setRenameReplacement("$1" + indexSuffix)

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -103,12 +103,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         createIndexWithContent(indexFast, dataNode2, dataNode);
 
         assertSuccessful(
-            client().admin()
-                .cluster()
-                .prepareCreateSnapshot(repoName, "fast-snapshot")
-                .setIndices(indexFast)
-                .setWaitForCompletion(true)
-                .execute()
+            clusterAdmin().prepareCreateSnapshot(repoName, "fast-snapshot").setIndices(indexFast).setWaitForCompletion(true).execute()
         );
 
         assertThat(createSlowFuture.isDone(), is(false));
@@ -203,7 +198,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             }
             snapshotNames.removeAll(toDelete);
             final StepListener<AcknowledgedResponse> future = new StepListener<>();
-            client().admin().cluster().prepareDeleteSnapshot(repoName, toDelete.toArray(Strings.EMPTY_ARRAY)).execute(future);
+            clusterAdmin().prepareDeleteSnapshot(repoName, toDelete.toArray(Strings.EMPTY_ARRAY)).execute(future);
             deleteFutures.add(future);
         }
 
@@ -243,12 +238,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final ActionFuture<CreateSnapshotResponse> createSlowFuture = startAndBlockFailingFullSnapshot(blockedRepoName, "blocked-snapshot");
 
-        client().admin()
-            .cluster()
-            .prepareCreateSnapshot(otherRepoName, "snapshot")
-            .setIndices("does-not-exist-*")
-            .setWaitForCompletion(false)
-            .get();
+        clusterAdmin().prepareCreateSnapshot(otherRepoName, "snapshot").setIndices("does-not-exist-*").setWaitForCompletion(false).get();
 
         unblockNode(blockedRepoName, internalCluster().getMasterName());
         expectThrows(SnapshotException.class, createSlowFuture::actionGet);
@@ -384,9 +374,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         awaitNDeletionsInProgress(1);
 
         logger.info("--> start third snapshot");
-        final ActionFuture<CreateSnapshotResponse> thirdSnapshotResponse = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, "snapshot-three")
+        final ActionFuture<CreateSnapshotResponse> thirdSnapshotResponse = clusterAdmin().prepareCreateSnapshot(repoName, "snapshot-three")
             .setIndices(secondIndex)
             .setWaitForCompletion(true)
             .execute();
@@ -406,7 +394,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> verify that the first snapshot is gone");
         assertThat(
-            client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(),
+            clusterAdmin().prepareGetSnapshots(repoName).get().getSnapshots(),
             containsInAnyOrder(secondSnapshotInfo, thirdSnapshotInfo)
         );
     }
@@ -470,7 +458,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertAcked(allDeletedResponse.get());
 
         logger.info("--> verify that all snapshots are gone");
-        assertThat(client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
+        assertThat(clusterAdmin().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
     }
 
     public void testMasterFailOverWithQueuedDeletes() throws Exception {
@@ -556,7 +544,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> verify that all snapshots are gone and no more work is left in the cluster state");
         awaitNoMoreRunningOperations();
-        assertThat(client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
+        assertThat(clusterAdmin().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
     }
 
     public void testAssertMultipleSnapshotsAndPrimaryFailOver() throws Exception {
@@ -615,7 +603,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final SnapshotException snapshotException = expectThrows(SnapshotException.class, snapshotFuture::actionGet);
         assertThat(snapshotException.getMessage(), containsString(SnapshotsInProgress.ABORTED_FAILURE_TEXT));
 
-        assertThat(client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
+        assertThat(clusterAdmin().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
     }
 
     public void testQueuedDeletesWithOverlap() throws Exception {
@@ -642,7 +630,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final SnapshotException snapshotException = expectThrows(SnapshotException.class, snapshotFuture::actionGet);
         assertThat(snapshotException.getMessage(), containsString(SnapshotsInProgress.ABORTED_FAILURE_TEXT));
 
-        assertThat(client().admin().cluster().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
+        assertThat(clusterAdmin().prepareGetSnapshots(repoName).get().getSnapshots(), empty());
     }
 
     public void testQueuedOperationsOnMasterRestart() throws Exception {
@@ -655,7 +643,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         startAndBlockOnDeleteSnapshot(repoName, "*");
 
-        client().admin().cluster().prepareCreateSnapshot(repoName, "snapshot-three").setWaitForCompletion(false).get();
+        clusterAdmin().prepareCreateSnapshot(repoName, "snapshot-three").setWaitForCompletion(false).get();
 
         startDeleteSnapshot(repoName, "*");
         awaitNDeletionsInProgress(2);
@@ -771,7 +759,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         corruptIndexN(repoPath, generation);
 
-        client().admin().cluster().prepareCreateSnapshot(repoName, "snapshot-three").setWaitForCompletion(false).get();
+        clusterAdmin().prepareCreateSnapshot(repoName, "snapshot-three").setWaitForCompletion(false).get();
 
         final ActionFuture<AcknowledgedResponse> deleteFuture = startDeleteFromNonMasterClient(repoName, "*");
         awaitNDeletionsInProgress(2);
@@ -960,10 +948,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         logger.info("--> wait for relocations to start");
         assertBusy(
-            () -> assertThat(
-                client().admin().cluster().prepareHealth(testIndex).execute().actionGet().getRelocatingShards(),
-                greaterThan(0)
-            ),
+            () -> assertThat(clusterAdmin().prepareHealth(testIndex).execute().actionGet().getRelocatingShards(), greaterThan(0)),
             1L,
             TimeUnit.MINUTES
         );
@@ -971,15 +956,11 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> start two snapshots");
         final String snapshotOne = "snap-1";
         final String snapshotTwo = "snap-2";
-        final ActionFuture<CreateSnapshotResponse> snapOneResponse = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, snapshotOne)
+        final ActionFuture<CreateSnapshotResponse> snapOneResponse = clusterAdmin().prepareCreateSnapshot(repoName, snapshotOne)
             .setWaitForCompletion(false)
             .setIndices(testIndex)
             .execute();
-        final ActionFuture<CreateSnapshotResponse> snapTwoResponse = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, snapshotTwo)
+        final ActionFuture<CreateSnapshotResponse> snapTwoResponse = clusterAdmin().prepareCreateSnapshot(repoName, snapshotTwo)
             .setWaitForCompletion(false)
             .setIndices(testIndex)
             .execute();
@@ -1071,7 +1052,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final int deletes = randomIntBetween(2, 10);
         final List<ActionFuture<AcknowledgedResponse>> deleteResponses = new ArrayList<>(deletes);
         for (int i = 0; i < deletes; ++i) {
-            deleteResponses.add(client().admin().cluster().prepareDeleteSnapshot(repoName, "*").execute());
+            deleteResponses.add(clusterAdmin().prepareDeleteSnapshot(repoName, "*").execute());
         }
         waitForBlock(masterName, repoName);
         awaitNDeletionsInProgress(1);
@@ -1273,10 +1254,10 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         blockMasterFromFinalizingSnapshotOnIndexFile(repoName);
         blockMasterFromFinalizingSnapshotOnIndexFile(otherRepoName);
 
-        client().admin().cluster().prepareCreateSnapshot(repoName, "snapshot-blocked-1").setWaitForCompletion(false).get();
-        client().admin().cluster().prepareCreateSnapshot(repoName, "snapshot-blocked-2").setWaitForCompletion(false).get();
-        client().admin().cluster().prepareCreateSnapshot(otherRepoName, "snapshot-other-blocked-1").setWaitForCompletion(false).get();
-        client().admin().cluster().prepareCreateSnapshot(otherRepoName, "snapshot-other-blocked-2").setWaitForCompletion(false).get();
+        clusterAdmin().prepareCreateSnapshot(repoName, "snapshot-blocked-1").setWaitForCompletion(false).get();
+        clusterAdmin().prepareCreateSnapshot(repoName, "snapshot-blocked-2").setWaitForCompletion(false).get();
+        clusterAdmin().prepareCreateSnapshot(otherRepoName, "snapshot-other-blocked-1").setWaitForCompletion(false).get();
+        clusterAdmin().prepareCreateSnapshot(otherRepoName, "snapshot-other-blocked-2").setWaitForCompletion(false).get();
 
         awaitNumberOfSnapshotsInProgress(4);
         final String initialMaster = internalCluster().getMasterName();
@@ -1323,7 +1304,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
 
         final ConcurrentSnapshotExecutionException cse = expectThrows(
             ConcurrentSnapshotExecutionException.class,
-            () -> client().admin().cluster().prepareCreateSnapshot(repoName, "expected-to-fail").execute().actionGet()
+            () -> clusterAdmin().prepareCreateSnapshot(repoName, "expected-to-fail").execute().actionGet()
         );
         assertThat(
             cse.getMessage(),
@@ -1337,7 +1318,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         );
         boolean deleteAndAbortAll = false;
         if (deleteFuture == null && randomBoolean()) {
-            deleteFuture = client().admin().cluster().prepareDeleteSnapshot(repoName, "*").execute();
+            deleteFuture = clusterAdmin().prepareDeleteSnapshot(repoName, "*").execute();
             deleteAndAbortAll = true;
             if (randomBoolean()) {
                 awaitNDeletionsInProgress(1);
@@ -1490,9 +1471,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         for (int i = 0; i < nbIndices; i++) {
             if (randomBoolean()) {
                 restoreFutures.add(
-                    client().admin()
-                        .cluster()
-                        .prepareRestoreSnapshot(repository, "snapshot-" + i)
+                    clusterAdmin().prepareRestoreSnapshot(repository, "snapshot-" + i)
                         .setIndices("index-" + i)
                         .setRenamePattern("(.+)")
                         .setRenameReplacement("$1-restored-" + i)
@@ -1501,11 +1480,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
                 );
             } else {
                 cloneFutures.add(
-                    client().admin()
-                        .cluster()
-                        .prepareCloneSnapshot(repository, "snapshot-" + i, "clone-" + i)
-                        .setIndices("index-" + i)
-                        .execute()
+                    clusterAdmin().prepareCloneSnapshot(repository, "snapshot-" + i, "clone-" + i).setIndices("index-" + i).execute()
                 );
             }
         }
@@ -2080,10 +2055,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     private static void assertSnapshotStatusCountOnRepo(String otherBlockedRepoName, int count) {
-        final SnapshotsStatusResponse snapshotsStatusResponse = client().admin()
-            .cluster()
-            .prepareSnapshotStatus(otherBlockedRepoName)
-            .get();
+        final SnapshotsStatusResponse snapshotsStatusResponse = clusterAdmin().prepareSnapshotStatus(otherBlockedRepoName).get();
         final List<SnapshotStatus> snapshotStatuses = snapshotsStatusResponse.getSnapshots();
         assertThat(snapshotStatuses, hasSize(count));
     }
@@ -2153,12 +2125,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
     }
 
     private static List<SnapshotInfo> currentSnapshots(String repoName) {
-        return client().admin()
-            .cluster()
-            .prepareGetSnapshots(repoName)
-            .setSnapshots(GetSnapshotsRequest.CURRENT_SNAPSHOT)
-            .get()
-            .getSnapshots();
+        return clusterAdmin().prepareGetSnapshots(repoName).setSnapshots(GetSnapshotsRequest.CURRENT_SNAPSHOT).get().getSnapshots();
     }
 
     private ActionFuture<AcknowledgedResponse> startAndBlockOnDeleteSnapshot(String repoName, String snapshotName) throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -70,9 +70,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         final String snapshot = "test-snap";
 
         logger.info("--> creating snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, snapshot)
+        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(repoName, snapshot)
             .setWaitForCompletion(true)
             .setIndices("test-idx-1")
             .get();
@@ -89,15 +87,12 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         assertRepositoryBlocked(repoName, snapshot);
 
         logger.info("--> recreate repository with same settings in order to reset corrupted state");
-        assertAcked(client().admin().cluster().preparePutRepository(repoName).setType("fs").setSettings(settings));
+        assertAcked(clusterAdmin().preparePutRepository(repoName).setType("fs").setSettings(settings));
 
         startDeleteSnapshot(repoName, snapshot).get();
 
         logger.info("--> make sure snapshot doesn't exist");
-        expectThrows(
-            SnapshotMissingException.class,
-            () -> client().admin().cluster().prepareGetSnapshots(repoName).addSnapshots(snapshot).get()
-        );
+        expectThrows(SnapshotMissingException.class, () -> clusterAdmin().prepareGetSnapshots(repoName).addSnapshots(snapshot).get());
     }
 
     public void testConcurrentlyChangeRepositoryContents() throws Exception {
@@ -200,9 +195,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         final String snapshot = "test-snap";
 
         logger.info("--> creating snapshot");
-        CreateSnapshotResponse createSnapshotResponse = client().admin()
-            .cluster()
-            .prepareCreateSnapshot(repoName, snapshot)
+        CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(repoName, snapshot)
             .setWaitForCompletion(true)
             .setIndices("test-idx-*")
             .get();
@@ -248,10 +241,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         assertThat(getRepositoryData(repoName).getGenId(), is(beforeMoveGen + 2));
 
         logger.info("--> make sure snapshot doesn't exist");
-        expectThrows(
-            SnapshotMissingException.class,
-            () -> client().admin().cluster().prepareGetSnapshots(repoName).addSnapshots(snapshot).get()
-        );
+        expectThrows(SnapshotMissingException.class, () -> clusterAdmin().prepareGetSnapshots(repoName).addSnapshots(snapshot).get());
     }
 
     public void testHandlingMissingRootLevelSnapshotMetadata() throws Exception {
@@ -274,9 +264,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         for (int i = 0; i < snapshots; ++i) {
             // Workaround to simulate BwC situation: taking a snapshot without indices here so that we don't create any new version shard
             // generations (the existence of which would short-circuit checks for the repo containing old version snapshots)
-            CreateSnapshotResponse createSnapshotResponse = client().admin()
-                .cluster()
-                .prepareCreateSnapshot(repoName, snapshotPrefix + i)
+            CreateSnapshotResponse createSnapshotResponse = clusterAdmin().prepareCreateSnapshot(repoName, snapshotPrefix + i)
                 .setIndices()
                 .setWaitForCompletion(true)
                 .get();
@@ -475,7 +463,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         );
 
         logger.info("--> recreating repository to clear caches");
-        client().admin().cluster().prepareDeleteRepository(repoName).get();
+        clusterAdmin().prepareDeleteRepository(repoName).get();
         createRepository(repoName, "fs", repoPath);
 
         createFullSnapshot(repoName, "snapshot-2");

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/DedicatedClusterSnapshotRestoreIT.java
@@ -196,7 +196,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
         logger.info("--> making sure that snapshot no longer exists");
         expectThrows(
             SnapshotMissingException.class,
-            () -> client().admin().cluster().prepareGetSnapshots("test-repo").setSnapshots("test-snap").execute().actionGet()
+            () -> clusterAdmin().prepareGetSnapshots("test-repo").setSnapshots("test-snap").execute().actionGet()
         );
 
         logger.info("--> Go through a loop of creating and deleting a snapshot to trigger repository cleanup");
@@ -1223,7 +1223,7 @@ public class DedicatedClusterSnapshotRestoreIT extends AbstractSnapshotIntegTest
 
     public void testGetReposWithWildcard() {
         internalCluster().startMasterOnlyNode();
-        List<RepositoryMetadata> repositoryMetadata = client().admin().cluster().prepareGetRepositories("*").get().repositories();
+        List<RepositoryMetadata> repositoryMetadata = clusterAdmin().prepareGetRepositories("*").get().repositories();
         assertThat(repositoryMetadata, empty());
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -75,9 +75,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertIndexMetadataLoads("snap", "others", 0);
 
         // Getting a snapshot does not load any metadata
-        GetSnapshotsResponse getSnapshotsResponse = client().admin()
-            .cluster()
-            .prepareGetSnapshots("repository")
+        GetSnapshotsResponse getSnapshotsResponse = clusterAdmin().prepareGetSnapshots("repository")
             .addSnapshots("snap")
             .setVerbose(randomBoolean())
             .get();
@@ -87,11 +85,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertIndexMetadataLoads("snap", "others", 0);
 
         // Getting the status of a snapshot loads indices metadata but not global metadata
-        SnapshotsStatusResponse snapshotStatusResponse = client().admin()
-            .cluster()
-            .prepareSnapshotStatus("repository")
-            .setSnapshots("snap")
-            .get();
+        SnapshotsStatusResponse snapshotStatusResponse = clusterAdmin().prepareSnapshotStatus("repository").setSnapshots("snap").get();
         assertThat(snapshotStatusResponse.getSnapshots(), hasSize(1));
         assertGlobalMetadataLoads("snap", 0);
         assertIndexMetadataLoads("snap", "docs", 1);
@@ -100,9 +94,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertAcked(client().admin().indices().prepareDelete("docs", "others"));
 
         // Restoring a snapshot loads indices metadata but not the global state
-        RestoreSnapshotResponse restoreSnapshotResponse = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot("repository", "snap")
+        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repository", "snap")
             .setWaitForCompletion(true)
             .get();
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
@@ -113,9 +105,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertAcked(client().admin().indices().prepareDelete("docs"));
 
         // Restoring a snapshot with selective indices loads only required index metadata
-        restoreSnapshotResponse = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot("repository", "snap")
+        restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repository", "snap")
             .setIndices("docs")
             .setWaitForCompletion(true)
             .get();
@@ -127,9 +117,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertAcked(client().admin().indices().prepareDelete("docs", "others"));
 
         // Restoring a snapshot including the global state loads it with the index metadata
-        restoreSnapshotResponse = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot("repository", "snap")
+        restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repository", "snap")
             .setIndices("docs", "oth*")
             .setRestoreGlobalState(true)
             .setWaitForCompletion(true)
@@ -140,7 +128,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertIndexMetadataLoads("snap", "others", 3);
 
         // Deleting a snapshot does not load the global metadata state but loads each index metadata
-        assertAcked(client().admin().cluster().prepareDeleteSnapshot("repository", "snap").get());
+        assertAcked(clusterAdmin().prepareDeleteSnapshot("repository", "snap").get());
         assertGlobalMetadataLoads("snap", 1);
         assertIndexMetadataLoads("snap", "docs", 4);
         assertIndexMetadataLoads("snap", "others", 3);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -916,7 +916,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String oldSnapshot = initWithSnapshotVersion(repoName, repoPath, oldVersion);
         final SnapshotRestoreException snapshotRestoreException = expectThrows(
             SnapshotRestoreException.class,
-            () -> client().admin().cluster().prepareRestoreSnapshot(repoName, oldSnapshot).execute().actionGet()
+            () -> clusterAdmin().prepareRestoreSnapshot(repoName, oldSnapshot).execute().actionGet()
         );
         assertThat(
             snapshotRestoreException.getMessage(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -80,7 +80,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
     public void testRandomActivities() throws InterruptedException {
-        final DiscoveryNodes discoveryNodes = client().admin().cluster().prepareState().clear().setNodes(true).get().getState().nodes();
+        final DiscoveryNodes discoveryNodes = clusterAdmin().prepareState().clear().setNodes(true).get().getState().nodes();
         new TrackedCluster(internalCluster(), nodeNames(discoveryNodes.getMasterNodes()), nodeNames(discoveryNodes.getDataNodes())).run();
         disableRepoConsistencyCheck("have not necessarily written to all repositories");
     }
@@ -338,20 +338,14 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
             if (failedPermitAcquisitions.isEmpty() == false) {
                 logger.warn("--> failed to acquire all permits: {}", failedPermitAcquisitions);
-                logger.info(
-                    "--> current cluster state:\n{}",
-                    Strings.toString(client().admin().cluster().prepareState().get().getState(), true, true)
-                );
+                logger.info("--> current cluster state:\n{}", Strings.toString(clusterAdmin().prepareState().get().getState(), true, true));
                 fail("failed to acquire all permits: " + failedPermitAcquisitions);
             }
             logger.info("--> acquired all permits");
 
             if (ThreadPool.terminate(threadPool, 30, TimeUnit.SECONDS) == false) {
                 logger.warn("--> threadpool termination timed out");
-                logger.info(
-                    "--> current cluster state:\n{}",
-                    Strings.toString(client().admin().cluster().prepareState().get().getState(), true, true)
-                );
+                logger.info("--> current cluster state:\n{}", Strings.toString(clusterAdmin().prepareState().get().getState(), true, true));
             }
         }
 
@@ -371,7 +365,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         logger.warn("--> failed to acquire permit [{}]", label);
                         logger.info(
                             "--> current cluster state:\n{}",
-                            Strings.toString(client().admin().cluster().prepareState().get().getState(), true, true)
+                            Strings.toString(clusterAdmin().prepareState().get().getState(), true, true)
                         );
                         logger.info(
                             "--> hot threads:\n{}",
@@ -550,9 +544,10 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
                 closeIndicesStep.addListener(mustSucceed(ignored1 -> deleteIndicesStep.addListener(mustSucceed(ignored2 -> {
 
-                    final RestoreSnapshotRequestBuilder restoreSnapshotRequestBuilder = client().admin()
-                        .cluster()
-                        .prepareRestoreSnapshot(snapshotInfo.repository(), snapshotInfo.snapshotId().getName());
+                    final RestoreSnapshotRequestBuilder restoreSnapshotRequestBuilder = clusterAdmin().prepareRestoreSnapshot(
+                        snapshotInfo.repository(),
+                        snapshotInfo.snapshotId().getName()
+                    );
 
                     if (restoreSpecificIndices) {
                         restoreSnapshotRequestBuilder.setIndices(indicesToRestore);
@@ -898,9 +893,10 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                             targetIndexNames
                         );
 
-                        final CreateSnapshotRequestBuilder createSnapshotRequestBuilder = client().admin()
-                            .cluster()
-                            .prepareCreateSnapshot(trackedRepository.repositoryName, snapshotName);
+                        final CreateSnapshotRequestBuilder createSnapshotRequestBuilder = clusterAdmin().prepareCreateSnapshot(
+                            trackedRepository.repositoryName,
+                            snapshotName
+                        );
 
                         if (snapshotSpecificIndices) {
                             createSnapshotRequestBuilder.setIndices(targetIndexNames.toArray(new String[0]));
@@ -988,10 +984,10 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         targetIndexNames
                     );
 
-                    final CreateSnapshotRequestBuilder createSnapshotRequestBuilder = client().admin()
-                        .cluster()
-                        .prepareCreateSnapshot(trackedRepository.repositoryName, snapshotName)
-                        .setPartial(true);
+                    final CreateSnapshotRequestBuilder createSnapshotRequestBuilder = clusterAdmin().prepareCreateSnapshot(
+                        trackedRepository.repositoryName,
+                        snapshotName
+                    ).setPartial(true);
 
                     if (snapshotSpecificIndices) {
                         createSnapshotRequestBuilder.setIndices(targetIndexNames.toArray(new String[0]));
@@ -1252,7 +1248,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         final Releasable releaseAll = localReleasables.transfer();
 
                         logger.info("--> delete repo [{}]", repositoryName);
-                        client().admin().cluster().prepareDeleteRepository(repositoryName).execute(mustSucceed(acknowledgedResponse -> {
+                        clusterAdmin().prepareDeleteRepository(repositoryName).execute(mustSucceed(acknowledgedResponse -> {
                             assertTrue(acknowledgedResponse.isAcknowledged());
                             logger.info("--> finished delete repo [{}]", repositoryName);
                             putRepositoryAndContinue(client, releaseAll);
@@ -1416,9 +1412,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
     // Prepares a health request with twice the default (30s) timeout that waits for all cluster tasks to finish as well as all cluster
     // nodes before returning
     private static ClusterHealthRequestBuilder prepareClusterHealthRequest(String... targetIndexNames) {
-        return client().admin()
-            .cluster()
-            .prepareHealth(targetIndexNames)
+        return clusterAdmin().prepareHealth(targetIndexNames)
             .setTimeout(TimeValue.timeValueSeconds(60))
             .setWaitForNodes(Integer.toString(internalCluster().getNodeNames().length))
             .setWaitForEvents(Priority.LANGUID);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotThrottlingIT.java
@@ -50,9 +50,7 @@ public class SnapshotThrottlingIT extends AbstractSnapshotIntegTestCase {
                 .put("max_restore_bytes_per_sec", maxRestoreBytesPerSec)
         );
         createSnapshot("test-repo", "test-snap", Collections.singletonList("test-idx"));
-        RestoreSnapshotResponse restoreSnapshotResponse = client().admin()
-            .cluster()
-            .prepareRestoreSnapshot("test-repo", "test-snap")
+        RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap")
             .setRenamePattern("test-")
             .setRenameReplacement("test2-")
             .setWaitForCompletion(true)

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -708,11 +708,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         // Stop a random data node so we lose a shard from the partial index
         internalCluster().stopRandomDataNode();
-        assertBusy(
-            () -> assertEquals(ClusterHealthStatus.RED, client().admin().cluster().prepareHealth().get().getStatus()),
-            30,
-            TimeUnit.SECONDS
-        );
+        assertBusy(() -> assertEquals(ClusterHealthStatus.RED, clusterAdmin().prepareHealth().get().getStatus()), 30, TimeUnit.SECONDS);
 
         // Get ready to block
         blockMasterFromFinalizingSnapshotOnIndexFile(REPO_NAME);


### PR DESCRIPTION
Just some automated refactoring I started a while back and ran through a couple more spots over the weekend. Using the shortcuts whereever possible has the potential of saving ~10k LoC across all tests so I figured I'd do 10% of that work here. Also it enables further simplifcations of common repeated patterns in internal cluster tests in follow-ups.
