### PR TITLE
Fixes breaking change introduced in #95558.

### DIFF
--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -235,7 +235,7 @@ PUT my-index-000001/_doc/1
 You can specify a list of patterns using a JSON array for either the
 `match` or `unmatch` fields.
 
-The next example matches all fields whose name starts with `ip_` or ends with `_ip`,
+The next example matches all fields whose name starts with `ip_` or ends with `_ip`, 
 except for fields which start with `one` or end with `two` and maps them
 as `ip` fields:
 
@@ -271,12 +271,6 @@ PUT my-index/_doc/1
 <2> The `ip_two` field is unmatched, so uses the default mapping of `text`.
 <3> The `three_ip` field is mapped as type `ip`.
 <4> The `ip_four` field is mapped as type `ip`.
-
-
-*Note:* when specifying patterns (for `match`, `unmatch`, etc.) in an array,
-{es} enforces that all values must be strings. However, for backwards
-compatibility, {es} allows non-string values (such as numbers) for
-single-valued match (and unmatch) fields.
 
 
 [[path-match-unmatch]]

--- a/docs/reference/mapping/dynamic/templates.asciidoc
+++ b/docs/reference/mapping/dynamic/templates.asciidoc
@@ -235,7 +235,7 @@ PUT my-index-000001/_doc/1
 You can specify a list of patterns using a JSON array for either the
 `match` or `unmatch` fields.
 
-The next example matches all fields whose name starts with `ip_` or ends with `_ip`, 
+The next example matches all fields whose name starts with `ip_` or ends with `_ip`,
 except for fields which start with `one` or end with `two` and maps them
 as `ip` fields:
 
@@ -271,6 +271,12 @@ PUT my-index/_doc/1
 <2> The `ip_two` field is unmatched, so uses the default mapping of `text`.
 <3> The `three_ip` field is mapped as type `ip`.
 <4> The `ip_four` field is mapped as type `ip`.
+
+
+*Note:* when specifying patterns (for `match`, `unmatch`, etc.) in an array,
+{es} enforces that all values must be strings. However, for backwards
+compatibility, {es} allows non-string values (such as numbers) for
+single-valued match (and unmatch) fields.
 
 
 [[path-match-unmatch]]

--- a/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DynamicTemplate.java
@@ -237,22 +237,20 @@ public class DynamicTemplate implements ToXContentObject {
     }
 
     private static void addEntriesToPatternList(List<String> matchList, String propName, Map.Entry<String, Object> entry) {
-        if (entry.getValue() instanceof String s) {
-            matchList.add(s);
-        } else if (entry.getValue() instanceof List<?> ls) {
+        if (entry.getValue() instanceof List<?> ls) {
             for (Object o : ls) {
                 if (o instanceof String s) {
                     matchList.add(s);
                 } else {
+                    // for array-based matches, we enforce that only strings are allowed as un/match values in the array
                     throw new MapperParsingException(
                         Strings.format("[%s] values must either be a string or list of strings, but was [%s]", propName, entry.getValue())
                     );
                 }
             }
         } else {
-            throw new MapperParsingException(
-                Strings.format("[%s] values must either be a string or list of strings, but was [%s]", propName, entry.getValue())
-            );
+            // to preserve backwards compatability for single-valued matches, we convert whatever the user provided to a string
+            matchList.add(entry.getValue().toString());
         }
     }
 


### PR DESCRIPTION
Match and unmatch fields in dynamic_templates (match, unmatch, path_match, path_unmatch) can either be single-valued or a list of values. If a list of values is provided, the values must all be strings. Numbers, boolean, other lists, etc. are not allowed and an error will be returned to the user in that case.

However, previously (before #95558) we allowed any JSON type for the match/unmatch fields (not just string), so changing that would be a breaking change. Thus, this commit no longer enforces string-only types for single-valued match/unmatch fields in dynamic_templates.