### PR TITLE
Clarifying that POST is required for the DLM lifecycle explain API

### DIFF
--- a/docs/reference/dlm/apis/explain-data-lifecycle.asciidoc
+++ b/docs/reference/dlm/apis/explain-data-lifecycle.asciidoc
@@ -11,7 +11,7 @@ Retrieves the current data lifecycle status for one or more data stream backing 
 [[dlm-explain-lifecycle-request]]
 ==== {api-request-title}
 
-`GET <target>/_lifecycle/explain`
+`POST <target>/_lifecycle/explain`
 
 [[dlm-explain-lifecycle-desc]]
 ==== {api-description-title}
@@ -43,7 +43,7 @@ The following example retrieves the lifecycle state of the index `.ds-metrics-20
 
 [source,console]
 --------------------------------------------------
-GET .ds-metrics-2023.03.22-000001/_lifecycle/explain
+POST .ds-metrics-2023.03.22-000001/_lifecycle/explain
 --------------------------------------------------
 // TEST[skip:we're not setting up DLM in these tests]
 


### PR DESCRIPTION
Our DLM lifecycle explain docs show that you use the `GET` method to call the lifecycle explain API. But in reality it requires a `POST`. This commit corrects our documentation to align with what the code actually does.