### PR TITLE
Don't propagate no such file in fs blob container

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -182,17 +182,19 @@ public class FsBlobContainer extends AbstractBlobContainer {
         long suppressedExceptions = 0;
         while (blobNames.hasNext()) {
             try {
-                IOUtils.rm(path.resolve(blobNames.next()));
-            } catch (FileNotFoundException e) {
-                // Ignore since this is "delete while ignoring not exists" method
+                Path resolve = path.resolve(blobNames.next());
+                IOUtils.rm(resolve);
             } catch (IOException e) {
-                // track up to 10 delete exceptions and try to continue deleting on exceptions
-                if (ioe == null) {
-                    ioe = e;
-                } else if (ioe.getSuppressed().length < 10) {
-                    ioe.addSuppressed(e);
-                } else {
-                    ++suppressedExceptions;
+                // IOUtils.rm puts the original exception as a string in the IOException message. Ignore no such file exception.
+                if (e.getMessage().contains("NoSuchFileException") == false) {
+                    // track up to 10 delete exceptions and try to continue deleting on exceptions
+                    if (ioe == null) {
+                        ioe = e;
+                    } else if (ioe.getSuppressed().length < 10) {
+                        ioe.addSuppressed(e);
+                    } else {
+                        ++suppressedExceptions;
+                    }
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
+++ b/server/src/main/java/org/elasticsearch/common/blobstore/fs/FsBlobContainer.java
@@ -183,6 +183,8 @@ public class FsBlobContainer extends AbstractBlobContainer {
         while (blobNames.hasNext()) {
             try {
                 IOUtils.rm(path.resolve(blobNames.next()));
+            } catch (FileNotFoundException e) {
+                // Ignore since this is "delete while ignoring not exists" method
             } catch (IOException e) {
                 // track up to 10 delete exceptions and try to continue deleting on exceptions
                 if (ioe == null) {


### PR DESCRIPTION
Blob container defines a method deleteBlobsIgnoringIfNotExists.
Currently in FsBlobContainer, this method is propogating a no such
file exception to the caller, when though the method name indicates
that should not happen.