### PR TITLE
Implement StartRecoveryRequest#getDescription

### DIFF
--- a/docs/changelog/95731.yaml
+++ b/docs/changelog/95731.yaml
@@ -1,0 +1,5 @@
+pr: 95731
+summary: Implement `StartRecoveryRequest#getDescription`
+area: Recovery
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StartRecoveryRequest.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.indices.recovery;
 
 import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.index.seqno.SequenceNumbers;
@@ -121,6 +122,22 @@ public class StartRecoveryRequest extends TransportRequest {
 
     public boolean canDownloadSnapshotFiles() {
         return canDownloadSnapshotFiles;
+    }
+
+    @Override
+    public String getDescription() {
+        return Strings.format(
+            """
+                recovery of %s to %s \
+                [recoveryId=%d, targetAllocationId=%s, startingSeqNo=%d, primaryRelocation=%s, canDownloadSnapshotFiles=%s]""",
+            shardId,
+            targetNode.descriptionWithoutAttributes(),
+            recoveryId,
+            targetAllocationId,
+            startingSeqNo,
+            primaryRelocation,
+            canDownloadSnapshotFiles
+        );
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -77,8 +77,9 @@ public class StartRecoveryRequestTests extends ESTestCase {
     public void testDescription() {
         final var node = new DiscoveryNode("a", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
         assertEquals(
-            "recovery of [index][0] to {a}{w4jpez6qQ42IMRLeOjUIsg}{0.0.0.0}{0.0.0.0:1}{8.9.0} [recoveryId=1, "
-                + "targetAllocationId=allocationId, startingSeqNo=-2, primaryRelocation=false, canDownloadSnapshotFiles=true]",
+            "recovery of [index][0] to "
+                + node.descriptionWithoutAttributes()
+                + " [recoveryId=1, targetAllocationId=allocationId, startingSeqNo=-2, primaryRelocation=false, canDownloadSnapshotFiles=true]",
             new StartRecoveryRequest(
                 new ShardId("index", "uuid", 0),
                 "allocationId",

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -74,4 +74,23 @@ public class StartRecoveryRequestTests extends ESTestCase {
         assertThat(outRequest.startingSeqNo(), equalTo(inRequest.startingSeqNo()));
     }
 
+    public void testDescription() {
+        final var node = new DiscoveryNode("a", buildNewFakeTransportAddress(), emptyMap(), emptySet(), Version.CURRENT);
+        assertEquals(
+            "recovery of [index][0] to {a}{w4jpez6qQ42IMRLeOjUIsg}{0.0.0.0}{0.0.0.0:1}{8.9.0} [recoveryId=1, "
+                + "targetAllocationId=allocationId, startingSeqNo=-2, primaryRelocation=false, canDownloadSnapshotFiles=true]",
+            new StartRecoveryRequest(
+                new ShardId("index", "uuid", 0),
+                "allocationId",
+                null,
+                node,
+                Store.MetadataSnapshot.EMPTY,
+                false,
+                1,
+                SequenceNumbers.UNASSIGNED_SEQ_NO,
+                true
+            ).getDescription()
+        );
+    }
+
 }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -79,7 +79,8 @@ public class StartRecoveryRequestTests extends ESTestCase {
         assertEquals(
             "recovery of [index][0] to "
                 + node.descriptionWithoutAttributes()
-                + " [recoveryId=1, targetAllocationId=allocationId, startingSeqNo=-2, primaryRelocation=false, canDownloadSnapshotFiles=true]",
+                + " [recoveryId=1, targetAllocationId=allocationId, startingSeqNo=-2, "
+                + "primaryRelocation=false, canDownloadSnapshotFiles=true]",
             new StartRecoveryRequest(
                 new ShardId("index", "uuid", 0),
                 "allocationId",


### PR DESCRIPTION
Today the transport actions associated with recoveries appear in the task list but there is nothing to identify which recovery is which. This commit adds that identifying information.