### PR TITLE
Docs: Add updateable flag to synonym filters

### DIFF
--- a/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-graph-tokenfilter.asciidoc
@@ -53,6 +53,9 @@ The above configures a `search_synonyms` filter, with a path of
 
 Additional settings are:
 
+* `updateable` (defaults to `false`). If `true` allows
+<<indices-reload-analyzers,reloading>> search analyzers to pick up
+changes to synonym files. Only to be used for search analyzers.
 * `expand` (defaults to `true`).
 * `lenient` (defaults to `false`). If `true` ignores exceptions while parsing the synonym configuration. It is important
 to note that only those synonym rules which cannot get parsed are ignored. For instance consider the following request:

--- a/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
+++ b/docs/reference/analysis/tokenfilters/synonym-tokenfilter.asciidoc
@@ -42,10 +42,13 @@ appear before it in the chain.
 
 Additional settings are:
 
+* `updateable` (defaults to `false`). If `true` allows
+<<indices-reload-analyzers,reloading>> search analyzers to pick up
+changes to synonym files. Only to be used for search analyzers.
 * `expand` (defaults to `true`).
 * `lenient` (defaults to `false`). If `true` ignores exceptions while parsing the synonym configuration. It is important
 to note that only those synonym rules which cannot get parsed are ignored. For instance consider the following request:
- 
+
 
 [source,console]
 --------------------------------------------------


### PR DESCRIPTION
In #45135 we introduced `updateable` flag to synonym filters, but we forgot to add this flag to documentation.
This PR fixes this.

Relates to #45135