### PR TITLE
[DOCS] Note limits for queries on downsampled indices

### DIFF
--- a/docs/reference/data-streams/downsampling-ilm.asciidoc
+++ b/docs/reference/data-streams/downsampling-ilm.asciidoc
@@ -401,7 +401,7 @@ index, in this case `downsample-6tkn-.ds-datastream-2022.08.26-000001`.
 // TEST[skip:todo]
 // TEST[continued]
 
-Run a search query on the datastream.
+Run a search query on the datastream (note that when querying downsampled indices there are <<querying-downsampled-indices-notes,a few nuances to be aware of>>).
 
 [source,console]
 ----

--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -376,7 +376,7 @@ DELETE /sample-01
 ==== View the results
 
 
-Re-run your search query:
+Re-run your search query (note that when querying downsampled indices there are <<querying-downsampled-indices-notes,a few nuances to be aware of>>):
 
 [source,console]
 ----

--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -123,9 +123,11 @@ on a downsampled index that has been downsampled at an hourly resolution
 minute 0, then 59 empty buckets, and then a bucket with data again for the next
 hour.
 
-NOTE:
+[discrete]
+[[querying-downsampled-indices-notes]]
+==== Notes on downsample queries
 
-There are a few things to note when querying downsampled indices:
+There are a few things to note about querying downsampled indices:
 
 * When you run queries in {kib} and through Elastic solutions, a normal
 response is returned without notification that some of the queried indices are


### PR DESCRIPTION
As [suggested](https://github.com/elastic/elasticsearch/issues/87986#issuecomment-1531627826) by @dej611, we should make it more obvious that when querying downsampled indices, timestamps are always in UTC format. 

I think rather than repeating the note about UTC format in three places, we could add a link in each of the downsampling examples (the manual one and the ILM one) that points to a "Notes on downsample queries" section. 

By the way, I called this section "Notes" rather than "Restrictions" or "Limitations" since: 
 - There's already a big section about downsampling restrictions on the page (which is about the downsampling process, rather than queries)
 - This leaves open the possibility that we include non-restriction content, such as tips.

Closes: #87986 
