### PR TITLE
Speed up indices stats yaml tests

### DIFF
--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/13_fields.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/13_fields.yml
@@ -4,13 +4,12 @@ setup:
   - do:
       indices.create:
           index:  test1
-          wait_for_active_shards: all
           body:
               settings:
                 # Limit the number of shards so that shards are unlikely
                 # to be relocated or being initialized between the test
                 # set up and the test execution
-                index.number_of_shards: 3
+                index.number_of_shards: 2
               mappings:
                   properties:
                       bar:
@@ -28,6 +27,7 @@ setup:
 
   - do:
       cluster.health:
+        index: test1
         wait_for_no_relocating_shards: true
 
   - do:


### PR DESCRIPTION
Backport of #95708 to 8.7 branch.

The tests in `13_fields.yml` file are taking a very long time in any test cluster with a single node. This is because the create index api call in the test setup waits for all shards to be allocated. Also for the replica shards and that never happens in a single node cluster. The create index api waits for this to happen for 30 seconds.

This seems to be added a while ago when dealing with mixed cluster rest test failures. No shards seem to be available in that past causing test failures. But the subsequent cluster health api should be sufficient to ensure that at least one copy per shard is allocated.

This change also changes the number of shards from 3 to 2 (2 shards is sufficient for this test) and bounds to cluster health api call only to test1 index.

Closes #95580