### PR TITLE
[Profiling] Add experimental support to resolve aliases for mget

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetShardRequest.java
@@ -26,8 +26,8 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
     private boolean realtime;
     private boolean refresh;
 
-    List<Integer> locations;
-    List<MultiGetRequest.Item> items;
+    public List<Integer> locations;
+    public List<MultiGetRequest.Item> items;
 
     /**
      * Should this request force {@link SourceLoader.Synthetic synthetic source}?
@@ -37,7 +37,7 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
      */
     private final boolean forceSyntheticSource;
 
-    MultiGetShardRequest(MultiGetRequest multiGetRequest, String index, int shardId) {
+    public MultiGetShardRequest(MultiGetRequest multiGetRequest, String index, int shardId) {
         super(index);
         this.shardId = shardId;
         locations = new ArrayList<>();
@@ -142,7 +142,7 @@ public class MultiGetShardRequest extends SingleShardRequest<MultiGetShardReques
         return forceSyntheticSource;
     }
 
-    void add(int location, MultiGetRequest.Item item) {
+    public void add(int location, MultiGetRequest.Item item) {
         this.locations.add(location);
         this.items.add(item);
     }

--- a/server/src/main/java/org/elasticsearch/action/get/MultiGetShardResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/get/MultiGetShardResponse.java
@@ -18,9 +18,9 @@ import java.util.List;
 
 public class MultiGetShardResponse extends ActionResponse {
 
-    final List<Integer> locations;
-    final List<GetResponse> responses;
-    final List<MultiGetResponse.Failure> failures;
+    public final List<Integer> locations;
+    public final List<GetResponse> responses;
+    public final List<MultiGetResponse.Failure> failures;
 
     MultiGetShardResponse() {
         locations = new ArrayList<>();

--- a/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
+++ b/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
@@ -18,7 +18,7 @@ public class GetProfilingActionIT extends ProfilingTestCase {
     }
 
     public void testGetProfilingDataUnfiltered() throws Exception {
-        GetProfilingRequest request = new GetProfilingRequest(1, null);
+        GetProfilingRequest request = new GetProfilingRequest(1, false, null);
         GetProfilingResponse response = client().execute(GetProfilingAction.INSTANCE, request).get();
         assertEquals(RestStatus.OK, response.status());
         assertEquals(1, response.getTotalFrames());

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingRequest.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingRequest.java
@@ -36,29 +36,35 @@ import static org.elasticsearch.index.query.AbstractQueryBuilder.parseTopLevelQu
 public class GetProfilingRequest extends ActionRequest implements IndicesRequest {
     public static final ParseField QUERY_FIELD = new ParseField("query");
     public static final ParseField SAMPLE_SIZE_FIELD = new ParseField("sample_size");
+    public static final ParseField RESOLVE_ALIASES_FIELD = new ParseField("resolve_aliases");
 
     private QueryBuilder query;
 
     private Integer sampleSize;
 
+    private Boolean resolveAliases;
+
     public GetProfilingRequest() {
-        this(null, null);
+        this(null, null, null);
     }
 
-    public GetProfilingRequest(Integer sampleSize, QueryBuilder query) {
+    public GetProfilingRequest(Integer sampleSize, Boolean resolveAliases, QueryBuilder query) {
         this.sampleSize = sampleSize;
         this.query = query;
+        this.resolveAliases = resolveAliases;
     }
 
     public GetProfilingRequest(StreamInput in) throws IOException {
         this.query = in.readOptionalNamedWriteable(QueryBuilder.class);
         this.sampleSize = in.readOptionalInt();
+        this.resolveAliases = in.readOptionalBoolean();
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalNamedWriteable(query);
         out.writeOptionalInt(sampleSize);
+        out.writeOptionalBoolean(resolveAliases);
     }
 
     public Integer getSampleSize() {
@@ -67,6 +73,10 @@ public class GetProfilingRequest extends ActionRequest implements IndicesRequest
 
     public QueryBuilder getQuery() {
         return query;
+    }
+
+    public boolean isResolveAliases() {
+        return resolveAliases != null && resolveAliases.booleanValue();
     }
 
     public void parseXContent(XContentParser parser) throws IOException {
@@ -86,6 +96,8 @@ public class GetProfilingRequest extends ActionRequest implements IndicesRequest
             } else if (token.isValue()) {
                 if (SAMPLE_SIZE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     this.sampleSize = parser.intValue();
+                } else if (RESOLVE_ALIASES_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                    this.resolveAliases = parser.booleanValue();
                 } else {
                     throw new ParsingException(
                         parser.getTokenLocation(),
@@ -167,6 +179,9 @@ public class GetProfilingRequest extends ActionRequest implements IndicesRequest
         indices.add("profiling-stacktraces");
         indices.add("profiling-stackframes");
         indices.add("profiling-executables");
+        indices.add("profiling-stacktraces-query");
+        indices.add("profiling-stackframes-query");
+        indices.add("profiling-executables-query");
         indices.addAll(EventsIndex.indexNames());
         return indices.toArray(new String[0]);
     }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackTrace.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackTrace.java
@@ -170,8 +170,17 @@ final class StackTrace implements ToXContentObject {
     }
 
     public static StackTrace fromSource(Map<String, Object> source) {
-        String inputFrameIDs = ObjectPath.eval("Stacktrace.frame.ids", source);
-        String inputFrameTypes = ObjectPath.eval("Stacktrace.frame.types", source);
+        String inputFrameIDs;
+        String inputFrameTypes;
+
+        // synthetic source
+        if (source.containsKey("Stacktrace")) {
+            inputFrameIDs = ObjectPath.eval("Stacktrace.frame.ids", source);
+            inputFrameTypes = ObjectPath.eval("Stacktrace.frame.types", source);
+        } else {
+            inputFrameIDs = source.get("Stacktrace.frame.ids").toString();
+            inputFrameTypes = source.get("Stacktrace.frame.types").toString();
+        }
         int countsFrameIDs = inputFrameIDs.length() / BASE64_FRAME_ID_LENGTH;
 
         List<String> fileIDs = new ArrayList<>(countsFrameIDs);

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingRequestTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingRequestTests.java
@@ -30,7 +30,7 @@ public class GetProfilingRequestTests extends ESTestCase {
         Integer sampleSize = randomBoolean() ? randomIntBetween(0, Integer.MAX_VALUE) : null;
         QueryBuilder query = randomBoolean() ? new BoolQueryBuilder() : null;
 
-        GetProfilingRequest request = new GetProfilingRequest(sampleSize, query);
+        GetProfilingRequest request = new GetProfilingRequest(sampleSize, false, query);
         try (BytesStreamOutput out = new BytesStreamOutput()) {
             request.writeTo(out);
             try (NamedWriteableAwareStreamInput in = new NamedWriteableAwareStreamInput(out.bytes().streamInput(), writableRegistry())) {


### PR DESCRIPTION
With this commit we add experimental support in the profiling plugin to resolve aliases that point to multiple indices before issuing mget requests. This is not intended to be merged but rather just for experimentation.