### PR TITLE
Fixes a typo in 7.0 migration guide

### DIFF
--- a/docs/reference/migration/migrate_7_0/analysis.asciidoc
+++ b/docs/reference/migration/migrate_7_0/analysis.asciidoc
@@ -63,8 +63,8 @@ or analyzing documents. Both names should be replaced by `ngram` or `edge_ngram`
 [discrete]
 ==== Limit to the difference between max_size and min_size in NGramTokenFilter and NGramTokenizer
 
-To safeguard against creating too many index terms, the difference between `max_ngram` and
-`min_ngram` in `NGramTokenFilter` and `NGramTokenizer` has been limited to 1. This default
+To safeguard against creating too many index terms, the difference between `max_gram` and
+`min_gram` in `NGramTokenFilter` and `NGramTokenizer` has been limited to 1. This default
 limit can be changed with the index setting `index.max_ngram_diff`. Note that if the limit is
 exceeded a error is thrown only for new indices. For existing pre-7.0 indices, a deprecation
 warning is logged.


### PR DESCRIPTION
This is a small fix to the 7.0 migration guide docs. There is a typo referencing the properties of the n-gram filter.