### PR TITLE
[8.8] Bad ref to 'node_id' parameter in Task Mgt doc (#90380)

### DIFF
--- a/docs/reference/cluster/tasks.asciidoc
+++ b/docs/reference/cluster/tasks.asciidoc
@@ -44,7 +44,7 @@ include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=detailed]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=group-by]
 
-include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=node-id-query-parm]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=nodes]
 
 include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=parent-task-id]
 

--- a/docs/reference/rest-api/common-parms.asciidoc
+++ b/docs/reference/rest-api/common-parms.asciidoc
@@ -714,12 +714,11 @@ tag::node-id[]
 returned information.
 end::node-id[]
 
-tag::node-id-query-parm[]
-`node_id`::
-(Optional, string)
-Comma-separated list of node IDs or names
-used to limit returned information.
-end::node-id-query-parm[]
+tag::nodes[]
+`nodes`::
+(Optional, string) Comma-separated list of node IDs or names used to limit
+returned information.
+end::nodes[]
 
 tag::offsets[]
 `<offsets>`::


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Bad ref to 'node_id' parameter in Task Mgt doc (#90380)