### PR TITLE
[ML] Re-enable upgrade tests with workaround for invalid pipeline config  

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -96,7 +96,6 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
         client().performRequest(request);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/95360")
     public void testTrainedModelDeployment() throws Exception {
         assumeTrue("NLP model deployments added in 8.0", UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_0_0));
 
@@ -112,10 +111,21 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                     request.addParameter("wait_for_status", "yellow");
                     request.addParameter("timeout", "70s");
                 }));
-                waitForDeploymentStarted(modelId);
-                // attempt inference on new and old nodes multiple times
-                for (int i = 0; i < 10; i++) {
-                    assertInfer(modelId);
+
+                // Workaround for an upgrade test failure where an ingest
+                // pipeline config cannot be parsed by older nodes:
+                // https://github.com/elastic/elasticsearch/issues/95766
+                //
+                // In version 8.3.1 ml stopped parsing the full ingest
+                // pipeline configuration so will avoid this problem.
+                // TODO remove this check once https://github.com/elastic/elasticsearch/issues/95766
+                // is resolved
+                if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_3_1)) {
+                    waitForDeploymentStarted(modelId);
+                    // attempt inference on new and old nodes multiple times
+                    for (int i = 0; i < 10; i++) {
+                        assertInfer(modelId);
+                    }
                 }
             }
             case UPGRADED -> {


### PR DESCRIPTION
In #95766 the ML trained model deployment upgrade tests fail due to an invalid ingest processor configuration.  ML stopped parsing the full ingest pipeline during a call to GET _ml/trained_models/_stats in version 8.3.1 so the tests can be re-enable when upgrading from 8.3.1 or later. Earlier versions are still tested but the problematic _stats call is skipped. 

Once #95766 is resolved these changes should be removed. 
Closes #95360