### PR TITLE
Checking that all nodes in the cluster are >= 8.8.0 before installing…

### DIFF
--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
@@ -61,7 +61,7 @@ public class AnalyticsIngestPipelineRegistry extends PipelineRegistry {
     }
 
     @Override
-    protected Version getMinClusterVersion() {
+    protected Version getMinSupportedNodeVersion() {
         return Version.V_8_8_0;
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistry.java
@@ -6,6 +6,7 @@
  */
 package org.elasticsearch.xpack.application.analytics;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
@@ -57,6 +58,11 @@ public class AnalyticsIngestPipelineRegistry extends PipelineRegistry {
     @Override
     protected boolean isClusterReady(ClusterChangedEvent event) {
         return super.isClusterReady(event) && (isIngestPipelineInstalled(event.state()) || hasAnalyticsEventDataStream(event.state()));
+    }
+
+    @Override
+    protected Version getMinClusterVersion() {
+        return Version.V_8_8_0;
     }
 
     private boolean hasAnalyticsEventDataStream(ClusterState state) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
@@ -86,17 +86,20 @@ public abstract class PipelineRegistry implements ClusterStateListener {
             return false;
         }
 
-        if (getMinClusterVersion() != null && event.state().nodes().getMinNodeVersion().onOrBefore(getMinClusterVersion())) {
-            // Not all node satisfies the minimum version requirement: skipping install.
+        Version minNodeVersion = event.state().nodes().getMinNodeVersion();
+        if (getMinSupportedNodeVersion().after(minNodeVersion)) {
             return false;
         }
 
         return true;
     }
 
-    protected Version getMinClusterVersion() {
-        return null;
-    }
+    /**
+     * Pipelines will not be installed until all nodes in the cluster are updated to at least the version returned by the method.
+     *
+     * @return {@link Version} minimum required version.
+     */
+    protected abstract Version getMinSupportedNodeVersion();
 
     private void addIngestPipelinesIfMissing(ClusterState state) {
         for (PipelineTemplateConfiguration pipelineTemplateConfig : getIngestPipelineConfigs()) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/utils/ingest/PipelineRegistry.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.application.utils.ingest;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ingest.PutPipelineAction;
 import org.elasticsearch.action.ingest.PutPipelineRequest;
@@ -85,7 +86,16 @@ public abstract class PipelineRegistry implements ClusterStateListener {
             return false;
         }
 
+        if (getMinClusterVersion() != null && event.state().nodes().getMinNodeVersion().onOrBefore(getMinClusterVersion())) {
+            // Not all node satisfies the minimum version requirement: skipping install.
+            return false;
+        }
+
         return true;
+    }
+
+    protected Version getMinClusterVersion() {
+        return null;
     }
 
     private void addIngestPipelinesIfMissing(ClusterState state) {

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsIngestPipelineRegistryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.application.analytics;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -173,6 +174,25 @@ public class AnalyticsIngestPipelineRegistryTests extends ESTestCase {
 
         client.setVerifier((a, r, l) -> {
             fail("if the master is missing nothing should happen");
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
+        registry.clusterChanged(event);
+    }
+
+    public void testThatNothingIsInstalledWhenAllNodesAreNotUpdated() {
+        DiscoveryNode updatedNode = TestDiscoveryNode.create("updatedNode");
+        DiscoveryNode outdatedNode = TestDiscoveryNode.create("outdatedNode", ESTestCase.buildNewFakeTransportAddress(), Version.V_8_7_0);
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .localNodeId("updatedNode")
+            .masterNodeId("updatedNode")
+            .add(updatedNode)
+            .add(outdatedNode)
+            .build();
+
+        client.setVerifier((a, r, l) -> {
+            fail("if some cluster mode are not updated to at least v.8.8.0 nothing should happen");
             return null;
         });
 


### PR DESCRIPTION
Closes #95766

We now avoid installing pipelines before all the nodes in the cluster are satisfying a minimum condition version.