### PR TITLE
Add support for serialization of Duration and Period

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -33,9 +33,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalTime;
 import java.time.OffsetTime;
+import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
@@ -781,6 +783,8 @@ public abstract class StreamInput extends InputStream {
             case 25 -> readCollection(StreamInput::readGenericValue, Sets::newHashSetWithExpectedSize, Collections.emptySet());
             case 26 -> readBigInteger();
             case 27 -> readOffsetTime();
+            case 28 -> readDuration();
+            case 29 -> readPeriod();
             default -> throw new IOException("Can't read unknown type [" + type + "]");
         };
     }
@@ -822,6 +826,19 @@ public abstract class StreamInput extends InputStream {
     private OffsetTime readOffsetTime() throws IOException {
         final String zoneOffsetId = readString();
         return OffsetTime.of(LocalTime.ofNanoOfDay(readLong()), ZoneOffset.of(zoneOffsetId));
+    }
+
+    private Duration readDuration() throws IOException {
+        final long seconds = readLong();
+        final long nanos = readLong();
+        return Duration.ofSeconds(seconds, nanos);
+    }
+
+    private Period readPeriod() throws IOException {
+        final int years = readInt();
+        final int months = readInt();
+        final int days = readInt();
+        return Period.of(years, months, days);
     }
 
     private static final Object[] EMPTY_OBJECT_ARRAY = new Object[0];

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamOutput.java
@@ -28,8 +28,10 @@ import org.elasticsearch.xcontent.XContentType;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.math.BigInteger;
+import java.time.Duration;
 import java.time.Instant;
 import java.time.OffsetTime;
+import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Arrays;
@@ -767,6 +769,19 @@ public abstract class StreamOutput extends OutputStream {
             final OffsetTime offsetTime = (OffsetTime) v;
             o.writeString(offsetTime.getOffset().getId());
             o.writeLong(offsetTime.toLocalTime().toNanoOfDay());
+        }),
+        entry(Duration.class, (o, v) -> {
+            o.writeByte((byte) 28);
+            final Duration duration = (Duration) v;
+            o.writeLong(duration.getSeconds());
+            o.writeLong(duration.getNano());
+        }),
+        entry(Period.class, (o, v) -> {
+            o.writeByte((byte) 29);
+            final Period period = (Period) v;
+            o.writeInt(period.getYears());
+            o.writeInt(period.getMonths());
+            o.writeInt(period.getDays());
         })
     );
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -28,8 +28,11 @@ import org.elasticsearch.test.ESTestCase;
 
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.time.Instant;
+import java.time.Period;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,6 +46,7 @@ import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -446,6 +450,61 @@ public abstract class AbstractStreamTests extends ESTestCase {
                 assertEquals(instant, serialized);
             }
         }
+    }
+
+    public void testDurationSerialization() throws IOException {
+        Stream.generate(AbstractStreamTests::randomDuration)
+            .limit(100)
+            .forEach(this::assertDurationSerialization);
+    }
+
+    void assertDurationSerialization(Duration duration) {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeGenericValue(duration);
+            try (StreamInput in = getStreamInput(out.bytes())) {
+                final Duration deserialized = (Duration) in.readGenericValue();
+                assertEquals(duration, deserialized);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    public void testPeriodSerialization() {
+        Stream.generate(AbstractStreamTests::randomPeriod)
+            .limit(100)
+            .forEach(this::assertPeriodSerialization);
+    }
+
+    void assertPeriodSerialization(Period period) {
+        try (BytesStreamOutput out = new BytesStreamOutput()) {
+            out.writeGenericValue(period);
+            try (StreamInput in = getStreamInput(out.bytes())) {
+                final Period deserialized = (Period) in.readGenericValue();
+                assertEquals(period, deserialized);
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    static Duration randomDuration() {
+        return randomFrom(List.of(
+            Duration.ofNanos(randomIntBetween(1, 100_000)),
+            Duration.ofMillis(randomIntBetween(1, 1_000)),
+            Duration.ofSeconds(randomIntBetween(1, 100)),
+            Duration.ofHours(randomIntBetween(1, 10)),
+            Duration.ofDays(randomIntBetween(1, 5))
+        ));
+    }
+
+    static Period randomPeriod() {
+        return randomFrom(List.of(
+            Period.ofDays(randomIntBetween(1, 31)),
+            Period.ofWeeks(randomIntBetween(1, 52)),
+            Period.ofMonths(randomIntBetween(1, 12)),
+            Period.ofYears(randomIntBetween(1, 1000))
+        ));
     }
 
     public void testOptionalInstantSerialization() throws IOException {

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -453,9 +453,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
     }
 
     public void testDurationSerialization() throws IOException {
-        Stream.generate(AbstractStreamTests::randomDuration)
-            .limit(100)
-            .forEach(this::assertDurationSerialization);
+        Stream.generate(AbstractStreamTests::randomDuration).limit(100).forEach(this::assertDurationSerialization);
     }
 
     void assertDurationSerialization(Duration duration) {
@@ -471,9 +469,7 @@ public abstract class AbstractStreamTests extends ESTestCase {
     }
 
     public void testPeriodSerialization() {
-        Stream.generate(AbstractStreamTests::randomPeriod)
-            .limit(100)
-            .forEach(this::assertPeriodSerialization);
+        Stream.generate(AbstractStreamTests::randomPeriod).limit(100).forEach(this::assertPeriodSerialization);
     }
 
     void assertPeriodSerialization(Period period) {
@@ -489,22 +485,26 @@ public abstract class AbstractStreamTests extends ESTestCase {
     }
 
     static Duration randomDuration() {
-        return randomFrom(List.of(
-            Duration.ofNanos(randomIntBetween(1, 100_000)),
-            Duration.ofMillis(randomIntBetween(1, 1_000)),
-            Duration.ofSeconds(randomIntBetween(1, 100)),
-            Duration.ofHours(randomIntBetween(1, 10)),
-            Duration.ofDays(randomIntBetween(1, 5))
-        ));
+        return randomFrom(
+            List.of(
+                Duration.ofNanos(randomIntBetween(1, 100_000)),
+                Duration.ofMillis(randomIntBetween(1, 1_000)),
+                Duration.ofSeconds(randomIntBetween(1, 100)),
+                Duration.ofHours(randomIntBetween(1, 10)),
+                Duration.ofDays(randomIntBetween(1, 5))
+            )
+        );
     }
 
     static Period randomPeriod() {
-        return randomFrom(List.of(
-            Period.ofDays(randomIntBetween(1, 31)),
-            Period.ofWeeks(randomIntBetween(1, 52)),
-            Period.ofMonths(randomIntBetween(1, 12)),
-            Period.ofYears(randomIntBetween(1, 1000))
-        ));
+        return randomFrom(
+            List.of(
+                Period.ofDays(randomIntBetween(1, 31)),
+                Period.ofWeeks(randomIntBetween(1, 52)),
+                Period.ofMonths(randomIntBetween(1, 12)),
+                Period.ofYears(randomIntBetween(1, 1000))
+            )
+        );
     }
 
     public void testOptionalInstantSerialization() throws IOException {


### PR DESCRIPTION
This commit adds support to stream's read/write generic value for `j.t.Duration` and `j.t.Period` (similar to `j.t.OffsetTime`).