### PR TITLE
Remove script context and lang apis from serverless

### DIFF
--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
@@ -13,8 +13,6 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetScriptContextRequ
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.Scope;
-import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptContextAction.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.PUBLIC)
 public class RestGetScriptContextAction extends BaseRestHandler {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
@@ -22,7 +22,6 @@ import java.util.List;
 
 import static org.elasticsearch.rest.RestRequest.Method.GET;
 
-@ServerlessScope(Scope.PUBLIC)
 public class RestGetScriptLanguageAction extends BaseRestHandler {
 
     @Override

--- a/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/admin/cluster/RestGetScriptLanguageAction.java
@@ -13,8 +13,6 @@ import org.elasticsearch.action.admin.cluster.storedscripts.GetScriptLanguageReq
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.Scope;
-import org.elasticsearch.rest.ServerlessScope;
 import org.elasticsearch.rest.action.RestToXContentListener;
 
 import java.io.IOException;


### PR DESCRIPTION
These APIs were made public under the assumption Kibana was using them, but they are not. This commit removes the public annotation for serverless.

relates ES-5792