### PR TITLE
[8.8] [DOCS] Note limits for queries on downsampled indices (#95749)

### DIFF
--- a/docs/reference/data-streams/downsampling-ilm.asciidoc
+++ b/docs/reference/data-streams/downsampling-ilm.asciidoc
@@ -401,7 +401,7 @@ index, in this case `downsample-6tkn-.ds-datastream-2022.08.26-000001`.
 // TEST[skip:todo]
 // TEST[continued]
 
-Run a search query on the datastream.
+Run a search query on the datastream (note that when querying downsampled indices there are <<querying-downsampled-indices-notes,a few nuances to be aware of>>).
 
 [source,console]
 ----

--- a/docs/reference/data-streams/downsampling-manual.asciidoc
+++ b/docs/reference/data-streams/downsampling-manual.asciidoc
@@ -376,7 +376,7 @@ DELETE /sample-01
 ==== View the results
 
 
-Re-run your search query:
+Re-run your search query (note that when querying downsampled indices there are <<querying-downsampled-indices-notes,a few nuances to be aware of>>):
 
 [source,console]
 ----

--- a/docs/reference/data-streams/downsampling.asciidoc
+++ b/docs/reference/data-streams/downsampling.asciidoc
@@ -123,9 +123,11 @@ on a downsampled index that has been downsampled at an hourly resolution
 minute 0, then 59 empty buckets, and then a bucket with data again for the next
 hour.
 
-NOTE:
+[discrete]
+[[querying-downsampled-indices-notes]]
+==== Notes on downsample queries
 
-There are a few things to note when querying downsampled indices:
+There are a few things to note about querying downsampled indices:
 
 * When you run queries in {kib} and through Elastic solutions, a normal
 response is returned without notification that some of the queried indices are


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Note limits for queries on downsampled indices (#95749)