### PR TITLE
[DOCS] Document xpack.ml.model_repository setting

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -175,7 +175,22 @@ cluster scaling. If you set it to the maximum possible size of future {ml} nodes
 when a {ml} job is assigned to a lazy node it can check (and fail quickly) when
 scaling cannot support the size of the job. When the {operator-feature} is
 enabled, this setting can be updated only by operator users. Defaults to `0b`,
-which means it will be assumed that automatic cluster scaling can add arbitrarily large nodes to the cluster. 
+which means it will be assumed that automatic cluster scaling can add 
+arbitrarily large nodes to the cluster. 
+
+[[xpack.ml.model_repository]]
+`xpack.ml.model_repository`::
+(<<cluster-update-settings,Dynamic>>)
+The location of the {ml} model repository where the model artifact files are 
+available in case of a modell installation in a restricted or closed network. 
+`xpack.ml.model_repository` can be a string of a file location or an HTTP/HTTPS 
+server. Example values can be:
+```
+xpack.ml.model_repository: file://${path.home}/config/models/
+xpack.ml.model_repository: https://my-custom-backend
+```
+If `xpack.ml.model_repository` is a file location, it must point to a 
+subdirectory of the `config` directory of {es}.
 
 `xpack.ml.persist_results_max_retries`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of times to retry bulk

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -182,7 +182,7 @@ arbitrarily large nodes to the cluster.
 `xpack.ml.model_repository`::
 (<<cluster-update-settings,Dynamic>>)
 The location of the {ml} model repository where the model artifact files are 
-available in case of a modell installation in a restricted or closed network. 
+available in case of a model installation in a restricted or closed network. 
 `xpack.ml.model_repository` can be a string of a file location or an HTTP/HTTPS 
 server. Example values can be:
 ```

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -184,9 +184,12 @@ arbitrarily large nodes to the cluster.
 The location of the {ml} model repository where the model artifact files are 
 available in case of a model installation in a restricted or closed network. 
 `xpack.ml.model_repository` can be a string of a file location or an HTTP/HTTPS 
-server. Example values can be:
+server. Example values are:
 ```
 xpack.ml.model_repository: file://${path.home}/config/models/
+```
+or
+```
 xpack.ml.model_repository: https://my-custom-backend
 ```
 If `xpack.ml.model_repository` is a file location, it must point to a 

--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -185,6 +185,8 @@ The location of the {ml} model repository where the model artifact files are
 available in case of a model installation in a restricted or closed network. 
 `xpack.ml.model_repository` can be a string of a file location or an HTTP/HTTPS 
 server. Example values are:
++
+--
 ```
 xpack.ml.model_repository: file://${path.home}/config/models/
 ```
@@ -194,6 +196,7 @@ xpack.ml.model_repository: https://my-custom-backend
 ```
 If `xpack.ml.model_repository` is a file location, it must point to a 
 subdirectory of the `config` directory of {es}.
+--
 
 `xpack.ml.persist_results_max_retries`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of times to retry bulk


### PR DESCRIPTION
## Overview

This PR documents the ML setting `xpack-ml.model_repository`.

### Preview

[ML settings](https://elasticsearch_95789.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/ml-settings.html)