### PR TITLE
Change TransportVersion to a record

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -62,7 +62,7 @@ import java.util.regex.Pattern;
  */
 public class TransportVersion implements Comparable<TransportVersion> {
 
-    private static final Map<String, Integer> IDS = new HashMap<>();
+    private static Map<String, Integer> IDS = new HashMap<>();
 
     private static TransportVersion registerTransportVersion(int id, String uniqueId) {
         Strings.requireNonEmpty(uniqueId, "Each TransportVersion needs a unique string id");
@@ -170,6 +170,11 @@ public class TransportVersion implements Comparable<TransportVersion> {
      * READ THE JAVADOC ABOVE BEFORE ADDING NEW TRANSPORT VERSIONS
      * Detached transport versions added below here.
      */
+
+    static {
+        // now we're registered the TVs, we can remove the map
+        IDS = null;
+    }
 
     /**
      * Reference to the most recent transport version.

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -59,6 +59,11 @@ import java.util.TreeMap;
  */
 public record TransportVersion(int id) implements Comparable<TransportVersion> {
 
+    /*
+     * NOTE: IntelliJ lies!
+     * This map is used during class construction, referenced by the registerTransportVersion method.
+     * When all the transport version constants have been registered, the map is cleared & never touched again.
+     */
     private static Map<String, Integer> IDS = new HashMap<>();
 
     private static TransportVersion registerTransportVersion(int id, String uniqueId) {
@@ -171,7 +176,8 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
      */
 
     static {
-        // now we're registered the TVs, we can remove the map
+        // see comment on IDS field
+        // now we're registered the transport versions, we can clear the map
         IDS = null;
     }
 
@@ -306,28 +312,4 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public String toString() {
         return Integer.toString(id);
     }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
-
-        TransportVersion version = (TransportVersion) o;
-
-        if (id != version.id) {
-            return false;
-        }
-
-        return true;
-    }
-
-    @Override
-    public int hashCode() {
-        return id;
-    }
-
 }

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -61,99 +61,111 @@ import java.util.regex.Pattern;
  * representing the reverted change. <em>Do not</em> let the transport version go backwards, it must <em>always</em> be incremented.
  */
 public class TransportVersion implements Comparable<TransportVersion> {
-    public static final TransportVersion ZERO = new TransportVersion(0, "00000000-0000-0000-0000-000000000000");
-    public static final TransportVersion V_7_0_0 = new TransportVersion(7_00_00_99, "7505fd05-d982-43ce-a63f-ff4c6c8bdeec");
-    public static final TransportVersion V_7_0_1 = new TransportVersion(7_00_01_99, "ae772780-e6f9-46a1-b0a0-20ed0cae37f7");
-    public static final TransportVersion V_7_1_0 = new TransportVersion(7_01_00_99, "fd09007c-1c54-450a-af99-9f941e1a53c2");
-    public static final TransportVersion V_7_1_1 = new TransportVersion(7_01_01_99, "f7ddb16c-3495-42ef-8d54-1461570ca68c");
-    public static final TransportVersion V_7_2_0 = new TransportVersion(7_02_00_99, "b74dbc52-e727-472c-af21-2156482e8796");
-    public static final TransportVersion V_7_2_1 = new TransportVersion(7_02_01_99, "a3217b94-f436-4aab-a020-162c83ba18f2");
-    public static final TransportVersion V_7_3_0 = new TransportVersion(7_03_00_99, "4f04e4c9-c5aa-49e4-8b99-abeb4e284a5a");
-    public static final TransportVersion V_7_3_1 = new TransportVersion(7_03_01_99, "532b9bc9-e11f-48a2-b997-67ca68ffb354");
-    public static final TransportVersion V_7_3_2 = new TransportVersion(7_03_02_99, "60da3953-8415-4d4f-a18d-853c3e68ebd6");
-    public static final TransportVersion V_7_4_0 = new TransportVersion(7_04_00_99, "ec7e58aa-55b4-4064-a9dd-fd723a2ba7a8");
-    public static final TransportVersion V_7_4_1 = new TransportVersion(7_04_01_99, "a316c26d-8e6a-4608-b1ec-062331552b98");
-    public static final TransportVersion V_7_4_2 = new TransportVersion(7_04_02_99, "031a77e1-3640-4c8a-80cf-28ded96bab48");
-    public static final TransportVersion V_7_5_0 = new TransportVersion(7_05_00_99, "cc6e14dc-9dc7-4b74-8e15-1f99a6cfbe03");
-    public static final TransportVersion V_7_5_1 = new TransportVersion(7_05_01_99, "9d12be44-16dc-44a8-a89a-45c9174ea596");
-    public static final TransportVersion V_7_5_2 = new TransportVersion(7_05_02_99, "484ed9de-7f5b-4e6b-a79a-0cb5e7570093");
-    public static final TransportVersion V_7_6_0 = new TransportVersion(7_06_00_99, "4637b8ae-f3df-43ae-a065-ad4c29f3373a");
-    public static final TransportVersion V_7_6_1 = new TransportVersion(7_06_01_99, "fe5b9f95-a311-4a92-943b-30ec256a331c");
-    public static final TransportVersion V_7_6_2 = new TransportVersion(7_06_02_99, "5396cb30-d91c-4789-85e8-77efd552c785");
-    public static final TransportVersion V_7_7_0 = new TransportVersion(7_07_00_99, "7bb73c48-ddb8-4437-b184-30371c35dd4b");
-    public static final TransportVersion V_7_7_1 = new TransportVersion(7_07_01_99, "85507b0f-0fca-4daf-a80b-451fe75e04a0");
-    public static final TransportVersion V_7_8_0 = new TransportVersion(7_08_00_99, "c3cc74af-d15e-494b-a907-6ad6dd2f4660");
-    public static final TransportVersion V_7_8_1 = new TransportVersion(7_08_01_99, "7acb9f6e-32f2-45ce-b87d-ca1f165b8e7a");
-    public static final TransportVersion V_7_9_0 = new TransportVersion(7_09_00_99, "9388fe76-192a-4053-b51c-d2a7b8eae545");
-    public static final TransportVersion V_7_9_1 = new TransportVersion(7_09_01_99, "30fa10fc-df6b-4435-bd9e-acdb9ae1b268");
-    public static final TransportVersion V_7_9_2 = new TransportVersion(7_09_02_99, "b58bb181-cecc-464e-b955-f6c1c1e7b4d0");
-    public static final TransportVersion V_7_9_3 = new TransportVersion(7_09_03_99, "4406926c-e2b6-4b9a-a72a-1bee8357ad3e");
-    public static final TransportVersion V_7_10_0 = new TransportVersion(7_10_00_99, "4efca195-38e4-4f74-b877-c26fb2a40733");
-    public static final TransportVersion V_7_10_1 = new TransportVersion(7_10_01_99, "0070260c-aa0b-4fc2-9c87-5cd5f23b005f");
-    public static final TransportVersion V_7_10_2 = new TransportVersion(7_10_02_99, "b369e2ed-261c-4b2f-8b42-0f0ba0549f8c");
-    public static final TransportVersion V_7_11_0 = new TransportVersion(7_11_00_99, "3b43bcbc-1c5e-4cc2-a3b4-8ac8b64239e8");
-    public static final TransportVersion V_7_11_1 = new TransportVersion(7_11_01_99, "2f75d13c-adde-4762-a46e-def8acce62b7");
-    public static final TransportVersion V_7_11_2 = new TransportVersion(7_11_02_99, "2c852a4b-236d-4e8b-9373-336c9b52685a");
-    public static final TransportVersion V_7_12_0 = new TransportVersion(7_12_00_99, "3be9ff6f-2d9f-4fc2-ba91-394dd5ebcf33");
-    public static final TransportVersion V_7_12_1 = new TransportVersion(7_12_01_99, "ee4fdfac-2039-4b00-b42d-579cbde7120c");
-    public static final TransportVersion V_7_13_0 = new TransportVersion(7_13_00_99, "e1fe494a-7c66-4571-8f8f-1d7e6d8df1b3");
-    public static final TransportVersion V_7_13_1 = new TransportVersion(7_13_01_99, "66bc8d82-36da-4d54-b22d-aca691dc3d70");
-    public static final TransportVersion V_7_13_2 = new TransportVersion(7_13_02_99, "2a6fc74c-4c44-4264-a619-37437cd2c5a0");
-    public static final TransportVersion V_7_13_3 = new TransportVersion(7_13_03_99, "a31592f5-f8d2-490c-a02e-da9501823d8d");
-    public static final TransportVersion V_7_13_4 = new TransportVersion(7_13_04_99, "3143240d-1831-4186-8a19-963336c4cea0");
-    public static final TransportVersion V_7_14_0 = new TransportVersion(7_14_00_99, "8cf0954c-b085-467f-b20b-3cb4b2e69e3e");
-    public static final TransportVersion V_7_14_1 = new TransportVersion(7_14_01_99, "3dbb62c3-cf73-4c76-8d5a-4ca70afe2c70");
-    public static final TransportVersion V_7_14_2 = new TransportVersion(7_14_02_99, "7943ae20-df60-45e5-97ba-82fc0dfc8b89");
-    public static final TransportVersion V_7_15_0 = new TransportVersion(7_15_00_99, "2273ac0e-00bb-4024-9e2e-ab78981623c6");
-    public static final TransportVersion V_7_15_1 = new TransportVersion(7_15_01_99, "a8c3503d-3452-45cf-b385-e855e16547fe");
-    public static final TransportVersion V_7_15_2 = new TransportVersion(7_15_02_99, "fbb8ad69-02e2-4c90-b2e4-23947107f8b4");
-    public static final TransportVersion V_7_16_0 = new TransportVersion(7_16_00_99, "59abadd2-25db-4547-a991-c92306a3934e");
-    public static final TransportVersion V_7_16_1 = new TransportVersion(7_16_01_99, "4ace6b6b-8bba-427f-8755-9e3b40092138");
-    public static final TransportVersion V_7_16_2 = new TransportVersion(7_16_02_99, "785567b9-b320-48ef-b538-1753228904cd");
-    public static final TransportVersion V_7_16_3 = new TransportVersion(7_16_03_99, "facf5ae7-3d4e-479c-9142-72529b784e30");
-    public static final TransportVersion V_7_17_0 = new TransportVersion(7_17_00_99, "322efe93-4c73-4e15-9274-bb76836c8fa8");
-    public static final TransportVersion V_7_17_1 = new TransportVersion(7_17_01_99, "51c72842-7974-4669-ad25-bf13ba307307");
-    public static final TransportVersion V_7_17_2 = new TransportVersion(7_17_02_99, "82bea8d0-bfea-47c2-b7d3-217d8feb67e3");
-    public static final TransportVersion V_7_17_3 = new TransportVersion(7_17_03_99, "a909c2f4-5cb8-46bf-af0f-cd18d1b7e9d2");
-    public static final TransportVersion V_7_17_4 = new TransportVersion(7_17_04_99, "5076e164-18a4-4373-8be7-15f1843c46db");
-    public static final TransportVersion V_7_17_5 = new TransportVersion(7_17_05_99, "da7e3509-7f61-4dd2-8d23-a61f628a62f6");
-    public static final TransportVersion V_7_17_6 = new TransportVersion(7_17_06_99, "a47ecf02-e457-474f-887d-ee15a7ebd969");
-    public static final TransportVersion V_7_17_7 = new TransportVersion(7_17_07_99, "108ba576-bb28-42f4-bcbf-845a0ce52560");
-    public static final TransportVersion V_7_17_8 = new TransportVersion(7_17_08_99, "82a3e70d-cf0e-4efb-ad16-6077ab9fe19f");
-    public static final TransportVersion V_7_17_9 = new TransportVersion(7_17_09_99, "afd50dda-735f-4eae-9309-3218ffec1b2d");
-    public static final TransportVersion V_7_17_10 = new TransportVersion(7_17_10_99, "18ae7108-6f7a-4205-adbb-cfcd6aa6ccc6");
-    public static final TransportVersion V_7_17_11 = new TransportVersion(7_17_11_99, "71c96c2a-e90b-4311-a4ac-23c453b075aa");
-    public static final TransportVersion V_8_0_0 = new TransportVersion(8_00_00_99, "c7d2372c-9f01-4a79-8b11-227d862dfe4f");
-    public static final TransportVersion V_8_0_1 = new TransportVersion(8_00_01_99, "56e044c3-37e5-4f7e-bd38-f493927354ac");
-    public static final TransportVersion V_8_1_0 = new TransportVersion(8_01_00_99, "3dc49dce-9cef-492a-ac8d-3cc79f6b4280");
-    public static final TransportVersion V_8_1_1 = new TransportVersion(8_01_01_99, "40cf32e5-17b0-4187-9de1-022cdea69db9");
-    public static final TransportVersion V_8_1_2 = new TransportVersion(8_01_02_99, "54aa6394-08f3-4db7-b82e-314ae4b5b562");
-    public static final TransportVersion V_8_1_3 = new TransportVersion(8_01_03_99, "9772b54b-1e14-485f-92e8-8847b3a3d569");
-    public static final TransportVersion V_8_2_0 = new TransportVersion(8_02_00_99, "8ce6d555-202e-47db-ab7d-ade9dda1b7e8");
-    public static final TransportVersion V_8_2_1 = new TransportVersion(8_02_01_99, "ffbb67e8-cc33-4b02-a995-b461d9ee36c8");
-    public static final TransportVersion V_8_2_2 = new TransportVersion(8_02_02_99, "2499ee77-187d-4e10-8366-8e60d5f03676");
-    public static final TransportVersion V_8_2_3 = new TransportVersion(8_02_03_99, "046aae43-3090-4ece-8c27-8d489f097548");
-    public static final TransportVersion V_8_3_0 = new TransportVersion(8_03_00_99, "559ddb66-d857-4208-bed5-a995ccf478ea");
-    public static final TransportVersion V_8_3_1 = new TransportVersion(8_03_01_99, "31f9b136-dbbe-4fa1-b811-d6afa2a1b472");
-    public static final TransportVersion V_8_3_2 = new TransportVersion(8_03_02_99, "f6e9cd4c-2a71-4f9b-80d4-7ba97ebd18b2");
-    public static final TransportVersion V_8_3_3 = new TransportVersion(8_03_03_99, "a784de3e-533e-4844-8728-c55c6932dd8e");
-    public static final TransportVersion V_8_4_0 = new TransportVersion(8_04_00_99, "c0d12906-aa5b-45d4-94c7-cbcf4d9818ca");
-    public static final TransportVersion V_8_4_1 = new TransportVersion(8_04_01_99, "9a915f76-f259-4361-b53d-3f19c7797fd8");
-    public static final TransportVersion V_8_4_2 = new TransportVersion(8_04_02_99, "87c5b7b2-0f57-4172-8a81-b9f9a0198525");
-    public static final TransportVersion V_8_4_3 = new TransportVersion(8_04_03_99, "327cb1a0-9b5d-4be9-8033-285c2549f770");
-    public static final TransportVersion V_8_5_0 = new TransportVersion(8_05_00_99, "be3d7f23-7240-4904-9d7f-e25a0f766eca");
-    public static final TransportVersion V_8_5_1 = new TransportVersion(8_05_01_99, "d349d202-f01c-4dbb-85dd-947fb4267c99");
-    public static final TransportVersion V_8_5_2 = new TransportVersion(8_05_02_99, "b68b1331-fd64-44d9-9e71-f6796ec2024c");
-    public static final TransportVersion V_8_5_3 = new TransportVersion(8_05_03_99, "9ca3c835-e3b7-4622-a08e-d51e42403b06");
-    public static final TransportVersion V_8_5_4 = new TransportVersion(8_05_04_99, "97ee525c-555d-45ca-83dc-59cd592c8e86");
-    public static final TransportVersion V_8_6_0 = new TransportVersion(8_06_00_99, "e209c5ed-3488-4415-b561-33492ca3b789");
-    public static final TransportVersion V_8_6_1 = new TransportVersion(8_06_01_99, "9f113acb-1b21-4fda-bef9-2a3e669b5c7b");
-    public static final TransportVersion V_8_6_2 = new TransportVersion(8_06_02_99, "5a82fb68-b265-4a06-97c5-53496f823f51");
-    public static final TransportVersion V_8_7_0 = new TransportVersion(8_07_00_99, "f1ee7a85-4fa6-43f5-8679-33e2b750448b");
-    public static final TransportVersion V_8_7_1 = new TransportVersion(8_07_01_99, "018de9d8-9e8b-4ac7-8f4b-3a6fbd0487fb");
-    public static final TransportVersion V_8_7_2 = new TransportVersion(8_07_02_99, "bd84976c-fb8a-4a4c-b017-9563f8d888d9");
-    public static final TransportVersion V_8_8_0 = new TransportVersion(8_08_00_99, "f64fe576-0767-4ec3-984e-3e30b33b6c46");
-    public static final TransportVersion V_8_9_0 = new TransportVersion(8_09_00_99, "13c1c2cb-d975-461f-ab98-309ebc1c01bc");
+
+    private static final Map<String, Integer> IDS = new HashMap<>();
+
+    private static TransportVersion registerTransportVersion(int id, String uniqueId) {
+        Strings.requireNonEmpty(uniqueId, "Each TransportVersion needs a unique string id");
+        Integer existing = IDS.put(uniqueId, id);
+        if (existing != null) {
+            throw new IllegalArgumentException("Versions " + id + " and " + existing + " have the same unique id");
+        }
+        return new TransportVersion(id);
+    }
+
+    public static final TransportVersion ZERO = registerTransportVersion(0, "00000000-0000-0000-0000-000000000000");
+    public static final TransportVersion V_7_0_0 = registerTransportVersion(7_00_00_99, "7505fd05-d982-43ce-a63f-ff4c6c8bdeec");
+    public static final TransportVersion V_7_0_1 = registerTransportVersion(7_00_01_99, "ae772780-e6f9-46a1-b0a0-20ed0cae37f7");
+    public static final TransportVersion V_7_1_0 = registerTransportVersion(7_01_00_99, "fd09007c-1c54-450a-af99-9f941e1a53c2");
+    public static final TransportVersion V_7_1_1 = registerTransportVersion(7_01_01_99, "f7ddb16c-3495-42ef-8d54-1461570ca68c");
+    public static final TransportVersion V_7_2_0 = registerTransportVersion(7_02_00_99, "b74dbc52-e727-472c-af21-2156482e8796");
+    public static final TransportVersion V_7_2_1 = registerTransportVersion(7_02_01_99, "a3217b94-f436-4aab-a020-162c83ba18f2");
+    public static final TransportVersion V_7_3_0 = registerTransportVersion(7_03_00_99, "4f04e4c9-c5aa-49e4-8b99-abeb4e284a5a");
+    public static final TransportVersion V_7_3_1 = registerTransportVersion(7_03_01_99, "532b9bc9-e11f-48a2-b997-67ca68ffb354");
+    public static final TransportVersion V_7_3_2 = registerTransportVersion(7_03_02_99, "60da3953-8415-4d4f-a18d-853c3e68ebd6");
+    public static final TransportVersion V_7_4_0 = registerTransportVersion(7_04_00_99, "ec7e58aa-55b4-4064-a9dd-fd723a2ba7a8");
+    public static final TransportVersion V_7_4_1 = registerTransportVersion(7_04_01_99, "a316c26d-8e6a-4608-b1ec-062331552b98");
+    public static final TransportVersion V_7_4_2 = registerTransportVersion(7_04_02_99, "031a77e1-3640-4c8a-80cf-28ded96bab48");
+    public static final TransportVersion V_7_5_0 = registerTransportVersion(7_05_00_99, "cc6e14dc-9dc7-4b74-8e15-1f99a6cfbe03");
+    public static final TransportVersion V_7_5_1 = registerTransportVersion(7_05_01_99, "9d12be44-16dc-44a8-a89a-45c9174ea596");
+    public static final TransportVersion V_7_5_2 = registerTransportVersion(7_05_02_99, "484ed9de-7f5b-4e6b-a79a-0cb5e7570093");
+    public static final TransportVersion V_7_6_0 = registerTransportVersion(7_06_00_99, "4637b8ae-f3df-43ae-a065-ad4c29f3373a");
+    public static final TransportVersion V_7_6_1 = registerTransportVersion(7_06_01_99, "fe5b9f95-a311-4a92-943b-30ec256a331c");
+    public static final TransportVersion V_7_6_2 = registerTransportVersion(7_06_02_99, "5396cb30-d91c-4789-85e8-77efd552c785");
+    public static final TransportVersion V_7_7_0 = registerTransportVersion(7_07_00_99, "7bb73c48-ddb8-4437-b184-30371c35dd4b");
+    public static final TransportVersion V_7_7_1 = registerTransportVersion(7_07_01_99, "85507b0f-0fca-4daf-a80b-451fe75e04a0");
+    public static final TransportVersion V_7_8_0 = registerTransportVersion(7_08_00_99, "c3cc74af-d15e-494b-a907-6ad6dd2f4660");
+    public static final TransportVersion V_7_8_1 = registerTransportVersion(7_08_01_99, "7acb9f6e-32f2-45ce-b87d-ca1f165b8e7a");
+    public static final TransportVersion V_7_9_0 = registerTransportVersion(7_09_00_99, "9388fe76-192a-4053-b51c-d2a7b8eae545");
+    public static final TransportVersion V_7_9_1 = registerTransportVersion(7_09_01_99, "30fa10fc-df6b-4435-bd9e-acdb9ae1b268");
+    public static final TransportVersion V_7_9_2 = registerTransportVersion(7_09_02_99, "b58bb181-cecc-464e-b955-f6c1c1e7b4d0");
+    public static final TransportVersion V_7_9_3 = registerTransportVersion(7_09_03_99, "4406926c-e2b6-4b9a-a72a-1bee8357ad3e");
+    public static final TransportVersion V_7_10_0 = registerTransportVersion(7_10_00_99, "4efca195-38e4-4f74-b877-c26fb2a40733");
+    public static final TransportVersion V_7_10_1 = registerTransportVersion(7_10_01_99, "0070260c-aa0b-4fc2-9c87-5cd5f23b005f");
+    public static final TransportVersion V_7_10_2 = registerTransportVersion(7_10_02_99, "b369e2ed-261c-4b2f-8b42-0f0ba0549f8c");
+    public static final TransportVersion V_7_11_0 = registerTransportVersion(7_11_00_99, "3b43bcbc-1c5e-4cc2-a3b4-8ac8b64239e8");
+    public static final TransportVersion V_7_11_1 = registerTransportVersion(7_11_01_99, "2f75d13c-adde-4762-a46e-def8acce62b7");
+    public static final TransportVersion V_7_11_2 = registerTransportVersion(7_11_02_99, "2c852a4b-236d-4e8b-9373-336c9b52685a");
+    public static final TransportVersion V_7_12_0 = registerTransportVersion(7_12_00_99, "3be9ff6f-2d9f-4fc2-ba91-394dd5ebcf33");
+    public static final TransportVersion V_7_12_1 = registerTransportVersion(7_12_01_99, "ee4fdfac-2039-4b00-b42d-579cbde7120c");
+    public static final TransportVersion V_7_13_0 = registerTransportVersion(7_13_00_99, "e1fe494a-7c66-4571-8f8f-1d7e6d8df1b3");
+    public static final TransportVersion V_7_13_1 = registerTransportVersion(7_13_01_99, "66bc8d82-36da-4d54-b22d-aca691dc3d70");
+    public static final TransportVersion V_7_13_2 = registerTransportVersion(7_13_02_99, "2a6fc74c-4c44-4264-a619-37437cd2c5a0");
+    public static final TransportVersion V_7_13_3 = registerTransportVersion(7_13_03_99, "a31592f5-f8d2-490c-a02e-da9501823d8d");
+    public static final TransportVersion V_7_13_4 = registerTransportVersion(7_13_04_99, "3143240d-1831-4186-8a19-963336c4cea0");
+    public static final TransportVersion V_7_14_0 = registerTransportVersion(7_14_00_99, "8cf0954c-b085-467f-b20b-3cb4b2e69e3e");
+    public static final TransportVersion V_7_14_1 = registerTransportVersion(7_14_01_99, "3dbb62c3-cf73-4c76-8d5a-4ca70afe2c70");
+    public static final TransportVersion V_7_14_2 = registerTransportVersion(7_14_02_99, "7943ae20-df60-45e5-97ba-82fc0dfc8b89");
+    public static final TransportVersion V_7_15_0 = registerTransportVersion(7_15_00_99, "2273ac0e-00bb-4024-9e2e-ab78981623c6");
+    public static final TransportVersion V_7_15_1 = registerTransportVersion(7_15_01_99, "a8c3503d-3452-45cf-b385-e855e16547fe");
+    public static final TransportVersion V_7_15_2 = registerTransportVersion(7_15_02_99, "fbb8ad69-02e2-4c90-b2e4-23947107f8b4");
+    public static final TransportVersion V_7_16_0 = registerTransportVersion(7_16_00_99, "59abadd2-25db-4547-a991-c92306a3934e");
+    public static final TransportVersion V_7_16_1 = registerTransportVersion(7_16_01_99, "4ace6b6b-8bba-427f-8755-9e3b40092138");
+    public static final TransportVersion V_7_16_2 = registerTransportVersion(7_16_02_99, "785567b9-b320-48ef-b538-1753228904cd");
+    public static final TransportVersion V_7_16_3 = registerTransportVersion(7_16_03_99, "facf5ae7-3d4e-479c-9142-72529b784e30");
+    public static final TransportVersion V_7_17_0 = registerTransportVersion(7_17_00_99, "322efe93-4c73-4e15-9274-bb76836c8fa8");
+    public static final TransportVersion V_7_17_1 = registerTransportVersion(7_17_01_99, "51c72842-7974-4669-ad25-bf13ba307307");
+    public static final TransportVersion V_7_17_2 = registerTransportVersion(7_17_02_99, "82bea8d0-bfea-47c2-b7d3-217d8feb67e3");
+    public static final TransportVersion V_7_17_3 = registerTransportVersion(7_17_03_99, "a909c2f4-5cb8-46bf-af0f-cd18d1b7e9d2");
+    public static final TransportVersion V_7_17_4 = registerTransportVersion(7_17_04_99, "5076e164-18a4-4373-8be7-15f1843c46db");
+    public static final TransportVersion V_7_17_5 = registerTransportVersion(7_17_05_99, "da7e3509-7f61-4dd2-8d23-a61f628a62f6");
+    public static final TransportVersion V_7_17_6 = registerTransportVersion(7_17_06_99, "a47ecf02-e457-474f-887d-ee15a7ebd969");
+    public static final TransportVersion V_7_17_7 = registerTransportVersion(7_17_07_99, "108ba576-bb28-42f4-bcbf-845a0ce52560");
+    public static final TransportVersion V_7_17_8 = registerTransportVersion(7_17_08_99, "82a3e70d-cf0e-4efb-ad16-6077ab9fe19f");
+    public static final TransportVersion V_7_17_9 = registerTransportVersion(7_17_09_99, "afd50dda-735f-4eae-9309-3218ffec1b2d");
+    public static final TransportVersion V_7_17_10 = registerTransportVersion(7_17_10_99, "18ae7108-6f7a-4205-adbb-cfcd6aa6ccc6");
+    public static final TransportVersion V_7_17_11 = registerTransportVersion(7_17_11_99, "71c96c2a-e90b-4311-a4ac-23c453b075aa");
+    public static final TransportVersion V_8_0_0 = registerTransportVersion(8_00_00_99, "c7d2372c-9f01-4a79-8b11-227d862dfe4f");
+    public static final TransportVersion V_8_0_1 = registerTransportVersion(8_00_01_99, "56e044c3-37e5-4f7e-bd38-f493927354ac");
+    public static final TransportVersion V_8_1_0 = registerTransportVersion(8_01_00_99, "3dc49dce-9cef-492a-ac8d-3cc79f6b4280");
+    public static final TransportVersion V_8_1_1 = registerTransportVersion(8_01_01_99, "40cf32e5-17b0-4187-9de1-022cdea69db9");
+    public static final TransportVersion V_8_1_2 = registerTransportVersion(8_01_02_99, "54aa6394-08f3-4db7-b82e-314ae4b5b562");
+    public static final TransportVersion V_8_1_3 = registerTransportVersion(8_01_03_99, "9772b54b-1e14-485f-92e8-8847b3a3d569");
+    public static final TransportVersion V_8_2_0 = registerTransportVersion(8_02_00_99, "8ce6d555-202e-47db-ab7d-ade9dda1b7e8");
+    public static final TransportVersion V_8_2_1 = registerTransportVersion(8_02_01_99, "ffbb67e8-cc33-4b02-a995-b461d9ee36c8");
+    public static final TransportVersion V_8_2_2 = registerTransportVersion(8_02_02_99, "2499ee77-187d-4e10-8366-8e60d5f03676");
+    public static final TransportVersion V_8_2_3 = registerTransportVersion(8_02_03_99, "046aae43-3090-4ece-8c27-8d489f097548");
+    public static final TransportVersion V_8_3_0 = registerTransportVersion(8_03_00_99, "559ddb66-d857-4208-bed5-a995ccf478ea");
+    public static final TransportVersion V_8_3_1 = registerTransportVersion(8_03_01_99, "31f9b136-dbbe-4fa1-b811-d6afa2a1b472");
+    public static final TransportVersion V_8_3_2 = registerTransportVersion(8_03_02_99, "f6e9cd4c-2a71-4f9b-80d4-7ba97ebd18b2");
+    public static final TransportVersion V_8_3_3 = registerTransportVersion(8_03_03_99, "a784de3e-533e-4844-8728-c55c6932dd8e");
+    public static final TransportVersion V_8_4_0 = registerTransportVersion(8_04_00_99, "c0d12906-aa5b-45d4-94c7-cbcf4d9818ca");
+    public static final TransportVersion V_8_4_1 = registerTransportVersion(8_04_01_99, "9a915f76-f259-4361-b53d-3f19c7797fd8");
+    public static final TransportVersion V_8_4_2 = registerTransportVersion(8_04_02_99, "87c5b7b2-0f57-4172-8a81-b9f9a0198525");
+    public static final TransportVersion V_8_4_3 = registerTransportVersion(8_04_03_99, "327cb1a0-9b5d-4be9-8033-285c2549f770");
+    public static final TransportVersion V_8_5_0 = registerTransportVersion(8_05_00_99, "be3d7f23-7240-4904-9d7f-e25a0f766eca");
+    public static final TransportVersion V_8_5_1 = registerTransportVersion(8_05_01_99, "d349d202-f01c-4dbb-85dd-947fb4267c99");
+    public static final TransportVersion V_8_5_2 = registerTransportVersion(8_05_02_99, "b68b1331-fd64-44d9-9e71-f6796ec2024c");
+    public static final TransportVersion V_8_5_3 = registerTransportVersion(8_05_03_99, "9ca3c835-e3b7-4622-a08e-d51e42403b06");
+    public static final TransportVersion V_8_5_4 = registerTransportVersion(8_05_04_99, "97ee525c-555d-45ca-83dc-59cd592c8e86");
+    public static final TransportVersion V_8_6_0 = registerTransportVersion(8_06_00_99, "e209c5ed-3488-4415-b561-33492ca3b789");
+    public static final TransportVersion V_8_6_1 = registerTransportVersion(8_06_01_99, "9f113acb-1b21-4fda-bef9-2a3e669b5c7b");
+    public static final TransportVersion V_8_6_2 = registerTransportVersion(8_06_02_99, "5a82fb68-b265-4a06-97c5-53496f823f51");
+    public static final TransportVersion V_8_7_0 = registerTransportVersion(8_07_00_99, "f1ee7a85-4fa6-43f5-8679-33e2b750448b");
+    public static final TransportVersion V_8_7_1 = registerTransportVersion(8_07_01_99, "018de9d8-9e8b-4ac7-8f4b-3a6fbd0487fb");
+    public static final TransportVersion V_8_7_2 = registerTransportVersion(8_07_02_99, "bd84976c-fb8a-4a4c-b017-9563f8d888d9");
+    public static final TransportVersion V_8_8_0 = registerTransportVersion(8_08_00_99, "f64fe576-0767-4ec3-984e-3e30b33b6c46");
+    public static final TransportVersion V_8_9_0 = registerTransportVersion(8_09_00_99, "13c1c2cb-d975-461f-ab98-309ebc1c01bc");
     /*
      * READ THE JAVADOC ABOVE BEFORE ADDING NEW TRANSPORT VERSIONS
      * Detached transport versions added below here.
@@ -179,7 +191,6 @@ public class TransportVersion implements Comparable<TransportVersion> {
 
     static NavigableMap<Integer, TransportVersion> getAllVersionIds(Class<?> cls) {
         Map<Integer, String> versionIdFields = new HashMap<>();
-        Map<String, String> uniqueIdFields = new HashMap<>();
         NavigableMap<Integer, TransportVersion> builder = new TreeMap<>();
 
         Set<String> ignore = Set.of("ZERO", "CURRENT", "MINIMUM_COMPATIBLE", "MINIMUM_CCS_VERSION");
@@ -241,15 +252,6 @@ public class TransportVersion implements Comparable<TransportVersion> {
                         assert false : "Version [" + fieldName + "] does not have the correct name format";
                         continue;
                     }
-
-                    // check the id is unique
-                    var sameUniqueId = uniqueIdFields.put(version.uniqueId, fieldName);
-                    assert sameUniqueId == null
-                        : "Versions ["
-                            + fieldName
-                            + "] and ["
-                            + sameUniqueId
-                            + "] have the same unique id. Each TransportVersion should have a different unique id";
                 }
             }
         }
@@ -273,7 +275,7 @@ public class TransportVersion implements Comparable<TransportVersion> {
             return known;
         }
         // this is a version we don't otherwise know about - just create a placeholder
-        return new TransportVersion(id, "<unknown>");
+        return new TransportVersion(id);
     }
 
     public static void writeVersion(TransportVersion version, StreamOutput out) throws IOException {
@@ -295,11 +297,9 @@ public class TransportVersion implements Comparable<TransportVersion> {
     }
 
     public final int id;
-    private final String uniqueId;
 
-    TransportVersion(int id, String uniqueId) {
+    TransportVersion(int id) {
         this.id = id;
-        this.uniqueId = Strings.requireNonEmpty(uniqueId, "Each TransportVersion needs a unique string id");
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -60,11 +60,13 @@ import java.util.regex.Pattern;
  * If you revert a commit with a transport version change, you <em>must</em> ensure there is a <em>new</em> transport version
  * representing the reverted change. <em>Do not</em> let the transport version go backwards, it must <em>always</em> be incremented.
  */
-public class TransportVersion implements Comparable<TransportVersion> {
+public record TransportVersion(int id) implements Comparable<TransportVersion> {
 
     private static Map<String, Integer> IDS = new HashMap<>();
 
     private static TransportVersion registerTransportVersion(int id, String uniqueId) {
+        if (IDS == null) throw new IllegalStateException("The IDS map needs to be present to call this method");
+
         Strings.requireNonEmpty(uniqueId, "Each TransportVersion needs a unique string id");
         Integer existing = IDS.put(uniqueId, id);
         if (existing != null) {
@@ -299,12 +301,6 @@ public class TransportVersion implements Comparable<TransportVersion> {
      */
     public static TransportVersion max(TransportVersion version1, TransportVersion version2) {
         return version1.id > version2.id ? version1 : version2;
-    }
-
-    public final int id;
-
-    TransportVersion(int id) {
-        this.id = id;
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/info/NodesInfoResponse.java
@@ -64,7 +64,7 @@ public class NodesInfoResponse extends BaseNodesResponse<NodeInfo> implements To
             builder.field("ip", nodeInfo.getNode().getHostAddress());
 
             builder.field("version", nodeInfo.getVersion());
-            builder.field("transport_version", nodeInfo.getTransportVersion().id);
+            builder.field("transport_version", nodeInfo.getTransportVersion().id());
             // flavor no longer exists, but we keep it here for backcompat
             builder.field("build_flavor", "default");
             builder.field("build_type", nodeInfo.getBuild().type().displayName());

--- a/server/src/main/java/org/elasticsearch/transport/TcpHeader.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpHeader.java
@@ -68,7 +68,7 @@ public class TcpHeader {
         }
         output.writeLong(requestId);
         output.writeByte(status);
-        output.writeInt(version.id);
+        output.writeInt(version.id());
         if (version.onOrAfter(VERSION_WITH_HEADER_SIZE)) {
             assert variableHeaderSize != -1 : "Variable header size not set";
             output.writeInt(variableHeaderSize);

--- a/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
+++ b/server/src/main/java/org/elasticsearch/transport/TcpTransport.java
@@ -274,7 +274,7 @@ public abstract class TcpTransport extends AbstractLifecycleComponent implements
         public Version getVersion() {
             // TODO: this should be the below, but in some cases the node version does not match the passed-in version.
             // return node.getVersion();
-            return Version.fromId(version.id);
+            return Version.fromId(version.id());
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -56,26 +56,20 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public static class CorrectFakeVersion {
-        public static final TransportVersion V_0_00_01 = new TransportVersion(199, "1");
-        public static final TransportVersion V_0_000_002 = new TransportVersion(2, "2");
-        public static final TransportVersion V_0_000_003 = new TransportVersion(3, "3");
-        public static final TransportVersion V_0_000_004 = new TransportVersion(4, "4");
+        public static final TransportVersion V_0_00_01 = new TransportVersion(199);
+        public static final TransportVersion V_0_000_002 = new TransportVersion(2);
+        public static final TransportVersion V_0_000_003 = new TransportVersion(3);
+        public static final TransportVersion V_0_000_004 = new TransportVersion(4);
     }
 
     public static class IncorrectFormatVersion {
-        public static final TransportVersion V_1 = new TransportVersion(1, "1");
+        public static final TransportVersion V_1 = new TransportVersion(1);
     }
 
     public static class DuplicatedIdFakeVersion {
-        public static final TransportVersion V_0_000_001 = new TransportVersion(1, "1");
-        public static final TransportVersion V_0_000_002 = new TransportVersion(2, "2");
-        public static final TransportVersion V_0_000_003 = new TransportVersion(2, "3");
-    }
-
-    public static class DuplicatedStringIdFakeVersion {
-        public static final TransportVersion V_0_000_001 = new TransportVersion(1, "1");
-        public static final TransportVersion V_0_000_002 = new TransportVersion(2, "2");
-        public static final TransportVersion V_0_000_003 = new TransportVersion(3, "2");
+        public static final TransportVersion V_0_000_001 = new TransportVersion(1);
+        public static final TransportVersion V_0_000_002 = new TransportVersion(2);
+        public static final TransportVersion V_0_000_003 = new TransportVersion(2);
     }
 
     public void testStaticTransportVersionChecks() {
@@ -98,8 +92,6 @@ public class TransportVersionTests extends ESTestCase {
         assertThat(e.getMessage(), containsString("does not have the correct name format"));
         e = expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(DuplicatedIdFakeVersion.class));
         assertThat(e.getMessage(), containsString("have the same version number"));
-        e = expectThrows(AssertionError.class, () -> TransportVersion.getAllVersionIds(DuplicatedStringIdFakeVersion.class));
-        assertThat(e.getMessage(), containsString("have the same unique id"));
     }
 
     public void testDefinedConstants() throws IllegalAccessException {

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -138,7 +138,7 @@ public class TransportVersionTests extends ESTestCase {
         );
         TransportVersion version = TransportVersionUtils.randomVersion();
         TransportVersion version1 = TransportVersionUtils.randomVersion();
-        if (version.id <= version1.id) {
+        if (version.id() <= version1.id()) {
             assertEquals(version, TransportVersion.min(version1, version));
         } else {
             assertEquals(version1, TransportVersion.min(version1, version));
@@ -150,7 +150,7 @@ public class TransportVersionTests extends ESTestCase {
         assertEquals(TransportVersion.CURRENT, TransportVersion.max(TransportVersion.fromId(1_01_01_99), TransportVersion.CURRENT));
         TransportVersion version = TransportVersionUtils.randomVersion();
         TransportVersion version1 = TransportVersionUtils.randomVersion();
-        if (version.id >= version1.id) {
+        if (version.id() >= version1.id()) {
             assertEquals(version, TransportVersion.max(version1, version));
         } else {
             assertEquals(version1, TransportVersion.max(version1, version));
@@ -159,12 +159,12 @@ public class TransportVersionTests extends ESTestCase {
 
     public void testVersionConstantPresent() {
         Set<TransportVersion> ignore = Set.of(TransportVersion.ZERO, TransportVersion.CURRENT, TransportVersion.MINIMUM_COMPATIBLE);
-        assertThat(TransportVersion.CURRENT, sameInstance(TransportVersion.fromId(TransportVersion.CURRENT.id)));
+        assertThat(TransportVersion.CURRENT, sameInstance(TransportVersion.fromId(TransportVersion.CURRENT.id())));
         final int iters = scaledRandomIntBetween(20, 100);
         for (int i = 0; i < iters; i++) {
             TransportVersion version = TransportVersionUtils.randomVersion(ignore);
 
-            assertThat(version, sameInstance(TransportVersion.fromId(version.id)));
+            assertThat(version, sameInstance(TransportVersion.fromId(version.id())));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/InboundDecoderTests.java
@@ -401,7 +401,7 @@ public class InboundDecoderTests extends ESTestCase {
             throw new AssertionError(e);
         }
 
-        var invalid = TransportVersion.fromId(TransportHandshaker.EARLIEST_HANDSHAKE_VERSION.id - 1);
+        var invalid = TransportVersion.fromId(TransportHandshaker.EARLIEST_HANDSHAKE_VERSION.id() - 1);
         try {
             InboundDecoder.checkHandshakeVersionCompatibility(invalid);
             fail();

--- a/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportActionProxyTests.java
@@ -53,7 +53,7 @@ public class TransportActionProxyTests extends ESTestCase {
     protected MockTransportService serviceA;
 
     protected static final Version version1 = Version.fromId(CURRENT_VERSION.id + 1);
-    protected static final TransportVersion transportVersion1 = TransportVersion.fromId(TransportVersion.CURRENT.id + 1);
+    protected static final TransportVersion transportVersion1 = TransportVersion.fromId(TransportVersion.CURRENT.id() + 1);
     protected DiscoveryNode nodeB;
     protected MockTransportService serviceB;
 

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -122,7 +122,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
     protected ClusterSettings clusterSettingsA;
 
     protected static final Version version1 = Version.fromId(version0.id + 1);
-    protected static final TransportVersion transportVersion1 = TransportVersion.fromId(transportVersion0.id + 1);
+    protected static final TransportVersion transportVersion1 = TransportVersion.fromId(transportVersion0.id() + 1);
     protected volatile DiscoveryNode nodeB;
     protected volatile MockTransportService serviceB;
 
@@ -2200,7 +2200,7 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
 
     public void testHandshakeWithIncompatVersion() {
         assumeTrue("only tcp transport has a handshake method", serviceA.getOriginalTransport() instanceof TcpTransport);
-        TransportVersion transportVersion = TransportVersion.fromId(TransportVersion.MINIMUM_COMPATIBLE.id - 1);
+        TransportVersion transportVersion = TransportVersion.fromId(TransportVersion.MINIMUM_COMPATIBLE.id() - 1);
         try (
             MockTransportService service = buildService(
                 "TS_C",

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/TokenService.java
@@ -2091,7 +2091,7 @@ public final class TokenService {
         } catch (ExecutionException e) {
             throw new ElasticsearchSecurityException("Failed to compute secret key for active salt", e);
         }
-        cipher.updateAAD(ByteBuffer.allocate(4).putInt(version.id).array());
+        cipher.updateAAD(ByteBuffer.allocate(4).putInt(version.id()).array());
         cipher.updateAAD(salt.bytes);
         return cipher;
     }
@@ -2135,7 +2135,7 @@ public final class TokenService {
     private Cipher getDecryptionCipher(byte[] iv, SecretKey key, TransportVersion version, BytesKey salt) throws GeneralSecurityException {
         Cipher cipher = Cipher.getInstance(ENCRYPTION_CIPHER);
         cipher.init(Cipher.DECRYPT_MODE, key, new GCMParameterSpec(128, iv), secureRandom);
-        cipher.updateAAD(ByteBuffer.allocate(4).putInt(version.id).array());
+        cipher.updateAAD(ByteBuffer.allocate(4).putInt(version.id()).array());
         cipher.updateAAD(salt.bytes);
         return cipher;
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/UserToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/UserToken.java
@@ -126,7 +126,7 @@ public final class UserToken implements Writeable, ToXContentObject {
         builder.startObject();
         builder.field("id", id);
         builder.field("expiration_time", expirationTime.toEpochMilli());
-        builder.field("version", version.id);
+        builder.field("version", version.id());
         builder.field("metadata", metadata);
         try (BytesStreamOutput output = new BytesStreamOutput()) {
             output.setTransportVersion(version);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/ServerTransportFilter.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/transport/ServerTransportFilter.java
@@ -105,7 +105,7 @@ class ServerTransportFilter {
             if (authentication != null) {
                 if (securityAction.equals(TransportService.HANDSHAKE_ACTION_NAME)
                     && SystemUser.is(authentication.getEffectiveSubject().getUser()) == false) {
-                    securityContext.executeAsSystemUser(TransportVersion.fromId(version.id), original -> {
+                    securityContext.executeAsSystemUser(version, original -> {
                         final Authentication replaced = securityContext.getAuthentication();
                         authzService.authorize(replaced, securityAction, request, listener);
                     });

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plugin/CursorTests.java
@@ -50,7 +50,7 @@ public class CursorTests extends ESTestCase {
         // encoded with a different but compatible version
         assertEquals(
             cursor,
-            decodeFromString(encodeToString(cursor, TransportVersion.fromId(TransportVersion.CURRENT.id + 1), randomZone()))
+            decodeFromString(encodeToString(cursor, TransportVersion.fromId(TransportVersion.CURRENT.id() + 1), randomZone()))
         );
 
         TransportVersion otherVersion = TransportVersionUtils.randomVersionBetween(


### PR DESCRIPTION
Change `TransportVersion` to a record. This then allows the JVM to inline the `id` field access.

As part of this, checking the unique id is moved to somewhat hacky static constructors that are then thrown away after initialization.