### PR TITLE
[8.8] [DOCS] Document xpack.ml.model_repository setting (#95789)

### DIFF
--- a/docs/reference/settings/ml-settings.asciidoc
+++ b/docs/reference/settings/ml-settings.asciidoc
@@ -175,7 +175,28 @@ cluster scaling. If you set it to the maximum possible size of future {ml} nodes
 when a {ml} job is assigned to a lazy node it can check (and fail quickly) when
 scaling cannot support the size of the job. When the {operator-feature} is
 enabled, this setting can be updated only by operator users. Defaults to `0b`,
-which means it will be assumed that automatic cluster scaling can add arbitrarily large nodes to the cluster. 
+which means it will be assumed that automatic cluster scaling can add 
+arbitrarily large nodes to the cluster. 
+
+[[xpack.ml.model_repository]]
+`xpack.ml.model_repository`::
+(<<cluster-update-settings,Dynamic>>)
+The location of the {ml} model repository where the model artifact files are 
+available in case of a model installation in a restricted or closed network. 
+`xpack.ml.model_repository` can be a string of a file location or an HTTP/HTTPS 
+server. Example values are:
++
+--
+```
+xpack.ml.model_repository: file://${path.home}/config/models/
+```
+or
+```
+xpack.ml.model_repository: https://my-custom-backend
+```
+If `xpack.ml.model_repository` is a file location, it must point to a 
+subdirectory of the `config` directory of {es}.
+--
 
 `xpack.ml.persist_results_max_retries`::
 (<<cluster-update-settings,Dynamic>>) The maximum number of times to retry bulk


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Document xpack.ml.model_repository setting (#95789)](https://github.com/elastic/elasticsearch/pull/95789)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)