### PR TITLE
[8.7] Fix release highlights generator (#95747)

### DIFF
--- a/build-tools-internal/src/main/resources/templates/release-highlights.asciidoc
+++ b/build-tools-internal/src/main/resources/templates/release-highlights.asciidoc
@@ -4,19 +4,18 @@
 coming::[{minor-version}]
 
 Here are the highlights of what's new and improved in {es} {minor-version}!
-ifeval::[\\{release-state}\\"!=\\"unreleased\\"]
+ifeval::["{release-state}"!="unreleased"]
 For detailed information about this release, see the <<es-release-notes>> and
 <<breaking-changes>>.
-endif::[]
 <% if (priorVersions.size() > 0) { %>
 // Add previous release to the list
 Other versions:
 
 <%
 print priorVersions.join("\n| ")
-print "\n"
-}
-
+print "\n" }%>
+endif::[]
+<%
 /* The `notable-highlights` tag needs to exist, whether or not we actually have any notable highlights. */
 if (notableHighlights.isEmpty()) { %>
 // The notable-highlights tag marks entries that

--- a/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGeneratorTest.generateFile.asciidoc
+++ b/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGeneratorTest.generateFile.asciidoc
@@ -4,10 +4,9 @@
 coming::[{minor-version}]
 
 Here are the highlights of what's new and improved in {es} {minor-version}!
-ifeval::[\{release-state}\"!=\"unreleased\"]
+ifeval::["{release-state}"!="unreleased"]
 For detailed information about this release, see the <<es-release-notes>> and
 <<breaking-changes>>.
-endif::[]
 
 // Add previous release to the list
 Other versions:
@@ -16,6 +15,8 @@ Other versions:
 | {ref-bare}/8.2/release-highlights.html[8.2]
 | {ref-bare}/8.1/release-highlights.html[8.1]
 | {ref-bare}/8.0/release-highlights.html[8.0]
+
+endif::[]
 
 // tag::notable-highlights[]
 

--- a/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGeneratorTest.noHighlights.generateFile.asciidoc
+++ b/build-tools-internal/src/test/resources/org/elasticsearch/gradle/internal/release/ReleaseHighlightsGeneratorTest.noHighlights.generateFile.asciidoc
@@ -4,10 +4,9 @@
 coming::[{minor-version}]
 
 Here are the highlights of what's new and improved in {es} {minor-version}!
-ifeval::[\{release-state}\"!=\"unreleased\"]
+ifeval::["{release-state}"!="unreleased"]
 For detailed information about this release, see the <<es-release-notes>> and
 <<breaking-changes>>.
-endif::[]
 
 // Add previous release to the list
 Other versions:
@@ -16,6 +15,8 @@ Other versions:
 | {ref-bare}/8.2/release-highlights.html[8.2]
 | {ref-bare}/8.1/release-highlights.html[8.1]
 | {ref-bare}/8.0/release-highlights.html[8.0]
+
+endif::[]
 
 // The notable-highlights tag marks entries that
 // should be featured in the Stack Installation and Upgrade Guide:


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix release highlights generator (#95747)