### PR TITLE
[8.7] Update snyk ci job to use branch as target reference (#95794)

### DIFF
--- a/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring.yml
+++ b/.ci/jobs.t/elastic+elasticsearch+periodic+snyk-dependency-monitoring.yml
@@ -18,4 +18,4 @@
           export SNYK_TOKEN=$(vault read -field=token secret/elasticsearch-ci/snyk)
           unset VAULT_TOKEN
           set -x
-          $WORKSPACE/.ci/scripts/run-gradle.sh uploadSnykDependencyGraph
+          $WORKSPACE/.ci/scripts/run-gradle.sh uploadSnykDependencyGraph -PsnykTargetReference=%BRANCH%


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Update snyk ci job to use branch as target reference (#95794)