### PR TITLE
Refactor BWC handling to support more flexible testing scenarios

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -84,11 +84,11 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
         TaskProvider<LoggedExec> addRemoteTaskProvider = tasks.register("addRemote", LoggedExec.class, addRemote -> {
             addRemote.dependsOn(findRemoteTaskProvider);
             addRemote.onlyIf("remote exists", task -> ((boolean) extraProperties.get("remoteExists")) == false);
-            addRemote.getWorkingDir().set(gitExtension.getCheckoutDir().get());
+            addRemote.getWorkingDir().set(gitExtension.getCheckoutDir());
             String remoteRepo = remote.get();
             // for testing only we can override the base remote url
             String remoteRepoUrl = providerFactory.systemProperty("testRemoteRepo")
-                .getOrElse("https://github.com/" + remoteRepo + "/elasticsearch.git");
+                .getOrElse("https://github.com/" + remoteRepo + "/" + project.getRootProject().getName());
             addRemote.commandLine("git", "remote", "add", remoteRepo, remoteRepoUrl);
         });
 
@@ -105,8 +105,9 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
             });
             fetchLatest.onlyIf("online and gitFetchLatest == true", t -> isOffline == false && gitFetchLatest.get());
             fetchLatest.dependsOn(addRemoteTaskProvider);
-            fetchLatest.getWorkingDir().set(gitExtension.getCheckoutDir().get());
-            fetchLatest.commandLine("git", "fetch", "--all");
+            fetchLatest.getWorkingDir().set(gitExtension.getCheckoutDir());
+            // Fetch latest from remotes, including tags, overriding any existing local refs
+            fetchLatest.commandLine("git", "fetch", "--all", "--tags", "--force");
         });
 
         String projectPath = project.getPath();
@@ -119,13 +120,14 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
                     String bwcBranch = gitExtension.getBwcBranch().get();
                     final String refspec = providerFactory.systemProperty("bwc.refspec." + bwcBranch)
                         .orElse(providerFactory.systemProperty("tests.bwc.refspec." + bwcBranch))
+                        .orElse(task.getExtensions().getExtraProperties().get("refspec").toString())
                         .getOrElse(remote.get() + "/" + bwcBranch);
 
                     String effectiveRefSpec = maybeAlignedRefSpec(task.getLogger(), refspec);
                     task.getLogger().lifecycle("Performing checkout of {}...", refspec);
                     LoggedExec.exec(execOperations, spec -> {
                         spec.workingDir(checkoutDir);
-                        spec.commandLine("git", "checkout", effectiveRefSpec);
+                        spec.commandLine("git", "checkout", "--recurse-submodules", effectiveRefSpec);
                     });
 
                     String checkoutHash = GitInfo.gitInfo(checkoutDir).getRevision();

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -120,7 +120,11 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
                     String bwcBranch = gitExtension.getBwcBranch().get();
                     final String refspec = providerFactory.systemProperty("bwc.refspec." + bwcBranch)
                         .orElse(providerFactory.systemProperty("tests.bwc.refspec." + bwcBranch))
-                        .orElse(task.getExtensions().getExtraProperties().get("refspec").toString())
+                        .orElse(
+                            task.getExtensions().getExtraProperties().has("refspec")
+                                ? task.getExtensions().getExtraProperties().get("refspec").toString()
+                                : null
+                        )
                         .getOrElse(remote.get() + "/" + bwcBranch);
 
                     String effectiveRefSpec = maybeAlignedRefSpec(task.getLogger(), refspec);

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalBwcGitPlugin.java
@@ -121,9 +121,11 @@ public class InternalBwcGitPlugin implements Plugin<Project> {
                     final String refspec = providerFactory.systemProperty("bwc.refspec." + bwcBranch)
                         .orElse(providerFactory.systemProperty("tests.bwc.refspec." + bwcBranch))
                         .orElse(
-                            task.getExtensions().getExtraProperties().has("refspec")
-                                ? task.getExtensions().getExtraProperties().get("refspec").toString()
-                                : null
+                            providerFactory.provider(
+                                () -> task.getExtensions().getExtraProperties().has("refspec")
+                                    ? task.getExtensions().getExtraProperties().get("refspec").toString()
+                                    : null
+                            )
                         )
                         .getOrElse(remote.get() + "/" + bwcBranch);
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/InternalDistributionDownloadPlugin.java
@@ -172,11 +172,11 @@ public class InternalDistributionDownloadPlugin implements Plugin<Project> {
         return projectName + distribution.getType().getName();
     }
 
-    private static class ProjectBasedDistributionDependency implements DistributionDependency {
+    public static class ProjectBasedDistributionDependency implements DistributionDependency {
 
         private Function<String, Dependency> function;
 
-        ProjectBasedDistributionDependency(Function<String, Dependency> function) {
+        public ProjectBasedDistributionDependency(Function<String, Dependency> function) {
             this.function = function;
         }
 

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/info/GlobalBuildInfoPlugin.java
@@ -100,8 +100,7 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
         File runtimeJavaHome = findRuntimeJavaHome();
         boolean isRuntimeJavaHomeSet = Jvm.current().getJavaHome().equals(runtimeJavaHome) == false;
 
-        File rootDir = project.getRootDir();
-        GitInfo gitInfo = GitInfo.gitInfo(rootDir);
+        GitInfo gitInfo = GitInfo.gitInfo(project.getRootDir());
 
         BuildParams.init(params -> {
             params.reset();
@@ -132,7 +131,13 @@ public class GlobalBuildInfoPlugin implements Plugin<Project> {
             params.setInFipsJvm(Util.getBooleanProperty("tests.fips.enabled", false));
             params.setIsSnapshotBuild(Util.getBooleanProperty("build.snapshot", true));
             AtomicReference<BwcVersions> cache = new AtomicReference<>();
-            params.setBwcVersions(providers.provider(() -> cache.updateAndGet(val -> val == null ? resolveBwcVersions(rootDir) : val)));
+            params.setBwcVersions(
+                providers.provider(
+                    () -> cache.updateAndGet(
+                        val -> val == null ? resolveBwcVersions(Util.locateElasticsearchWorkspace(project.getGradle())) : val
+                    )
+                )
+            );
         });
 
         // Enforce the minimum compiler version

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/InternalJavaRestTestPlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/InternalJavaRestTestPlugin.java
@@ -35,7 +35,9 @@ public class InternalJavaRestTestPlugin implements Plugin<Project> {
         SourceSetContainer sourceSets = project.getExtensions().getByType(SourceSetContainer.class);
         SourceSet javaTestSourceSet = sourceSets.create(SOURCE_SET_NAME);
 
-        project.getDependencies().add(javaTestSourceSet.getImplementationConfigurationName(), project.project(":test:test-clusters"));
+        if (project.findProject(":test:test-clusters") != null) {
+            project.getDependencies().add(javaTestSourceSet.getImplementationConfigurationName(), project.project(":test:test-clusters"));
+        }
 
         // setup the javaRestTest task
         // we use a StandloneRestIntegTestTask here so that the conventions of RestTestBasePlugin don't create a test cluster

--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/test/rest/RestTestBasePlugin.java
@@ -161,7 +161,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
             task.getExtensions().getExtraProperties().set("usesBwcDistribution", new Closure<Void>(task) {
                 @Override
                 public Void call(Object... args) {
-                    if (args.length != 1 && args[0] instanceof Version == false) {
+                    if (args.length != 1 || args[0] instanceof Version == false) {
                         throw new IllegalArgumentException("Expected exactly one argument of type org.elasticsearch.gradle.Version");
                     }
 
@@ -178,7 +178,7 @@ public class RestTestBasePlugin implements Plugin<Project> {
                         providerFactory.provider(() -> bwcDistro.getExtracted().getSingleFile().getPath())
                     );
 
-                    if (version.before(BuildParams.getBwcVersions().getMinimumWireCompatibleVersion())) {
+                    if (version.getMajor() > 0 && version.before(BuildParams.getBwcVersions().getMinimumWireCompatibleVersion())) {
                         // If we are upgrade testing older versions we also need to upgrade to 7.last
                         this.call(BuildParams.getBwcVersions().getMinimumWireCompatibleVersion());
                     }

--- a/test/test-clusters/build.gradle
+++ b/test/test-clusters/build.gradle
@@ -1,12 +1,10 @@
 import org.elasticsearch.gradle.internal.conventions.util.Util
 
 apply plugin: 'elasticsearch.java'
-apply plugin: 'com.github.johnrengelman.shadow'
 
 dependencies {
-  shadow "junit:junit:${versions.junit}"
-  shadow "org.apache.logging.log4j:log4j-api:${versions.log4j}"
-
+  api "junit:junit:${versions.junit}"
+  implementation "org.apache.logging.log4j:log4j-api:${versions.log4j}"
   implementation "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
   implementation "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson}"
   implementation "com.fasterxml.jackson.core:jackson-databind:${versions.jackson}"

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ClusterHandle.java
@@ -106,4 +106,9 @@ public interface ClusterHandle extends Closeable {
      * @param version version to upgrade to
      */
     void upgradeToVersion(Version version);
+
+    /**
+     * Cleans up any resources created by this cluster.
+     */
+    void close();
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ElasticsearchCluster.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/ElasticsearchCluster.java
@@ -23,12 +23,12 @@ import org.junit.rules.TestRule;
 public interface ElasticsearchCluster extends TestRule, ClusterHandle {
 
     /**
-     * Creates a new {@link DefaultLocalClusterSpecBuilder} for defining a locally orchestrated cluster. Local clusters use a locally built
+     * Creates a new {@link LocalClusterSpecBuilder} for defining a locally orchestrated cluster. Local clusters use a locally built
      * Elasticsearch distribution.
      *
      * @return a builder for a local cluster
      */
-    static LocalClusterSpecBuilder local() {
+    static LocalClusterSpecBuilder<ElasticsearchCluster> local() {
         return new DefaultLocalClusterSpecBuilder();
     }
 

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalClusterSpecBuilder.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.test.cluster.local;
+
+import org.elasticsearch.test.cluster.ElasticsearchCluster;
+import org.elasticsearch.test.cluster.local.LocalClusterSpec.LocalNodeSpec;
+import org.elasticsearch.test.cluster.local.distribution.DistributionType;
+import org.elasticsearch.test.cluster.local.model.User;
+import org.elasticsearch.test.cluster.util.Version;
+import org.elasticsearch.test.cluster.util.resource.Resource;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+public abstract class AbstractLocalClusterSpecBuilder<T extends ElasticsearchCluster> extends AbstractLocalSpecBuilder<
+    LocalClusterSpecBuilder<T>> implements LocalClusterSpecBuilder<T> {
+
+    private String name = "test-cluster";
+    private final List<DefaultLocalNodeSpecBuilder> nodeBuilders = new ArrayList<>();
+    private final List<User> users = new ArrayList<>();
+    private final List<Resource> roleFiles = new ArrayList<>();
+    private final List<Supplier<LocalClusterConfigProvider>> lazyConfigProviders = new ArrayList<>();
+
+    public AbstractLocalClusterSpecBuilder() {
+        super(null);
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> name(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> apply(LocalClusterConfigProvider configProvider) {
+        configProvider.apply(this);
+        return this;
+    }
+
+    @Override
+    public LocalClusterSpecBuilder<T> apply(Supplier<LocalClusterConfigProvider> configProvider) {
+        lazyConfigProviders.add(configProvider);
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> nodes(int nodes) {
+        if (nodes < nodeBuilders.size()) {
+            throw new IllegalArgumentException(
+                "Cannot shrink cluster to " + nodes + ". " + nodeBuilders.size() + " nodes already configured"
+            );
+        }
+
+        int newNodes = nodes - nodeBuilders.size();
+        for (int i = 0; i < newNodes; i++) {
+            nodeBuilders.add(new DefaultLocalNodeSpecBuilder(this));
+        }
+
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> withNode(Consumer<? super LocalNodeSpecBuilder> config) {
+        DefaultLocalNodeSpecBuilder builder = new DefaultLocalNodeSpecBuilder(this);
+        config.accept(builder);
+        nodeBuilders.add(builder);
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> node(int index, Consumer<? super LocalNodeSpecBuilder> config) {
+        try {
+            DefaultLocalNodeSpecBuilder builder = nodeBuilders.get(index);
+            config.accept(builder);
+        } catch (IndexOutOfBoundsException e) {
+            throw new IllegalArgumentException(
+                "No node at index + " + index + " exists. Only " + nodeBuilders.size() + " nodes have been configured"
+            );
+        }
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> user(String username, String password) {
+        this.users.add(new User(username, password));
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> user(String username, String password, String role) {
+        this.users.add(new User(username, password, role));
+        return this;
+    }
+
+    @Override
+    public AbstractLocalClusterSpecBuilder<T> rolesFile(Resource rolesFile) {
+        this.roleFiles.add(rolesFile);
+        return this;
+    }
+
+    protected LocalClusterSpec buildClusterSpec() {
+        // Apply lazily provided configuration
+        lazyConfigProviders.forEach(s -> s.get().apply(this));
+
+        List<User> clusterUsers = users.isEmpty() ? List.of(User.DEFAULT_USER) : users;
+        LocalClusterSpec clusterSpec = new LocalClusterSpec(name, clusterUsers, roleFiles);
+        List<LocalNodeSpec> nodeSpecs;
+
+        if (nodeBuilders.isEmpty()) {
+            // No node-specific configuration so assume a single-node cluster
+            nodeSpecs = List.of(new DefaultLocalNodeSpecBuilder(this).build(clusterSpec));
+        } else {
+            nodeSpecs = nodeBuilders.stream().map(node -> node.build(clusterSpec)).toList();
+        }
+
+        clusterSpec.setNodes(nodeSpecs);
+        clusterSpec.validate();
+
+        return clusterSpec;
+    }
+
+    public static class DefaultLocalNodeSpecBuilder extends AbstractLocalSpecBuilder<LocalNodeSpecBuilder> implements LocalNodeSpecBuilder {
+        private String name;
+
+        protected DefaultLocalNodeSpecBuilder(AbstractLocalSpecBuilder<?> parent) {
+            super(parent);
+        }
+
+        @Override
+        public DefaultLocalNodeSpecBuilder name(String name) {
+            this.name = name;
+            return this;
+        }
+
+        private LocalNodeSpec build(LocalClusterSpec cluster) {
+
+            return new LocalNodeSpec(
+                cluster,
+                name,
+                Optional.ofNullable(getVersion()).orElse(Version.CURRENT),
+                getSettingsProviders(),
+                getSettings(),
+                getEnvironmentProviders(),
+                getEnvironment(),
+                getModules(),
+                getPlugins(),
+                Optional.ofNullable(getDistributionType()).orElse(DistributionType.INTEG_TEST),
+                getFeatures(),
+                getKeystoreProviders(),
+                getKeystoreSettings(),
+                getKeystoreFiles(),
+                getKeystorePassword(),
+                getExtraConfigFiles(),
+                getSystemProperties(),
+                getSecrets()
+            );
+        }
+    }
+}

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultLocalClusterSpecBuilder.java
@@ -8,28 +8,17 @@
 
 package org.elasticsearch.test.cluster.local;
 
+import org.elasticsearch.test.cluster.DefaultElasticsearchCluster;
 import org.elasticsearch.test.cluster.ElasticsearchCluster;
-import org.elasticsearch.test.cluster.local.LocalClusterSpec.LocalNodeSpec;
-import org.elasticsearch.test.cluster.local.distribution.DistributionType;
-import org.elasticsearch.test.cluster.local.model.User;
-import org.elasticsearch.test.cluster.util.Version;
+import org.elasticsearch.test.cluster.local.distribution.LocalDistributionResolver;
+import org.elasticsearch.test.cluster.local.distribution.ReleasedDistributionResolver;
+import org.elasticsearch.test.cluster.local.distribution.SnapshotDistributionResolver;
 import org.elasticsearch.test.cluster.util.resource.Resource;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-
-public class DefaultLocalClusterSpecBuilder extends AbstractLocalSpecBuilder<LocalClusterSpecBuilder> implements LocalClusterSpecBuilder {
-    private String name = "test-cluster";
-    private final List<DefaultLocalNodeSpecBuilder> nodeBuilders = new ArrayList<>();
-    private final List<User> users = new ArrayList<>();
-    private final List<Resource> roleFiles = new ArrayList<>();
-    private final List<Supplier<LocalClusterConfigProvider>> lazyConfigProviders = new ArrayList<>();
+public class DefaultLocalClusterSpecBuilder extends AbstractLocalClusterSpecBuilder<ElasticsearchCluster> {
 
     public DefaultLocalClusterSpecBuilder() {
-        super(null);
+        super();
         this.apply(new FipsEnabledClusterConfigProvider());
         this.settings(new DefaultSettingsProvider());
         this.environment(new DefaultEnvironmentProvider());
@@ -37,139 +26,10 @@ public class DefaultLocalClusterSpecBuilder extends AbstractLocalSpecBuilder<Loc
     }
 
     @Override
-    public DefaultLocalClusterSpecBuilder name(String name) {
-        this.name = name;
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder apply(LocalClusterConfigProvider configProvider) {
-        configProvider.apply(this);
-        return this;
-    }
-
-    @Override
-    public LocalClusterSpecBuilder apply(Supplier<LocalClusterConfigProvider> configProvider) {
-        lazyConfigProviders.add(configProvider);
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder nodes(int nodes) {
-        if (nodes < nodeBuilders.size()) {
-            throw new IllegalArgumentException(
-                "Cannot shrink cluster to " + nodes + ". " + nodeBuilders.size() + " nodes already configured"
-            );
-        }
-
-        int newNodes = nodes - nodeBuilders.size();
-        for (int i = 0; i < newNodes; i++) {
-            nodeBuilders.add(new DefaultLocalNodeSpecBuilder(this));
-        }
-
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder withNode(Consumer<? super LocalNodeSpecBuilder> config) {
-        DefaultLocalNodeSpecBuilder builder = new DefaultLocalNodeSpecBuilder(this);
-        config.accept(builder);
-        nodeBuilders.add(builder);
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder node(int index, Consumer<? super LocalNodeSpecBuilder> config) {
-        try {
-            DefaultLocalNodeSpecBuilder builder = nodeBuilders.get(index);
-            config.accept(builder);
-        } catch (IndexOutOfBoundsException e) {
-            throw new IllegalArgumentException(
-                "No node at index + " + index + " exists. Only " + nodeBuilders.size() + " nodes have been configured"
-            );
-        }
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder user(String username, String password) {
-        this.users.add(new User(username, password));
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder user(String username, String password, String role) {
-        this.users.add(new User(username, password, role));
-        return this;
-    }
-
-    @Override
-    public DefaultLocalClusterSpecBuilder rolesFile(Resource rolesFile) {
-        this.roleFiles.add(rolesFile);
-        return this;
-    }
-
-    @Override
     public ElasticsearchCluster build() {
-        return new LocalElasticsearchCluster(this);
-    }
-
-    LocalClusterSpec buildClusterSpec() {
-        // Apply lazily provided configuration
-        lazyConfigProviders.forEach(s -> s.get().apply(this));
-
-        List<User> clusterUsers = users.isEmpty() ? List.of(User.DEFAULT_USER) : users;
-        LocalClusterSpec clusterSpec = new LocalClusterSpec(name, clusterUsers, roleFiles);
-        List<LocalNodeSpec> nodeSpecs;
-
-        if (nodeBuilders.isEmpty()) {
-            // No node-specific configuration so assume a single-node cluster
-            nodeSpecs = List.of(new DefaultLocalNodeSpecBuilder(this).build(clusterSpec));
-        } else {
-            nodeSpecs = nodeBuilders.stream().map(node -> node.build(clusterSpec)).toList();
-        }
-
-        clusterSpec.setNodes(nodeSpecs);
-        clusterSpec.validate();
-
-        return clusterSpec;
-    }
-
-    public static class DefaultLocalNodeSpecBuilder extends AbstractLocalSpecBuilder<LocalNodeSpecBuilder> implements LocalNodeSpecBuilder {
-        private String name;
-
-        protected DefaultLocalNodeSpecBuilder(AbstractLocalSpecBuilder<?> parent) {
-            super(parent);
-        }
-
-        @Override
-        public DefaultLocalNodeSpecBuilder name(String name) {
-            this.name = name;
-            return this;
-        }
-
-        private LocalNodeSpec build(LocalClusterSpec cluster) {
-
-            return new LocalNodeSpec(
-                cluster,
-                name,
-                Optional.ofNullable(getVersion()).orElse(Version.CURRENT),
-                getSettingsProviders(),
-                getSettings(),
-                getEnvironmentProviders(),
-                getEnvironment(),
-                getModules(),
-                getPlugins(),
-                Optional.ofNullable(getDistributionType()).orElse(DistributionType.INTEG_TEST),
-                getFeatures(),
-                getKeystoreProviders(),
-                getKeystoreSettings(),
-                getKeystoreFiles(),
-                getKeystorePassword(),
-                getExtraConfigFiles(),
-                getSystemProperties(),
-                getSecrets()
-            );
-        }
+        return new DefaultElasticsearchCluster<>(
+            this::buildClusterSpec,
+            new LocalClusterFactory(new LocalDistributionResolver(new SnapshotDistributionResolver(new ReleasedDistributionResolver())))
+        );
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/DefaultSettingsProvider.java
@@ -21,7 +21,6 @@ public class DefaultSettingsProvider implements SettingsProvider {
     public Map<String, String> get(LocalNodeSpec nodeSpec) {
         Map<String, String> settings = new HashMap<>();
 
-        settings.put("node.name", nodeSpec.getName());
         settings.put("node.attr.testattr", "test");
         settings.put("node.portsfile", "true");
         settings.put("http.port", "0");

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/FipsEnabledClusterConfigProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/FipsEnabledClusterConfigProvider.java
@@ -13,7 +13,7 @@ import org.elasticsearch.test.cluster.util.resource.Resource;
 public class FipsEnabledClusterConfigProvider implements LocalClusterConfigProvider {
 
     @Override
-    public void apply(LocalClusterSpecBuilder builder) {
+    public void apply(LocalClusterSpecBuilder<?> builder) {
         if (isFipsEnabled()) {
             builder.configFile(
                 "fips_java.security",

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterConfigProvider.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterConfigProvider.java
@@ -10,5 +10,5 @@ package org.elasticsearch.test.cluster.local;
 
 public interface LocalClusterConfigProvider {
 
-    void apply(LocalClusterSpecBuilder builder);
+    void apply(LocalClusterSpecBuilder<?> builder);
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -120,7 +120,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             this.baseWorkingDir = baseWorkingDir;
             this.distributionResolver = distributionResolver;
             this.spec = spec;
-            this.name = spec.getCluster().getName() + "-" + (suffix == null ? spec.getName() : spec.getName() + "-" + suffix);
+            this.name = suffix == null ? spec.getName() : spec.getName() + "-" + suffix;
             this.workingDir = baseWorkingDir.resolve(name);
             this.repoDir = baseWorkingDir.resolve("repo");
             this.dataDir = workingDir.resolve("data");

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterFactory.java
@@ -68,28 +68,37 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
     private static final String ENABLE_DEBUG_JVM_ARGS = "-agentlib:jdwp=transport=dt_socket,server=n,suspend=y,address=";
     private static final int DEFAULT_DEBUG_PORT = 5007;
 
-    private final ObjectMapper objectMapper;
     private final DistributionResolver distributionResolver;
-    private Path baseWorkingDir;
 
     public LocalClusterFactory(DistributionResolver distributionResolver) {
-        this.objectMapper = new ObjectMapper();
         this.distributionResolver = distributionResolver;
     }
 
     @Override
     public LocalClusterHandle create(LocalClusterSpec spec) {
+        Path baseWorkingDir;
         try {
-            this.baseWorkingDir = Files.createTempDirectory(spec.getName());
+            baseWorkingDir = Files.createTempDirectory(spec.getName());
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }
 
-        return new LocalClusterHandle(spec.getName(), spec.getNodes().stream().map(Node::new).toList());
+        return createHandle(baseWorkingDir, spec);
     }
 
-    public class Node {
+    protected LocalClusterHandle createHandle(Path baseWorkingDir, LocalClusterSpec spec) {
+        return new LocalClusterHandle(
+            spec.getName(),
+            spec.getNodes().stream().map(s -> new Node(baseWorkingDir, distributionResolver, s)).toList()
+        );
+    }
+
+    public static class Node {
+        private final ObjectMapper objectMapper;
+        private final Path baseWorkingDir;
+        private final DistributionResolver distributionResolver;
         private final LocalNodeSpec spec;
+        private final String name;
         private final Path workingDir;
         private final Path repoDir;
         private final Path dataDir;
@@ -102,9 +111,17 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         private Process process = null;
         private DistributionDescriptor distributionDescriptor;
 
-        public Node(LocalNodeSpec spec) {
+        public Node(Path baseWorkingDir, DistributionResolver distributionResolver, LocalNodeSpec spec) {
+            this(baseWorkingDir, distributionResolver, spec, null);
+        }
+
+        public Node(Path baseWorkingDir, DistributionResolver distributionResolver, LocalNodeSpec spec, String suffix) {
+            this.objectMapper = new ObjectMapper();
+            this.baseWorkingDir = baseWorkingDir;
+            this.distributionResolver = distributionResolver;
             this.spec = spec;
-            this.workingDir = baseWorkingDir.resolve(spec.getName());
+            this.name = spec.getCluster().getName() + "-" + (suffix == null ? spec.getName() : spec.getName() + "-" + suffix);
+            this.workingDir = baseWorkingDir.resolve(name);
             this.repoDir = baseWorkingDir.resolve("repo");
             this.dataDir = workingDir.resolve("data");
             this.logsDir = workingDir.resolve("logs");
@@ -113,15 +130,15 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         }
 
         public synchronized void start(Version version) {
-            LOGGER.info("Starting Elasticsearch node '{}'", spec.getName());
+            LOGGER.info("Starting Elasticsearch node '{}'", name);
             if (version != null) {
                 spec.setVersion(version);
             }
 
             if (currentVersion == null || currentVersion.equals(spec.getVersion()) == false) {
-                LOGGER.info("Creating installation for node '{}' in {}", spec.getName(), workingDir);
+                LOGGER.info("Creating installation for node '{}' in {}", name, workingDir);
                 distributionDescriptor = resolveDistribution();
-                LOGGER.info("Distribution for node '{}': {}", spec.getName(), distributionDescriptor);
+                LOGGER.info("Distribution for node '{}': {}", name, distributionDescriptor);
                 initializeWorkingDirectory(currentVersion != null);
                 createConfigDirectory();
                 copyExtraConfigFiles(); // extra config files might be needed for running cli tools like plugin install
@@ -147,6 +164,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         }
 
         public synchronized void stop(boolean forcibly) {
+            LOGGER.info("Shutting down node '{}'", name);
             if (process != null) {
                 ProcessUtils.stopHandle(process.toHandle(), forcibly);
                 ProcessReaper.instance().unregister(getServiceName());
@@ -198,6 +216,10 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             } catch (IOException e) {
                 throw new UncheckedIOException("Failed to write unicast_hosts for: " + this, e);
             }
+        }
+
+        public String getName() {
+            return name;
         }
 
         public LocalNodeSpec getSpec() {
@@ -280,7 +302,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 Files.createDirectories(logsDir);
                 Files.createDirectories(tempDir);
             } catch (IOException e) {
-                throw new UncheckedIOException("Failed to create working directory for node '" + spec.getName() + "'", e);
+                throw new UncheckedIOException("Failed to create working directory for node '" + name + "'", e);
             }
         }
 
@@ -325,6 +347,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             try {
                 // Write settings to elasticsearch.yml
                 Map<String, String> finalSettings = new HashMap<>();
+                finalSettings.put("node.name", name);
                 finalSettings.put("path.repo", repoDir.toString());
                 finalSettings.put("path.data", dataDir.toString());
                 finalSettings.put("path.logs", logsDir.toString());
@@ -341,10 +364,12 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                 );
 
                 // Copy additional configuration from distribution
-                try (Stream<Path> configFiles = Files.list(distributionDir.resolve("config"))) {
+                try (Stream<Path> configFiles = Files.walk(distributionDir.resolve("config"))) {
                     for (Path file : configFiles.toList()) {
-                        Path dest = configFile.getParent().resolve(file.getFileName());
+                        Path relativePath = distributionDir.resolve("config").relativize(file);
+                        Path dest = configDir.resolve(relativePath);
                         if (Files.exists(dest) == false) {
+                            Files.createDirectories(dest.getParent());
                             Files.copy(file, dest);
                         }
                     }
@@ -430,7 +455,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         private void configureSecurity() {
             if (spec.isSecurityEnabled()) {
                 if (spec.getUsers().isEmpty() == false) {
-                    LOGGER.info("Setting up roles.yml for node '{}'", spec.getName());
+                    LOGGER.info("Setting up roles.yml for node '{}'", name);
 
                     Path destination = workingDir.resolve("config").resolve("roles.yml");
                     spec.getRolesFiles().forEach(rolesFile -> {
@@ -445,7 +470,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
                     });
                 }
 
-                LOGGER.info("Creating users for node '{}'", spec.getName());
+                LOGGER.info("Creating users for node '{}'", name);
                 for (User user : spec.getUsers()) {
                     runToolScript(
                         "elasticsearch-users",
@@ -465,7 +490,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
             if (spec.getPlugins().isEmpty() == false) {
                 Pattern pattern = Pattern.compile("(.+)(?:-\\d\\.\\d\\.\\d-SNAPSHOT\\.zip)?");
 
-                LOGGER.info("Installing plugins {} into node '{}", spec.getPlugins(), spec.getName());
+                LOGGER.info("Installing plugins {} into node '{}", spec.getPlugins(), name);
                 List<Path> pluginPaths = Arrays.stream(System.getProperty(TESTS_CLUSTER_PLUGINS_PATH_SYSPROP).split(File.pathSeparator))
                     .map(Path::of)
                     .toList();
@@ -514,7 +539,7 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
 
         private void installModules() {
             if (spec.getModules().isEmpty() == false) {
-                LOGGER.info("Installing modules {} into node '{}", spec.getModules(), spec.getName());
+                LOGGER.info("Installing modules {} into node '{}", spec.getModules(), name);
                 List<Path> modulePaths = Arrays.stream(System.getProperty(TESTS_CLUSTER_MODULES_PATH_SYSPROP).split(File.pathSeparator))
                     .map(Path::of)
                     .toList();
@@ -661,12 +686,12 @@ public class LocalClusterFactory implements ClusterFactory<LocalClusterSpec, Loc
         }
 
         private String getServiceName() {
-            return baseWorkingDir.getFileName() + "-" + spec.getName();
+            return baseWorkingDir.getFileName() + "-" + name;
         }
 
         @Override
         public String toString() {
-            return "{ cluster: '" + spec.getCluster().getName() + "', node: '" + spec.getName() + "' }";
+            return "{ cluster: '" + spec.getCluster().getName() + "', node: '" + name + "' }";
         }
     }
 }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterHandle.java
@@ -141,7 +141,7 @@ public class LocalClusterHandle implements ClusterHandle {
     public void upgradeNodeToVersion(int index, Version version) {
         Node node = nodes.get(index);
         node.stop(false);
-        LOGGER.info("Upgrading node '{}' to version {}", node.getSpec().getName(), version);
+        LOGGER.info("Upgrading node '{}' to version {}", node.getName(), version);
         node.start(version);
         waitUntilReady();
     }
@@ -156,7 +156,7 @@ public class LocalClusterHandle implements ClusterHandle {
         waitUntilReady();
     }
 
-    private void waitUntilReady() {
+    protected void waitUntilReady() {
         writeUnicastHostsFile();
         try {
             WaitForHttpResource wait = configureWaitForReady();

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -194,6 +194,10 @@ public class LocalClusterSpec implements ClusterSpec {
             return getSetting("node.roles", "master").contains("master");
         }
 
+        public boolean hasRole(String role) {
+            return getSetting("node.roles", "[]").contains("search");
+        }
+
         /**
          * Return node configured setting or the provided default if no explicit value has been configured. This method returns all
          * settings, to include security settings provided to the keystore

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpecBuilder.java
@@ -14,33 +14,33 @@ import org.elasticsearch.test.cluster.util.resource.Resource;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
-public interface LocalClusterSpecBuilder extends LocalSpecBuilder<LocalClusterSpecBuilder> {
+public interface LocalClusterSpecBuilder<T extends ElasticsearchCluster> extends LocalSpecBuilder<LocalClusterSpecBuilder<T>> {
     /**
      * Sets the node name. By default, "test-cluster" is used.
      */
-    LocalClusterSpecBuilder name(String name);
+    LocalClusterSpecBuilder<T> name(String name);
 
     /**
      * Apply configuration from a {@link LocalClusterConfigProvider}. This configuration is applied eagerly. Subsequent calls to this
      * builder will override provider settings.
      */
-    LocalClusterSpecBuilder apply(LocalClusterConfigProvider configProvider);
+    LocalClusterSpecBuilder<T> apply(LocalClusterConfigProvider configProvider);
 
     /**
      * Apply configuration from a {@link LocalClusterConfigProvider} created by the given {@link Supplier}. This configuration is applied
      * lazily and will override existing builder settings.
      */
-    LocalClusterSpecBuilder apply(Supplier<LocalClusterConfigProvider> configProvider);
+    LocalClusterSpecBuilder<T> apply(Supplier<LocalClusterConfigProvider> configProvider);
 
     /**
      * Sets the number of nodes for the cluster.
      */
-    LocalClusterSpecBuilder nodes(int nodes);
+    LocalClusterSpecBuilder<T> nodes(int nodes);
 
     /**
      * Adds a new node to the cluster and configures the node.
      */
-    LocalClusterSpecBuilder withNode(Consumer<? super LocalNodeSpecBuilder> config);
+    LocalClusterSpecBuilder<T> withNode(Consumer<? super LocalNodeSpecBuilder> config);
 
     /**
      * Configures an existing node.
@@ -48,22 +48,22 @@ public interface LocalClusterSpecBuilder extends LocalSpecBuilder<LocalClusterSp
      * @param index the index of the node to configure
      * @param config configuration to apply to the node
      */
-    LocalClusterSpecBuilder node(int index, Consumer<? super LocalNodeSpecBuilder> config);
+    LocalClusterSpecBuilder<T> node(int index, Consumer<? super LocalNodeSpecBuilder> config);
 
     /**
      * Register a user using the default test role.
      */
-    LocalClusterSpecBuilder user(String username, String password);
+    LocalClusterSpecBuilder<T> user(String username, String password);
 
     /**
      * Register a user using the given role.
      */
-    LocalClusterSpecBuilder user(String username, String password, String role);
+    LocalClusterSpecBuilder<T> user(String username, String password, String role);
 
     /**
      * Register a roles file with cluster via the supplied {@link Resource}.
      */
-    LocalClusterSpecBuilder rolesFile(Resource rolesFile);
+    LocalClusterSpecBuilder<T> rolesFile(Resource rolesFile);
 
-    ElasticsearchCluster build();
+    T build();
 }


### PR DESCRIPTION
This pull request includes two main groups of changes:

First, the BWC Git handling has been made more flexible, specifically to support submodules and using remote tags and checkout ref specs. There's also some miscellaneous changes to make consuming these plugins simpler from composite builds.

Second, the test clusters framework has been refactored to make implementing alternative cluster types easier.