### PR TITLE
Using GET instead of POST for DLM explain API

### DIFF
--- a/modules/dlm/src/main/java/org/elasticsearch/dlm/rest/RestExplainDataLifecycleAction.java
+++ b/modules/dlm/src/main/java/org/elasticsearch/dlm/rest/RestExplainDataLifecycleAction.java
@@ -20,7 +20,7 @@ import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 
 import java.util.List;
 
-import static org.elasticsearch.rest.RestRequest.Method.POST;
+import static org.elasticsearch.rest.RestRequest.Method.GET;
 
 @ServerlessScope(Scope.PUBLIC)
 public class RestExplainDataLifecycleAction extends BaseRestHandler {
@@ -32,7 +32,7 @@ public class RestExplainDataLifecycleAction extends BaseRestHandler {
 
     @Override
     public List<Route> routes() {
-        return List.of(new Route(POST, "/{index}/_lifecycle/explain"));
+        return List.of(new Route(GET, "/{index}/_lifecycle/explain"));
     }
 
     @Override

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
@@ -16,7 +16,7 @@
         {
           "path": "/{index}/_lifecycle/explain",
           "methods": [
-            "POST"
+            "GET"
           ],
           "parts": {
             "index": {


### PR DESCRIPTION
DLM's explain API (/{index}/_lifecycle/explain) was accessible only using a POST. After a conversation, we've decided to change this to GET-only. Our docs are already correct.