### PR TITLE
Drop temporary extra assert from EnrichAdvancedSecurityIT

### DIFF
--- a/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
+++ b/x-pack/plugin/enrich/qa/common/src/main/java/org/elasticsearch/test/enrich/CommonEnrichRestTestCase.java
@@ -352,15 +352,7 @@ public abstract class CommonEnrichRestTestCase extends ESRestTestCase {
             maxExecutedSearchesTotal = Math.max(maxExecutedSearchesTotal, foundExecutedSearchesTotal);
         }
 
-        // the asserts after this if block keep failing randomly,
-        // so here we're going to pre-check early and fail with more useful information for debugging purposes
-        // that is, given that the search result didn't have a positive value for these, but it does have a non-zero number
-        // of hits, what's in it!? and maybe the size of search result is the interesting thing (since we only get 10 hits by default...)?
-        if (maxRemoteRequestsTotal == 0 || maxExecutedSearchesTotal == 0) {
-            assertThat(response.toString(), equalTo(""));
-        }
-
-        assertThat(maxRemoteRequestsTotal, greaterThanOrEqualTo(1));
-        assertThat(maxExecutedSearchesTotal, greaterThanOrEqualTo(1));
+        assertThat("Maximum remote_requests_total was zero. Response: " + response, maxRemoteRequestsTotal, greaterThanOrEqualTo(1));
+        assertThat("Maximum executed_searches_total was zero. Response: " + response, maxExecutedSearchesTotal, greaterThanOrEqualTo(1));
     }
 }


### PR DESCRIPTION
Closes https://github.com/elastic/elasticsearch/issues/86061
Closes https://github.com/elastic/elasticsearch/issues/94920
Closes https://github.com/elastic/elasticsearch/issues/95129
Closes https://github.com/elastic/elasticsearch/issues/95589

Follow up to https://github.com/elastic/elasticsearch/pull/95592 and https://github.com/elastic/elasticsearch/pull/95635

![Screen Shot 2023-05-03 at 3 59 53 PM](https://user-images.githubusercontent.com/187034/236034448-97ec4bc5-3813-4c72-983a-b00ff2ae80e2.png)

https://github.com/elastic/elasticsearch/pull/95635 seems to have solved the problem we were having here. The failure from May 1 is spurious (it was a pull request that hadn't merged in a recent copy of `main`, and so did not have the fix).

My goal with this PR is to drop the temporary debugging assert from #95592, but to keep the additional information in a useful way if the test were to fail again in the future.

Here's an example failure of this code where I changed the `greaterThanOrEqualTo(1)` to instead be `greaterThanOrEqualTo(10)`:

```
Suite: Test class org.elasticsearch.xpack.enrich.EnrichAdvancedSecurityIT
  1> [2023-05-03T09:50:53,020][INFO ][o.e.x.e.EnrichAdvancedSecurityIT] [testBasicFlowDouble] before test
  1> [2023-05-03T09:50:53,041][INFO ][o.e.x.e.EnrichAdvancedSecurityIT] [testBasicFlowDouble] initializing REST clients against [http://[::1]:60044, http://127.0.0.1:60045]
  1> [2023-05-03T09:54:00,337][INFO ][o.e.x.e.EnrichAdvancedSecurityIT] [testBasicFlowDouble] There are still tasks running after this test that might break subsequent tests [health-node[c]].
  1> [2023-05-03T09:54:00,351][INFO ][o.e.x.e.EnrichAdvancedSecurityIT] [testBasicFlowDouble] after test
  2> REPRODUCE WITH: ./gradlew ':x-pack:plugin:enrich:qa:rest-with-advanced-security:javaRestTest' --tests "org.elasticsearch.xpack.enrich.EnrichAdvancedSecurityIT.testBasicFlowDouble" -Dtests.seed=A4400ED315863113 -Dtests.locale=en-CA -Dtests.timezone=Etc/GMT+10 -Druntime.java=20
  2> java.lang.AssertionError: Maximum remote_requests_total was zero. Response: {_shards={total=1, failed=0, successful=1, skipped=0}, hits={hits=[{_index=.monitoring-es-7-2023.05.03, _source={interval_ms=10000, enrich_coordinator_stats={executed_searches_total=1, queue_size=0, remote_requests_current=0, remote_requests_total=1, node_id=Xly3WqQvSTmt5jdDWSwc2A},
 cluster_uuid=Ao0emvdDRuu5J86kPZejrg, source_node={transport_address=127.0.0.1:60043, ip=127.0.0.1, host=127.0.0.1, name=javaRestTest-0, uuid=Xly3WqQvSTmt5jdDWSwc2A, timestamp=2023-05-03T19:53:49.896Z}, type=enrich_coordinator_stats, timestamp=2023-05-03T19:53:49.918Z}, _id=BGYt44cBjIIDPbzznOpj, sort=[1683143629918], _score=null}, {_index=.monitoring-es-7-2023.0
5.03, _source={interval_ms=10000, enrich_coordinator_stats={executed_searches_total=1, queue_size=0, remote_requests_current=0, remote_requests_total=1, node_id=Xly3WqQvSTmt5jdDWSwc2A}, cluster_uuid=Ao0emvdDRuu5J86kPZejrg, source_node={transport_address=127.0.0.1:60043, ip=127.0.0.1, host=127.0.0.1, name=javaRestTest-0, uuid=Xly3WqQvSTmt5jdDWSwc2A, timestamp=202
3-05-03T19:53:39.892Z}, type=enrich_coordinator_stats, timestamp=2023-05-03T19:53:39.915Z}, _id=-2Yt44cBjIIDPbzzdelQ, sort=[1683143619915], _score=null}, {_index=.monitoring-es-7-2023.05.03, _source={interval_ms=10000, enrich_coordinator_stats={executed_searches_total=1, queue_size=0, remote_requests_current=0, remote_requests_total=1, node_id=Xly3WqQvSTmt5jdDWS
wc2A}, cluster_uuid=Ao0emvdDRuu5J86kPZejrg, source_node={transport_address=127.0.0.1:60043, ip=127.0.0.1, host=127.0.0.1, name=javaRestTest-0, uuid=Xly3WqQvSTmt5jdDWSwc2A, timestamp=2023-05-03T19:53:29.891Z}, type=enrich_coordinator_stats, timestamp=2023-05-03T19:53:29.914Z}, _id=8mYt44cBjIIDPbzzTuk_, sort=[1683143609914], _score=null}, {_index=.monitoring-es-7-
2023.05.03, _source={interval_ms=10000, enrich_coordinator_stats={executed_searches_total=1, queue_size=0, remote_requests_current=0, remote_requests_total=1, node_id=Xly3WqQvSTmt5jdDWSwc2A}, cluster_uuid=Ao0emvdDRuu5J86kPZejrg, source_node={transport_address=127.0.0.1:60043, ip=127.0.0.1, host=127.0.0.1, name=javaRestTest-0, uuid=Xly3WqQvSTmt5jdDWSwc2A, timesta
mp=2023-05-03T19:53:19.891Z}, type=enrich_coordinator_stats, timestamp=2023-05-03T19:53:19.913Z}, _id=6WYt44cBjIIDPbzzJ-kw, sort=[1683143599913], _score=null}, {_index=.monitoring-es-7-2023.05.03, _source={interval_ms=10000, enrich_coordinator_stats={executed_searches_total=1, queue_size=0, remote_requests_current=0, remote_requests_total=1, node_id=Xly3WqQvSTmt
5jdDWSwc2A}, cluster_uuid=Ao0emvdDRuu5J86kPZejrg, source_node={transport_address=127.0.0.1:60043, ip=127.0.0.1, host=127.0.0.1, name=javaRestTest-0, uuid=Xly3WqQvSTmt5jdDWSwc2A, timestamp=2023-05-03T19:53:09.887Z}, type=enrich_coordinator_stats, timestamp=2023-05-03T19:53:09.909Z}, _id=4GYt44cBjIIDPbzzAOkZ, sort=[1683143589909], _score=null}], total={value=18, r
elation=eq}, max_score=null}, took=1032, timed_out=false}
    Expected: a value equal to or greater than <10>
         but: <1> was less than <10>
        at __randomizedtesting.SeedInfo.seed([A4400ED315863113:AC644CB3C81450FE]:0)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:18)
        at org.junit.Assert.assertThat(Assert.java:956)
        at org.elasticsearch.test.enrich.CommonEnrichRestTestCase.verifyEnrichMonitoring(CommonEnrichRestTestCase.java:355)
        at org.elasticsearch.test.ESTestCase.assertBusy(ESTestCase.java:1158)
        at org.elasticsearch.test.enrich.CommonEnrichRestTestCase.testBasicFlowDouble(CommonEnrichRestTestCase.java:189)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
        at java.base/java.lang.reflect.Method.invoke(Method.java:578)
        at com.carrotsearch.randomizedtesting.RandomizedRunner.invoke(RandomizedRunner.java:1758)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$8.evaluate(RandomizedRunner.java:946)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$9.evaluate(RandomizedRunner.java:982)
        at com.carrotsearch.randomizedtesting.RandomizedRunner$10.evaluate(RandomizedRunner.java:996)
        at com.carrotsearch.randomizedtesting.rules.StatementAdapter.evaluate(StatementAdapter.java:36)
        at org.apache.lucene.tests.util.TestRuleSetupTeardownChained$1.evaluate(TestRuleSetupTeardownChained.java:48)
        at org.apache.lucene.tests.util.AbstractBeforeAfterRule$1.evaluate(AbstractBeforeAfterRule.java:43)
        at org.apache.lucene.tests.util.TestRuleThreadAndTestName$1.evaluate(TestRuleThreadAndTestName.java:45)
        at org.apache.lucene.tests.util.TestRuleIgnoreAfterMaxFailures$1.evaluate(TestRuleIgnoreAfterMaxFailures.java:60)
```