### PR TITLE
Add version getter to LocallyMountedSecrets

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -170,6 +170,13 @@ public class LocallyMountedSecrets implements SecureSettings {
         return MessageDigests.sha256().digest(getString(setting).toString().getBytes(StandardCharsets.UTF_8));
     }
 
+    /**
+     * @return version number from the secrets file
+     */
+    public long getVersion() {
+        return secrets.get().metadata.version();
+    }
+
     @Override
     public void close() throws IOException {
         if (null != secrets.get() && secrets.get().map().isEmpty() == false) {

--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -171,7 +171,7 @@ public class LocallyMountedSecrets implements SecureSettings {
     }
 
     /**
-     * @return version number from the secrets file
+     * Returns version number from the secrets file
      */
     public long getVersion() {
         return secrets.get().metadata.version();

--- a/server/src/test/java/org/elasticsearch/common/settings/LocallyMountedSecretsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/LocallyMountedSecretsTests.java
@@ -64,6 +64,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
         writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertTrue(secrets.isLoaded());
+        assertThat(secrets.getVersion(), equalTo(1));
         assertThat(secrets.getSettingNames(), containsInAnyOrder("aaa", "ccc"));
         assertEquals("bbb", secrets.getString("aaa").toString());
         assertEquals("ddd", secrets.getString("ccc").toString());

--- a/server/src/test/java/org/elasticsearch/common/settings/LocallyMountedSecretsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/settings/LocallyMountedSecretsTests.java
@@ -64,7 +64,7 @@ public class LocallyMountedSecretsTests extends ESTestCase {
         writeTestFile(env.configFile().resolve("secrets").resolve("secrets.json"), testJSON);
         LocallyMountedSecrets secrets = new LocallyMountedSecrets(env);
         assertTrue(secrets.isLoaded());
-        assertThat(secrets.getVersion(), equalTo(1));
+        assertThat(secrets.getVersion(), equalTo(1L));
         assertThat(secrets.getSettingNames(), containsInAnyOrder("aaa", "ccc"));
         assertEquals("bbb", secrets.getString("aaa").toString());
         assertEquals("ddd", secrets.getString("ccc").toString());


### PR DESCRIPTION
We need to be able to get the version number from a locally mounted secrets object.