### PR TITLE
[8.8] [Doc] JWT realm's claims.principal setting is mandatory (#95813)

### DIFF
--- a/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
+++ b/x-pack/docs/en/security/authentication/jwt-realm.asciidoc
@@ -342,8 +342,8 @@ it, while a JWT realm of `access_token` will just ignore it.
 
 `principal`::
 (Required, String) Contains the user's principal (username). The value is
-configurable using the realm setting `claims.principal`. If not set, the value
-defaults to `sub`. You can configure an optional regular expression using the
+configurable using the realm setting `claims.principal`.
+You can configure an optional regular expression using the
 `claims.principal_pattern` to extract a substring.
 
 `groups`::


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [Doc] JWT realm's claims.principal setting is mandatory (#95813)