### PR TITLE
Mute testDeleteIgnoringIfNotExistsDoesNotThrowFileNotFound

### DIFF
--- a/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
+++ b/server/src/test/java/org/elasticsearch/common/blobstore/fs/FsBlobContainerTests.java
@@ -104,6 +104,7 @@ public class FsBlobContainerTests extends ESTestCase {
         assertThat(FsBlobContainer.isTempBlobName(tempBlobName), is(true));
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/95768")
     public void testDeleteIgnoringIfNotExistsDoesNotThrowFileNotFound() throws IOException {
         final String blobName = randomAlphaOfLengthBetween(1, 20).toLowerCase(Locale.ROOT);
         final byte[] blobData = randomByteArrayOfLength(512);


### PR DESCRIPTION
Relates https://github.com/elastic/elasticsearch/issues/95768.
Probably will be fixed/removed in https://github.com/elastic/elasticsearch/pull/95815.