### PR TITLE
[ML] Fix partial disablement of ML

### DIFF
--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlPartialEnablementAdOnlyIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlPartialEnablementAdOnlyIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDatafeedsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsAction;
+import org.elasticsearch.xpack.core.ml.action.GetJobsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.MlInfoAction;
+import org.elasticsearch.xpack.core.ml.action.MlMemoryAction;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.elasticsearch.xpack.ml.LocalStateMachineLearningAdOnly;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+
+import java.util.Collection;
+
+public class MlPartialEnablementAdOnlyIT extends MlSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(
+            LocalStateMachineLearningAdOnly.class,
+            DataStreamsPlugin.class,
+            ReindexPlugin.class,
+            IngestCommonPlugin.class,
+            MockPainlessScriptEngine.TestPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class,
+            // Needed for scaled_float
+            MapperExtrasPlugin.class
+        );
+    }
+
+    /**
+     * The objective here is to detect if one of these very basic actions relies on some other action that is not available.
+     * We don't expect them to return anything, but if they are unexpectedly calling an action that has been disabled then
+     * an exception will be thrown which will fail the test.
+     */
+    public void testBasicInfoCalls() {
+        client().execute(MlInfoAction.INSTANCE, new MlInfoAction.Request()).actionGet();
+        client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("*")).actionGet();
+        client().execute(GetJobsAction.INSTANCE, new GetJobsAction.Request("*")).actionGet();
+        client().execute(GetJobsStatsAction.INSTANCE, new GetJobsStatsAction.Request("*")).actionGet();
+        client().execute(GetDatafeedsAction.INSTANCE, new GetDatafeedsAction.Request("*")).actionGet();
+        client().execute(GetDatafeedsStatsAction.INSTANCE, new GetDatafeedsStatsAction.Request("*")).actionGet();
+    }
+}

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlPartialEnablementDfaOnlyIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlPartialEnablementDfaOnlyIT.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsAction;
+import org.elasticsearch.xpack.core.ml.action.GetDataFrameAnalyticsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.MlInfoAction;
+import org.elasticsearch.xpack.core.ml.action.MlMemoryAction;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.elasticsearch.xpack.ml.LocalStateMachineLearningDfaOnly;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+
+import java.util.Collection;
+
+public class MlPartialEnablementDfaOnlyIT extends MlSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(
+            LocalStateMachineLearningDfaOnly.class,
+            DataStreamsPlugin.class,
+            ReindexPlugin.class,
+            IngestCommonPlugin.class,
+            MockPainlessScriptEngine.TestPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class,
+            // Needed for scaled_float
+            MapperExtrasPlugin.class
+        );
+    }
+
+    /**
+     * The objective here is to detect if one of these very basic actions relies on some other action that is not available.
+     * We don't expect them to return anything, but if they are unexpectedly calling an action that has been disabled then
+     * an exception will be thrown which will fail the test.
+     */
+    public void testBasicInfoCalls() {
+        client().execute(MlInfoAction.INSTANCE, new MlInfoAction.Request()).actionGet();
+        client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("*")).actionGet();
+        client().execute(GetDataFrameAnalyticsAction.INSTANCE, new GetDataFrameAnalyticsAction.Request("*")).actionGet();
+        client().execute(GetDataFrameAnalyticsStatsAction.INSTANCE, new GetDataFrameAnalyticsStatsAction.Request("*")).actionGet();
+        client().execute(GetTrainedModelsAction.INSTANCE, new GetTrainedModelsAction.Request("*")).actionGet();
+        client().execute(GetTrainedModelsStatsAction.INSTANCE, new GetTrainedModelsStatsAction.Request("*")).actionGet();
+    }
+}

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlPartialEnablementNlpOnlyIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/MlPartialEnablementNlpOnlyIT.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.ml.integration;
+
+import org.elasticsearch.datastreams.DataStreamsPlugin;
+import org.elasticsearch.index.mapper.extras.MapperExtrasPlugin;
+import org.elasticsearch.ingest.common.IngestCommonPlugin;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.reindex.ReindexPlugin;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsAction;
+import org.elasticsearch.xpack.core.ml.action.GetTrainedModelsStatsAction;
+import org.elasticsearch.xpack.core.ml.action.MlInfoAction;
+import org.elasticsearch.xpack.core.ml.action.MlMemoryAction;
+import org.elasticsearch.xpack.ilm.IndexLifecycle;
+import org.elasticsearch.xpack.ml.LocalStateMachineLearningNlpOnly;
+import org.elasticsearch.xpack.ml.MlSingleNodeTestCase;
+
+import java.util.Collection;
+
+public class MlPartialEnablementNlpOnlyIT extends MlSingleNodeTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> getPlugins() {
+        return pluginList(
+            LocalStateMachineLearningNlpOnly.class,
+            DataStreamsPlugin.class,
+            ReindexPlugin.class,
+            IngestCommonPlugin.class,
+            MockPainlessScriptEngine.TestPlugin.class,
+            // ILM is required for .ml-state template index settings
+            IndexLifecycle.class,
+            // Needed for scaled_float
+            MapperExtrasPlugin.class
+        );
+    }
+
+    /**
+     * The objective here is to detect if one of these very basic actions relies on some other action that is not available.
+     * We don't expect them to return anything, but if they are unexpectedly calling an action that has been disabled then
+     * an exception will be thrown which will fail the test.
+     */
+    public void testBasicInfoCalls() {
+        client().execute(MlInfoAction.INSTANCE, new MlInfoAction.Request()).actionGet();
+        client().execute(MlMemoryAction.INSTANCE, new MlMemoryAction.Request("*")).actionGet();
+        client().execute(GetTrainedModelsAction.INSTANCE, new GetTrainedModelsAction.Request("*")).actionGet();
+        client().execute(GetTrainedModelsStatsAction.INSTANCE, new GetTrainedModelsStatsAction.Request("*")).actionGet();
+    }
+}

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -559,6 +559,7 @@ public class MachineLearning extends Plugin
 
     @Override
     public void loadExtensions(ExtensionLoader loader) {
+        logger.warn("DMR loading extensions");
         if (loader != null) {
             loader.loadExtensions(MachineLearningExtension.class).forEach(machineLearningExtension::set);
         }
@@ -1394,6 +1395,8 @@ public class MachineLearning extends Plugin
         actionHandlers.add(new ActionHandler<>(MlMemoryAction.INSTANCE, TransportMlMemoryAction.class));
         actionHandlers.add(new ActionHandler<>(SetUpgradeModeAction.INSTANCE, TransportSetUpgradeModeAction.class));
         actionHandlers.add(new ActionHandler<>(SetResetModeAction.INSTANCE, TransportSetResetModeAction.class));
+        // Included in this section as it's used by MlMemoryAction
+        actionHandlers.add(new ActionHandler<>(TrainedModelCacheInfoAction.INSTANCE, TransportTrainedModelCacheInfoAction.class));
         if (machineLearningExtension.get().isAnomalyDetectionEnabled()) {
             actionHandlers.add(new ActionHandler<>(GetJobsAction.INSTANCE, TransportGetJobsAction.class));
             actionHandlers.add(new ActionHandler<>(GetJobsStatsAction.INSTANCE, TransportGetJobsStatsAction.class));
@@ -1465,6 +1468,7 @@ public class MachineLearning extends Plugin
             );
             actionHandlers.add(new ActionHandler<>(InferModelAction.INSTANCE, TransportInternalInferModelAction.class));
             actionHandlers.add(new ActionHandler<>(InferModelAction.EXTERNAL_INSTANCE, TransportExternalInferModelAction.class));
+            actionHandlers.add(new ActionHandler<>(GetDeploymentStatsAction.INSTANCE, TransportGetDeploymentStatsAction.class));
             if (machineLearningExtension.get().isDataFrameAnalyticsEnabled()) {
                 actionHandlers.add(new ActionHandler<>(GetDataFrameAnalyticsAction.INSTANCE, TransportGetDataFrameAnalyticsAction.class));
                 actionHandlers.add(
@@ -1485,7 +1489,6 @@ public class MachineLearning extends Plugin
                 actionHandlers.add(
                     new ActionHandler<>(ExplainDataFrameAnalyticsAction.INSTANCE, TransportExplainDataFrameAnalyticsAction.class)
                 );
-                actionHandlers.add(new ActionHandler<>(TrainedModelCacheInfoAction.INSTANCE, TransportTrainedModelCacheInfoAction.class));
                 actionHandlers.add(
                     new ActionHandler<>(PreviewDataFrameAnalyticsAction.INSTANCE, TransportPreviewDataFrameAnalyticsAction.class)
                 );
@@ -1507,7 +1510,6 @@ public class MachineLearning extends Plugin
                     new ActionHandler<>(PutTrainedModelVocabularyAction.INSTANCE, TransportPutTrainedModelVocabularyAction.class)
                 );
                 actionHandlers.add(new ActionHandler<>(ClearDeploymentCacheAction.INSTANCE, TransportClearDeploymentCacheAction.class));
-                actionHandlers.add(new ActionHandler<>(GetDeploymentStatsAction.INSTANCE, TransportGetDeploymentStatsAction.class));
                 actionHandlers.add(
                     new ActionHandler<>(CreateTrainedModelAssignmentAction.INSTANCE, TransportCreateTrainedModelAssignmentAction.class)
                 );
@@ -2065,7 +2067,10 @@ public class MachineLearning extends Plugin
         ActionListener<CloseJobAction.Response> afterAnomalyDetectionClosed = ActionListener.wrap(closeJobResponse -> {
             // Handle the response
             results.put("anomaly_detectors", closeJobResponse.isClosed());
-
+            if (machineLearningExtension.get().isDataFrameAnalyticsEnabled() == false) {
+                afterDataframesStopped.onResponse(new StopDataFrameAnalyticsAction.Response(true));
+                return;
+            }
             // Stop data frame analytics
             StopDataFrameAnalyticsAction.Request stopDataFramesReq = new StopDataFrameAnalyticsAction.Request("_all").setAllowNoMatch(true);
             client.execute(
@@ -2085,7 +2090,10 @@ public class MachineLearning extends Plugin
         ActionListener<StopDatafeedAction.Response> afterDataFeedsStopped = ActionListener.wrap(datafeedResponse -> {
             // Handle the response
             results.put("datafeeds", datafeedResponse.isStopped());
-
+            if (machineLearningExtension.get().isAnomalyDetectionEnabled() == false) {
+                afterAnomalyDetectionClosed.onResponse(new CloseJobAction.Response(true));
+                return;
+            }
             CloseJobAction.Request closeJobsRequest = new CloseJobAction.Request().setAllowNoMatch(true).setJobId("_all");
             // First attempt to kill all anomaly jobs
             client.execute(
@@ -2112,6 +2120,10 @@ public class MachineLearning extends Plugin
         // Stop data feeds
         ActionListener<CancelJobModelSnapshotUpgradeAction.Response> cancelSnapshotUpgradesListener = ActionListener.wrap(
             cancelUpgradesResponse -> {
+                if (machineLearningExtension.get().isAnomalyDetectionEnabled() == false) {
+                    afterDataFeedsStopped.onResponse(new StopDatafeedAction.Response(true));
+                    return;
+                }
                 StopDatafeedAction.Request stopDatafeedsReq = new StopDatafeedAction.Request("_all").setAllowNoMatch(true);
                 client.execute(
                     StopDatafeedAction.INSTANCE,
@@ -2127,6 +2139,10 @@ public class MachineLearning extends Plugin
 
         // Cancel model snapshot upgrades
         ActionListener<AcknowledgedResponse> stopDeploymentsListener = ActionListener.wrap(acknowledgedResponse -> {
+            if (machineLearningExtension.get().isAnomalyDetectionEnabled() == false) {
+                cancelSnapshotUpgradesListener.onResponse(new CancelJobModelSnapshotUpgradeAction.Response(true));
+                return;
+            }
             CancelJobModelSnapshotUpgradeAction.Request cancelSnapshotUpgradesReq = new CancelJobModelSnapshotUpgradeAction.Request(
                 "_all",
                 "_all"
@@ -2136,7 +2152,7 @@ public class MachineLearning extends Plugin
 
         // Stop all model deployments
         ActionListener<AcknowledgedResponse> pipelineValidation = ActionListener.wrap(acknowledgedResponse -> {
-            if (trainedModelAllocationClusterServiceSetOnce.get() == null) {
+            if (trainedModelAllocationClusterServiceSetOnce.get() == null || machineLearningExtension.get().isNlpEnabled() == false) {
                 stopDeploymentsListener.onResponse(AcknowledgedResponse.TRUE);
                 return;
             }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -559,7 +559,6 @@ public class MachineLearning extends Plugin
 
     @Override
     public void loadExtensions(ExtensionLoader loader) {
-        logger.warn("DMR loading extensions");
         if (loader != null) {
             loader.loadExtensions(MachineLearningExtension.class).forEach(machineLearningExtension::set);
         }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearning.java
@@ -42,6 +42,10 @@ public class LocalStateMachineLearning extends LocalStateCompositeXPackPlugin {
     private final MachineLearning mlPlugin;
 
     public LocalStateMachineLearning(final Settings settings, final Path configPath) {
+        this(settings, configPath, null);
+    }
+
+    protected LocalStateMachineLearning(final Settings settings, final Path configPath, final ExtensionLoader extensionLoader) {
         super(settings, configPath);
         LocalStateMachineLearning thisVar = this;
         mlPlugin = new MachineLearning(settings) {
@@ -50,7 +54,7 @@ public class LocalStateMachineLearning extends LocalStateCompositeXPackPlugin {
                 return thisVar.getLicenseState();
             }
         };
-        mlPlugin.loadExtensions(null);
+        mlPlugin.loadExtensions(extensionLoader);
         mlPlugin.setCircuitBreaker(new NoopCircuitBreaker(TRAINED_MODEL_CIRCUIT_BREAKER_NAME));
         plugins.add(mlPlugin);
         plugins.add(new Monitoring(settings) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearningAdOnly.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearningAdOnly.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.ml.MachineLearningTests.MlTestExtension;
+import org.elasticsearch.xpack.ml.MachineLearningTests.MlTestExtensionLoader;
+
+import java.nio.file.Path;
+
+public class LocalStateMachineLearningAdOnly extends LocalStateMachineLearning {
+    public LocalStateMachineLearningAdOnly(final Settings settings, final Path configPath) {
+        super(settings, configPath, new MlTestExtensionLoader(new MlTestExtension(true, true, true, false, false)));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearningDfaOnly.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearningDfaOnly.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.ml.MachineLearningTests.MlTestExtension;
+import org.elasticsearch.xpack.ml.MachineLearningTests.MlTestExtensionLoader;
+
+import java.nio.file.Path;
+
+public class LocalStateMachineLearningDfaOnly extends LocalStateMachineLearning {
+    public LocalStateMachineLearningDfaOnly(final Settings settings, final Path configPath) {
+        super(settings, configPath, new MlTestExtensionLoader(new MlTestExtension(true, true, false, true, false)));
+    }
+}

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearningNlpOnly.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/LocalStateMachineLearningNlpOnly.java
@@ -1,0 +1,19 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+package org.elasticsearch.xpack.ml;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.ml.MachineLearningTests.MlTestExtension;
+import org.elasticsearch.xpack.ml.MachineLearningTests.MlTestExtensionLoader;
+
+import java.nio.file.Path;
+
+public class LocalStateMachineLearningNlpOnly extends LocalStateMachineLearning {
+    public LocalStateMachineLearningNlpOnly(final Settings settings, final Path configPath) {
+        super(settings, configPath, new MlTestExtensionLoader(new MlTestExtension(true, true, false, false, true)));
+    }
+}


### PR DESCRIPTION
This change is a followup to #95387 that fixes some mistakes made in the original PR, and also adds better tests that the most basic stats and info endpoints (of the sort that will be called on top-level UI pages) do not call unexpected actions outside their area.