### PR TITLE
Simulate blackhole connection to register

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/AtomicRegisterCoordinatorTests.java
@@ -74,9 +74,16 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
     }
 
     @Override
-    @AwaitsFix(bugUrl = "ES-5645")
     public void testAckListenerReceivesNacksIfLeaderStandsDown() {
-        // The leader still has access to the register, therefore it acknowledges the state update
+        // must allow a little extra time for the heartbeat to expire before the election can happen
+        testAckListenerReceivesNacksIfLeaderStandsDown(
+            Settings.builder()
+                .put(MAX_MISSED_HEARTBEATS.getKey(), 1)
+                .put(HEARTBEAT_FREQUENCY.getKey(), TimeValue.timeValueSeconds(1))
+                .put(FollowersChecker.FOLLOWER_CHECK_RETRY_COUNT_SETTING.getKey(), 1000)
+                .build(),
+            TimeValue.timeValueSeconds(1)
+        );
     }
 
     @Override
@@ -195,20 +202,16 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
             Settings settings,
             ClusterSettings clusterSettings,
             CoordinationState.PersistedState persistedState,
-            BooleanSupplier isDisruptedSupplier
+            DisruptibleRegisterConnection disruptibleRegisterConnection
         ) {
             final TimeValue heartbeatFrequency = HEARTBEAT_FREQUENCY.get(settings);
-            final var atomicRegister = new AtomicRegister(currentTermRef, isDisruptedSupplier);
-            final var atomicHeartbeat = new StoreHeartbeatService(new DisruptibleHeartbeatStore(new SharedHeartbeatStore(heartBeatRef)) {
-                @Override
-                protected boolean isDisrupted() {
-                    return isDisruptedSupplier.getAsBoolean();
-                }
-            },
+            final var atomicRegister = new AtomicRegister(currentTermRef, disruptibleRegisterConnection);
+            final var atomicHeartbeat = new StoreHeartbeatService(
+                new DisruptibleHeartbeatStore(new SharedHeartbeatStore(heartBeatRef), disruptibleRegisterConnection),
                 threadPool,
                 heartbeatFrequency,
                 TimeValue.timeValueMillis(heartbeatFrequency.millis() * MAX_MISSED_HEARTBEATS.get(settings)),
-                listener -> ActionListener.completeWith(listener, () -> OptionalLong.of(atomicRegister.readCurrentTerm()))
+                listener -> atomicRegister.readCurrentTerm(listener.map(OptionalLong::of))
             );
             var reconfigurator = new SingleNodeReconfigurator(settings, clusterSettings);
             var electionStrategy = new AtomicRegisterElectionStrategy(atomicRegister, () -> disruptElections, () -> disruptPublications);
@@ -324,19 +327,25 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
 
         @Override
         public void onNewElection(DiscoveryNode localNode, long proposedTerm, ActionListener<StartJoinRequest> listener) {
-            ActionListener.completeWith(listener, () -> {
-                if (disruptElectionsSupplier.getAsBoolean()) {
-                    throw new IOException("simulating failure to acquire term during election");
-                }
+            if (disruptElectionsSupplier.getAsBoolean()) {
+                listener.onFailure(new IOException("simulating failure to acquire term during election"));
+                return;
+            }
 
-                final var currentTerm = register.readCurrentTerm();
+            register.readCurrentTerm(listener.delegateFailure((l1, currentTerm) -> {
                 final var electionTerm = Math.max(proposedTerm, currentTerm + 1);
-                final var witness = register.compareAndExchange(currentTerm, electionTerm);
-                if (witness != currentTerm) {
-                    throw new CoordinationStateRejectedException("could not claim " + electionTerm + ", current term is " + witness);
-                }
-                return new StartJoinRequest(localNode, electionTerm);
-            });
+                register.compareAndExchange(
+                    currentTerm,
+                    electionTerm,
+                    l1.delegateFailure((l2, witness) -> ActionListener.completeWith(l2, () -> {
+                        if (witness.equals(currentTerm)) {
+                            return new StartJoinRequest(localNode, electionTerm);
+                        } else {
+                            throw new CoordinationStateRejectedException("couldn't claim " + electionTerm + ", current term is " + witness);
+                        }
+                    }))
+                );
+            }));
         }
 
         @Override
@@ -352,12 +361,13 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
         @Override
         public void beforeCommit(long term, long version, ActionListener<Void> listener) {
             // TODO: add a test to ensure that this gets called
-            ActionListener.completeWith(listener, () -> {
-                if (disruptPublicationsSupplier.getAsBoolean()) {
-                    throw new IOException("simulating failure to verify term during publication");
-                }
 
-                final var currentTerm = register.readCurrentTerm();
+            if (disruptPublicationsSupplier.getAsBoolean()) {
+                listener.onFailure(new IOException("simulating failure to verify term during publication"));
+                return;
+            }
+
+            register.readCurrentTerm(listener.delegateFailure((l, currentTerm) -> ActionListener.completeWith(l, () -> {
                 if (currentTerm == term) {
                     return null;
                 } else {
@@ -371,7 +381,7 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
                         )
                     );
                 }
-            });
+            })));
         }
     }
 
@@ -422,29 +432,19 @@ public class AtomicRegisterCoordinatorTests extends CoordinatorTests {
 
     private static class AtomicRegister {
         private final AtomicLong currentTermRef;
-        private final BooleanSupplier isDisruptedSupplier;
+        private final DisruptibleRegisterConnection disruptibleRegisterConnection;
 
-        AtomicRegister(AtomicLong currentTermRef, BooleanSupplier isDisruptedSupplier) {
+        AtomicRegister(AtomicLong currentTermRef, DisruptibleRegisterConnection disruptibleRegisterConnection) {
             this.currentTermRef = currentTermRef;
-            this.isDisruptedSupplier = isDisruptedSupplier;
+            this.disruptibleRegisterConnection = disruptibleRegisterConnection;
         }
 
-        private boolean isDisrupted() {
-            return isDisruptedSupplier.getAsBoolean();
+        void readCurrentTerm(ActionListener<Long> listener) {
+            disruptibleRegisterConnection.runDisrupted(listener, l -> l.onResponse(currentTermRef.get()));
         }
 
-        long readCurrentTerm() throws IOException {
-            if (isDisrupted()) {
-                throw new IOException("simulating disrupted access to shared store");
-            }
-            return currentTermRef.get();
-        }
-
-        long compareAndExchange(long expected, long updated) throws IOException {
-            if (isDisrupted()) {
-                throw new IOException("simulating disrupted access to shared store");
-            }
-            return currentTermRef.compareAndExchange(expected, updated);
+        void compareAndExchange(long expected, long updated, ActionListener<Long> listener) {
+            disruptibleRegisterConnection.runDisrupted(listener, l -> l.onResponse(currentTermRef.compareAndExchange(expected, updated)));
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/CoordinatorTests.java
@@ -657,7 +657,11 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
     }
 
     public void testAckListenerReceivesNacksIfLeaderStandsDown() {
-        try (Cluster cluster = new Cluster(3)) {
+        testAckListenerReceivesNacksIfLeaderStandsDown(Settings.EMPTY, TimeValue.ZERO);
+    }
+
+    protected void testAckListenerReceivesNacksIfLeaderStandsDown(Settings settings, TimeValue extraStabilisationTime) {
+        try (Cluster cluster = new Cluster(3, true, settings)) {
             cluster.runRandomly();
             cluster.stabilise();
             final ClusterNode leader = cluster.getAnyLeader();
@@ -670,7 +674,7 @@ public class CoordinatorTests extends AbstractCoordinatorTestCase {
             // let followers elect a leader among themselves before healing the leader and running the publication
             cluster.runFor(
                 DEFAULT_DELAY_VARIABILITY // disconnect is scheduled
-                    + DEFAULT_ELECTION_DELAY,
+                    + DEFAULT_ELECTION_DELAY + extraStabilisationTime.millis(),
                 "elect new leader"
             );
             // cluster has two nodes in mode LEADER, in different terms ofc, and the one in the lower term won’t be able to publish anything

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -43,6 +43,7 @@ import org.elasticsearch.cluster.service.ClusterApplierService;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.FakeThreadPoolMasterService;
 import org.elasticsearch.common.Randomness;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
@@ -569,6 +570,14 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
 
             runFor(stabilisationDurationMillis, "stabilising");
 
+            // There's no timeout on the register check when committing a publication, so if there's a blackholed former-master then we must
+            // complete that check exceptionally. Relates https://github.com/elastic/elasticsearch/issues/80400.
+            // noinspection ReplaceInefficientStreamCount using .count() to run the filter on every node
+            while (clusterNodes.stream().filter(ClusterNode::deliverBlackholedRegisterRequests).count() != 0L) {
+                logger.debug("--> delivering blackholed register requests");
+                runFor(DEFAULT_DELAY_VARIABILITY, "re-stabilising");
+            }
+
             final ClusterNode leader = getAnyLeader();
             final long leaderTerm = leader.coordinator.getCurrentTerm();
 
@@ -949,6 +958,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             private final NodeHealthService nodeHealthService;
             List<BiConsumer<DiscoveryNode, ClusterState>> extraJoinValidators = new ArrayList<>();
             private ClearableRecycler clearableRecycler;
+            private List<Runnable> blackholedRegisterOperations = new ArrayList<>();
 
             ClusterNode(int nodeIndex, boolean masterEligible, Settings nodeSettings, NodeHealthService nodeHealthService) {
                 this(
@@ -1091,10 +1101,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
                     settings,
                     clusterSettings,
                     persistedState,
-                    () -> disconnectedNodes.contains(localNode.getId())
-                        || blackholedNodes.contains(localNode.getId())
-                        || nodeHealthService.getHealth().getStatus() != HEALTHY
-                        || (disruptStorage && rarely())
+                    new NodeDisruptibleRegisterConnection()
                 );
                 coordinator = new Coordinator(
                     "test_node",
@@ -1464,11 +1471,74 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             }
 
             boolean deliverBlackholedRequests() {
-                return mockTransport.deliverBlackholedRequests();
+                final boolean deliveredBlackholedRequests = mockTransport.deliverBlackholedRequests();
+                final boolean deliveredBlackholedRegisterRequests = deliverBlackholedRegisterRequests();
+                return deliveredBlackholedRequests || deliveredBlackholedRegisterRequests;
+            }
+
+            boolean deliverBlackholedRegisterRequests() {
+                if (blackholedRegisterOperations.isEmpty()) {
+                    return false;
+                } else {
+                    blackholedRegisterOperations.forEach(deterministicTaskQueue::scheduleNow);
+                    blackholedRegisterOperations.clear();
+                    return true;
+                }
             }
 
             int getPendingTaskCount() {
                 return masterService.numberOfPendingTasks();
+            }
+
+            private class NodeDisruptibleRegisterConnection implements DisruptibleRegisterConnection {
+                @Override
+                public <R> void runDisrupted(ActionListener<R> listener, Consumer<ActionListener<R>> consumer) {
+                    if (isDisconnected()) {
+                        listener.onFailure(new IOException("simulated disrupted connection to register"));
+                    } else if (isBlackholed()) {
+                        final var exception = new IOException("simulated eventual failure to blackholed register");
+                        logger.trace(() -> Strings.format("delaying failure of register request for [%s]", listener), exception);
+                        blackholedRegisterOperations.add(onNode(new DisruptableMockTransport.RebootSensitiveRunnable() {
+                            @Override
+                            public void ifRebooted() {
+                                run();
+                            }
+
+                            @Override
+                            public void run() {
+                                listener.onFailure(exception);
+                            }
+
+                            @Override
+                            public String toString() {
+                                return "simulated eventual failure to blackholed register: " + listener;
+                            }
+                        }));
+                    } else {
+                        consumer.accept(listener);
+                    }
+                }
+
+                @Override
+                public <R> void runDisruptedOrDrop(ActionListener<R> listener, Consumer<ActionListener<R>> consumer) {
+                    if (isDisconnected()) {
+                        listener.onFailure(new IOException("simulated disrupted connection to register"));
+                    } else if (isBlackholed()) {
+                        logger.trace(() -> Strings.format("dropping register request for [%s]", listener));
+                    } else {
+                        consumer.accept(listener);
+                    }
+                }
+
+                private boolean isDisconnected() {
+                    return disconnectedNodes.contains(localNode.getId())
+                        || nodeHealthService.getHealth().getStatus() != HEALTHY
+                        || (disruptStorage && rarely());
+                }
+
+                private boolean isBlackholed() {
+                    return blackholedNodes.contains(localNode.getId());
+                }
             }
         }
 
@@ -1483,13 +1553,27 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
         return NOOP_TRANSPORT_INTERCEPTOR;
     }
 
+    public interface DisruptibleRegisterConnection {
+
+        /**
+         * If disconnected, fail the listener; if blackholed then retain the listener for future failure; otherwise pass the listener to the
+         * consumer.
+         */
+        <R> void runDisrupted(ActionListener<R> listener, Consumer<ActionListener<R>> consumer);
+
+        /**
+         * If disconnected, fail the listener; if blackholed then do nothing; otherwise pass the listener to the consumer.
+         */
+        <R> void runDisruptedOrDrop(ActionListener<R> listener, Consumer<ActionListener<R>> consumer);
+    }
+
     protected interface CoordinatorStrategy extends Closeable {
         CoordinationServices getCoordinationServices(
             ThreadPool threadPool,
             Settings settings,
             ClusterSettings clusterSettings,
             CoordinationState.PersistedState persistedState,
-            BooleanSupplier isDisruptedSupplier
+            DisruptibleRegisterConnection disruptibleRegisterConnection
         );
 
         CoordinationState.PersistedState createFreshPersistedState(
@@ -1539,7 +1623,7 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             Settings settings,
             ClusterSettings clusterSettings,
             CoordinationState.PersistedState persistedState,
-            BooleanSupplier isDisruptedSupplier
+            DisruptibleRegisterConnection disruptibleRegisterConnection
         ) {
             return new CoordinationServices() {
                 @Override

--- a/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/coordination/AbstractCoordinatorTestCase.java
@@ -575,7 +575,8 @@ public class AbstractCoordinatorTestCase extends ESTestCase {
             // noinspection ReplaceInefficientStreamCount using .count() to run the filter on every node
             while (clusterNodes.stream().filter(ClusterNode::deliverBlackholedRegisterRequests).count() != 0L) {
                 logger.debug("--> delivering blackholed register requests");
-                runFor(DEFAULT_DELAY_VARIABILITY, "re-stabilising");
+                // one delay to schedule the request failure, but this forks back to CLUSTER_COORDINATION so a second delay is needed
+                runFor(DEFAULT_DELAY_VARIABILITY * 2, "re-stabilising");
             }
 
             final ClusterNode leader = getAnyLeader();


### PR DESCRIPTION
Today in `AtomicRegisterCoordinatorTests` if a node is blackholed then we immediately fail all register operations. With this commit we simulate a more realistic blackhole which arbitrarily delays the failures.

Reinstates `testAckListenerReceivesNacksIfLeaderStandsDown`
Relates ES-5645