### PR TITLE
Adding support for source and source_content_type params

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: all
-      reason: https://github.com/elastic/elasticsearch/issues/95293
-
   - do:
       indices.create:
         index: test-search-index1

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/RestQuerySearchApplicationAction.java
@@ -40,8 +40,8 @@ public class RestQuerySearchApplicationAction extends BaseRestHandler {
     protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         final String searchAppName = restRequest.param("name");
         SearchApplicationSearchRequest request;
-        if (restRequest.hasContent()) {
-            request = SearchApplicationSearchRequest.fromXContent(searchAppName, restRequest.contentParser());
+        if (restRequest.hasContentOrSourceParam()) {
+            request = SearchApplicationSearchRequest.fromXContent(searchAppName, restRequest.contentOrSourceParamParser());
         } else {
             request = new SearchApplicationSearchRequest(searchAppName);
         }


### PR DESCRIPTION
This PR adds the support for source and source_content_type params in the Search Application search rest endpoint. These params are sometimes used by the rest tests on endpoints that accepts GET requests with a body.

Closes #95293