### PR TITLE
Fix _xpack/usage for enterprise_search in docs tests

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -129,13 +129,6 @@ GET /_xpack/usage
         }
       }
     },
-    "enterprise_search" : {
-      "available": true,
-      "enabled": true,
-      "search_applications" : {
-        "count": 0
-      }
-    },
     "inference" : {
       "ingest_processors" : {
         "_all" : {
@@ -413,6 +406,13 @@ GET /_xpack/usage
     "enabled" : true,
     "invocations": {
       "total": 0
+    }
+  },
+  "enterprise_search" : {
+    "available": true,
+    "enabled": true,
+    "search_applications" : {
+      "count": 0
     }
   }
 }


### PR DESCRIPTION
The previous fix (#95565) didn't work since the section was misplaced. Note that this test runs only on snapshot build so I tested manually and the failure is now related to remote_clusters section missing.

Closes #95603