### PR TITLE
[Test] Fix authz error message assertion

### DIFF
--- a/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
+++ b/x-pack/plugin/ilm/qa/with-security/src/javaRestTest/java/org/elasticsearch/xpack/security/PermissionsIT.java
@@ -144,7 +144,7 @@ public class PermissionsIT extends ESRestTestCase {
                                 + " for user [test_ilm]"
                                 + " with effective roles [ilm]"
                                 + " on indices [not-ilm],"
-                                + " this action is granted by the index privileges [monitor,manage,all]"
+                                + " this action is granted by the index privileges [monitor,cross_cluster_replication,manage,all]"
                         )
                     );
                 }


### PR DESCRIPTION
A new cross_cluster_replication privilege is added in #95651. It grants permission for indicesStats action. As such it now appears in the list of named privileges in the error message when the action is denied.

Resolves: #95825
