### PR TITLE
[8.8] Update range-query.asciidoc (#95822)

### DIFF
--- a/docs/reference/query-dsl/range-query.asciidoc
+++ b/docs/reference/query-dsl/range-query.asciidoc
@@ -154,7 +154,7 @@ GET /_search
     "range": {
       "timestamp": {
         "gte": "now-1d/d",
-        "lt": "now/d"
+        "lte": "now/d"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Update range-query.asciidoc (#95822)