### PR TITLE
[8.7] Note renaming a cluster requires a full restart (#95858)

### DIFF
--- a/docs/reference/setup/important-settings/cluster-name.asciidoc
+++ b/docs/reference/setup/important-settings/cluster-name.asciidoc
@@ -13,3 +13,6 @@ cluster.name: logging-prod
 
 IMPORTANT: Do not reuse the same cluster names in different environments.
 Otherwise, nodes might join the wrong cluster.
+
+NOTE: Changing the name of a cluster requires a <<restart-cluster-full,full
+cluster restart>>.


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Note renaming a cluster requires a full restart (#95858)