### PR TITLE
Track node-left generation in DiscoveryNodes

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.cluster.node;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.Diff;
 import org.elasticsearch.cluster.SimpleDiffable;
@@ -44,6 +45,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
 
     public static final DiscoveryNodes EMPTY_NODES = builder().build();
 
+    private final long nodeLeftGeneration;
     private final Map<String, DiscoveryNode> nodes;
     private final Map<String, DiscoveryNode> dataNodes;
     private final Map<String, DiscoveryNode> masterNodes;
@@ -64,6 +66,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
     private final Set<String> availableRoles;
 
     private DiscoveryNodes(
+        long nodeLeftGeneration,
         Map<String, DiscoveryNode> nodes,
         Map<String, DiscoveryNode> dataNodes,
         Map<String, DiscoveryNode> masterNodes,
@@ -74,6 +77,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
         Version maxNodeVersion,
         Version minNodeVersion
     ) {
+        this.nodeLeftGeneration = nodeLeftGeneration;
         this.nodes = nodes;
         this.dataNodes = dataNodes;
         this.masterNodes = masterNodes;
@@ -317,6 +321,19 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
     }
 
     /**
+     * Return the node-left generation, which is the number of times the cluster membership has been updated by removing one or more nodes.
+     * <p>
+     * Since node-left events are rare, nodes can use the fact that this value has not changed to very efficiently verify that they have not
+     * been removed from the cluster. If the node-left generation changes then that indicates <i>some</i> node has left the cluster, which
+     * triggers some more expensive checks to determine the new cluster membership.
+     * <p>
+     * Not tracked if the cluster has any nodes older than v8.9.0, in which case this method returns zero.
+     */
+    public long getNodeLeftGeneration() {
+        return nodeLeftGeneration;
+    }
+
+    /**
      * Resolve a node with a given id
      *
      * @param node id of the node to discover
@@ -474,7 +491,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
-        sb.append("nodes: \n");
+        sb.append("nodes (node-left generation: ").append(nodeLeftGeneration).append("):\n");
         for (DiscoveryNode node : this) {
             sb.append("   ").append(node);
             if (node == getLocalNode()) {
@@ -589,6 +606,9 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeOptionalString(masterNodeId);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+            out.writeVLong(nodeLeftGeneration);
+        } // else nodeLeftGeneration is zero, or we're sending this to a remote cluster which does not care about the nodeLeftGeneration
         out.writeCollection(nodes.values());
     }
 
@@ -600,6 +620,11 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
         if (localNode != null) {
             builder.localNodeId(localNode.getId());
         }
+
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+            builder.nodeLeftGeneration(in.readVLong());
+        } // else nodeLeftGeneration is zero, or we're receiving this from a remote cluster so the nodeLeftGeneration does not matter to us
+
         int size = in.readVInt();
         for (int i = 0; i < size; i++) {
             DiscoveryNode node = new DiscoveryNode(in);
@@ -632,15 +657,22 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
         private final Map<String, DiscoveryNode> nodes;
         private String masterNodeId;
         private String localNodeId;
+        private boolean removedNode;
+
+        private final long oldNodeLeftGeneration;
+        @Nullable // if not specified
+        private Long nodeLeftGeneration;
 
         public Builder() {
             nodes = new HashMap<>();
+            oldNodeLeftGeneration = 0L;
         }
 
         public Builder(DiscoveryNodes nodes) {
             this.masterNodeId = nodes.getMasterNodeId();
             this.localNodeId = nodes.getLocalNodeId();
             this.nodes = new HashMap<>(nodes.getNodes());
+            this.oldNodeLeftGeneration = nodes.nodeLeftGeneration;
         }
 
         /**
@@ -672,13 +704,16 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
         }
 
         public Builder remove(String nodeId) {
-            nodes.remove(nodeId);
+            if (nodes.remove(nodeId) != null) {
+                removedNode = true;
+            }
             return this;
         }
 
         public Builder remove(DiscoveryNode node) {
             if (node.equals(nodes.get(node.getId()))) {
                 nodes.remove(node.getId());
+                removedNode = true;
             }
             return this;
         }
@@ -738,7 +773,21 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
                 maxNodeVersion = maxNodeVersion == null ? version : Version.max(maxNodeVersion, version);
             }
 
+            final long newNodeLeftGeneration;
+            if (minNodeVersion == null || minNodeVersion.before(Version.V_8_9_0)) {
+                assert this.nodeLeftGeneration == null || this.nodeLeftGeneration == 0L;
+                newNodeLeftGeneration = 0L;
+            } else if (this.nodeLeftGeneration != null) {
+                assert removedNode == false;
+                newNodeLeftGeneration = nodeLeftGeneration;
+            } else if (removedNode) {
+                newNodeLeftGeneration = oldNodeLeftGeneration + 1L;
+            } else {
+                newNodeLeftGeneration = oldNodeLeftGeneration;
+            }
+
             return new DiscoveryNodes(
+                newNodeLeftGeneration,
                 Map.copyOf(nodes),
                 filteredNodes(nodes, DiscoveryNode::canContainData),
                 filteredNodes(nodes, DiscoveryNode::isMasterNode),
@@ -753,6 +802,12 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
 
         public boolean isLocalNodeElectedMaster() {
             return masterNodeId != null && masterNodeId.equals(localNodeId);
+        }
+
+        void nodeLeftGeneration(long nodeLeftGeneration) {
+            // only for deserialization
+            assert this.nodeLeftGeneration == null : nodeLeftGeneration + " vs " + this.nodeLeftGeneration;
+            this.nodeLeftGeneration = nodeLeftGeneration;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
+++ b/server/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodes.java
@@ -778,6 +778,7 @@ public class DiscoveryNodes extends AbstractCollection<DiscoveryNode> implements
                 assert this.nodeLeftGeneration == null || this.nodeLeftGeneration == 0L;
                 newNodeLeftGeneration = 0L;
             } else if (this.nodeLeftGeneration != null) {
+                // only happens during deserialization
                 assert removedNode == false;
                 newNodeLeftGeneration = nodeLeftGeneration;
             } else if (removedNode) {

--- a/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/node/DiscoveryNodesTests.java
@@ -10,10 +10,13 @@ package org.elasticsearch.cluster.node;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.VersionUtils;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,6 +27,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.IntFunction;
+import java.util.function.ObjLongConsumer;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -444,4 +451,81 @@ public class DiscoveryNodesTests extends ESTestCase {
         return stringBuilder.toString();
     }
 
+    public void testNodeLeftGeneration() {
+
+        final ObjLongConsumer<Consumer<DiscoveryNodes.Builder>> testHarness = new ObjLongConsumer<>() {
+            DiscoveryNodes discoveryNodes;
+
+            @Override
+            public void accept(Consumer<DiscoveryNodes.Builder> update, long expectedGeneration) {
+                final var builder = discoveryNodes == null ? DiscoveryNodes.builder() : DiscoveryNodes.builder(discoveryNodes);
+                update.accept(builder);
+                discoveryNodes = builder.build();
+                if (randomBoolean()) {
+                    try {
+                        discoveryNodes = copyWriteable(
+                            discoveryNodes,
+                            writableRegistry(),
+                            in -> DiscoveryNodes.readFrom(in, null),
+                            TransportVersion.CURRENT
+                        );
+                    } catch (IOException e) {
+                        throw new AssertionError("unexpected", e);
+                    }
+                }
+                assertEquals(expectedGeneration, discoveryNodes.getNodeLeftGeneration());
+            }
+        };
+
+        final BiFunction<Integer, Version, DiscoveryNode> nodeVersionFactory = (i, v) -> new DiscoveryNode(
+            "name" + i,
+            "id" + i,
+            buildNewFakeTransportAddress(),
+            Collections.emptyMap(),
+            new HashSet<>(randomSubsetOf(DiscoveryNodeRole.roles())),
+            v
+        );
+
+        final IntFunction<DiscoveryNode> nodeFactory = i -> nodeVersionFactory.apply(i, Version.CURRENT);
+
+        final var node0 = nodeVersionFactory.apply(0, VersionUtils.randomVersion(random()));
+        testHarness.accept(builder -> builder.add(node0), 0L);
+
+        final var node1 = nodeFactory.apply(1);
+        testHarness.accept(builder -> builder.add(node1), 0L);
+
+        // removing a node by ID increments the generation
+        testHarness.accept(builder -> builder.remove(node0.getId()), 1L);
+
+        // no-op removal by ID changes nothing
+        testHarness.accept(builder -> builder.remove("not-an-id"), 1L);
+
+        // no-op removal by instance changes nothing
+        final var node2 = nodeFactory.apply(2);
+        testHarness.accept(builder -> builder.remove(node2), 1L);
+
+        // adding another node changes nothing
+        testHarness.accept(builder -> builder.add(node2), 1L);
+
+        // and removing it by instance increments the generation
+        testHarness.accept(builder -> builder.remove(node2), 2L);
+
+        // if old nodes are present then the generation is forced to zero
+        final var node3 = nodeVersionFactory.apply(3, Version.V_8_8_0);
+        testHarness.accept(builder -> builder.add(node3), 0L);
+
+        // and it remains at zero while the old node is present
+        testHarness.accept(builder -> builder.remove(node1), 0L);
+
+        // but it starts incrementing again when the old node is removed
+        final var node4 = nodeFactory.apply(4);
+        testHarness.accept(builder -> builder.add(node4).remove(node3), 1L);
+
+        // removing multiple nodes at once increments it only by one
+        final var node5 = nodeFactory.apply(5);
+        final var node6 = nodeFactory.apply(6);
+        final var node7 = nodeFactory.apply(7);
+        testHarness.accept(builder -> builder.add(node5).add(node6).add(node7), 1L);
+        testHarness.accept(builder -> builder.remove(node5).remove(node6).remove(node7), 2L);
+    }
 }


### PR DESCRIPTION
Adds tracking of the node-left generation, which is the number of times the cluster membership has been updated by removing one or more nodes.

Since node-left events are rare, nodes can use the fact that this value has not changed to very efficiently verify that they have not been removed from the cluster. If the node-left generation changes then that indicates _some_ node has left the cluster, which triggers some more expensive checks to determine the new cluster membership.

Relates ES-5913