### PR TITLE
[8.8] Fix explain data lifecycle api spec (#95855)

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/indices.explain_data_lifecycle.json
@@ -31,6 +31,10 @@
       "include_defaults": {
         "type": "boolean",
         "description": "indicates if the API should return the default values the system uses for the index's lifecycle"
+      },
+      "master_timeout": {
+        "type": "time",
+        "description": "Specify timeout for connection to master"
       }
     }
   }


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix explain data lifecycle api spec (#95855)