### PR TITLE
Enable validation for versionSettings

### DIFF
--- a/docs/changelog/95874.yaml
+++ b/docs/changelog/95874.yaml
@@ -1,6 +1,6 @@
 pr: 95874
 summary: Enable validation for `versionSettings`
-area: "Infra/Settings, Search"
+area: "Infra/Settings"
 type: bug
 issues:
  - 95873

--- a/docs/changelog/95874.yaml
+++ b/docs/changelog/95874.yaml
@@ -1,0 +1,6 @@
+pr: 95874
+summary: Enable validation for `versionSettings`
+area: "Infra/Settings, Search"
+type: bug
+issues:
+ - 95873

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1278,7 +1278,7 @@ public class Setting<T> implements ToXContentObject {
         Validator<Version> validator,
         Property... properties
     ) {
-        return new Setting<>(key, fallbackSetting, s -> Version.fromId(Integer.parseInt(s)), properties);
+        return new Setting<>(key, fallbackSetting, s -> Version.fromId(Integer.parseInt(s)), validator, properties);
     }
 
     public static Setting<Float> floatSetting(String key, float defaultValue, Property... properties) {

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -189,9 +189,13 @@ public class NodeJoinExecutorTests extends ESTestCase {
     public static Settings.Builder randomCompatibleVersionSettings() {
         Settings.Builder builder = Settings.builder();
         if (randomBoolean()) {
-            builder.put(IndexMetadata.SETTING_VERSION_CREATED, getRandomCompatibleVersion());
+            Version createdVersion = getRandomCompatibleVersion();
+            builder.put(IndexMetadata.SETTING_VERSION_CREATED, createdVersion);
             if (randomBoolean()) {
-                builder.put(IndexMetadata.SETTING_VERSION_COMPATIBILITY, getRandomCompatibleVersion());
+                builder.put(
+                    IndexMetadata.SETTING_VERSION_COMPATIBILITY,
+                    VersionUtils.randomVersionBetween(random(), createdVersion, Version.CURRENT)
+                );
             }
         } else {
             builder.put(IndexMetadata.SETTING_VERSION_CREATED, randomFrom(Version.fromString("5.0.0"), Version.fromString("6.0.0")));


### PR DESCRIPTION
This fixes #95873.

Validation was not enabled when this method was written. This turns it back on. I'm unclear what the effect of turning it on now will be - whether there could be indexes with invalid settings, that will then be rejected by this change that were previously accepted.