### PR TITLE
Disable auto-creation of indices in the AnalyticsEventEmitter

### DIFF
--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
@@ -1,8 +1,4 @@
 setup:
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/95717"
-
   - do:
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
@@ -16,12 +12,10 @@ teardown:
   - do:
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
-        ignore: 404
 
   - do:
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection2
-        ignore: 404
 
 ---
 "Get Analytics Collection for a particular collection":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/70_behavioral_analytics_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/70_behavioral_analytics_put.yml
@@ -2,7 +2,6 @@ teardown:
   - do:
       search_application.delete_behavioral_analytics:
         name: test-analytics-collection
-        ignore: 404
 
 ---
 "Create Analytics Collection":

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
@@ -1,19 +1,13 @@
 setup:
-  - skip:
-      version: "all"
-      reason: "@AwaitsFix https://github.com/elastic/elasticsearch/issues/95686"
-
   - do:
       search_application.put_behavioral_analytics:
         name: my-test-analytics-collection
-        ignore: 400 # Sometimes teardown does not delete the collection and tests get flaky - this fixes it
 
 ---
 teardown:
   - do:
       search_application.delete_behavioral_analytics:
         name: my-test-analytics-collection
-        ignore: 404
 
 
 # Page view event tests #########################################

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
@@ -108,6 +108,8 @@ public class AnalyticsEventEmitter extends AbstractLifecycleComponent {
 
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             return client.prepareIndex(collection.getEventDataStream())
+                // disable auto-creation of the underlying index
+                .setRequireAlias(true)
                 .setCreate(true)
                 .setSource(event.toXContent(builder, ToXContent.EMPTY_PARAMS))
                 .request();


### PR DESCRIPTION
The analytics event emitter delegates the posted events to a bulk processor. When deleting the analytics collection, there's no guarantee that some events are still in flight. This change ensures that these events cannot re-create the underlying index after its deletion. 

Closes #95629
Closes #95657
Closes #95686
Closes #95717