### PR TITLE
Fix compilation error for converting DiscoveryNodes to Collection

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -121,7 +121,7 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
                     timeProvider,
                     (SearchTask) task,
                     searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis),
-                    listener.map(shardIts -> new SearchShardsResponse(toGroups(shardIts), clusterState.nodes(), aliasFilters))
+                    listener.map(shardIts -> new SearchShardsResponse(toGroups(shardIts), clusterState.nodes().getAllNodes(), aliasFilters))
                 );
                 canMatchPhase.start();
             }, listener::onFailure)


### PR DESCRIPTION
`DiscoveryNodes` now implements `Iterable` not extends `Collection`, so we have to add an additional `getAllNodes` call.

See #95872