### PR TITLE
[7.17] Use RefCountingListener SearchableSnapshotDirectory#prewarmCache (#95866)

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
@@ -66,7 +66,6 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
@@ -195,14 +194,14 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
         logger.debug("--> mounting indices");
         final Thread[] threads = new Thread[nbIndices];
         final AtomicArray<Throwable> throwables = new AtomicArray<>(nbIndices);
-        final CountDownLatch latch = new CountDownLatch(1);
+        final CountDownLatch startMounting = new CountDownLatch(1);
 
         for (int i = 0; i < threads.length; i++) {
             int threadId = i;
             final String indexName = "index-" + threadId;
             final Thread thread = new Thread(() -> {
                 try {
-                    latch.await();
+                    startMounting.await();
 
                     final Settings restoredIndexSettings = Settings.builder()
                         .put(SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
@@ -245,7 +244,7 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
             thread.start();
         }
 
-        latch.countDown();
+        startMounting.countDown();
         for (Thread thread : threads) {
             thread.join();
         }
@@ -287,14 +286,16 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
                     .stream()
                     .filter(file -> file.metadata().hashEqualsContents() == false)
                     .filter(file -> exclusionsPerIndex.get(indexName).contains(IndexFileNames.getExtension(file.physicalName())) == false)
-                    .collect(Collectors.toList());
+                    .toList();
 
                 for (BlobStoreIndexShardSnapshot.FileInfo expectedPrewarmedBlob : expectedPrewarmedBlobs) {
                     for (int part = 0; part < expectedPrewarmedBlob.numberOfParts(); part++) {
                         final String blobName = expectedPrewarmedBlob.partName(part);
-                        long actualBytesRead = tracker.totalBytesRead(blobName);
-                        long expectedBytesRead = expectedPrewarmedBlob.partBytes(part);
-                        assertThat("Blob [" + blobName + "] not fully warmed", actualBytesRead, greaterThanOrEqualTo(expectedBytesRead));
+                        assertThat(
+                            "Blob [" + blobName + "] not fully warmed",
+                            tracker.totalBytesRead(blobName),
+                            greaterThanOrEqualTo(expectedPrewarmedBlob.partBytes(part))
+                        );
                     }
                 }
             }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectory.java
@@ -8,7 +8,6 @@ package org.elasticsearch.xpack.searchablesnapshots.store;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.apache.logging.log4j.message.ParameterizedMessage;
 import org.apache.lucene.index.IndexFileNames;
 import org.apache.lucene.store.BaseDirectory;
 import org.apache.lucene.store.Directory;
@@ -19,9 +18,8 @@ import org.apache.lucene.store.IndexOutput;
 import org.apache.lucene.store.SingleInstanceLockFactory;
 import org.apache.lucene.util.BytesRef;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.ActionRunnable;
-import org.elasticsearch.action.StepListener;
-import org.elasticsearch.action.support.GroupedActionListener;
+import org.elasticsearch.action.support.RefCountingListener;
+import org.elasticsearch.blobcache.common.ByteRange;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.RecoverySource;
 import org.elasticsearch.common.blobstore.BlobContainer;
@@ -32,10 +30,9 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.LazyInitializable;
 import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
-import org.elasticsearch.core.CheckedRunnable;
+import org.elasticsearch.common.util.concurrent.ThrottledTaskRunner;
+import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Nullable;
-import org.elasticsearch.core.TimeValue;
-import org.elasticsearch.core.Tuple;
 import org.elasticsearch.core.internal.io.IOUtils;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.shard.ShardId;
@@ -78,10 +75,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.Executor;
-import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.LongSupplier;
 import java.util.function.Supplier;
@@ -493,103 +487,71 @@ public class SearchableSnapshotDirectory extends BaseDirectory {
     }
 
     private void prewarmCache(ActionListener<Void> listener) {
-        if (prewarmCache == false) {
+        try (var completionListener = new RefCountingListener(listener.map(v -> {
             recoveryState.setPreWarmComplete();
-            listener.onResponse(null);
-            return;
-        }
-
-        final BlockingQueue<Tuple<ActionListener<Void>, CheckedRunnable<Exception>>> queue = new LinkedBlockingQueue<>();
-        final Executor executor = prewarmExecutor();
-
-        final GroupedActionListener<Void> completionListener = new GroupedActionListener<>(ActionListener.wrap(voids -> {
-            recoveryState.setPreWarmComplete();
-            listener.onResponse(null);
-        }, listener::onFailure), snapshot().totalFileCount());
-
-        for (BlobStoreIndexShardSnapshot.FileInfo file : snapshot().indexFiles()) {
-            boolean hashEqualsContents = file.metadata().hashEqualsContents();
-            if (hashEqualsContents || isExcludedFromCache(file.physicalName())) {
-                if (hashEqualsContents) {
-                    recoveryState.getIndex().addFileDetail(file.physicalName(), file.length(), true);
-                } else {
-                    recoveryState.ignoreFile(file.physicalName());
-                }
-                completionListener.onResponse(null);
-                continue;
-            }
-            recoveryState.getIndex().addFileDetail(file.physicalName(), file.length(), false);
-            boolean submitted = false;
-            try {
-                final IndexInput input = openInput(file.physicalName(), CachedBlobContainerIndexInput.CACHE_WARMING_CONTEXT);
-                assert input instanceof CachedBlobContainerIndexInput : "expected cached index input but got " + input.getClass();
-
-                final int numberOfParts = file.numberOfParts();
-                final StepListener<Collection<Void>> fileCompletionListener = new StepListener<>();
-                fileCompletionListener.addListener(completionListener.map(voids -> null));
-                fileCompletionListener.whenComplete(voids -> {
-                    logger.debug("{} file [{}] prewarmed", shardId, file.physicalName());
-                    input.close();
-                }, e -> {
-                    logger.warn(() -> new ParameterizedMessage("{} prewarming failed for file [{}]", shardId, file.physicalName()), e);
-                    IOUtils.closeWhileHandlingException(input);
-                });
-
-                final GroupedActionListener<Void> partsListener = new GroupedActionListener<>(fileCompletionListener, numberOfParts);
-                submitted = true;
-                for (int p = 0; p < numberOfParts; p++) {
-                    final int part = p;
-                    queue.add(Tuple.tuple(partsListener, () -> {
-                        ensureOpen();
-
-                        logger.trace("{} warming cache for [{}] part [{}/{}]", shardId, file.physicalName(), part + 1, numberOfParts);
-                        final long startTimeInNanos = statsCurrentTimeNanosSupplier.getAsLong();
-                        final long persistentCacheLength = ((CachedBlobContainerIndexInput) input).prefetchPart(part).v1();
-                        if (persistentCacheLength == file.length()) {
-                            recoveryState.markIndexFileAsReused(file.physicalName());
-                        } else {
-                            recoveryState.getIndex().addRecoveredBytesToFile(file.physicalName(), file.partBytes(part));
-                        }
-
-                        logger.trace(
-                            () -> new ParameterizedMessage(
-                                "{} part [{}/{}] of [{}] warmed in [{}] ms",
-                                shardId,
-                                part + 1,
-                                numberOfParts,
-                                file.physicalName(),
-                                TimeValue.timeValueNanos(statsCurrentTimeNanosSupplier.getAsLong() - startTimeInNanos).millis()
-                            )
-                        );
-                    }));
-                }
-            } catch (IOException e) {
-                logger.warn(() -> new ParameterizedMessage("{} unable to prewarm file [{}]", shardId, file.physicalName()), e);
-                if (submitted == false) {
-                    completionListener.onFailure(e);
-                }
-            }
-        }
-
-        logger.debug("{} warming shard cache for [{}] files", shardId, queue.size());
-
-        // Start as many workers as fit into the prewarming pool at once at the most
-        final int workers = Math.min(threadPool.info(SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME).getMax(), queue.size());
-        for (int i = 0; i < workers; ++i) {
-            prewarmNext(executor, queue);
-        }
-    }
-
-    private void prewarmNext(final Executor executor, final BlockingQueue<Tuple<ActionListener<Void>, CheckedRunnable<Exception>>> queue) {
-        try {
-            final Tuple<ActionListener<Void>, CheckedRunnable<Exception>> next = queue.poll(0L, TimeUnit.MILLISECONDS);
-            if (next == null) {
+            return v;
+        }))) {
+            if (prewarmCache == false) {
                 return;
             }
-            executor.execute(ActionRunnable.run(ActionListener.runAfter(next.v1(), () -> prewarmNext(executor, queue)), next.v2()));
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            logger.warn(() -> new ParameterizedMessage("{} prewarming worker has been interrupted", shardId), e);
+            var prewarmTaskRunner = new ThrottledTaskRunner(
+                "prewarm_task_runner" + shardId,
+                threadPool.info(SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME).getMax(),
+                prewarmExecutor()
+            );
+
+            for (BlobStoreIndexShardSnapshot.FileInfo file : snapshot().indexFiles()) {
+                boolean hashEqualsContents = file.metadata().hashEqualsContents();
+                if (hashEqualsContents || isExcludedFromCache(file.physicalName())) {
+                    if (hashEqualsContents) {
+                        recoveryState.getIndex().addFileDetail(file.physicalName(), file.length(), true);
+                    } else {
+                        recoveryState.ignoreFile(file.physicalName());
+                    }
+                    continue;
+                }
+                recoveryState.getIndex().addFileDetail(file.physicalName(), file.length(), false);
+                try {
+                    final IndexInput input = openInput(file.physicalName(), CachedBlobContainerIndexInput.CACHE_WARMING_CONTEXT);
+                    assert input instanceof CachedBlobContainerIndexInput : "expected cached index input but got " + input.getClass();
+
+                    try (
+                        var fileListener = new RefCountingListener(
+                            ActionListener.runBefore(completionListener.acquire(), () -> IOUtils.closeWhileHandlingException(input))
+                        )
+                    ) {
+                        for (int p = 0; p < file.numberOfParts(); p++) {
+                            final int part = p;
+                            prewarmTaskRunner.enqueueTask(fileListener.acquire().map(releasable -> {
+                                try (releasable) {
+                                    ensureOpen();
+                                    var fileName = file.physicalName();
+                                    final long startTimeInNanos = statsCurrentTimeNanosSupplier.getAsLong();
+                                    final long persistentCacheLength = ((CachedBlobContainerIndexInput) input).prefetchPart(part).v1();
+                                    if (persistentCacheLength == file.length()) {
+                                        recoveryState.markIndexFileAsReused(fileName);
+                                    } else {
+                                        recoveryState.getIndex().addRecoveredFromSnapshotBytesToFile(fileName, file.partBytes(part));
+                                    }
+                                    logger.trace(
+                                        () -> format(
+                                            "%s part [%s/%s] of [%s] warmed in [%s] ms",
+                                            shardId,
+                                            part + 1,
+                                            file.numberOfParts(),
+                                            fileName,
+                                            timeValueNanos(statsCurrentTimeNanosSupplier.getAsLong() - startTimeInNanos).millis()
+                                        )
+                                    );
+                                    return null;
+                                }
+                            }));
+                        }
+                    }
+                } catch (Exception e) {
+                    logger.warn(() -> format("%s unable to prewarm file [%s]", shardId, file.physicalName()), e);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This method uses two `CountDownActionListener` for files and part of files to prewarm. We can simplify this by using `RefCountingListener` instead. This change also simplifies the blocking queue used to poll prewarming tasks and removes some log traces that I think are not very useful.

Backport of #95866