### PR TITLE
Optimize VersionType's static toString

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/VersionType.java
+++ b/server/src/main/java/org/elasticsearch/index/VersionType.java
@@ -13,7 +13,6 @@ import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.lucene.uid.Versions;
 
 import java.io.IOException;
-import java.util.Locale;
 
 public enum VersionType implements Writeable {
     INTERNAL((byte) 0) {
@@ -286,7 +285,11 @@ public enum VersionType implements Writeable {
     }
 
     public static String toString(VersionType versionType) {
-        return versionType.name().toLowerCase(Locale.ROOT);
+        return switch (versionType) {
+            case INTERNAL -> "internal";
+            case EXTERNAL -> "external";
+            case EXTERNAL_GTE -> "external_gte";
+        };
     }
 
     public static VersionType fromValue(byte value) {

--- a/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.index;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.test.ESTestCase;
 
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
 public class VersionTypeTests extends ESTestCase {
@@ -162,5 +163,19 @@ public class VersionTypeTests extends ESTestCase {
         // } else { // external version type
         // updatedVersion = expectedVersion;
         // }
+    }
+
+    public void testStaticFromString() {
+        assertThat(VersionType.fromString("internal"), equalTo(VersionType.INTERNAL));
+        assertThat(VersionType.fromString("external"), equalTo(VersionType.EXTERNAL));
+        assertThat(VersionType.fromString("external_gt"), equalTo(VersionType.EXTERNAL));
+        assertThat(VersionType.fromString("external_gte"), equalTo(VersionType.EXTERNAL_GTE));
+
+        IllegalArgumentException exception;
+        exception = expectThrows(IllegalArgumentException.class, () -> VersionType.fromString("other"));
+        assertThat(exception.toString(), containsString("No version type match [other]"));
+
+        exception = expectThrows(IllegalArgumentException.class, () -> VersionType.fromString(null));
+        assertThat(exception.toString(), containsString("No version type match [null]"));
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
@@ -11,6 +11,8 @@ package org.elasticsearch.index;
 import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.test.ESTestCase;
 
+import java.util.Locale;
+
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 
@@ -189,5 +191,10 @@ public class VersionTypeTests extends ESTestCase {
             npe.toString(),
             containsString("Cannot invoke \"org.elasticsearch.index.VersionType.ordinal()\" because \"versionType\" is null")
         );
+
+        // compare the current implementation with the previous implementation
+        for (VersionType type : VersionType.values()) {
+            assertThat(VersionType.toString(type), equalTo(type.name().toLowerCase(Locale.ROOT)));
+        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
@@ -187,7 +187,7 @@ public class VersionTypeTests extends ESTestCase {
         NullPointerException npe = expectThrows(NullPointerException.class, () -> VersionType.toString(null));
         assertThat(
             npe.toString(),
-            containsString("Cannot invoke \"org.elasticsearch.index.VersionType.name()\" because \"versionType\" is null")
+            containsString("Cannot invoke \"org.elasticsearch.index.VersionType.ordinal()\" because \"versionType\" is null")
         );
     }
 }

--- a/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/VersionTypeTests.java
@@ -178,4 +178,16 @@ public class VersionTypeTests extends ESTestCase {
         exception = expectThrows(IllegalArgumentException.class, () -> VersionType.fromString(null));
         assertThat(exception.toString(), containsString("No version type match [null]"));
     }
+
+    public void testStaticToString() {
+        assertThat(VersionType.toString(VersionType.INTERNAL), equalTo("internal"));
+        assertThat(VersionType.toString(VersionType.EXTERNAL), equalTo("external"));
+        assertThat(VersionType.toString(VersionType.EXTERNAL_GTE), equalTo("external_gte"));
+
+        NullPointerException npe = expectThrows(NullPointerException.class, () -> VersionType.toString(null));
+        assertThat(
+            npe.toString(),
+            containsString("Cannot invoke \"org.elasticsearch.index.VersionType.name()\" because \"versionType\" is null")
+        );
+    }
 }


### PR DESCRIPTION
Just a small optimization. 

We call this method for each document that goes through an ingest pipeline. The current implementation allocates a new `String` each time (because of the call to `.toLowerCase()`), and then we immediately use that `String` as a `HashMap` key, so we also have the calculate a fresh hash code each time, too. This new implementation statically allocates the result Strings, so they're not re-allocated each time, and we can rely on `java.lang.String`'s hash caching, then, which also helps.

Before (the expense here is both to actual `toString` call on the right and then also the subsequent `hashCode` call on the left):
<img width="1784" alt="Screen Shot 2023-05-06 at 9 09 25 AM" src="https://user-images.githubusercontent.com/187034/236626233-66ca8595-1a24-4d84-a4b9-d49df57bfec3.png">

After (gloriously empty):
<img width="1784" alt="Screen Shot 2023-05-06 at 9 09 36 AM" src="https://user-images.githubusercontent.com/187034/236626238-12146c92-a432-4bbf-9b16-cab90b388315.png">
