### PR TITLE
Add test coverage for unmapped fields for avg aggregator

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/avg_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/avg_metric.yml
@@ -43,11 +43,31 @@ setup:
              double_field: 151.0
              string_field: foo
 
+  - do:
+      indices.create:
+        index: test_2
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              other_field:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_2
+              _id:    "1"
+          - other_field: "other value"
 ---
 "Basic test":
 
   - do:
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           aggs:
@@ -68,6 +88,7 @@ setup:
 
   - do:
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           size: 0
@@ -89,6 +110,7 @@ setup:
 
   - do:
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           query:
@@ -116,6 +138,7 @@ setup:
 
   - do:
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           aggs:
@@ -133,6 +156,7 @@ setup:
 
   - do:
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           aggs:
@@ -149,6 +173,7 @@ setup:
 
   - do:
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           aggs:
@@ -169,9 +194,45 @@ setup:
   - do:
       catch: bad_request
       search:
+        index: test_1
         rest_total_hits_as_int: true
         body:
           aggs:
             the_string_avg:
               avg:
                 field: string_field
+
+---
+"Partially unmapped":
+
+  - do:
+      search:
+        index: test_1,test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_avg:
+              avg:
+                field: int_field
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_avg.value: 76.0 }
+
+---
+"Partially unmapped with missing":
+
+  - do:
+      search:
+        index: test_1,test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_avg:
+              avg:
+                field: int_field
+                missing: 10
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_avg.value: 62.8 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorTests.java
@@ -257,31 +257,6 @@ public class AvgAggregatorTests extends AggregatorTestCase {
         }, avg -> assertEquals(expected, avg.getValue(), delta), fieldType);
     }
 
-    public void testSingleValuedFieldPartiallyUnmapped() throws IOException {
-        Directory directory = newDirectory();
-        RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-        indexWriter.addDocument(singleton(new NumericDocValuesField("number", 7)));
-        indexWriter.addDocument(singleton(new NumericDocValuesField("number", 2)));
-        indexWriter.addDocument(singleton(new NumericDocValuesField("number", 3)));
-        indexWriter.addDocument(singleton(new NumericDocValuesField("unrelated", 100)));
-        indexWriter.close();
-
-        DirectoryReader indexReader = DirectoryReader.open(directory);
-        IndexSearcher indexSearcher = newIndexSearcher(indexReader);
-
-        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
-        AvgAggregationBuilder aggregationBuilder = new AvgAggregationBuilder("_name").field("number");
-
-        InternalAvg avg = searchAndReduce(indexSearcher, new AggTestConfig(aggregationBuilder, fieldType));
-
-        assertEquals(4, avg.getValue(), 0);
-        assertEquals(3, avg.getCount(), 0);
-        assertTrue(AggregationInspectionHelper.hasValue(avg));
-
-        indexReader.close();
-        directory.close();
-    }
-
     public void testSingleValuedField() throws IOException {
         testAggregation(new MatchAllDocsQuery(), iw -> {
             iw.addDocument(singleton(new NumericDocValuesField("number", 7)));


### PR DESCRIPTION
Add test coverage when one index has the field unmapped for avg aggregator.

related to https://github.com/elastic/elasticsearch/issues/95884