### PR TITLE
Add test coverage for unmapped fields for max aggregator

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -274,12 +274,12 @@ setup:
         body:
           aggs:
             the_int_max:
-              avg:
+              max:
                 field: int_field
 
   - match: { hits.total: 5 }
   - length: { hits.hits: 5 }
-  - match: { aggregations.the_int_max.value: 76.0 }
+  - match: { aggregations.the_int_max.value: 151.0 }
 
 ---
 "Partially unmapped with missing":

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/max_metric.yml
@@ -263,3 +263,38 @@ setup:
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
   - match: { aggregations.the_counter_max.value: 4 }
+
+---
+"Partially unmapped":
+
+  - do:
+      search:
+        index: test_1,date_test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_max:
+              avg:
+                field: int_field
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_max.value: 76.0 }
+
+---
+"Partially unmapped with missing":
+
+  - do:
+      search:
+        index: test_1,date_test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_max:
+              max:
+                field: int_field
+                missing: 100000
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_max.value: 100000 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorTests.java
@@ -456,32 +456,6 @@ public class MaxAggregatorTests extends AggregatorTestCase {
         directory.close();
     }
 
-    public void testSingleValuedFieldPartiallyUnmapped() throws IOException {
-        Directory directory = newDirectory();
-        RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-        final int numDocs = 10;
-        for (int i = 0; i < numDocs; i++) {
-            indexWriter.addDocument(singleton(new NumericDocValuesField("value", i + 1)));
-        }
-        indexWriter.addDocument(singleton(new NumericDocValuesField("unrelated", 100)));
-        indexWriter.close();
-
-        DirectoryReader indexReader = DirectoryReader.open(directory);
-        IndexSearcher indexSearcher = newIndexSearcher(indexReader);
-
-        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("value", NumberFieldMapper.NumberType.INTEGER);
-        AggregationBuilder aggregationBuilder = new MaxAggregationBuilder("max").field("value");
-
-        Max max = searchAndReduce(indexSearcher, new AggTestConfig(aggregationBuilder, fieldType));
-
-        assertEquals(10.0, max.value(), 0);
-        assertEquals("max", max.getName());
-        assertTrue(AggregationInspectionHelper.hasValue(max));
-
-        indexReader.close();
-        directory.close();
-    }
-
     public void testSingleValuedFieldWithValueScript() throws IOException {
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("value", NumberFieldMapper.NumberType.INTEGER);
 


### PR DESCRIPTION
Add test coverage when one index has the field unmapped for max aggregator.

related to https://github.com/elastic/elasticsearch/issues/95884