### PR TITLE
Fix SecurityNetty4HttpServerTransportTests

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/internal/HttpHeadersAuthenticatorUtils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/internal/HttpHeadersAuthenticatorUtils.java
@@ -53,7 +53,7 @@ public final class HttpHeadersAuthenticatorUtils {
             } else {
                 // cannot authenticate the request because it's not wrapped correctly, see {@link #wrapAsMessageWithAuthenticationContext}
                 assert false;
-                //listener.onFailure(new IllegalStateException("Cannot authenticate unwrapped requests"));
+                // listener.onFailure(new IllegalStateException("Cannot authenticate unwrapped requests"));
             }
         }, threadContext);
     }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/internal/HttpHeadersAuthenticatorUtils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/internal/HttpHeadersAuthenticatorUtils.java
@@ -52,8 +52,7 @@ public final class HttpHeadersAuthenticatorUtils {
                 }, e -> listener.onFailure(new HttpHeadersValidationException(e))));
             } else {
                 // cannot authenticate the request because it's not wrapped correctly, see {@link #wrapAsMessageWithAuthenticationContext}
-                assert false;
-                // listener.onFailure(new IllegalStateException("Cannot authenticate unwrapped requests"));
+                listener.onFailure(new IllegalStateException("Cannot authenticate unwrapped requests"));
             }
         }, threadContext);
     }

--- a/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/internal/HttpHeadersAuthenticatorUtils.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/http/netty4/internal/HttpHeadersAuthenticatorUtils.java
@@ -52,7 +52,8 @@ public final class HttpHeadersAuthenticatorUtils {
                 }, e -> listener.onFailure(new HttpHeadersValidationException(e))));
             } else {
                 // cannot authenticate the request because it's not wrapped correctly, see {@link #wrapAsMessageWithAuthenticationContext}
-                listener.onFailure(new IllegalStateException("Cannot authenticate unwrapped requests"));
+                assert false;
+                //listener.onFailure(new IllegalStateException("Cannot authenticate unwrapped requests"));
             }
         }, threadContext);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -283,6 +283,7 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
         final HttpServerTransport.Dispatcher dispatcher = new HttpServerTransport.Dispatcher() {
             @Override
             public void dispatchRequest(final RestRequest request, final RestChannel channel, final ThreadContext threadContext) {
+                request.getHttpRequest().release();
                 // STEP 2: store the dispatched request, which should be wrapping the context
                 dispatchedHttpRequestReference.set(request.getHttpRequest());
             }


### PR DESCRIPTION
Fixes SecurityNetty4HttpServerTransportTests
testAuthnContextWrapping

The mocking removed code that called `release` on request objects. 

Closes https://github.com/elastic/elasticsearch/issues/95846