### PR TITLE
Add test coverage for unmapped fields for min aggregator

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/min_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/min_metric.yml
@@ -43,12 +43,33 @@ setup:
              double_field: 151.0
              string_field: foo
 
+  - do:
+      indices.create:
+        index: test_2
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              other_field:
+                type: keyword
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_2
+              _id:    "1"
+          - other_field: "other value"
+
 ---
 "Basic test":
 
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_int_min:
@@ -69,6 +90,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           size: 0
           aggs:
@@ -90,6 +112,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           query:
             constant_score:
@@ -117,6 +140,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_missing_min:
@@ -134,6 +158,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_missing_min:
@@ -150,6 +175,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_int_min:
@@ -170,6 +196,7 @@ setup:
       catch: bad_request
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_string_min:
@@ -217,3 +244,38 @@ setup:
   - match: { hits.total: 2 }
   - length: { hits.hits: 2 }
   - match: { aggregations.the_counter_min.value: 2 }
+
+---
+"Partially unmapped":
+
+  - do:
+      search:
+        index: test_1,test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_min:
+              min:
+                field: int_field
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_min.value: 1.0 }
+
+---
+"Partially unmapped with missing":
+
+  - do:
+      search:
+        index: test_1,test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_min:
+              min:
+                field: int_field
+                missing: -100000
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_min.value: -100000 }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorTests.java
@@ -354,29 +354,6 @@ public class MinAggregatorTests extends AggregatorTestCase {
         }, new AggTestConfig(globalBuilder, fieldType));
     }
 
-    public void testSingleValuedFieldPartiallyUnmapped() throws IOException {
-
-        MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);
-        MinAggregationBuilder aggregationBuilder = new MinAggregationBuilder("min").field("number");
-
-        try (Directory directory = newDirectory(); Directory unmappedDirectory = newDirectory()) {
-            RandomIndexWriter indexWriter = new RandomIndexWriter(random(), directory);
-            indexWriter.addDocument(singleton(new NumericDocValuesField("number", 7)));
-            indexWriter.addDocument(singleton(new NumericDocValuesField("number", 2)));
-            indexWriter.addDocument(singleton(new NumericDocValuesField("number", 3)));
-            indexWriter.addDocument(singleton(new NumericDocValuesField("unrelated", 100)));
-            indexWriter.close();
-
-            try (DirectoryReader indexReader = DirectoryReader.open(directory)) {
-                IndexSearcher indexSearcher = newIndexSearcher(indexReader);
-
-                Min min = searchAndReduce(indexSearcher, new AggTestConfig(aggregationBuilder, fieldType));
-                assertEquals(2.0, min.value(), 0);
-                assertTrue(AggregationInspectionHelper.hasValue(min));
-            }
-        }
-    }
-
     public void testSingleValuedFieldPartiallyUnmappedWithMissing() throws IOException {
 
         MappedFieldType fieldType = new NumberFieldMapper.NumberFieldType("number", NumberFieldMapper.NumberType.INTEGER);


### PR DESCRIPTION
Add test coverage when one index has the field unmapped for min aggregator.

related to https://github.com/elastic/elasticsearch/issues/95884