### PR TITLE
[8.7] Fix typo in Graph Explore API docs (#95907)

### DIFF
--- a/docs/reference/graph/explore.asciidoc
+++ b/docs/reference/graph/explore.asciidoc
@@ -66,7 +66,7 @@ Elasticsearch query. For example:
 
 
 vertices::
-Specifies or more fields that contain the terms you want to include in the
+Specifies one or more fields that contain the terms you want to include in the
 graph as vertices. For example:
 +
 [source,js]


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Fix typo in Graph Explore API docs (#95907)