### PR TITLE
Refactor NodeSeenService to use task queues

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
@@ -12,18 +12,25 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.cluster.ClusterStateTaskExecutor;
+import org.elasticsearch.cluster.ClusterStateTaskListener;
 import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
+import org.elasticsearch.common.Priority;
 import org.elasticsearch.core.SuppressForbidden;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import static org.elasticsearch.cluster.metadata.NodesShutdownMetadata.getShutdownsOrEmpty;
 import static org.elasticsearch.core.Strings.format;
 
 /**
@@ -36,8 +43,14 @@ public class NodeSeenService implements ClusterStateListener {
 
     final ClusterService clusterService;
 
+    private final MasterServiceTaskQueue<SetSeenNodesShutdownTask> setSeenTaskQueue;
     public NodeSeenService(ClusterService clusterService) {
         this.clusterService = clusterService;
+        this.setSeenTaskQueue = clusterService.createTaskQueue(
+            "shutdown-seen-nodes-updater",
+            Priority.NORMAL,
+            new SetSeenNodesShutdownExecutor()
+        );
         clusterService.addListener(this);
     }
 
@@ -71,44 +84,48 @@ public class NodeSeenService implements ClusterStateListener {
             .collect(Collectors.toUnmodifiableSet());
 
         if (nodesNotPreviouslySeen.isEmpty() == false) {
-            submitUnbatchedTask("shutdown-seen-nodes-updater", new ClusterStateUpdateTask() {
-                @Override
-                public ClusterState execute(ClusterState currentState) throws Exception {
-                    NodesShutdownMetadata currentShutdownMetadata = currentState.metadata().custom(NodesShutdownMetadata.TYPE);
-
-                    final Map<String, SingleNodeShutdownMetadata> newShutdownMetadataMap = currentShutdownMetadata.getAllNodeMetadataMap()
-                        .values()
-                        .stream()
-                        .map(singleNodeShutdownMetadata -> {
-                            if (nodesNotPreviouslySeen.contains(singleNodeShutdownMetadata.getNodeId())
-                                || currentState.nodes().nodeExists(singleNodeShutdownMetadata.getNodeId())) {
-                                return SingleNodeShutdownMetadata.builder(singleNodeShutdownMetadata).setNodeSeen(true).build();
-                            }
-                            return singleNodeShutdownMetadata;
-                        })
-                        .collect(Collectors.toUnmodifiableMap(SingleNodeShutdownMetadata::getNodeId, Function.identity()));
-
-                    final NodesShutdownMetadata newNodesMetadata = new NodesShutdownMetadata(newShutdownMetadataMap);
-                    if (newNodesMetadata.equals(currentShutdownMetadata)) {
-                        // Turns out the update was a no-op
-                        return currentState;
-                    }
-
-                    return ClusterState.builder(currentState)
-                        .metadata(Metadata.builder(currentState.metadata()).putCustom(NodesShutdownMetadata.TYPE, newNodesMetadata).build())
-                        .build();
-                }
-
-                @Override
-                public void onFailure(Exception e) {
-                    logger.warn(() -> format("failed to mark shutting down nodes as seen: %s", nodesNotPreviouslySeen), e);
-                }
-            });
+            setSeenTaskQueue.submitTask("saw new nodes", new SetSeenNodesShutdownTask(nodesNotPreviouslySeen), null);
         }
     }
 
-    @SuppressForbidden(reason = "legacy usage of unbatched task") // TODO add support for batching here
-    private void submitUnbatchedTask(@SuppressWarnings("SameParameterValue") String source, ClusterStateUpdateTask task) {
-        clusterService.submitUnbatchedStateUpdateTask(source, task);
+    record SetSeenNodesShutdownTask(Set<String> nodesNotPreviouslySeen) implements ClusterStateTaskListener {
+        @Override
+        public void onFailure(Exception e) {
+            logger.warn(() -> format("failed to mark shutting down nodes as seen: %s", nodesNotPreviouslySeen), e);
+        }
+    }
+
+    private static class SetSeenNodesShutdownExecutor implements ClusterStateTaskExecutor<SetSeenNodesShutdownTask> {
+
+        @Override
+        public ClusterState execute(BatchExecutionContext<SetSeenNodesShutdownTask> batchExecutionContext) throws Exception {
+            final var initialState = batchExecutionContext.initialState();
+            var shutdownMetadata = new HashMap<>(getShutdownsOrEmpty(initialState).getAllNodeMetadataMap());
+
+            var nodesNotPreviouslySeen = new HashSet<>();
+            for (final var taskContext : batchExecutionContext.taskContexts()) {
+                nodesNotPreviouslySeen.addAll(taskContext.getTask().nodesNotPreviouslySeen());
+            }
+
+            var nodes = initialState.nodes();
+            shutdownMetadata.replaceAll((k, v) -> {
+                if (v.getNodeSeen() == false && (nodesNotPreviouslySeen.contains(v.getNodeId()) || nodes.nodeExists(v.getNodeId()))) {
+                    return SingleNodeShutdownMetadata.builder(v).setNodeSeen(true).build();
+                }
+                return v;
+            });
+
+            if (shutdownMetadata.equals(getShutdownsOrEmpty(initialState).getAllNodeMetadataMap())) {
+                return initialState;
+            }
+
+            return ClusterState.builder(initialState)
+                .metadata(
+                    Metadata.builder(initialState.metadata())
+                        .putCustom(NodesShutdownMetadata.TYPE, new NodesShutdownMetadata(shutdownMetadata))
+                        .build()
+                )
+                .build();
+        }
     }
 }

--- a/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
+++ b/x-pack/plugin/shutdown/src/main/java/org/elasticsearch/xpack/shutdown/NodeSeenService.java
@@ -14,20 +14,16 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateListener;
 import org.elasticsearch.cluster.ClusterStateTaskExecutor;
 import org.elasticsearch.cluster.ClusterStateTaskListener;
-import org.elasticsearch.cluster.ClusterStateUpdateTask;
 import org.elasticsearch.cluster.metadata.Metadata;
 import org.elasticsearch.cluster.metadata.NodesShutdownMetadata;
 import org.elasticsearch.cluster.metadata.SingleNodeShutdownMetadata;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
-import org.elasticsearch.core.SuppressForbidden;
 
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.cluster.metadata.NodesShutdownMetadata.getShutdownsOrEmpty;
@@ -44,6 +40,7 @@ public class NodeSeenService implements ClusterStateListener {
     final ClusterService clusterService;
 
     private final MasterServiceTaskQueue<SetSeenNodesShutdownTask> setSeenTaskQueue;
+
     public NodeSeenService(ClusterService clusterService) {
         this.clusterService = clusterService;
         this.setSeenTaskQueue = clusterService.createTaskQueue(


### PR DESCRIPTION
NodeSeenService uses the deprecated `clusterService.submitUnbatchedStateUpdateTask`.  

I'll need to do some metadata manipulation for the work to cleanup SIGTERM shutdowns.  This refactoring uses task queues so that future work doesn't continue to add new code to the deprecated unbatched task.