### PR TITLE
Fixing a watcher history race condition in TimeThrottleIntegrationTests

### DIFF
--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/TimeThrottleIntegrationTests.java
@@ -111,12 +111,17 @@ public class TimeThrottleIntegrationTests extends AbstractWatcherIntegrationTest
         });
     }
 
-    private void assertTotalHistoryEntries(String id, long expectedCount) {
-        SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
-            .setSize(0)
-            .setSource(new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(termQuery("watch_id", id))))
-            .get();
+    private void assertTotalHistoryEntries(String id, long expectedCount) throws Exception {
+        assertBusy(() -> {
+            // Watcher history is now written asynchronously, so we check this in an assertBusy
+            ensureGreen(HistoryStoreField.DATA_STREAM);
+            SearchResponse searchResponse = client().prepareSearch(HistoryStoreField.DATA_STREAM + "*")
+                .setSize(0)
+                .setSource(new SearchSourceBuilder().query(QueryBuilders.boolQuery().must(termQuery("watch_id", id))))
+                .get();
 
-        assertThat(searchResponse.getHits().getTotalHits().value, is(oneOf(expectedCount, expectedCount + 1)));
+            assertThat(searchResponse.getHits().getTotalHits().value, is(oneOf(expectedCount, expectedCount + 1)));
+        });
+
     }
 }


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/94133 we made it so that watcher history writes are non-blocking. This means that if we query for watcher history documents immediately in tests they sometimes aren't there yet. This adds an assertBusy block to keep trying for a few seconds.
Closes #95875