### PR TITLE
Set the redact processor's skip_if_unlicensed config default to false

### DIFF
--- a/x-pack/plugin/redact/src/main/java/org/elasticsearch/xpack/redact/RedactProcessor.java
+++ b/x-pack/plugin/redact/src/main/java/org/elasticsearch/xpack/redact/RedactProcessor.java
@@ -384,7 +384,7 @@ public class RedactProcessor extends AbstractProcessor {
             String matchField = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "field");
             List<String> matchPatterns = ConfigurationUtils.readList(TYPE, processorTag, config, "patterns");
             boolean ignoreMissing = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "ignore_missing", true);
-            boolean skipIfUnlicensed = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "skip_if_unlicensed", true);
+            boolean skipIfUnlicensed = ConfigurationUtils.readBooleanProperty(TYPE, processorTag, config, "skip_if_unlicensed", false);
 
             String redactStart = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "prefix", DEFAULT_REDACTED_START);
             String redactEnd = ConfigurationUtils.readStringProperty(TYPE, processorTag, config, "suffix", DEFAULT_REDACTED_END);

--- a/x-pack/plugin/redact/src/test/java/org/elasticsearch/xpack/redact/RedactProcessorTests.java
+++ b/x-pack/plugin/redact/src/test/java/org/elasticsearch/xpack/redact/RedactProcessorTests.java
@@ -236,9 +236,7 @@ public class RedactProcessorTests extends ESTestCase {
             config.put("field", "to_redact");
             config.put("patterns", List.of("foo"));
             config.put("ignore_missing", false); // usually, this would throw, but here it doesn't because of the license check
-            if (randomBoolean()) {
-                config.put("skip_if_unlicensed", true); // set the value to true (versus just using the default, also true)
-            }
+            config.put("skip_if_unlicensed", true); // set the value to true (versus using the default, which is false)
             var processor = new RedactProcessor.Factory(notAllowed, MatcherWatchdog.noop()).create(null, "t", "d", config);
             assertThat(processor.getSkipIfUnlicensed(), equalTo(true));
             var ingestDoc = createIngestDoc(Map.of("not_the_field", "fieldValue"));


### PR DESCRIPTION
Followup to #95477

Per conversation on that PR, and subsequent discussion elsewhere, the more cautious default value for `skip_if_unlicensed` is `false`.