### PR TITLE
Add test coverage for unmapped fields for sum aggregator

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/sum_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/sum_metric.yml
@@ -43,12 +43,34 @@ setup:
              double_field: 151.0
              string_field: foo
 
+  - do:
+      indices.create:
+        index: test_2
+        body:
+          settings:
+            number_of_replicas: 0
+          mappings:
+            properties:
+              other_field:
+                type: keyword
+
+
+  - do:
+     bulk:
+        refresh: true
+        body:
+          - index:
+              _index: test_2
+              _id:    "1"
+          - other_field: "other value"
+
 ---
 "Basic test":
 
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_int_sum:
@@ -69,6 +91,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           size: 0
           aggs:
@@ -90,6 +113,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           query:
             constant_score:
@@ -117,6 +141,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_missing_sum:
@@ -134,6 +159,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_missing_sum:
@@ -150,6 +176,7 @@ setup:
   - do:
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_int_sum:
@@ -170,8 +197,44 @@ setup:
       catch: bad_request
       search:
         rest_total_hits_as_int: true
+        index: test_1
         body:
           aggs:
             the_string_sum:
               sum:
                 field: string_field
+
+---
+"Partially unmapped":
+
+  - do:
+      search:
+        index: test_1,test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_sum:
+              sum:
+                field: int_field
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_sum.value: 304.0 }
+
+---
+"Partially unmapped with missing":
+
+  - do:
+      search:
+        index: test_1,test_2
+        rest_total_hits_as_int: true
+        body:
+          aggs:
+            the_int_sum:
+              sum:
+                field: int_field
+                missing: 100000
+
+  - match: { hits.total: 5 }
+  - length: { hits.hits: 5 }
+  - match: { aggregations.the_int_sum.value: 100304.0 }


### PR DESCRIPTION
Add test coverage when one index has the field unmapped for sum aggregator.

related to https://github.com/elastic/elasticsearch/issues/95884