### PR TITLE
[ILM] Fix the migrate to tiers service and migrate action tiers configuration

### DIFF
--- a/docs/changelog/95934.yaml
+++ b/docs/changelog/95934.yaml
@@ -1,0 +1,5 @@
+pr: 95934
+summary: "[ILM] Fix the migrate to tiers service and migrate action tiers configuration"
+area: ILM+SLM
+type: bug
+issues: []

--- a/docs/reference/ilm/actions/ilm-migrate.asciidoc
+++ b/docs/reference/ilm/actions/ilm-migrate.asciidoc
@@ -31,10 +31,8 @@ to `data_cold,data_warm,data_hot`. This moves the index to nodes in the
 The migrate action is not allowed in the frozen phase. The frozen phase directly
 mounts the searchable snapshot using a
 <<tier-preference-allocation-filter, `index.routing.allocation.include._tier_preference`>>
-of `data_frozen,data_cold,data_warm,data_hot`. This moves the index to nodes in the
-<<frozen-tier, frozen tier>>. If there are no nodes in the frozen tier, it falls back to the
-<<cold-tier, cold>> tier, then the <<warm-tier, warm>> tier, then finally the <<hot-tier, hot>>
-tier.
+of `data_frozen`. This moves the index to nodes in the
+<<frozen-tier, frozen tier>>.
 
 The migrate action is not allowed in the hot phase.
 The initial index allocation is performed <<data-tier-allocation, automatically>>,

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DataTier.java
@@ -100,10 +100,15 @@ public class DataTier {
         final Map<String, Settings> tmpSettings = new HashMap<>();
         for (int i = 0, ordered_frozen_to_hot_tiersSize = ORDERED_FROZEN_TO_HOT_TIERS.size(); i < ordered_frozen_to_hot_tiersSize; i++) {
             String tier = ORDERED_FROZEN_TO_HOT_TIERS.get(i);
-            final String prefTierString = String.join(",", ORDERED_FROZEN_TO_HOT_TIERS.subList(i, ORDERED_FROZEN_TO_HOT_TIERS.size()))
-                .intern();
-            tmp.put(tier, prefTierString);
-            tmpSettings.put(tier, Settings.builder().put(DataTier.TIER_PREFERENCE, prefTierString).build());
+            if (tier.equals(DATA_FROZEN)) {
+                tmp.put(tier, DATA_FROZEN);
+                tmpSettings.put(DATA_FROZEN, Settings.builder().put(DataTier.TIER_PREFERENCE, DATA_FROZEN).build());
+            } else {
+                final String prefTierString = String.join(",", ORDERED_FROZEN_TO_HOT_TIERS.subList(i, ORDERED_FROZEN_TO_HOT_TIERS.size()))
+                    .intern();
+                tmp.put(tier, prefTierString);
+                tmpSettings.put(tier, Settings.builder().put(DataTier.TIER_PREFERENCE, prefTierString).build());
+            }
         }
         PREFERENCE_TIER_CONFIGURATIONS = Map.copyOf(tmp);
         PREFERENCE_TIER_CONFIGURATION_SETTINGS = Map.copyOf(tmpSettings);

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/DataTierTests.java
@@ -28,6 +28,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.elasticsearch.cluster.routing.allocation.DataTier.DATA_COLD;
+import static org.elasticsearch.cluster.routing.allocation.DataTier.DATA_FROZEN;
 import static org.elasticsearch.cluster.routing.allocation.DataTier.DATA_HOT;
 import static org.elasticsearch.cluster.routing.allocation.DataTier.DATA_WARM;
 import static org.elasticsearch.cluster.routing.allocation.DataTier.getPreferredTiersConfiguration;
@@ -120,6 +121,7 @@ public class DataTierTests extends ESTestCase {
         assertThat(getPreferredTiersConfiguration(DATA_HOT), is(DATA_HOT));
         assertThat(getPreferredTiersConfiguration(DATA_WARM), is(DATA_WARM + "," + DATA_HOT));
         assertThat(getPreferredTiersConfiguration(DATA_COLD), is(DATA_COLD + "," + DATA_WARM + "," + DATA_HOT));
+        assertThat(getPreferredTiersConfiguration(DATA_FROZEN), is(DATA_FROZEN));
         IllegalArgumentException exception = expectThrows(IllegalArgumentException.class, () -> getPreferredTiersConfiguration("no_tier"));
         assertThat(exception.getMessage(), is("invalid data tier [no_tier]"));
     }


### PR DESCRIPTION
The migrate action (although no allowed in the frozen phase) would seem to convert `frozen` to `data_frozen,data_cold,data_warm,data_hot` tier configuration. As the migrate action is not allowed in the frozen phase this would never happen, however the code is confusing as it seems like it could.

The migrate to data tiers routing service shared the code used by the `migrate` action that converted `frozen` to `data_frozen,data_cold,data_warm,data_hot` if it would encounter an index without any `_tier_preference` setting 
but with a custom node attribute configured to `frozen` e.g. `include.data: frozen`

As part of https://github.com/elastic/elasticsearch/issues/84758 we have seen frozen indices with the `data_frozen,data_cold,data_warm,data_hot` tier preference however we could never reproduce it.

Relates to https://github.com/elastic/elasticsearch/issues/84758