### PR TITLE
Fix nanos comparisons related to UnassignedInfo

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/UnassignedInfo.java
@@ -445,7 +445,7 @@ public final class UnassignedInfo implements ToXContentFragment, Writeable {
             .map(TimeValue::nanos)
             .map(knownRestartDelay -> Math.max(indexLevelDelay, knownRestartDelay))
             .orElse(indexLevelDelay);
-        assert nanoTimeNow >= unassignedTimeNanos;
+        assert nanoTimeNow - unassignedTimeNanos >= 0;
         return Math.max(0L, delayTimeoutNanos - (nanoTimeNow - unassignedTimeNanos));
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/ShardsAvailabilityHealthIndicatorService.java
@@ -451,7 +451,7 @@ public class ShardsAvailabilityHealthIndicatorService implements HealthIndicator
         }
         var now = System.nanoTime();
         var restartingAllocationDelayExpiration = info.getUnassignedTimeInNanos() + shutdown.getAllocationDelay().nanos();
-        return now <= restartingAllocationDelayExpiration;
+        return now - restartingAllocationDelayExpiration <= 0;
     }
 
     private static boolean isUnassignedDueToNewInitialization(ShardRouting routing) {


### PR DESCRIPTION
System.nanoTime() can in principle wrap around and thus comparing values directly is not guaranteed to work. Instead we compare the difference.
