### PR TITLE
[8.8] Cancel cold cache prewarming tasks if store is closing (#95891)

### DIFF
--- a/docs/changelog/95891.yaml
+++ b/docs/changelog/95891.yaml
@@ -1,0 +1,6 @@
+pr: 95891
+summary: Cancel cold cache prewarming tasks if store is closing
+area: Snapshot/Restore
+type: bug
+issues:
+ - 95504

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/full/SearchableSnapshotsPrewarmingIntegTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotR
 import org.elasticsearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.elasticsearch.action.bulk.BulkRequestBuilder;
 import org.elasticsearch.action.bulk.BulkResponse;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.routing.allocation.decider.ThrottlingAllocationDecider;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -25,11 +26,16 @@ import org.elasticsearch.common.blobstore.support.FilterBlobContainer;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeUnit;
 import org.elasticsearch.common.util.BigArrays;
+import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.env.Environment;
+import org.elasticsearch.index.Index;
 import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
+import org.elasticsearch.index.store.LuceneFilesExtensions;
+import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.recovery.RecoverySettings;
+import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.license.LicenseSettings;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.plugins.PluginsService;
@@ -56,23 +62,29 @@ import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Path;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
+import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING;
 import static org.elasticsearch.xpack.searchablesnapshots.SearchableSnapshots.SNAPSHOT_CACHE_PREWARM_ENABLED_SETTING;
+import static org.hamcrest.Matchers.anyOf;
 import static org.hamcrest.Matchers.emptyCollectionOf;
+import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
@@ -187,10 +199,14 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
 
         final Map<String, List<String>> exclusionsPerIndex = new HashMap<>();
         for (int index = 0; index < nbIndices; index++) {
-            exclusionsPerIndex.put("index-" + index, randomSubsetOf(Arrays.asList("fdt", "fdx", "nvd", "dvd", "tip", "cfs", "dim")));
+            exclusionsPerIndex.put(
+                "index-" + index,
+                randomSubsetOf(Stream.of(LuceneFilesExtensions.values()).map(LuceneFilesExtensions::getExtension).toList())
+            );
         }
 
         logger.debug("--> mounting indices");
+        final List<String> mountedIndices = new ArrayList<>(nbIndices);
         final Thread[] threads = new Thread[nbIndices];
         final AtomicArray<Throwable> throwables = new AtomicArray<>(nbIndices);
         final CountDownLatch startMounting = new CountDownLatch(1);
@@ -198,6 +214,7 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
         for (int i = 0; i < threads.length; i++) {
             int threadId = i;
             final String indexName = "index-" + threadId;
+            mountedIndices.add(indexName);
             final Thread thread = new Thread(() -> {
                 try {
                     startMounting.await();
@@ -243,6 +260,31 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
             thread.start();
         }
 
+        // some indices are randomly removed before prewarming completes
+        final Set<String> deletedIndicesDuringPrewarming = randomBoolean() ? Set.copyOf(randomSubsetOf(mountedIndices)) : Set.of();
+
+        final CountDownLatch startPrewarmingLatch = new CountDownLatch(1);
+        final var threadPool = getInstanceFromNode(ThreadPool.class);
+        final int maxUploadTasks = threadPool.info(CACHE_PREWARMING_THREAD_POOL_NAME).getMax();
+        for (int i = 0; i < maxUploadTasks; i++) {
+            threadPool.executor(CACHE_PREWARMING_THREAD_POOL_NAME).execute(new AbstractRunnable() {
+
+                @Override
+                protected void doRun() throws Exception {
+                    startPrewarmingLatch.await();
+                }
+
+                @Override
+                public void onFailure(Exception e) {
+                    throw new AssertionError(e);
+                }
+            });
+        }
+
+        var prewarmingExecutor = threadPool.executor(CACHE_PREWARMING_THREAD_POOL_NAME);
+        assertThat(prewarmingExecutor, instanceOf(ThreadPoolExecutor.class));
+        assertThat(((ThreadPoolExecutor) prewarmingExecutor).getActiveCount(), equalTo(maxUploadTasks));
+
         startMounting.countDown();
         for (Thread thread : threads) {
             thread.join();
@@ -250,11 +292,40 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
 
         assertThat("Failed to mount snapshot as indices", throwables.asList(), emptyCollectionOf(Throwable.class));
 
-        logger.debug("--> waiting for background cache prewarming to");
+        logger.debug("--> waiting for background cache to complete");
         assertBusy(() -> {
-            final ThreadPool threadPool = getInstanceFromNode(ThreadPool.class);
-            assertThat(threadPool.info(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME).getQueueSize(), nullValue());
-            assertThat(threadPool.info(SearchableSnapshots.CACHE_PREWARMING_THREAD_POOL_NAME).getQueueSize(), nullValue());
+            if (threadPool.executor(SearchableSnapshots.CACHE_FETCH_ASYNC_THREAD_POOL_NAME) instanceof ThreadPoolExecutor executor) {
+                assertThat(executor.getQueue().size(), equalTo(0));
+                assertThat(executor.getActiveCount(), equalTo(0));
+            }
+        });
+
+        if (deletedIndicesDuringPrewarming.isEmpty() == false) {
+            Set<Index> deletedIndices = deletedIndicesDuringPrewarming.stream().map(this::resolveIndex).collect(Collectors.toSet());
+            logger.debug("--> deleting indices [{}] before prewarming", deletedIndices);
+            assertAcked(client().admin().indices().prepareDelete(deletedIndicesDuringPrewarming.toArray(String[]::new)));
+
+            var indicesService = getInstanceFromNode(IndicesService.class);
+            assertBusy(() -> deletedIndices.forEach(deletedIndex -> assertThat(indicesService.hasIndex(deletedIndex), is(false))));
+        }
+
+        startPrewarmingLatch.countDown();
+
+        // wait for recovery to be DONE
+        assertBusy(() -> {
+            var recoveryResponse = client().admin()
+                .indices()
+                .prepareRecoveries(mountedIndices.toArray(String[]::new))
+                .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
+                .get();
+            assertThat(
+                recoveryResponse.shardRecoveryStates()
+                    .values()
+                    .stream()
+                    .flatMap(Collection::stream)
+                    .allMatch(recoveryState -> recoveryState.getStage().equals(RecoveryState.Stage.DONE)),
+                is(true)
+            );
         });
 
         logger.debug("--> loading snapshot metadata");
@@ -286,14 +357,53 @@ public class SearchableSnapshotsPrewarmingIntegTests extends ESSingleNodeTestCas
                     .filter(file -> exclusionsPerIndex.get(indexName).contains(IndexFileNames.getExtension(file.physicalName())) == false)
                     .toList();
 
-                for (BlobStoreIndexShardSnapshot.FileInfo expectedPrewarmedBlob : expectedPrewarmedBlobs) {
-                    for (int part = 0; part < expectedPrewarmedBlob.numberOfParts(); part++) {
-                        final String blobName = expectedPrewarmedBlob.partName(part);
-                        assertThat(
-                            "Blob [" + blobName + "] not fully warmed",
-                            tracker.totalBytesRead(blobName),
-                            greaterThanOrEqualTo(expectedPrewarmedBlob.partBytes(part))
-                        );
+                if (deletedIndicesDuringPrewarming.contains(indexName) == false) {
+                    for (BlobStoreIndexShardSnapshot.FileInfo blob : expectedPrewarmedBlobs) {
+                        for (int part = 0; part < blob.numberOfParts(); part++) {
+                            final String blobName = blob.partName(part);
+                            try {
+                                assertThat(
+                                    "Blob [" + blobName + "][" + blob.physicalName() + "] not prewarmed",
+                                    tracker.totalBytesRead(blobName),
+                                    equalTo(blob.partBytes(part))
+                                );
+                            } catch (AssertionError ae) {
+                                assertThat(
+                                    "Only blobs from physical file with specific extensions are expected to be prewarmed over their sizes ["
+                                        + blobName
+                                        + "]["
+                                        + blob.physicalName()
+                                        + "] but got :"
+                                        + ae,
+                                    blob.physicalName(),
+                                    anyOf(endsWith(".cfe"), endsWith(".cfs"))
+                                );
+                            }
+                        }
+                    }
+                } else {
+                    for (BlobStoreIndexShardSnapshot.FileInfo blob : expectedPrewarmedBlobs) {
+                        for (int part = 0; part < blob.numberOfParts(); part++) {
+                            final String blobName = blob.partName(part);
+                            try {
+                                assertThat(
+                                    "Blob [" + blobName + "][" + blob.physicalName() + "] should not have been fully prewarmed",
+                                    tracker.totalBytesRead(blobName),
+                                    nullValue()
+                                );
+                            } catch (AssertionError ae) {
+                                assertThat(
+                                    "Only blobs from physical file with specific extensions are expected to be prewarmed over their sizes ["
+                                        + blobName
+                                        + "]["
+                                        + blob.physicalName()
+                                        + "] but got :"
+                                        + ae,
+                                    blob.physicalName(),
+                                    anyOf(endsWith(".cfe"), endsWith(".cfs"))
+                                );
+                            }
+                        }
                     }
                 }
             }

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexEventListener.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotIndexEventListener.java
@@ -65,10 +65,11 @@ public class SearchableSnapshotIndexEventListener implements IndexEventListener 
     }
 
     private static void ensureSnapshotIsLoaded(IndexShard indexShard) {
-        final SearchableSnapshotDirectory directory = unwrapDirectory(indexShard.store().directory());
+        final var store = indexShard.store();
+        final SearchableSnapshotDirectory directory = unwrapDirectory(store.directory());
         assert directory != null;
         final StepListener<Void> preWarmListener = new StepListener<>();
-        final boolean success = directory.loadSnapshot(indexShard.recoveryState(), preWarmListener);
+        final boolean success = directory.loadSnapshot(indexShard.recoveryState(), store::isClosing, preWarmListener);
         final ShardRouting shardRouting = indexShard.routingEntry();
         if (success && shardRouting.isRelocationTarget()) {
             final Runnable preWarmCondition = indexShard.addCleanFilesDependency();

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -694,7 +694,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
             DiscoveryNode targetNode = new DiscoveryNode("local", buildNewFakeTransportAddress(), Version.CURRENT);
             RecoveryState recoveryState = new SearchableSnapshotRecoveryState(shardRouting, targetNode, null);
             final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-            final boolean loaded = directory.loadSnapshot(recoveryState, future);
+            final boolean loaded = directory.loadSnapshot(recoveryState, () -> false, future);
             future.get();
             assertThat("Failed to load snapshot", loaded, is(true));
             assertThat("Snapshot should be loaded", directory.snapshot(), notNullValue());

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -674,7 +674,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                     )
                 ) {
                     final PlainActionFuture<Void> f = PlainActionFuture.newFuture();
-                    final boolean loaded = snapshotDirectory.loadSnapshot(recoveryState, f);
+                    final boolean loaded = snapshotDirectory.loadSnapshot(recoveryState, store::isClosing, f);
                     try {
                         f.get();
                     } catch (ExecutionException e) {
@@ -779,7 +779,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
             ) {
                 final RecoveryState recoveryState = createRecoveryState(randomBoolean());
                 final PlainActionFuture<Void> f = PlainActionFuture.newFuture();
-                final boolean loaded = directory.loadSnapshot(recoveryState, f);
+                final boolean loaded = directory.loadSnapshot(recoveryState, () -> false, f);
                 f.get();
                 assertThat("Failed to load snapshot", loaded, is(true));
                 assertThat("Snapshot should be loaded", directory.snapshot(), sameInstance(snapshot));

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -127,7 +127,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 ) {
                     RecoveryState recoveryState = createRecoveryState(recoveryFinalizedDone);
                     final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-                    final boolean loaded = directory.loadSnapshot(recoveryState, future);
+                    final boolean loaded = directory.loadSnapshot(recoveryState, () -> false, future);
                     if (randomBoolean()) {
                         // randomly wait for pre-warm before running the below reads
                         future.get();
@@ -233,7 +233,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
             ) {
                 RecoveryState recoveryState = createRecoveryState(randomBoolean());
                 final PlainActionFuture<Void> f = PlainActionFuture.newFuture();
-                final boolean loaded = searchableSnapshotDirectory.loadSnapshot(recoveryState, f);
+                final boolean loaded = searchableSnapshotDirectory.loadSnapshot(recoveryState, () -> false, f);
                 try {
                     f.get();
                 } catch (ExecutionException e) {

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -111,7 +111,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
             )
         ) {
             cacheService.start();
-            directory.loadSnapshot(createRecoveryState(true), ActionListener.noop());
+            directory.loadSnapshot(createRecoveryState(true), () -> false, ActionListener.noop());
 
             // TODO does not test using the recovery range size
             final IndexInput indexInput = directory.openInput(fileName, randomIOContext());


### PR DESCRIPTION
Cold cache prewarming tasks are not stopped immediately when the shard is closed, causing excessive use of disk for nothing. This change adds a `Supplier<Boolean>` to prewarming logic that can be checked before executing any consuming operation to know if the `Store` is closing.

I'm not super happy with my test changes but the logic for checking if prewarming works correctly is tricky.

Closes  #95504
