### PR TITLE
[8.8] Fix 0 default value for repo snapshot speed (#95854)

### DIFF
--- a/docs/changelog/95854.yaml
+++ b/docs/changelog/95854.yaml
@@ -1,0 +1,6 @@
+pr: 95854
+summary: Fix 0 default value for repo snapshot speed
+area: Snapshot/Restore
+type: bug
+issues:
+ - 95561

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySettings.java
@@ -701,7 +701,7 @@ public class RecoverySettings {
     /**
      * Whether the node bandwidth recovery settings are set.
      */
-    public static boolean hasNodeBandwidthRecoverySettings(Settings settings) {
+    private static boolean hasNodeBandwidthRecoverySettings(Settings settings) {
         return NODE_BANDWIDTH_RECOVERY_SETTINGS.stream()
             .filter(setting -> setting.get(settings) != ByteSizeValue.MINUS_ONE)
             .count() == NODE_BANDWIDTH_RECOVERY_SETTINGS.size();


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix 0 default value for repo snapshot speed (#95854)