### PR TITLE
Disable header warning format assertions

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -330,8 +330,9 @@ public class HeaderWarning {
         if (iterator.hasNext()) {
             final String formattedMessage = LoggerMessageFormat.format(message, params);
             final String warningHeaderValue = formatWarning(formattedMessage);
-            assert WARNING_HEADER_PATTERN.matcher(warningHeaderValue).matches();
-            assert extractWarningValueFromWarningHeader(warningHeaderValue, false).equals(escapeAndEncode(formattedMessage));
+            // TODO #95972: Temporarily commented out to avoid StackOverflowError, see https://github.com/elastic/elasticsearch/issues/95972
+            // assert WARNING_HEADER_PATTERN.matcher(warningHeaderValue).matches();
+            // assert extractWarningValueFromWarningHeader(warningHeaderValue, false).equals(escapeAndEncode(formattedMessage));
             while (iterator.hasNext()) {
                 try {
                     final ThreadContext next = iterator.next();


### PR DESCRIPTION
With this commit we temporarily disable two assertions that assert the correct format of header warnings because they can lead to `StackOverflowError` in certain situations. We also add a test case that demonstrates the behavior when the assertions are activated again.

Relates #95972