### PR TITLE
Fix CartesianCentroidIT flaky test

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractGeoTestCase.java
@@ -113,27 +113,25 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
         }
 
         List<IndexRequestBuilder> builders = new ArrayList<>();
-
-        SpatialPoint singleVal;
-        final SpatialPoint[] multiVal = new SpatialPoint[2];
-        double newMVLat, newMVLon;
+        final SpatialPoint[] allSingleVal = new SpatialPoint[numDocs];
+        final SpatialPoint[] allMultiVal = new SpatialPoint[2 * numDocs];
         for (int i = 0; i < numDocs; i++) {
-            singleVal = singleValues[i % numUniqueGeoPoints];
-            multiVal[0] = multiValues[i % numUniqueGeoPoints];
-            multiVal[1] = multiValues[(i + 1) % numUniqueGeoPoints];
+            allSingleVal[i] = singleValues[i % numUniqueGeoPoints];
+            allMultiVal[2 * i] = multiValues[i % numUniqueGeoPoints];
+            allMultiVal[2 * i + 1] = multiValues[(i + 1) % numUniqueGeoPoints];
             builders.add(
                 client().prepareIndex(IDX_NAME)
                     .setSource(
                         jsonBuilder().startObject()
-                            .array(SINGLE_VALUED_FIELD_NAME, singleVal.getX(), singleVal.getY())
+                            .array(SINGLE_VALUED_FIELD_NAME, allSingleVal[i].getX(), allSingleVal[i].getY())
                             .startArray(MULTI_VALUED_FIELD_NAME)
                             .startArray()
-                            .value(multiVal[0].getX())
-                            .value(multiVal[0].getY())
+                            .value(allMultiVal[2 * i].getX())
+                            .value(allMultiVal[2 * i].getY())
                             .endArray()
                             .startArray()
-                            .value(multiVal[1].getX())
-                            .value(multiVal[1].getY())
+                            .value(allMultiVal[2 * i + 1].getX())
+                            .value(allMultiVal[2 * i + 1].getY())
                             .endArray()
                             .endArray()
                             .field(NUMBER_FIELD_NAME, i)
@@ -141,20 +139,9 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
                             .endObject()
                     )
             );
-            singleCentroid = reset(
-                singleCentroid,
-                singleCentroid.getX() + (singleVal.getX() - singleCentroid.getX()) / (i + 1),
-                singleCentroid.getY() + (singleVal.getY() - singleCentroid.getY()) / (i + 1)
-            );
-            newMVLat = (multiVal[0].getY() + multiVal[1].getY()) / 2d;
-            newMVLon = (multiVal[0].getX() + multiVal[1].getX()) / 2d;
-            multiCentroid = reset(
-                multiCentroid,
-                multiCentroid.getX() + (newMVLon - multiCentroid.getX()) / (i + 1),
-                multiCentroid.getY() + (newMVLat - multiCentroid.getY()) / (i + 1)
-            );
         }
-
+        singleCentroid = computeCentroid(allSingleVal);
+        multiCentroid = computeCentroid(allMultiVal);
         assertAcked(prepareCreate(EMPTY_IDX_NAME).setMapping(SINGLE_VALUED_FIELD_NAME, "type=" + fieldTypeName()));
 
         assertAcked(
@@ -204,7 +191,7 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
         );
 
         for (int i = 0; i < 2000; i++) {
-            singleVal = singleValues[i % numUniqueGeoPoints];
+            SpatialPoint singleVal = singleValues[i % numUniqueGeoPoints];
             builders.add(
                 client().prepareIndex(HIGH_CARD_IDX_NAME)
                     .setSource(
@@ -261,6 +248,16 @@ public abstract class AbstractGeoTestCase extends ESIntegTestCase {
             assertThat("Hit " + i + " has wrong value", value.intValue(), equalTo(i));
         }
         assertThat(totalHits, equalTo(2000L));
+    }
+
+    private SpatialPoint computeCentroid(SpatialPoint[] points) {
+        final CompensatedSum compensatedSumX = new CompensatedSum(0, 0);
+        final CompensatedSum compensatedSumY = new CompensatedSum(0, 0);
+        for (SpatialPoint spatialPoint : points) {
+            compensatedSumX.add(spatialPoint.getX());
+            compensatedSumY.add(spatialPoint.getY());
+        }
+        return makePoint(compensatedSumX.value() / points.length, compensatedSumY.value() / points.length);
     }
 
     private void updateGeohashBucketsCentroid(final SpatialPoint location) {

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianCentroidIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianCentroidIT.java
@@ -51,7 +51,7 @@ public class CartesianCentroidIT extends CentroidAggregationTestBase {
     @Override
     protected CartesianPoint randomPoint() {
         Point point = ShapeTestUtils.randomPointNotExtreme(false);
-        return makePoint(point.getX(), point.getY());
+        return makePoint((float) point.getX(), (float) point.getY());
     }
 
     @Override


### PR DESCRIPTION
This test is flaky because of the way the centroid is computed in the test. In particular the aggregation use compensated sums for computing it while the test does not, this might make a big difference for big numbers in cartesian. This PR just changes the way the test computes the centroid to use compensated sums, which makes the test happy. I run for 100k iterations without error.

fixes https://github.com/elastic/elasticsearch/issues/95916