### PR TITLE
fix: change visibility of SearchService#ResultsType to protected

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/SearchService.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchService.java
@@ -1469,7 +1469,7 @@ public class SearchService extends AbstractLifecycleComponent implements IndexEv
     /**
      * Used to indicate which result object should be instantiated when creating a search context
      */
-    enum ResultsType {
+    protected enum ResultsType {
         DFS {
             @Override
             void addResultsObject(SearchContext context) {


### PR DESCRIPTION
Backport PR for #95671

The `SearchService#createContext` method takes the recently added `ResultsType` enum which is package private. In order to be able to keep on calling that method, which is protected, from another package, the visibility of the enum `ResultsType` should be increased to protected.


