### PR TITLE
[DOCS] Adds example of semantic search with ELSER

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -23,7 +23,7 @@ search on your data.
 
 To perform semantic search by using ELSER, you must have the NLP model deployed 
 in your cluster. Refer to the 
-{ml-docs}/ml-nlp-elser.asciidoc[ELSER documentation] to learn how to download and 
+{ml-docs}/ml-nlp-elser.html[ELSER documentation] to learn how to download and 
 deploy the model.
 
 
@@ -52,6 +52,7 @@ PUT my-index
   }
 }
 ----
+// TEST[skip:TBD]
 <1> The field that contains the prediction is a `rank_features` field.
 <2> The text field from which to create the sparse vector representation.
 
@@ -86,6 +87,7 @@ PUT _ingest/pipeline/elser
   ]
 }
 ----
+// TEST[skip:TBD]
 <1> The `text_expansion` inference type needs to be used in the {infer} ingest 
 pipeline.
 
@@ -133,6 +135,7 @@ POST _reindex?wait_for_completion=false
   }
 }
 ----
+// TEST[skip:TBD]
 
 The call returns a task ID to monitor the progress:
 
@@ -140,6 +143,7 @@ The call returns a task ID to monitor the progress:
 ----
 GET _tasks/<task_id>
 ----
+// TEST[skip:TBD]
 
 You can also open the Trained Models UI, select the Pipelines tab under ELSER to 
 follow the progress. It may take a couple of minutes to complete the process.
@@ -167,6 +171,7 @@ GET my-index/_search
    }
 }
 ----
+// TEST[skip:TBD]
 
 The result is the top 10 documents that are closest in meaning to your query 
 text from the `my-index` index sorted by their relevancy. The result also 
@@ -216,5 +221,5 @@ weights.
 [[further-reading]]
 === Further reading
 
-* {ml-docs}/ml-nlp-elser.asciidoc[How to download and deploy ELSER]
+* {ml-docs}/ml-nlp-elser.html[How to download and deploy ELSER]
 // TO DO: refer to the ELSER blog post

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -6,3 +6,72 @@
 
 :keywords: {ml-init}, {stack}, {nlp}, ELSER
 :description: ELSER is a learned sparse ranking model trained by Elastic.
+
+Elastic Learned Sparse Encoder - or ELSER - is an NLP model trained by Elstic 
+that enables you to perform semantic search by using sparse vector 
+representation. Instead of literal matching on search terms, semantic search 
+retrieves results based on the intent and the contextual meaning of a search 
+query.
+
+
+[discrete]
+[[requirements]]
+=== Requirements
+
+To perform semantic search by using ELSER, you must have the NLP model deployed 
+in your cluster. Refer to the 
+{ml-docs}ml-nlp-elser.asciidoc[ELSER documentation] to learn how to download and 
+deploy the model.
+
+
+[discrete]
+[[elser-mappings]]
+=== Create the index mapping
+
+First, the mapping of the index you use for ELSER must be created.
+
+[source,js]
+----
+PUT test-index
+{
+   "mappings":{
+      "properties":{
+         "ml":{
+            "properties":{
+               "inference":{
+                  "properties":{
+                     "description_expanded":{
+                        "properties":{
+                           "model_id":{
+                              "type":"keyword"
+                           },
+                           "predicted_value":{
+                              "type":"rank_features"
+                           }
+                        }
+                     },
+                     "title_expanded":{
+                        "properties":{
+                           "model_id":{
+                              "type":"keyword"
+                           },
+                           "predicted_value":{
+                              "type":"rank_features"
+                           }
+                        }
+                     }
+                  }
+               }
+            }
+         }
+      }
+   }
+}
+----
+
+
+
+[discrete]
+[[text-expansion-query]]
+=== The `text_expansion` query
+

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -1,5 +1,5 @@
 [[semantic-search-elser]]
-== Perform semantic search with ELSER
+== Tutorial: semantic search with ELSER
 ++++
 <titleabbrev>Semantic search with ELSER</titleabbrev>
 ++++
@@ -13,7 +13,7 @@ representation. Instead of literal matching on search terms, semantic search
 retrieves results based on the intent and the contextual meaning of a search 
 query.
 
-The instructions on this page shows you how to use ELSER to perform semantic 
+The instructions in this tutorial shows you how to use ELSER to perform semantic 
 search on your data.
 
 

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -167,7 +167,8 @@ GET my-index/_search
 
 The result is the top 10 documents that are closest in meaning to your query 
 text from the `my-index` index sorted by their relevancy. The result also 
-contains the extracted tokens for each of the relevant search results.
+contains the extracted tokens for each of the relevant search results with their 
+weights.
 
 [source,console-result]
 ----

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -7,7 +7,7 @@
 :keywords: {ml-init}, {stack}, {nlp}, ELSER
 :description: ELSER is a learned sparse ranking model trained by Elastic.
 
-Elastic Learned Sparse EncodeR - or ELSER - is an NLP model trained by Elstic 
+Elastic Learned Sparse EncodeR - or ELSER - is an NLP model trained by Elastic 
 that enables you to perform semantic search by using sparse vector 
 representation. Instead of literal matching on search terms, semantic search 
 retrieves results based on the intent and the contextual meaning of a search 
@@ -67,7 +67,7 @@ that is being ingested in the pipeline.
 
 [source,console]
 ----
-PUT _ingest/pipeline/elser
+PUT _ingest/pipeline/elser-v1-test
 {
   "processors": [
     {
@@ -79,7 +79,7 @@ PUT _ingest/pipeline/elser
         },
         "inference_config": {
           "text_expansion": { <1>
-            "results_field": "tokens"
+            "results_field": "ml.tokens"
           }
         }
       }
@@ -89,7 +89,7 @@ PUT _ingest/pipeline/elser
 ----
 // TEST[skip:TBD]
 <1> The `text_expansion` inference type needs to be used in the {infer} ingest 
-pipeline.
+processor.
 
 
 [discrete]
@@ -131,7 +131,7 @@ POST _reindex?wait_for_completion=false
   },
   "dest": {
     "index": "my-index",
-    "pipeline": "elser"
+    "pipeline": "elser-v1-test"
   }
 }
 ----

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -16,6 +16,9 @@ query.
 The instructions in this tutorial shows you how to use ELSER to perform semantic 
 search on your data.
 
+NOTE: Only the first 512 extracted tokens per field are considered during 
+semantic search with ELSER v1.
+
 
 [discrete]
 [[requirements]]
@@ -98,9 +101,6 @@ processor.
 
 In this step, you load the data that you later use in the {infer} ingest 
 pipeline to extract tokens from it.
-
-NOTE: Only the first 512 extracted tokens of the ingested docs are considered 
-during semantic search with ELSER v1.
 
 Use the `msmarco-passagetest2019-top1000` data set, which is a subset of the MS 
 MACRO Passage Ranking data set. It consists of 200 queries, each accompanied by 
@@ -222,4 +222,5 @@ weights.
 === Further reading
 
 * {ml-docs}/ml-nlp-elser.html[How to download and deploy ELSER]
+* {ml-docs}/ml-nlp-limitations.html#ml-nlp-elser-v1-limit-512[ELSER v1 limitation]
 // TO DO: refer to the ELSER blog post

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -100,7 +100,7 @@ In this step, you load the data that you later use in the {infer} ingest
 pipeline to extract tokens from it.
 
 NOTE: Only the first 512 extracted tokens of the ingested docs are considered 
-during semantic search.
+during semantic search with ELSER v1.
 
 Use the `msmarco-passagetest2019-top1000` data set, which is a subset of the MS 
 MACRO Passage Ranking data set. It consists of 200 queries, each accompanied by 

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -97,6 +97,9 @@ pipeline.
 In this step, you load the data that you later use in the {infer} ingest 
 pipeline to extract tokens from it.
 
+NOTE: Only the first 512 extracted tokens of the ingested docs are considered 
+during semantic search.
+
 Use the `msmarco-passagetest2019-top1000` data set, which is a subset of the MS 
 MACRO Passage Ranking data set. It consists of 200 queries, each accompanied by 
 a list of relevant text passages. All unique passages, along with their IDs, 
@@ -170,7 +173,7 @@ text from the `my-index` index sorted by their relevancy. The result also
 contains the extracted tokens for each of the relevant search results with their 
 weights.
 
-[source,console-result]
+[source,js]
 ----
 "hits":[
    {
@@ -207,7 +210,7 @@ weights.
    (...)
 ]
 ----
-//NOTCONSOLE
+
 
 [discrete]
 [[further-reading]]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -36,7 +36,7 @@ that the model created based on your text - must be created.  The destination
 index must have a field with the <<rank-features, `rank_features`>> field type 
 to index the ELSER output.
 
-[source,js]
+[source,console]
 ----
 PUT my-index
 {
@@ -64,7 +64,7 @@ Create an <<ingest,ingest pipeline>> with an
 <<inference-processor,{infer} processor>> to use ELSER to infer against the data 
 that is being ingested in the pipeline.
 
-[source,js]
+[source,console]
 ----
 PUT _ingest/pipeline/elser
 {
@@ -117,7 +117,7 @@ can see an index named `test-data` with 182469 documents.
 Create the tokens from the text by reindexing the data throught the {infer} 
 pipeline that uses ELSER as the inference model.
 
-[source,js]
+[source,console]
 ----
 POST _reindex?wait_for_completion=false
 {
@@ -133,7 +133,7 @@ POST _reindex?wait_for_completion=false
 
 The call returns a task ID to monitor the progress:
 
-[source,js]
+[source,console]
 ----
 GET _tasks/<task_id>
 ----
@@ -150,7 +150,7 @@ To perform semantic search, pass a `text_expansion` object to the search API
 call, and provide the query text and the ELSER model ID. The example below uses 
 the query text "How to avoid muscle soreness after running?":
 
-[source,js]
+[source,console]
 ----
 GET my-index/_search
 {
@@ -207,6 +207,7 @@ weights.
    (...)
 ]
 ----
+
 
 [discrete]
 [[further-reading]]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -79,7 +79,7 @@ PUT _ingest/pipeline/elser-v1-test
         },
         "inference_config": {
           "text_expansion": { <1>
-            "results_field": "ml.tokens"
+            "results_field": "tokens"
           }
         }
       }

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -178,7 +178,7 @@ text from the `my-index` index sorted by their relevancy. The result also
 contains the extracted tokens for each of the relevant search results with their 
 weights.
 
-[source,js]
+[source,consol-result]
 ----
 "hits":[
    {
@@ -215,7 +215,7 @@ weights.
    (...)
 ]
 ----
-// TEST[skip:TBD]
+// NOTCONSOLE
 
 [discrete]
 [[further-reading]]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -7,11 +7,14 @@
 :keywords: {ml-init}, {stack}, {nlp}, ELSER
 :description: ELSER is a learned sparse ranking model trained by Elastic.
 
-Elastic Learned Sparse Encoder - or ELSER - is an NLP model trained by Elstic 
+Elastic Learned Sparse EncodeR - or ELSER - is an NLP model trained by Elstic 
 that enables you to perform semantic search by using sparse vector 
 representation. Instead of literal matching on search terms, semantic search 
 retrieves results based on the intent and the contextual meaning of a search 
 query.
+
+The instructions on this page shows you how to use ELSER to perform semantic 
+search on your data.
 
 
 [discrete]
@@ -28,50 +31,185 @@ deploy the model.
 [[elser-mappings]]
 === Create the index mapping
 
-First, the mapping of the index you use for ELSER must be created.
+First, the mapping of the destination index - the index that contains the tokens 
+that the model created based on your text - must be created.  The destination 
+index must have a field with the <<rank-features, `rank_features`>> field type 
+to index the ELSER output.
 
 [source,js]
 ----
-PUT test-index
+PUT my-index
 {
-   "mappings":{
-      "properties":{
-         "ml":{
-            "properties":{
-               "inference":{
-                  "properties":{
-                     "description_expanded":{
-                        "properties":{
-                           "model_id":{
-                              "type":"keyword"
-                           },
-                           "predicted_value":{
-                              "type":"rank_features"
-                           }
-                        }
-                     },
-                     "title_expanded":{
-                        "properties":{
-                           "model_id":{
-                              "type":"keyword"
-                           },
-                           "predicted_value":{
-                              "type":"rank_features"
-                           }
-                        }
-                     }
-                  }
-               }
-            }
+  "mappings": {
+    "properties": {
+      "ml.tokens": {
+        "type": "rank_features" <1>
+      },
+      "text_field": {
+        "type": "text" <2>
+      }
+    }
+  }
+}
+----
+<1> The field that contains the prediction is a `rank_features` field.
+<2> The text field from which to create the sparse vector representation.
+
+
+[discrete]
+[[inference-ingest-pipeline]]
+=== Create an ingest pipeline with an inference processor
+
+Create an <<ingest,ingest pipeline>> with an 
+<<inference-processor,{infer} processor>> to use ELSER to infer against the data 
+that is being ingested in the pipeline.
+
+[source,js]
+----
+PUT _ingest/pipeline/elser
+{
+  "processors": [
+    {
+      "inference": {
+        "model_id": ".elser_model_1",
+        "target_field": "ml",
+        "field_map": {
+          "text": "text_field"
+        },
+        "inference_config": {
+          "text_expansion": { <1>
+            "results_field": "tokens"
+          }
+        }
+      }
+    }
+  ]
+}
+----
+<1> The `text_expansion` inference type needs to be used in the {infer} ingest 
+pipeline.
+
+
+[discrete]
+[[load-data]]
+=== Load data
+
+In this step, you load the data that you later use in the {infer} ingest 
+pipeline to extract tokens from it.
+
+Use the `msmarco-passagetest2019-top1000` data set, which is a subset of the MS 
+MACRO Passage Ranking data set. It consists of 200 queries, each accompanied by 
+a list of relevant text passages. All unique passages, along with their IDs, 
+have been extracted from that data set and compiled into a 
+https://github.com/elastic/stack-docs/blob/main/docs/en/stack/ml/nlp/data/msmarco-passagetest2019-unique.tsv[tsv file].
+
+Download the file and upload it to your cluster using the 
+{kibana-ref}/connect-to-elasticsearch.html#upload-data-kibana[Data Visualizer] 
+in the {ml-app} UI. Assign the name `id` to the first column and `text` to the 
+second column. The index name is `test-data`. Once the upload is complete, you 
+can see an index named `test-data` with 182469 documents.
+
+
+[discrete]
+[[reindexing-data-elser]]
+=== Ingest the data through the {infer} ingest pipeline
+
+Create the tokens from the text by reindexing the data throught the {infer} 
+pipeline that uses ELSER as the inference model.
+
+[source,js]
+----
+POST _reindex?wait_for_completion=false
+{
+  "source": {
+    "index": "test-data"
+  },
+  "dest": {
+    "index": "my-index",
+    "pipeline": "elser"
+  }
+}
+----
+
+The call returns a task ID to monitor the progress:
+
+[source,js]
+----
+GET _tasks/<task_id>
+----
+
+You can also open the Trained Models UI, select the Pipelines tab under ELSER to 
+follow the progress. It may take a couple of minutes to complete the process.
+
+
+[discrete]
+[[text-expansion-query]]
+=== Semantic search by using the `text_expansion` query
+
+To perform semantic search, pass a `text_expansion` object to the search API 
+call, and provide the query text and the ELSER model ID. The example below uses 
+the query text "How to avoid muscle soreness after running?":
+
+[source,js]
+----
+GET my-index/_search
+{
+   "query":{
+      "text_expansion":{
+         "ml.tokens":{
+            "model_id":".elser_model_1",
+            "model_text":"How to avoid muscle soreness after running?"
          }
       }
    }
 }
 ----
 
+The result is the top 10 documents that are closest in meaning to your query 
+text from the `my-index` index sorted by their relevancy. The result also 
+contains the extracted tokens for each of the relevant search results.
 
+[source,console-result]
+----
+"hits":[
+   {
+      "_index":"my-index",
+      "_id":"978UAYgBKCQMet06sLEy",
+      "_score":18.612831,
+      "_ignored":[
+         "text.keyword"
+      ],
+      "_source":{
+         "id":7361587,
+         "text":"For example, if you go for a run, you will mostly use the muscles in your lower body. Give yourself 2 days to rest those muscles so they have a chance to heal before you exercise them again. Not giving your muscles enough time to rest can cause muscle damage, rather than muscle development.",
+         "ml":{
+            "tokens":{
+               "muscular":0.075696334,
+               "mostly":0.52380747,
+               "practice":0.23430172,
+               "rehab":0.3673556,
+               "cycling":0.13947526,
+               "your":0.35725075,
+               "years":0.69484913,
+               "soon":0.005317828,
+               "leg":0.41748235,
+               "fatigue":0.3157955,
+               "rehabilitation":0.13636169,
+               "muscles":1.302141,
+               "exercises":0.36694175,
+               (...)
+            },
+            "model_id":".elser_model_1"
+         }
+      }
+   },
+   (...)
+]
+----
 
 [discrete]
-[[text-expansion-query]]
-=== The `text_expansion` query
+[[further-reading]]
+=== Further reading
 
+* {ml-docs}ml-nlp-elser.asciidoc[How to download and deploy ELSER]
+// TO DO: refer to the ELSER blog post

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -215,7 +215,7 @@ weights.
    (...)
 ]
 ----
-
+// TEST[skip:TBD]
 
 [discrete]
 [[further-reading]]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -153,8 +153,8 @@ follow the progress. It may take a couple of minutes to complete the process.
 [[text-expansion-query]]
 === Semantic search by using the `text_expansion` query
 
-To perform semantic search, pass a `text_expansion` object to the search API 
-call, and provide the query text and the ELSER model ID. The example below uses 
+To perform semantic search, use the `text_expansion` query, 
+and provide the query text and the ELSER model ID. The example below uses 
 the query text "How to avoid muscle soreness after running?":
 
 [source,console]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -23,7 +23,7 @@ search on your data.
 
 To perform semantic search by using ELSER, you must have the NLP model deployed 
 in your cluster. Refer to the 
-{ml-docs}ml-nlp-elser.asciidoc[ELSER documentation] to learn how to download and 
+{ml-docs}/ml-nlp-elser.asciidoc[ELSER documentation] to learn how to download and 
 deploy the model.
 
 
@@ -207,11 +207,11 @@ weights.
    (...)
 ]
 ----
-
+//NOTCONSOLE
 
 [discrete]
 [[further-reading]]
 === Further reading
 
-* {ml-docs}ml-nlp-elser.asciidoc[How to download and deploy ELSER]
+* {ml-docs}/ml-nlp-elser.asciidoc[How to download and deploy ELSER]
 // TO DO: refer to the ELSER blog post

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -17,7 +17,9 @@ The instructions in this tutorial shows you how to use ELSER to perform semantic
 search on your data.
 
 NOTE: Only the first 512 extracted tokens per field are considered during 
-semantic search with ELSER v1.
+semantic search with ELSER v1. Refer to 
+{ml-docs}/ml-nlp-limitations.html#ml-nlp-elser-v1-limit-512[this page] for more 
+information.
 
 
 [discrete]


### PR DESCRIPTION
## Overview

This PR adds an example of how to use ELSER to perform semantic search.
The example uses a downloadable data set (the same that is used in the text embedding example) instead of bulk ingesting some documents to an index. The letter is easier, the former has more demonstrative power and provides more possibilities for the users to play around with the model and the functionality.

### Preview

[Semantic search with ELSER](https://elasticsearch_95992.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-elser.html)