### PR TITLE
Fixing DateProcessor when the format is epoch_millis

### DIFF
--- a/docs/changelog/95996.yaml
+++ b/docs/changelog/95996.yaml
@@ -1,0 +1,5 @@
+pr: 95996
+summary: Fixing `DateProcessor` when the format is `epoch_millis`
+area: Ingest Node
+type: bug
+issues: []

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -26,6 +26,7 @@ import java.util.function.Function;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
+import static java.time.temporal.ChronoField.INSTANT_SECONDS;
 import static java.time.temporal.ChronoField.MINUTE_OF_DAY;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
@@ -77,7 +78,8 @@ enum DateFormat {
             MINUTE_OF_DAY,
             HOUR_OF_DAY,
             DAY_OF_MONTH,
-            MONTH_OF_YEAR
+            MONTH_OF_YEAR,
+            INSTANT_SECONDS
         );
 
         @Override
@@ -101,7 +103,7 @@ enum DateFormat {
                     ZonedDateTime newTime = Instant.EPOCH.atZone(ZoneOffset.UTC).withYear(year);
                     for (ChronoField field : FIELDS) {
                         if (accessor.isSupported(field)) {
-                            newTime = newTime.with(field, accessor.get(field));
+                            newTime = newTime.with(field, accessor.getLong(field));
                         }
                     }
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/DateFormat.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 
 import static java.time.temporal.ChronoField.DAY_OF_MONTH;
 import static java.time.temporal.ChronoField.HOUR_OF_DAY;
-import static java.time.temporal.ChronoField.INSTANT_SECONDS;
 import static java.time.temporal.ChronoField.MINUTE_OF_DAY;
 import static java.time.temporal.ChronoField.MONTH_OF_YEAR;
 import static java.time.temporal.ChronoField.NANO_OF_SECOND;
@@ -78,8 +77,7 @@ enum DateFormat {
             MINUTE_OF_DAY,
             HOUR_OF_DAY,
             DAY_OF_MONTH,
-            MONTH_OF_YEAR,
-            INSTANT_SECONDS
+            MONTH_OF_YEAR
         );
 
         @Override
@@ -98,12 +96,13 @@ enum DateFormat {
                 // fill the rest of the date up with the parsed date
                 if (accessor.isSupported(ChronoField.YEAR) == false
                     && accessor.isSupported(ChronoField.YEAR_OF_ERA) == false
-                    && accessor.isSupported(WeekFields.of(locale).weekBasedYear()) == false) {
+                    && accessor.isSupported(WeekFields.of(locale).weekBasedYear()) == false
+                    && accessor.isSupported(ChronoField.INSTANT_SECONDS) == false) {
                     int year = LocalDate.now(ZoneOffset.UTC).getYear();
                     ZonedDateTime newTime = Instant.EPOCH.atZone(ZoneOffset.UTC).withYear(year);
                     for (ChronoField field : FIELDS) {
                         if (accessor.isSupported(field)) {
-                            newTime = newTime.with(field, accessor.getLong(field));
+                            newTime = newTime.with(field, accessor.get(field));
                         }
                     }
 

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateFormatTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.ingest.common;
 
 import org.elasticsearch.common.time.DateFormatter;
 import org.elasticsearch.common.time.DateUtils;
+import org.elasticsearch.common.time.FormatNames;
 import org.elasticsearch.test.ESTestCase;
 
 import java.time.ZoneId;
@@ -131,6 +132,19 @@ public class DateFormatTests extends ESTestCase {
         // this means that hour will be 00:00 (default) at -01:00 as timezone was not on a pattern, but -01:00 was an ingest param
         ZonedDateTime dateTime = javaFunction.apply("2020-01-01");
         assertThat(dateTime, equalTo(ZonedDateTime.of(2020, 01, 01, 0, 0, 0, 0, timezone)));
+    }
+
+    public void testParseAllFormatNames() {
+        ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
+        for (FormatNames formatName : FormatNames.values()) {
+            String name = formatName.getName();
+            DateFormatter formatter = DateFormatter.forPattern(name);
+            String formattedInput = formatter.format(now);
+            DateFormat dateFormat = DateFormat.fromString(name);
+            ZonedDateTime parsed = dateFormat.getFunction(name, ZoneOffset.UTC, Locale.ROOT).apply(formattedInput);
+            String formattedOutput = formatter.format(parsed);
+            assertThat(name, formattedOutput, equalTo(formattedInput));
+        }
     }
 
     public void testParseUnixMs() {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -264,6 +264,23 @@ public class DateProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
     }
 
+    public void testUnix() {
+        DateProcessor dateProcessor = new DateProcessor(
+            randomAlphaOfLength(10),
+            null,
+            templatize(ZoneOffset.UTC),
+            templatize(randomLocale(random())),
+            "date_as_string",
+            List.of("UNIX"),
+            "date_as_date"
+        );
+        Map<String, Object> document = new HashMap<>();
+        document.put("date_as_string", "1000.5");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
+    }
+
     public void testEpochMillis() {
         DateProcessor dateProcessor = new DateProcessor(
             randomAlphaOfLength(10),
@@ -285,23 +302,6 @@ public class DateProcessorTests extends ESTestCase {
         ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
         dateProcessor.execute(ingestDocument);
         assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("2023-05-10T06:55:16.065Z"));
-    }
-
-    public void testUnix() {
-        DateProcessor dateProcessor = new DateProcessor(
-            randomAlphaOfLength(10),
-            null,
-            templatize(ZoneOffset.UTC),
-            templatize(randomLocale(random())),
-            "date_as_string",
-            List.of("UNIX"),
-            "date_as_date"
-        );
-        Map<String, Object> document = new HashMap<>();
-        document.put("date_as_string", "1000.5");
-        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
-        dateProcessor.execute(ingestDocument);
-        assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
     }
 
     public void testInvalidTimezone() {

--- a/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
+++ b/modules/ingest-common/src/test/java/org/elasticsearch/ingest/common/DateProcessorTests.java
@@ -264,6 +264,29 @@ public class DateProcessorTests extends ESTestCase {
         assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("1970-01-01T00:16:40.500Z"));
     }
 
+    public void testEpochMillis() {
+        DateProcessor dateProcessor = new DateProcessor(
+            randomAlphaOfLength(10),
+            null,
+            templatize(ZoneOffset.UTC),
+            templatize(randomLocale(random())),
+            "date_as_string",
+            List.of("epoch_millis"),
+            "date_as_date"
+        );
+        Map<String, Object> document = new HashMap<>();
+        document.put("date_as_string", "1683701716065");
+        IngestDocument ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("2023-05-10T06:55:16.065Z"));
+
+        document = new HashMap<>();
+        document.put("date_as_string", 1683701716065L);
+        ingestDocument = RandomDocumentPicks.randomIngestDocument(random(), document);
+        dateProcessor.execute(ingestDocument);
+        assertThat(ingestDocument.getFieldValue("date_as_date", String.class), equalTo("2023-05-10T06:55:16.065Z"));
+    }
+
     public void testUnix() {
         DateProcessor dateProcessor = new DateProcessor(
             randomAlphaOfLength(10),


### PR DESCRIPTION
As described in https://discuss.elastic.co/t/difference-between-unix-ms-and-epoch-millis-in-date-processor/333048, if you create a DateProcessor with a `format` of `epoch_milllis`, we oddly capture the year and nanoseconds for `@timestamp`, but not the month, day, hour, second, etc. It looks like the problem is that problem is that the ChronoField that we get from the DateFormatter created with `epoch_millis` that has all of that information is `INSTANT_SECONDS`. We don't look at `INSTANT_SECONDS` though, so all of that is lost.