### PR TITLE
Fix disable auto-creation of indices in the AnalyticsEventEmitter

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-template.json
@@ -8,6 +8,7 @@
     "behavioral_analytics-events-settings",
     "behavioral_analytics-events-mappings"
   ],
+  "allow_auto_create": false,
   "_meta": {
     "description": "Built-in template applied by default to behavioral analytics event data streams.",
     "managed": true

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/ingest/AnalyticsEventEmitter.java
@@ -108,8 +108,6 @@ public class AnalyticsEventEmitter extends AbstractLifecycleComponent {
 
         try (XContentBuilder builder = JsonXContent.contentBuilder()) {
             return client.prepareIndex(collection.getEventDataStream())
-                // disable auto-creation of the underlying index
-                .setRequireAlias(true)
                 .setCreate(true)
                 .setSource(event.toXContent(builder, ToXContent.EMPTY_PARAMS))
                 .request();


### PR DESCRIPTION
The previous fix (#95890) that relied on an alias couldn't work since we're not using an explicit alias to index documents. We don't have any test that checks if the events are correctly indexed so I had to manually check this change. I also had to use 8.8 since the feature is in broken state in main due to #95917. I am opening this PR as a quick fix for 8.8.x and will open another one to add explicit tests for the indexation.