### PR TITLE
[8.8] Fix searching a filtered and unfiltered data stream alias (#95865)

### DIFF
--- a/docs/changelog/95865.yaml
+++ b/docs/changelog/95865.yaml
@@ -1,0 +1,6 @@
+pr: 95865
+summary: Fix searching a filtered and unfiltered data stream alias
+area: Data streams
+type: bug
+issues:
+ - 95786


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix searching a filtered and unfiltered data stream alias (#95865)