### PR TITLE
Check shard availability before including in stats

### DIFF
--- a/docs/changelog/96015.yaml
+++ b/docs/changelog/96015.yaml
@@ -1,0 +1,7 @@
+pr: 96015
+summary: Check shard availability before including in stats
+area: Other
+type: bug
+issues:
+ - 96000
+ - 87001

--- a/docs/changelog/96015.yaml
+++ b/docs/changelog/96015.yaml
@@ -1,6 +1,6 @@
 pr: 96015
 summary: Check shard availability before including in stats
-area: Other
+area: Distributed 
 type: bug
 issues:
  - 96000

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -206,7 +206,8 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
                 accumulator.docCount += shardStat.getTotal().getDocs().getCount();
 
                 // Accumulate stats about started shards
-                if (node.getByShardId(shardStat.getShardId()).state() == ShardRoutingState.STARTED) {
+                ShardRouting shardRouting = node.getByShardId(shardStat.getShardId());
+                if (shardRouting != null && shardRouting.state() == ShardRoutingState.STARTED) {
                     accumulator.totalShardCount += 1;
 
                     // Accumulate stats about started primary shards


### PR DESCRIPTION
With this commit we check whether there is an available shard routing before we test whether it has been started. This makes `DataTiersUsageTransportAction` more resilient to potential temporary inconsistencies between cluster state and node stats due to concurrent shard movement.

Closes #87001
Closes #96000