### PR TITLE
[8.8] Check shard availability before including in stats (#96015)

### DIFF
--- a/docs/changelog/96015.yaml
+++ b/docs/changelog/96015.yaml
@@ -1,0 +1,7 @@
+pr: 96015
+summary: Check shard availability before including in stats
+area: Distributed 
+type: bug
+issues:
+ - 96000
+ - 87001

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersUsageTransportAction.java
@@ -206,7 +206,8 @@ public class DataTiersUsageTransportAction extends XPackUsageFeatureTransportAct
                 accumulator.docCount += shardStat.getTotal().getDocs().getCount();
 
                 // Accumulate stats about started shards
-                if (node.getByShardId(shardStat.getShardId()).state() == ShardRoutingState.STARTED) {
+                ShardRouting shardRouting = node.getByShardId(shardStat.getShardId());
+                if (shardRouting != null && shardRouting.state() == ShardRoutingState.STARTED) {
                     accumulator.totalShardCount += 1;
 
                     // Accumulate stats about started primary shards


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Check shard availability before including in stats (#96015)