### PR TITLE
Add a flag to control the concurrent execution of aggregations

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
@@ -125,6 +125,11 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
         return true;
     }
 
+    @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
     public boolean isKeyed() {
         return keyed;
     }

--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/bucket/timeseries/TimeSeriesAggregationBuilder.java
@@ -125,11 +125,6 @@ public class TimeSeriesAggregationBuilder extends AbstractAggregationBuilder<Tim
         return true;
     }
 
-    @Override
-    public boolean supportsConcurrentExecution() {
-        return false;
-    }
-
     public boolean isKeyed() {
         return keyed;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationBuilder.java
@@ -220,6 +220,18 @@ public abstract class AggregationBuilder
     }
 
     /**
+     * Return false if this aggregation or any of the child aggregations does not support concurrent search
+     */
+    public boolean supportsConcurrentExecution() {
+        for (AggregationBuilder builder : factoriesBuilder.getAggregatorFactories()) {
+            if (builder.supportsConcurrentExecution() == false) {
+                return false;
+            }
+        }
+        return isInSortOrderExecutionRequired() == false;
+    }
+
+    /**
      * Called by aggregations whose parents must be sequentially ordered.
      * @param type the type of the aggregation being validated
      * @param name the name of the aggregation being validated

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregationBuilder.java
@@ -96,6 +96,11 @@ public class CompositeAggregationBuilder extends AbstractAggregationBuilder<Comp
         return true;
     }
 
+    @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
     public CompositeAggregationBuilder(StreamInput in) throws IOException {
         super(in);
         int num = in.readVInt();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/nested/NestedAggregationBuilder.java
@@ -81,6 +81,11 @@ public class NestedAggregationBuilder extends AbstractAggregationBuilder<NestedA
     }
 
     @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
+    @Override
     protected AggregatorFactory doBuild(AggregationContext context, AggregatorFactory parent, Builder subFactoriesBuilder)
         throws IOException {
         NestedObjectMapper nestedMapper = context.nestedLookup().getNestedMappers().get(path);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/TermsAggregationBuilder.java
@@ -134,6 +134,11 @@ public class TermsAggregationBuilder extends ValuesSourceAggregationBuilder<Term
     }
 
     @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
+    @Override
     protected ValuesSourceType defaultValueSourceType() {
         return CoreValuesSourceType.KEYWORD;
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregationBuilder.java
@@ -113,6 +113,11 @@ public final class CardinalityAggregationBuilder extends ValuesSourceAggregation
     }
 
     @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
+    @Override
     protected boolean serializeTargetValueType(TransportVersion version) {
         return true;
     }

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/AggregatorTestCase.java
@@ -24,6 +24,7 @@ import org.apache.lucene.index.LeafReaderContext;
 import org.apache.lucene.index.NoMergePolicy;
 import org.apache.lucene.sandbox.document.HalfFloatPoint;
 import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
@@ -36,7 +37,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.tests.analysis.MockAnalyzer;
 import org.apache.lucene.tests.index.AssertingDirectoryReader;
 import org.apache.lucene.tests.index.RandomIndexWriter;
-import org.apache.lucene.tests.search.AssertingIndexSearcher;
 import org.apache.lucene.tests.util.LuceneTestCase;
 import org.apache.lucene.util.Accountable;
 import org.apache.lucene.util.BytesRef;
@@ -58,6 +58,7 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.MockBigArrays;
 import org.elasticsearch.common.util.MockPageCacheRecycler;
+import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
@@ -136,6 +137,8 @@ import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.internal.SubSearchContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.InternalAggregationTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.ContextParser;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.junit.After;
@@ -145,6 +148,7 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -152,6 +156,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.stream.Stream;
@@ -161,7 +167,6 @@ import static java.util.Collections.singletonList;
 import static java.util.stream.Collectors.toList;
 import static org.elasticsearch.test.InternalAggregationTestCase.DEFAULT_MAX_BUCKETS;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
@@ -177,7 +182,7 @@ import static org.mockito.Mockito.when;
  */
 public abstract class AggregatorTestCase extends ESTestCase {
     private NamedWriteableRegistry namedWriteableRegistry;
-    private List<AggregationContext> releasables = new ArrayList<>();
+    private final List<AggregationContext> releasables = new ArrayList<>();
     protected ValuesSourceRegistry valuesSourceRegistry;
     private AnalysisModule analysisModule;
 
@@ -192,9 +197,21 @@ public abstract class AggregatorTestCase extends ESTestCase {
         CompletionFieldMapper.CONTENT_TYPE, // TODO support completion
         FieldAliasMapper.CONTENT_TYPE // TODO support alias
     );
+    ThreadPool threadPool;
+    ThreadPoolExecutor threadPoolExecutor;
 
     @Before
     public final void initPlugins() {
+        int numThreads = randomIntBetween(2, 4);
+        threadPool = new TestThreadPool(AggregatorTestCase.class.getName());
+        threadPoolExecutor = EsExecutors.newFixed(
+            "test",
+            numThreads,
+            10,
+            EsExecutors.daemonThreadFactory("test"),
+            threadPool.getThreadContext(),
+            randomBoolean()
+        );
         List<SearchPlugin> plugins = new ArrayList<>(getSearchPlugins());
         plugins.add(new AggCardinalityUpperBoundPlugin());
         SearchModule searchModule = new SearchModule(Settings.EMPTY, plugins);
@@ -475,7 +492,14 @@ public abstract class AggregatorTestCase extends ESTestCase {
             } catch (CircuitBreakingException e) {
                 // Circuit breaks from the cranky breaker are expected - it randomly fails, after all
                 assertThat(e.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
-            } catch (IOException e) {
+            } catch (RuntimeException e) {
+                if (e.getCause() instanceof ExecutionException executionException) {
+                    if (executionException.getCause() instanceof CircuitBreakingException circuitBreakingException) {
+                        // Circuit breaks from the cranky breaker are expected - it randomly fails, after all
+                        assertThat(circuitBreakingException.getMessage(), equalTo(CrankyCircuitBreakerService.ERROR_MESSAGE));
+                        return;
+                    }
+                }
                 throw e;
             }
         }
@@ -497,7 +521,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
 
         final IndexReaderContext ctx = searcher.getTopReaderContext();
         final PipelineTree pipelines = builder.buildPipelineTree();
-        List<InternalAggregation> aggs = new ArrayList<>();
+        List<InternalAggregation> internalAggs = new ArrayList<>();
         Query rewritten = searcher.rewrite(query);
 
         if (splitLeavesIntoSeparateAggregators
@@ -533,7 +557,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
                     }
                     a.postCollection();
                     assertEquals(shouldBeCached, context.isCacheable());
-                    aggs.add(a.buildTopLevel());
+                    internalAggs.add(a.buildTopLevel());
                 } finally {
                     Releasables.close(context);
                 }
@@ -550,39 +574,61 @@ public abstract class AggregatorTestCase extends ESTestCase {
                 fieldTypes
             );
             try {
-                C root = createAggregator(builder, context);
-                root.preCollection();
+                List<C> aggregators = new ArrayList<>();
                 if (context.isInSortOrderExecutionRequired()) {
+                    C root = createAggregator(builder, context);
+                    root.preCollection();
+                    aggregators.add(root);
                     new TimeSeriesIndexSearcher(searcher, List.of()).search(rewritten, MultiBucketCollector.wrap(true, List.of(root)));
                 } else {
-                    searcher.search(rewritten, MultiBucketCollector.wrap(true, List.of(root)).asCollector());
+                    CollectorManager<Collector, Void> collectorManager = new CollectorManager<>() {
+                        @Override
+                        public Collector newCollector() throws IOException {
+                            C collector = createAggregator(builder, context);
+                            collector.preCollection();
+                            aggregators.add(collector);
+                            return MultiBucketCollector.wrap(true, List.of(collector)).asCollector();
+                        }
+
+                        @Override
+                        public Void reduce(Collection<Collector> collectors) {
+                            return null;
+                        }
+                    };
+                    if (aggTestConfig.builder().supportsConcurrentExecution()) {
+                        searcher.search(rewritten, collectorManager);
+                    } else {
+                        searcher.search(rewritten, collectorManager.newCollector());
+                    }
                 }
-                root.postCollection();
-                aggs.add(root.buildTopLevel());
+                for (C agg : aggregators) {
+                    agg.postCollection();
+                    internalAggs.add(agg.buildTopLevel());
+                }
             } finally {
                 Releasables.close(context);
             }
         }
-        assertRoundTrip(aggs);
+        assertRoundTrip(internalAggs);
 
         BigArrays bigArraysForReduction = new MockBigArrays(new MockPageCacheRecycler(Settings.EMPTY), breakerService);
         try {
-            if (aggTestConfig.incrementalReduce() && aggs.size() > 1) {
+            if (aggTestConfig.incrementalReduce() && internalAggs.size() > 1) {
                 // sometimes do an incremental reduce
-                int toReduceSize = aggs.size();
-                Collections.shuffle(aggs, random());
+                int toReduceSize = internalAggs.size();
+                Collections.shuffle(internalAggs, random());
                 int r = randomIntBetween(1, toReduceSize);
-                List<InternalAggregation> toReduce = aggs.subList(0, r);
+                List<InternalAggregation> toReduce = internalAggs.subList(0, r);
                 AggregationReduceContext reduceContext = new AggregationReduceContext.ForPartial(
                     bigArraysForReduction,
                     getMockScriptService(),
                     () -> false,
                     builder
                 );
-                A reduced = (A) aggs.get(0).reduce(toReduce, reduceContext);
-                aggs = new ArrayList<>(aggs.subList(r, toReduceSize));
-                aggs.add(reduced);
-                assertRoundTrip(aggs);
+                A reduced = (A) internalAggs.get(0).reduce(toReduce, reduceContext);
+                internalAggs = new ArrayList<>(internalAggs.subList(r, toReduceSize));
+                internalAggs.add(reduced);
+                assertRoundTrip(internalAggs);
             }
 
             // now do the final reduce
@@ -600,7 +646,7 @@ public abstract class AggregatorTestCase extends ESTestCase {
             );
 
             @SuppressWarnings("unchecked")
-            A internalAgg = (A) aggs.get(0).reduce(aggs, reduceContext);
+            A internalAgg = (A) internalAggs.get(0).reduce(internalAggs, reduceContext);
             assertRoundTrip(internalAgg);
 
             // materialize any parent pipelines
@@ -870,17 +916,24 @@ public abstract class AggregatorTestCase extends ESTestCase {
     }
 
     /**
-     * Added to randomly run with more assertions on the index searcher level,
-     * like {@link org.apache.lucene.tests.util.LuceneTestCase#newSearcher(IndexReader)}, which can't be used because it also
-     * wraps in the IndexSearcher's IndexReader with other implementations that we can't handle. (e.g. ParallelCompositeReader)
+     * Creates a {@link ContextIndexSearcher} that supports concurrency running each segment in a different thread. It randomly
+     * sets the IndexSearcher to run on concurrent mode.
      */
-    protected static IndexSearcher newIndexSearcher(DirectoryReader indexReader) throws IOException {
-        if (randomBoolean()) {
-            // this executes basic query checks and asserts that weights are normalized only once etc.
-            return new AssertingIndexSearcher(random(), indexReader);
-        } else {
-            return new IndexSearcher(indexReader);
-        }
+    protected IndexSearcher newIndexSearcher(DirectoryReader indexReader) throws IOException {
+        return new ContextIndexSearcher(
+            indexReader,
+            IndexSearcher.getDefaultSimilarity(),
+            IndexSearcher.getDefaultQueryCache(),
+            IndexSearcher.getDefaultQueryCachingPolicy(),
+            randomBoolean(),
+            randomBoolean() ? this.threadPoolExecutor : null
+        ) {
+            @Override
+            protected LeafSlice[] slices(List<LeafReaderContext> leaves) {
+                // get a thread per segment
+                return slices(leaves, 1, 1);
+            }
+        };
     }
 
     /**
@@ -1179,6 +1232,8 @@ public abstract class AggregatorTestCase extends ESTestCase {
     public void cleanupReleasables() {
         Releasables.close(releasables);
         releasables.clear();
+        threadPoolExecutor.shutdown();
+        terminate(threadPool);
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/aggregations/BaseAggregationTestCase.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.common.io.stream.NamedWriteableAwareStreamInput;
 import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.search.aggregations.bucket.histogram.HistogramAggregationBuilder;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregationBuilder;
 import org.elasticsearch.test.AbstractBuilderTestCase;
 import org.elasticsearch.xcontent.ToXContent;
@@ -27,6 +28,7 @@ import java.util.List;
 import java.util.Set;
 
 import static org.elasticsearch.test.EqualsHashCodeTestUtils.checkEqualsAndHashCode;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuilder<AB>> extends AbstractBuilderTestCase {
@@ -54,6 +56,15 @@ public abstract class BaseAggregationTestCase<AB extends AbstractAggregationBuil
         assertNotSame(newAgg, testAgg);
         assertEquals(testAgg, newAgg);
         assertEquals(testAgg.hashCode(), newAgg.hashCode());
+    }
+
+    public void testSupportsConcurrentExecution() {
+        AB builder = createTestAggregatorBuilder();
+        boolean supportsConcurrency = builder.supportsConcurrentExecution();
+        AggregationBuilder bucketBuilder = new HistogramAggregationBuilder("test");
+        assertThat(bucketBuilder.supportsConcurrentExecution(), equalTo(true));
+        bucketBuilder.subAggregation(builder);
+        assertThat(bucketBuilder.supportsConcurrentExecution(), equalTo(supportsConcurrency));
     }
 
     /**

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregationBuilder.java
@@ -152,6 +152,11 @@ public class MultiTermsAggregationBuilder extends AbstractAggregationBuilder<Mul
         return true;
     }
 
+    @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
     /**
      * Sets the field to use for this aggregation.
      */

--- a/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
+++ b/x-pack/plugin/analytics/src/test/java/org/elasticsearch/xpack/analytics/multiterms/MultiTermsAggregatorTests.java
@@ -589,6 +589,33 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
 
     }
 
+    public void testShardSize() throws IOException {
+        testCase(
+            new MatchAllDocsQuery(),
+            List.of(
+                new MultiValuesSourceFieldConfig.Builder().setFieldName(INT_FIELD).build(),
+                new MultiValuesSourceFieldConfig.Builder().setFieldName(DATE_FIELD).build()
+            ),
+            ab -> ab.size(1).shardSize(1),
+            iw -> {
+                for (int i = 0; i < 100; i++) {
+                    iw.addDocument(docWithDate("2020-01-01", new NumericDocValuesField(INT_FIELD, 1)));
+                    if (i < 80) {
+                        iw.addDocument(docWithDate("2020-01-01", new NumericDocValuesField(INT_FIELD, 2)));
+                    }
+                    if (i < 60) {
+                        iw.addDocument(docWithDate("2020-01-01", new NumericDocValuesField(INT_FIELD, 3)));
+                    }
+                }
+            },
+            h -> {
+                assertThat(h.getBuckets(), hasSize(1));
+                assertThat(h.getBuckets().get(0).getDocCount(), equalTo(100L));
+            },
+            false
+        );
+    }
+
     private void testCase(
         Query query,
         String[] terms,
@@ -610,6 +637,17 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
         CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
         Consumer<InternalMultiTerms> verify
     ) throws IOException {
+        testCase(query, terms, builderSetup, buildIndex, verify, randomBoolean());
+    }
+
+    private void testCase(
+        Query query,
+        List<MultiValuesSourceFieldConfig> terms,
+        Consumer<MultiTermsAggregationBuilder> builderSetup,
+        CheckedConsumer<RandomIndexWriter, IOException> buildIndex,
+        Consumer<InternalMultiTerms> verify,
+        boolean withSplitLeavesIntoSeparateAggregators
+    ) throws IOException {
         MappedFieldType dateType = dateFieldType(DATE_FIELD);
         MappedFieldType intType = new NumberFieldMapper.NumberFieldType(INT_FIELD, NumberFieldMapper.NumberType.INTEGER);
         MappedFieldType floatType = new NumberFieldMapper.NumberFieldType(FLOAT_FIELD, NumberFieldMapper.NumberType.FLOAT);
@@ -630,7 +668,9 @@ public class MultiTermsAggregatorTests extends AggregatorTestCase {
                 builder.size(randomIntBetween(10, 200));
             }
         }
-        testCase(buildIndex, verify, new AggTestConfig(builder, dateType, intType, floatType, keywordType).withQuery(query));
+        AggTestConfig aggTestConfig = new AggTestConfig(builder, dateType, intType, floatType, keywordType).withQuery(query)
+            .withSplitLeavesIntoSeperateAggregators(withSplitLeavesIntoSeparateAggregators);
+        testCase(buildIndex, verify, aggTestConfig);
     }
 
     @Override


### PR DESCRIPTION
Initial testing has shown that some aggregations are problematic when running on concurrency mode. In order to be able to run aggregations with concurrency, this PR proposes to add a flag that can tell if an aggregation block can be run concurrently. In addition it updates the `AggregationTestCase` to randomly run concurrently. This test has been used to uncover the problematic aggregations.

The problematic aggregations fall into two groups:

1) The first group fails with error similar to:
```
java.lang.AssertionError: Sorted doc values are only supposed to be consumed in the thread in which they have been acquired. But was acquired in Thread[#52,test[T#1],5,TGRP-CardinalityAggregatorTests] and consumed in Thread[#36,TEST-CardinalityAggregatorTests.testIndexedAllDifferentValues-seed#[CAF09AA8E1D11977],5,TGRP-CardinalityAggregatorTests].
	at __randomizedtesting.SeedInfo.seed([CAF09AA8E1D11977:1F5E1886B5DDDAC8]:0)
	at org.apache.lucene.tests.index.AssertingLeafReader.assertThread(AssertingLeafReader.java:67)
	at org.apache.lucene.tests.index.AssertingLeafReader$AssertingSortedDocValues.getValueCount(AssertingLeafReader.java:917)
	at org.apache.lucene.index.SortedDocValuesTermsEnum.seekExact(SortedDocValuesTermsEnum.java:68)

```

The issue with this aggregations is that they have a post-collection phase that uses some generated data structures during the collection phase. Because this are run on different threads, we hit a lucene assertion. These aggregations are Cardinality, nested and Composite aggregations.

2) The second group fails because the result of the aggregation might be different between concurrent and non-concurrent mode. This is actually expected because now each concurrent slice uses its own aggregator, so aggregation that might loose information before reduction might give different results. These aggregations are Terms and MultiTerms, the erros will depends on the shard size which now is applied to each concurrent slice. 

Label the PR as non-issue as we don't support concurrent searches.