### PR TITLE
Relax limit on max string size

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
@@ -10,8 +10,11 @@ package org.elasticsearch.xcontent.provider.json;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+
+import com.fasterxml.jackson.core.StreamReadConstraints;
 
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -44,7 +47,12 @@ public class JsonXContentImpl implements XContent {
     }
 
     static {
-        jsonFactory = new JsonFactory();
+        var builder = new JsonFactoryBuilder();
+        // jackson 2.15 introduced a max string length. We have other limits in place to constrain max doc size,
+        // so here we set to max value (2GiB) so as not to constrain further than those existing limits.
+        builder.streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+
+        jsonFactory = builder.build();
         jsonFactory.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, true);
         jsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         jsonFactory.configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...

--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
@@ -13,7 +13,6 @@ import com.fasterxml.jackson.core.JsonFactory;
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
-
 import com.fasterxml.jackson.core.StreamReadConstraints;
 
 import org.elasticsearch.xcontent.XContent;


### PR DESCRIPTION
Jackson 2.15 introduced a (rough) maximum limit on string length. This commit relaxes that limit to its maximum size, leaving document size constraints to other existing limits in the system. We can revisit whether string length within a document should be independently constrained later.

Fixes #96036