### PR TITLE
Add SLES 15.4 to the docker exclusion list

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -12,6 +12,7 @@ sles-12.5
 sles-15.1
 sles-15.2
 sles-15.3
+sles-15.4
 
 # These OSes are deprecated and filtered starting with 8.0.0, but need to be excluded
 # for PR checks


### PR DESCRIPTION
Our docker exclusion list is sensitive to minor versions. With SLES 15.4 we need to explicitly add it to the exclusion list since it doesn't play nicely with Docker in CI.

Closes https://github.com/elastic/elasticsearch/issues/93898