### PR TITLE
Assert that RetryableAction.finalListener is called once

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/RetryableAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RetryableAction.java
@@ -98,7 +98,7 @@ public abstract class RetryableAction<Response> {
         }
         this.timeoutMillis = timeoutValue.getMillis();
         this.startMillis = threadPool.relativeTimeInMillis();
-        this.finalListener = listener;
+        this.finalListener = ActionListener.assertOnce(listener);
         this.executor = executor;
 
     }


### PR DESCRIPTION
It should never happen since finalListener is always called after an atomic CAS in RetryableAction, but it costs nothing to assert it.