### PR TITLE
[8.8] Relax limit on max string size (#96031)

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/json/JsonXContentImpl.java
@@ -10,8 +10,10 @@ package org.elasticsearch.xcontent.provider.json;
 
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 
 import org.elasticsearch.xcontent.XContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -44,7 +46,12 @@ public class JsonXContentImpl implements XContent {
     }
 
     static {
-        jsonFactory = new JsonFactory();
+        var builder = new JsonFactoryBuilder();
+        // jackson 2.15 introduced a max string length. We have other limits in place to constrain max doc size,
+        // so here we set to max value (2GiB) so as not to constrain further than those existing limits.
+        builder.streamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
+
+        jsonFactory = builder.build();
         jsonFactory.configure(JsonGenerator.Feature.QUOTE_FIELD_NAMES, true);
         jsonFactory.configure(JsonParser.Feature.ALLOW_COMMENTS, true);
         jsonFactory.configure(JsonFactory.Feature.FAIL_ON_SYMBOL_HASH_OVERFLOW, false); // this trips on many mappings now...


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Relax limit on max string size (#96031)