### PR TITLE
[7.17] Add SLES 15.4 to the docker exclusion list (#96037)

### DIFF
--- a/.ci/dockerOnLinuxExclusions
+++ b/.ci/dockerOnLinuxExclusions
@@ -15,3 +15,4 @@ sles-12.5
 sles-15.1
 sles-15.2
 sles-15.3
+sles-15.4


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Add SLES 15.4 to the docker exclusion list (#96037)