### PR TITLE
Fixing expectations in ExplainDataLifecycleIT when there is a single node

### DIFF
--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/ExplainDataLifecycleIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/ExplainDataLifecycleIT.java
@@ -120,7 +120,10 @@ public class ExplainDataLifecycleIT extends ESIntegTestCase {
                 assertThat(explainIndex.getIndexCreationDate(), notNullValue());
                 assertThat(explainIndex.getLifecycle(), notNullValue());
                 assertThat(explainIndex.getLifecycle().getDataRetention(), nullValue());
-                assertThat(explainIndex.getError(), nullValue());
+                if (internalCluster().numDataNodes() > 1) {
+                    // If the number of nodes is 1 then the cluster will be yellow so forcemerge will report an error if it has run
+                    assertThat(explainIndex.getError(), nullValue());
+                }
 
                 if (explainIndex.getIndex().equals(DataStream.getDefaultBackingIndexName(dataStreamName, 1))) {
                     // first generation index was rolled over
@@ -262,8 +265,10 @@ public class ExplainDataLifecycleIT extends ESIntegTestCase {
                 assertThat(explainIndex.getGenerationTime(System::currentTimeMillis), nullValue());
                 assertThat(explainIndex.getRolloverDate(), nullValue());
                 assertThat(explainIndex.getTimeSinceRollover(System::currentTimeMillis), nullValue());
-
-                assertThat(explainIndex.getError(), nullValue());
+                if (internalCluster().numDataNodes() > 1) {
+                    // If the number of nodes is 1 then the cluster will be yellow so forcemerge will report an error if it has run
+                    assertThat(explainIndex.getError(), nullValue());
+                }
             }
         });
     }


### PR DESCRIPTION
If the ExplainDataLifecycleIT tests happen to run with a single node in the cluster, then if forcemerge runs it will report an error (since there are replica shards that can't be allocated). The ExplainDataLifecycleIT tests that assert that the error is null fail. This changes ExplainDataLifecycleIT to only make those assertions when running with more than node.
Relates #95204 