### PR TITLE
[Fleet] Give kibana_system delete privilege on .fleet-secrets index

### DIFF
--- a/docs/changelog/96080.yaml
+++ b/docs/changelog/96080.yaml
@@ -1,5 +1,0 @@
-pr: 96080
-summary: "[Fleet] Give `kibana_system` delete privilege on .fleet-secrets index"
-area: Infra/Plugins
-type: feature
-issues: []

--- a/docs/changelog/96080.yaml
+++ b/docs/changelog/96080.yaml
@@ -1,0 +1,5 @@
+pr: 96080
+summary: "[Fleet] Give `kibana_system` delete privilege on .fleet-secrets index"
+area: Infra/Plugins
+type: feature
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -764,7 +764,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry
                 RoleDescriptor.IndicesPrivileges.builder().indices(".logs-endpoint.diagnostic.collection-*").privileges("read").build(),
-                // Fleet secrets, Kibana can only write t this index.
+                // Fleet secrets, Kibana can only write to this index.
                 // This definition must come before .fleet* below.
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-secrets*")

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -764,11 +764,11 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 RoleDescriptor.IndicesPrivileges.builder().indices("*").privileges("view_index_metadata", "monitor").build(),
                 // Endpoint diagnostic information. Kibana reads from these indices to send telemetry
                 RoleDescriptor.IndicesPrivileges.builder().indices(".logs-endpoint.diagnostic.collection-*").privileges("read").build(),
-                // Fleet secrets, Kibana can only write ot this index.
+                // Fleet secrets, Kibana can only write t this index.
                 // This definition must come before .fleet* below.
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(".fleet-secrets*")
-                    .privileges("write", "create_index")
+                    .privileges("write", "delete", "create_index")
                     .allowRestrictedIndices(true)
                     .build(),
                 // Fleet Server indices. Kibana create this indice before Fleet Server use them.


### PR DESCRIPTION
In https://github.com/elastic/elasticsearch/pull/95625 I forgot to add the delete privilege to the kibana_system user.

