### PR TITLE
Ignore index-level ignore_malformed for data stream @timestamp mappings

### DIFF
--- a/docs/changelog/96081.yaml
+++ b/docs/changelog/96081.yaml
@@ -1,0 +1,5 @@
+pr: 96081
+summary: Ignore index-level `ignore_malformed` for data stream @timestamp mappings
+area: Data streams
+type: enhancement
+issues: []

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/mapper/DataStreamTimestampFieldMapperTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/mapper/DataStreamTimestampFieldMapperTests.java
@@ -168,20 +168,17 @@ public class DataStreamTimestampFieldMapperTests extends MetadataMapperTestCase 
 
     public void testValidateDefaultIgnoreMalformed() throws Exception {
         Settings indexSettings = Settings.builder().put(FieldMapper.IGNORE_MALFORMED_SETTING.getKey(), true).build();
-        Exception e = expectThrows(
-            IllegalArgumentException.class,
-            () -> createMapperService(Version.CURRENT, indexSettings, () -> true, timestampMapping(true, b -> {
-                b.startObject("@timestamp");
-                b.field("type", "date");
-                b.endObject();
-            }))
-        );
-        assertThat(
-            e.getMessage(),
-            equalTo("data stream timestamp field [@timestamp] has disallowed [ignore_malformed] attribute specified")
-        );
 
         MapperService mapperService = createMapperService(Version.CURRENT, indexSettings, () -> true, timestampMapping(true, b -> {
+            b.startObject("@timestamp");
+            b.field("type", "date");
+            b.endObject();
+        }));
+        assertThat(mapperService, notNullValue());
+        assertThat(mapperService.documentMapper().mappers().getMapper("@timestamp"), notNullValue());
+        assertThat(((DateFieldMapper) mapperService.documentMapper().mappers().getMapper("@timestamp")).ignoreMalformed(), is(false));
+
+        mapperService = createMapperService(Version.CURRENT, indexSettings, () -> true, timestampMapping(true, b -> {
             b.startObject("@timestamp");
             b.field("type", "date");
             b.field("ignore_malformed", false);

--- a/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/DateFieldMapper.java
@@ -356,6 +356,14 @@ public final class DateFieldMapper extends FieldMapper {
                 scriptValues(),
                 meta.getValue()
             );
+            // data streams don't allow the @timestamp field to ignore malformed values
+            // in case ignore malformed is enabled on the index level, disable it for data stream timestamp fields
+            if (ignoreMalformed.get()
+                && ignoreMalformed.isConfigured() == false
+                && name.equals(DataStreamTimestampFieldMapper.DEFAULT_PATH)
+                && context.isDataStream()) {
+                ignoreMalformed.setValue(false);
+            }
 
             Long nullTimestamp = parseNullValue(ft);
             return new DateFieldMapper(name, ft, multiFieldsBuilder.build(this, context), copyTo.build(), nullTimestamp, resolution, this);

--- a/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/FieldMapper.java
@@ -345,9 +345,6 @@ public abstract class FieldMapper extends Mapper implements Cloneable {
 
     @Override
     public final FieldMapper merge(Mapper mergeWith, MapperBuilderContext mapperBuilderContext) {
-        if (mergeWith == this) {
-            return this;
-        }
         if (mergeWith instanceof FieldMapper == false) {
             throw new IllegalArgumentException(
                 "mapper ["

--- a/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/MappingParser.java
@@ -103,6 +103,7 @@ public final class MappingParser {
         Map<Class<? extends MetadataFieldMapper>, MetadataFieldMapper> metadataMappers = metadataMappersSupplier.get();
         Map<String, Object> meta = null;
         boolean isSourceSynthetic = false;
+        boolean isDataStream = false;
 
         Iterator<Map.Entry<String, Object>> iterator = mapping.entrySet().iterator();
         while (iterator.hasNext()) {
@@ -124,6 +125,8 @@ public final class MappingParser {
                 assert fieldNodeMap.isEmpty();
                 if (metadataFieldMapper instanceof SourceFieldMapper sfm) {
                     isSourceSynthetic = sfm.isSynthetic();
+                } else if (metadataFieldMapper instanceof DataStreamTimestampFieldMapper dstfm) {
+                    isDataStream = dstfm.isEnabled();
                 }
             }
         }
@@ -153,7 +156,7 @@ public final class MappingParser {
         }
 
         return new Mapping(
-            rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic)),
+            rootObjectMapper.build(MapperBuilderContext.root(isSourceSynthetic, isDataStream)),
             metadataMappers.values().toArray(new MetadataFieldMapper[0]),
             meta
         );

--- a/x-pack/plugin/core/src/main/resources/data-streams-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/data-streams-mappings.json
@@ -33,8 +33,7 @@
       "date_detection": false,
       "properties": {
         "@timestamp": {
-          "type": "date",
-          "ignore_malformed": false
+          "type": "date"
         },
         "data_stream": {
           "properties": {

--- a/x-pack/plugin/core/src/main/resources/logs-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/logs-mappings.json
@@ -3,8 +3,7 @@
     "mappings": {
       "properties": {
         "@timestamp": {
-          "type": "date",
-          "ignore_malformed": false
+          "type": "date"
         },
         "data_stream": {
           "properties": {


### PR DESCRIPTION
Prior to this change, when `index.mapping.ignore_malformed: true` is configured as an index-level setting, you needed to explicitly set `ignore_malformed: false` for `@timestamp` mappings on data streams.

This change does that implicitly.

Explicitly setting `ignore_malformed: true` on a data stream timestamp mapping will still cause validation to fail at index template creation time.

Relates to https://github.com/elastic/elasticsearch/pull/96051

While there's still debate on whether that's the behavior we want, this PR proves the technical feasibility.