### PR TITLE
[8.8] Retry `downsample` ILM action using a new target index (#94965)

### DIFF
--- a/docs/changelog/94965.yaml
+++ b/docs/changelog/94965.yaml
@@ -1,0 +1,6 @@
+pr: 94965
+summary: Retry downsample ILM action using a new target index
+area: "ILM+SLM"
+type: bug
+issues:
+ - 93580

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/LifecycleExecutionState.java
@@ -81,7 +81,7 @@ public record LifecycleExecutionState(
             .setSnapshotName(state.snapshotName)
             .setShrinkIndexName(state.shrinkIndexName)
             .setSnapshotIndexName(state.snapshotIndexName)
-            .setRollupIndexName(state.downsampleIndexName)
+            .setDownsampleIndexName(state.downsampleIndexName)
             .setStepTime(state.stepTime);
     }
 
@@ -187,9 +187,9 @@ public record LifecycleExecutionState(
         if (snapshotIndexName != null) {
             builder.setSnapshotIndexName(snapshotIndexName);
         }
-        String rollupIndexName = customData.get(DOWNSAMPLE_INDEX_NAME);
-        if (rollupIndexName != null) {
-            builder.setRollupIndexName(rollupIndexName);
+        String downsampleIndexName = customData.get(DOWNSAMPLE_INDEX_NAME);
+        if (downsampleIndexName != null) {
+            builder.setDownsampleIndexName(downsampleIndexName);
         }
         return builder.build();
     }
@@ -273,7 +273,7 @@ public record LifecycleExecutionState(
         private String snapshotRepository;
         private String shrinkIndexName;
         private String snapshotIndexName;
-        private String rollupIndexName;
+        private String downsampleIndexName;
 
         public Builder setPhase(String phase) {
             this.phase = phase;
@@ -355,8 +355,8 @@ public record LifecycleExecutionState(
             return this;
         }
 
-        public Builder setRollupIndexName(String rollupIndexName) {
-            this.rollupIndexName = rollupIndexName;
+        public Builder setDownsampleIndexName(String downsampleIndexName) {
+            this.downsampleIndexName = downsampleIndexName;
             return this;
         }
 
@@ -378,7 +378,7 @@ public record LifecycleExecutionState(
                 snapshotName,
                 shrinkIndexName,
                 snapshotIndexName,
-                rollupIndexName
+                downsampleIndexName
             );
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleStep.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/DownsampleStep.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.core.ilm;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ClusterStateObserver;
@@ -35,9 +34,20 @@ public class DownsampleStep extends AsyncActionStep {
     private static final Logger logger = LogManager.getLogger(DownsampleStep.class);
 
     private final DateHistogramInterval fixedInterval;
+    private final StepKey nextStepOnSuccess;
+    private final StepKey nextStepOnFailure;
+    private volatile boolean downsampleFailed;
 
-    public DownsampleStep(StepKey key, StepKey nextStepKey, Client client, DateHistogramInterval fixedInterval) {
-        super(key, nextStepKey, client);
+    public DownsampleStep(
+        StepKey key,
+        StepKey nextStepOnSuccess,
+        StepKey nextStepOnFailure,
+        Client client,
+        DateHistogramInterval fixedInterval
+    ) {
+        super(key, null, client);
+        this.nextStepOnSuccess = nextStepOnSuccess;
+        this.nextStepOnFailure = nextStepOnFailure;
         this.fixedInterval = fixedInterval;
     }
 
@@ -62,24 +72,25 @@ public class DownsampleStep extends AsyncActionStep {
         final String indexName = indexMetadata.getIndex().getName();
         final String downsampleIndexName = lifecycleState.downsampleIndexName();
         if (Strings.hasText(downsampleIndexName) == false) {
+            downsampleFailed = true;
             listener.onFailure(
                 new IllegalStateException(
-                    "rollup index name was not generated for policy [" + policyName + "] and index [" + indexName + "]"
+                    "downsample index name was not generated for policy [" + policyName + "] and index [" + indexName + "]"
                 )
             );
             return;
         }
 
-        IndexMetadata rollupIndexMetadata = currentState.metadata().index(downsampleIndexName);
-        if (rollupIndexMetadata != null) {
-            IndexMetadata.DownsampleTaskStatus rollupIndexStatus = IndexMetadata.INDEX_DOWNSAMPLE_STATUS.get(
-                rollupIndexMetadata.getSettings()
+        IndexMetadata downsampleIndexMetadata = currentState.metadata().index(downsampleIndexName);
+        if (downsampleIndexMetadata != null) {
+            IndexMetadata.DownsampleTaskStatus downsampleIndexStatus = IndexMetadata.INDEX_DOWNSAMPLE_STATUS.get(
+                downsampleIndexMetadata.getSettings()
             );
-            // Rollup index has already been created with the generated name and its status is "success".
-            // So we skip index rollup creation.
-            if (IndexMetadata.DownsampleTaskStatus.SUCCESS.equals(rollupIndexStatus)) {
+            if (IndexMetadata.DownsampleTaskStatus.SUCCESS.equals(downsampleIndexStatus)) {
+                // Downsample index has already been created with the generated name and its status is "success".
+                // So we skip index downsample creation.
                 logger.warn(
-                    "skipping [{}] step for index [{}] as part of policy [{}] as the rollup index [{}] already exists",
+                    "skipping [{}] step for index [{}] as part of policy [{}] as the downsample index [{}] already exists",
                     DownsampleStep.NAME,
                     indexName,
                     policyName,
@@ -87,47 +98,37 @@ public class DownsampleStep extends AsyncActionStep {
                 );
                 listener.onResponse(null);
             } else {
-                logger.warn(
-                    "[{}] step for index [{}] as part of policy [{}] found the rollup index [{}] already exists. Deleting it.",
-                    DownsampleStep.NAME,
-                    indexName,
-                    policyName,
-                    downsampleIndexName
+                // Downsample index has already been created with the generated name but its status is not "success".
+                // So we fail this step so that we go back to cleaning up the index and try again with a new downsample
+                // index name.
+                downsampleFailed = true;
+                listener.onFailure(
+                    new IllegalStateException(
+                        "failing ["
+                            + DownsampleStep.NAME
+                            + "] step for index ["
+                            + indexName
+                            + "] as part of policy ["
+                            + policyName
+                            + "] because the downsample index ["
+                            + downsampleIndexName
+                            + "] already exists with downsample status ["
+                            + downsampleIndexStatus
+                            + "]"
+                    )
                 );
-                // Rollup index has already been created with the generated name but its status is not "success".
-                // So we delete the index and proceed with executing the rollup step.
-                DeleteIndexRequest deleteRequest = new DeleteIndexRequest(downsampleIndexName);
-                getClient().admin().indices().delete(deleteRequest, ActionListener.wrap(response -> {
-                    if (response.isAcknowledged()) {
-                        performDownsampleIndex(indexName, downsampleIndexName, listener);
-                    } else {
-                        listener.onFailure(
-                            new IllegalStateException(
-                                "failing ["
-                                    + DownsampleStep.NAME
-                                    + "] step for index ["
-                                    + indexName
-                                    + "] as part of policy ["
-                                    + policyName
-                                    + "] because the rollup index ["
-                                    + downsampleIndexName
-                                    + "] already exists with rollup status ["
-                                    + rollupIndexStatus
-                                    + "]"
-                            )
-                        );
-                    }
-                }, listener::onFailure));
             }
-            return;
+        } else {
+            performDownsampleIndex(indexName, downsampleIndexName, ActionListener.wrap(listener::onResponse, e -> {
+                downsampleFailed = true;
+                listener.onFailure(e);
+            }));
         }
-
-        performDownsampleIndex(indexName, downsampleIndexName, listener);
     }
 
-    private void performDownsampleIndex(String indexName, String rollupIndexName, ActionListener<Void> listener) {
+    void performDownsampleIndex(String indexName, String downsampleIndexName, ActionListener<Void> listener) {
         DownsampleConfig config = new DownsampleConfig(fixedInterval);
-        DownsampleAction.Request request = new DownsampleAction.Request(indexName, rollupIndexName, config).masterNodeTimeout(
+        DownsampleAction.Request request = new DownsampleAction.Request(indexName, downsampleIndexName, config).masterNodeTimeout(
             TimeValue.MAX_VALUE
         );
         // Currently, DownsampleAction always acknowledges action was complete when no exceptions are thrown.
@@ -138,17 +139,25 @@ public class DownsampleStep extends AsyncActionStep {
         );
     }
 
+    @Override
+    public final StepKey getNextStepKey() {
+        return downsampleFailed ? nextStepOnFailure : nextStepOnSuccess;
+    }
+
     public DateHistogramInterval getFixedInterval() {
         return fixedInterval;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), fixedInterval);
+        return Objects.hash(super.hashCode(), fixedInterval, nextStepOnSuccess, nextStepOnFailure);
     }
 
     @Override
     public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
         if (obj == null) {
             return false;
         }
@@ -156,6 +165,9 @@ public class DownsampleStep extends AsyncActionStep {
             return false;
         }
         DownsampleStep other = (DownsampleStep) obj;
-        return super.equals(obj) && Objects.equals(fixedInterval, other.fixedInterval);
+        return super.equals(obj)
+            && Objects.equals(fixedInterval, other.fixedInterval)
+            && Objects.equals(nextStepOnSuccess, other.nextStepOnSuccess)
+            && Objects.equals(nextStepOnFailure, other.nextStepOnFailure);
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/DownsampleActionTests.java
@@ -76,14 +76,14 @@ public class DownsampleActionTests extends AbstractActionTestCase<DownsampleActi
 
         assertTrue(steps.get(2) instanceof WaitForNoFollowersStep);
         assertThat(steps.get(2).getKey().name(), equalTo(WaitForNoFollowersStep.NAME));
-        assertThat(steps.get(2).getNextStepKey().name(), equalTo(CleanupTargetIndexStep.NAME));
+        assertThat(steps.get(2).getNextStepKey().name(), equalTo(ReadOnlyStep.NAME));
 
-        assertTrue(steps.get(3) instanceof CleanupTargetIndexStep);
-        assertThat(steps.get(3).getKey().name(), equalTo(CleanupTargetIndexStep.NAME));
-        assertThat(steps.get(3).getNextStepKey().name(), equalTo(ReadOnlyStep.NAME));
+        assertTrue(steps.get(3) instanceof ReadOnlyStep);
+        assertThat(steps.get(3).getKey().name(), equalTo(ReadOnlyStep.NAME));
+        assertThat(steps.get(3).getNextStepKey().name(), equalTo(CleanupTargetIndexStep.NAME));
 
-        assertTrue(steps.get(4) instanceof ReadOnlyStep);
-        assertThat(steps.get(4).getKey().name(), equalTo(ReadOnlyStep.NAME));
+        assertTrue(steps.get(4) instanceof CleanupTargetIndexStep);
+        assertThat(steps.get(4).getKey().name(), equalTo(CleanupTargetIndexStep.NAME));
         assertThat(steps.get(4).getNextStepKey().name(), equalTo(GENERATE_DOWNSAMPLE_STEP_NAME));
 
         assertTrue(steps.get(5) instanceof GenerateUniqueIndexNameStep);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/LifecycleExecutionStateTests.java
@@ -181,7 +181,9 @@ public class LifecycleExecutionStateTests extends ESTestCase {
                 newState.setSnapshotName(randomValueOtherThan(toMutate.snapshotName(), () -> randomAlphaOfLengthBetween(5, 20)));
                 break;
             case 14:
-                newState.setRollupIndexName(randomValueOtherThan(toMutate.downsampleIndexName(), () -> randomAlphaOfLengthBetween(5, 20)));
+                newState.setDownsampleIndexName(
+                    randomValueOtherThan(toMutate.downsampleIndexName(), () -> randomAlphaOfLengthBetween(5, 20))
+                );
                 break;
             case 15:
                 newState.setIsAutoRetryableError(randomValueOtherThan(toMutate.isAutoRetryableError(), ESTestCase::randomBoolean));


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Retry `downsample` ILM action using a new target index (#94965)