### PR TITLE
[8.8] Adjust BoundedGeoHexGridTiler#FACTOR to prevent missing hits (#96088)

### DIFF
--- a/docs/changelog/96088.yaml
+++ b/docs/changelog/96088.yaml
@@ -1,0 +1,6 @@
+pr: 96088
+summary: Adjust `BoundedGeoHexGridTiler#FACTOR` to prevent missing hits
+area: Geo
+type: bug
+issues:
+ - 96057

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTiler.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/bucket/geogrid/GeoHexGridTiler.java
@@ -240,7 +240,7 @@ public abstract class GeoHexGridTiler extends GeoGridTiler {
         private final GeoBoundingBox bbox;
         private final GeoHexVisitor visitor;
         private final int resolution;
-        private static final double FACTOR = 0.35;
+        private static final double FACTOR = 0.36;
 
         BoundedGeoHexGridTiler(int resolution, GeoBoundingBox bbox) {
             super(resolution);


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Adjust BoundedGeoHexGridTiler#FACTOR to prevent missing hits (#96088)