### PR TITLE
Fix failing CommonAnalysisPluginTests testSystemSynonymsIndexName test

### DIFF
--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
@@ -226,7 +226,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
     }
 
     public void testSystemSynonymsIndexName() {
-        assumeTrue("This test should only run with enabled synonyms feature flag",isEnabled());
+        assumeTrue("This test should only run with enabled synonyms feature flag", isEnabled());
         assertEquals(
             List.of(SYNONYMS_INDEX),
             new CommonAnalysisPlugin().getSystemIndexDescriptors(Settings.EMPTY)

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/CommonAnalysisPluginTests.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.elasticsearch.analysis.common.synonyms.SynonymsManagementAPIService.SYNONYMS_INDEX;
+import static org.elasticsearch.analysis.common.synonyms.SynonymsManagementAPIService.isEnabled;
 
 public class CommonAnalysisPluginTests extends ESTestCase {
 
@@ -225,6 +226,7 @@ public class CommonAnalysisPluginTests extends ESTestCase {
     }
 
     public void testSystemSynonymsIndexName() {
+        assumeTrue("This test should only run with enabled synonyms feature flag",isEnabled());
         assertEquals(
             List.of(SYNONYMS_INDEX),
             new CommonAnalysisPlugin().getSystemIndexDescriptors(Settings.EMPTY)


### PR DESCRIPTION
The test should only run when the "synonyms_api" feature flag is set. This is the case in snapshot build, but in release builds the flag is disabled, so we need to skip checking for the existence of the synonyms system index then.

Closes #95840