### PR TITLE
[ML] set model memory usage for ELSER to 2004MB

### DIFF
--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportGetTrainedModelsStatsAction.java
@@ -290,7 +290,7 @@ public class TransportGetTrainedModelsStatsAction extends HandledTransportAction
                             new TrainedModelSizeStats(
                                 totalDefinitionLength,
                                 totalDefinitionLength > 0L
-                                    ? StartTrainedModelDeploymentAction.estimateMemoryUsageBytes(totalDefinitionLength)
+                                    ? StartTrainedModelDeploymentAction.estimateMemoryUsageBytes(model.getModelId(), totalDefinitionLength)
                                     : 0L
                             )
                         );


### PR DESCRIPTION
This change hardcodes the pretrained/fixed elser model to 2004MB until
we found a better way to set/calculate model memory usage.