### PR TITLE
Search shards should not perform can match without query

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchShardsIT.java
@@ -8,20 +8,35 @@
 
 package org.elasticsearch.action.search;
 
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.CollectionUtils;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.query.MatchAllQueryBuilder;
 import org.elasticsearch.index.query.RangeQueryBuilder;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.test.hamcrest.ElasticsearchAssertions;
+import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.transport.TransportService;
+
+import java.util.Collection;
+import java.util.Queue;
 
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.emptyIterable;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.not;
 
 public class SearchShardsIT extends ESIntegTestCase {
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return CollectionUtils.appendToCopy(super.nodePlugins(), MockTransportService.TestPlugin.class);
+    }
 
     public void testBasic() {
         int indicesWithData = between(1, 10);
@@ -130,6 +145,57 @@ public class SearchShardsIT extends ESIntegTestCase {
             assertThat(searchShardsResponse.getGroups(), hasSize(searchResponse.getTotalShards()));
             long skippedShards = searchShardsResponse.getGroups().stream().filter(SearchShardsGroup::skipped).count();
             assertThat(skippedShards, equalTo((long) searchResponse.getSkippedShards()));
+        }
+    }
+
+    public void testNoCanMatchWithoutQuery() {
+        Queue<CanMatchNodeRequest> canMatchRequests = ConcurrentCollections.newQueue();
+        for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
+            MockTransportService ts = (MockTransportService) transportService;
+            ts.addSendBehavior((connection, requestId, action, request, options) -> {
+                if (action.equals(SearchTransportService.QUERY_CAN_MATCH_NODE_NAME)) {
+                    canMatchRequests.add((CanMatchNodeRequest) request);
+                }
+                connection.sendRequest(requestId, action, request, options);
+            });
+        }
+        try {
+            int numIndices = randomIntBetween(1, 10);
+            int totalShards = 0;
+            for (int i = 0; i < numIndices; i++) {
+                String index = "index-" + i;
+                int numShards = between(1, 5);
+                ElasticsearchAssertions.assertAcked(
+                    admin().indices()
+                        .prepareCreate(index)
+                        .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards))
+                );
+                totalShards += numShards;
+                int numDocs = randomIntBetween(10, 100);
+                for (int j = 0; j < numDocs; j++) {
+                    client().prepareIndex(index).setSource("value", i).setId(Integer.toString(i)).get();
+                }
+                client().admin().indices().prepareRefresh(index).get();
+            }
+            SearchShardsRequest request = new SearchShardsRequest(
+                new String[] { "index-*" },
+                IndicesOptions.LENIENT_EXPAND_OPEN,
+                randomBoolean() ? new MatchAllQueryBuilder() : null,
+                null,
+                null,
+                randomBoolean(),
+                null
+            );
+            SearchShardsResponse resp = client().execute(SearchShardsAction.INSTANCE, request).actionGet();
+            assertThat(resp.getGroups(), hasSize(totalShards));
+            for (SearchShardsGroup group : resp.getGroups()) {
+                assertFalse(group.skipped());
+            }
+            assertThat(canMatchRequests, emptyIterable());
+        } finally {
+            for (TransportService transportService : internalCluster().getInstances(TransportService.class)) {
+                ((MockTransportService) transportService).clearAllRules();
+            }
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -108,29 +108,35 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
                     concreteIndices
                 );
                 String[] concreteIndexNames = Arrays.stream(concreteIndices).map(Index::getName).toArray(String[]::new);
-                var shardIterators = transportSearchAction.getLocalShardsIterator(
-                    clusterState,
-                    searchRequest,
-                    searchShardsRequest.clusterAlias(),
-                    indicesAndAliases,
-                    concreteIndexNames
+                GroupShardsIterator<SearchShardIterator> shardIts = GroupShardsIterator.sortAndCreate(
+                    transportSearchAction.getLocalShardsIterator(
+                        clusterState,
+                        searchRequest,
+                        searchShardsRequest.clusterAlias(),
+                        indicesAndAliases,
+                        concreteIndexNames
+                    )
                 );
-                var canMatchPhase = new CanMatchPreFilterSearchPhase(logger, searchTransportService, (clusterAlias, node) -> {
-                    assert Objects.equals(clusterAlias, searchShardsRequest.clusterAlias());
-                    return transportService.getConnection(clusterState.nodes().get(node));
-                },
-                    aliasFilters,
-                    Map.of(),
-                    threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
-                    searchRequest,
-                    GroupShardsIterator.sortAndCreate(shardIterators),
-                    timeProvider,
-                    (SearchTask) task,
-                    false,
-                    searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis),
-                    listener.map(shardIts -> new SearchShardsResponse(toGroups(shardIts), clusterState.nodes().getAllNodes(), aliasFilters))
-                );
-                canMatchPhase.start();
+                if (SearchService.canRewriteToMatchNone(searchRequest.source()) == false) {
+                    listener.onResponse(new SearchShardsResponse(toGroups(shardIts), clusterState.nodes().getAllNodes(), aliasFilters));
+                } else {
+                    var canMatchPhase = new CanMatchPreFilterSearchPhase(logger, searchTransportService, (clusterAlias, node) -> {
+                        assert Objects.equals(clusterAlias, searchShardsRequest.clusterAlias());
+                        return transportService.getConnection(clusterState.nodes().get(node));
+                    },
+                        aliasFilters,
+                        Map.of(),
+                        threadPool.executor(ThreadPool.Names.SEARCH_COORDINATION),
+                        searchRequest,
+                        shardIts,
+                        timeProvider,
+                        (SearchTask) task,
+                        false,
+                        searchService.getCoordinatorRewriteContextProvider(timeProvider::absoluteStartMillis),
+                        listener.map(its -> new SearchShardsResponse(toGroups(its), clusterState.nodes().getAllNodes(), aliasFilters))
+                    );
+                    canMatchPhase.start();
+                }
             }, listener::onFailure)
         );
     }


### PR DESCRIPTION
If the query cannot be rewritten to match_none, then search_shards API should skip the can_match phase and return all groups of shard copies.

Relates #94534