### PR TITLE
Remove prefilter from search shards response

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchShardsIT.java
@@ -61,7 +61,6 @@ public class SearchShardsIT extends ESIntegTestCase {
             for (SearchShardsGroup g : resp.getGroups()) {
                 String indexName = g.shardId().getIndexName();
                 assertThat(g.allocatedNodes(), not(empty()));
-                assertTrue(g.preFiltered());
                 if (indexName.contains("without")) {
                     assertTrue(g.skipped());
                     skipped++;
@@ -87,7 +86,6 @@ public class SearchShardsIT extends ESIntegTestCase {
             assertThat(resp.getGroups(), hasSize(indicesWithData + indicesWithoutData));
             for (SearchShardsGroup g : resp.getGroups()) {
                 assertFalse(g.skipped());
-                assertTrue(g.preFiltered());
             }
         }
     }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsGroup.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsGroup.java
@@ -24,22 +24,18 @@ import java.util.Objects;
 public class SearchShardsGroup implements Writeable {
     private final ShardId shardId;
     private final List<String> allocatedNodes;
-    private final boolean preFiltered;
     private final boolean skipped;
 
-    public SearchShardsGroup(ShardId shardId, List<String> allocatedNodes, boolean preFiltered, boolean skipped) {
+    public SearchShardsGroup(ShardId shardId, List<String> allocatedNodes, boolean skipped) {
         this.shardId = shardId;
         this.allocatedNodes = allocatedNodes;
         this.skipped = skipped;
-        this.preFiltered = preFiltered;
-        assert skipped == false || preFiltered;
     }
 
     public SearchShardsGroup(StreamInput in) throws IOException {
         this.shardId = new ShardId(in);
         this.allocatedNodes = in.readStringList();
         this.skipped = in.readBoolean();
-        this.preFiltered = in.readBoolean();
     }
 
     @Override
@@ -47,7 +43,6 @@ public class SearchShardsGroup implements Writeable {
         shardId.writeTo(out);
         out.writeStringCollection(allocatedNodes);
         out.writeBoolean(skipped);
-        out.writeBoolean(preFiltered);
     }
 
     public ShardId shardId() {
@@ -62,14 +57,6 @@ public class SearchShardsGroup implements Writeable {
     }
 
     /**
-     * Returns true if the can_match was performed against this group. This flag is for BWC purpose. It's always
-     * true for a response from the new search_shards API; but always false for a response from the old API.
-     */
-    public boolean preFiltered() {
-        return preFiltered;
-    }
-
-    /**
      * The list of node ids that shard copies on this group are allocated on.
      */
     public List<String> allocatedNodes() {
@@ -81,14 +68,11 @@ public class SearchShardsGroup implements Writeable {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SearchShardsGroup group = (SearchShardsGroup) o;
-        return skipped == group.skipped
-            && preFiltered == group.preFiltered
-            && shardId.equals(group.shardId)
-            && allocatedNodes.equals(group.allocatedNodes);
+        return skipped == group.skipped && shardId.equals(group.shardId) && allocatedNodes.equals(group.allocatedNodes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(shardId, allocatedNodes, skipped, preFiltered);
+        return Objects.hash(shardId, allocatedNodes, skipped);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchShardsAction.java
@@ -146,7 +146,7 @@ public class TransportSearchShardsAction extends HandledTransportAction<SearchSh
                 targetNodes.add(target.getNodeId());
             }
             ShardId shardId = shardIt.shardId();
-            groups.add(new SearchShardsGroup(shardId, targetNodes, true, skip));
+            groups.add(new SearchShardsGroup(shardId, targetNodes, skip));
         }
         return groups;
     }

--- a/server/src/test/java/org/elasticsearch/action/search/SearchShardsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchShardsResponseTests.java
@@ -53,7 +53,7 @@ public class SearchShardsResponseTests extends AbstractWireSerializingTestCase<S
             for (int j = 0; j < numOfAllocatedNodes; j++) {
                 allocatedNodes.add(UUIDs.randomBase64UUID());
             }
-            groups.add(new SearchShardsGroup(shardId, allocatedNodes, true, randomBoolean()));
+            groups.add(new SearchShardsGroup(shardId, allocatedNodes, randomBoolean()));
         }
         Map<String, AliasFilter> aliasFilters = new HashMap<>();
         for (SearchShardsGroup g : groups) {
@@ -74,7 +74,7 @@ public class SearchShardsResponseTests extends AbstractWireSerializingTestCase<S
             case 0 -> {
                 List<SearchShardsGroup> groups = new ArrayList<>(r.getGroups());
                 ShardId shardId = new ShardId(randomAlphaOfLengthBetween(5, 10), UUIDs.randomBase64UUID(), randomInt(2));
-                groups.add(new SearchShardsGroup(shardId, List.of(), true, randomBoolean()));
+                groups.add(new SearchShardsGroup(shardId, List.of(), randomBoolean()));
                 return new SearchShardsResponse(groups, r.getNodes(), r.getAliasFilters());
             }
             case 1 -> {


### PR DESCRIPTION
The `preFiltered` flag aimed to facilitate a smooth transition from the old response to the new response. However, instead of serializing this flag over the wire, we prefer an alternative approach. Since the new API has not been used thus far, there is no need to handle backward compatibility or introduce a new transport version.

Relates https://github.com/elastic/elasticsearch/pull/94534