### PR TITLE
[8.8] Mute testEveryActionIsEitherOperatorOnlyOrNonOperator (#96126)

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -94,6 +94,7 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         client().performRequest(mainRequest);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96105")
     @SuppressWarnings("unchecked")
     public void testEveryActionIsEitherOperatorOnlyOrNonOperator() throws IOException {
         final String message = "An action should be declared to be either operator-only in ["


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Mute testEveryActionIsEitherOperatorOnlyOrNonOperator (#96126)