### PR TITLE
[8.7] Tweak test output path normalization edge cases (#96090)

### DIFF
--- a/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
+++ b/build-tools/src/testFixtures/java/org/elasticsearch/gradle/internal/test/TestUtils.java
@@ -24,6 +24,7 @@ public class TestUtils {
                 .map(it -> it.replaceAll("\\d+\\.\\d\\ds", "0.00s"))
                 .map(it -> it.replaceAll(cannonicalNormalizedPathPrefix, "."))
                 .map(it -> it.replaceAll(normalizedPathPrefix, "."))
+                .map(it -> it.replaceAll("file:/./", "file:./"))
                 .map(it -> it.replaceAll("Gradle Test Executor \\d", "Gradle Test Executor 1"))
                 .collect(Collectors.joining("\n"));
         } catch (IOException e) {


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Tweak test output path normalization edge cases (#96090)