### PR TITLE
[8.8] Mute testRestartDataNodesDuringScrollSearch (#96140)

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -683,6 +683,7 @@ public class SearchScrollIT extends ESIntegTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/95759")
     public void testRestartDataNodesDuringScrollSearch() throws Exception {
         final String dataNode = internalCluster().startDataOnlyNode();
         createIndex(


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Mute testRestartDataNodesDuringScrollSearch (#96140)