### PR TITLE
Simplify privilege requirement for QuerySearchApplicationAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -144,7 +144,6 @@ public record IndicesOptions(EnumSet<Option> options, EnumSet<WildcardStates> ex
         EnumSet.of(Option.FORBID_ALIASES_TO_MULTIPLE_INDICES, Option.FORBID_CLOSED_INDICES),
         EnumSet.noneOf(WildcardStates.class)
     );
-
     public static final IndicesOptions STRICT_NO_EXPAND_FORBID_CLOSED = new IndicesOptions(
         EnumSet.of(Option.FORBID_CLOSED_INDICES),
         EnumSet.noneOf(WildcardStates.class)

--- a/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
+++ b/server/src/main/java/org/elasticsearch/action/support/IndicesOptions.java
@@ -145,6 +145,11 @@ public record IndicesOptions(EnumSet<Option> options, EnumSet<WildcardStates> ex
         EnumSet.noneOf(WildcardStates.class)
     );
 
+    public static final IndicesOptions STRICT_NO_EXPAND_FORBID_CLOSED = new IndicesOptions(
+        EnumSet.of(Option.FORBID_CLOSED_INDICES),
+        EnumSet.noneOf(WildcardStates.class)
+    );
+
     /**
      * @return Whether specified concrete indices should be ignored when unavailable (missing or closed)
      */
@@ -577,6 +582,13 @@ public record IndicesOptions(EnumSet<Option> options, EnumSet<WildcardStates> ex
      */
     public static IndicesOptions strictExpandHidden() {
         return STRICT_EXPAND_OPEN_CLOSED_HIDDEN;
+    }
+
+    /**
+     * @return indices option that requires each specified index or alias to exist, doesn't expand wildcards.
+     */
+    public static IndicesOptions strictNoExpandForbidClosed() {
+        return STRICT_NO_EXPAND_FORBID_CLOSED;
     }
 
     /**

--- a/x-pack/plugin/ent-search/qa/rest/build.gradle
+++ b/x-pack/plugin/ent-search/qa/rest/build.gradle
@@ -16,6 +16,7 @@ testClusters.configureEach {
   setting 'xpack.security.enabled', 'true'
   setting 'xpack.license.self_generated.type', 'trial'
   extraConfigFile 'roles.yml', file('roles.yml')
-  user username: 'entsearch-admin', password: 'entsearch-admin-password', role: 'superuser'
-  user username: 'entsearch-user', password: 'entsearch-user-password', role: 'entsearch'
+  user username: 'entsearch-superuser', password: 'entsearch-superuser-password', role: 'superuser'
+  user username: 'entsearch-admin', password: 'entsearch-admin-password', role: 'admin'
+  user username: 'entsearch-user', password: 'entsearch-user-password', role: 'user'
 }

--- a/x-pack/plugin/ent-search/qa/rest/roles.yml
+++ b/x-pack/plugin/ent-search/qa/rest/roles.yml
@@ -1,4 +1,4 @@
-entsearch:
+admin:
   cluster:
     - manage_search_application
     - manage_behavioral_analytics
@@ -24,10 +24,20 @@ entsearch:
         "test-nonexistent-search-application",
         "test-search-application-with-invalid-template"
     ]
-      privileges: [ "manage" ]
+      privileges: [ "manage", "read" ]
     - names: [
       # indices used for indexing and searching
       "test-search-index1",
       "test-search-index2",
     ]
       privileges: [ "manage", "read", "write" ]
+
+user:
+  cluster:
+    - post_behavioral_analytics_event
+  indices:
+    - names: [
+      "test-search-application"
+    ]
+      privileges: [ "read" ]
+

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/entsearch/EnterpriseSearchRestIT.java
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/java/org/elasticsearch/xpack/entsearch/EnterpriseSearchRestIT.java
@@ -28,14 +28,13 @@ public class EnterpriseSearchRestIT extends ESClientYamlSuiteTestCase {
 
     @Override
     protected Settings restAdminSettings() {
-        final String value = basicAuthHeaderValue("entsearch-admin", new SecureString("entsearch-admin-password".toCharArray()));
+        final String value = basicAuthHeaderValue("entsearch-superuser", new SecureString("entsearch-superuser-password".toCharArray()));
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", value).build();
     }
 
     @Override
     protected Settings restClientSettings() {
-        final String value = basicAuthHeaderValue("entsearch-user", new SecureString("entsearch-user-password".toCharArray()));
+        final String value = basicAuthHeaderValue("entsearch-admin", new SecureString("entsearch-admin-password".toCharArray()));
         return Settings.builder().put(ThreadContext.PREFIX + ".Authorization", value).build();
     }
-
 }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -172,7 +172,7 @@ teardown:
 "Query Search Application - not found":
 
   - do:
-      catch: "missing"
+      catch: "forbidden"
       search_application.search:
         name: nonexisting-test-search-application
         body:

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -93,10 +93,12 @@ teardown:
 ---
 "Query Search Application with default parameters":
   - skip:
+      features: headers
       version: all
       reason: "AwaitsFix https://github.com/elastic/enterprise-search-team/issues/4540"
 
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: test-search-application
 
@@ -107,10 +109,12 @@ teardown:
 ---
 "Query Search Application overriding part of the parameters":
   - skip:
+      features: headers
       version: all
       reason: "AwaitsFix https://github.com/elastic/enterprise-search-team/issues/4540"
 
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: test-search-application
         body:
@@ -124,10 +128,12 @@ teardown:
 ---
 "Query Search Application overriding all parameters":
   - skip:
+      features: headers
       version: all
       reason: "AwaitsFix https://github.com/elastic/enterprise-search-team/issues/4540"
 
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: test-search-application
         body:
@@ -142,11 +148,13 @@ teardown:
 ---
 "Query Search Application with invalid parameter validation":
   - skip:
+      features: headers
       version: all
       reason: "AwaitsFix https://github.com/elastic/enterprise-search-team/issues/4540"
 
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: test-search-application
         body:
@@ -157,11 +165,13 @@ teardown:
 ---
 "Query Search Application without required parameter":
   - skip:
+      features: headers
       version: all
       reason: "AwaitsFix https://github.com/elastic/enterprise-search-team/issues/4540"
 
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: test-search-application
         body:
@@ -170,9 +180,12 @@ teardown:
 
 ---
 "Query Search Application - not found":
+  - skip:
+      features: headers
 
   - do:
       catch: "forbidden"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: nonexisting-test-search-application
         body:
@@ -182,6 +195,8 @@ teardown:
 
 ---
 "Query Search Application - no read permissions on index":
+  - skip:
+      features: headers
 
   - do:
       search_application.put:
@@ -201,5 +216,6 @@ teardown:
 
   - do:
       catch: "forbidden"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.search:
         name: test-search-application

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
@@ -13,7 +13,11 @@ teardown:
 # Page view event tests #########################################
 ---
 "Post page_view analytics event":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -27,8 +31,12 @@ teardown:
 
 ---
 "Post page_view analytics event - Missing page.url":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -41,7 +49,11 @@ teardown:
 
 ---
 "Post page_view analytics event - With document":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -58,7 +70,11 @@ teardown:
 
 ---
 "Post page_view analytics event - With page title":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -73,7 +89,11 @@ teardown:
 
 ---
 "Post page_view analytics event - With referrer":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -95,6 +115,7 @@ teardown:
       headers:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
+        Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -131,7 +152,11 @@ teardown:
 # Search event tests ############################################
 ---
 "Post search analytics event":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -145,8 +170,12 @@ teardown:
 
 ---
 "Post search analytics event – Missing search query":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -159,7 +188,11 @@ teardown:
 
 ---
 "Post search analytics event - With sort order":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -175,7 +208,11 @@ teardown:
 
 ---
 "Post search analytics event - With sort name and direction":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -192,7 +229,11 @@ teardown:
 
 ---
 "Post search analytics event - With pagination":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -209,7 +250,11 @@ teardown:
 
 ---
 "Post search analytics event - With search application":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -224,7 +269,11 @@ teardown:
 
 ---
 "Post search analytics event - With search results":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -253,7 +302,11 @@ teardown:
 
 ---
 "Post search analytics event - With filters":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -278,6 +331,7 @@ teardown:
       headers:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
+        Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
@@ -339,7 +393,11 @@ teardown:
 # Search click event tests #######################################
 ---
 "Post search_click analytics event":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -364,6 +422,7 @@ teardown:
       headers:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
+        Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -396,7 +455,11 @@ teardown:
 
 ---
 "Post search_click analytics event - Page Only":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -412,7 +475,11 @@ teardown:
 
 ---
 "Post search_click analytics event - Document Only":
+  - skip:
+      features: headers
+
   - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -429,8 +496,12 @@ teardown:
 
 ---
 "Post search_click analytics event – Missing search query":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -445,8 +516,12 @@ teardown:
 
 ---
 "Post search_click analytics event – Missing page url and document":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
@@ -462,8 +537,12 @@ teardown:
 # Generic errors tests ###############################################
 ---
 "Post analytics event - Analytics collection does not exist":
+  - skip:
+      features: headers
+
   - do:
       catch: "missing"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: test-nonexistent-analytics-collection
         event_type: "page_view"
@@ -477,8 +556,12 @@ teardown:
 
 ---
 "Post analytics event - Event type does not exist":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "nonexistent-event-type"
@@ -494,8 +577,12 @@ teardown:
 
 ---
 "Post page_view analytics event - Missing session.id":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -508,8 +595,12 @@ teardown:
 
 ---
 "Post page_view analytics event - Missing user.id":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
@@ -522,8 +613,12 @@ teardown:
 
 ---
 "Post analytics event - Unknown event field":
+  - skip:
+      features: headers
+
   - do:
       catch: "bad_request"
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # entsearch-user
       search_application.post_behavioral_analytics_event:
         collection_name: my-test-analytics-collection
         event_type: "nonexistent-event-type"

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/QuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/QuerySearchApplicationAction.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.search.SearchResponse;
 public class QuerySearchApplicationAction extends ActionType<SearchResponse> {
 
     public static final QuerySearchApplicationAction INSTANCE = new QuerySearchApplicationAction();
-    public static final String NAME = "cluster:admin/xpack/application/search_application/search";
+    public static final String NAME = "indices:data/read/xpack/application/search_application/search";
 
     public QuerySearchApplicationAction() {
         super(NAME, SearchResponse::new);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationSearchRequest.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/SearchApplicationSearchRequest.java
@@ -9,6 +9,8 @@ package org.elasticsearch.xpack.application.search.action;
 
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.IndicesRequest;
+import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -27,7 +29,7 @@ import java.util.Objects;
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 import static org.elasticsearch.xcontent.ConstructingObjectParser.constructorArg;
 
-public class SearchApplicationSearchRequest extends ActionRequest {
+public class SearchApplicationSearchRequest extends ActionRequest implements IndicesRequest {
 
     private static final ParseField QUERY_PARAMS_FIELD = new ParseField("params");
     private final String name;
@@ -109,5 +111,15 @@ public class SearchApplicationSearchRequest extends ActionRequest {
     @Override
     public int hashCode() {
         return Objects.hash(name, queryParams);
+    }
+
+    @Override
+    public String[] indices() {
+        return new String[] { name };
+    }
+
+    @Override
+    public IndicesOptions indicesOptions() {
+        return IndicesOptions.strictNoExpandForbidClosed();
     }
 }


### PR DESCRIPTION
This change allows the usage of the QuerySearchApplicationAction to roles that have the read privilege on the underlying alias. 
The `manage_search_application` is no longer needed.