### PR TITLE
Stop creating geo metric aggregations with no values

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoBoundsAggregatorFactory.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -43,7 +45,13 @@ class GeoBoundsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new GeoBoundsAggregator(name, context, parent, config, wrapLongitude, metadata);
+        final InternalAggregation empty = InternalGeoBounds.empty(name, wrapLongitude, metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregator.java
@@ -41,22 +41,17 @@ final class GeoCentroidAggregator extends MetricsAggregator {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: Stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource() : null;
-        if (valuesSource != null) {
-            lonSum = bigArrays().newDoubleArray(1, true);
-            lonCompensations = bigArrays().newDoubleArray(1, true);
-            latSum = bigArrays().newDoubleArray(1, true);
-            latCompensations = bigArrays().newDoubleArray(1, true);
-            counts = bigArrays().newLongArray(1, true);
-        }
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (ValuesSource.GeoPoint) valuesSourceConfig.getValuesSource();
+        lonSum = bigArrays().newDoubleArray(1, true);
+        lonCompensations = bigArrays().newDoubleArray(1, true);
+        latSum = bigArrays().newDoubleArray(1, true);
+        latCompensations = bigArrays().newDoubleArray(1, true);
+        counts = bigArrays().newLongArray(1, true);
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final MultiGeoPointValues values = valuesSource.geoPointValues(aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
@@ -103,7 +98,7 @@ final class GeoCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= counts.size()) {
+        if (bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         final long bucketCount = counts.get(bucket);
@@ -115,7 +110,7 @@ final class GeoCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoCentroid(name, null, 0L, metadata());
+        return InternalGeoCentroid.empty(name, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/GeoCentroidAggregatorFactory.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -39,7 +41,13 @@ class GeoCentroidAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new GeoCentroidAggregator(name, config, context, parent, metadata);
+        final InternalCentroid empty = InternalGeoCentroid.empty(name, metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
@@ -68,7 +68,7 @@ public class InternalGeoBounds extends InternalBounds<GeoPoint> implements GeoBo
         out.writeBoolean(wrapLongitude);
     }
 
-    static InternalGeoBounds empty(String name, boolean wrapLongitude, Map<String, Object> metadata) {
+    public static InternalGeoBounds empty(String name, boolean wrapLongitude, Map<String, Object> metadata) {
         return new InternalGeoBounds(
             name,
             Double.NEGATIVE_INFINITY,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoBounds.java
@@ -68,6 +68,20 @@ public class InternalGeoBounds extends InternalBounds<GeoPoint> implements GeoBo
         out.writeBoolean(wrapLongitude);
     }
 
+    static InternalGeoBounds empty(String name, boolean wrapLongitude, Map<String, Object> metadata) {
+        return new InternalGeoBounds(
+            name,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            wrapLongitude,
+            metadata
+        );
+    }
+
     @Override
     public String getWriteableName() {
         return GeoBoundsAggregationBuilder.NAME;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalGeoCentroid.java
@@ -58,6 +58,10 @@ public class InternalGeoCentroid extends InternalCentroid implements GeoCentroid
         super(in, new FieldExtractor("lat", SpatialPoint::getY), new FieldExtractor("lon", SpatialPoint::getX));
     }
 
+    public static InternalGeoCentroid empty(String name, Map<String, Object> metadata) {
+        return new InternalGeoCentroid(name, null, 0L, metadata);
+    }
+
     @Override
     protected GeoPoint centroidFromStream(StreamInput in) throws IOException {
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_2_0)) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregator.java
@@ -32,15 +32,13 @@ public final class CartesianBoundsAggregator extends CartesianBoundsAggregatorBa
         ValuesSourceConfig valuesSourceConfig,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, valuesSourceConfig.hasValues() == false, metadata);
-        this.valuesSource = isNoOp() ? null : (CartesianPointValuesSource) valuesSourceConfig.getValuesSource();
+        super(name, context, parent, metadata);
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (CartesianPointValuesSource) valuesSourceConfig.getValuesSource();
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
-        if (isNoOp()) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final CartesianPointValuesSource.MultiCartesianPointValues values = valuesSource.pointValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregatorBase.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregatorBase.java
@@ -24,35 +24,22 @@ import static java.lang.Math.min;
  * A metric aggregator that computes a cartesian-bounds from a {@code point} type field
  */
 public abstract class CartesianBoundsAggregatorBase extends MetricsAggregator {
-    private final boolean isNoOp;
     private DoubleArray tops;
     private DoubleArray bottoms;
     private DoubleArray lefts;
     private DoubleArray rights;
 
-    public CartesianBoundsAggregatorBase(
-        String name,
-        AggregationContext context,
-        Aggregator parent,
-        boolean isNoOp,
-        Map<String, Object> metadata
-    ) throws IOException {
+    public CartesianBoundsAggregatorBase(String name, AggregationContext context, Aggregator parent, Map<String, Object> metadata)
+        throws IOException {
         super(name, context, parent, metadata);
-        this.isNoOp = isNoOp;
-        if (isNoOp == false) {
-            tops = bigArrays().newDoubleArray(1, false);
-            tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
-            bottoms = bigArrays().newDoubleArray(1, false);
-            bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
-            lefts = bigArrays().newDoubleArray(1, false);
-            lefts.fill(0, lefts.size(), Double.POSITIVE_INFINITY);
-            rights = bigArrays().newDoubleArray(1, false);
-            rights.fill(0, rights.size(), Double.NEGATIVE_INFINITY);
-        }
-    }
-
-    protected boolean isNoOp() {
-        return isNoOp;
+        tops = bigArrays().newDoubleArray(1, false);
+        tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
+        bottoms = bigArrays().newDoubleArray(1, false);
+        bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
+        lefts = bigArrays().newDoubleArray(1, false);
+        lefts.fill(0, lefts.size(), Double.POSITIVE_INFINITY);
+        rights = bigArrays().newDoubleArray(1, false);
+        rights.fill(0, rights.size(), Double.NEGATIVE_INFINITY);
     }
 
     protected void addBounds(long bucket, double top, double bottom, double left, double right) {
@@ -78,7 +65,7 @@ public abstract class CartesianBoundsAggregatorBase extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
-        if (isNoOp) {
+        if (owningBucketOrdinal >= tops.size()) {
             return buildEmptyAggregation();
         }
         double top = tops.get(owningBucketOrdinal);
@@ -90,14 +77,7 @@ public abstract class CartesianBoundsAggregatorBase extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalCartesianBounds(
-            name,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
-            Double.NEGATIVE_INFINITY,
-            metadata()
-        );
+        return InternalCartesianBounds.empty(name, metadata());
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregatorFactory.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianBoundsAggregatorFactory.java
@@ -11,6 +11,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
 import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
@@ -37,7 +39,13 @@ class CartesianBoundsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new CartesianBoundsAggregator(name, context, parent, config, metadata);
+        final InternalCartesianBounds empty = InternalCartesianBounds.empty(name, metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianCentroidAggregatorFactory.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianCentroidAggregatorFactory.java
@@ -11,6 +11,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.metrics.MetricAggregatorSupplier;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -39,7 +41,13 @@ class CartesianCentroidAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new CartesianCentroidAggregator(name, config, context, parent, metadata);
+        InternalCartesianCentroid empty = InternalCartesianCentroid.empty(name, metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeBoundsAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeBoundsAggregator.java
@@ -33,15 +33,13 @@ public final class CartesianShapeBoundsAggregator extends CartesianBoundsAggrega
         ValuesSourceConfig valuesSourceConfig,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, context, parent, valuesSourceConfig.hasValues() == false, metadata);
-        this.valuesSource = isNoOp() ? null : (CartesianShapeValuesSource) valuesSourceConfig.getValuesSource();
+        super(name, context, parent, metadata);
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (CartesianShapeValuesSource) valuesSourceConfig.getValuesSource();
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
-        if (isNoOp()) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         CartesianShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/CartesianShapeCentroidAggregator.java
@@ -47,25 +47,20 @@ public final class CartesianShapeCentroidAggregator extends MetricsAggregator {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (CartesianShapeValuesSource) valuesSourceConfig.getValuesSource() : null;
-        if (valuesSource != null) {
-            lonSum = bigArrays().newDoubleArray(1, true);
-            lonCompensations = bigArrays().newDoubleArray(1, true);
-            latSum = bigArrays().newDoubleArray(1, true);
-            latCompensations = bigArrays().newDoubleArray(1, true);
-            weightSum = bigArrays().newDoubleArray(1, true);
-            weightCompensations = bigArrays().newDoubleArray(1, true);
-            counts = bigArrays().newLongArray(1, true);
-            dimensionalShapeTypes = bigArrays().newByteArray(1, true);
-        }
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (CartesianShapeValuesSource) valuesSourceConfig.getValuesSource();
+        lonSum = bigArrays().newDoubleArray(1, true);
+        lonCompensations = bigArrays().newDoubleArray(1, true);
+        latSum = bigArrays().newDoubleArray(1, true);
+        latCompensations = bigArrays().newDoubleArray(1, true);
+        weightSum = bigArrays().newDoubleArray(1, true);
+        weightCompensations = bigArrays().newDoubleArray(1, true);
+        counts = bigArrays().newLongArray(1, true);
+        dimensionalShapeTypes = bigArrays().newByteArray(1, true);
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final CartesianShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
@@ -128,7 +123,7 @@ public final class CartesianShapeCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= counts.size()) {
+        if (bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         final long bucketCount = counts.get(bucket);
@@ -141,7 +136,7 @@ public final class CartesianShapeCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoCentroid(name, null, 0L, metadata());
+        return InternalGeoCentroid.empty(name, metadata());
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeBoundsAggregator.java
@@ -43,29 +43,25 @@ public final class GeoShapeBoundsAggregator extends MetricsAggregator {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = valuesSourceConfig.hasValues() ? (GeoShapeValuesSource) valuesSourceConfig.getValuesSource() : null;
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (GeoShapeValuesSource) valuesSourceConfig.getValuesSource();
         this.wrapLongitude = wrapLongitude;
-        if (valuesSource != null) {
-            tops = bigArrays().newDoubleArray(1, false);
-            tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
-            bottoms = bigArrays().newDoubleArray(1, false);
-            bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
-            posLefts = bigArrays().newDoubleArray(1, false);
-            posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
-            posRights = bigArrays().newDoubleArray(1, false);
-            posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
-            negLefts = bigArrays().newDoubleArray(1, false);
-            negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
-            negRights = bigArrays().newDoubleArray(1, false);
-            negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
-        }
+        tops = bigArrays().newDoubleArray(1, false);
+        tops.fill(0, tops.size(), Double.NEGATIVE_INFINITY);
+        bottoms = bigArrays().newDoubleArray(1, false);
+        bottoms.fill(0, bottoms.size(), Double.POSITIVE_INFINITY);
+        posLefts = bigArrays().newDoubleArray(1, false);
+        posLefts.fill(0, posLefts.size(), Double.POSITIVE_INFINITY);
+        posRights = bigArrays().newDoubleArray(1, false);
+        posRights.fill(0, posRights.size(), Double.NEGATIVE_INFINITY);
+        negLefts = bigArrays().newDoubleArray(1, false);
+        negLefts.fill(0, negLefts.size(), Double.POSITIVE_INFINITY);
+        negRights = bigArrays().newDoubleArray(1, false);
+        negRights.fill(0, negRights.size(), Double.NEGATIVE_INFINITY);
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final GeoShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override
@@ -105,9 +101,6 @@ public final class GeoShapeBoundsAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildAggregation(long owningBucketOrdinal) {
-        if (valuesSource == null) {
-            return buildEmptyAggregation();
-        }
         double top = tops.get(owningBucketOrdinal);
         double bottom = bottoms.get(owningBucketOrdinal);
         double posLeft = posLefts.get(owningBucketOrdinal);
@@ -119,17 +112,7 @@ public final class GeoShapeBoundsAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoBounds(
-            name,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
-            Double.NEGATIVE_INFINITY,
-            Double.POSITIVE_INFINITY,
-            Double.NEGATIVE_INFINITY,
-            wrapLongitude,
-            metadata()
-        );
+        return InternalGeoBounds.empty(name, wrapLongitude, metadata());
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/GeoShapeCentroidAggregator.java
@@ -47,25 +47,20 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (GeoShapeValuesSource) valuesSourceConfig.getValuesSource() : null;
-        if (valuesSource != null) {
-            lonSum = bigArrays().newDoubleArray(1, true);
-            lonCompensations = bigArrays().newDoubleArray(1, true);
-            latSum = bigArrays().newDoubleArray(1, true);
-            latCompensations = bigArrays().newDoubleArray(1, true);
-            weightSum = bigArrays().newDoubleArray(1, true);
-            weightCompensations = bigArrays().newDoubleArray(1, true);
-            counts = bigArrays().newLongArray(1, true);
-            dimensionalShapeTypes = bigArrays().newByteArray(1, true);
-        }
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (GeoShapeValuesSource) valuesSourceConfig.getValuesSource();
+        lonSum = bigArrays().newDoubleArray(1, true);
+        lonCompensations = bigArrays().newDoubleArray(1, true);
+        latSum = bigArrays().newDoubleArray(1, true);
+        latCompensations = bigArrays().newDoubleArray(1, true);
+        weightSum = bigArrays().newDoubleArray(1, true);
+        weightCompensations = bigArrays().newDoubleArray(1, true);
+        counts = bigArrays().newLongArray(1, true);
+        dimensionalShapeTypes = bigArrays().newByteArray(1, true);
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final GeoShapeValues values = valuesSource.shapeValues(aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedSumLat = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumLon = new CompensatedSum(0, 0);
@@ -128,7 +123,7 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= counts.size()) {
+        if (bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         final long bucketCount = counts.get(bucket);
@@ -141,7 +136,7 @@ public final class GeoShapeCentroidAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoCentroid(name, null, 0L, metadata());
+        return InternalGeoCentroid.empty(name, metadata());
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianBounds.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianBounds.java
@@ -50,6 +50,17 @@ public class InternalCartesianBounds extends InternalBounds<CartesianPoint> impl
         out.writeDouble(right);
     }
 
+    static InternalCartesianBounds empty(String name, Map<String, Object> metadata) {
+        return new InternalCartesianBounds(
+            name,
+            Double.NEGATIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.POSITIVE_INFINITY,
+            Double.NEGATIVE_INFINITY,
+            metadata
+        );
+    }
+
     @Override
     public String getWriteableName() {
         return CartesianBoundsAggregationBuilder.NAME;

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroid.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/metrics/InternalCartesianCentroid.java
@@ -40,6 +40,10 @@ public class InternalCartesianCentroid extends InternalCentroid implements Carte
         return new CartesianPoint(in.readDouble(), in.readDouble());
     }
 
+    static InternalCartesianCentroid empty(String name, Map<String, Object> metadata) {
+        return new InternalCartesianCentroid(name, null, 0L, metadata);
+    }
+
     @Override
     protected void centroidToStream(StreamOutput out) throws IOException {
         out.writeDouble(centroid.getX());


### PR DESCRIPTION
We have a TODO in those aggregations to stop creating them  when `valuesSourceConfig.hasValues()` is false. Instead we should create a `NonCollectingAggregator`. This is happening in the factory method `createUnmapped`.
