### PR TITLE
[DOCS] Adds reference documentation to the text expansion query

### DIFF
--- a/docs/reference/query-dsl.asciidoc
+++ b/docs/reference/query-dsl.asciidoc
@@ -80,6 +80,8 @@ include::query-dsl/special-queries.asciidoc[]
 
 include::query-dsl/term-level-queries.asciidoc[]
 
+include::query-dsl/text-expansion-query.asciidoc[]
+
 include::query-dsl/minimum-should-match.asciidoc[]
 
 include::query-dsl/multi-term-rewrite.asciidoc[]

--- a/docs/reference/query-dsl/text-expansion-query.asciidoc
+++ b/docs/reference/query-dsl/text-expansion-query.asciidoc
@@ -1,0 +1,85 @@
+[[query-dsl-text-expansion-query]]
+== Text expansion query
+++++
+<titleabbrev>Text expansion</titleabbrev>
+++++
+
+Uses a {nlp} model to convert the query text into a list of token-weight pairs 
+which are then used in a query against a <<rank-features,rank features field>>.
+
+[discrete]
+[[text-expansion-query-ex-request]]
+=== Example request
+
+
+[source,console]
+----
+GET _search
+{
+   "query":{
+      "text_expansion":{
+         "<rank_features_field>":{
+            "model_id":"the model to produce the token weights",
+            "model_text":"the query string"
+         }
+      }
+   }
+}
+----
+// TEST[skip: TBD]
+
+[discrete]
+[[text-expansion-query-params]]
+=== Parameters
+
+`text_expansion`::
+(Required, object)
+The query configuration object which contains the information necessary to 
+perform semantic search.
++
+.Properties of `text_expansion`
+[%collapsible%open]
+====
+`<rank_features_field>`:::
+(Required, string)
+The name of the field that contains the token-weight pairs the NLP model created 
+based on the input text.
++
+.Properties of `<rank_features_field>`
+[%collapsible%open]
+=====
+`model_id`::::
+(Required, string)
+The ID of the same model that created the tokens from the input text.
+
+`model_text`::::
+(Required, string)
+The query text you want to use for search. 
+=====
+====
+
+
+[discrete]
+[[text-expansion-query-notes]]
+=== Notes
+
+The following is an example of the `text_expansion` query that references the 
+ELSER model to perform semantic search. For a more detailed description of how 
+to perform semantic search by using ELSER and the `text_expansion` query, refer 
+to <<semantic-search-elser,this tutorial>>.
+
+[source,console]
+----
+GET my-index/_search
+{
+   "query":{
+      "text_expansion":{
+         "ml.tokens":{
+            "model_id":".elser_model_1",
+            "model_text":"How is the weather in Jamaica?"
+         }
+      }
+   }
+}
+----
+// TEST[skip: TBD]

--- a/docs/reference/query-dsl/text-expansion-query.asciidoc
+++ b/docs/reference/query-dsl/text-expansion-query.asciidoc
@@ -4,8 +4,9 @@
 <titleabbrev>Text expansion</titleabbrev>
 ++++
 
-Uses a {nlp} model to convert the query text into a list of token-weight pairs 
-which are then used in a query against a <<rank-features,rank features field>>.
+The text expansion query uses a {nlp} model to convert the query text into a 
+list of token-weight pairs which are then used in a query against a 
+<<rank-features,rank features field>>.
 
 [discrete]
 [[text-expansion-query-ex-request]]
@@ -50,7 +51,9 @@ based on the input text.
 =====
 `model_id`::::
 (Required, string)
-The ID of the same model that created the tokens from the input text.
+The ID of the model to use to convert the query text into token-weight pairs. It 
+must be the same model ID that was used to create the tokens from the input 
+text.
 
 `model_text`::::
 (Required, string)

--- a/docs/reference/query-dsl/text-expansion-query.asciidoc
+++ b/docs/reference/query-dsl/text-expansion-query.asciidoc
@@ -37,18 +37,12 @@ GET _search
 (Required, object)
 The query configuration object which contains the information necessary to 
 perform semantic search.
-+
-.Properties of `text_expansion`
-[%collapsible%open]
-====
+
 `<rank_features_field>`:::
 (Required, string)
 The name of the field that contains the token-weight pairs the NLP model created 
 based on the input text.
-+
-.Properties of `<rank_features_field>`
-[%collapsible%open]
-=====
+
 `model_id`::::
 (Required, string)
 The ID of the model to use to convert the query text into token-weight pairs. It 
@@ -58,8 +52,6 @@ text.
 `model_text`::::
 (Required, string)
 The query text you want to use for search. 
-=====
-====
 
 
 [discrete]

--- a/docs/reference/query-dsl/text-expansion-query.asciidoc
+++ b/docs/reference/query-dsl/text-expansion-query.asciidoc
@@ -31,17 +31,16 @@ GET _search
 
 [discrete]
 [[text-expansion-query-params]]
-=== Parameters
-
-`text_expansion`::
-(Required, object)
-The query configuration object which contains the information necessary to 
-perform semantic search.
+=== Top level parameters for `text_expansion`
 
 `<rank_features_field>`:::
-(Required, string)
+(Required, object)
 The name of the field that contains the token-weight pairs the NLP model created 
 based on the input text.
+
+[discrete]
+[[text-expansion-rank-feature-field-params]]
+=== Top level parameters for `<rank_features_field>`
 
 `model_id`::::
 (Required, string)


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/elasticsearch/pull/93694.
This PR provides reference documentation and a simple example of using the `text_expansion` query for semantic search.

### Preview

* [Text expansion query](https://elasticsearch_96151.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/query-dsl-text-expansion-query.html)