### PR TITLE
Fix incorrect apt-get update usage in fixture DockerFile

### DIFF
--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre-headless
+RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
 
 ARG port
 ARG bucket

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre-headless
+RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/s3-fixture/sts/Dockerfile
+++ b/test/fixtures/s3-fixture/sts/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre-headless
+RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/url-fixture/Dockerfile
+++ b/test/fixtures/url-fixture/Dockerfile
@@ -1,7 +1,6 @@
 FROM ubuntu:20.04
 
-RUN apt-get update -qqy
-RUN apt-get install -qqy openjdk-17-jre-headless
+RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
 
 ARG port
 ARG workingDir


### PR DESCRIPTION
We had a couple of spots where we do the update in a separate step from the install. This has led to apt returning error 100 from going out of sync more than once for me locally.
-> Fix by always doing update + install in the same step so we don't run into stale metadata during install (see https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#apt-get).