### PR TITLE
[Behavioral Analytics] Temporary remove GeoIP Processor from pipeline

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/behavioral_analytics-events-final_pipeline.json
@@ -58,13 +58,6 @@
       }
     },
     {
-      "geoip": {
-        "field": "session.ip",
-        "target_field": "session.location",
-        "ignore_missing": true
-      }
-    },
-    {
       "remove": {
         "field": "session.ip",
         "ignore_missing": true


### PR DESCRIPTION
Due to the impact in tests https://github.com/elastic/elasticsearch/issues/96129, we want to remove the geoip processor and re-introduce it for 8.9, once we have figured a path to lazily load the geoip database that the geo-ip processor requires. 

