### PR TITLE
[Fleet] Rename `.fleet-secrets` index to `.secrets-fleet` to prevent privileges conflict

### DIFF
--- a/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
+++ b/x-pack/docs/en/rest-api/security/get-service-accounts.asciidoc
@@ -107,7 +107,7 @@ GET /_security/service/elastic/fleet-server
         },
         {
           "names": [
-            ".fleet-secrets*"
+            ".secrets-fleet*"
           ],
           "privileges": [
             "read",

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -767,7 +767,7 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                 // Fleet secrets, Kibana can only write to this index.
                 // This definition must come before .fleet* below.
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".fleet-secrets*")
+                    .indices(".secrets-fleet*")
                     .privileges("write", "delete", "create_index")
                     .allowRestrictedIndices(true)
                     .build(),

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -152,16 +152,16 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
     }
 
     public void testCreationOfFleetSecrets() throws Exception {
-        Request request = new Request("PUT", ".fleet-secrets");
+        Request request = new Request("PUT", ".secrets-fleet");
         Response response = client().performRequest(request);
         assertEquals(200, response.getStatusLine().getStatusCode());
 
-        request = new Request("GET", ".fleet-secrets/_mapping");
+        request = new Request("GET", ".secrets-fleet/_mapping");
         response = client().performRequest(request);
         String responseBody = EntityUtils.toString(response.getEntity());
         assertThat(responseBody, containsString("value"));
 
-        request = new Request("GET", ".fleet-secrets-7/_mapping");
+        request = new Request("GET", ".secrets-fleet-7/_mapping");
         response = client().performRequest(request);
         responseBody = EntityUtils.toString(response.getEntity());
         assertThat(responseBody, containsString("value"));

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/Fleet.java
@@ -201,9 +201,9 @@ public class Fleet extends Plugin implements SystemIndexPlugin {
             .setVersionMetaKey(VERSION_KEY)
             .setMappings(request.mappings())
             .setSettings(request.settings())
-            .setPrimaryIndex(".fleet-secrets-" + CURRENT_INDEX_VERSION)
-            .setIndexPattern(".fleet-secrets*")
-            .setAliasName(".fleet-secrets")
+            .setPrimaryIndex(".secrets-fleet-" + CURRENT_INDEX_VERSION)
+            .setIndexPattern(".secrets-fleet*")
+            .setAliasName(".secrets-fleet")
             .setDescription("Secret values managed by Fleet")
             .build();
     }

--- a/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
+++ b/x-pack/plugin/fleet/src/test/java/org/elasticsearch/xpack/fleet/FleetTests.java
@@ -36,7 +36,7 @@ public class FleetTests extends ESTestCase {
                 ".fleet-policies-leader*",
                 ".fleet-enrollment-api-keys*",
                 ".fleet-artifacts*",
-                ".fleet-secrets*"
+                ".secrets-fleet*"
             )
         );
 

--- a/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
+++ b/x-pack/plugin/security/qa/service-account/src/javaRestTest/java/org/elasticsearch/xpack/security/authc/service/ServiceAccountIT.java
@@ -126,7 +126,7 @@ public class ServiceAccountIT extends ESRestTestCase {
                 },
                 {
                   "names": [
-                    ".fleet-secrets*"
+                    ".secrets-fleet*"
                   ],
                   "privileges": [
                     "read"

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -84,7 +84,7 @@ final class ElasticServiceAccounts {
                     .privileges("read", "monitor", "maintenance")
                     .build(),
                 RoleDescriptor.IndicesPrivileges.builder()
-                    .indices(".fleet-secrets*")
+                    .indices(".secrets-fleet*")
                     .privileges("read")
                     .allowRestrictedIndices(true)
                     .build(),


### PR DESCRIPTION
The kibana_system user has `all` privileges on `.fleet*` indices. This was conflicting with the more restrcited privileges we needed on the `.fleet-secrets` index in https://github.com/elastic/elasticsearch/pull/95625. I thought defining the `.fleet-secrets` rule first would mean it took precedence (And I thought I had successfully tested this!) but it seems not.

renaming the index to `.secrets-fleet` prevents this conflict. 