### PR TITLE
Stop creating  metric aggregations with no values (cont)

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregator.java
@@ -43,27 +43,22 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO Stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
-        if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            counts = bigArrays.newLongArray(1, true);
-            sums = bigArrays.newDoubleArray(1, true);
-            compensations = bigArrays.newDoubleArray(1, true);
-        }
+        final BigArrays bigArrays = context.bigArrays();
+        counts = bigArrays.newLongArray(1, true);
+        sums = bigArrays.newDoubleArray(1, true);
+        compensations = bigArrays.newDoubleArray(1, true);
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
 
@@ -98,7 +93,7 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= sums.size()) {
+        if (owningBucketOrd >= sums.size()) {
             return Double.NaN;
         }
         return sums.get(owningBucketOrd) / counts.get(owningBucketOrd);
@@ -106,7 +101,7 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= sums.size()) {
+        if (bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
         return new InternalAvg(name, sums.get(bucket), counts.get(bucket), format, metadata());
@@ -114,7 +109,7 @@ class AvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalAvg(name, 0.0, 0L, format, metadata());
+        return InternalAvg.empty(name, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
@@ -12,8 +12,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -52,12 +50,7 @@ class AvgAggregatorFactory extends ValuesSourceAggregatorFactory {
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
         final InternalAvg empty = InternalAvg.empty(name, config.format(), metadata);
-        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
-            @Override
-            public InternalAggregation buildEmptyAggregation() {
-                return empty;
-            }
-        };
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AvgAggregatorFactory.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -49,7 +51,13 @@ class AvgAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new AvgAggregator(name, config, context, parent, metadata);
+        final InternalAvg empty = InternalAvg.empty(name, config.format(), metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -13,6 +13,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -201,7 +203,13 @@ public class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory 
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new CardinalityAggregator(name, config, precision(), null, context, parent, metadata);
+        final InternalCardinality empty = InternalCardinality.empty(name, metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/CardinalityAggregatorFactory.java
@@ -13,8 +13,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
@@ -204,12 +202,7 @@ public class CardinalityAggregatorFactory extends ValuesSourceAggregatorFactory 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
         final InternalCardinality empty = InternalCardinality.empty(name, metadata);
-        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
-            @Override
-            public InternalAggregation buildEmptyAggregation() {
-                return empty;
-            }
-        };
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -52,29 +52,34 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        assert valuesSourceConfig.hasValues();
-        this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
+        // TODO: stop depending on nulls here
+        this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
         this.format = valuesSourceConfig.format();
         this.sigma = sigma;
-        final BigArrays bigArrays = context.bigArrays();
-        counts = bigArrays.newLongArray(1, true);
-        sums = bigArrays.newDoubleArray(1, true);
-        compensations = bigArrays.newDoubleArray(1, true);
-        mins = bigArrays.newDoubleArray(1, false);
-        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-        maxes = bigArrays.newDoubleArray(1, false);
-        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-        sumOfSqrs = bigArrays.newDoubleArray(1, true);
-        compensationOfSqrs = bigArrays.newDoubleArray(1, true);
+        if (valuesSource != null) {
+            final BigArrays bigArrays = context.bigArrays();
+            counts = bigArrays.newLongArray(1, true);
+            sums = bigArrays.newDoubleArray(1, true);
+            compensations = bigArrays.newDoubleArray(1, true);
+            mins = bigArrays.newDoubleArray(1, false);
+            mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+            maxes = bigArrays.newDoubleArray(1, false);
+            maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+            sumOfSqrs = bigArrays.newDoubleArray(1, true);
+            compensationOfSqrs = bigArrays.newDoubleArray(1, true);
+        }
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
+        if (valuesSource == null) {
+            return LeafBucketCollector.NO_OP_COLLECTOR;
+        }
         final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedSum = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumOfSqr = new CompensatedSum(0, 0);
@@ -143,7 +148,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public double metric(String name, long owningBucketOrd) {
-        if (owningBucketOrd >= counts.size()) {
+        if (valuesSource == null || owningBucketOrd >= counts.size()) {
             return switch (InternalExtendedStats.Metrics.resolve(name)) {
                 case count -> 0;
                 case sum -> 0;
@@ -203,7 +208,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (bucket >= counts.size()) {
+        if (valuesSource == null || bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         return new InternalExtendedStats(
@@ -221,7 +226,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return InternalExtendedStats.empty(name, sigma, format, metadata());
+        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, sigma, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
@@ -12,8 +12,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -55,13 +53,7 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        final InternalExtendedStats empty = InternalExtendedStats.empty(name, sigma, config.format(), metadata);
-        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
-            @Override
-            public InternalAggregation buildEmptyAggregation() {
-                return empty;
-            }
-        };
+        return new ExtendedStatsAggregator(name, config, context, parent, sigma, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -53,7 +55,13 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new ExtendedStatsAggregator(name, config, context, parent, sigma, metadata);
+        final InternalExtendedStats empty = InternalExtendedStats.empty(name, sigma, config.format(), metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalAvg.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalAvg.java
@@ -46,6 +46,10 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
         out.writeVLong(count);
     }
 
+    static InternalAvg empty(String name, DocValueFormat format, Map<String, Object> metadata) {
+        return new InternalAvg(name, 0.0, 0L, format, metadata);
+    }
+
     @Override
     public double value() {
         return getValue();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalAvg.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalAvg.java
@@ -46,7 +46,7 @@ public class InternalAvg extends InternalNumericMetricsAggregation.SingleValue i
         out.writeVLong(count);
     }
 
-    static InternalAvg empty(String name, DocValueFormat format, Map<String, Object> metadata) {
+    public static InternalAvg empty(String name, DocValueFormat format, Map<String, Object> metadata) {
         return new InternalAvg(name, 0.0, 0L, format, metadata);
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalCardinality.java
@@ -57,6 +57,10 @@ public final class InternalCardinality extends InternalNumericMetricsAggregation
         return CardinalityAggregationBuilder.NAME;
     }
 
+    static InternalCardinality empty(String name, Map<String, Object> metadata) {
+        return new InternalCardinality(name, null, metadata);
+    }
+
     @Override
     public double value() {
         return getValue();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -94,6 +94,10 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
         return ExtendedStatsAggregationBuilder.NAME;
     }
 
+    static InternalExtendedStats empty(String name, double sigma, DocValueFormat format, Map<String, Object> metadata) {
+        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, sigma, format, metadata);
+    }
+
     @Override
     public double value(String name) {
         if ("sum_of_squares".equals(name)) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -94,10 +94,6 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
         return ExtendedStatsAggregationBuilder.NAME;
     }
 
-    static InternalExtendedStats empty(String name, double sigma, DocValueFormat format, Map<String, Object> metadata) {
-        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, sigma, format, metadata);
-    }
-
     @Override
     public double value(String name) {
         if ("sum_of_squares".equals(name)) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviation.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalMedianAbsoluteDeviation.java
@@ -62,6 +62,10 @@ public class InternalMedianAbsoluteDeviation extends InternalNumericMetricsAggre
         out.writeDouble(medianAbsoluteDeviation);
     }
 
+    static InternalMedianAbsoluteDeviation empty(String name, Map<String, Object> metadata, DocValueFormat format, double compression) {
+        return new InternalMedianAbsoluteDeviation(name, metadata, format, new TDigestState(compression));
+    }
+
     @Override
     public InternalAggregation reduce(List<InternalAggregation> aggregations, AggregationReduceContext reduceContext) {
         final TDigestState valueMerged = new TDigestState(valuesSketch.compression());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalValueCount.java
@@ -48,6 +48,10 @@ public class InternalValueCount extends InternalNumericMetricsAggregation.Single
         return ValueCountAggregationBuilder.NAME;
     }
 
+    public static InternalValueCount empty(String name, Map<String, Object> metadata) {
+        return new InternalValueCount(name, 0L, metadata);
+    }
+
     @Override
     public long getValue() {
         return value;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvg.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalWeightedAvg.java
@@ -46,6 +46,10 @@ public class InternalWeightedAvg extends InternalNumericMetricsAggregation.Singl
         out.writeDouble(weight);
     }
 
+    static InternalWeightedAvg empty(String name, DocValueFormat format, Map<String, Object> metadata) {
+        return new InternalWeightedAvg(name, 0.0, 0L, format, metadata);
+    }
+
     @Override
     public double value() {
         return getValue();

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregator.java
@@ -44,12 +44,10 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
     MaxAggregator(String name, ValuesSourceConfig config, AggregationContext context, Aggregator parent, Map<String, Object> metadata)
         throws IOException {
         super(name, context, parent, metadata);
-        // TODO stop expecting nulls here
-        this.valuesSource = config.hasValues() ? (ValuesSource.Numeric) config.getValuesSource() : null;
-        if (valuesSource != null) {
-            maxes = context.bigArrays().newDoubleArray(1, false);
-            maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-        }
+        assert config.hasValues();
+        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
+        maxes = context.bigArrays().newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         this.formatter = config.format();
         this.pointConverter = pointReaderIfAvailable(config);
         if (pointConverter != null) {
@@ -61,14 +59,11 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         if (pointConverter != null) {
             Number segMax = findLeafMaxValue(aggCtx.getLeafReaderContext().reader(), pointField, pointConverter);
             if (segMax != null) {
@@ -108,7 +103,7 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= maxes.size()) {
+        if (owningBucketOrd >= maxes.size()) {
             return Double.NEGATIVE_INFINITY;
         }
         return maxes.get(owningBucketOrd);
@@ -116,7 +111,7 @@ class MaxAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= maxes.size()) {
+        if (bucket >= maxes.size()) {
             return buildEmptyAggregation();
         }
         return new Max(name, maxes.get(bucket), formatter, metadata());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
@@ -12,8 +12,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
@@ -59,12 +57,7 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory {
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
         final Max empty = Max.createEmptyMax(name, config.format(), metadata);
-        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
-            @Override
-            public InternalAggregation buildEmptyAggregation() {
-                return empty;
-            }
-        };
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MaxAggregatorFactory.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
@@ -56,7 +58,13 @@ class MaxAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new MaxAggregator(name, config, context, parent, metadata);
+        final Max empty = Max.createEmptyMax(name, config.format(), metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorFactory.java
@@ -12,8 +12,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.ValuesSourceAggregatorFactory;
@@ -55,12 +53,7 @@ public class MedianAbsoluteDeviationAggregatorFactory extends ValuesSourceAggreg
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
         final InternalMedianAbsoluteDeviation empty = InternalMedianAbsoluteDeviation.empty(name, metadata, config.format(), compression);
-        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
-            @Override
-            public InternalAggregation buildEmptyAggregation() {
-                return empty;
-            }
-        };
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregatorSupplier.java
@@ -10,7 +10,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -18,7 +18,7 @@ import java.util.Map;
 public interface MedianAbsoluteDeviationAggregatorSupplier {
     Aggregator build(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         DocValueFormat format,
         AggregationContext context,
         Aggregator parent,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregator.java
@@ -45,12 +45,10 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
     MinAggregator(String name, ValuesSourceConfig config, AggregationContext context, Aggregator parent, Map<String, Object> metadata)
         throws IOException {
         super(name, context, parent, metadata);
-        // TODO: Stop using nulls here
-        this.valuesSource = config.hasValues() ? (ValuesSource.Numeric) config.getValuesSource() : null;
-        if (valuesSource != null) {
-            mins = context.bigArrays().newDoubleArray(1, false);
-            mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-        }
+        assert config.hasValues();
+        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
+        mins = context.bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         this.format = config.format();
         this.pointConverter = pointReaderIfAvailable(config);
         if (pointConverter != null) {
@@ -62,14 +60,11 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         if (pointConverter != null) {
             Number segMin = findLeafMinValue(aggCtx.getLeafReaderContext().reader(), pointField, pointConverter);
             if (segMin != null) {
@@ -107,7 +102,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= mins.size()) {
+        if (owningBucketOrd >= mins.size()) {
             return Double.POSITIVE_INFINITY;
         }
         return mins.get(owningBucketOrd);
@@ -115,7 +110,7 @@ public class MinAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= mins.size()) {
+        if (bucket >= mins.size()) {
             return buildEmptyAggregation();
         }
         return new Min(name, mins.get(bucket), format, metadata());

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
@@ -12,8 +12,6 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
-import org.elasticsearch.search.aggregations.InternalAggregation;
-import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
@@ -59,12 +57,7 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory {
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
         final Min empty = Min.createEmptyMin(name, config.format(), metadata);
-        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
-            @Override
-            public InternalAggregation buildEmptyAggregation() {
-                return empty;
-            }
-        };
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MinAggregatorFactory.java
@@ -12,6 +12,8 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.AggregatorFactories;
 import org.elasticsearch.search.aggregations.AggregatorFactory;
 import org.elasticsearch.search.aggregations.CardinalityUpperBound;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.NonCollectingAggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.CoreValuesSourceType;
 import org.elasticsearch.search.aggregations.support.TimeSeriesValuesSourceType;
@@ -56,7 +58,13 @@ class MinAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new MinAggregator(name, config, context, parent, metadata);
+        final Min empty = Min.createEmptyMin(name, config.format(), metadata);
+        return new NonCollectingAggregator(name, context, parent, factories, metadata) {
+            @Override
+            public InternalAggregation buildEmptyAggregation() {
+                return empty;
+            }
+        };
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NonCollectingSingleMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NonCollectingSingleMetricAggregator.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.io.IOException;
+import java.util.Map;
+
+/**
+ * An {@link NumericMetricsAggregator.SingleValue} that is not collected, this can typically be used when running
+ * an aggregation over a field that doesn't have a mapping.
+ *
+ * see {@link org.elasticsearch.search.aggregations.NonCollectingAggregator}
+ */
+public final class NonCollectingSingleMetricAggregator extends NumericMetricsAggregator.SingleValue {
+
+    private final InternalNumericMetricsAggregation.SingleValue emptyAggregation;
+
+    /**
+     * Build a {@linkplain NonCollectingSingleMetricAggregator} for {@link NumericMetricsAggregator.SingleValue} aggregators.
+     */
+    public NonCollectingSingleMetricAggregator(
+        String name,
+        AggregationContext context,
+        Aggregator parent,
+        InternalNumericMetricsAggregation.SingleValue emptyAggregation,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, context, parent, metadata);
+        this.emptyAggregation = emptyAggregation;
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
+        // the framework will automatically eliminate it
+        return LeafBucketCollector.NO_OP_COLLECTOR;
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrd) throws IOException {
+        return buildEmptyAggregation();
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return emptyAggregation;
+    }
+
+    @Override
+    public double metric(long owningBucketOrd) {
+        return emptyAggregation.value();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Sum.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/Sum.java
@@ -47,6 +47,10 @@ public class Sum extends InternalNumericMetricsAggregation.SingleValue {
         return SumAggregationBuilder.NAME;
     }
 
+    public static Sum empty(String name, DocValueFormat format, Map<String, Object> metadata) {
+        return new Sum(name, 0.0, format, metadata);
+    }
+
     @Override
     public double value() {
         return sum;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregator.java
@@ -40,25 +40,20 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (ValuesSource.Numeric) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
-        if (valuesSource != null) {
-            sums = bigArrays().newDoubleArray(1, true);
-            compensations = bigArrays().newDoubleArray(1, true);
-        }
+        sums = bigArrays().newDoubleArray(1, true);
+        compensations = bigArrays().newDoubleArray(1, true);
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         return new LeafBucketCollectorBase(sub, values) {
@@ -89,7 +84,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= sums.size()) {
+        if (owningBucketOrd >= sums.size()) {
             return 0.0;
         }
         return sums.get(owningBucketOrd);
@@ -97,7 +92,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= sums.size()) {
+        if (bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
         return new Sum(name, sums.get(bucket), format, metadata());
@@ -105,7 +100,7 @@ public class SumAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Sum(name, 0.0, format, metadata());
+        return Sum.empty(name, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/SumAggregatorFactory.java
@@ -51,7 +51,8 @@ class SumAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new SumAggregator(name, config, context, parent, metadata);
+        final Sum empty = Sum.empty(name, config.format(), metadata);
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregator.java
@@ -46,19 +46,13 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, aggregationContext, parent, metadata);
-        // TODO: stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? valuesSourceConfig.getValuesSource() : null;
-        if (valuesSource != null) {
-            counts = bigArrays().newLongArray(1, true);
-        }
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = valuesSourceConfig.getValuesSource();
+        counts = bigArrays().newLongArray(1, true);
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
-
         if (valuesSource instanceof ValuesSource.Numeric) {
             final SortedNumericDocValues values = ((ValuesSource.Numeric) valuesSource).longValues(aggCtx.getLeafReaderContext());
             return new LeafBucketCollectorBase(sub, values) {
@@ -102,12 +96,12 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        return (valuesSource == null || owningBucketOrd >= counts.size()) ? 0 : counts.get(owningBucketOrd);
+        return owningBucketOrd >= counts.size() ? 0 : counts.get(owningBucketOrd);
     }
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= counts.size()) {
+        if (bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         return new InternalValueCount(name, counts.get(bucket), metadata());
@@ -115,12 +109,12 @@ public class ValueCountAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalValueCount(name, 0L, metadata());
+        return InternalValueCount.empty(name, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ValueCountAggregatorFactory.java
@@ -45,7 +45,8 @@ class ValueCountAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new ValueCountAggregator(name, config, context, parent, metadata);
+        final InternalValueCount empty = InternalValueCount.empty(name, metadata);
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregator.java
@@ -35,7 +35,7 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
     private DoubleArray valueSums;
     private DoubleArray valueCompensations;
     private DoubleArray weightCompensations;
-    private DocValueFormat format;
+    private final DocValueFormat format;
 
     WeightedAvgAggregator(
         String name,
@@ -46,26 +46,22 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
+        assert valuesSources != null;
         this.valuesSources = valuesSources;
         this.format = format;
-        if (valuesSources != null) {
-            weights = bigArrays().newDoubleArray(1, true);
-            valueSums = bigArrays().newDoubleArray(1, true);
-            valueCompensations = bigArrays().newDoubleArray(1, true);
-            weightCompensations = bigArrays().newDoubleArray(1, true);
-        }
+        weights = bigArrays().newDoubleArray(1, true);
+        valueSums = bigArrays().newDoubleArray(1, true);
+        valueCompensations = bigArrays().newDoubleArray(1, true);
+        weightCompensations = bigArrays().newDoubleArray(1, true);
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSources != null && valuesSources.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSources.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSources == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues docValues = valuesSources.getField(VALUE_FIELD.getPreferredName(), aggCtx.getLeafReaderContext());
         final SortedNumericDoubleValues docWeights = valuesSources.getField(WEIGHT_FIELD.getPreferredName(), aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedValueSum = new CompensatedSum(0, 0);
@@ -118,7 +114,7 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSources == null || owningBucketOrd >= valueSums.size()) {
+        if (owningBucketOrd >= valueSums.size()) {
             return Double.NaN;
         }
         return valueSums.get(owningBucketOrd) / weights.get(owningBucketOrd);
@@ -126,7 +122,7 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSources == null || bucket >= valueSums.size()) {
+        if (bucket >= valueSums.size()) {
             return buildEmptyAggregation();
         }
         return new InternalWeightedAvg(name, valueSums.get(bucket), weights.get(bucket), format, metadata());
@@ -134,7 +130,7 @@ class WeightedAvgAggregator extends NumericMetricsAggregator.SingleValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalWeightedAvg(name, 0.0, 0L, format, metadata());
+        return InternalWeightedAvg.empty(name, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/WeightedAvgAggregatorFactory.java
@@ -39,7 +39,8 @@ class WeightedAvgAggregatorFactory extends MultiValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new WeightedAvgAggregator(name, null, format, context, parent, metadata);
+        final InternalWeightedAvg empty = InternalWeightedAvg.empty(name, format, metadata);
+        return new NonCollectingSingleMetricAggregator(name, context, parent, empty, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMaxAggregator.java
@@ -40,25 +40,20 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = config.hasValues() ? (HistogramValuesSource.Histogram) config.getValuesSource() : null;
-        if (valuesSource != null) {
-            maxes = bigArrays().newDoubleArray(1, false);
-            maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-        }
+        assert config.hasValues();
+        this.valuesSource = (HistogramValuesSource.Histogram) config.getValuesSource();
+        maxes = bigArrays().newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         this.formatter = config.format();
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
-
         final HistogramValues values = valuesSource.getHistogramValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
 
@@ -84,7 +79,7 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= maxes.size()) {
+        if (owningBucketOrd >= maxes.size()) {
             return Double.NEGATIVE_INFINITY;
         }
         return maxes.get(owningBucketOrd);
@@ -92,7 +87,7 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= maxes.size()) {
+        if (bucket >= maxes.size()) {
             return buildEmptyAggregation();
         }
         return new Max(name, maxes.get(bucket), formatter, metadata());
@@ -100,7 +95,7 @@ public class HistoBackedMaxAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Max(name, Double.NEGATIVE_INFINITY, formatter, metadata());
+        return Max.createEmptyMax(name, formatter, metadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedMinAggregator.java
@@ -40,25 +40,20 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = config.hasValues() ? (HistogramValuesSource.Histogram) config.getValuesSource() : null;
-        if (valuesSource != null) {
-            mins = bigArrays().newDoubleArray(1, false);
-            mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-        }
+        assert config.hasValues();
+        this.valuesSource = (HistogramValuesSource.Histogram) config.getValuesSource();
+        mins = bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         this.format = config.format();
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
-
         final HistogramValues values = valuesSource.getHistogramValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
 
@@ -86,7 +81,7 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= mins.size()) {
+        if (owningBucketOrd >= mins.size()) {
             return Double.POSITIVE_INFINITY;
         }
         return mins.get(owningBucketOrd);
@@ -94,7 +89,7 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= mins.size()) {
+        if (bucket >= mins.size()) {
             return buildEmptyAggregation();
         }
         return new Min(name, mins.get(bucket), format, metadata());
@@ -102,7 +97,7 @@ public class HistoBackedMinAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Min(name, Double.POSITIVE_INFINITY, format, metadata());
+        return Min.createEmptyMin(name, format, metadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedSumAggregator.java
@@ -49,27 +49,21 @@ public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleVal
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop expecting a null here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (HistogramValuesSource.Histogram) valuesSourceConfig.getValuesSource() : null;
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (HistogramValuesSource.Histogram) valuesSourceConfig.getValuesSource();
         this.format = valuesSourceConfig.format();
-        if (valuesSource != null) {
-            sums = bigArrays().newDoubleArray(1, true);
-            compensations = bigArrays().newDoubleArray(1, true);
-        }
+        sums = bigArrays().newDoubleArray(1, true);
+        compensations = bigArrays().newDoubleArray(1, true);
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final HistogramValues values = valuesSource.getHistogramValues(aggCtx.getLeafReaderContext());
-
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
         return new LeafBucketCollectorBase(sub, values) {
             @Override
@@ -96,7 +90,7 @@ public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= sums.size()) {
+        if (owningBucketOrd >= sums.size()) {
             return 0.0;
         }
         return sums.get(owningBucketOrd);
@@ -104,7 +98,7 @@ public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= sums.size()) {
+        if (bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
         return new Sum(name, sums.get(bucket), format, metadata());
@@ -112,7 +106,7 @@ public class HistoBackedSumAggregator extends NumericMetricsAggregator.SingleVal
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Sum(name, 0.0, format, metadata());
+        return Sum.empty(name, format, metadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedValueCountAggregator.java
@@ -44,19 +44,13 @@ public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.Si
         Map<String, Object> metadata
     ) throws IOException {
         super(name, aggregationContext, parent, metadata);
-        // TODO: stop using nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (HistogramValuesSource.Histogram) valuesSourceConfig.getValuesSource() : null;
-        if (valuesSource != null) {
-            counts = bigArrays().newLongArray(1, true);
-        }
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (HistogramValuesSource.Histogram) valuesSourceConfig.getValuesSource();
+        counts = bigArrays().newLongArray(1, true);
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
-
         final HistogramValues values = valuesSource.getHistogramValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override
@@ -74,12 +68,12 @@ public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.Si
 
     @Override
     public double metric(long owningBucketOrd) {
-        return (valuesSource == null || owningBucketOrd >= counts.size()) ? 0 : counts.get(owningBucketOrd);
+        return owningBucketOrd >= counts.size() ? 0 : counts.get(owningBucketOrd);
     }
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= counts.size()) {
+        if (bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         return new InternalValueCount(name, counts.get(bucket), metadata());
@@ -87,7 +81,7 @@ public class HistoBackedValueCountAggregator extends NumericMetricsAggregator.Si
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalValueCount(name, 0L, metadata());
+        return InternalValueCount.empty(name, metadata());
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMaxAggregator.java
@@ -43,25 +43,20 @@ class AggregateMetricBackedMaxAggregator extends NumericMetricsAggregator.Single
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = config.hasValues() ? (AggregateMetricsValuesSource.AggregateDoubleMetric) config.getValuesSource() : null;
-        if (valuesSource != null) {
-            maxes = context.bigArrays().newDoubleArray(1, false);
-            maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-        }
+        assert config.hasValues();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) config.getValuesSource();
+        maxes = context.bigArrays().newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
         this.formatter = config.format();
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
-
         final BigArrays bigArrays = bigArrays();
         final SortedNumericDoubleValues allValues = valuesSource.getAggregateMetricValues(aggCtx.getLeafReaderContext(), Metric.max);
         final NumericDoubleValues values = MultiValueMode.MAX.select(allValues);
@@ -86,7 +81,7 @@ class AggregateMetricBackedMaxAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= maxes.size()) {
+        if (owningBucketOrd >= maxes.size()) {
             return Double.NEGATIVE_INFINITY;
         }
         return maxes.get(owningBucketOrd);
@@ -94,7 +89,7 @@ class AggregateMetricBackedMaxAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= maxes.size()) {
+        if (bucket >= maxes.size()) {
             return buildEmptyAggregation();
         }
         return new Max(name, maxes.get(bucket), formatter, metadata());
@@ -102,7 +97,7 @@ class AggregateMetricBackedMaxAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Max(name, Double.NEGATIVE_INFINITY, formatter, metadata());
+        return Max.createEmptyMax(name, formatter, metadata());
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedMinAggregator.java
@@ -43,25 +43,20 @@ class AggregateMetricBackedMinAggregator extends NumericMetricsAggregator.Single
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = config.hasValues() ? (AggregateMetricsValuesSource.AggregateDoubleMetric) config.getValuesSource() : null;
-        if (valuesSource != null) {
-            mins = context.bigArrays().newDoubleArray(1, false);
-            mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-        }
+        assert config.hasValues();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) config.getValuesSource();
+        mins = context.bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
         this.format = config.format();
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
-
         final BigArrays bigArrays = bigArrays();
         final SortedNumericDoubleValues allValues = valuesSource.getAggregateMetricValues(aggCtx.getLeafReaderContext(), Metric.min);
         final NumericDoubleValues values = MultiValueMode.MIN.select(allValues);
@@ -86,7 +81,7 @@ class AggregateMetricBackedMinAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= mins.size()) {
+        if (owningBucketOrd >= mins.size()) {
             return Double.POSITIVE_INFINITY;
         }
         return mins.get(owningBucketOrd);
@@ -94,7 +89,7 @@ class AggregateMetricBackedMinAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= mins.size()) {
+        if (bucket >= mins.size()) {
             return buildEmptyAggregation();
         }
         return new Min(name, mins.get(bucket), format, metadata());
@@ -102,7 +97,7 @@ class AggregateMetricBackedMinAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Min(name, Double.POSITIVE_INFINITY, format, metadata());
+        return Min.createEmptyMin(name, format, metadata());
     }
 
     @Override

--- a/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregator.java
+++ b/x-pack/plugin/mapper-aggregate-metric/src/main/java/org/elasticsearch/xpack/aggregatemetric/aggregations/metrics/AggregateMetricBackedSumAggregator.java
@@ -44,27 +44,20 @@ class AggregateMetricBackedSumAggregator extends NumericMetricsAggregator.Single
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop expecting nulls here
-        this.valuesSource = valuesSourceConfig.hasValues()
-            ? (AggregateMetricsValuesSource.AggregateDoubleMetric) valuesSourceConfig.getValuesSource()
-            : null;
-        if (valuesSource != null) {
-            sums = context.bigArrays().newDoubleArray(1, true);
-            compensations = context.bigArrays().newDoubleArray(1, true);
-        }
+        assert valuesSourceConfig.hasValues();
+        this.valuesSource = (AggregateMetricsValuesSource.AggregateDoubleMetric) valuesSourceConfig.getValuesSource();
+        sums = context.bigArrays().newDoubleArray(1, true);
+        compensations = context.bigArrays().newDoubleArray(1, true);
         this.format = valuesSourceConfig.format();
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final BigArrays bigArrays = bigArrays();
         final SortedNumericDoubleValues values = valuesSource.getAggregateMetricValues(aggCtx.getLeafReaderContext(), Metric.sum);
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
@@ -95,7 +88,7 @@ class AggregateMetricBackedSumAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public double metric(long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= sums.size()) {
+        if (owningBucketOrd >= sums.size()) {
             return 0.0;
         }
         return sums.get(owningBucketOrd);
@@ -103,7 +96,7 @@ class AggregateMetricBackedSumAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= sums.size()) {
+        if (bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
         return new Sum(name, sums.get(bucket), format, metadata());
@@ -111,7 +104,7 @@ class AggregateMetricBackedSumAggregator extends NumericMetricsAggregator.Single
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new Sum(name, 0.0, format, metadata());
+        return Sum.empty(name, format, metadata());
     }
 
     @Override


### PR DESCRIPTION
We have a TODO in those aggregations to stop creating them when valuesSourceConfig.hasValues() is false. Instead we should create a NonCollectingAggregator. This is happening in the factory method createUnmapped.

relates https://github.com/elastic/elasticsearch/pull/96146