### PR TITLE
[DOCS] Adds deployment ID param documentation to trained model APIs

### DIFF
--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -16,7 +16,7 @@ ingested in the pipeline.
 [options="header"]
 |======
 | Name                                  | Required  | Default                        | Description
-| `model_id` or `deployment_id`         | yes       | -                              | (String) The ID or alias for the trained model, or the ID of the deployment.
+| `model_id` .                          | yes       | -                              | (String) The ID or alias for the trained model, or the ID of the deployment.
 | `target_field`                        | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
 | `field_map`                           | no        | If defined the model's default field map | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
 | `inference_config`                    | no        | The default settings defined in the model  | (Object) Contains the inference type and its options.
@@ -28,7 +28,7 @@ include::common-options.asciidoc[]
 --------------------------------------------------
 {
   "inference": {
-    "deployment_id": "model_deployment_for_inference",
+    "model_id": "model_deployment_for_inference",
     "target_field": "FlightDelayMin_prediction_infer",
     "field_map": {
       "your_field": "my_field"

--- a/docs/reference/ingest/processors/inference.asciidoc
+++ b/docs/reference/ingest/processors/inference.asciidoc
@@ -15,11 +15,11 @@ ingested in the pipeline.
 .{infer-cap} Options
 [options="header"]
 |======
-| Name               | Required  | Default                        | Description
-| `model_id`         | yes       | -                              | (String) The ID or alias for the trained model.
-| `target_field`     | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
-| `field_map`        | no        | If defined the model's default field map | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
-| `inference_config` | no        | The default settings defined in the model  | (Object) Contains the inference type and its options.
+| Name                                  | Required  | Default                        | Description
+| `model_id` or `deployment_id`         | yes       | -                              | (String) The ID or alias for the trained model, or the ID of the deployment.
+| `target_field`                        | no        | `ml.inference.<processor_tag>` | (String) Field added to incoming documents to contain results objects.
+| `field_map`                           | no        | If defined the model's default field map | (Object) Maps the document field names to the known field names of the model. This mapping takes precedence over any default mappings provided in the model configuration.
+| `inference_config`                    | no        | The default settings defined in the model  | (Object) Contains the inference type and its options.
 include::common-options.asciidoc[]
 |======
 
@@ -28,7 +28,7 @@ include::common-options.asciidoc[]
 --------------------------------------------------
 {
   "inference": {
-    "model_id": "flight_delay_regression-1571767128603",
+    "deployment_id": "model_deployment_for_inference",
     "target_field": "FlightDelayMin_prediction_infer",
     "field_map": {
       "your_field": "my_field"
@@ -384,6 +384,7 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=inference-config-nlp-tokenizati
 [discrete]
 [[inference-processor-config-example]]
 ==== {infer-cap} processor examples
+
 [source,js]
 --------------------------------------------------
 "inference":{

--- a/docs/reference/ml/ml-shared.asciidoc
+++ b/docs/reference/ml/ml-shared.asciidoc
@@ -498,6 +498,10 @@ that document will not be used for training, but a prediction with the trained
 model will be generated for it. It is also known as continuous target variable.
 end::dependent-variable[]
 
+tag::deployment-id[]
+A unique identifier for the deployment of the model.
+end::deployment-id[]
+
 tag::desc-results[]
 If true, the results are sorted in descending order.
 end::desc-results[]

--- a/docs/reference/ml/trained-models/apis/clear-trained-model-deployment-cache.asciidoc
+++ b/docs/reference/ml/trained-models/apis/clear-trained-model-deployment-cache.asciidoc
@@ -6,12 +6,13 @@
 <titleabbrev>Clear trained model deployment cache</titleabbrev>
 ++++
 
-Clears a trained model deployment cache on all nodes where the trained model is assigned.
+Clears a trained model deployment cache on all nodes where the trained model is 
+assigned.
 
 [[clear-trained-model-deployment-cache-request]]
 == {api-request-title}
 
-`POST _ml/trained_models/<model_id>/deployment/cache/_clear`
+`POST _ml/trained_models/<deployment_id>/deployment/cache/_clear`
 
 [[clear-trained-model-deployment-cache-prereq]]
 == {api-prereq-title}
@@ -29,9 +30,9 @@ deployment.
 [[clear-trained-model-deployment-cache-path-params]]
 == {api-path-parms-title}
 
-`<model_id>`::
+`deployment_id`::
 (Required, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 [[clear-trained-model-deployment-cache-example]]
 == {api-examples-title}

--- a/docs/reference/ml/trained-models/apis/clear-trained-model-deployment-cache.asciidoc
+++ b/docs/reference/ml/trained-models/apis/clear-trained-model-deployment-cache.asciidoc
@@ -6,8 +6,7 @@
 <titleabbrev>Clear trained model deployment cache</titleabbrev>
 ++++
 
-Clears a trained model deployment cache on all nodes where the deployment is 
-assigned.
+Clears the {infer} cache on all nodes where the deployment is assigned.
 
 [[clear-trained-model-deployment-cache-request]]
 == {api-request-title}

--- a/docs/reference/ml/trained-models/apis/clear-trained-model-deployment-cache.asciidoc
+++ b/docs/reference/ml/trained-models/apis/clear-trained-model-deployment-cache.asciidoc
@@ -6,7 +6,7 @@
 <titleabbrev>Clear trained model deployment cache</titleabbrev>
 ++++
 
-Clears a trained model deployment cache on all nodes where the trained model is 
+Clears a trained model deployment cache on all nodes where the deployment is 
 assigned.
 
 [[clear-trained-model-deployment-cache-request]]
@@ -23,9 +23,9 @@ Requires the `manage_ml` cluster privilege. This privilege is included in the
 [[clear-trained-model-deployment-cache-desc]]
 == {api-description-title}
 
-A trained model deployment may have an inference cache enabled. As requests are handled by each allocated node,
-their responses may be cached on that individual node. Calling this API clears the caches without restarting the
-deployment.
+A trained model deployment may have an inference cache enabled. As requests are 
+handled by each allocated node, their responses may be cached on that individual 
+node. Calling this API clears the caches without restarting the deployment.
 
 [[clear-trained-model-deployment-cache-path-params]]
 == {api-path-parms-title}

--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -16,13 +16,11 @@ Retrieves usage information for trained models.
 
 `GET _ml/trained_models/_all/_stats` +
 
-`GET _ml/trained_models/<model_id>/_stats` +
+`GET _ml/trained_models/<model_id_or_deployment_id>/_stats` +
 
-`GET _ml/trained_models/<model_id>,<model_id_2>/_stats` +
+`GET _ml/trained_models/<model_id_or_deployment_id>,<model_id_2_or_deployment_id2>/_stats` +
 
-`GET _ml/trained_models/<model_id_pattern*>,<model_id_2>/_stats`
-
-`GET _ml/trained_models/<deployment_id>/_stats`
+`GET _ml/trained_models/<model_id_pattern*_or_deployment_id_pattern*>,<model_id_2_or_deployment_id2>/_stats`
 
 
 [[ml-get-trained-models-stats-prereq]]
@@ -43,14 +41,12 @@ IDs, deployment IDs, or a wildcard expression.
 [[ml-get-trained-models-stats-path-params]]
 == {api-path-parms-title}
 
-`<model_id>`::
+`<model_id_or_deployment_id>`::
 (Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
-
-`<deployment_id>`::
-(Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
-
+The unique identifier of the model or the deployment. If a model has multiple 
+deployments, and the ID of one of the deployments matches the model ID, then the 
+model ID takes precedence; the results are returned for all deployments of the 
+model.
 
 [[ml-get-trained-models-stats-query-params]]
 == {api-query-parms-title}

--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -18,9 +18,9 @@ Retrieves usage information for trained models.
 
 `GET _ml/trained_models/<model_id_or_deployment_id>/_stats` +
 
-`GET _ml/trained_models/<model_id_or_deployment_id>,<model_id_2_or_deployment_id2>/_stats` +
+`GET _ml/trained_models/<model_id_or_deployment_id>,<model_id_2_or_deployment_id_2>/_stats` +
 
-`GET _ml/trained_models/<model_id_pattern*_or_deployment_id_pattern*>,<model_id_2_or_deployment_id2>/_stats`
+`GET _ml/trained_models/<model_id_pattern*_or_deployment_id_pattern*>,<model_id_2_or_deployment_id_2>/_stats`
 
 
 [[ml-get-trained-models-stats-prereq]]

--- a/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
+++ b/docs/reference/ml/trained-models/apis/get-trained-models-stats.asciidoc
@@ -22,6 +22,8 @@ Retrieves usage information for trained models.
 
 `GET _ml/trained_models/<model_id_pattern*>,<model_id_2>/_stats`
 
+`GET _ml/trained_models/<deployment_id>/_stats`
+
 
 [[ml-get-trained-models-stats-prereq]]
 == {api-prereq-title}
@@ -33,8 +35,9 @@ Requires the `monitor_ml` cluster privilege. This privilege is included in the
 [[ml-get-trained-models-stats-desc]]
 == {api-description-title}
 
-You can get usage information for multiple trained models in a single API
-request by using a comma-separated list of model IDs or a wildcard expression.
+You can get usage information for multiple trained models or trained model 
+deployments in a single API request by using a comma-separated list of model 
+IDs, deployment IDs, or a wildcard expression.
 
 
 [[ml-get-trained-models-stats-path-params]]
@@ -43,6 +46,10 @@ request by using a comma-separated list of model IDs or a wildcard expression.
 `<model_id>`::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
+
+`<deployment_id>`::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 
 [[ml-get-trained-models-stats-query-params]]
@@ -115,6 +122,9 @@ The detailed allocation state related to the nodes.
 (integer)
 The desired number of nodes for model allocation.
 ======
+
+`deployment_id`:::
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 `error_count`:::
 (integer)

--- a/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
@@ -30,8 +30,9 @@ deprecated::[8.3.0,Replaced by <<infer-trained-model>>.]
 == {api-path-parms-title}
 
 `<model_id>`::
-(Required, string)
+(Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
+
 
 [[infer-trained-model-deployment-query-params]]
 == {api-query-parms-title}

--- a/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model-deployment.asciidoc
@@ -30,9 +30,8 @@ deprecated::[8.3.0,Replaced by <<infer-trained-model>>.]
 == {api-path-parms-title}
 
 `<model_id>`::
-(Optional, string)
+(Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
-
 
 [[infer-trained-model-deployment-query-params]]
 == {api-query-parms-title}

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -33,8 +33,11 @@ directly from the {infer} cache.
 == {api-path-parms-title}
 
 `<model_id>`::
-(Required, string)
+(Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
+If you specify the `model_id` in the API call, and the model has multiple 
+deployments, a random deployment will be used. If the `model_id` matches the ID 
+of one of the deployments, that deployment will be used.
 
 `<deployment_id>`::
 (Optional, string)

--- a/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
+++ b/docs/reference/ml/trained-models/apis/infer-trained-model.asciidoc
@@ -16,6 +16,7 @@ directly from the {infer} cache.
 == {api-request-title}
 
 `POST _ml/trained_models/<model_id>/_infer`
+`POST _ml/trained_models/<deployment_id>/_infer`
 
 ////
 [[infer-trained-model-prereq]]
@@ -34,6 +35,10 @@ directly from the {infer} cache.
 `<model_id>`::
 (Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id-or-alias]
+
+`<deployment_id>`::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 [[infer-trained-model-query-params]]
 == {api-query-parms-title}

--- a/docs/reference/ml/trained-models/apis/put-trained-models-aliases.asciidoc
+++ b/docs/reference/ml/trained-models/apis/put-trained-models-aliases.asciidoc
@@ -35,8 +35,7 @@ An alias must be unique and refer to only a single trained model. However,
 you can have multiple aliases for each trained model.
 
 API Restrictions:
-+
---
+
 * You are not allowed to update an alias such that it references a different
 trained model ID and the model uses a different type of {dfanalytics}. For example,
 this situation occurs if you have a trained model for
@@ -45,7 +44,6 @@ alias from one type of trained model to another.
 * You cannot update an alias from a `pytorch` model and a {dfanalytics} model.
 * You cannot update the alias from a deployed `pytorch` model to one
 not currently deployed.
---
 
 If you use this API to update an alias and there are very few input fields in
 common between the old and new trained models for the model alias, the API

--- a/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
@@ -27,7 +27,8 @@ in an ingest pipeline or directly in the <<infer-trained-model>> API.
 
 A model can be deployed multiple times by using deployment IDs. A deployment ID 
 must be unique and should not match any other deployment ID or model ID, unless 
-it is the same as the ID of the model being deployed.  
+it is the same as the ID of the model being deployed. If `deployment_id` is not 
+set, it defaults to the `model_id`.
 
 Scaling inference performance can be achieved by setting the parameters
 `number_of_allocations` and `threads_per_allocation`.
@@ -67,6 +68,7 @@ cache, `0b` can be provided.
 `deployment_id`::
 (Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
+Defaults to `model_id`.
 
 `number_of_allocations`::
 (Optional, integer)
@@ -164,7 +166,8 @@ The API returns the following results:
 === Using deployment IDs
 
 The following example starts a new deployment for the `my_model` trained model 
-with the ID `my_model_for_ingest`. 
+with the ID `my_model_for_ingest`. The deployment ID an be used in {infer} API 
+calls or in {infer} processors.
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/start-trained-model-deployment.asciidoc
@@ -25,6 +25,10 @@ Currently only `pytorch` models are supported for deployment. Once deployed
 the model can be used by the <<inference-processor,{infer-cap} processor>>
 in an ingest pipeline or directly in the <<infer-trained-model>> API.
 
+A model can be deployed multiple times by using deployment IDs. A deployment ID 
+must be unique and should not match any other deployment ID or model ID, unless 
+it is the same as the ID of the model being deployed.  
+
 Scaling inference performance can be achieved by setting the parameters
 `number_of_allocations` and `threads_per_allocation`.
 
@@ -59,6 +63,10 @@ The inference cache size (in memory outside the JVM heap) per node for the
 model. The default value is the size of the model as reported by the
 `model_size_bytes` field in the <<get-trained-models-stats>>. To disable the
 cache, `0b` can be provided.
+
+`deployment_id`::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 `number_of_allocations`::
 (Optional, integer)
@@ -150,3 +158,24 @@ The API returns the following results:
     }
 }
 ----
+
+
+[[start-trained-model-deployment-deployment-id-example]]
+=== Using deployment IDs
+
+The following example starts a new deployment for the `my_model` trained model 
+with the ID `my_model_for_ingest`. 
+
+[source,console]
+--------------------------------------------------
+POST _ml/trained_models/my_model/deployment/_start?deployment_id=my_model_for_ingest
+--------------------------------------------------
+// TEST[skip:TBD]
+
+The `my_model` trained model can be deployed again with a different ID:
+
+[source,console]
+--------------------------------------------------
+POST _ml/trained_models/my_model/deployment/_start?deployment_id=my_model_for_search
+--------------------------------------------------
+// TEST[skip:TBD]

--- a/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
@@ -11,7 +11,7 @@ Stops a trained model deployment.
 [[stop-trained-model-deployment-request]]
 == {api-request-title}
 
-`POST _ml/trained_models/<model_id>/deployment/_stop`
+`POST _ml/trained_models/<deployment_id>/deployment/_stop`
 
 [[stop-trained-model-deployment-prereq]]
 == {api-prereq-title}
@@ -27,12 +27,8 @@ Deployment is required only for trained models that have a PyTorch `model_type`.
 [[stop-trained-model-deployment-path-params]]
 == {api-path-parms-title}
 
-`<model_id>`::
-(Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
-
 `<deployment_id>`::
-(Optional, string)
+(Required, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 
@@ -62,17 +58,7 @@ until you restart the model deployment.
 [[stop-trained-model-deployment-example]]
 == {api-examples-title}
 
-The following example stops a deployment of a
-`elastic__distilbert-base-uncased-finetuned-conll03-english` trained model:
-
-[source,console]
---------------------------------------------------
-POST _ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/_stop
---------------------------------------------------
-
-
-The following example stops the `my_model_for_search` deployment of the 
-`my_model` trained model:
+The following example stops the `my_model_for_search` deployment:
 
 [source,console]
 --------------------------------------------------

--- a/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/stop-trained-model-deployment.asciidoc
@@ -28,8 +28,12 @@ Deployment is required only for trained models that have a PyTorch `model_type`.
 == {api-path-parms-title}
 
 `<model_id>`::
-(Required, string)
+(Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
+
+`<deployment_id>`::
+(Optional, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 
 [[stop-trained-model-deployment-query-params]]
@@ -40,9 +44,9 @@ include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=allow-no-match-deployments]
 
 `force`::
-(Optional, Boolean) If true, the deployment is stopped even if it or one of its model aliases
-is referenced by ingest pipelines. You can't use these pipelines until you restart the model
-deployment.
+(Optional, Boolean) If true, the deployment is stopped even if it or one of its 
+model aliases is referenced by ingest pipelines. You can't use these pipelines 
+until you restart the model deployment.
 
 ////
 [role="child_attributes"]
@@ -55,7 +59,22 @@ deployment.
 == {api-response-codes-title}
 ////
 
-////
 [[stop-trained-model-deployment-example]]
 == {api-examples-title}
-////
+
+The following example stops a deployment of a
+`elastic__distilbert-base-uncased-finetuned-conll03-english` trained model:
+
+[source,console]
+--------------------------------------------------
+POST _ml/trained_models/elastic__distilbert-base-uncased-finetuned-conll03-english/deployment/_stop
+--------------------------------------------------
+
+
+The following example stops the `my_model_for_search` deployment of the 
+`my_model` trained model:
+
+[source,console]
+--------------------------------------------------
+POST _ml/trained_models/my_model_for_search/deployment/_stop
+--------------------------------------------------

--- a/docs/reference/ml/trained-models/apis/update-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/update-trained-model-deployment.asciidoc
@@ -14,8 +14,6 @@ beta::[]
 [[update-trained-model-deployment-request]]
 == {api-request-title}
 
-`POST _ml/trained_models/<model_id>/deployment/_update`
-
 `POST _ml/trained_models/<deployment_id>/deployment/_update`
 
 
@@ -34,9 +32,9 @@ You can either increase or decrease the number of allocations of such a deployme
 [[update-trained-model-deployments-path-parms]]
 == {api-path-parms-title}
 
-`<model_id>`::
-(Optional, string)
-include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
+`<deployment_id>`::
+(Required, string)
+include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=deployment-id]
 
 [[update-trained-model-deployment-request-body]]
 == {api-request-body-title}

--- a/docs/reference/ml/trained-models/apis/update-trained-model-deployment.asciidoc
+++ b/docs/reference/ml/trained-models/apis/update-trained-model-deployment.asciidoc
@@ -16,6 +16,8 @@ beta::[]
 
 `POST _ml/trained_models/<model_id>/deployment/_update`
 
+`POST _ml/trained_models/<deployment_id>/deployment/_update`
+
 
 [[update-trained-model-deployments-prereqs]]
 == {api-prereq-title}
@@ -33,7 +35,7 @@ You can either increase or decrease the number of allocations of such a deployme
 == {api-path-parms-title}
 
 `<model_id>`::
-(Required, string)
+(Optional, string)
 include::{es-repo-dir}/ml/ml-shared.asciidoc[tag=model-id]
 
 [[update-trained-model-deployment-request-body]]


### PR DESCRIPTION
## Overview

This PR adds documentation of the `deployment_id` parameter to the trained model API docs.