### PR TITLE
Fix SecurityNetty4HttpServerTransportTests

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -2002,4 +2002,9 @@ public abstract class ESTestCase extends LuceneTestCase {
             throw new AssertionError("unexpected", e);
         }
     }
+
+    protected static boolean isTurkishLocale() {
+        return Locale.getDefault().getLanguage().equals(new Locale("tr").getLanguage())
+            || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());
+    }
 }

--- a/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/test/IdpSamlTestCase.java
+++ b/x-pack/plugin/identity-provider/src/test/java/org/elasticsearch/xpack/idp/saml/test/IdpSamlTestCase.java
@@ -76,11 +76,6 @@ public abstract class IdpSamlTestCase extends ESTestCase {
         }
     }
 
-    private static boolean isTurkishLocale() {
-        return Locale.getDefault().getLanguage().equals(new Locale("tr").getLanguage())
-            || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());
-    }
-
     @AfterClass
     public static void restoreLocale() {
         if (restoreLocale != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/saml/SamlTestCase.java
@@ -53,11 +53,6 @@ public abstract class SamlTestCase extends ESTestCase {
         SamlUtils.initialize(logger);
     }
 
-    private static boolean isTurkishLocale() {
-        return Locale.getDefault().getLanguage().equals(new Locale("tr").getLanguage())
-            || Locale.getDefault().getLanguage().equals(new Locale("az").getLanguage());
-    }
-
     @AfterClass
     public static void restoreLocale() {
         if (restoreLocale != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -526,7 +526,7 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
 
     public void testMalformedRequestDispatchedNoAuthn() throws Exception {
         assumeTrue(
-            "This test doesn't work correctly under turkish-like locale, " + "because it uses String#toUpper() for asserted error messages",
+            "This test doesn't work correctly under turkish-like locale, because it uses String#toUpper() for asserted error messages",
             !isTurkishLocale()
         );
         final AtomicReference<Throwable> dispatchThrowableReference = new AtomicReference<>();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -527,7 +527,7 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
     public void testMalformedRequestDispatchedNoAuthn() throws Exception {
         assumeTrue(
             "This test doesn't work correctly under turkish-like locale, because it uses String#toUpper() for asserted error messages",
-            !isTurkishLocale()
+            isTurkishLocale() == false
         );
         final AtomicReference<Throwable> dispatchThrowableReference = new AtomicReference<>();
         final AtomicInteger authnInvocationCount = new AtomicInteger();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SecurityNetty4HttpServerTransportTests.java
@@ -525,6 +525,10 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
     }
 
     public void testMalformedRequestDispatchedNoAuthn() throws Exception {
+        assumeTrue(
+            "This test doesn't work correctly under turkish-like locale, " + "because it uses String#toUpper() for asserted error messages",
+            !isTurkishLocale()
+        );
         final AtomicReference<Throwable> dispatchThrowableReference = new AtomicReference<>();
         final AtomicInteger authnInvocationCount = new AtomicInteger();
         final AtomicInteger badDispatchInvocationCount = new AtomicInteger();
@@ -574,8 +578,8 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
                 EmbeddedChannel ch = new EmbeddedChannel(handler);
                 ByteBuf buf = ch.alloc().buffer();
                 ByteBufUtil.copy(AsciiString.of("This is not a valid HTTP line"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 var writeFuture = testThreadPool.generic().submit(() -> {
                     ch.writeInbound(buf);
                     ch.flushInbound();
@@ -590,8 +594,8 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
                 EmbeddedChannel ch = new EmbeddedChannel(handler);
                 ByteBuf buf = ch.alloc().buffer();
                 ByteBufUtil.copy(AsciiString.of("GET /this/is/a/valid/but/too/long/initial/line HTTP/1.1"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 var writeFuture = testThreadPool.generic().submit(() -> {
                     ch.writeInbound(buf);
                     ch.flushInbound();
@@ -606,10 +610,10 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
                 EmbeddedChannel ch = new EmbeddedChannel(handler);
                 ByteBuf buf = ch.alloc().buffer();
                 ByteBufUtil.copy(AsciiString.of("GET /url HTTP/1.1"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 ByteBufUtil.copy(AsciiString.of("Host"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 var writeFuture = testThreadPool.generic().submit(() -> {
                     ch.writeInbound(buf);
                     ch.flushInbound();
@@ -624,10 +628,10 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
                 EmbeddedChannel ch = new EmbeddedChannel(handler);
                 ByteBuf buf = ch.alloc().buffer();
                 ByteBufUtil.copy(AsciiString.of("GET /url HTTP/1.1"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 ByteBufUtil.copy(AsciiString.of("Host: this.looks.like.a.good.url.but.is.longer.than.permitted"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 var writeFuture = testThreadPool.generic().submit(() -> {
                     ch.writeInbound(buf);
                     ch.flushInbound();
@@ -642,10 +646,11 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
                 EmbeddedChannel ch = new EmbeddedChannel(handler);
                 ByteBuf buf = ch.alloc().buffer();
                 ByteBufUtil.copy(AsciiString.of("GET /url HTTP/1.1"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
-                ByteBufUtil.copy(AsciiString.of("Host: invalid host value"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
+                ByteBufUtil.copy(AsciiString.of("Host: invalid header value"), buf);
+                buf.writeByte(0x01);
+                buf.writeByte(HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 var writeFuture = testThreadPool.generic().submit(() -> {
                     ch.writeInbound(buf);
                     ch.flushInbound();
@@ -660,9 +665,9 @@ public class SecurityNetty4HttpServerTransportTests extends AbstractHttpServerTr
                 EmbeddedChannel ch = new EmbeddedChannel(handler);
                 ByteBuf buf = ch.alloc().buffer();
                 ByteBufUtil.copy(AsciiString.of("GET /url HTTP/1.1"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 ByteBufUtil.copy(AsciiString.of("Host: localhost"), buf);
-                ByteBufUtil.writeShortBE(buf, HttpConstants.LF);
+                buf.writeByte(HttpConstants.LF);
                 testThreadPool.generic().submit(() -> {
                     ch.writeInbound(buf);
                     ch.flushInbound();


### PR DESCRIPTION
Skips SecurityNetty4HttpServerTransportTests
testMalformedRequestDispatchedNoAuthn
under turkish-like locales because the asserted
messages are internally processed with
`String#toUpper()`. This results in different
error messages under such locales, and it's
easier to skip the test entirely than to assert
the different messages.

Closes: https://github.com/elastic/elasticsearch/issues/95983