### PR TITLE
Make periodic refresh async

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -15,6 +15,7 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -927,7 +928,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         if (indexSettings.getRefreshInterval().millis() > 0 || force) {
             for (IndexShard shard : this.shards.values()) {
                 try {
-                    shard.scheduledRefresh();
+                    shard.scheduledRefresh(ActionListener.noop());
                 } catch (IndexShardClosedException | AlreadyClosedException ex) {
                     // fine - continue;
                 }

--- a/server/src/main/java/org/elasticsearch/index/IndexService.java
+++ b/server/src/main/java/org/elasticsearch/index/IndexService.java
@@ -15,7 +15,6 @@ import org.apache.lucene.search.Sort;
 import org.apache.lucene.store.AlreadyClosedException;
 import org.apache.lucene.store.Directory;
 import org.apache.lucene.util.Accountable;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.IndexNameExpressionResolver;
@@ -928,7 +927,7 @@ public class IndexService extends AbstractIndexComponent implements IndicesClust
         if (indexSettings.getRefreshInterval().millis() > 0 || force) {
             for (IndexShard shard : this.shards.values()) {
                 try {
-                    shard.scheduledRefresh(ActionListener.noop());
+                    shard.scheduledRefresh();
                 } catch (IndexShardClosedException | AlreadyClosedException ex) {
                     // fine - continue;
                 }

--- a/server/src/main/java/org/elasticsearch/index/engine/Engine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Engine.java
@@ -1041,11 +1041,10 @@ public abstract class Engine implements Closeable {
     }
 
     /**
-     * Synchronously refreshes the engine for new search operations to reflect the latest
+     * Refreshes the engine for new search operations to reflect the latest
      * changes unless another thread is already refreshing the engine concurrently.
      */
-    @Nullable
-    public abstract RefreshResult maybeRefresh(String source) throws EngineException;
+    public abstract void maybeRefresh(String source, ActionListener<RefreshResult> listener);
 
     /**
      * Called when our engine is using too much heap and should move buffered indexed/deleted documents to disk.

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1925,8 +1925,8 @@ public class InternalEngine extends Engine {
     }
 
     @Override
-    public RefreshResult maybeRefresh(String source) throws EngineException {
-        return refresh(source, SearcherScope.EXTERNAL, false);
+    public void maybeRefresh(String source, ActionListener<RefreshResult> listener) {
+        externalRefresh(source, false, listener);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/InternalEngine.java
@@ -1929,6 +1929,18 @@ public class InternalEngine extends Engine {
         return refresh(source, SearcherScope.EXTERNAL, false);
     }
 
+    @Override
+    public void externalRefresh(String source, ActionListener<RefreshResult> listener) {
+        externalRefresh(source, true, listener);
+    }
+
+    protected void externalRefresh(String source, boolean block, ActionListener<Engine.RefreshResult> listener) {
+        ActionListener.completeWith(listener, () -> {
+            logger.trace("external refresh with source [{}]", source);
+            return refresh(source, SearcherScope.EXTERNAL, block);
+        });
+    }
+
     final RefreshResult refresh(String source, SearcherScope scope, boolean block) throws EngineException {
         // both refresh types will result in an internal refresh but only the external will also
         // pass the new reader reference to the external reader manager.

--- a/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/ReadOnlyEngine.java
@@ -429,8 +429,8 @@ public class ReadOnlyEngine extends Engine {
     }
 
     @Override
-    public RefreshResult maybeRefresh(String source) throws EngineException {
-        return RefreshResult.NO_REFRESH;
+    public void maybeRefresh(String source, ActionListener<RefreshResult> listener) {
+        listener.onResponse(RefreshResult.NO_REFRESH);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3737,10 +3737,15 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
                 logger.trace("refresh with source [schedule]");
                 getEngine().maybeRefresh("schedule", listener);
             }
-        } else {
-            getEngine().maybePruneDeletes(); // try to prune the deletes in the engine if we accumulated some
-            listener.onResponse(Engine.RefreshResult.NO_REFRESH);
+            return;
         }
+        final Engine engine = getEngine();
+        engine.maybePruneDeletes(); // try to prune the deletes in the engine if we accumulated some
+        listener.onResponse(Engine.RefreshResult.NO_REFRESH);
+    }
+
+    public void scheduledRefresh() {
+        scheduledRefresh(ActionListener.noop());
     }
 
     /**


### PR DESCRIPTION
A continuation of https://github.com/elastic/elasticsearch/pull/95869 and https://github.com/elastic/elasticsearch/pull/95940 that allows using `externalRefresh` for the periodic refreshes.

Relates ES-6047