### PR TITLE
Modularize Node Shutdown plugin

### DIFF
--- a/x-pack/plugin/shutdown/src/main/java/module-info.java
+++ b/x-pack/plugin/shutdown/src/main/java/module-info.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module org.elasticsearch.shutdown {
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.xcontent;
+    requires org.elasticsearch.xcore;
+
+    requires org.apache.logging.log4j;
+
+    exports org.elasticsearch.xpack.shutdown;
+}


### PR DESCRIPTION
This PR updates the Node Shutdown plugin to use Java modules.

Relates https://github.com/elastic/elasticsearch/issues/78744