### PR TITLE
Address flakiness in `top_metrics.having` test

### DIFF
--- a/docs/changelog/96186.yaml
+++ b/docs/changelog/96186.yaml
@@ -1,6 +1,0 @@
-pr: 96186
-summary: Address flakiness in `top_metrics.having` test
-area: Aggregations
-type: bug
-issues:
- - 96149

--- a/docs/changelog/96186.yaml
+++ b/docs/changelog/96186.yaml
@@ -1,0 +1,6 @@
+pr: 96186
+summary: Address flakiness in `top_metrics.having` test
+area: Aggregations
+type: bug
+issues:
+ - 96149

--- a/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
+++ b/x-pack/plugin/src/yamlRestTest/resources/rest-api-spec/test/analytics/top_metrics.yml
@@ -771,14 +771,6 @@
           - { index: { } }
           - { gender: 1, salary: 2000, birth_date: 1982 }
           - { index: { } }
-          - { gender: 1, salary: 3000, birth_date: 1981 }
-          - { index: { } }
-          - { gender: 1, salary: 4000, birth_date: 1982 }
-          - { index: { } }
-          - { gender: 2, salary: 6000, birth_date: 1982 }
-          - { index: { } }
-          - { gender: 2, salary: 7000, birth_date: 1981 }
-          - { index: { } }
           - { gender: 2, salary: 8000, birth_date: 1982 }
           - { index: { } }
           - { gender: 2, salary: 9000, birth_date: 1981 }
@@ -817,7 +809,7 @@
   - match: { aggregations.groupby.buckets.0.top_salary.top.0.metrics.salary: 1000}
   - match: { aggregations.groupby.buckets.1.key.gender_comp: 2}
   - match: { aggregations.groupby.buckets.1.top_salary.top.0.sort.0: 1981}
-  - match: { aggregations.groupby.buckets.1.top_salary.top.0.metrics.salary: 7000}
+  - match: { aggregations.groupby.buckets.1.top_salary.top.0.metrics.salary: 9000}
 
   # Similar to a SQL query with HAVING clause:
   #


### PR DESCRIPTION
It's currently possible to return different results ([example](https://gradle-enterprise.elastic.co/s/cse3t6slxxcmi/tests/:x-pack:plugin:yamlRestTest/org.elasticsearch.xpack.test.rest.XPackRestIT/test%20%7Bp0=analytics%2Ftop_metrics%2Fhaving%7D?page=eyJvdXRwdXQiOnsiMCI6NX19&top-execution=1), [example](https://gradle-enterprise.elastic.co/s/6pilk27aaf3he/tests/:x-pack:plugin:yamlRestTest/org.elasticsearch.xpack.test.rest.XPackRestIT/test%20%7Bp0=analytics%2Ftop_metrics%2Fhaving%7D?top-execution=1)) that, although correct, they fail the specified matchers. Reducing the size of the input addresses flakiness.

Fixes #96149.
