### PR TITLE
Use openjdk base image for fixtures

### DIFF
--- a/test/fixtures/gcs-fixture/Dockerfile
+++ b/test/fixtures/gcs-fixture/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:20.04
-
-RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
+FROM openjdk:17.0.2
 
 ARG port
 ARG bucket

--- a/test/fixtures/s3-fixture/Dockerfile
+++ b/test/fixtures/s3-fixture/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:20.04
-
-RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
+FROM openjdk:17.0.2
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/s3-fixture/sts/Dockerfile
+++ b/test/fixtures/s3-fixture/sts/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:20.04
-
-RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
+FROM openjdk:17.0.2
 
 ARG fixtureClass
 ARG port

--- a/test/fixtures/url-fixture/Dockerfile
+++ b/test/fixtures/url-fixture/Dockerfile
@@ -1,6 +1,4 @@
-FROM ubuntu:20.04
-
-RUN apt-get update -qqy && apt-get install -qqy openjdk-17-jre-headless
+FROM openjdk:17.0.2
 
 ARG port
 ARG workingDir


### PR DESCRIPTION
No need to build our own from a full ubuntu image
when the openjdk image fully suffices.

follow up to #96156 