### PR TITLE
Simplify AbstractFileWatchingService

### DIFF
--- a/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
+++ b/server/src/main/java/org/elasticsearch/reservedstate/service/FileSettingsService.java
@@ -71,7 +71,7 @@ public class FileSettingsService extends AbstractFileWatchingService {
      * @param mdBuilder the current metadata builder for the new cluster state
      */
     public void handleSnapshotRestore(ClusterState clusterState, Metadata.Builder mdBuilder) {
-        assert currentNodeMaster(clusterState);
+        assert clusterState.nodes().isLocalNodeElectedMaster();
 
         ReservedStateMetadata fileSettingsMetadata = clusterState.metadata().reservedStateMetadata().get(NAMESPACE);
 


### PR DESCRIPTION
Just a random find from looking at a profile, shouldn't matter much but simplifies the code ...

We can use built in cluster state methods to check if we're master, also no need to repeatedly enter a synchronized method if we're not master and also were not the master in the previous state.
