### PR TITLE
[ML] Reenable model upgrade tests after pipeline parsing fix

### DIFF
--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -113,20 +113,10 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                     request.addParameter("timeout", "70s");
                 }));
 
-                // Workaround for an upgrade test failure where an ingest
-                // pipeline config cannot be parsed by older nodes:
-                // https://github.com/elastic/elasticsearch/issues/95766
-                //
-                // In version 8.3.1 ml stopped parsing the full ingest
-                // pipeline configuration so will avoid this problem.
-                // TODO remove this check once https://github.com/elastic/elasticsearch/issues/95766
-                // is resolved
-                if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_3_1)) {
-                    waitForDeploymentStarted(modelId);
-                    // attempt inference on new and old nodes multiple times
-                    for (int i = 0; i < 10; i++) {
-                        assertInfer(modelId);
-                    }
+                waitForDeploymentStarted(modelId);
+                // attempt inference on new and old nodes multiple times
+                for (int i = 0; i < 10; i++) {
+                    assertInfer(modelId);
                 }
             }
             case UPGRADED -> {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
@@ -75,18 +75,8 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
                 }));
                 List<String> modelIds = getTrainedModels();
 
-                // Workaround for an upgrade test failure where an ingest
-                // pipeline config cannot be parsed by older nodes:
-                // https://github.com/elastic/elasticsearch/issues/95766
-                //
-                // In version 8.3.1 ml stopped parsing the full ingest
-                // pipeline configuration so will avoid this problem.
-                // TODO remove this check once https://github.com/elastic/elasticsearch/issues/95766
-                // is resolved
-                if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_3_1)) {
-                    // Test that stats are serializable and can be gathered
-                    getTrainedModelStats();
-                }
+                // Test that stats are serializable and can be gathered
+                getTrainedModelStats();
                 // Verify that the pipelines still work and inference is possible
                 testInfer(modelIds);
             }


### PR DESCRIPTION
Now that #95766 is resolved the work around add in #95778 can be removed.