### PR TITLE
Fix vector fields javadocs

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnByteVectorField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnByteVectorField.java
@@ -8,17 +8,16 @@
 
 package org.elasticsearch.index.mapper.vectors;
 
-/**
- * This class extends {@link org.apache.lucene.document.KnnByteVectorField}
- * with a single goal to override the Lucene's limit of max vector dimensions,
- * and set it to {@link org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMENSIONS}
- */
-
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnByteVectorField;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
+/**
+ * This class extends {@link org.apache.lucene.document.KnnByteVectorField}
+ * with a single goal to override the Lucene's limit of max vector dimensions,
+ * and set it to {@link org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper#MAX_DIMS_COUNT}
+ */
 public class XKnnByteVectorField extends KnnByteVectorField {
 
     private static FieldType createType(byte[] v, VectorSimilarityFunction similarityFunction) {

--- a/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnFloatVectorField.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/vectors/XKnnFloatVectorField.java
@@ -8,17 +8,16 @@
 
 package org.elasticsearch.index.mapper.vectors;
 
-/**
- * This class extends {@link org.apache.lucene.document.KnnFloatVectorField}
- * with a single goal to override the Lucene's limit of max vector dimensions,
- * and set it to {@link org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper.MAX_DIMENSIONS}
- */
-
 import org.apache.lucene.document.FieldType;
 import org.apache.lucene.document.KnnFloatVectorField;
 import org.apache.lucene.index.VectorEncoding;
 import org.apache.lucene.index.VectorSimilarityFunction;
 
+/**
+ * This class extends {@link org.apache.lucene.document.KnnFloatVectorField}
+ * with a single goal to override the Lucene's limit of max vector dimensions,
+ * and set it to {@link org.elasticsearch.index.mapper.vectors.DenseVectorFieldMapper#MAX_DIMS_COUNT}
+ */
 public class XKnnFloatVectorField extends KnnFloatVectorField {
     private static FieldType createType(float[] v, VectorSimilarityFunction similarityFunction) {
         if (v == null) {


### PR DESCRIPTION
Javadocs is dangling before the imports, and has a wrong link to the max number of dimensions limit. This commit fixes both issues.