### PR TITLE
[Search Applications] Support arrays in stored mustache templates 

### DIFF
--- a/docs/changelog/96197.yaml
+++ b/docs/changelog/96197.yaml
@@ -1,0 +1,5 @@
+pr: 96197
+summary: "[Search Applications] Support arrays in stored mustache templates"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -43,12 +43,31 @@ setup:
                 field_value: value1
             dictionary:
               additionalProperties: false
-              required: [ "field_name" ]
+              required: [ "text_fields" ]
               properties:
                 field_name:
                   type: string
                 field_value:
                   type: string
+
+  - do:
+      search_application.put:
+        name: another-test-search-application
+        body:
+          indices: [ "test-search-index1", "test-search-index2" ]
+          template:
+            script:
+              source: "{ \"query\": { \"multi_match\":{ \"query\": \"{{query_string}}\", \"fields\": [{{#text_fields}}\"{{name}}^{{boost}}\",{{/text_fields}}] } } }"
+              params:
+                query_string: "elastic"
+                text_fields:
+                  - name: field1
+                    boost: 1
+                  - name: field2
+                    boost: 2
+                  - name: field3
+                    boost: 3
+              lang: "mustache"
 
   - do:
       index:
@@ -140,6 +159,32 @@ teardown:
           params:
             field_name: field3
             field_value: value3
+
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._id: "doc2" }
+
+---
+"Query Search Application with list of parameters":
+  - skip:
+      features: headers
+      version: all
+      reason: "AwaitsFix https://github.com/elastic/enterprise-search-team/issues/4540"
+
+  - do:
+      headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
+      search_application.search:
+        name: test-search-application-with-list
+        body:
+          params:
+            query_string: elastic
+            text_fields:
+              - name: field1
+                boost: 1
+              - name: field2
+                boost: 2
+              - name: field3
+                boost: 3
 
 
   - match: { hits.total.value: 1 }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/55_search_application_search.yml
@@ -43,7 +43,7 @@ setup:
                 field_value: value1
             dictionary:
               additionalProperties: false
-              required: [ "text_fields" ]
+              required: [ "field_name" ]
               properties:
                 field_name:
                   type: string

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationTemplateService.java
@@ -43,8 +43,9 @@ public class SearchApplicationTemplateService {
         template.validateTemplateParams(templateParams);
         final Map<String, Object> renderedTemplateParams = renderTemplate(searchApplication, templateParams);
         final Script script = template.script();
+
         TemplateScript compiledTemplate = scriptService.compile(script, TemplateScript.CONTEXT).newInstance(renderedTemplateParams);
-        String requestSource = compiledTemplate.execute();
+        final String requestSource = SearchTemplateHelper.stripTrailingComma(compiledTemplate.execute());
         XContentParserConfiguration parserConfig = XContentParserConfiguration.EMPTY.withRegistry(xContentRegistry)
             .withDeprecationHandler(LoggingDeprecationHandler.INSTANCE);
         try (XContentParser parser = XContentFactory.xContent(XContentType.JSON).createParser(parserConfig, requestSource)) {


### PR DESCRIPTION
Followup to https://github.com/elastic/elasticsearch/pull/95200 

Supports mustache templates with commas, without having workarounds in order to produce valid JSON query DSL. 