### PR TITLE
[8.8] [DOCS] Removes metadata tags from ELSER tutorial. (#96200)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -4,9 +4,6 @@
 <titleabbrev>Semantic search with ELSER</titleabbrev>
 ++++
 
-:keywords: {ml-init}, {stack}, {nlp}, ELSER
-:description: ELSER is a learned sparse ranking model trained by Elastic.
-
 Elastic Learned Sparse EncodeR - or ELSER - is an NLP model trained by Elastic 
 that enables you to perform semantic search by using sparse vector 
 representation. Instead of literal matching on search terms, semantic search 


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Removes metadata tags from ELSER tutorial. (#96200)