### PR TITLE
Small optimization of the looping in ingest's remove processor

### DIFF
--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java
@@ -58,9 +58,13 @@ public final class RemoveProcessor extends AbstractProcessor {
 
     private void fieldsToRemoveProcessor(IngestDocument document) {
         if (ignoreMissing) {
-            fieldsToRemove.forEach(field -> removeWhenPresent(document, document.renderTemplate(field)));
+            for (TemplateScript.Factory field : fieldsToRemove) {
+                removeWhenPresent(document, document.renderTemplate(field));
+            }
         } else {
-            fieldsToRemove.forEach(document::removeField);
+            for (TemplateScript.Factory field : fieldsToRemove) {
+                document.removeField(field);
+            }
         }
     }
 

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/RemoveProcessor.java
@@ -57,6 +57,7 @@ public final class RemoveProcessor extends AbstractProcessor {
     }
 
     private void fieldsToRemoveProcessor(IngestDocument document) {
+        // micro-optimization note: actual for-each loops here rather than a .forEach because it happens to be ~5% faster in benchmarks
         if (ignoreMissing) {
             for (TemplateScript.Factory field : fieldsToRemove) {
                 removeWhenPresent(document, document.renderTemplate(field));


### PR DESCRIPTION
The literal for-each JITs better than the logical `.forEach` with a lambda. This change by itself is giving me a 5% improvement in `remove` processor performance when I run the nightly Logging benchmark.

Here's a flamegraph of the original:

![Screen Shot 2023-05-17 at 11 41 04 AM](https://github.com/elastic/elasticsearch/assets/187034/a8746ddd-82d6-4270-b9f4-fd6ad1d8e4de)

Here's a flamegraph of the new:

![Screen Shot 2023-05-17 at 11 41 23 AM](https://github.com/elastic/elasticsearch/assets/187034/e164dc30-6c08-4d99-9e89-f18753ce58f4)