### PR TITLE
Add a 'between' method to TransportVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -247,6 +247,11 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
         return version.id >= id;
     }
 
+    public boolean between(TransportVersion lowerInclusive, TransportVersion upperExclusive) {
+        if (upperExclusive.onOrBefore(lowerInclusive)) throw new IllegalArgumentException();
+        return onOrAfter(lowerInclusive) && before(upperExclusive);
+    }
+
     public static TransportVersion fromString(String str) {
         return TransportVersion.fromId(Integer.parseInt(str));
     }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplate.java
@@ -401,7 +401,7 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
             } else {
                 allowCustomRouting = false;
             }
-            if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0) && in.getTransportVersion().before(TransportVersion.V_8_3_0)) {
+            if (in.getTransportVersion().between(TransportVersion.V_8_1_0, TransportVersion.V_8_3_0)) {
                 // Accidentally included index_mode to binary node to node protocol in previous releases.
                 // (index_mode is removed and was part of code based when tsdb was behind a feature flag)
                 // (index_mode was behind a feature in the xcontent parser, so it could never actually used)
@@ -447,8 +447,7 @@ public class ComposableIndexTemplate implements SimpleDiffable<ComposableIndexTe
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)) {
                 out.writeBoolean(allowCustomRouting);
             }
-            if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0)
-                && out.getTransportVersion().before(TransportVersion.V_8_3_0)) {
+            if (out.getTransportVersion().between(TransportVersion.V_8_1_0, TransportVersion.V_8_3_0)) {
                 // See comment in constructor.
                 out.writeBoolean(false);
             }

--- a/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
+++ b/server/src/main/java/org/elasticsearch/search/DocValueFormat.java
@@ -241,7 +241,7 @@ public interface DocValueFormat extends NamedWriteable {
             this.formatter = DateFormatter.forPattern(formatterPattern).withZone(this.timeZone);
             this.parser = formatter.toDateMathParser();
             this.resolution = DateFieldMapper.Resolution.ofOrdinal(in.readVInt());
-            if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_7_0) && in.getTransportVersion().before(TransportVersion.V_8_0_0)) {
+            if (in.getTransportVersion().between(TransportVersion.V_7_7_0, TransportVersion.V_8_0_0)) {
                 /* when deserialising from 7.7+ nodes expect a flag indicating if a pattern is of joda style
                    This is only used to support joda style indices in 7.x, in 8 we no longer support this.
                    All indices in 8 should use java style pattern. Hence we can ignore this flag.
@@ -265,8 +265,7 @@ public interface DocValueFormat extends NamedWriteable {
             out.writeString(formatter.pattern());
             out.writeString(timeZone.getId());
             out.writeVInt(resolution.ordinal());
-            if (out.getTransportVersion().onOrAfter(TransportVersion.V_7_7_0)
-                && out.getTransportVersion().before(TransportVersion.V_8_0_0)) {
+            if (out.getTransportVersion().between(TransportVersion.V_7_7_0, TransportVersion.V_8_0_0)) {
                 /* when serializing to 7.7+  send out a flag indicating if a pattern is of joda style
                    This is only used to support joda style indices in 7.x, in 8 we no longer support this.
                    All indices in 8 should use java style pattern. Hence this flag is always false.

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/protocol/xpack/XPackInfoRequest.java
@@ -97,6 +97,6 @@ public class XPackInfoRequest extends ActionRequest {
     }
 
     private static boolean hasLicenseVersionField(TransportVersion streamVersion) {
-        return streamVersion.onOrAfter(TransportVersion.V_7_8_1) && streamVersion.before(TransportVersion.V_8_0_0);
+        return streamVersion.between(TransportVersion.V_7_8_1, TransportVersion.V_8_0_0);
     }
 }


### PR DESCRIPTION
Add a between method to easily determine if a transport version is in a range