### PR TITLE
Stop creating multi value metric aggregations with no values

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractHDRPercentilesAggregator.java
@@ -10,7 +10,6 @@ package org.elasticsearch.search.aggregations.metrics;
 
 import org.HdrHistogram.DoubleHistogram;
 import org.apache.lucene.search.ScoreMode;
-import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasables;
@@ -22,15 +21,12 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
 abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
-
-    private static int indexOfKey(double[] keys, double key) {
-        return ArrayUtils.binarySearch(keys, key, 0.001);
-    }
 
     protected final double[] keys;
     protected final ValuesSource valuesSource;
@@ -41,7 +37,7 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
 
     AbstractHDRPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] keys,
@@ -51,7 +47,8 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = valuesSource;
+        assert config.hasValues();
+        this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.format = formatter;
         this.states = context.bigArrays().newObjectArray(1);
@@ -61,14 +58,11 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues values = ((ValuesSource.Numeric) valuesSource).doubleValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override
@@ -105,7 +99,7 @@ abstract class AbstractHDRPercentilesAggregator extends NumericMetricsAggregator
 
     @Override
     public boolean hasMetric(String name) {
-        return indexOfKey(keys, Double.parseDouble(name)) >= 0;
+        return PercentilesConfig.indexOfKey(keys, Double.parseDouble(name)) >= 0;
     }
 
     protected DoubleHistogram getState(long bucketOrd) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -27,10 +27,6 @@ import java.util.Map;
 
 abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
 
-    // private static int indexOfKey(double[] keys, double key) {
-    // return ArrayUtils.binarySearch(keys, key, 0.001);
-    // }
-
     protected final double[] keys;
     protected final ValuesSource valuesSource;
     protected final DocValueFormat formatter;

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractTDigestPercentilesAggregator.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.search.aggregations.metrics;
 
 import org.apache.lucene.search.ScoreMode;
-import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasables;
@@ -21,15 +20,16 @@ import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
 
 abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
 
-    private static int indexOfKey(double[] keys, double key) {
-        return ArrayUtils.binarySearch(keys, key, 0.001);
-    }
+    // private static int indexOfKey(double[] keys, double key) {
+    // return ArrayUtils.binarySearch(keys, key, 0.001);
+    // }
 
     protected final double[] keys;
     protected final ValuesSource valuesSource;
@@ -40,7 +40,7 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
 
     AbstractTDigestPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] keys,
@@ -50,7 +50,8 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = valuesSource;
+        assert config.hasValues();
+        this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.formatter = formatter;
         this.states = context.bigArrays().newObjectArray(1);
@@ -60,14 +61,11 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues values = ((ValuesSource.Numeric) valuesSource).doubleValues(aggCtx.getLeafReaderContext());
         return new LeafBucketCollectorBase(sub, values) {
             @Override
@@ -95,7 +93,7 @@ abstract class AbstractTDigestPercentilesAggregator extends NumericMetricsAggreg
 
     @Override
     public boolean hasMetric(String name) {
-        return indexOfKey(keys, Double.parseDouble(name)) >= 0;
+        return PercentilesConfig.indexOfKey(keys, Double.parseDouble(name)) >= 0;
     }
 
     protected TDigestState getState(long bucketOrd) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -45,41 +45,36 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     ExtendedStatsAggregator(
         String name,
-        ValuesSourceConfig valuesSourceConfig,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double sigma,
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop depending on nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
-        this.format = valuesSourceConfig.format();
+        assert config.hasValues();
+        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
+        this.format = config.format();
         this.sigma = sigma;
-        if (valuesSource != null) {
-            final BigArrays bigArrays = context.bigArrays();
-            counts = bigArrays.newLongArray(1, true);
-            sums = bigArrays.newDoubleArray(1, true);
-            compensations = bigArrays.newDoubleArray(1, true);
-            mins = bigArrays.newDoubleArray(1, false);
-            mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-            maxes = bigArrays.newDoubleArray(1, false);
-            maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-            sumOfSqrs = bigArrays.newDoubleArray(1, true);
-            compensationOfSqrs = bigArrays.newDoubleArray(1, true);
-        }
+        final BigArrays bigArrays = context.bigArrays();
+        counts = bigArrays.newLongArray(1, true);
+        sums = bigArrays.newDoubleArray(1, true);
+        compensations = bigArrays.newDoubleArray(1, true);
+        mins = bigArrays.newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+        maxes = bigArrays.newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+        sumOfSqrs = bigArrays.newDoubleArray(1, true);
+        compensationOfSqrs = bigArrays.newDoubleArray(1, true);
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
         final CompensatedSum compensatedSum = new CompensatedSum(0, 0);
         final CompensatedSum compensatedSumOfSqr = new CompensatedSum(0, 0);
@@ -138,17 +133,12 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public boolean hasMetric(String name) {
-        try {
-            InternalExtendedStats.Metrics.resolve(name);
-            return true;
-        } catch (IllegalArgumentException iae) {
-            return false;
-        }
+        return InternalStats.Metrics.hasMetric(name);
     }
 
     @Override
     public double metric(String name, long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= counts.size()) {
+        if (owningBucketOrd >= counts.size()) {
             return switch (InternalExtendedStats.Metrics.resolve(name)) {
                 case count -> 0;
                 case sum -> 0;
@@ -208,7 +198,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= counts.size()) {
+        if (bucket >= counts.size()) {
             return buildEmptyAggregation();
         }
         return new InternalExtendedStats(
@@ -226,7 +216,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, sigma, format, metadata());
+        return InternalExtendedStats.empty(name, sigma, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregator.java
@@ -133,7 +133,7 @@ class ExtendedStatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public boolean hasMetric(String name) {
-        return InternalStats.Metrics.hasMetric(name);
+        return InternalExtendedStats.Metrics.hasMetric(name);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/ExtendedStatsAggregatorFactory.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
@@ -53,7 +54,9 @@ class ExtendedStatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new ExtendedStatsAggregator(name, config, context, parent, sigma, metadata);
+        final InternalExtendedStats empty = InternalExtendedStats.empty(name, sigma, config.format(), metadata);
+        final Predicate<String> hasMetric = InternalExtendedStats.Metrics::hasMetric;
+        return new NonCollectingMultiMetricAggregator(name, context, parent, empty, hasMetric, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentileRanksAggregator.java
@@ -12,7 +12,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -21,7 +21,7 @@ class HDRPercentileRanksAggregator extends AbstractHDRPercentilesAggregator {
 
     HDRPercentileRanksAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -30,7 +30,7 @@ class HDRPercentileRanksAggregator extends AbstractHDRPercentilesAggregator {
         DocValueFormat format,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, format, metadata);
+        super(name, config, context, parent, percents, numberOfSignificantValueDigits, keyed, format, metadata);
     }
 
     @Override
@@ -45,7 +45,7 @@ class HDRPercentileRanksAggregator extends AbstractHDRPercentilesAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalHDRPercentileRanks(name, keys, null, keyed, format, metadata());
+        return InternalHDRPercentileRanks.empty(name, keys, keyed, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/HDRPercentilesAggregator.java
@@ -12,7 +12,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -21,7 +21,7 @@ class HDRPercentilesAggregator extends AbstractHDRPercentilesAggregator {
 
     HDRPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -30,7 +30,7 @@ class HDRPercentilesAggregator extends AbstractHDRPercentilesAggregator {
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, formatter, metadata);
+        super(name, config, context, parent, percents, numberOfSignificantValueDigits, keyed, formatter, metadata);
     }
 
     @Override
@@ -55,6 +55,6 @@ class HDRPercentilesAggregator extends AbstractHDRPercentilesAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalHDRPercentiles(name, keys, null, keyed, format, metadata());
+        return InternalHDRPercentiles.empty(name, keys, keyed, format, metadata());
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalExtendedStats.java
@@ -49,6 +49,15 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
         public static Metrics resolve(String name) {
             return Metrics.valueOf(name);
         }
+
+        public static boolean hasMetric(String name) {
+            try {
+                InternalExtendedStats.Metrics.resolve(name);
+                return true;
+            } catch (IllegalArgumentException iae) {
+                return false;
+            }
+        }
     }
 
     static final Set<String> METRIC_NAMES = Collections.unmodifiableSet(
@@ -92,6 +101,10 @@ public class InternalExtendedStats extends InternalStats implements ExtendedStat
     @Override
     public String getWriteableName() {
         return ExtendedStatsAggregationBuilder.NAME;
+    }
+
+    static InternalExtendedStats empty(String name, double sigma, DocValueFormat format, Map<String, Object> metadata) {
+        return new InternalExtendedStats(name, 0, 0d, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0d, sigma, format, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentileRanks.java
@@ -41,6 +41,16 @@ public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles i
         return NAME;
     }
 
+    public static InternalHDRPercentileRanks empty(
+        String name,
+        double[] keys,
+        boolean keyed,
+        DocValueFormat format,
+        Map<String, Object> metadata
+    ) {
+        return new InternalHDRPercentileRanks(name, keys, null, keyed, format, metadata);
+    }
+
     @Override
     public Iterator<Percentile> iterator() {
         return new Iter(keys, state);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentiles.java
@@ -41,6 +41,16 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
         return NAME;
     }
 
+    public static InternalHDRPercentiles empty(
+        String name,
+        double[] keys,
+        boolean keyed,
+        DocValueFormat format,
+        Map<String, Object> metadata
+    ) {
+        return new InternalHDRPercentiles(name, keys, null, keyed, format, metadata);
+    }
+
     @Override
     public Iterator<Percentile> iterator() {
         return new Iter(keys, state);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalStats.java
@@ -36,6 +36,15 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
         public static Metrics resolve(String name) {
             return Metrics.valueOf(name);
         }
+
+        public static boolean hasMetric(String name) {
+            try {
+                InternalStats.Metrics.resolve(name);
+                return true;
+            } catch (IllegalArgumentException iae) {
+                return false;
+            }
+        }
     }
 
     static final Set<String> METRIC_NAMES = Collections.unmodifiableSet(
@@ -89,6 +98,10 @@ public class InternalStats extends InternalNumericMetricsAggregation.MultiValue 
     @Override
     public String getWriteableName() {
         return StatsAggregationBuilder.NAME;
+    }
+
+    static InternalStats empty(String name, DocValueFormat format, Map<String, Object> metadata) {
+        return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, format, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
@@ -40,6 +40,17 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
         return NAME;
     }
 
+    public static InternalTDigestPercentileRanks empty(
+        String name,
+        double[] keys,
+        double compression,
+        boolean keyed,
+        DocValueFormat format,
+        Map<String, Object> metadata
+    ) {
+        return InternalTDigestPercentileRanks.empty(name, keys, compression, keyed, format, metadata);
+    }
+
     @Override
     public Iterator<Percentile> iterator() {
         return new Iter(keys, state);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
@@ -48,7 +48,7 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
         DocValueFormat format,
         Map<String, Object> metadata
     ) {
-        return InternalTDigestPercentileRanks.empty(name, keys, compression, keyed, format, metadata);
+        return new InternalTDigestPercentileRanks(name, keys, new TDigestState(compression), keyed, format, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -40,6 +40,16 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
         return NAME;
     }
 
+    public static InternalTDigestPercentiles empty(
+        String name,
+        double[] keys,
+        boolean keyed,
+        DocValueFormat format,
+        Map<String, Object> metadata
+    ) {
+        return new InternalTDigestPercentiles(name, keys, null, keyed, format, metadata);
+    }
+
     @Override
     public Iterator<Percentile> iterator() {
         return new Iter(keys, state);

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NonCollectingMultiMetricAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/NonCollectingMultiMetricAggregator.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.aggregations.metrics;
+
+import org.elasticsearch.search.aggregations.AggregationExecutionContext;
+import org.elasticsearch.search.aggregations.Aggregator;
+import org.elasticsearch.search.aggregations.InternalAggregation;
+import org.elasticsearch.search.aggregations.LeafBucketCollector;
+import org.elasticsearch.search.aggregations.support.AggregationContext;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.function.Predicate;
+
+/**
+ * An {@link SingleValue} that is not collected, this can typically be used when running
+ * an aggregation over a field that doesn't have a mapping.
+ *
+ * see {@link org.elasticsearch.search.aggregations.NonCollectingAggregator}
+ */
+public final class NonCollectingMultiMetricAggregator extends NumericMetricsAggregator.MultiValue {
+
+    private final InternalNumericMetricsAggregation.MultiValue emptyAggregation;
+    private final Predicate<String> hasMetric;
+
+    /**
+     * Build a {@linkplain NonCollectingMultiMetricAggregator} for {@link SingleValue} aggregators.
+     */
+    public NonCollectingMultiMetricAggregator(
+        String name,
+        AggregationContext context,
+        Aggregator parent,
+        InternalNumericMetricsAggregation.MultiValue emptyAggregation,
+        Predicate<String> hasMetric,
+        Map<String, Object> metadata
+    ) throws IOException {
+        super(name, context, parent, metadata);
+        this.emptyAggregation = emptyAggregation;
+        this.hasMetric = hasMetric;
+    }
+
+    @Override
+    public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, LeafBucketCollector sub) {
+        // the framework will automatically eliminate it
+        return LeafBucketCollector.NO_OP_COLLECTOR;
+    }
+
+    @Override
+    public InternalAggregation buildAggregation(long owningBucketOrd) throws IOException {
+        return buildEmptyAggregation();
+    }
+
+    @Override
+    public InternalAggregation buildEmptyAggregation() {
+        return emptyAggregation;
+    }
+
+    @Override
+    public boolean hasMetric(String name) {
+        return hasMetric.test(name);
+    }
+
+    @Override
+    public double metric(String name, long owningBucketOrd) {
+        return emptyAggregation.value(name);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregatorSupplier.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesAggregatorSupplier.java
@@ -10,7 +10,7 @@ package org.elasticsearch.search.aggregations.metrics;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -18,7 +18,7 @@ import java.util.Map;
 public interface PercentilesAggregatorSupplier {
     Aggregator build(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregator.java
@@ -37,38 +37,28 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
     DoubleArray mins;
     DoubleArray maxes;
 
-    StatsAggregator(
-        String name,
-        ValuesSourceConfig valuesSourceConfig,
-        AggregationContext context,
-        Aggregator parent,
-        Map<String, Object> metadata
-    ) throws IOException {
+    StatsAggregator(String name, ValuesSourceConfig config, AggregationContext context, Aggregator parent, Map<String, Object> metadata)
+        throws IOException {
         super(name, context, parent, metadata);
-        // TODO: stop using nulls here
-        this.valuesSource = valuesSourceConfig.hasValues() ? (ValuesSource.Numeric) valuesSourceConfig.getValuesSource() : null;
-        if (valuesSource != null) {
-            counts = bigArrays().newLongArray(1, true);
-            sums = bigArrays().newDoubleArray(1, true);
-            compensations = bigArrays().newDoubleArray(1, true);
-            mins = bigArrays().newDoubleArray(1, false);
-            mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
-            maxes = bigArrays().newDoubleArray(1, false);
-            maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
-        }
-        this.format = valuesSourceConfig.format();
+        assert config.hasValues();
+        this.valuesSource = (ValuesSource.Numeric) config.getValuesSource();
+        counts = bigArrays().newLongArray(1, true);
+        sums = bigArrays().newDoubleArray(1, true);
+        compensations = bigArrays().newDoubleArray(1, true);
+        mins = bigArrays().newDoubleArray(1, false);
+        mins.fill(0, mins.size(), Double.POSITIVE_INFINITY);
+        maxes = bigArrays().newDoubleArray(1, false);
+        maxes.fill(0, maxes.size(), Double.NEGATIVE_INFINITY);
+        this.format = config.format();
     }
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final SortedNumericDoubleValues values = valuesSource.doubleValues(aggCtx.getLeafReaderContext());
         final CompensatedSum kahanSummation = new CompensatedSum(0, 0);
 
@@ -115,17 +105,12 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public boolean hasMetric(String name) {
-        try {
-            InternalStats.Metrics.resolve(name);
-            return true;
-        } catch (IllegalArgumentException iae) {
-            return false;
-        }
+        return InternalStats.Metrics.hasMetric(name);
     }
 
     @Override
     public double metric(String name, long owningBucketOrd) {
-        if (valuesSource == null || owningBucketOrd >= counts.size()) {
+        if (owningBucketOrd >= counts.size()) {
             return switch (InternalStats.Metrics.resolve(name)) {
                 case count -> 0;
                 case sum -> 0;
@@ -145,7 +130,7 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public InternalAggregation buildAggregation(long bucket) {
-        if (valuesSource == null || bucket >= sums.size()) {
+        if (bucket >= sums.size()) {
             return buildEmptyAggregation();
         }
         return new InternalStats(name, counts.get(bucket), sums.get(bucket), mins.get(bucket), maxes.get(bucket), format, metadata());
@@ -153,7 +138,7 @@ class StatsAggregator extends NumericMetricsAggregator.MultiValue {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalStats(name, 0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, format, metadata());
+        return InternalStats.empty(name, format, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorFactory.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/StatsAggregatorFactory.java
@@ -21,6 +21,7 @@ import org.elasticsearch.search.aggregations.support.ValuesSourceRegistry;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 class StatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
@@ -51,7 +52,9 @@ class StatsAggregatorFactory extends ValuesSourceAggregatorFactory {
 
     @Override
     protected Aggregator createUnmapped(Aggregator parent, Map<String, Object> metadata) throws IOException {
-        return new StatsAggregator(name, config, context, parent, metadata);
+        final InternalStats empty = InternalStats.empty(name, config.format(), metadata);
+        final Predicate<String> hasMetric = InternalStats.Metrics::hasMetric;
+        return new NonCollectingMultiMetricAggregator(name, context, parent, empty, hasMetric, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
@@ -44,7 +44,7 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTDigestPercentileRanks(name, keys, new TDigestState(compression), keyed, formatter, metadata());
+        return InternalTDigestPercentileRanks.empty(name, keys, compression, keyed, formatter, metadata());
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentileRanksAggregator.java
@@ -11,7 +11,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -20,7 +20,7 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
 
     TDigestPercentileRanksAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -29,7 +29,7 @@ class TDigestPercentileRanksAggregator extends AbstractTDigestPercentilesAggrega
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, metadata);
+        super(name, config, context, parent, percents, compression, keyed, formatter, metadata);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/TDigestPercentilesAggregator.java
@@ -11,7 +11,7 @@ import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -20,7 +20,7 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
 
     TDigestPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -29,7 +29,7 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, metadata);
+        super(name, config, context, parent, percents, compression, keyed, formatter, metadata);
     }
 
     @Override
@@ -54,6 +54,6 @@ class TDigestPercentilesAggregator extends AbstractTDigestPercentilesAggregator 
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTDigestPercentiles(name, keys, null, keyed, formatter, metadata());
+        return InternalTDigestPercentiles.empty(name, keys, keyed, formatter, metadata());
     }
 }

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/AnalyticsAggregatorFactory.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/AnalyticsAggregatorFactory.java
@@ -37,12 +37,12 @@ public class AnalyticsAggregatorFactory {
         builder.register(
             PercentilesAggregationBuilder.REGISTRY_KEY,
             AnalyticsValuesSourceType.HISTOGRAM,
-            (name, valuesSource, context, parent, percents, percentilesConfig, keyed, formatter, metadata) -> {
+            (name, config, context, parent, percents, percentilesConfig, keyed, formatter, metadata) -> {
                 if (percentilesConfig.getMethod().equals(PercentilesMethod.TDIGEST)) {
                     double compression = ((PercentilesConfig.TDigest) percentilesConfig).getCompression();
                     return new HistoBackedTDigestPercentilesAggregator(
                         name,
-                        valuesSource,
+                        config,
                         context,
                         parent,
                         percents,
@@ -56,7 +56,7 @@ public class AnalyticsAggregatorFactory {
                     int numSigFig = ((PercentilesConfig.Hdr) percentilesConfig).getNumberOfSignificantValueDigits();
                     return new HistoBackedHDRPercentilesAggregator(
                         name,
-                        valuesSource,
+                        config,
                         context,
                         parent,
                         percents,
@@ -79,12 +79,12 @@ public class AnalyticsAggregatorFactory {
         builder.register(
             PercentileRanksAggregationBuilder.REGISTRY_KEY,
             AnalyticsValuesSourceType.HISTOGRAM,
-            (name, valuesSource, context, parent, percents, percentilesConfig, keyed, formatter, metadata) -> {
+            (name, config, context, parent, percents, percentilesConfig, keyed, formatter, metadata) -> {
                 if (percentilesConfig.getMethod().equals(PercentilesMethod.TDIGEST)) {
                     double compression = ((PercentilesConfig.TDigest) percentilesConfig).getCompression();
                     return new HistoBackedTDigestPercentileRanksAggregator(
                         name,
-                        valuesSource,
+                        config,
                         context,
                         parent,
                         percents,
@@ -98,7 +98,7 @@ public class AnalyticsAggregatorFactory {
                     int numSigFig = ((PercentilesConfig.Hdr) percentilesConfig).getNumberOfSignificantValueDigits();
                     return new HistoBackedHDRPercentileRanksAggregator(
                         name,
-                        valuesSource,
+                        config,
                         context,
                         parent,
                         percents,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedHDRPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedHDRPercentilesAggregator.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.analytics.aggregations.metrics;
 
 import org.HdrHistogram.DoubleHistogram;
 import org.apache.lucene.search.ScoreMode;
-import org.elasticsearch.common.util.ArrayUtils;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.ObjectArray;
 import org.elasticsearch.core.Releasables;
@@ -21,8 +20,10 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.LeafBucketCollector;
 import org.elasticsearch.search.aggregations.LeafBucketCollectorBase;
 import org.elasticsearch.search.aggregations.metrics.NumericMetricsAggregator;
+import org.elasticsearch.search.aggregations.metrics.PercentilesConfig;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
 import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 import org.elasticsearch.xpack.analytics.aggregations.support.HistogramValuesSource;
 
 import java.io.IOException;
@@ -30,9 +31,9 @@ import java.util.Map;
 
 abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
 
-    private static int indexOfKey(double[] keys, double key) {
-        return ArrayUtils.binarySearch(keys, key, 0.001);
-    }
+    // private static int indexOfKey(double[] keys, double key) {
+    // return ArrayUtils.binarySearch(keys, key, 0.001);
+    // }
 
     protected final double[] keys;
     protected final ValuesSource valuesSource;
@@ -43,7 +44,7 @@ abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetric
 
     AbstractHistoBackedHDRPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] keys,
@@ -53,7 +54,8 @@ abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetric
         Map<String, Object> metadata
     ) throws IOException {
         super(name, context, parent, metadata);
-        this.valuesSource = valuesSource;
+        assert config.hasValues();
+        this.valuesSource = config.getValuesSource();
         this.keyed = keyed;
         this.format = formatter;
         this.states = context.bigArrays().newObjectArray(1);
@@ -63,14 +65,11 @@ abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetric
 
     @Override
     public ScoreMode scoreMode() {
-        return valuesSource != null && valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
+        return valuesSource.needsScores() ? ScoreMode.COMPLETE : ScoreMode.COMPLETE_NO_SCORES;
     }
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx, final LeafBucketCollector sub) throws IOException {
-        if (valuesSource == null) {
-            return LeafBucketCollector.NO_OP_COLLECTOR;
-        }
         final HistogramValues values = ((HistogramValuesSource.Histogram) valuesSource).getHistogramValues(aggCtx.getLeafReaderContext());
 
         return new LeafBucketCollectorBase(sub, values) {
@@ -107,7 +106,7 @@ abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetric
 
     @Override
     public boolean hasMetric(String name) {
-        return indexOfKey(keys, Double.parseDouble(name)) >= 0;
+        return PercentilesConfig.indexOfKey(keys, Double.parseDouble(name)) >= 0;
     }
 
     protected DoubleHistogram getState(long bucketOrd) {

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedHDRPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/AbstractHistoBackedHDRPercentilesAggregator.java
@@ -31,10 +31,6 @@ import java.util.Map;
 
 abstract class AbstractHistoBackedHDRPercentilesAggregator extends NumericMetricsAggregator.MultiValue {
 
-    // private static int indexOfKey(double[] keys, double key) {
-    // return ArrayUtils.binarySearch(keys, key, 0.001);
-    // }
-
     protected final double[] keys;
     protected final ValuesSource valuesSource;
     protected final DocValueFormat format;

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedHDRPercentileRanksAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedHDRPercentileRanksAggregator.java
@@ -13,7 +13,7 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalHDRPercentileRanks;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class HistoBackedHDRPercentileRanksAggregator extends AbstractHistoBacked
 
     public HistoBackedHDRPercentileRanksAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -31,7 +31,7 @@ public class HistoBackedHDRPercentileRanksAggregator extends AbstractHistoBacked
         DocValueFormat format,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, format, metadata);
+        super(name, config, context, parent, percents, numberOfSignificantValueDigits, keyed, format, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedHDRPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedHDRPercentilesAggregator.java
@@ -13,7 +13,7 @@ import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalHDRPercentiles;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class HistoBackedHDRPercentilesAggregator extends AbstractHistoBackedHDRP
 
     public HistoBackedHDRPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -31,7 +31,7 @@ public class HistoBackedHDRPercentilesAggregator extends AbstractHistoBackedHDRP
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, numberOfSignificantValueDigits, keyed, formatter, metadata);
+        super(name, config, context, parent, percents, numberOfSignificantValueDigits, keyed, formatter, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentileRanksAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentileRanksAggregator.java
@@ -46,7 +46,7 @@ public class HistoBackedTDigestPercentileRanksAggregator extends AbstractHistoBa
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalTDigestPercentileRanks(name, keys, new TDigestState(compression), keyed, formatter, metadata());
+        return InternalTDigestPercentileRanks.empty(name, keys, compression, keyed, formatter, metadata());
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentileRanksAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentileRanksAggregator.java
@@ -13,7 +13,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentileRanks;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class HistoBackedTDigestPercentileRanksAggregator extends AbstractHistoBa
 
     public HistoBackedTDigestPercentileRanksAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -31,7 +31,7 @@ public class HistoBackedTDigestPercentileRanksAggregator extends AbstractHistoBa
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, metadata);
+        super(name, config, context, parent, percents, compression, keyed, formatter, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentilesAggregator.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/aggregations/metrics/HistoBackedTDigestPercentilesAggregator.java
@@ -13,7 +13,7 @@ import org.elasticsearch.search.aggregations.InternalAggregation;
 import org.elasticsearch.search.aggregations.metrics.InternalTDigestPercentiles;
 import org.elasticsearch.search.aggregations.metrics.TDigestState;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -22,7 +22,7 @@ public class HistoBackedTDigestPercentilesAggregator extends AbstractHistoBacked
 
     public HistoBackedTDigestPercentilesAggregator(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         AggregationContext context,
         Aggregator parent,
         double[] percents,
@@ -31,7 +31,7 @@ public class HistoBackedTDigestPercentilesAggregator extends AbstractHistoBacked
         DocValueFormat formatter,
         Map<String, Object> metadata
     ) throws IOException {
-        super(name, valuesSource, context, parent, percents, compression, keyed, formatter, metadata);
+        super(name, config, context, parent, percents, compression, keyed, formatter, metadata);
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorSupplier.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregatorSupplier.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.analytics.boxplot;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.Aggregator;
 import org.elasticsearch.search.aggregations.support.AggregationContext;
-import org.elasticsearch.search.aggregations.support.ValuesSource;
+import org.elasticsearch.search.aggregations.support.ValuesSourceConfig;
 
 import java.io.IOException;
 import java.util.Map;
@@ -19,7 +19,7 @@ import java.util.Map;
 public interface BoxplotAggregatorSupplier {
     Aggregator build(
         String name,
-        ValuesSource valuesSource,
+        ValuesSourceConfig config,
         DocValueFormat formatter,
         double compression,
         AggregationContext context,

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/InternalBoxplot.java
@@ -120,6 +120,15 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             return Metrics.valueOf(name.toUpperCase(Locale.ROOT));
         }
 
+        public static boolean hasMetric(String name) {
+            try {
+                InternalBoxplot.Metrics.resolve(name);
+                return true;
+            } catch (IllegalArgumentException iae) {
+                return false;
+            }
+        }
+
         public String value() {
             return name().toLowerCase(Locale.ROOT);
         }
@@ -166,6 +175,10 @@ public class InternalBoxplot extends InternalNumericMetricsAggregation.MultiValu
             results[1] = state.getMax();
         }
         return results;
+    }
+
+    static InternalBoxplot empty(String name, double compression, DocValueFormat format, Map<String, Object> metadata) {
+        return new InternalBoxplot(name, new TDigestState(compression), format, metadata);
     }
 
     static final Set<String> METRIC_NAMES = Collections.unmodifiableSet(


### PR DESCRIPTION
We have a TODO in those aggregations to stop creating them when valuesSourceConfig.hasValues() is false. We introduce here a `NonCollectingMultiMetricAggregator` that is created in case the field is unmapped.

relates https://github.com/elastic/elasticsearch/pull/96146