### PR TITLE
[Transform] Fix TransformIT.testStartTransform_GivenTimeout_Returns408 test case

### DIFF
--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformIT.java
@@ -39,6 +39,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasKey;
@@ -471,12 +472,26 @@ public class TransformIT extends TransformRestTestCase {
             .build();
 
         putTransform(transformId, Strings.toString(config), RequestOptions.DEFAULT);
+
         ResponseException e = expectThrows(
             ResponseException.class,
             () -> startTransform(config.getId(), RequestOptions.DEFAULT.toBuilder().addParameter("timeout", "1nanos").build())
         );
 
         assertThat(e.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.REQUEST_TIMEOUT.getStatus()));
+        assertThat(e.getMessage(), containsString("Starting transform [" + transformId + "] timed out after [1nanos]"));
+
+        // After we've verified that the _start call timed out, we stop the transform (which might have been started despite timeout).
+        try {
+            stopTransform(transformId);
+        } catch (ResponseException e2) {
+            // It can be that the _stop call timed out because of the race condition, i.e.: the _stop call executed *before* the _start call
+            // because of how threads were scheduled by the generic thread pool and now the current transform state is STARTED.
+            // In such a case, we repeat the _stop call to make the transform STOPPED.
+            assertThat(e2.getResponse().getStatusLine().getStatusCode(), equalTo(RestStatus.REQUEST_TIMEOUT.getStatus()));
+            assertThat(e2.getMessage(), containsString("Could not stop the transforms [" + transformId + "] as they timed out [30s]."));
+            stopTransform(transformId);
+        }
     }
 
     private void indexMoreDocs(long timestamp, long userId, String index) throws Exception {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformRestTestCase.java
@@ -210,8 +210,7 @@ public abstract class TransformRestTestCase extends ESRestTestCase {
     }
 
     protected void deleteTransform(String id) throws IOException {
-        Request request = new Request("DELETE", TRANSFORM_ENDPOINT + id);
-        assertOK(adminClient().performRequest(request));
+        deleteTransform(id, false);
     }
 
     protected void deleteTransform(String id, boolean force) throws IOException {

--- a/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
+++ b/x-pack/plugin/transform/qa/multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/continuous/TransformContinuousIT.java
@@ -436,7 +436,7 @@ public class TransformContinuousIT extends TransformRestTestCase {
 
     private void stopTransforms() throws IOException {
         for (ContinuousTestCase testCase : transformTestCases) {
-            stopTransform(testCase.getName(), true, null, false);
+            stopTransform(testCase.getName());
         }
     }
 


### PR DESCRIPTION
This PR fixes the occasional failures of `TransformIT.testStartTransform_GivenTimeout_Returns408` test case.
The failure scenario is as follows:
1. transform is started with a very small timeout (`1ns`) so the `_start` call is guaranteed to time out
2. the `_start` call indeed times out, but the code is executing anyway (as we do not cancel the persistent task due to timeout on `_start`)
3. the `_stop` call is issued by the clean-up code after the test
4. since there is little time in between (2.) and (3.) and both operations delegate work to generic thread pool at some point, it can happen that `_stop` executes first and writes `STOPPED` state
5. then `_start` executes and writes `STARTED` state
6. now the `_stop` call waits until the persistent task is `STOPPED` but that will never happen as the task got started in step (5.) due to reversed execution of `_start` and `_stop`.

This PR fixes the test by stopping the transform in the test (handling potential timeout that might occur due to reversed execution) rather than relying on clean-up code stopping it (which does not handle potential timeout).

Fixes https://github.com/elastic/elasticsearch/issues/95725