### PR TITLE
Search idle info transport version bump

### DIFF
--- a/docs/changelog/95740.yaml
+++ b/docs/changelog/95740.yaml
@@ -1,0 +1,6 @@
+pr: 95740
+summary: Include search idle info to shard stats
+area: "Search"
+type: enhancement
+issues:
+ - 95727

--- a/docs/changelog/96213.yaml
+++ b/docs/changelog/96213.yaml
@@ -1,5 +1,5 @@
 pr: 96213
 summary: Search idle info transport version bump
-area: "TSDB, Search"
+area: "Search"
 type: enhancement
 issues: []

--- a/docs/changelog/96213.yaml
+++ b/docs/changelog/96213.yaml
@@ -1,0 +1,5 @@
+pr: 96213
+summary: Search idle info transport version bump
+area: "TSDB, Search"
+type: enhancement
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/100_search_idle.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/indices.stats/100_search_idle.yml
@@ -1,0 +1,28 @@
+---
+setup:
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 2
+            number_of_replicas: 0
+            index:
+              search:
+                idle:
+                  after: 60s
+
+---
+"Search idle stats":
+  - skip:
+      version: " - 8.8.99"
+      reason: "search idle stats added in 8.9.0"
+
+  - do:
+      indices.stats: { level: shards }
+
+  - is_false: indices.test.shards.0.0.search_idle
+  - gte: { indices.test.shards.0.0.search_idle_time: 0 }
+
+  - is_false: indices.test.shards.1.0.search_idle
+  - gte: { indices.test.shards.1.0.search_idle_time: 0 }

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -123,12 +123,13 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_000 = registerTransportVersion(8_500_000, "dc3cbf06-3ed5-4e1b-9978-ee1d04d235bc");
     public static final TransportVersion V_8_500_001 = registerTransportVersion(8_500_001, "c943cfe5-c89d-4eae-989f-f5f4537e84e0");
     public static final TransportVersion V_8_500_002 = registerTransportVersion(8_500_002, "055dd314-ff40-4313-b4c6-9fccddfa42a8");
+    public static final TransportVersion V_8_500_003 = registerTransportVersion(8_500_003, "179e81fd-c65b-4d87-b739-fa35cc3d4ee9");
 
     /**
      * Reference to the most recent transport version.
      * This should be the transport version with the highest id.
      */
-    public static final TransportVersion CURRENT = V_8_500_002;
+    public static final TransportVersion CURRENT = V_8_500_003;
 
     /**
      * Reference to the earliest compatible transport version to this version of the codebase.

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -222,7 +222,9 @@ public class TransportClusterStatsAction extends TransportNodesAction<
                             CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, SHARD_STATS_FLAGS),
                             commitStats,
                             seqNoStats,
-                            retentionLeaseStats
+                            retentionLeaseStats,
+                            indexShard.isSearchIdle(),
+                            indexShard.searchIdleTime()
                         )
                     );
                 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -41,6 +41,10 @@ public class ShardStats implements Writeable, ToXContentFragment {
     private final String statePath;
     private final boolean isCustomDataPath;
 
+    private final boolean isSearchIdle;
+
+    private final long searchIdleTime;
+
     public ShardStats(StreamInput in) throws IOException {
         shardRouting = new ShardRouting(in);
         commonStats = new CommonStats(in);
@@ -54,26 +58,13 @@ public class ShardStats implements Writeable, ToXContentFragment {
         isCustomDataPath = in.readBoolean();
         seqNoStats = in.readOptionalWriteable(SeqNoStats::new);
         retentionLeaseStats = in.readOptionalWriteable(RetentionLeaseStats::new);
-    }
-
-    public ShardStats(
-        final ShardRouting shardRouting,
-        final ShardPath shardPath,
-        final CommonStats commonStats,
-        final CommitStats commitStats,
-        final SeqNoStats seqNoStats,
-        final RetentionLeaseStats retentionLeaseStats
-    ) {
-        this(
-            shardRouting,
-            commonStats,
-            commitStats,
-            seqNoStats,
-            retentionLeaseStats,
-            shardPath.getRootDataPath().toString(),
-            shardPath.getRootStatePath().toString(),
-            shardPath.isCustomDataPath()
-        );
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+            isSearchIdle = in.readBoolean();
+            searchIdleTime = in.readVLong();
+        } else {
+            isSearchIdle = false;
+            searchIdleTime = 0;
+        }
     }
 
     public ShardStats(
@@ -84,7 +75,9 @@ public class ShardStats implements Writeable, ToXContentFragment {
         RetentionLeaseStats retentionLeaseStats,
         String dataPath,
         String statePath,
-        boolean isCustomDataPath
+        boolean isCustomDataPath,
+        boolean isSearchIdle,
+        long searchIdleTime
     ) {
         this.shardRouting = shardRouting;
         this.commonStats = commonStats;
@@ -94,6 +87,32 @@ public class ShardStats implements Writeable, ToXContentFragment {
         this.dataPath = dataPath;
         this.statePath = statePath;
         this.isCustomDataPath = isCustomDataPath;
+        this.isSearchIdle = isSearchIdle;
+        this.searchIdleTime = searchIdleTime;
+    }
+
+    public ShardStats(
+        final ShardRouting shardRouting,
+        final ShardPath shardPath,
+        final CommonStats commonStats,
+        final CommitStats commitStats,
+        final SeqNoStats seqNoStats,
+        final RetentionLeaseStats retentionLeaseStats,
+        boolean isSearchIdle,
+        long searchIdleTime
+    ) {
+        this(
+            shardRouting,
+            commonStats,
+            commitStats,
+            seqNoStats,
+            retentionLeaseStats,
+            shardPath.getRootDataPath().toString(),
+            shardPath.getRootStatePath().toString(),
+            shardPath.isCustomDataPath(),
+            isSearchIdle,
+            searchIdleTime
+        );
     }
 
     @Override
@@ -108,12 +127,25 @@ public class ShardStats implements Writeable, ToXContentFragment {
             && Objects.equals(commitStats, that.commitStats)
             && Objects.equals(commonStats, that.commonStats)
             && Objects.equals(seqNoStats, that.seqNoStats)
-            && Objects.equals(retentionLeaseStats, that.retentionLeaseStats);
+            && Objects.equals(retentionLeaseStats, that.retentionLeaseStats)
+            && Objects.equals(isSearchIdle, that.isSearchIdle)
+            && Objects.equals(searchIdleTime, that.searchIdleTime);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(shardRouting, dataPath, statePath, isCustomDataPath, commitStats, commonStats, seqNoStats, retentionLeaseStats);
+        return Objects.hash(
+            shardRouting,
+            dataPath,
+            statePath,
+            isCustomDataPath,
+            commitStats,
+            commonStats,
+            seqNoStats,
+            retentionLeaseStats,
+            isSearchIdle,
+            searchIdleTime
+        );
     }
 
     /**
@@ -158,6 +190,14 @@ public class ShardStats implements Writeable, ToXContentFragment {
         return isCustomDataPath;
     }
 
+    public boolean isSearchIdle() {
+        return isSearchIdle;
+    }
+
+    public long getSearchIdleTime() {
+        return searchIdleTime;
+    }
+
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         shardRouting.writeTo(out);
@@ -172,6 +212,10 @@ public class ShardStats implements Writeable, ToXContentFragment {
         out.writeBoolean(isCustomDataPath);
         out.writeOptionalWriteable(seqNoStats);
         out.writeOptionalWriteable(retentionLeaseStats);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+            out.writeBoolean(isSearchIdle);
+            out.writeVLong(searchIdleTime);
+        }
     }
 
     @Override
@@ -198,6 +242,8 @@ public class ShardStats implements Writeable, ToXContentFragment {
         builder.field(Fields.DATA_PATH, dataPath);
         builder.field(Fields.IS_CUSTOM_DATA_PATH, isCustomDataPath);
         builder.endObject();
+        builder.field(Fields.SEARCH_IDLE, isSearchIdle);
+        builder.field(Fields.SEARCH_IDLE_TIME, searchIdleTime);
         return builder;
     }
 
@@ -211,6 +257,8 @@ public class ShardStats implements Writeable, ToXContentFragment {
         static final String PRIMARY = "primary";
         static final String NODE = "node";
         static final String RELOCATING_NODE = "relocating_node";
+        static final String SEARCH_IDLE = "search_idle";
+        static final String SEARCH_IDLE_TIME = "search_idle_time";
     }
 
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/ShardStats.java
@@ -58,7 +58,7 @@ public class ShardStats implements Writeable, ToXContentFragment {
         isCustomDataPath = in.readBoolean();
         seqNoStats = in.readOptionalWriteable(SeqNoStats::new);
         retentionLeaseStats = in.readOptionalWriteable(RetentionLeaseStats::new);
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_003)) {
             isSearchIdle = in.readBoolean();
             searchIdleTime = in.readVLong();
         } else {
@@ -212,7 +212,7 @@ public class ShardStats implements Writeable, ToXContentFragment {
         out.writeBoolean(isCustomDataPath);
         out.writeOptionalWriteable(seqNoStats);
         out.writeOptionalWriteable(retentionLeaseStats);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_003)) {
             out.writeBoolean(isSearchIdle);
             out.writeVLong(searchIdleTime);
         }

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/TransportIndicesStatsAction.java
@@ -135,7 +135,9 @@ public class TransportIndicesStatsAction extends TransportBroadcastByNodeAction<
                 commonStats,
                 commitStats,
                 seqNoStats,
-                retentionLeaseStats
+                retentionLeaseStats,
+                indexShard.isSearchIdle(),
+                indexShard.searchIdleTime()
             );
         });
     }

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -3752,6 +3752,10 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
         return (threadPool.relativeTimeInMillis() - lastSearcherAccess.get()) >= indexSettings.getSearchIdleAfter().getMillis();
     }
 
+    public long searchIdleTime() {
+        return threadPool.relativeTimeInMillis() - lastSearcherAccess.get();
+    }
+
     /**
      * Returns the last timestamp the searcher was accessed. This is a relative timestamp in milliseconds.
      */

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -537,7 +537,9 @@ public class IndicesService extends AbstractLifecycleComponent
                     CommonStats.getShardLevelStats(indicesService.getIndicesQueryCache(), indexShard, flags),
                     commitStats,
                     seqNoStats,
-                    retentionLeaseStats
+                    retentionLeaseStats,
+                    indexShard.isSearchIdle(),
+                    indexShard.searchIdleTime()
                 ) }
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -706,7 +706,7 @@ public class NodeStatsTests extends ESTestCase {
             .resolve(shardRouting.shardId().getIndex().getUUID())
             .resolve(String.valueOf(shardRouting.shardId().id()));
         ShardPath shardPath = new ShardPath(false, path, path, shardRouting.shardId());
-        return new ShardStats(shardRouting, shardPath, createShardLevelCommonStats(), null, null, null);
+        return new ShardStats(shardRouting, shardPath, createShardLevelCommonStats(), null, null, null, false, 0);
     }
 
     public static NodeStats createNodeStats() {

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/stats/VersionStatsTests.java
@@ -117,7 +117,9 @@ public class VersionStatsTests extends AbstractWireSerializingTestCase<VersionSt
             CommonStats.getShardLevelStats(null, indexShard, new CommonStatsFlags(CommonStatsFlags.Flag.Store)),
             null,
             null,
-            null
+            null,
+            false,
+            0
         );
         ClusterStatsNodeResponse nodeResponse = new ClusterStatsNodeResponse(
             TestDiscoveryNode.create("id"),

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/rollover/TransportRolloverActionTests.java
@@ -490,7 +490,7 @@ public class TransportRolloverActionTests extends ESTestCase {
                 stats.get = new GetStats();
                 stats.flush = new FlushStats();
                 stats.warmer = new WarmerStats();
-                shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null));
+                shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, null, null, false, 0));
             }
         }
         return IndicesStatsTests.newIndicesStatsResponse(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponseTests.java
@@ -75,7 +75,7 @@ public class IndicesStatsResponseTests extends ESTestCase {
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(shardId));
                 ShardPath shardPath = new ShardPath(false, path, path, shId);
                 ShardRouting routing = createShardRouting(shId, (shardId == 0));
-                shards.add(new ShardStats(routing, shardPath, null, null, null, null));
+                shards.add(new ShardStats(routing, shardPath, null, null, null, null, false, 0));
                 AtomicLong primaryShardsCounter = expectedIndexToPrimaryShardsCount.computeIfAbsent(
                     index.getName(),
                     k -> new AtomicLong(0L)
@@ -124,7 +124,7 @@ public class IndicesStatsResponseTests extends ESTestCase {
             Path path = createTempDir().resolve("indices").resolve(shId.getIndex().getUUID()).resolve(String.valueOf(shId.id()));
             ShardPath shardPath = new ShardPath(false, path, path, shId);
             ShardRouting routing = createShardRouting(shId, (shId.id() == 0));
-            stats.add(new ShardStats(routing, shardPath, new CommonStats(), null, null, null));
+            stats.add(new ShardStats(routing, shardPath, new CommonStats(), null, null, null, false, 0));
         }
         final IndicesStatsResponse indicesStatsResponse = new IndicesStatsResponse(
             stats.toArray(new ShardStats[0]),

--- a/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/DiskUsageTests.java
@@ -123,9 +123,18 @@ public class DiskUsageTests extends ESTestCase {
         CommonStats commonStats2 = new CommonStats();
         commonStats2.store = new StoreStats(1000, 999, 0L);
         ShardStats[] stats = new ShardStats[] {
-            new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0, null, null, null),
-            new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1, null, null, null),
-            new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats2, null, null, null) };
+            new ShardStats(test_0, new ShardPath(false, test0Path, test0Path, test_0.shardId()), commonStats0, null, null, null, false, 0),
+            new ShardStats(test_1, new ShardPath(false, test1Path, test1Path, test_1.shardId()), commonStats1, null, null, null, false, 0),
+            new ShardStats(
+                test_1,
+                new ShardPath(false, test1Path, test1Path, test_1.shardId()),
+                commonStats2,
+                null,
+                null,
+                null,
+                false,
+                0
+            ) };
         Map<String, Long> shardSizes = new HashMap<>();
         Map<ShardId, Long> shardDataSetSizes = new HashMap<>();
         Map<ClusterInfo.NodeAndShard, String> routingToPath = new HashMap<>();

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/IndexMetadataStatsTests.java
@@ -114,6 +114,6 @@ public class IndexMetadataStatsTests extends ESTestCase {
             .add(
                 new IndexingStats.Stats(0, 0, 0, 0, 0, 0, 0, 0, false, 0, totalIndexingTimeSinceShardStartedInNanos, totalActiveTimeInNanos)
             );
-        return new ShardStats(shardRouting, commonStats, null, null, null, null, null, false);
+        return new ShardStats(shardRouting, commonStats, null, null, null, null, null, false, false, 0);
     }
 }

--- a/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/cat/RestShardsActionTests.java
@@ -58,7 +58,9 @@ public class RestShardsActionTests extends ESTestCase {
                 null,
                 null,
                 null,
-                null
+                null,
+                false,
+                0
             );
             shardStatsMap.put(shardRouting, shardStats);
             shardRoutings.add(shardRouting);

--- a/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/MockInternalClusterInfoService.java
@@ -119,7 +119,9 @@ public class MockInternalClusterInfoService extends InternalClusterInfoService {
                 shardStats.getRetentionLeaseStats(),
                 shardStats.getDataPath(),
                 shardStats.getStatePath(),
-                shardStats.isCustomDataPath()
+                shardStats.isCustomDataPath(),
+                shardStats.isSearchIdle(),
+                shardStats.getSearchIdleTime()
             );
         }).toArray(ShardStats[]::new);
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/DataTiersUsageTransportActionTests.java
@@ -774,7 +774,7 @@ public class DataTiersUsageTransportActionTests extends ESTestCase {
         Path fakePath = PathUtils.get("test/dir/" + routing.shardId().getIndex().getUUID() + "/" + routing.shardId().id());
         ShardPath fakeShardPath = new ShardPath(false, fakePath, fakePath, routing.shardId());
 
-        return new ShardStats(routing, fakeShardPath, commonStats, null, null, null);
+        return new ShardStats(routing, fakeShardPath, commonStats, null, null, null, false, 0);
     }
 
     private static NodeStats mockNodeStats(DiscoveryNode node, NodeIndicesStats indexStats) {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ilm/WaitForNoFollowersStepTests.java
@@ -184,7 +184,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
             .numberOfReplicas(randomIntBetween(1, 10))
             .build();
 
-        ShardStats sStats = new ShardStats(null, mockShardPath(), null, null, null, null);
+        ShardStats sStats = new ShardStats(null, mockShardPath(), null, null, null, null, false, 0);
         ShardStats[] shardStats = new ShardStats[1];
         shardStats[0] = sStats;
 
@@ -293,7 +293,7 @@ public class WaitForNoFollowersStepTests extends AbstractStepTestCase<WaitForNoF
     }
 
     private ShardStats randomShardStats(boolean isLeaderIndex) {
-        return new ShardStats(null, mockShardPath(), null, null, null, randomRetentionLeaseStats(isLeaderIndex));
+        return new ShardStats(null, mockShardPath(), null, null, null, randomRetentionLeaseStats(isLeaderIndex), false, 0);
     }
 
     private RetentionLeaseStats randomRetentionLeaseStats(boolean isLeaderIndex) {

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/collector/indices/IndicesStatsMonitoringDocTests.java
@@ -55,10 +55,10 @@ public class IndicesStatsMonitoringDocTests extends BaseFilteredMonitoringDocTes
                 null,
                 new ShardStats[] {
                     // Primaries
-                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null),
-                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null),
+                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0),
+                    new ShardStats(mockShardRouting(true), mockShardPath(), mockCommonStats(), null, null, null, false, 0),
                     // Replica
-                    new ShardStats(mockShardRouting(false), mockShardPath(), mockCommonStats(), null, null, null) }
+                    new ShardStats(mockShardRouting(false), mockShardPath(), mockCommonStats(), null, null, null, false, 0) }
             )
         );
     }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -384,7 +384,9 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
                 );
                 Path path = createTempDir().resolve("indices").resolve(index.getUUID()).resolve(String.valueOf(i));
 
-                shardStats.add(new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, seqNoStats, null));
+                shardStats.add(
+                    new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, seqNoStats, null, false, 0)
+                );
             }
 
         }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformsCheckpointServiceTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/checkpoint/TransformsCheckpointServiceTests.java
@@ -237,11 +237,29 @@ public class TransformsCheckpointServiceTests extends ESTestCase {
                             globalCheckpoint - randomLongBetween(10L, 100L)
                         );
                         shardStats.add(
-                            new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, invalidSeqNoStats, null)
+                            new ShardStats(
+                                shardRouting,
+                                new ShardPath(false, path, path, shardId),
+                                stats,
+                                null,
+                                invalidSeqNoStats,
+                                null,
+                                false,
+                                0
+                            )
                         );
                     } else {
                         shardStats.add(
-                            new ShardStats(shardRouting, new ShardPath(false, path, path, shardId), stats, null, validSeqNoStats, null)
+                            new ShardStats(
+                                shardRouting,
+                                new ShardPath(false, path, path, shardId),
+                                stats,
+                                null,
+                                validSeqNoStats,
+                                null,
+                                false,
+                                0
+                            )
                         );
                     }
                 }


### PR DESCRIPTION
This PR is the same as #95740 but also includes using the new "serverless-compatible" TransportVersion and the new version added according to our bumping rules. The previous PR was reverted by #96204 because it was breaking serverless.