### PR TITLE
convert `HttpsStats` & `ClientStats` to records

### DIFF
--- a/docs/changelog/96214.yaml
+++ b/docs/changelog/96214.yaml
@@ -1,5 +1,0 @@
-pr: 96214
-summary: Convert `HttpsStats` & `ClientStats` to records
-area: Stats
-type: enhancement
-issues: []

--- a/docs/changelog/96214.yaml
+++ b/docs/changelog/96214.yaml
@@ -1,0 +1,5 @@
+pr: 96214
+summary: Convert `HttpsStats` & `ClientStats` to records
+area: Stats
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
+++ b/server/src/main/java/org/elasticsearch/http/AbstractHttpServerTransport.java
@@ -157,7 +157,7 @@ public abstract class AbstractHttpServerTransport extends AbstractLifecycleCompo
 
     @Override
     public HttpStats stats() {
-        return new HttpStats(httpClientStatsTracker.getClientStats(), httpChannels.size(), totalChannelsAccepted.get());
+        return new HttpStats(httpChannels.size(), totalChannelsAccepted.get(), httpClientStatsTracker.getClientStats());
     }
 
     protected void bindServer() {

--- a/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpClientStatsTracker.java
@@ -145,7 +145,7 @@ public class HttpClientStatsTracker {
             final LongPredicate keepTimePredicate = closeTimeMillis -> currentTimeMillis - closeTimeMillis <= maxClosedChannelAgeMillis;
             pruneStaleClosedChannelStats(keepTimePredicate);
             return Stream.concat(
-                closedChannelStats.stream().filter(c -> keepTimePredicate.test(c.closedTimeMillis)),
+                closedChannelStats.stream().filter(c -> keepTimePredicate.test(c.closedTimeMillis())),
                 httpChannelStats.values().stream().map(c -> c.build(NOT_CLOSED))
             ).toList();
         } else {
@@ -164,7 +164,7 @@ public class HttpClientStatsTracker {
                     return;
                 }
 
-                if (keepTimePredicate.test(nextStats.closedTimeMillis)) {
+                if (keepTimePredicate.test(nextStats.closedTimeMillis())) {
                     // the list elements are pretty much in the order in which the channels were closed so keep all the remaining items
                     return;
                 }

--- a/server/src/main/java/org/elasticsearch/http/HttpStats.java
+++ b/server/src/main/java/org/elasticsearch/http/HttpStats.java
@@ -21,26 +21,14 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-public class HttpStats implements Writeable, ChunkedToXContent {
-
-    private final long serverOpen;
-    private final long totalOpen;
-    private final List<ClientStats> clientStats;
-
-    public HttpStats(List<ClientStats> clientStats, long serverOpen, long totalOpened) {
-        this.clientStats = clientStats;
-        this.serverOpen = serverOpen;
-        this.totalOpen = totalOpened;
-    }
+public record HttpStats(long serverOpen, long totalOpen, List<ClientStats> clientStats) implements Writeable, ChunkedToXContent {
 
     public HttpStats(long serverOpen, long totalOpened) {
-        this(List.of(), serverOpen, totalOpened);
+        this(serverOpen, totalOpened, List.of());
     }
 
     public HttpStats(StreamInput in) throws IOException {
-        serverOpen = in.readVLong();
-        totalOpen = in.readVLong();
-        clientStats = in.readList(ClientStats::new);
+        this(in.readVLong(), in.readVLong(), in.readList(ClientStats::new));
     }
 
     @Override
@@ -95,63 +83,38 @@ public class HttpStats implements Writeable, ChunkedToXContent {
         );
     }
 
-    public static class ClientStats implements Writeable, ToXContentFragment {
+    public record ClientStats(
+        int id,
+        String agent,
+        String localAddress,
+        String remoteAddress,
+        String lastUri,
+        String forwardedFor,
+        String opaqueId,
+        long openedTimeMillis,
+        long closedTimeMillis,
+        long lastRequestTimeMillis,
+        long requestCount,
+        long requestSizeBytes
+    ) implements Writeable, ToXContentFragment {
+
         public static final long NOT_CLOSED = -1L;
 
-        final int id;
-        final String agent;
-        final String localAddress;
-        final String remoteAddress;
-        final String lastUri;
-        final String forwardedFor;
-        final String opaqueId;
-        final long openedTimeMillis;
-        final long closedTimeMillis;
-        final long lastRequestTimeMillis;
-        final long requestCount;
-        final long requestSizeBytes;
-
-        public ClientStats(
-            int id,
-            String agent,
-            String localAddress,
-            String remoteAddress,
-            String lastUri,
-            String forwardedFor,
-            String opaqueId,
-            long openedTimeMillis,
-            long closedTimeMillis,
-            long lastRequestTimeMillis,
-            long requestCount,
-            long requestSizeBytes
-        ) {
-            this.id = id;
-            this.agent = agent;
-            this.localAddress = localAddress;
-            this.remoteAddress = remoteAddress;
-            this.lastUri = lastUri;
-            this.forwardedFor = forwardedFor;
-            this.opaqueId = opaqueId;
-            this.openedTimeMillis = openedTimeMillis;
-            this.closedTimeMillis = closedTimeMillis;
-            this.lastRequestTimeMillis = lastRequestTimeMillis;
-            this.requestCount = requestCount;
-            this.requestSizeBytes = requestSizeBytes;
-        }
-
         ClientStats(StreamInput in) throws IOException {
-            this.id = in.readInt();
-            this.agent = in.readOptionalString();
-            this.localAddress = in.readOptionalString();
-            this.remoteAddress = in.readOptionalString();
-            this.lastUri = in.readOptionalString();
-            this.forwardedFor = in.readOptionalString();
-            this.opaqueId = in.readOptionalString();
-            this.openedTimeMillis = in.readLong();
-            this.closedTimeMillis = in.readLong();
-            this.lastRequestTimeMillis = in.readLong();
-            this.requestCount = in.readLong();
-            this.requestSizeBytes = in.readLong();
+            this(
+                in.readInt(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readOptionalString(),
+                in.readLong(),
+                in.readLong(),
+                in.readLong(),
+                in.readLong(),
+                in.readLong()
+            );
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -294,12 +294,9 @@ public class NodeStatsTests extends ESTestCase {
                         deserializedNodeStats.getTransport().getOutboundHandlingTimeBucketFrequencies()
                     );
                 }
-                if (nodeStats.getHttp() == null) {
-                    assertNull(deserializedNodeStats.getHttp());
-                } else {
-                    assertEquals(nodeStats.getHttp().getServerOpen(), deserializedNodeStats.getHttp().getServerOpen());
-                    assertEquals(nodeStats.getHttp().getTotalOpen(), deserializedNodeStats.getHttp().getTotalOpen());
-                }
+
+                assertEquals(nodeStats.getHttp(), deserializedNodeStats.getHttp());
+
                 if (nodeStats.getBreaker() == null) {
                     assertNull(deserializedNodeStats.getBreaker());
                 } else {
@@ -924,7 +921,7 @@ public class NodeStatsTests extends ESTestCase {
                 );
                 clientStats.add(cs);
             }
-            httpStats = new HttpStats(clientStats, randomNonNegativeLong(), randomNonNegativeLong());
+            httpStats = new HttpStats(randomNonNegativeLong(), randomNonNegativeLong(), clientStats);
         }
         AllCircuitBreakerStats allCircuitBreakerStats = null;
         if (frequently()) {

--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -757,9 +757,9 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
 
             HttpStats httpStats = transport.stats();
             assertThat(httpStats.getClientStats().size(), equalTo(1));
-            assertThat(httpStats.getClientStats().get(0).remoteAddress, equalTo(NetworkAddress.format(remoteAddress)));
-            assertThat(httpStats.getClientStats().get(0).opaqueId, equalTo(opaqueId));
-            assertThat(httpStats.getClientStats().get(0).lastUri, equalTo("/internal/stats_test"));
+            assertThat(httpStats.getClientStats().get(0).remoteAddress(), equalTo(NetworkAddress.format(remoteAddress)));
+            assertThat(httpStats.getClientStats().get(0).opaqueId(), equalTo(opaqueId));
+            assertThat(httpStats.getClientStats().get(0).lastUri(), equalTo("/internal/stats_test"));
 
             remoteAddress = new InetSocketAddress(randomIp(randomBoolean()), randomIntBetween(1, 65535));
             opaqueId = UUIDs.randomBase64UUID(random());
@@ -774,13 +774,13 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             assertThat(httpStats.getClientStats().size(), equalTo(2));
 
             // due to non-deterministic ordering in map iteration, the second client may not be the second entry in the list
-            HttpStats.ClientStats secondClientStats = httpStats.getClientStats().get(0).opaqueId.equals(opaqueId)
+            HttpStats.ClientStats secondClientStats = httpStats.getClientStats().get(0).opaqueId().equals(opaqueId)
                 ? httpStats.getClientStats().get(0)
                 : httpStats.getClientStats().get(1);
 
-            assertThat(secondClientStats.remoteAddress, equalTo(NetworkAddress.format(remoteAddress)));
-            assertThat(secondClientStats.opaqueId, equalTo(opaqueId));
-            assertThat(secondClientStats.lastUri, equalTo("/internal/stats_test2"));
+            assertThat(secondClientStats.remoteAddress(), equalTo(NetworkAddress.format(remoteAddress)));
+            assertThat(secondClientStats.opaqueId(), equalTo(opaqueId));
+            assertThat(secondClientStats.lastUri(), equalTo("/internal/stats_test2"));
         }
     }
 
@@ -834,7 +834,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
             // HTTP client stats should default to enabled
             HttpStats httpStats = transport.stats();
             assertThat(httpStats.getClientStats().size(), equalTo(1));
-            assertThat(httpStats.getClientStats().get(0).opaqueId, equalTo(opaqueId));
+            assertThat(httpStats.getClientStats().get(0).opaqueId(), equalTo(opaqueId));
 
             clusterSettings.applySettings(
                 Settings.builder().put(HttpTransportSettings.SETTING_HTTP_CLIENT_STATS_ENABLED.getKey(), false).build()

--- a/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
+++ b/server/src/test/java/org/elasticsearch/http/HttpClientStatsTrackerTests.java
@@ -97,16 +97,16 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             final List<HttpStats.ClientStats> clientsStats = httpClientStatsTracker.getClientStats();
             assertThat(clientsStats, hasSize(1));
             final HttpStats.ClientStats clientStats = clientsStats.get(0);
-            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
-            assertNull(clientStats.lastUri);
-            assertThat(clientStats.requestCount, equalTo(0L));
-            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
-            assertThat(clientStats.closedTimeMillis, equalTo(-1L));
-            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+            assertThat(clientStats.remoteAddress(), equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertNull(clientStats.lastUri());
+            assertThat(clientStats.requestCount(), equalTo(0L));
+            assertThat(clientStats.requestSizeBytes(), equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis(), equalTo(-1L));
+            assertThat(clientStats.openedTimeMillis(), equalTo(openTimeMillis));
 
-            assertNull(clientStats.agent);
-            assertNull(clientStats.forwardedFor);
-            assertNull(clientStats.opaqueId);
+            assertNull(clientStats.agent());
+            assertNull(clientStats.forwardedFor());
+            assertNull(clientStats.opaqueId());
         }
 
         threadPool.setRandomTime();
@@ -117,17 +117,17 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             assertThat(clientsStats, hasSize(1));
 
             final HttpStats.ClientStats clientStats = clientsStats.get(0);
-            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
-            assertThat(clientStats.lastUri, equalTo(httpRequest1.uri()));
-            assertThat(clientStats.requestCount, equalTo(1L));
+            assertThat(clientStats.remoteAddress(), equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertThat(clientStats.lastUri(), equalTo(httpRequest1.uri()));
+            assertThat(clientStats.requestCount(), equalTo(1L));
             requestLength += httpRequest1.content().length();
-            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
-            assertThat(clientStats.closedTimeMillis, equalTo(-1L));
-            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+            assertThat(clientStats.requestSizeBytes(), equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis(), equalTo(-1L));
+            assertThat(clientStats.openedTimeMillis(), equalTo(openTimeMillis));
 
             final Map<String, String> relevantHeaders = getRelevantHeaders(httpRequest1);
             assertThat(
-                clientStats.agent,
+                clientStats.agent(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders.get("x-elastic-product-origin")))
@@ -135,8 +135,8 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
                         .orElse(null)
                 )
             );
-            assertThat(clientStats.forwardedFor, equalTo(relevantHeaders.get("x-forwarded-for")));
-            assertThat(clientStats.opaqueId, equalTo(relevantHeaders.get("x-opaque-id")));
+            assertThat(clientStats.forwardedFor(), equalTo(relevantHeaders.get("x-forwarded-for")));
+            assertThat(clientStats.opaqueId(), equalTo(relevantHeaders.get("x-opaque-id")));
         }
 
         threadPool.setRandomTime();
@@ -147,18 +147,18 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             assertThat(clientsStats, hasSize(1));
 
             final HttpStats.ClientStats clientStats = clientsStats.get(0);
-            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
-            assertThat(clientStats.lastUri, equalTo(httpRequest2.uri()));
-            assertThat(clientStats.requestCount, equalTo(2L));
+            assertThat(clientStats.remoteAddress(), equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertThat(clientStats.lastUri(), equalTo(httpRequest2.uri()));
+            assertThat(clientStats.requestCount(), equalTo(2L));
             requestLength += httpRequest2.content().length();
-            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
-            assertThat(clientStats.closedTimeMillis, equalTo(-1L));
-            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+            assertThat(clientStats.requestSizeBytes(), equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis(), equalTo(-1L));
+            assertThat(clientStats.openedTimeMillis(), equalTo(openTimeMillis));
 
             final Map<String, String> relevantHeaders1 = getRelevantHeaders(httpRequest1);
             final Map<String, String> relevantHeaders2 = getRelevantHeaders(httpRequest2);
             assertThat(
-                clientStats.agent,
+                clientStats.agent(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders1.get("x-elastic-product-origin")))
@@ -169,7 +169,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
                 )
             );
             assertThat(
-                clientStats.forwardedFor,
+                clientStats.forwardedFor(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders1.get("x-forwarded-for")))
@@ -178,7 +178,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
                 )
             );
             assertThat(
-                clientStats.opaqueId,
+                clientStats.opaqueId(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders1.get("x-opaque-id")))
@@ -196,17 +196,17 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             assertThat(clientsStats, hasSize(1));
 
             final HttpStats.ClientStats clientStats = clientsStats.get(0);
-            assertThat(clientStats.remoteAddress, equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
-            assertThat(clientStats.lastUri, equalTo(httpRequest2.uri()));
-            assertThat(clientStats.requestCount, equalTo(2L));
-            assertThat(clientStats.requestSizeBytes, equalTo(requestLength));
-            assertThat(clientStats.closedTimeMillis, equalTo(closeTimeMillis));
-            assertThat(clientStats.openedTimeMillis, equalTo(openTimeMillis));
+            assertThat(clientStats.remoteAddress(), equalTo(NetworkAddress.format(httpChannel.getRemoteAddress())));
+            assertThat(clientStats.lastUri(), equalTo(httpRequest2.uri()));
+            assertThat(clientStats.requestCount(), equalTo(2L));
+            assertThat(clientStats.requestSizeBytes(), equalTo(requestLength));
+            assertThat(clientStats.closedTimeMillis(), equalTo(closeTimeMillis));
+            assertThat(clientStats.openedTimeMillis(), equalTo(openTimeMillis));
 
             final Map<String, String> relevantHeaders1 = getRelevantHeaders(httpRequest1);
             final Map<String, String> relevantHeaders2 = getRelevantHeaders(httpRequest2);
             assertThat(
-                clientStats.agent,
+                clientStats.agent(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders1.get("x-elastic-product-origin")))
@@ -217,7 +217,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
                 )
             );
             assertThat(
-                clientStats.forwardedFor,
+                clientStats.forwardedFor(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders1.get("x-forwarded-for")))
@@ -226,7 +226,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
                 )
             );
             assertThat(
-                clientStats.opaqueId,
+                clientStats.opaqueId(),
                 equalTo(
                     Optional.empty()
                         .or(() -> Optional.ofNullable(relevantHeaders1.get("x-opaque-id")))
@@ -311,7 +311,10 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
                 closeLock.writeLock().lock();
                 final List<HttpStats.ClientStats> clientStats = httpClientStatsTracker.getClientStats();
                 closeLock.writeLock().unlock();
-                assertThat(clientStats.stream().filter(c -> c.closedTimeMillis >= 0L).count(), lessThanOrEqualTo((long) closedClientLimit));
+                assertThat(
+                    clientStats.stream().filter(c -> c.closedTimeMillis() >= 0L).count(),
+                    lessThanOrEqualTo((long) closedClientLimit)
+                );
             }
 
         }, "stats-thread");
@@ -387,7 +390,7 @@ public class HttpClientStatsTrackerTests extends ESTestCase {
             assertTrue(
                 httpClientStatsTracker.getClientStats()
                     .stream()
-                    .anyMatch(cs -> cs.remoteAddress.equals(NetworkAddress.format(httpChannel.getRemoteAddress())))
+                    .anyMatch(cs -> cs.remoteAddress().equals(NetworkAddress.format(httpChannel.getRemoteAddress())))
             );
         } finally {
             for (Thread clientThread : clientThreads) {


### PR DESCRIPTION
before merging #96198 I'd like to improve the code converting these objects to records and not pollute the other PR with not directly related changes