### PR TITLE
Release aggregations early during the aggregation phase

### DIFF
--- a/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
+++ b/benchmarks/src/main/java/org/elasticsearch/benchmark/search/aggregations/AggConstructionContentionBenchmark.java
@@ -295,6 +295,11 @@ public class AggConstructionContentionBenchmark {
         }
 
         @Override
+        public void removeReleasable(Aggregator aggregator) {
+            releaseMe.remove(aggregator);
+        }
+
+        @Override
         public int maxBuckets() {
             return Integer.MAX_VALUE;
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -672,6 +672,9 @@ public class TransportSearchIT extends ESIntegTestCase {
         }
 
         @Override
+        public void releaseAggregations() {}
+
+        @Override
         public InternalAggregation buildEmptyAggregation() {
             return new Max(name(), Double.NaN, DocValueFormat.RAW, null);
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AdaptingAggregator.java
@@ -51,6 +51,11 @@ public abstract class AdaptingAggregator extends Aggregator {
     protected abstract InternalAggregation adapt(InternalAggregation delegateResult) throws IOException;
 
     @Override
+    public void releaseAggregations() {
+        delegate.releaseAggregations();
+    }
+
+    @Override
     public final void close() {
         delegate.close();
     }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -103,6 +103,8 @@ public class AggregationPhase {
             } catch (IOException e) {
                 throw new AggregationExecutionException("Failed to build aggregation [" + aggregator.name() + "]", e);
             }
+            // release the aggregator to claim the used bytes as we don't need it anymore
+            aggregator.releaseAggregations();
         }
         context.queryResult().aggregations(InternalAggregations.from(aggregations));
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/Aggregator.java
@@ -144,6 +144,11 @@ public abstract class Aggregator extends BucketCollector implements Releasable {
     public abstract InternalAggregation[] buildAggregations(long[] ordsToCollect) throws IOException;
 
     /**
+     * Release this aggregation and its sub-aggregations.
+     */
+    public abstract void releaseAggregations();
+
+    /**
      * Build the result of this aggregation if it is at the "top level"
      * of the aggregation tree. If, instead, it is a sub-aggregation of
      * another aggregation then the aggregation that contains it will call

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregatorBase.java
@@ -273,6 +273,15 @@ public abstract class AggregatorBase extends Aggregator {
         return subAggregatorbyName.get(aggName);
     }
 
+    @Override
+    public void releaseAggregations() {
+        // release sub aggregations
+        Arrays.stream(subAggregators).forEach(Aggregator::releaseAggregations);
+        // release this aggregation
+        close();
+        context.removeReleasable(this);
+    }
+
     /**
      * Called after collection of all document is done.
      * <p>

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/DeferringBucketCollector.java
@@ -84,6 +84,11 @@ public abstract class DeferringBucketCollector extends BucketCollector {
         }
 
         @Override
+        public void releaseAggregations() {
+            in.releaseAggregations();
+        }
+
+        @Override
         public InternalAggregation buildEmptyAggregation() {
             return in.buildEmptyAggregation();
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/AggregationContext.java
@@ -230,6 +230,11 @@ public abstract class AggregationContext implements Releasable {
     public abstract void addReleasable(Aggregator aggregator);
 
     /**
+     * Cause this aggregation to be released when the search is finished.
+     */
+    public abstract void removeReleasable(Aggregator aggregator);
+
+    /**
      * Max buckets provided by the search.max_buckets setting
      */
     public abstract int maxBuckets();
@@ -517,7 +522,16 @@ public abstract class AggregationContext implements Releasable {
 
         @Override
         public void addReleasable(Aggregator aggregator) {
+            assert releaseMe.contains(aggregator) == false
+                : "adding aggregator [" + aggregator.name() + "] twice in the aggregation context";
             releaseMe.add(aggregator);
+        }
+
+        @Override
+        public void removeReleasable(Aggregator aggregator) {
+            assert releaseMe.contains(aggregator)
+                : "removing non-existing aggregator [" + aggregator.name() + "] from the the aggregation context";
+            releaseMe.remove(aggregator);
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
@@ -82,6 +82,11 @@ public class ProfilingAggregator extends Aggregator {
     }
 
     @Override
+    public void releaseAggregations() {
+        delegate.releaseAggregations();
+    }
+
+    @Override
     public InternalAggregation buildEmptyAggregation() {
         return delegate.buildEmptyAggregation();
     }

--- a/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/mapper/MapperServiceTestCase.java
@@ -490,6 +490,11 @@ public abstract class MapperServiceTestCase extends ESTestCase {
             }
 
             @Override
+            public void removeReleasable(Aggregator aggregator) {
+                // TODO we'll have to handle this in the tests eventually
+            }
+
+            @Override
             public int maxBuckets() {
                 return Integer.MAX_VALUE;
             }


### PR DESCRIPTION
We currently wait until the search is over to release the aggregations objects but we can do it early, just after building the sparse representation. This might be useful when there are a lots of top level aggregations.