### PR TITLE
[Transform] Call listener in order to prevent the request from hanging

### DIFF
--- a/docs/changelog/96221.yaml
+++ b/docs/changelog/96221.yaml
@@ -1,0 +1,5 @@
+pr: 96221
+summary: Call listener in order to prevent the request from hanging
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -15,6 +15,7 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Strings;
+import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -23,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
 
 public class TransformUpdateIT extends TransformRestTestCase {
 
@@ -146,6 +148,28 @@ public class TransformUpdateIT extends TransformRestTestCase {
 
     public void testUpdateTransferRightsSecondaryAuthHeaders() throws Exception {
         updateTransferRightsTester(true);
+    }
+
+    public void testUpdateThatChangesSettingsButNotHeaders() throws Exception {
+        String transformId = "test_update_that_changes_settings";
+        String destIndex = transformId + "-dest";
+
+        // Create the transform
+        createPivotReviewsTransform(transformId, destIndex, null, null, null);
+
+        final Request updateTransformRequest = createRequestWithAuth(
+            "POST",
+            getTransformEndpoint() + transformId + "/_update",
+            null
+        );
+        updateTransformRequest.setJsonEntity("""
+            { "settings": { "max_page_search_size": 123 } }""");
+
+        // Update the transform's settings
+        Map<String, Object> updatedConfig = entityAsMap(client().performRequest(updateTransformRequest));
+
+        // Verify that the settings got updated
+        assertThat(updatedConfig.get("settings"), is(equalTo(Map.of("max_page_search_size", 123))));
     }
 
     private void updateTransferRightsTester(boolean useSecondaryAuthHeaders) throws Exception {

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -15,7 +15,6 @@ import org.elasticsearch.client.RestClientBuilder;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.xcontent.support.XContentMapValues;
 import org.elasticsearch.core.Strings;
-import org.elasticsearch.xpack.core.transform.transforms.SettingsConfig;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -157,11 +156,7 @@ public class TransformUpdateIT extends TransformRestTestCase {
         // Create the transform
         createPivotReviewsTransform(transformId, destIndex, null, null, null);
 
-        final Request updateTransformRequest = createRequestWithAuth(
-            "POST",
-            getTransformEndpoint() + transformId + "/_update",
-            null
-        );
+        Request updateTransformRequest = createRequestWithAuth("POST", getTransformEndpoint() + transformId + "/_update", null);
         updateTransformRequest.setJsonEntity("""
             { "settings": { "max_page_search_size": 123 } }""");
 

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/action/TransportUpdateTransformAction.java
@@ -205,6 +205,8 @@ public class TransportUpdateTransformAction extends TransportTasksAction<Transfo
                                     authState,
                                     ActionListener.wrap(aVoid -> listener.onResponse(new Response(updatedConfig)), listener::onFailure)
                                 );
+                            } else {
+                                listener.onResponse(new Response(updatedConfig));
                             }
                         } else {
                             listener.onResponse(new Response(updatedConfig));


### PR DESCRIPTION
This PR fixes a bug when the `_update` call hangs indefinitely due to listener not being called in one of the code paths.
A regression test is also added.

Relates https://github.com/elastic/elasticsearch/issues/93259