### PR TITLE
Change behavioral analytics API Spec naming

### DIFF
--- a/docs/changelog/96225.yaml
+++ b/docs/changelog/96225.yaml
@@ -1,0 +1,5 @@
+pr: 96225
+summary: Change behavioral analytics API Spec naming
+area: Application
+type: tech debt
+issues: []

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.delete.json
@@ -1,8 +1,8 @@
 {
-  "search_application.put_behavioral_analytics": {
+  "behavioral_analytics.delete": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
-      "description": "Creates a behavioral analytics collection."
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
+      "description": "Delete a behavioral analytics collection."
     },
     "stability": "experimental",
     "visibility": "public",
@@ -16,12 +16,12 @@
         {
           "path": "/_application/analytics/{name}",
           "methods": [
-            "PUT"
+            "DELETE"
           ],
           "parts": {
             "name": {
               "type": "string",
-              "description": "The name of the analytics collection to be created or updated"
+              "description": "The name of the analytics collection to be deleted"
             }
           }
         }

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.get.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.get.json
@@ -1,5 +1,5 @@
 {
-  "search_application.get_behavioral_analytics": {
+  "behavioral_analytics.get": {
     "documentation": {
       "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/list-analytics-collection.html",
       "description": "Returns the existing behavioral analytics collections."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.post_event.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.post_event.json
@@ -1,5 +1,5 @@
 {
-  "search_application.post_behavioral_analytics_event": {
+  "behavioral_analytics.post_event": {
     "documentation": {
       "url": "http://todo.com/tbd",
       "description": "Creates a behavioral analytics event for existing collection."

--- a/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/behavioral_analytics.put.json
@@ -1,8 +1,8 @@
 {
-  "search_application.delete_behavioral_analytics": {
+  "behavioral_analytics.put": {
     "documentation": {
-      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-analytics-collection.html",
-      "description": "Delete a behavioral analytics collection."
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/put-analytics-collection.html",
+      "description": "Creates a behavioral analytics collection."
     },
     "stability": "experimental",
     "visibility": "public",
@@ -16,12 +16,12 @@
         {
           "path": "/_application/analytics/{name}",
           "methods": [
-            "DELETE"
+            "PUT"
           ],
           "parts": {
             "name": {
               "type": "string",
-              "description": "The name of the analytics collection to be deleted"
+              "description": "The name of the analytics collection to be created or updated"
             }
           }
         }

--- a/x-pack/plugin/ent-search/qa/rest/build.gradle
+++ b/x-pack/plugin/ent-search/qa/rest/build.gradle
@@ -7,7 +7,7 @@ dependencies {
 
 restResources {
   restApi {
-    include '_common', 'cluster', 'nodes', 'indices', 'index', 'search_application', 'xpack'
+    include '_common', 'cluster', 'nodes', 'indices', 'index', 'search_application', 'xpack', 'behavioral_analytics'
   }
 }
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/60_behavioral_analytics_list.yml
@@ -1,26 +1,26 @@
 setup:
   - do:
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: my-test-analytics-collection
 
   - do:
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: my-test-analytics-collection2
 
 ---
 teardown:
   - do:
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: my-test-analytics-collection
 
   - do:
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: my-test-analytics-collection2
 
 ---
 "Get Analytics Collection for a particular collection":
   - do:
-      search_application.get_behavioral_analytics:
+      behavioral_analytics.get:
         name: my-test-analytics-collection
 
   - match: {
@@ -34,7 +34,7 @@ teardown:
 ---
 "Get Analytics Collection list":
   - do:
-      search_application.get_behavioral_analytics:
+      behavioral_analytics.get:
         name:
 
   - match: {
@@ -56,6 +56,6 @@ teardown:
 "Get Analytics Collection - Resource does not exist":
   - do:
       catch: "missing"
-      search_application.get_behavioral_analytics:
+      behavioral_analytics.get:
         name: test-nonexistent-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/70_behavioral_analytics_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/70_behavioral_analytics_put.yml
@@ -1,12 +1,12 @@
 teardown:
   - do:
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: test-analytics-collection
 
 ---
 "Create Analytics Collection":
   - do:
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: test-analytics-collection
 
   - match: { acknowledged: true }
@@ -15,14 +15,14 @@ teardown:
 ---
 "Create Analytics Collection - analytics collection already exists":
   - do:
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: test-analytics-collection
 
   - match: { acknowledged: true }
 
   - do:
       catch: bad_request
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: test-analytics-collection
 
   - match: { error.type: "resource_already_exists_exception" }

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/80_behavioral_analytics_delete.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/80_behavioral_analytics_delete.yml
@@ -1,32 +1,32 @@
 setup:
   - do:
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: my-test-analytics-collection
 
 ---
 teardown:
   - do:
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: my-test-analytics-collection
         ignore: 404
 
 ---
 "Delete Analytics Collection":
   - do:
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: my-test-analytics-collection
 
   - match: { acknowledged: true }
 
   - do:
       catch: "missing"
-      search_application.get_behavioral_analytics:
+      behavioral_analytics.get:
         name: my-test-analytics-collection
 
 ---
 "Delete Analytics Collection - Analytics Collection does not exist":
   - do:
       catch: "missing"
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: test-nonexistent-analytics-collection
 

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/90_behavioral_analytics_event_post.yml
@@ -1,12 +1,12 @@
 setup:
   - do:
-      search_application.put_behavioral_analytics:
+      behavioral_analytics.put:
         name: my-test-analytics-collection
 
 ---
 teardown:
   - do:
-      search_application.delete_behavioral_analytics:
+      behavioral_analytics.delete:
         name: my-test-analytics-collection
 
 
@@ -18,7 +18,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -37,7 +37,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -54,7 +54,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -75,7 +75,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -94,7 +94,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -116,7 +116,7 @@ teardown:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
         Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         debug: true
@@ -157,7 +157,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -176,7 +176,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -193,7 +193,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -213,7 +213,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -234,7 +234,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -255,7 +255,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -274,7 +274,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -307,7 +307,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         body:
@@ -332,7 +332,7 @@ teardown:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
         Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search"
         debug: true
@@ -398,7 +398,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
         body:
@@ -423,7 +423,7 @@ teardown:
         X-Forwarded-For: 192.23.12.12
         User-Agent: Mozilla/5.0
         Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ="  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
         debug: true
@@ -460,7 +460,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
         body:
@@ -480,7 +480,7 @@ teardown:
 
   - do:
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
         body:
@@ -502,7 +502,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
         body:
@@ -522,7 +522,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "search_click"
         body:
@@ -543,7 +543,7 @@ teardown:
   - do:
       catch: "missing"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: test-nonexistent-analytics-collection
         event_type: "page_view"
         body:
@@ -562,7 +562,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "nonexistent-event-type"
         body:
@@ -583,7 +583,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -601,7 +601,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "page_view"
         body:
@@ -619,7 +619,7 @@ teardown:
   - do:
       catch: "bad_request"
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
-      search_application.post_behavioral_analytics_event:
+      behavioral_analytics.post_event:
         collection_name: my-test-analytics-collection
         event_type: "nonexistent-event-type"
         body:


### PR DESCRIPTION
Following the conversation in https://github.com/elastic/elasticsearch-specification/pull/2110, changing the API Spec file names to differentiate them from search applications.