### PR TITLE
Fixing expectations in DataLifecycleServiceIT when there is a single node

### DIFF
--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
@@ -541,7 +541,16 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
                 // error stores don't contain anything for the first generation index anymore
                 Iterable<DataLifecycleService> lifecycleServices = internalCluster().getInstances(DataLifecycleService.class);
                 for (DataLifecycleService lifecycleService : lifecycleServices) {
-                    assertThat(lifecycleService.getErrorStore().getError(firstGenerationIndex), nullValue());
+                    if (internalCluster().numDataNodes() > 1) {
+                        assertThat(lifecycleService.getErrorStore().getError(firstGenerationIndex), nullValue());
+                    } else {
+                        if (lifecycleService.getErrorStore().getError(firstGenerationIndex) != null) {
+                            assertThat(
+                                lifecycleService.getErrorStore().getError(firstGenerationIndex),
+                                containsString("Force merge request only had 1 successful shards out of a total of 2")
+                            );
+                        }
+                    }
                 }
             });
         } finally {

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
@@ -385,7 +385,10 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
     public void testErrorRecordingOnRollover() throws Exception {
         // empty lifecycle contains the default rollover
         DataLifecycle lifecycle = new DataLifecycle();
-
+        /*
+         * We set index.auto_expand_replicas to 0-1 so that if we get a single-node cluster it is not yellow. The cluster being yellow
+         * could result in DLM's automatic forcemerge failing, which would result in an unexpected error in the error store.
+         */
         putComposableIndexTemplate(
             "id1",
             null,
@@ -469,6 +472,10 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
         // that its retention execution fails
         DataLifecycle lifecycle = new DataLifecycle();
 
+        /*
+         * We set index.auto_expand_replicas to 0-1 so that if we get a single-node cluster it is not yellow. The cluster being yellow
+         * could result in DLM's automatic forcemerge failing, which would result in an unexpected error in the error store.
+         */
         putComposableIndexTemplate(
             "id1",
             null,


### PR DESCRIPTION
If an integration test brings up a 1-node cluster, and if DLM runs forcemerge, then forcemerge will report an error. This PR updates 2 DataLifecycleServiceIT tests to account for that, similar to #96047.
Closes #96070