### PR TITLE
[Profiling] Remove source type from stacktraces response

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -54,7 +54,6 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
                     i.readList(StreamInput::readString),
                     i.readList(StreamInput::readString),
                     i.readList(StreamInput::readInt),
-                    i.readList(StreamInput::readInt),
                     i.readList(StreamInput::readInt)
                 )
             )
@@ -115,7 +114,6 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
                 o.writeCollection(v.functionName, StreamOutput::writeString);
                 o.writeCollection(v.functionOffset, StreamOutput::writeInt);
                 o.writeCollection(v.lineNumber, StreamOutput::writeInt);
-                o.writeCollection(v.sourceType, StreamOutput::writeInt);
             });
         } else {
             out.writeBoolean(false);

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/StackFrame.java
@@ -22,19 +22,16 @@ final class StackFrame implements ToXContentObject {
     private static final String[] PATH_FUNCTION_NAME = new String[] { "Stackframe", "function", "name" };
     private static final String[] PATH_FUNCTION_OFFSET = new String[] { "Stackframe", "function", "offset" };
     private static final String[] PATH_LINE_NUMBER = new String[] { "Stackframe", "line", "number" };
-    private static final String[] PATH_SOURCE_TYPE = new String[] { "Stackframe", "source", "type" };
     List<String> fileName;
     List<String> functionName;
     List<Integer> functionOffset;
     List<Integer> lineNumber;
-    List<Integer> sourceType;
 
-    StackFrame(Object fileName, Object functionName, Object functionOffset, Object lineNumber, Object sourceType) {
+    StackFrame(Object fileName, Object functionName, Object functionOffset, Object lineNumber) {
         this.fileName = listOf(fileName);
         this.functionName = listOf(functionName);
         this.functionOffset = listOf(functionOffset);
         this.lineNumber = listOf(lineNumber);
-        this.sourceType = listOf(sourceType);
     }
 
     @SuppressWarnings("unchecked")
@@ -58,8 +55,7 @@ final class StackFrame implements ToXContentObject {
                 ObjectPath.eval(PATH_FILE_NAME, source),
                 ObjectPath.eval(PATH_FUNCTION_NAME, source),
                 ObjectPath.eval(PATH_FUNCTION_OFFSET, source),
-                ObjectPath.eval(PATH_LINE_NUMBER, source),
-                ObjectPath.eval(PATH_SOURCE_TYPE, source)
+                ObjectPath.eval(PATH_LINE_NUMBER, source)
             );
         } else {
             // regular source
@@ -67,8 +63,7 @@ final class StackFrame implements ToXContentObject {
                 source.get("Stackframe.file.name"),
                 source.get("Stackframe.function.name"),
                 source.get("Stackframe.function.offset"),
-                source.get("Stackframe.line.number"),
-                source.get("Stackframe.source.type")
+                source.get("Stackframe.line.number")
             );
         }
     }
@@ -80,7 +75,6 @@ final class StackFrame implements ToXContentObject {
         builder.field("function_name", this.functionName);
         builder.field("function_offset", this.functionOffset);
         builder.field("line_number", this.lineNumber);
-        builder.field("source_type", this.sourceType);
         builder.endObject();
         return builder;
     }
@@ -97,12 +91,11 @@ final class StackFrame implements ToXContentObject {
         return Objects.equals(fileName, that.fileName)
             && Objects.equals(functionName, that.functionName)
             && Objects.equals(functionOffset, that.functionOffset)
-            && Objects.equals(lineNumber, that.lineNumber)
-            && Objects.equals(sourceType, that.sourceType);
+            && Objects.equals(lineNumber, that.lineNumber);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(fileName, functionName, functionOffset, lineNumber, sourceType);
+        return Objects.hash(fileName, functionName, functionOffset, lineNumber);
     }
 }

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -41,8 +41,7 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
                     randomList(0, maxInlined, () -> randomAlphaOfLength(20)),
                     randomList(0, maxInlined, () -> randomAlphaOfLength(20)),
                     randomList(0, maxInlined, () -> randomIntBetween(1, Integer.MAX_VALUE)),
-                    randomList(0, maxInlined, () -> randomIntBetween(1, 30_000)),
-                    randomList(0, maxInlined, () -> randomIntBetween(1, 10))
+                    randomList(0, maxInlined, () -> randomIntBetween(1, 30_000))
                 )
             )
         );

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/StackFrameTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/StackFrameTests.java
@@ -66,18 +66,17 @@ public class StackFrameTests extends ESTestCase {
             .array("function_name", "helloWorld")
             .array("function_offset", 31733)
             .array("line_number", 22)
-            .array("source_type", 3)
             .endObject();
 
         XContentBuilder actualRequest = XContentFactory.contentBuilder(contentType);
-        StackFrame stackTrace = new StackFrame("Main.java", "helloWorld", 31733, 22, 3);
+        StackFrame stackTrace = new StackFrame("Main.java", "helloWorld", 31733, 22);
         stackTrace.toXContent(actualRequest, ToXContent.EMPTY_PARAMS);
 
         assertToXContentEquivalent(BytesReference.bytes(expectedRequest), BytesReference.bytes(actualRequest), contentType);
     }
 
     public void testEquality() {
-        StackFrame frame = new StackFrame("Main.java", "helloWorld", 31733, 22, 3);
+        StackFrame frame = new StackFrame("Main.java", "helloWorld", 31733, 22);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             frame,
             (o -> new StackFrame(o.fileName, o.functionName, o.functionOffset, o.lineNumber))

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/StackFrameTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/StackFrameTests.java
@@ -32,12 +32,10 @@ public class StackFrameTests extends ESTestCase {
                         "name", "helloWorld",
                         "offset", 31733
                     ),
-                "line", Map.of("number", 22),
-                "source", Map.of("type", 3))
+                "line", Map.of("number", 22))
                 )
         );
         // end::noformat
-        assertEquals(List.of(3), frame.sourceType);
         assertEquals(List.of("Main.java"), frame.fileName);
         assertEquals(List.of("helloWorld"), frame.functionName);
         assertEquals(List.of(31733), frame.functionOffset);
@@ -54,7 +52,6 @@ public class StackFrameTests extends ESTestCase {
             )
         );
         // end::noformat
-        assertEquals(Collections.emptyList(), frame.sourceType);
         assertEquals(List.of("Main.java"), frame.fileName);
         assertEquals(List.of("helloWorld"), frame.functionName);
         assertEquals(Collections.emptyList(), frame.functionOffset);
@@ -83,7 +80,7 @@ public class StackFrameTests extends ESTestCase {
         StackFrame frame = new StackFrame("Main.java", "helloWorld", 31733, 22, 3);
         EqualsHashCodeTestUtils.checkEqualsAndHashCode(
             frame,
-            (o -> new StackFrame(o.fileName, o.functionName, o.functionOffset, o.lineNumber, o.sourceType))
+            (o -> new StackFrame(o.fileName, o.functionName, o.functionOffset, o.lineNumber))
         );
 
     }


### PR DESCRIPTION
This commit removes the deprecated source type field from the response for the `_profiling/stacktraces` API.