### PR TITLE
Add more information for understanding GrokTests.testExponentialExpressions failure

### DIFF
--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -755,11 +755,15 @@ public class GrokTests extends ESTestCase {
     private void testExponentialExpressions(boolean ecsCompatibility) {
         AtomicBoolean run = new AtomicBoolean(true); // to avoid a lingering thread when test has completed
 
+        // keeping track of the matcher watchdog and whether it has executed at all (hunting a rare test failure)
+        AtomicBoolean hasExecuted = new AtomicBoolean(false);
+
         String grokPattern = "Bonsuche mit folgender Anfrage: Belegart->\\[%{WORD:param2},(?<param5>(\\s*%{NOTSPACE})*)\\] "
             + "Zustand->ABGESCHLOSSEN Kassennummer->%{WORD:param9} Bonnummer->%{WORD:param10} Datum->%{DATESTAMP_OTHER:param11}";
         String logLine = "Bonsuche mit folgender Anfrage: Belegart->[EINGESCHRAENKTER_VERKAUF, VERKAUF, NACHERFASSUNG] "
             + "Zustand->ABGESCHLOSSEN Kassennummer->2 Bonnummer->6362 Datum->Mon Jan 08 00:00:00 UTC 2018";
         BiConsumer<Long, Runnable> scheduler = (delay, command) -> {
+            hasExecuted.set(true);
             Thread t = new Thread(() -> {
                 try {
                     Thread.sleep(delay);
@@ -778,6 +782,20 @@ public class GrokTests extends ESTestCase {
             MatcherWatchdog.newInstance(10, 200, System::currentTimeMillis, scheduler),
             logger::warn
         );
+
+        // hunting a rare test failure -- sometimes we get a failure in the expectThrows below, and the most
+        // logical reason for it to be hit is that the matcher watchdog just never even started up.
+        Thread t = new Thread(() -> {
+            try {
+                Thread.sleep(100); // half of max execution, 10x the interval, should be plenty
+            } catch (InterruptedException e) {
+                throw new AssertionError(e);
+            }
+            assertTrue("The MatchWatchdog scheduler should have run by now", hasExecuted.get());
+        });
+        t.setName("Quis custodiet ipsos custodes?");
+        t.start();
+
         Exception e = expectThrows(RuntimeException.class, () -> grok.captures(logLine));
         run.set(false);
         assertThat(e.getMessage(), equalTo("grok pattern matching was interrupted after [200] ms"));

--- a/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
+++ b/libs/grok/src/test/java/org/elasticsearch/grok/GrokTests.java
@@ -760,12 +760,12 @@ public class GrokTests extends ESTestCase {
         String logLine = "Bonsuche mit folgender Anfrage: Belegart->[EINGESCHRAENKTER_VERKAUF, VERKAUF, NACHERFASSUNG] "
             + "Zustand->ABGESCHLOSSEN Kassennummer->2 Bonnummer->6362 Datum->Mon Jan 08 00:00:00 UTC 2018";
         BiConsumer<Long, Runnable> scheduler = (delay, command) -> {
-            try {
-                Thread.sleep(delay);
-            } catch (InterruptedException e) {
-                throw new AssertionError(e);
-            }
             Thread t = new Thread(() -> {
+                try {
+                    Thread.sleep(delay);
+                } catch (InterruptedException e) {
+                    throw new AssertionError(e);
+                }
                 if (run.get()) {
                     command.run();
                 }


### PR DESCRIPTION
Related to #58946

If you comment out the line below, then you can get the failure every time.

https://github.com/elastic/elasticsearch/blob/e45158f501d43366d40087cf58305edd715688c4/libs/grok/src/main/java/org/elasticsearch/grok/MatcherWatchdog.java#L117

But that's nonsense, of course. Unless somehow `running.compareAndSet(false, true)` were spuriously returning `false` for no good reason...

Anyway, the idea of this code is that we'll be better able to detect whether the failure is due to the `MatcherWatchdog` just never having run at all, versus whether it ran (at least once) but perhaps somehow terminated early...