### PR TITLE
Cleanup shutdown

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -444,16 +444,16 @@ class Elasticsearch {
             return; // never got far enough
         }
         var es = INSTANCE;
-        es.node.prepareForClose();
         try {
+            es.node.prepareForClose();
             IOUtils.close(es.node, es.spawner);
-            if (es.node != null && es.node.awaitClose(10, TimeUnit.SECONDS) == false) {
+            if (es.node.awaitClose(10, TimeUnit.SECONDS) == false) {
                 throw new IllegalStateException(
                     "Node didn't stop within 10 seconds. " + "Any outstanding requests or tasks might get killed."
                 );
             }
         } catch (IOException ex) {
-            throw new ElasticsearchException("failed to stop node", ex);
+            throw new ElasticsearchException("Failure occurred while shutting down node", ex);
         } catch (InterruptedException e) {
             LogManager.getLogger(Elasticsearch.class).warn("Thread got interrupted while waiting for the node to shutdown.");
             Thread.currentThread().interrupt();

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -44,6 +44,7 @@ import java.nio.file.Path;
 import java.security.Permission;
 import java.security.Security;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -423,8 +424,8 @@ class Elasticsearch {
     private final Thread keepAliveThread;
 
     private Elasticsearch(Spawner spawner, Node node) {
-        this.spawner = spawner;
-        this.node = node;
+        this.spawner = Objects.requireNonNull(spawner);
+        this.node = Objects.requireNonNull(node);
         this.keepAliveThread = new Thread(() -> {
             try {
                 keepAliveLatch.await();


### PR DESCRIPTION
This commit moves the close preparation hook call into the shutdown try. It also imporoves the error message when an error occurs, and removes an unnecessary null check that is never possible.

relates #95850