### PR TITLE
TransportTasksAction#processTasks returns tasks

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -106,14 +106,9 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
                 () -> taskManager.unregisterRemovedTaskListener(removedTaskListener)
             );
             try {
-                processTasks(request, task -> {
-                    if (task.getAction().startsWith(ListTasksAction.NAME) == false) {
-                        // It doesn't make sense to wait for List Tasks and it can cause an infinite loop of the task waiting
-                        // for itself or one of its child tasks
-                        matchedTasks.add(task);
-                    }
+                for (final var task : processTasks(request)) {
                     operation.accept(task);
-                });
+                }
             } catch (Exception e) {
                 allMatchedTasksRemovedListener.onFailure(e);
                 return;

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -107,6 +107,11 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
             );
             try {
                 for (final var task : processTasks(request)) {
+                    if (task.getAction().startsWith(ListTasksAction.NAME) == false) {
+                        // It doesn't make sense to wait for List Tasks and it can cause an infinite loop of the task waiting
+                        // for itself or one of its child tasks
+                        matchedTasks.add(task);
+                    }
                     operation.accept(task);
                 }
             } catch (Exception e) {

--- a/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/support/tasks/TransportTasksAction.java
@@ -158,18 +158,20 @@ public abstract class TransportTasksAction<
     }
 
     protected void processTasks(TasksRequest request, Consumer<OperationTask> operation, ActionListener<Void> nodeOperation) {
-        processTasks(request, operation);
+        for (final var task : processTasks(request)) {
+            operation.accept(task);
+        }
         nodeOperation.onResponse(null);
     }
 
     @SuppressWarnings("unchecked")
-    protected void processTasks(TasksRequest request, Consumer<OperationTask> operation) {
+    protected List<OperationTask> processTasks(TasksRequest request) {
         if (request.getTargetTaskId().isSet()) {
             // we are only checking one task, we can optimize it
             Task task = taskManager.getTask(request.getTargetTaskId().getId());
             if (task != null) {
                 if (request.match(task)) {
-                    operation.accept((OperationTask) task);
+                    return List.of((OperationTask) task);
                 } else {
                     throw new ResourceNotFoundException("task [{}] doesn't support this operation", request.getTargetTaskId());
                 }
@@ -177,11 +179,13 @@ public abstract class TransportTasksAction<
                 throw new ResourceNotFoundException("task [{}] is missing", request.getTargetTaskId());
             }
         } else {
+            final var tasks = new ArrayList<OperationTask>();
             for (Task task : taskManager.getTasks().values()) {
                 if (request.match(task)) {
-                    operation.accept((OperationTask) task);
+                    tasks.add((OperationTask) task);
                 }
             }
+            return tasks;
         }
     }
 

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportFollowStatsAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/TransportFollowStatsAction.java
@@ -28,13 +28,13 @@ import org.elasticsearch.xpack.ccr.CcrLicenseChecker;
 import org.elasticsearch.xpack.core.ccr.action.FollowStatsAction;
 import org.elasticsearch.xpack.core.ccr.action.ShardFollowTask;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 public class TransportFollowStatsAction extends TransportTasksAction<
@@ -98,17 +98,19 @@ public class TransportFollowStatsAction extends TransportTasksAction<
     }
 
     @Override
-    protected void processTasks(final FollowStatsAction.StatsRequest request, final Consumer<ShardFollowNodeTask> operation) {
+    protected List<ShardFollowNodeTask> processTasks(final FollowStatsAction.StatsRequest request) {
         final ClusterState state = clusterService.state();
         final Set<String> followerIndices = findFollowerIndicesFromShardFollowTasks(state, request.indices());
 
+        final var tasks = new ArrayList<ShardFollowNodeTask>();
         for (final Task task : taskManager.getTasks().values()) {
             if (task instanceof final ShardFollowNodeTask shardFollowNodeTask) {
                 if (followerIndices.contains(shardFollowNodeTask.getFollowShardId().getIndexName())) {
-                    operation.accept(shardFollowNodeTask);
+                    tasks.add(shardFollowNodeTask);
                 }
             }
         }
+        return tasks;
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStartRollupAction.java
@@ -21,7 +21,6 @@ import org.elasticsearch.xpack.core.rollup.action.StartRollupJobAction;
 import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.List;
-import java.util.function.Consumer;
 
 public class TransportStartRollupAction extends TransportTasksAction<
     RollupJobTask,
@@ -44,8 +43,8 @@ public class TransportStartRollupAction extends TransportTasksAction<
     }
 
     @Override
-    protected void processTasks(StartRollupJobAction.Request request, Consumer<RollupJobTask> operation) {
-        TransportTaskHelper.doProcessTasks(request.getId(), operation, taskManager);
+    protected List<RollupJobTask> processTasks(StartRollupJobAction.Request request) {
+        return TransportTaskHelper.doProcessTasks(request.getId(), taskManager);
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportStopRollupAction.java
@@ -26,7 +26,6 @@ import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.List;
 import java.util.function.BooleanSupplier;
-import java.util.function.Consumer;
 
 public class TransportStopRollupAction extends TransportTasksAction<
     RollupJobTask,
@@ -57,8 +56,8 @@ public class TransportStopRollupAction extends TransportTasksAction<
     }
 
     @Override
-    protected void processTasks(StopRollupJobAction.Request request, Consumer<RollupJobTask> operation) {
-        TransportTaskHelper.doProcessTasks(request.getId(), operation, taskManager);
+    protected List<RollupJobTask> processTasks(StopRollupJobAction.Request request) {
+        return TransportTaskHelper.doProcessTasks(request.getId(), taskManager);
     }
 
     @Override

--- a/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportTaskHelper.java
+++ b/x-pack/plugin/rollup/src/main/java/org/elasticsearch/xpack/rollup/action/TransportTaskHelper.java
@@ -10,7 +10,7 @@ import org.elasticsearch.tasks.Task;
 import org.elasticsearch.tasks.TaskManager;
 import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
-import java.util.function.Consumer;
+import java.util.List;
 
 public class TransportTaskHelper {
     /**
@@ -18,7 +18,7 @@ public class TransportTaskHelper {
      * or none at all.  Should not end up in a situation where there are multiple tasks with the same
      * ID... but if we do, this will help prevent the situation from getting worse.
      */
-    static void doProcessTasks(String id, Consumer<RollupJobTask> operation, TaskManager taskManager) {
+    static List<RollupJobTask> doProcessTasks(String id, TaskManager taskManager) {
         RollupJobTask matchingTask = null;
         for (Task task : taskManager.getTasks().values()) {
             if (task instanceof RollupJobTask rollupJobTask && rollupJobTask.getConfig().getId().equals(id)) {
@@ -32,7 +32,9 @@ public class TransportTaskHelper {
         }
 
         if (matchingTask != null) {
-            operation.accept(matchingTask);
+            return List.of(matchingTask);
+        } else {
+            return List.of();
         }
     }
 }

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/TransportTaskHelperTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/rollup/action/TransportTaskHelperTests.java
@@ -16,10 +16,11 @@ import org.elasticsearch.xpack.rollup.job.RollupJobTask;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.function.Consumer;
 
 import static org.elasticsearch.xpack.core.rollup.ConfigTestHelpers.randomRollupJobConfig;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -36,11 +37,12 @@ public class TransportTaskHelperTests extends ESTestCase {
         tasks.put(1L, task);
         when(taskManager.getTasks()).thenReturn(tasks);
 
-        Consumer<RollupJobTask> consumer = rollupJobTask -> {
+        final var rollupJobTasks = TransportTaskHelper.doProcessTasks("foo", taskManager);
+        assertThat(rollupJobTasks, hasSize(1));
+        for (final var rollupJobTask : rollupJobTasks) {
             assertThat(rollupJobTask.getDescription(), equalTo("rollup_foo"));
             assertThat(rollupJobTask.getConfig().getId(), equalTo(job.getId()));
-        };
-        TransportTaskHelper.doProcessTasks("foo", consumer, taskManager);
+        }
     }
 
     public void testProcessRequestNoMatching() {
@@ -48,8 +50,7 @@ public class TransportTaskHelperTests extends ESTestCase {
         Map<Long, Task> tasks = getRandomTasks();
         when(taskManager.getTasks()).thenReturn(tasks);
 
-        Consumer<RollupJobTask> consumer = rollupJobTask -> { fail("Should not have reached consumer"); };
-        TransportTaskHelper.doProcessTasks("foo", consumer, taskManager);
+        assertThat(TransportTaskHelper.doProcessTasks("foo", taskManager), empty());
     }
 
     public void testProcessRequestMultipleMatching() {
@@ -69,12 +70,11 @@ public class TransportTaskHelperTests extends ESTestCase {
         when(task2.getConfig()).thenReturn(job2);
         tasks.put(2L, task2);
 
-        Consumer<RollupJobTask> consumer = rollupJobTask -> { fail("Should not have reached consumer"); };
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> TransportTaskHelper.doProcessTasks("foo", consumer, taskManager)
+            () -> TransportTaskHelper.doProcessTasks("foo", taskManager)
         );
-        assertThat(e.getMessage(), equalTo("Found more than one matching task for rollup job [foo] when " + "there should only be one."));
+        assertThat(e.getMessage(), equalTo("Found more than one matching task for rollup job [foo] when there should only be one."));
     }
 
     private Map<Long, Task> getRandomTasks() {


### PR DESCRIPTION
Today `TransportTasksAction#processTasks` accepts a consumer which always just appends the matching tasks to a list. This indirection isn't necessary, we can just return the list of the matching tasks directly.

This commit adjusts the sync overload only. The async overload will be adjusted similarly in a follow-up.