### PR TITLE
Remove duplicated changelog

### DIFF
--- a/docs/changelog/96213.yaml
+++ b/docs/changelog/96213.yaml
@@ -1,5 +1,0 @@
-pr: 96213
-summary: Search idle info transport version bump
-area: "Search"
-type: enhancement
-issues: []


### PR DESCRIPTION
PR #96213 introduced two changelog files as a result of reverting PR #95740.
Here we remove the second one keeping the original changelog.