### PR TITLE
Change Version.luceneVersion to a method

### DIFF
--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
@@ -145,7 +145,7 @@ public class MainResponse {
             this.buildHash = buildHash;
             this.buildDate = buildDate;
             this.isSnapshot = isSnapshot;
-            this.luceneVersion() = luceneVersion;
+            this.luceneVersion = luceneVersion;
             this.minimumWireCompatibilityVersion = minimumWireCompatibilityVersion;
             this.minimumIndexCompatibilityVersion = minimumIndexCompatibilityVersion;
         }
@@ -197,7 +197,7 @@ public class MainResponse {
                 && Objects.equals(buildType, version.buildType)
                 && buildHash.equals(version.buildHash)
                 && buildDate.equals(version.buildDate)
-                && luceneVersion.equals(version.luceneVersion())
+                && luceneVersion.equals(version.luceneVersion)
                 && minimumWireCompatibilityVersion.equals(version.minimumWireCompatibilityVersion)
                 && minimumIndexCompatibilityVersion.equals(version.minimumIndexCompatibilityVersion);
         }

--- a/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
+++ b/client/rest-high-level/src/main/java/org/elasticsearch/client/core/MainResponse.java
@@ -145,7 +145,7 @@ public class MainResponse {
             this.buildHash = buildHash;
             this.buildDate = buildDate;
             this.isSnapshot = isSnapshot;
-            this.luceneVersion = luceneVersion;
+            this.luceneVersion() = luceneVersion;
             this.minimumWireCompatibilityVersion = minimumWireCompatibilityVersion;
             this.minimumIndexCompatibilityVersion = minimumIndexCompatibilityVersion;
         }
@@ -197,7 +197,7 @@ public class MainResponse {
                 && Objects.equals(buildType, version.buildType)
                 && buildHash.equals(version.buildHash)
                 && buildDate.equals(version.buildDate)
-                && luceneVersion.equals(version.luceneVersion)
+                && luceneVersion.equals(version.luceneVersion())
                 && minimumWireCompatibilityVersion.equals(version.minimumWireCompatibilityVersion)
                 && minimumIndexCompatibilityVersion.equals(version.minimumIndexCompatibilityVersion);
         }

--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
@@ -92,7 +92,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
             .field("build_hash", build.hash())
             .field("build_date", build.date())
             .field("build_snapshot", build.isSnapshot())
-            .field("lucene_version", version.luceneVersion.toString())
+            .field("lucene_version", version.luceneVersion().toString())
             .field("minimum_wire_compatibility_version", version.minimumCompatibilityVersion().toString())
             .field("minimum_index_compatibility_version", version.minimumIndexCompatibilityVersion().toString())
             .endObject();

--- a/modules/rest-root/src/test/java/org/elasticsearch/rest/root/MainResponseTests.java
+++ b/modules/rest-root/src/test/java/org/elasticsearch/rest/root/MainResponseTests.java
@@ -83,7 +83,7 @@ public class MainResponseTests extends AbstractXContentSerializingTestCase<MainR
                     current.hash(),
                     current.date(),
                     current.isSnapshot(),
-                        version.luceneVersion().toString(),
+                    version.luceneVersion().toString(),
                     version.minimumCompatibilityVersion().toString(),
                     version.minimumIndexCompatibilityVersion().toString()
                 )

--- a/modules/rest-root/src/test/java/org/elasticsearch/rest/root/MainResponseTests.java
+++ b/modules/rest-root/src/test/java/org/elasticsearch/rest/root/MainResponseTests.java
@@ -83,7 +83,7 @@ public class MainResponseTests extends AbstractXContentSerializingTestCase<MainR
                     current.hash(),
                     current.date(),
                     current.isSnapshot(),
-                    version.luceneVersion.toString(),
+                        version.luceneVersion().toString(),
                     version.minimumCompatibilityVersion().toString(),
                     version.minimumIndexCompatibilityVersion().toString()
                 )

--- a/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
+++ b/qa/full-cluster-restart/src/javaRestTest/java/org/elasticsearch/upgrades/FullClusterRestartIT.java
@@ -958,9 +958,9 @@ public class FullClusterRestartIT extends ParameterizedFullClusterRestartTestCas
             assertTrue("expected to find a primary but didn't\n" + recoveryResponse, foundPrimary);
             assertEquals("mismatch while checking for translog recovery\n" + recoveryResponse, shouldHaveTranslog, restoredFromTranslog);
 
-            String currentLuceneVersion = Version.CURRENT.luceneVersion.toString();
-            String bwcLuceneVersion = getOldClusterVersion().luceneVersion.toString();
-            String minCompatibleBWCVersion = Version.CURRENT.minimumCompatibilityVersion().luceneVersion.toString();
+            String currentLuceneVersion = Version.CURRENT.luceneVersion().toString();
+            String bwcLuceneVersion = getOldClusterVersion().luceneVersion().toString();
+            String minCompatibleBWCVersion = Version.CURRENT.minimumCompatibilityVersion().luceneVersion().toString();
             if (shouldHaveTranslog && false == currentLuceneVersion.equals(bwcLuceneVersion)) {
                 int numCurrentVersion = 0;
                 int numBwcVersion = 0;

--- a/qa/verify-version-constants/src/test/java/org/elasticsearch/qa/verify_version_constants/VerifyVersionConstantsIT.java
+++ b/qa/verify-version-constants/src/test/java/org/elasticsearch/qa/verify_version_constants/VerifyVersionConstantsIT.java
@@ -32,7 +32,7 @@ public class VerifyVersionConstantsIT extends ESRestTestCase {
         final Version elasticsearchVersion = Version.fromString(elasticsearchVersionString.replace("-SNAPSHOT", ""));
         final String luceneVersionString = objectPath.evaluate("version.lucene_version").toString();
         final org.apache.lucene.util.Version luceneVersion = org.apache.lucene.util.Version.parse(luceneVersionString);
-        assertThat(elasticsearchVersion.luceneVersion, equalTo(luceneVersion));
+        assertThat(elasticsearchVersion.luceneVersion(), equalTo(luceneVersion));
     }
 
     @Override

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/plan/ShardSnapshotsServiceIT.java
@@ -192,7 +192,7 @@ public class ShardSnapshotsServiceIT extends ESIntegTestCase {
             assertThat(commitVersion, is(equalTo(Version.CURRENT)));
             final org.apache.lucene.util.Version commitLuceneVersion = shardSnapshotData.getCommitLuceneVersion();
             assertThat(commitLuceneVersion, is(notNullValue()));
-            assertThat(commitLuceneVersion, is(equalTo(Version.CURRENT.luceneVersion)));
+            assertThat(commitLuceneVersion, is(equalTo(Version.CURRENT.luceneVersion())));
 
             assertThat(shardSnapshotInfo.getShardId(), is(equalTo(shardId)));
             assertThat(shardSnapshotInfo.getSnapshot().getSnapshotId().getName(), is(equalTo(snapshotName)));

--- a/server/src/main/java/org/elasticsearch/Version.java
+++ b/server/src/main/java/org/elasticsearch/Version.java
@@ -310,7 +310,7 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     public final byte minor;
     public final byte revision;
     public final byte build;
-    public final org.apache.lucene.util.Version luceneVersion;
+    private final org.apache.lucene.util.Version luceneVersion;
     private final String toString;
     private final int previousMajorId;
 
@@ -349,6 +349,10 @@ public class Version implements Comparable<Version>, ToXContentFragment {
     @Override
     public XContentBuilder toXContent(XContentBuilder builder, Params params) throws IOException {
         return builder.value(toString());
+    }
+
+    public org.apache.lucene.util.Version luceneVersion() {
+        return luceneVersion;
     }
 
     /*

--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -322,10 +322,10 @@ class Elasticsearch {
     }
 
     static void checkLucene() {
-        if (Version.CURRENT.luceneVersion.equals(org.apache.lucene.util.Version.LATEST) == false) {
+        if (Version.CURRENT.luceneVersion().equals(org.apache.lucene.util.Version.LATEST) == false) {
             throw new AssertionError(
                 "Lucene version mismatch this version of Elasticsearch requires lucene version ["
-                    + Version.CURRENT.luceneVersion
+                    + Version.CURRENT.luceneVersion()
                     + "]  but the current lucene version is ["
                     + org.apache.lucene.util.Version.LATEST
                     + "]"

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredCharFilter.java
@@ -61,7 +61,7 @@ public class PreConfiguredCharFilter extends PreConfiguredAnalysisComponent<Char
             name,
             CachingStrategy.LUCENE,
             useFilterForMultitermQueries,
-            (reader, version) -> create.apply(reader, version.luceneVersion)
+            (reader, version) -> create.apply(reader, version.luceneVersion())
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenFilter.java
@@ -70,7 +70,7 @@ public final class PreConfiguredTokenFilter extends PreConfiguredAnalysisCompone
             useFilterForMultitermQueries,
             true,
             CachingStrategy.LUCENE,
-            (tokenStream, version) -> create.apply(tokenStream, version.luceneVersion)
+            (tokenStream, version) -> create.apply(tokenStream, version.luceneVersion())
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenizer.java
+++ b/server/src/main/java/org/elasticsearch/index/analysis/PreConfiguredTokenizer.java
@@ -37,7 +37,7 @@ public final class PreConfiguredTokenizer extends PreConfiguredAnalysisComponent
      * @param create builds the tokenizer
      */
     public static PreConfiguredTokenizer luceneVersion(String name, Function<org.apache.lucene.util.Version, Tokenizer> create) {
-        return new PreConfiguredTokenizer(name, CachingStrategy.LUCENE, version -> create.apply(version.luceneVersion));
+        return new PreConfiguredTokenizer(name, CachingStrategy.LUCENE, version -> create.apply(version.luceneVersion()));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexShard.java
@@ -2006,7 +2006,7 @@ public class IndexShard extends AbstractIndexShardComponent implements IndicesCl
             : "opening index which was created post 5.5.0 but " + Engine.MAX_UNSAFE_AUTO_ID_TIMESTAMP_COMMIT_ID + " is not found in commit";
         final org.apache.lucene.util.Version commitLuceneVersion = segmentCommitInfos.getCommitLuceneVersion();
         // This relies in the previous minor having another lucene version
-        assert commitLuceneVersion.onOrAfter(RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion) == false
+        assert commitLuceneVersion.onOrAfter(RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion()) == false
             || userData.containsKey(Engine.ES_VERSION) && Version.fromString(userData.get(Engine.ES_VERSION)).onOrBefore(Version.CURRENT)
             : "commit point has an invalid ES_VERSION value. commit point lucene version ["
                 + commitLuceneVersion

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -176,7 +176,7 @@ public final class SimilarityService {
         TermStatistics termStats = new TermStatistics(new BytesRef("some_value"), 100, 130);
         SimScorer scorer = similarity.scorer(2f, collectionStats, termStats);
         FieldInvertState state = new FieldInvertState(
-            indexCreatedVersion.luceneVersion.major,
+                indexCreatedVersion.luceneVersion().major,
             "some_field",
             IndexOptions.DOCS_AND_FREQS,
             20,
@@ -202,7 +202,7 @@ public final class SimilarityService {
         TermStatistics termStats = new TermStatistics(new BytesRef("some_value"), 100, 130);
         SimScorer scorer = similarity.scorer(2f, collectionStats, termStats);
         FieldInvertState state = new FieldInvertState(
-            indexCreatedVersion.luceneVersion.major,
+                indexCreatedVersion.luceneVersion().major,
             "some_field",
             IndexOptions.DOCS_AND_FREQS,
             20,
@@ -237,7 +237,7 @@ public final class SimilarityService {
         float previousScore = Float.MAX_VALUE;
         for (int length = 1; length <= 10; ++length) {
             FieldInvertState state = new FieldInvertState(
-                indexCreatedVersion.luceneVersion.major,
+                    indexCreatedVersion.luceneVersion().major,
                 "some_field",
                 IndexOptions.DOCS_AND_FREQS,
                 length,

--- a/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
+++ b/server/src/main/java/org/elasticsearch/index/similarity/SimilarityService.java
@@ -176,7 +176,7 @@ public final class SimilarityService {
         TermStatistics termStats = new TermStatistics(new BytesRef("some_value"), 100, 130);
         SimScorer scorer = similarity.scorer(2f, collectionStats, termStats);
         FieldInvertState state = new FieldInvertState(
-                indexCreatedVersion.luceneVersion().major,
+            indexCreatedVersion.luceneVersion().major,
             "some_field",
             IndexOptions.DOCS_AND_FREQS,
             20,
@@ -202,7 +202,7 @@ public final class SimilarityService {
         TermStatistics termStats = new TermStatistics(new BytesRef("some_value"), 100, 130);
         SimScorer scorer = similarity.scorer(2f, collectionStats, termStats);
         FieldInvertState state = new FieldInvertState(
-                indexCreatedVersion.luceneVersion().major,
+            indexCreatedVersion.luceneVersion().major,
             "some_field",
             IndexOptions.DOCS_AND_FREQS,
             20,
@@ -237,7 +237,7 @@ public final class SimilarityService {
         float previousScore = Float.MAX_VALUE;
         for (int length = 1; length <= 10; ++length) {
             FieldInvertState state = new FieldInvertState(
-                    indexCreatedVersion.luceneVersion().major,
+                indexCreatedVersion.luceneVersion().major,
                 "some_field",
                 IndexOptions.DOCS_AND_FREQS,
                 length,

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -817,7 +817,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
                     }
                 }
                 if (maxVersion == null) {
-                    maxVersion = org.elasticsearch.Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion;
+                    maxVersion = org.elasticsearch.Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion();
                 }
                 final String segmentsFile = segmentCommitInfos.getSegmentsFileName();
                 checksumFromLuceneFile(
@@ -1470,7 +1470,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
      * creates an empty lucene index and a corresponding empty translog. Any existing data will be deleted.
      */
     public void createEmpty() throws IOException {
-        Version luceneVersion = indexSettings.getIndexVersionCreated().luceneVersion;
+        Version luceneVersion = indexSettings.getIndexVersionCreated().luceneVersion();
         metadataLock.writeLock().lock();
         try (IndexWriter writer = newTemporaryEmptyIndexWriter(directory, luceneVersion)) {
             final Map<String, String> map = new HashMap<>();

--- a/server/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCacheFactory.java
+++ b/server/src/main/java/org/elasticsearch/indices/analysis/PreBuiltCacheFactory.java
@@ -104,12 +104,12 @@ public class PreBuiltCacheFactory {
 
         @Override
         public T get(Version version) {
-            return mapModel.get(version.luceneVersion);
+            return mapModel.get(version.luceneVersion());
         }
 
         @Override
         public void put(org.elasticsearch.Version version, T model) {
-            mapModel.put(version.luceneVersion, model);
+            mapModel.put(version.luceneVersion(), model);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -253,7 +253,10 @@ public class VersionTests extends ESTestCase {
         for (Version version : VersionUtils.allReleasedVersions()) {
             for (Version other : VersionUtils.allReleasedVersions()) {
                 if (other.onOrAfter(version)) {
-                    assertTrue("lucene versions must be " + other + " >= " + version, other.luceneVersion().onOrAfter(version.luceneVersion()));
+                    assertTrue(
+                        "lucene versions must be " + other + " >= " + version,
+                        other.luceneVersion().onOrAfter(version.luceneVersion())
+                    );
                 }
                 if (other.major == version.major && other.minor == version.minor) {
                     assertEquals(version + " vs. " + other, other.luceneVersion().major, version.luceneVersion().major);

--- a/server/src/test/java/org/elasticsearch/VersionTests.java
+++ b/server/src/test/java/org/elasticsearch/VersionTests.java
@@ -91,12 +91,12 @@ public class VersionTests extends ESTestCase {
 
     public void testVersionConstantPresent() {
         assertThat(Version.CURRENT, sameInstance(Version.fromId(Version.CURRENT.id)));
-        assertThat(Version.CURRENT.luceneVersion, equalTo(org.apache.lucene.util.Version.LATEST));
+        assertThat(Version.CURRENT.luceneVersion(), equalTo(org.apache.lucene.util.Version.LATEST));
         final int iters = scaledRandomIntBetween(20, 100);
         for (int i = 0; i < iters; i++) {
             Version version = randomVersion(random());
             assertThat(version, sameInstance(Version.fromId(version.id)));
-            assertThat(version.luceneVersion, sameInstance(Version.fromId(version.id).luceneVersion));
+            assertThat(version.luceneVersion(), sameInstance(Version.fromId(version.id).luceneVersion()));
         }
     }
 
@@ -178,7 +178,7 @@ public class VersionTests extends ESTestCase {
         for (int i = 0; i < iters; i++) {
             Version version = randomVersion(random());
             if (random().nextBoolean()) {
-                version = new Version(version.id, version.luceneVersion);
+                version = new Version(version.id, version.luceneVersion());
             }
             Version parsedVersion = Version.fromString(version.toString());
             assertEquals(version, parsedVersion);
@@ -195,7 +195,7 @@ public class VersionTests extends ESTestCase {
     public void testParseLenient() {
         // note this is just a silly sanity check, we test it in lucene
         for (Version version : VersionUtils.allReleasedVersions()) {
-            org.apache.lucene.util.Version luceneVersion = version.luceneVersion;
+            org.apache.lucene.util.Version luceneVersion = version.luceneVersion();
             String string = luceneVersion.toString().toUpperCase(Locale.ROOT).replaceFirst("^LUCENE_(\\d+)_(\\d+)$", "$1.$2");
             assertThat(luceneVersion, Matchers.equalTo(Lucene.parseVersionLenient(string, null)));
         }
@@ -253,11 +253,11 @@ public class VersionTests extends ESTestCase {
         for (Version version : VersionUtils.allReleasedVersions()) {
             for (Version other : VersionUtils.allReleasedVersions()) {
                 if (other.onOrAfter(version)) {
-                    assertTrue("lucene versions must be " + other + " >= " + version, other.luceneVersion.onOrAfter(version.luceneVersion));
+                    assertTrue("lucene versions must be " + other + " >= " + version, other.luceneVersion().onOrAfter(version.luceneVersion()));
                 }
                 if (other.major == version.major && other.minor == version.minor) {
-                    assertEquals(version + " vs. " + other, other.luceneVersion.major, version.luceneVersion.major);
-                    assertEquals(version + " vs. " + other, other.luceneVersion.minor, version.luceneVersion.minor);
+                    assertEquals(version + " vs. " + other, other.luceneVersion().major, version.luceneVersion().major);
+                    assertEquals(version + " vs. " + other, other.luceneVersion().minor, version.luceneVersion().minor);
                     // should we also assert the lucene bugfix version?
                 }
             }

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionsTests.java
@@ -204,19 +204,19 @@ public class VersionsTests extends ESTestCase {
         final Version nextVersion = Version.fromId(version.id + 100);
         if (Version.getDeclaredVersions(Version.class).contains(nextVersion) == false) {
             // the version is not known, we make an assumption the Lucene version stays the same
-            assertEquals(nextVersion.luceneVersion, version.luceneVersion);
+            assertEquals(nextVersion.luceneVersion(), version.luceneVersion());
         } else {
             // the version is known, the most we can assert is that the Lucene version is not earlier
-            assertTrue(nextVersion.luceneVersion.onOrAfter(version.luceneVersion));
+            assertTrue(nextVersion.luceneVersion().onOrAfter(version.luceneVersion()));
         }
 
         // too old version, major should be the oldest supported lucene version minus 1
         version = Version.fromString("5.2.1");
-        assertEquals(VersionUtils.getFirstVersion().luceneVersion.major - 1, version.luceneVersion.major);
+        assertEquals(VersionUtils.getFirstVersion().luceneVersion().major - 1, version.luceneVersion().major);
 
         // future version, should be the same version as today
         version = Version.fromId(Version.CURRENT.id + 100);
-        assertEquals(Version.CURRENT.luceneVersion, version.luceneVersion);
+        assertEquals(Version.CURRENT.luceneVersion(), version.luceneVersion());
     }
 
     public void testTimeSeriesLoadDocIdAndVersion() throws Exception {

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -66,7 +66,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
-    private static final String MIN_SUPPORTED_LUCENE_VERSION = Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion().toString();
+    private static final String MIN_SUPPORTED_LUCENE_VERSION = Version.CURRENT.minimumIndexCompatibilityVersion()
+        .luceneVersion()
+        .toString();
 
     private final ShardId shardId = new ShardId("test", "_na_", 0);
     private final DiscoveryNode node1 = newNode("node1");

--- a/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/ReplicaShardAllocatorTests.java
@@ -66,7 +66,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
 
 public class ReplicaShardAllocatorTests extends ESAllocationTestCase {
-    private static final String MIN_SUPPORTED_LUCENE_VERSION = Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion.toString();
+    private static final String MIN_SUPPORTED_LUCENE_VERSION = Version.CURRENT.minimumIndexCompatibilityVersion().luceneVersion().toString();
 
     private final ShardId shardId = new ShardId("test", "_na_", 0);
     private final DiscoveryNode node1 = newNode("node1");

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineTests.java
@@ -6725,7 +6725,7 @@ public class InternalEngineTests extends EngineTestCase {
             Map<String, String> userData = new HashMap<>(store.readLastCommittedSegmentsInfo().userData);
             userData.remove(Engine.MIN_RETAINED_SEQNO);
             IndexWriterConfig indexWriterConfig = new IndexWriterConfig(null).setOpenMode(IndexWriterConfig.OpenMode.APPEND)
-                .setIndexCreatedVersionMajor(Version.CURRENT.luceneVersion.major)
+                .setIndexCreatedVersionMajor(Version.CURRENT.luceneVersion().major)
                 .setSoftDeletesField(Lucene.SOFT_DELETES_FIELD)
                 .setCommitOnClose(false)
                 .setMergePolicy(NoMergePolicy.INSTANCE);
@@ -6785,7 +6785,7 @@ public class InternalEngineTests extends EngineTestCase {
                 engine.refresh("test");
                 try (Engine.Searcher searcher = engine.acquireSearcher("test")) {
                     LeafReader leafReader = getOnlyLeafReader(searcher.getIndexReader());
-                    assertEquals(createdVersion.luceneVersion.major, leafReader.getMetaData().getCreatedVersionMajor());
+                    assertEquals(createdVersion.luceneVersion().major, leafReader.getMetaData().getCreatedVersionMajor());
                 }
             }
         }

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class FileInfoTests extends ESTestCase {
-    private static final org.apache.lucene.util.Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-        .minimumIndexCompatibilityVersion().luceneVersion;
+    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
+            .minimumIndexCompatibilityVersion().luceneVersion();
 
     public void testToFromXContent() throws IOException {
         final int iters = scaledRandomIntBetween(1, 10);

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -31,8 +31,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 
 public class FileInfoTests extends ESTestCase {
-    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-            .minimumIndexCompatibilityVersion().luceneVersion();
+    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT.minimumIndexCompatibilityVersion()
+        .luceneVersion();
 
     public void testToFromXContent() throws IOException {
         final int iters = scaledRandomIntBetween(1, 10);

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -106,7 +106,7 @@ public class StoreTests extends ESTestCase {
         Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build()
     );
     private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-        .minimumIndexCompatibilityVersion().luceneVersion;
+            .minimumIndexCompatibilityVersion().luceneVersion();
 
     public void testRefCount() {
         final ShardId shardId = new ShardId("index", "_na_", 1);

--- a/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
+++ b/server/src/test/java/org/elasticsearch/index/store/StoreTests.java
@@ -105,8 +105,8 @@ public class StoreTests extends ESTestCase {
         "index",
         Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, org.elasticsearch.Version.CURRENT).build()
     );
-    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-            .minimumIndexCompatibilityVersion().luceneVersion();
+    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT.minimumIndexCompatibilityVersion()
+        .luceneVersion();
 
     public void testRefCount() {
         final ShardId shardId = new ShardId("index", "_na_", 1);

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -274,7 +274,10 @@ public class AnalysisModuleTests extends ESTestCase {
                 .build()
         );
         assertTokenStreamContents(analyzers.get("no_version").tokenStream("", "test"), new String[] { "testno_version" });
-        assertTokenStreamContents(analyzers.get("lucene_version").tokenStream("", "test"), new String[] {"test" + version.luceneVersion() });
+        assertTokenStreamContents(
+            analyzers.get("lucene_version").tokenStream("", "test"),
+            new String[] { "test" + version.luceneVersion() }
+        );
         assertTokenStreamContents(analyzers.get("elasticsearch_version").tokenStream("", "test"), new String[] { "test" + version });
 
         assertEquals(
@@ -340,7 +343,10 @@ public class AnalysisModuleTests extends ESTestCase {
                 .build()
         );
         assertTokenStreamContents(analyzers.get("no_version").tokenStream("", "test"), new String[] { "testno_version" });
-        assertTokenStreamContents(analyzers.get("lucene_version").tokenStream("", "test"), new String[] {"test" + version.luceneVersion() });
+        assertTokenStreamContents(
+            analyzers.get("lucene_version").tokenStream("", "test"),
+            new String[] { "test" + version.luceneVersion() }
+        );
         assertTokenStreamContents(analyzers.get("elasticsearch_version").tokenStream("", "test"), new String[] { "test" + version });
 
         assertEquals(
@@ -426,7 +432,7 @@ public class AnalysisModuleTests extends ESTestCase {
         assertTokenStreamContents(analyzers.get("no_version").tokenStream("", "test"), new String[] { "no_version" });
         assertTokenStreamContents(
             analyzers.get("lucene_version").tokenStream("", "test"),
-            new String[] {version.luceneVersion().toString() }
+            new String[] { version.luceneVersion().toString() }
         );
         assertTokenStreamContents(analyzers.get("elasticsearch_version").tokenStream("", "test"), new String[] { version.toString() });
 

--- a/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/analysis/AnalysisModuleTests.java
@@ -274,7 +274,7 @@ public class AnalysisModuleTests extends ESTestCase {
                 .build()
         );
         assertTokenStreamContents(analyzers.get("no_version").tokenStream("", "test"), new String[] { "testno_version" });
-        assertTokenStreamContents(analyzers.get("lucene_version").tokenStream("", "test"), new String[] { "test" + version.luceneVersion });
+        assertTokenStreamContents(analyzers.get("lucene_version").tokenStream("", "test"), new String[] {"test" + version.luceneVersion() });
         assertTokenStreamContents(analyzers.get("elasticsearch_version").tokenStream("", "test"), new String[] { "test" + version });
 
         assertEquals(
@@ -282,7 +282,7 @@ public class AnalysisModuleTests extends ESTestCase {
             analyzers.get("no_version").normalize("", "test").utf8ToString()
         );
         assertEquals(
-            "test" + (luceneVersionSupportsMultiTerm ? version.luceneVersion.toString() : ""),
+            "test" + (luceneVersionSupportsMultiTerm ? version.luceneVersion().toString() : ""),
             analyzers.get("lucene_version").normalize("", "test").utf8ToString()
         );
         assertEquals(
@@ -340,7 +340,7 @@ public class AnalysisModuleTests extends ESTestCase {
                 .build()
         );
         assertTokenStreamContents(analyzers.get("no_version").tokenStream("", "test"), new String[] { "testno_version" });
-        assertTokenStreamContents(analyzers.get("lucene_version").tokenStream("", "test"), new String[] { "test" + version.luceneVersion });
+        assertTokenStreamContents(analyzers.get("lucene_version").tokenStream("", "test"), new String[] {"test" + version.luceneVersion() });
         assertTokenStreamContents(analyzers.get("elasticsearch_version").tokenStream("", "test"), new String[] { "test" + version });
 
         assertEquals(
@@ -348,7 +348,7 @@ public class AnalysisModuleTests extends ESTestCase {
             analyzers.get("no_version").normalize("", "test").utf8ToString()
         );
         assertEquals(
-            "test" + (luceneVersionSupportsMultiTerm ? version.luceneVersion.toString() : ""),
+            "test" + (luceneVersionSupportsMultiTerm ? version.luceneVersion().toString() : ""),
             analyzers.get("lucene_version").normalize("", "test").utf8ToString()
         );
         assertEquals(
@@ -426,7 +426,7 @@ public class AnalysisModuleTests extends ESTestCase {
         assertTokenStreamContents(analyzers.get("no_version").tokenStream("", "test"), new String[] { "no_version" });
         assertTokenStreamContents(
             analyzers.get("lucene_version").tokenStream("", "test"),
-            new String[] { version.luceneVersion.toString() }
+            new String[] {version.luceneVersion().toString() }
         );
         assertTokenStreamContents(analyzers.get("elasticsearch_version").tokenStream("", "test"), new String[] { version.toString() });
 

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.indices.recovery;
 import org.apache.lucene.backward_codecs.store.EndiannessReverserUtil;
 import org.apache.lucene.codecs.CodecUtil;
 import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.util.Version;
 import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
@@ -21,8 +22,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class RecoveryStatusTests extends ESSingleNodeTestCase {
-    private static final org.apache.lucene.util.Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-        .minimumIndexCompatibilityVersion().luceneVersion;
+    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
+            .minimumIndexCompatibilityVersion().luceneVersion();
 
     public void testRenameTempFiles() throws IOException {
         IndexService service = createIndex("foo");

--- a/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/RecoveryStatusTests.java
@@ -22,8 +22,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 
 public class RecoveryStatusTests extends ESSingleNodeTestCase {
-    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT
-            .minimumIndexCompatibilityVersion().luceneVersion();
+    private static final Version MIN_SUPPORTED_LUCENE_VERSION = org.elasticsearch.Version.CURRENT.minimumIndexCompatibilityVersion()
+        .luceneVersion();
 
     public void testRenameTempFiles() throws IOException {
         IndexService service = createIndex("foo");

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/ShardSnapshotTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/ShardSnapshotTaskRunnerTests.java
@@ -100,7 +100,7 @@ public class ShardSnapshotTaskRunnerTests extends ESTestCase {
 
     public static BlobStoreIndexShardSnapshot.FileInfo dummyFileInfo() {
         String filename = randomAlphaOfLength(10);
-        StoreFileMetadata metadata = new StoreFileMetadata(filename, 10, "CHECKSUM", Version.CURRENT.luceneVersion.toString());
+        StoreFileMetadata metadata = new StoreFileMetadata(filename, 10, "CHECKSUM", Version.CURRENT.luceneVersion().toString());
         return new BlobStoreIndexShardSnapshot.FileInfo(filename, metadata, null);
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ESTestCase.java
@@ -1896,7 +1896,7 @@ public abstract class ESTestCase extends LuceneTestCase {
      * @param message an additional message or link with information on the fix
      */
     protected void skipTestWaitingForLuceneFix(org.apache.lucene.util.Version luceneVersionWithFix, String message) {
-        final boolean currentVersionHasFix = Version.CURRENT.luceneVersion.onOrAfter(luceneVersionWithFix);
+        final boolean currentVersionHasFix = Version.CURRENT.luceneVersion().onOrAfter(luceneVersionWithFix);
         assumeTrue("Skipping test as it is waiting on a Lucene fix: " + message, currentVersionHasFix);
         fail("Remove call of skipTestWaitingForLuceneFix in " + RandomizedTest.getContext().getTargetMethod());
     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -641,7 +641,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
             fileName,
             fileContent.length,
             fileChecksum,
-            Version.CURRENT.luceneVersion.toString()
+                Version.CURRENT.luceneVersion().toString()
         );
         final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, ByteSizeValue.ofBytes(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryStatsTests.java
@@ -641,7 +641,7 @@ public class SearchableSnapshotDirectoryStatsTests extends AbstractSearchableSna
             fileName,
             fileContent.length,
             fileChecksum,
-                Version.CURRENT.luceneVersion().toString()
+            Version.CURRENT.luceneVersion().toString()
         );
         final List<FileInfo> files = List.of(new FileInfo(blobName, metadata, ByteSizeValue.ofBytes(fileContent.length)));
         final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(snapshotId.getName(), 0L, files, 0L, 0L, 0, 0L);

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -733,7 +733,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                 randomFiles.add(
                     new BlobStoreIndexShardSnapshot.FileInfo(
                         blobName,
-                        new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion.toString()),
+                        new StoreFileMetadata(fileName, input.length, checksum, Version.CURRENT.luceneVersion().toString()),
                         ByteSizeValue.ofBytes(input.length)
                     )
                 );

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -75,7 +75,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                     fileName,
                     input.length,
                     checksum,
-                        Version.CURRENT.luceneVersion().toString()
+                    Version.CURRENT.luceneVersion().toString()
                 );
 
                 final int partSize = randomBoolean() ? input.length : randomIntBetween(1, input.length);
@@ -195,7 +195,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 fileName,
                 input.length,
                 checksum,
-                    Version.CURRENT.luceneVersion().toString()
+                Version.CURRENT.luceneVersion().toString()
             );
 
             final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/CachedBlobContainerIndexInputTests.java
@@ -75,7 +75,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                     fileName,
                     input.length,
                     checksum,
-                    Version.CURRENT.luceneVersion.toString()
+                        Version.CURRENT.luceneVersion().toString()
                 );
 
                 final int partSize = randomBoolean() ? input.length : randomIntBetween(1, input.length);
@@ -195,7 +195,7 @@ public class CachedBlobContainerIndexInputTests extends AbstractSearchableSnapsh
                 fileName,
                 input.length,
                 checksum,
-                Version.CURRENT.luceneVersion.toString()
+                    Version.CURRENT.luceneVersion().toString()
             );
 
             final BlobStoreIndexShardSnapshot snapshot = new BlobStoreIndexShardSnapshot(

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/input/FrozenIndexInputTests.java
@@ -55,7 +55,7 @@ public class FrozenIndexInputTests extends AbstractSearchableSnapshotsTestCase {
 
         final FileInfo fileInfo = new FileInfo(
             randomAlphaOfLength(10),
-            new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion.toString()),
+            new StoreFileMetadata(fileName, fileData.length, checksum, Version.CURRENT.luceneVersion().toString()),
             ByteSizeValue.ofBytes(fileData.length)
         );
 

--- a/x-pack/plugin/snapshot-based-recoveries/src/main/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerService.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/main/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerService.java
@@ -187,8 +187,8 @@ public class SnapshotsRecoveryPlannerService implements RecoveryPlannerService {
         // NodeVersionAllocationDecider ensures that we only recover to a node that has newer or
         // same version.
         if (commitVersion == null) {
-            assert SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion.onOrAfter(snapshot.getCommitLuceneVersion());
-            return Version.CURRENT.luceneVersion.onOrAfter(snapshot.getCommitLuceneVersion());
+            assert SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION.luceneVersion().onOrAfter(snapshot.getCommitLuceneVersion());
+            return Version.CURRENT.luceneVersion().onOrAfter(snapshot.getCommitLuceneVersion());
         }
         return commitVersion.onOrBefore(Version.CURRENT);
     }

--- a/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
@@ -217,12 +217,12 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                 // then lucene version must be < RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION
                 if (snapshotVersion == null) {
                     luceneVersion = randomVersionBetween(
-                        random(),
-                        Version.V_7_0_0,
-                        RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_VERSION
-                    ).luceneVersion;
+                            random(),
+                            Version.V_7_0_0,
+                            RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_VERSION
+                    ).luceneVersion();
                 } else {
-                    luceneVersion = randomCompatibleVersion(random(), Version.CURRENT).luceneVersion;
+                    luceneVersion = randomCompatibleVersion(random(), Version.CURRENT).luceneVersion();
                 }
             } else {
                 snapshotVersion = Version.fromId(Integer.MAX_VALUE);
@@ -603,7 +603,7 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
     }
 
     private ShardSnapshot createShardSnapshotThatDoNotShareSegmentFiles(String repoName) {
-        return createShardSnapshotThatDoNotShareSegmentFiles(repoName, Version.CURRENT, Version.CURRENT.luceneVersion);
+        return createShardSnapshotThatDoNotShareSegmentFiles(repoName, Version.CURRENT, Version.CURRENT.luceneVersion());
     }
 
     private ShardSnapshot createShardSnapshotThatDoNotShareSegmentFiles(
@@ -632,7 +632,7 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
             );
             snapshotFiles.add(fileInfo);
         }
-        return createShardSnapshot(repository, snapshotFiles, Version.CURRENT, Version.CURRENT.luceneVersion);
+        return createShardSnapshot(repository, snapshotFiles, Version.CURRENT, Version.CURRENT.luceneVersion());
     }
 
     private ShardSnapshot createShardSnapshot(

--- a/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/test/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/plan/SnapshotsRecoveryPlannerServiceTests.java
@@ -216,11 +216,8 @@ public class SnapshotsRecoveryPlannerServiceTests extends ESTestCase {
                 // If snapshotVersion is not present,
                 // then lucene version must be < RecoverySettings.SEQ_NO_SNAPSHOT_RECOVERIES_SUPPORTED_VERSION
                 if (snapshotVersion == null) {
-                    luceneVersion = randomVersionBetween(
-                            random(),
-                            Version.V_7_0_0,
-                            RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_VERSION
-                    ).luceneVersion();
+                    luceneVersion = randomVersionBetween(random(), Version.V_7_0_0, RecoverySettings.SNAPSHOT_RECOVERIES_SUPPORTED_VERSION)
+                        .luceneVersion();
                 } else {
                     luceneVersion = randomCompatibleVersion(random(), Version.CURRENT).luceneVersion();
                 }


### PR DESCRIPTION
Split from #94827, changing `luceneVersion` field to a method to allow it to be redirected later on