### PR TITLE
[ML] Add initial extension point for serverless transform plugin

### DIFF
--- a/x-pack/plugin/transform/src/main/java/module-info.java
+++ b/x-pack/plugin/transform/src/main/java/module-info.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+module org.elasticsearch.transform {
+    requires org.apache.lucene.analysis.common;
+    requires org.elasticsearch.geo;
+    requires org.elasticsearch.logging;
+    requires org.elasticsearch.cli;
+    requires org.elasticsearch.xcore;
+    requires org.elasticsearch.base;
+    requires org.elasticsearch.grok;
+    requires org.elasticsearch.server;
+    requires org.elasticsearch.xcontent;
+    requires org.apache.httpcomponents.httpcore;
+    requires org.apache.httpcomponents.httpclient;
+    requires org.apache.httpcomponents.httpasyncclient;
+    requires org.apache.httpcomponents.httpcore.nio;
+    requires org.apache.logging.log4j;
+    requires org.apache.lucene.core;
+    requires org.apache.lucene.join;
+
+    exports org.elasticsearch.xpack.transform;
+    exports org.elasticsearch.xpack.transform.action;
+    exports org.elasticsearch.xpack.transform.checkpoint;
+    exports org.elasticsearch.xpack.transform.notifications;
+    exports org.elasticsearch.xpack.transform.persistence;
+    exports org.elasticsearch.xpack.transform.rest.action;
+    exports org.elasticsearch.xpack.transform.transforms;
+    exports org.elasticsearch.xpack.transform.transforms.common;
+    exports org.elasticsearch.xpack.transform.transforms.latest;
+    exports org.elasticsearch.xpack.transform.transforms.pivot;
+    exports org.elasticsearch.xpack.transform.transforms.scheduling;
+    exports org.elasticsearch.xpack.transform.utils;
+}

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -248,7 +248,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
             client,
             xContentRegistry
         );
-        TransformAuditor auditor = new TransformAuditor(client, clusterService.getNodeName(), clusterService);
+        TransformAuditor auditor = new TransformAuditor(client, clusterService.getNodeName(), clusterService, includeNodeInfo());
         Clock clock = Clock.systemUTC();
         TransformCheckpointService checkpointService = new TransformCheckpointService(
             clock,
@@ -437,4 +437,6 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
     public String getFeatureDescription() {
         return "Manages configuration and state for transforms";
     }
+
+    public boolean includeNodeInfo() { return true; }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/Transform.java
@@ -438,5 +438,7 @@ public class Transform extends Plugin implements SystemIndexPlugin, PersistentTa
         return "Manages configuration and state for transforms";
     }
 
-    public boolean includeNodeInfo() { return true; }
+    public boolean includeNodeInfo() {
+        return true;
+    }
 }

--- a/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/notifications/TransformAuditor.java
+++ b/x-pack/plugin/transform/src/main/java/org/elasticsearch/xpack/transform/notifications/TransformAuditor.java
@@ -32,7 +32,9 @@ public class TransformAuditor extends AbstractAuditor<TransformAuditMessage> {
 
     private volatile boolean isResetMode = false;
 
-    public TransformAuditor(Client client, String nodeName, ClusterService clusterService) {
+    private final boolean includeNodeInfo;
+
+    public TransformAuditor(Client client, String nodeName, ClusterService clusterService, boolean includeNodeInfo) {
         super(
             new OriginSettingClient(client, TRANSFORM_ORIGIN),
             TransformInternalIndexConstants.AUDIT_INDEX,
@@ -59,6 +61,11 @@ public class TransformAuditor extends AbstractAuditor<TransformAuditMessage> {
                 isResetMode = TransformMetadata.getTransformMetadata(event.state()).isResetMode();
             }
         });
+        this.includeNodeInfo = includeNodeInfo;
+    }
+
+    public boolean isIncludeNodeInfo() {
+        return includeNodeInfo;
     }
 
     @Override

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/notifications/MockTransformAuditor.java
@@ -57,7 +57,7 @@ public class MockTransformAuditor extends TransformAuditor {
     private final List<AuditExpectation> expectations;
 
     public MockTransformAuditor(ClusterService clusterService) {
-        super(mock(Client.class), MOCK_NODE_NAME, clusterService);
+        super(mock(Client.class), MOCK_NODE_NAME, clusterService, true);
         expectations = new CopyOnWriteArrayList<>();
     }
 


### PR DESCRIPTION
Add the initial extension points for the `Transform` plugin that will be overridden by the `TransformServerless` plugin.

Initially there is is just the one such extension point `includeNodeInfo()` which indicates whether or not node information should be included in the audit messages.

Creating as a draft since, while early visibility on this is a good thing, it has not yet been extensively tested.