### PR TITLE
Temporarily disable retries in docker build tasks

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/ShellRetry.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/docker/ShellRetry.java
@@ -8,9 +8,6 @@
 
 package org.elasticsearch.gradle.internal.docker;
 
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-
 /**
  * The methods in this class take a shell command and wrap it in retry logic, so that our
  * Docker builds can be more robust in the face of transient errors e.g. network issues.
@@ -20,7 +17,8 @@ public class ShellRetry {
         return loop(name, command, 4, "exit");
     }
 
-    static String loop(String name, String command, int indentSize, String exitKeyword) {
+    // TODO: Re-enable when we sort out https://github.com/elastic/elasticsearch/issues/96207
+    /*static String loop(String name, String command, int indentSize, String exitKeyword) {
         String indent = " ".repeat(indentSize);
 
         // bash understands the `{1..10}` syntax, but other shells don't e.g. the default in Alpine Linux.
@@ -37,5 +35,9 @@ public class ShellRetry {
 
         // We need to escape all newlines so that the build process doesn't run all lines onto a single line
         return commandWithRetry.toString().replaceAll(" *\n", " \\\\\n");
+    }*/
+
+    static String loop(String name, String command, int indentSize, String exitKeyword) {
+        return command.replaceAll(" *\n", " \\\\\n");
     }
 }


### PR DESCRIPTION
Related to https://github.com/elastic/elasticsearch/issues/96207, I believe our retry logic is either a) contributing to weird failures or b) masking the root cause of failures in our Docker builds. I'm temporarily disabling this for now to try and get some better diagnostics.