### PR TITLE
Fix testFollowerBehaviour

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -115,7 +115,10 @@ public class LeaderCheckerTests extends ESTestCase {
                 super.onSendRequest(requestId, action, request, node);
 
                 final boolean mustSucceed = leaderCheckRetryCount - 1 <= consecutiveFailedRequestsCount;
-                final long responseDelay = randomLongBetween(0, leaderCheckTimeoutMillis + (mustSucceed ? -2 : 60000));
+                final long responseDelay = randomValueOtherThan(
+                    leaderCheckTimeoutMillis,
+                    () -> randomLongBetween(0, leaderCheckTimeoutMillis + (mustSucceed ? -1 : 60000))
+                );
                 final boolean successResponse = allResponsesFail.get() == false && (mustSucceed || randomBoolean());
 
                 assert responseDelay != leaderCheckTimeoutMillis;

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/LeaderCheckerTests.java
@@ -115,10 +115,11 @@ public class LeaderCheckerTests extends ESTestCase {
                 super.onSendRequest(requestId, action, request, node);
 
                 final boolean mustSucceed = leaderCheckRetryCount - 1 <= consecutiveFailedRequestsCount;
-                final long responseDelay = randomLongBetween(0, leaderCheckTimeoutMillis + (mustSucceed ? -1 : 60000));
+                final long responseDelay = randomLongBetween(0, leaderCheckTimeoutMillis + (mustSucceed ? -2 : 60000));
                 final boolean successResponse = allResponsesFail.get() == false && (mustSucceed || randomBoolean());
 
-                if (responseDelay >= leaderCheckTimeoutMillis) {
+                assert responseDelay != leaderCheckTimeoutMillis;
+                if (responseDelay > leaderCheckTimeoutMillis) {
                     timeoutCount.incrementAndGet();
                     consecutiveFailedRequestsCount += 1;
                 } else if (successResponse == false) {


### PR DESCRIPTION
The test was failing when responseDelay == leaderCheckTimeoutMillis. This resulted in scheduling both handling the response and timeout at the same mills and executing them in random order. The fix makes it impossible to reply the same time as request is timed out as the behavior is not deterministic in such case.

Closes: #96124