### PR TITLE
[7.17] Avoiding running IO on scheduler thread in ResourceWatcherService (#96251)

### DIFF
--- a/docs/changelog/96251.yaml
+++ b/docs/changelog/96251.yaml
@@ -1,0 +1,5 @@
+pr: 96251
+summary: Avoiding running IO on scheduler thread in `ResourceWatcherService`
+area: Watcher
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
+++ b/server/src/main/java/org/elasticsearch/watcher/ResourceWatcherService.java
@@ -94,9 +94,9 @@ public class ResourceWatcherService implements Closeable {
         interval = RELOAD_INTERVAL_HIGH.get(settings);
         highMonitor = new ResourceMonitor(interval, Frequency.HIGH);
         if (enabled) {
-            lowFuture = threadPool.scheduleWithFixedDelay(lowMonitor, lowMonitor.interval, Names.SAME);
-            mediumFuture = threadPool.scheduleWithFixedDelay(mediumMonitor, mediumMonitor.interval, Names.SAME);
-            highFuture = threadPool.scheduleWithFixedDelay(highMonitor, highMonitor.interval, Names.SAME);
+            lowFuture = threadPool.scheduleWithFixedDelay(lowMonitor, lowMonitor.interval, Names.GENERIC);
+            mediumFuture = threadPool.scheduleWithFixedDelay(mediumMonitor, mediumMonitor.interval, Names.GENERIC);
+            highFuture = threadPool.scheduleWithFixedDelay(highMonitor, highMonitor.interval, Names.GENERIC);
         } else {
             lowFuture = null;
             mediumFuture = null;


### PR DESCRIPTION
Backports the following commits to 7.17:
 - Avoiding running IO on scheduler thread in ResourceWatcherService (#96251)