### PR TITLE
Auditing support for cross-cluster API keys

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseSingleUpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BaseSingleUpdateApiKeyRequest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.core.security.action.apikey;
+
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+public abstract class BaseSingleUpdateApiKeyRequest extends BaseUpdateApiKeyRequest {
+
+    private final String id;
+
+    public BaseSingleUpdateApiKeyRequest(
+        @Nullable final List<RoleDescriptor> roleDescriptors,
+        @Nullable final Map<String, Object> metadata,
+        String id
+    ) {
+        super(roleDescriptors, metadata);
+        this.id = Objects.requireNonNull(id, "API key ID must not be null");
+    }
+
+    public BaseSingleUpdateApiKeyRequest(StreamInput in) throws IOException {
+        super(in);
+        this.id = in.readString();
+    }
+
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        super.writeTo(out);
+        out.writeString(id);
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/UpdateApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/UpdateApiKeyRequest.java
@@ -8,44 +8,28 @@
 package org.elasticsearch.xpack.core.security.action.apikey;
 
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.security.authz.RoleDescriptor;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-public final class UpdateApiKeyRequest extends BaseUpdateApiKeyRequest {
+public final class UpdateApiKeyRequest extends BaseSingleUpdateApiKeyRequest {
     public static UpdateApiKeyRequest usingApiKeyId(final String id) {
         return new UpdateApiKeyRequest(id, null, null);
     }
-
-    private final String id;
 
     public UpdateApiKeyRequest(
         final String id,
         @Nullable final List<RoleDescriptor> roleDescriptors,
         @Nullable final Map<String, Object> metadata
     ) {
-        super(roleDescriptors, metadata);
-        this.id = Objects.requireNonNull(id, "API key ID must not be null");
+        super(roleDescriptors, metadata, id);
     }
 
     public UpdateApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        this.id = in.readString();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeString(id);
-    }
-
-    public String getId() {
-        return id;
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/UpdateCrossClusterApiKeyRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/UpdateCrossClusterApiKeyRequest.java
@@ -9,41 +9,26 @@ package org.elasticsearch.xpack.core.security.action.apikey;
 
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.common.io.stream.StreamInput;
-import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.core.Nullable;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import static org.elasticsearch.action.ValidateActions.addValidationError;
 
-public final class UpdateCrossClusterApiKeyRequest extends BaseUpdateApiKeyRequest {
-    private final String id;
+public final class UpdateCrossClusterApiKeyRequest extends BaseSingleUpdateApiKeyRequest {
 
     public UpdateCrossClusterApiKeyRequest(
         final String id,
         @Nullable CrossClusterApiKeyRoleDescriptorBuilder roleDescriptorBuilder,
         @Nullable final Map<String, Object> metadata
     ) {
-        super(roleDescriptorBuilder == null ? null : List.of(roleDescriptorBuilder.build()), metadata);
-        this.id = Objects.requireNonNull(id, "API key ID must not be null");
+        super(roleDescriptorBuilder == null ? null : List.of(roleDescriptorBuilder.build()), metadata, id);
     }
 
     public UpdateCrossClusterApiKeyRequest(StreamInput in) throws IOException {
         super(in);
-        this.id = in.readString();
-    }
-
-    @Override
-    public void writeTo(StreamOutput out) throws IOException {
-        super.writeTo(out);
-        out.writeString(id);
-    }
-
-    public String getId() {
-        return id;
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticator.java
@@ -60,8 +60,7 @@ class ApiKeyAuthenticator implements Authenticator {
                     ? authResult.getException()
                     : Exceptions.authenticationError(authResult.getMessage());
                 logger.debug(() -> "API key service terminated authentication for request [" + context.getRequest() + "]", e);
-                // TODO: emit audit event
-                listener.onFailure(e);
+                listener.onFailure(context.getRequest().exceptionProcessingRequest(e, authenticationToken));
             } else {
                 if (authResult.getMessage() != null) {
                     if (authResult.getException() != null) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticator.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticator.java
@@ -60,7 +60,8 @@ class ApiKeyAuthenticator implements Authenticator {
                     ? authResult.getException()
                     : Exceptions.authenticationError(authResult.getMessage());
                 logger.debug(() -> "API key service terminated authentication for request [" + context.getRequest() + "]", e);
-                listener.onFailure(context.getRequest().exceptionProcessingRequest(e, authenticationToken));
+                context.getRequest().exceptionProcessingRequest(e, authenticationToken);
+                listener.onFailure(e);
             } else {
                 if (authResult.getMessage() != null) {
                     if (authResult.getException() != null) {

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/audit/logfile/LoggingAuditTrailTests.java
@@ -52,12 +52,17 @@ import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyActio
 import org.elasticsearch.xpack.core.security.action.apikey.BulkUpdateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.CreateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.CreateCrossClusterApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.CrossClusterApiKeyRoleDescriptorBuilder;
 import org.elasticsearch.xpack.core.security.action.apikey.GrantApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.GrantApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.InvalidateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.InvalidateApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.apikey.UpdateApiKeyAction;
 import org.elasticsearch.xpack.core.security.action.apikey.UpdateApiKeyRequest;
+import org.elasticsearch.xpack.core.security.action.apikey.UpdateCrossClusterApiKeyAction;
+import org.elasticsearch.xpack.core.security.action.apikey.UpdateCrossClusterApiKeyRequest;
 import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesAction;
 import org.elasticsearch.xpack.core.security.action.privilege.DeletePrivilegesRequest;
 import org.elasticsearch.xpack.core.security.action.privilege.PutPrivilegesAction;
@@ -600,7 +605,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         String expectedCreateKeyAuditEventString = String.format(
             Locale.ROOT,
             """
-                "create":{"apikey":{"id":"%s","name":"%s","expiration":%s,%s%s}}\
+                "create":{"apikey":{"id":"%s","name":"%s","type":"rest","expiration":%s,%s%s}}\
                 """,
             createApiKeyRequest.getId(),
             keyName,
@@ -636,7 +641,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         final var expectedUpdateKeyAuditEventString = String.format(
             Locale.ROOT,
             """
-                "change":{"apikey":{"id":"%s"%s%s}}\
+                "change":{"apikey":{"id":"%s","type":"rest"%s%s}}\
                 """,
             keyId,
             updateApiKeyRequest.getRoleDescriptors() == null ? "" : "," + roleDescriptorsStringBuilder,
@@ -668,7 +673,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
         final var expectedBulkUpdateKeyAuditEventString = String.format(
             Locale.ROOT,
             """
-                "change":{"apikeys":{"ids":[%s]%s%s}}\
+                "change":{"apikeys":{"ids":[%s],"type":"rest"%s%s}}\
                 """,
             bulkUpdateApiKeyRequest.getIds().stream().map(s -> Strings.format("\"%s\"", s)).collect(Collectors.joining(",")),
             bulkUpdateApiKeyRequest.getRoleDescriptors() == null ? "" : "," + roleDescriptorsStringBuilder,
@@ -711,7 +716,7 @@ public class LoggingAuditTrailTests extends ESTestCase {
             .append(grantApiKeyRequest.getApiKeyRequest().getId())
             .append("\",\"name\":\"")
             .append(keyName)
-            .append("\",\"expiration\":")
+            .append("\",\"type\":\"rest\",\"expiration\":")
             .append(expiration != null ? "\"" + expiration + "\"" : "null")
             .append(",")
             .append(roleDescriptorsStringBuilder);
@@ -808,6 +813,103 @@ public class LoggingAuditTrailTests extends ESTestCase {
             .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "delete_role")
             .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
         assertMsg(generatedDeleteRoleAuditEventString, checkedFields.map());
+    }
+
+    public void testSecurityConfigChangeEventForCrossClusterApiKeys() throws IOException {
+        final CrossClusterApiKeyAccessWithSerialization accessWithSerialization = randomCrossClusterApiKeyAccessWithSerialization();
+        final var roleDescriptorBuilder = CrossClusterApiKeyRoleDescriptorBuilder.parse(accessWithSerialization.access());
+
+        // Create
+        final String apiKeyName = randomAlphaOfLengthBetween(3, 8);
+        final TimeValue expiration = randomFrom(TimeValue.timeValueHours(randomIntBetween(1, 99)), null);
+        final ApiKeyMetadataWithSerialization metadataWithSerialization = randomApiKeyMetadataWithSerialization();
+        final var createRequest = new CreateCrossClusterApiKeyRequest(
+            apiKeyName,
+            roleDescriptorBuilder,
+            expiration,
+            metadataWithSerialization.metadata()
+        );
+
+        final String requestId = randomRequestId();
+        final String[] expectedRoles = randomArray(0, 4, String[]::new, () -> randomBoolean() ? null : randomAlphaOfLengthBetween(1, 4));
+        final AuthorizationInfo authorizationInfo = () -> Collections.singletonMap(PRINCIPAL_ROLES_FIELD_NAME, expectedRoles);
+        final Authentication authentication = createAuthentication();
+        auditTrail.accessGranted(requestId, authentication, CreateCrossClusterApiKeyAction.NAME, createRequest, authorizationInfo);
+
+        final String expectedCreateAuditEventString = String.format(
+            Locale.ROOT,
+            """
+                "create":{"apikey":{"id":"%s","name":"%s","type":"cross_cluster","expiration":%s,"role_descriptors":%s%s}}\
+                """,
+            createRequest.getId(),
+            apiKeyName,
+            expiration != null ? "\"" + expiration + "\"" : "null",
+            accessWithSerialization.serialization(),
+            createRequest.getMetadata() == null || createRequest.getMetadata().isEmpty()
+                ? ""
+                : Strings.format(",\"metadata\":%s", metadataWithSerialization.serialization())
+        );
+
+        List<String> output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedCreateAuditEventString = output.get(1);
+        assertThat(generatedCreateAuditEventString, containsString(expectedCreateAuditEventString));
+        generatedCreateAuditEventString = generatedCreateAuditEventString.replace(", " + expectedCreateAuditEventString, "");
+        MapBuilder<String, String> checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+            .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+            .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "create_apikey")
+            .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedCreateAuditEventString, checkedFields.map());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
+
+        // Update
+        final CrossClusterApiKeyRoleDescriptorBuilder updateAccess = randomFrom(roleDescriptorBuilder, null);
+        final ApiKeyMetadataWithSerialization updateMetadataWithSerialization;
+        if (null == updateAccess) {
+            updateMetadataWithSerialization = randomValueOtherThanMany(
+                m -> m.metadata == null,
+                this::randomApiKeyMetadataWithSerialization
+            );
+        } else {
+            updateMetadataWithSerialization = randomApiKeyMetadataWithSerialization();
+        }
+
+        final var updateRequest = new UpdateCrossClusterApiKeyRequest(
+            createRequest.getId(),
+            updateAccess,
+            updateMetadataWithSerialization.metadata()
+        );
+        auditTrail.accessGranted(requestId, authentication, UpdateCrossClusterApiKeyAction.NAME, updateRequest, authorizationInfo);
+
+        final String expectedUpdateAuditEventString = String.format(
+            Locale.ROOT,
+            """
+                "change":{"apikey":{"id":"%s","type":"cross_cluster"%s%s}}\
+                """,
+            createRequest.getId(),
+            updateAccess == null ? "" : ",\"role_descriptors\":" + accessWithSerialization.serialization(),
+            updateRequest.getMetadata() == null ? "" : Strings.format(",\"metadata\":%s", updateMetadataWithSerialization.serialization())
+        );
+
+        output = CapturingLogger.output(logger.getName(), Level.INFO);
+        assertThat(output.size(), is(2));
+        String generatedUpdateAuditEventString = output.get(1);
+        assertThat(generatedUpdateAuditEventString, containsString(expectedUpdateAuditEventString));
+        generatedUpdateAuditEventString = generatedUpdateAuditEventString.replace(", " + expectedUpdateAuditEventString, "");
+        checkedFields = new MapBuilder<>(commonFields);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_ADDRESS_FIELD_NAME);
+        checkedFields.remove(LoggingAuditTrail.ORIGIN_TYPE_FIELD_NAME);
+        checkedFields.put("type", "audit")
+            .put(LoggingAuditTrail.EVENT_TYPE_FIELD_NAME, "security_config_change")
+            .put(LoggingAuditTrail.EVENT_ACTION_FIELD_NAME, "change_apikey")
+            .put(LoggingAuditTrail.REQUEST_ID_FIELD_NAME, requestId);
+        assertMsg(generatedUpdateAuditEventString, checkedFields.map());
+        // clear log
+        CapturingLogger.output(logger.getName(), Level.INFO).clear();
     }
 
     public void testSecurityConfigChangeEventFormattingForApiKeyInvalidation() throws IOException {
@@ -3136,5 +3238,82 @@ public class LoggingAuditTrailTests extends ESTestCase {
             }
             default -> throw new IllegalStateException("Unexpected case number: " + metadataCase);
         };
+    }
+
+    private record CrossClusterApiKeyAccessWithSerialization(String access, String serialization) {};
+
+    private CrossClusterApiKeyAccessWithSerialization randomCrossClusterApiKeyAccessWithSerialization() {
+        return randomFrom(
+            new CrossClusterApiKeyAccessWithSerialization(
+                """
+                    {
+                      "search": [
+                        {
+                          "names": [
+                            "logs*"
+                          ]
+                        }
+                      ]
+                    }""",
+                "[{\"cluster\":[\"cross_cluster_search\"],"
+                    + "\"indices\":[{\"names\":[\"logs*\"],"
+                    + "\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"]}],"
+                    + "\"applications\":[],\"run_as\":[]}]"
+            ),
+            new CrossClusterApiKeyAccessWithSerialization(
+                """
+                    {
+                      "replication": [
+                        {
+                          "names": [
+                            "archive*"
+                          ]
+                        }
+                      ]
+                    }""",
+                "[{\"cluster\":[\"cross_cluster_replication\"],"
+                    + "\"indices\":[{\"names\":[\"archive*\"],"
+                    + "\"privileges\":[\"cross_cluster_replication\",\"cross_cluster_replication_internal\"]}],"
+                    + "\"applications\":[],\"run_as\":[]}]"
+            ),
+            new CrossClusterApiKeyAccessWithSerialization(
+                """
+                    {
+                        "search": [
+                          {
+                            "names": [
+                              "logs*"
+                            ],
+                            "query": {
+                              "term": {
+                                "tag": 42
+                              }
+                            },
+                            "field_security": {
+                              "grant": [
+                                "*"
+                              ],
+                              "except": [
+                                "private"
+                              ]
+                            }
+                          }
+                        ],
+                        "replication": [
+                          {
+                            "names": [
+                              "archive"
+                            ],
+                            "allow_restricted_indices": true
+                          }
+                        ]
+                      }""",
+                "[{\"cluster\":[\"cross_cluster_search\",\"cross_cluster_replication\"],"
+                    + "\"indices\":[{\"names\":[\"logs*\"],\"privileges\":[\"read\",\"read_cross_cluster\",\"view_index_metadata\"],"
+                    + "\"field_security\":{\"grant\":[\"*\"],\"except\":[\"private\"]},\"query\":\"{\\\"term\\\":{\\\"tag\\\":42}}\"},"
+                    + "{\"names\":[\"archive\"],\"privileges\":[\"cross_cluster_replication\",\"cross_cluster_replication_internal\"],"
+                    + "\"allow_restricted_indices\":true}],\"applications\":[],\"run_as\":[]}]"
+            )
+        );
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticatorTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ApiKeyAuthenticatorTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.security.authc;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.action.apikey.ApiKey;
+import org.elasticsearch.xpack.core.security.authc.Authentication;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.ApiKeyService.ApiKeyCredentials;
+import org.elasticsearch.xpack.security.authc.AuthenticationService.AuditableRequest;
+
+import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ApiKeyAuthenticatorTests extends ESTestCase {
+
+    public void testAuditingOnAuthenticationTermination() {
+        final ApiKeyService apiKeyService = mock(ApiKeyService.class);
+        final ApiKeyAuthenticator apiKeyAuthenticator = new ApiKeyAuthenticator(apiKeyService, randomAlphaOfLengthBetween(3, 8));
+
+        final Authenticator.Context context = mock(Authenticator.Context.class);
+
+        final ApiKeyCredentials apiKeyCredentials = new ApiKeyCredentials(
+            randomAlphaOfLength(20),
+            new SecureString(randomAlphaOfLength(20).toCharArray()),
+            randomFrom(ApiKey.Type.values())
+        );
+        when(context.getMostRecentAuthenticationToken()).thenReturn(apiKeyCredentials);
+        final ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        when(context.getThreadContext()).thenReturn(threadContext);
+        final AuditableRequest auditableRequest = mock(AuditableRequest.class);
+        when(context.getRequest()).thenReturn(auditableRequest);
+
+        doAnswer(invocation -> {
+            final Exception e = invocation.getArgument(0);
+            return new ElasticsearchSecurityException("exception processing request", e);
+        }).when(auditableRequest).exceptionProcessingRequest(any(Exception.class), same(apiKeyCredentials));
+
+        final Exception terminationError = randomFrom(mock(Exception.class), null);
+        doAnswer(invocation -> {
+            final ActionListener<AuthenticationResult<User>> listener = invocation.getArgument(2);
+            listener.onResponse(AuthenticationResult.terminate("terminated by ApiKeyService", terminationError));
+            return null;
+        }).when(apiKeyService).tryAuthenticate(same(threadContext), same(apiKeyCredentials), anyActionListener());
+
+        final PlainActionFuture<AuthenticationResult<Authentication>> future = new PlainActionFuture<>();
+        apiKeyAuthenticator.authenticate(context, future);
+
+        final ElasticsearchSecurityException e = expectThrows(ElasticsearchSecurityException.class, future::actionGet);
+        assertThat(e.getMessage(), containsString("exception processing request"));
+        if (terminationError == null) {
+            final Throwable cause = e.getCause();
+            assertThat(cause, instanceOf(ElasticsearchSecurityException.class));
+            assertThat(cause.getMessage(), containsString("terminated by ApiKeyService"));
+        } else {
+            assertThat(e.getCause(), sameInstance(terminationError));
+        }
+    }
+
+}


### PR DESCRIPTION
This PR adds necessary auditing support for cross-cluster API keys:
* Security config change for creating a cross-cluster API key
* Security config change for updating a cross-cluster API key
* Authentication failure event for type mismatch on authentication