### PR TITLE
Cleanup + Speedup Sets Utilities

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageAnalyzerIT.java
@@ -13,7 +13,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.index.engine.EngineException;
@@ -60,7 +60,7 @@ public class IndexDiskUsageAnalyzerIT extends ESIntegTestCase {
         return plugins;
     }
 
-    private static final Set<ShardId> failOnFlushShards = Sets.newConcurrentHashSet();
+    private static final Set<ShardId> failOnFlushShards = ConcurrentCollections.newConcurrentSet();
 
     public static class EngineTestPlugin extends Plugin implements EnginePlugin {
         @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/tasks/list/TransportListTasksAction.java
@@ -17,7 +17,7 @@ import org.elasticsearch.action.support.ListenableActionFuture;
 import org.elasticsearch.action.support.tasks.TransportTasksAction;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.RefCounted;
 import org.elasticsearch.core.TimeValue;
@@ -80,8 +80,8 @@ public class TransportListTasksAction extends TransportTasksAction<Task, ListTas
         if (request.getWaitForCompletion()) {
             final ListenableActionFuture<List<Task>> future = new ListenableActionFuture<>();
             final List<Task> processedTasks = new ArrayList<>();
-            final Set<Task> removedTasks = Sets.newConcurrentHashSet();
-            final Set<Task> matchedTasks = Sets.newConcurrentHashSet();
+            final Set<Task> removedTasks = ConcurrentCollections.newConcurrentSet();
+            final Set<Task> matchedTasks = ConcurrentCollections.newConcurrentSet();
             final RefCounted removalRefs = AbstractRefCounted.of(() -> {
                 matchedTasks.removeAll(removedTasks);
                 removedTasks.clear();

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitor.java
@@ -31,7 +31,7 @@ import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.ClusterSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.gateway.GatewayService;
 
@@ -81,19 +81,19 @@ public class DiskThresholdMonitor {
      * The IDs of the nodes that were over the low threshold in the last check (and maybe over another threshold too). Tracked so that we
      * can log when such nodes are no longer over the low threshold.
      */
-    private final Set<String> nodesOverLowThreshold = Sets.newConcurrentHashSet();
+    private final Set<String> nodesOverLowThreshold = ConcurrentCollections.newConcurrentSet();
 
     /**
      * The IDs of the nodes that were over the high threshold in the last check (and maybe over another threshold too). Tracked so that we
      * can log when such nodes are no longer over the high threshold.
      */
-    private final Set<String> nodesOverHighThreshold = Sets.newConcurrentHashSet();
+    private final Set<String> nodesOverHighThreshold = ConcurrentCollections.newConcurrentSet();
 
     /**
      * The IDs of the nodes that were over the high threshold in the last check, but which are relocating shards that will bring them
      * under the high threshold again. Tracked so that we can log when such nodes are no longer in this state.
      */
-    private final Set<String> nodesOverHighThresholdAndRelocating = Sets.newConcurrentHashSet();
+    private final Set<String> nodesOverHighThresholdAndRelocating = ConcurrentCollections.newConcurrentSet();
 
     /**
      * The IDs of the nodes in the last info received. Tracked because when a new node joins we consider its disk usage to be equal to

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ConcurrentCollections.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ConcurrentCollections.java
@@ -46,7 +46,7 @@ public abstract class ConcurrentCollections {
     }
 
     public static <V> Set<V> newConcurrentSet() {
-        return Collections.newSetFromMap(ConcurrentCollections.<V, Boolean>newConcurrentMap());
+        return Collections.newSetFromMap(ConcurrentCollections.newConcurrentMap());
     }
 
     public static <T> Queue<T> newQueue() {

--- a/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
+++ b/server/src/main/java/org/elasticsearch/common/util/set/Sets.java
@@ -14,22 +14,15 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashSet;
-import java.util.Objects;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collector;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
-import static java.util.stream.Collectors.toUnmodifiableSet;
 
 public final class Sets {
     private Sets() {}
 
     public static <T> HashSet<T> newHashSet(Iterator<T> iterator) {
-        Objects.requireNonNull(iterator);
         HashSet<T> set = new HashSet<>();
         while (iterator.hasNext()) {
             set.add(iterator.next());
@@ -38,14 +31,12 @@ public final class Sets {
     }
 
     public static <T> HashSet<T> newHashSet(Iterable<T> iterable) {
-        Objects.requireNonNull(iterable);
         return iterable instanceof Collection ? new HashSet<>((Collection<T>) iterable) : newHashSet(iterable.iterator());
     }
 
     @SafeVarargs
     @SuppressWarnings("varargs")
     public static <T> HashSet<T> newHashSet(T... elements) {
-        Objects.requireNonNull(elements);
         return new HashSet<>(Arrays.asList(elements));
     }
 
@@ -62,20 +53,17 @@ public final class Sets {
         return expectedSize < 2 ? expectedSize + 1 : (int) (expectedSize / 0.75 + 1.0);
     }
 
-    public static <T> Set<T> newConcurrentHashSet() {
-        return Collections.newSetFromMap(new ConcurrentHashMap<>());
-    }
-
     public static <T> boolean haveEmptyIntersection(Set<T> left, Set<T> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
-        return left.stream().noneMatch(right::contains);
+        for (T t : left) {
+            if (right.contains(t)) {
+                return false;
+            }
+        }
+        return true;
     }
 
     public static <T> boolean haveNonEmptyIntersection(Set<T> left, Set<T> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
-        return left.stream().anyMatch(right::contains);
+        return haveEmptyIntersection(left, right) == false;
     }
 
     /**
@@ -88,9 +76,13 @@ public final class Sets {
      * @return the relative complement of the left set with respect to the right set
      */
     public static <T> Set<T> difference(Set<T> left, Set<T> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
-        return left.stream().filter(k -> right.contains(k) == false).collect(Collectors.toSet());
+        Set<T> set = new HashSet<>();
+        for (T k : left) {
+            if (right.contains(k) == false) {
+                set.add(k);
+            }
+        }
+        return set;
     }
 
     /**
@@ -104,35 +96,13 @@ public final class Sets {
      * @return the sorted relative complement of the left set with respect to the right set
      */
     public static <T> SortedSet<T> sortedDifference(final Set<T> left, final Set<T> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
-        return left.stream().filter(k -> right.contains(k) == false).collect(toSortedSet());
-    }
-
-    /**
-     * The relative complement, or difference, of the specified left and right set, returned as a sorted set. Namely, the resulting set
-     * contains all the elements that are in the left set but not in the right set, and the set is sorted using the natural ordering of
-     * element type. Neither input is mutated by this operation, an entirely new set is returned. The resulting set is unmodifiable.
-     *
-     * @param left  the left set
-     * @param right the right set
-     * @param <T>   the type of the elements of the sets
-     * @return the unmodifiable sorted relative complement of the left set with respect to the right set
-     */
-    public static <T> SortedSet<T> unmodifiableSortedDifference(final Set<T> left, final Set<T> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
-        return left.stream().filter(k -> right.contains(k) == false).collect(toUnmodifiableSortedSet());
-    }
-
-    /**
-     * Returns a {@link Collector} that accumulates the input elements into a sorted set.
-     *
-     * @param <T> the type of the input elements
-     * @return a sorted set
-     */
-    public static <T> Collector<T, SortedSet<T>, SortedSet<T>> toSortedSet() {
-        return Collector.of(TreeSet::new, SortedSet::add, Sets::addAllMutable);
+        final SortedSet<T> set = new TreeSet<>();
+        for (T k : left) {
+            if (right.contains(k) == false) {
+                set.add(k);
+            }
+        }
+        return set;
     }
 
     /**
@@ -143,17 +113,13 @@ public final class Sets {
      * @return an unmodifiable set where the underlying set is sorted
      */
     public static <T> Collector<T, SortedSet<T>, SortedSet<T>> toUnmodifiableSortedSet() {
-        return Collector.of(TreeSet::new, SortedSet::add, Sets::addAllMutable, Collections::unmodifiableSortedSet);
-    }
-
-    private static <T, S extends Set<T>> S addAllMutable(S a, S b) {
-        a.addAll(b);
-        return a;
+        return Collector.of(TreeSet::new, SortedSet::add, (a, b) -> {
+            a.addAll(b);
+            return a;
+        }, Collections::unmodifiableSortedSet);
     }
 
     public static <T> Set<T> union(Set<T> left, Set<T> right) {
-        Objects.requireNonNull(left);
-        Objects.requireNonNull(right);
         Set<T> union = new HashSet<>(left);
         union.addAll(right);
         return union;
@@ -168,8 +134,6 @@ public final class Sets {
      * @return the unmodifiable intersection of the two sets
      */
     public static <T> Set<T> intersection(Set<T> set1, Set<T> set2) {
-        Objects.requireNonNull(set1);
-        Objects.requireNonNull(set2);
         final Set<T> left;
         final Set<T> right;
         if (set1.size() < set2.size()) {
@@ -197,16 +161,6 @@ public final class Sets {
     }
 
     /**
-     * Creates a copy of the given set and adds extra element.
-     *
-     * @param set     set to copy
-     * @param element element to add
-     */
-    public static <E> Set<E> addToCopy(Set<E> set, E element) {
-        return Stream.concat(set.stream(), Stream.of(element)).collect(toUnmodifiableSet());
-    }
-
-    /**
      * Creates a copy of the given set and adds extra elements.
      *
      * @param set      set to copy
@@ -214,6 +168,8 @@ public final class Sets {
      */
     @SuppressWarnings("unchecked")
     public static <E> Set<E> addToCopy(Set<E> set, E... elements) {
-        return Stream.concat(set.stream(), Stream.of(elements)).collect(toUnmodifiableSet());
+        final var res = new HashSet<>(set);
+        Collections.addAll(res, elements);
+        return Set.copyOf(res);
     }
 }

--- a/server/src/main/java/org/elasticsearch/indices/IndicesService.java
+++ b/server/src/main/java/org/elasticsearch/indices/IndicesService.java
@@ -58,11 +58,11 @@ import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.EsExecutors;
 import org.elasticsearch.common.util.concurrent.EsRejectedExecutionException;
 import org.elasticsearch.common.util.concurrent.EsThreadPoolExecutor;
 import org.elasticsearch.common.util.iterable.Iterables;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.CheckedConsumer;
@@ -246,7 +246,7 @@ public class IndicesService extends AbstractLifecycleComponent
 
     @Nullable
     private final EsThreadPoolExecutor danglingIndicesThreadPoolExecutor;
-    private final Set<Index> danglingIndicesToWrite = Sets.newConcurrentHashSet();
+    private final Set<Index> danglingIndicesToWrite = ConcurrentCollections.newConcurrentSet();
     private final boolean nodeWriteDanglingIndicesInfo;
     private final ValuesSourceRegistry valuesSourceRegistry;
     private final TimestampFieldMapperService timestampFieldMapperService;

--- a/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/set/SetsTests.java
@@ -16,8 +16,6 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.SortedSet;
-import java.util.function.BiFunction;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -39,24 +37,9 @@ public class SetsTests extends ESTestCase {
     }
 
     public void testSortedDifference() {
-        runSortedDifferenceTest(Sets::sortedDifference, set -> {});
-    }
-
-    public void testUnmodifiableSortedDifference() {
-        runSortedDifferenceTest(
-            // assert the resulting difference us unmodifiable
-            Sets::unmodifiableSortedDifference,
-            set -> expectThrows(UnsupportedOperationException.class, () -> set.add(randomInt()))
-        );
-    }
-
-    private void runSortedDifferenceTest(
-        final BiFunction<Set<Integer>, Set<Integer>, SortedSet<Integer>> sortedDifference,
-        final Consumer<Set<Integer>> asserter
-    ) {
         final int endExclusive = randomIntBetween(0, 256);
         final Tuple<Set<Integer>, Set<Integer>> sets = randomSets(endExclusive);
-        final SortedSet<Integer> difference = sortedDifference.apply(sets.v1(), sets.v2());
+        final SortedSet<Integer> difference = Sets.sortedDifference(sets.v1(), sets.v2());
         assertDifference(endExclusive, sets, difference);
         final Iterator<Integer> it = difference.iterator();
         if (it.hasNext()) {
@@ -67,18 +50,22 @@ public class SetsTests extends ESTestCase {
                 current = next;
             }
         }
-        asserter.accept(difference);
     }
 
     public void testIntersection() {
         final int endExclusive = randomIntBetween(0, 256);
         final Tuple<Set<Integer>, Set<Integer>> sets = randomSets(endExclusive);
         final Set<Integer> intersection = Sets.intersection(sets.v1(), sets.v2());
-        final Set<Integer> expectedIntersection = IntStream.range(0, endExclusive)
-            .boxed()
-            .filter(i -> (sets.v1().contains(i) && sets.v2().contains(i)))
-            .collect(Collectors.toSet());
-        assertThat(intersection, containsInAnyOrder(expectedIntersection.toArray(new Integer[0])));
+        assertThat(
+            intersection,
+            containsInAnyOrder(
+                IntStream.range(0, endExclusive)
+                    .boxed()
+                    .filter(i -> (sets.v1().contains(i) && sets.v2().contains(i)))
+                    .distinct()
+                    .toArray(Integer[]::new)
+            )
+        );
 
         final Set<Integer> emptyIntersection = Sets.intersection(
             Sets.difference(sets.v1(), intersection),

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/accesscontrol/DocumentSubsetBitsetCache.java
@@ -30,8 +30,8 @@ import org.elasticsearch.common.settings.Setting;
 import org.elasticsearch.common.settings.Setting.Property;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
-import org.elasticsearch.common.util.set.Sets;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.lucene.util.BitSets;
@@ -238,7 +238,7 @@ public final class DocumentSubsetBitsetCache implements IndexReader.ClosedListen
                 // This ensures all insertions into the set are guarded by ConcurrentHashMap's atomicity guarantees.
                 keysByIndex.compute(indexKey, (ignore2, set) -> {
                     if (set == null) {
-                        set = Sets.newConcurrentHashSet();
+                        set = ConcurrentCollections.newConcurrentSet();
                     }
                     set.add(cacheKey);
                     return set;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksCustomMetadata;
@@ -573,7 +573,7 @@ public class TransportCloseJobAction extends TransportTasksAction<
             return;
         }
 
-        final Set<String> movedJobs = Sets.newConcurrentHashSet();
+        final Set<String> movedJobs = ConcurrentCollections.newConcurrentSet();
 
         ActionListener<CloseJobAction.Response> intermediateListener = ActionListener.wrap(response -> {
             for (String jobId : movedJobs) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
@@ -24,7 +24,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.inject.Inject;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.common.util.concurrent.AtomicArray;
-import org.elasticsearch.common.util.set.Sets;
+import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.discovery.MasterNotDiscoveredException;
 import org.elasticsearch.persistent.PersistentTasksClusterService;
@@ -263,7 +263,7 @@ public class TransportStopDatafeedAction extends TransportTasksAction<
         request.setResolvedStartedDatafeedIds(resolvedStartedDatafeeds.toArray(new String[0]));
         request.setNodes(executorNodes.toArray(new String[0]));
 
-        final Set<String> movedDatafeeds = Sets.newConcurrentHashSet();
+        final Set<String> movedDatafeeds = ConcurrentCollections.newConcurrentSet();
 
         ActionListener<StopDatafeedAction.Response> finalListener = ActionListener.wrap(
             response -> waitForDatafeedStopped(allDataFeedsToWaitFor, request, response, ActionListener.wrap(finished -> {


### PR DESCRIPTION
Use loops not streams for predictable performance if the performance of these ever matters (one spot only that brought me here and one that I'd like to introduce but still). Also, delete unused methods and remove redundant explicit null checks when we'd throw NPE anyway.
