### PR TITLE
Remove searchLookup method from FetchContext

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchContext.java
@@ -24,7 +24,6 @@ import org.elasticsearch.search.fetch.subphase.ScriptFieldsContext;
 import org.elasticsearch.search.fetch.subphase.highlight.SearchHighlightContext;
 import org.elasticsearch.search.internal.ContextIndexSearcher;
 import org.elasticsearch.search.internal.SearchContext;
-import org.elasticsearch.search.lookup.SearchLookup;
 import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.rescore.RescoreContext;
 
@@ -98,13 +97,6 @@ public class FetchContext {
      */
     public ContextIndexSearcher searcher() {
         return searchContext.searcher();
-    }
-
-    /**
-     * The {@code SearchLookup} for the this context
-     */
-    public SearchLookup searchLookup() {
-        return searchContext.getSearchExecutionContext().lookup();
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/subphase/FetchDocValuesPhase.java
@@ -12,6 +12,7 @@ import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.index.mapper.DocValueFetcher;
 import org.elasticsearch.index.mapper.MappedFieldType;
 import org.elasticsearch.index.mapper.ValueFetcher;
+import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.fetch.FetchContext;
 import org.elasticsearch.search.fetch.FetchSubPhase;
 import org.elasticsearch.search.fetch.FetchSubPhaseProcessor;
@@ -40,14 +41,15 @@ public final class FetchDocValuesPhase implements FetchSubPhase {
          * times with different configuration. That isn't possible with a `Map`.
          */
         List<DocValueField> fields = new ArrayList<>();
-        for (FieldAndFormat fieldAndFormat : context.docValuesContext().fields()) {
-            MappedFieldType ft = context.getSearchExecutionContext().getFieldType(fieldAndFormat.field);
+        for (FieldAndFormat fieldAndFormat : dvContext.fields()) {
+            SearchExecutionContext searchExecutionContext = context.getSearchExecutionContext();
+            MappedFieldType ft = searchExecutionContext.getFieldType(fieldAndFormat.field);
             if (ft == null) {
                 continue;
             }
             ValueFetcher fetcher = new DocValueFetcher(
                 ft.docValueFormat(fieldAndFormat.format, null),
-                context.searchLookup().getForField(ft, MappedFieldType.FielddataOperation.SEARCH)
+                searchExecutionContext.getForField(ft, MappedFieldType.FielddataOperation.SEARCH)
             );
             fields.add(new DocValueField(fieldAndFormat.field, fetcher));
         }


### PR DESCRIPTION
FetchContext provides access to a SearchLookup via a chained call to its enclosed SearchContexts
via SearchExecutionContext. 
This is access is currently only used in one spot in the FetchDocValuesPhase to access IndexFieldData.
Since the current SearchExecutionContext is already available in that location, we can reduce the methods 
FetchContext exposes.