### PR TITLE
[8.8] [DOCS] Fix small typo (#96242)

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -536,7 +536,6 @@ vector space.
 To alleviate this worry, there is a `similarity` parameter available in the `knn` clause. This value is the required
 minimum similarity for a vector to be considered a match. The `knn` search flow with this parameter is as follows:
 
-+
 --
 * Apply any user provided `filter` queries
 * Explore the vector space to get `k` vectors


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Fix small typo (#96242)](https://github.com/elastic/elasticsearch/pull/96242)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)