### PR TITLE
[DOCS] Adds missing parameter to the top metrics agg docs

### DIFF
--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -193,7 +193,7 @@ it should be treated as if it had the `N/A` value.
 
 The request results in the following response:
 
-[source,js]
+[source,console-result]
 ----
 {
   "aggregations": {
@@ -212,7 +212,6 @@ The request results in the following response:
   }
 }
 ----
-// TESTRESPONSE
 
 
 ==== `size`

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -142,6 +142,80 @@ Which returns:
 ----
 // TESTRESPONSE
 
+
+==== `missing`
+
+The `missing` parameter defines how documents with a missing value are treated. 
+By default, if any of the key components are missing, the entire document is 
+ignored. It is possible to treat the missing components as if they had a value 
+by using the `missing` parameter.
+
+[source,js]
+----
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "nr":    { "type": "integer" },  
+      "state":  { "type": "keyword"  } <1>
+    }
+  }
+}
+
+POST /my-index/_bulk?refresh
+{"index": {}}
+{"nr": 1, "state": "started"}
+{"index": {}}
+{"nr": 2, "state": "stopped"}
+{"index": {}}
+{"nr": 3, "state": "N/A"}
+{"index": {}}
+{"nr": 4} <2>
+
+POST /my-index/_search
+{
+  "aggs": {
+    "my_top_metrics": {
+      "top_metrics": {
+        "metrics": {
+          "field": "state",
+          "missing": "N/A"}, <3>
+        "sort": {"nr": "desc"}
+      }
+    }
+  }
+}
+----
+<1> If you want to use an aggregation on textual content, it must be a `keyword`
+type field or you must enable fielddata on that field.
+<2> This document has a missing `state` field value.
+<3> The `missing` parameter defines that if `state` field has a missing value, 
+it should be treated as if it had the `N/A` value.
+
+The request results in the following response:
+
+[source,js]
+----
+{
+  "aggregations": {
+    "my_top_metrics": {
+      "top": [
+        {
+          "sort": [
+            4
+          ],
+          "metrics": {
+            "state": "N/A"
+          }
+        }
+      ]
+    }
+  }
+}
+----
+// TESTRESPONSE
+
+
 ==== `size`
 
 `top_metrics` can return the top few document's worth of metrics using the size parameter:

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -161,7 +161,6 @@ PUT /my-index
     }
   }
 }
-
 POST /my-index/_bulk?refresh
 {"index": {}}
 {"nr": 1, "state": "started"}
@@ -171,7 +170,6 @@ POST /my-index/_bulk?refresh
 {"nr": 3, "state": "N/A"}
 {"index": {}}
 {"nr": 4} <2>
-
 POST /my-index/_search
 {
   "aggs": {

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -157,7 +157,7 @@ PUT /my-index
   "mappings": {
     "properties": {
       "nr":    { "type": "integer" },  
-      "state":  { "type": "keyword"  } <1>
+      "state":  { "type": "keyword"  }
     }
   }
 }
@@ -169,7 +169,7 @@ POST /my-index/_bulk?refresh
 {"index": {}}
 {"nr": 3, "state": "N/A"}
 {"index": {}}
-{"nr": 4} <2>
+{"nr": 4}
 POST /my-index/_search
 {
   "aggs": {
@@ -177,18 +177,19 @@ POST /my-index/_search
       "top_metrics": {
         "metrics": {
           "field": "state",
-          "missing": "N/A"}, <3>
+          "missing": "N/A"},
         "sort": {"nr": "desc"}
       }
     }
   }
 }
 ----
-<1> If you want to use an aggregation on textual content, it must be a `keyword`
-type field or you must enable fielddata on that field.
-<2> This document has a missing `state` field value.
-<3> The `missing` parameter defines that if `state` field has a missing value, 
-it should be treated as if it had the `N/A` value.
+
+// <1> If you want to use an aggregation on textual content, it must be a `keyword`
+// type field or you must enable fielddata on that field.
+// <2> This document has a missing `state` field value.
+// <3> The `missing` parameter defines that if `state` field has a missing value, 
+// it should be treated as if it had the `N/A` value. 
 
 The request results in the following response:
 

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -150,7 +150,7 @@ By default, if any of the key components are missing, the entire document is
 ignored. It is possible to treat the missing components as if they had a value 
 by using the `missing` parameter.
 
-[source,js]
+[source,console]
 ----
 PUT /my-index
 {

--- a/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
+++ b/docs/reference/aggregations/metrics/top-metrics-aggregation.asciidoc
@@ -157,7 +157,7 @@ PUT /my-index
   "mappings": {
     "properties": {
       "nr":    { "type": "integer" },  
-      "state":  { "type": "keyword"  }
+      "state":  { "type": "keyword"  } <1>
     }
   }
 }
@@ -169,15 +169,15 @@ POST /my-index/_bulk?refresh
 {"index": {}}
 {"nr": 3, "state": "N/A"}
 {"index": {}}
-{"nr": 4}
-POST /my-index/_search
+{"nr": 4} <2>
+POST /my-index/_search?filter_path=aggregations
 {
   "aggs": {
     "my_top_metrics": {
       "top_metrics": {
         "metrics": {
           "field": "state",
-          "missing": "N/A"},
+          "missing": "N/A"}, <3>
         "sort": {"nr": "desc"}
       }
     }
@@ -185,11 +185,11 @@ POST /my-index/_search
 }
 ----
 
-// <1> If you want to use an aggregation on textual content, it must be a `keyword`
-// type field or you must enable fielddata on that field.
-// <2> This document has a missing `state` field value.
-// <3> The `missing` parameter defines that if `state` field has a missing value, 
-// it should be treated as if it had the `N/A` value. 
+<1> If you want to use an aggregation on textual content, it must be a `keyword`
+type field or you must enable fielddata on that field.
+<2> This document has a missing `state` field value.
+<3> The `missing` parameter defines that if `state` field has a missing value, 
+it should be treated as if it had the `N/A` value. 
 
 The request results in the following response:
 


### PR DESCRIPTION
## Overview

Closes https://github.com/elastic/elasticsearch/issues/95792
This PR adds a description and an example of the `missing` parameter to the top metrics aggregation docs.

### Preview

[`missing`](https://elasticsearch_96297.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/search-aggregations-metrics-top-metrics.html#_missing)