### PR TITLE
[DOCS] Verifying Elasticsearch container image signatures with Cosign from Sigstore

### DIFF
--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -45,6 +45,8 @@ endif::[]
 
 ==== Optional: Verify the {es} Docker image signature
 
+Although it's optional, we highly recommend verifying the signatures included with your downloaded Docker images to ensure that the images are valid.
+
 Elastic images are signed with https://docs.sigstore.dev/cosign/overview/[Cosign] which is part of the https://www.sigstore.dev/[Sigstore] project.
 
 Cosign supports container signing, verification, and storage in an OCI registry.

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -43,7 +43,51 @@ docker pull {docker-repo}:{version}
 
 endif::[]
 
-Now that you have the {es} Docker image, you can start a
+==== Verify the {es} Docker image signature
+
+Elastic images are signed with https://docs.sigstore.dev/cosign/overview/[Cosign] which is part of the https://www.sigstore.dev/[Sigstore] project.
+
+Cosign supports container signing, verification, and storage in an OCI registry.
+
+ifeval::["{release-state}"=="unreleased"]
+
+WARNING: Version {version} of {es} has not yet been released, so no
+Docker image signature is currently available for this version.
+
+endif::[]
+
+ifeval::["{release-state}"!="unreleased"]
+
+Install the appropriate https://docs.sigstore.dev/cosign/installation/[Cosign application]
+for your operating system.
+
+The container image signature for Elasticsearch v{version} can be verified as follows:
+
+["source","sh",subs="attributes"]
+--------------------------------------------
+wget https://artifacts.elastic.co/cosign.pub <1>
+cosign verify --key cosign.pub {docker-repo}:{version} <2>
+--------------------------------------------
+<1> Download the Elastic public key to verify container signature
+<2> Verify the container against the Elastic public key
+
+The command prints out the check results and the signature payload in json format:
+
+[source,console-result]
+--------------------------------------------
+
+Verification for {docker-repo}:{version} --
+The following checks were performed on each of these signatures:
+  - The cosign claims were validated
+  - Existence of the claims in the transparency log was verified offline
+  - The signatures were verified against the specified public key
+
+{"critical":{"identity":{"docker-reference":"..."},"image":{"docker-manifest-digest":"..."},"type":"cosign container image signature"},"optional":"..."}
+--------------------------------------------
+
+endif::[]
+
+Now that you have verified the {es} Docker image signature, you can start a
 <<docker-cli-run-dev-mode,single-node>> or <<docker-compose-file,multi-node>>
 cluster.
 

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -61,7 +61,7 @@ ifeval::["{release-state}"!="unreleased"]
 Install the appropriate https://docs.sigstore.dev/cosign/installation/[Cosign application]
 for your operating system.
 
-The container image signature for Elasticsearch v{version} can be verified as follows:
+The container image signature for {es} v{version} can be verified as follows:
 
 ["source","sh",subs="attributes"]
 --------------------------------------------

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -71,7 +71,7 @@ cosign verify --key cosign.pub {docker-repo}:{version} <2>
 <1> Download the Elastic public key to verify container signature
 <2> Verify the container against the Elastic public key
 
-The command prints out the check results and the signature payload in json format:
+The command prints the check results and the signature payload in JSON format:
 
 [source,console]
 --------------------------------------------

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -73,7 +73,7 @@ cosign verify --key cosign.pub {docker-repo}:{version} <2>
 
 The command prints out the check results and the signature payload in json format:
 
-[source,console-result]
+[source,console]
 --------------------------------------------
 
 Verification for {docker-repo}:{version} --

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -43,6 +43,7 @@ docker pull {docker-repo}:{version}
 
 endif::[]
 
+[[docker-verify-signature]]
 ==== Optional: Verify the {es} Docker image signature
 
 Although it's optional, we highly recommend verifying the signatures included with your downloaded Docker images to ensure that the images are valid.
@@ -77,14 +78,11 @@ The command prints the check results and the signature payload in JSON format:
 
 [source,console]
 --------------------------------------------
-
 Verification for {docker-repo}:{version} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline
   - The signatures were verified against the specified public key
-
-{"critical":{"identity":{"docker-reference":"..."},"image":{"docker-manifest-digest":"..."},"type":"cosign container image signature"},"optional":"..."}
 --------------------------------------------
 
 endif::[]

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -76,7 +76,7 @@ cosign verify --key cosign.pub {docker-repo}:{version} <2>
 
 The command prints the check results and the signature payload in JSON format:
 
-[source,console]
+[source,sh]
 --------------------------------------------
 Verification for docker.elastic.co/elasticsearch/elasticsearch:{version} --
 The following checks were performed on each of these signatures:

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -43,7 +43,7 @@ docker pull {docker-repo}:{version}
 
 endif::[]
 
-==== Verify the {es} Docker image signature
+==== Optional: Verify the {es} Docker image signature
 
 Elastic images are signed with https://docs.sigstore.dev/cosign/overview/[Cosign] which is part of the https://www.sigstore.dev/[Sigstore] project.
 

--- a/docs/reference/setup/install/docker.asciidoc
+++ b/docs/reference/setup/install/docker.asciidoc
@@ -78,7 +78,7 @@ The command prints the check results and the signature payload in JSON format:
 
 [source,console]
 --------------------------------------------
-Verification for {docker-repo}:{version} --
+Verification for docker.elastic.co/elasticsearch/elasticsearch:{version} --
 The following checks were performed on each of these signatures:
   - The cosign claims were validated
   - Existence of the claims in the transparency log was verified offline


### PR DESCRIPTION
This commit adds a step to verify the Elasticsearch container image signatures after pulling the image and before starting any cluster.

The goal is to introduce an easy and standard way for Elastic users to verify the provenance of the Elasticsearch container images before deploying them to any infrastructure and therefore protect against supply chain attacks.

