### PR TITLE
Delayed scoring for Composite Aggregation

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/nested_with_scores.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/nested_with_scores.yml
@@ -8,6 +8,8 @@ setup:
                 properties:
                   "@timestamp":
                     type: date
+                  text:
+                      type: text
                   lines:
                     type: nested
                     properties:
@@ -24,6 +26,7 @@ setup:
         id:    "1"
         body: {
           "@timestamp": "2022-09-01",
+          "text": "I met a traveller from an antique land",
           "lines": [
             {
               "@timestamp": "2022-09-01",
@@ -53,13 +56,15 @@ setup:
       version: " - 8.5.99"
       reason:  fixed in 8.6
   - do:
-      catch: /Incompatible use of non-scorable and score-required aggregations/
       search:
         rest_total_hits_as_int: true
         index: test
         body:
           size: 0
           track_total_hits: -1
+          query:
+            match:
+              text: traveller
           aggregations:
             data:
               nested:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/nested_with_scores.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/nested_with_scores.yml
@@ -1,0 +1,162 @@
+---
+setup:
+  - do:
+        indices.create:
+          index: test
+          body:
+              mappings:
+                properties:
+                  "@timestamp":
+                    type: date
+                  lines:
+                    type: nested
+                    properties:
+                      "@timestamp":
+                        type: date
+                      value:
+                        type: integer
+                      name:
+                        type: keyword
+
+  - do:
+      index:
+        index: test
+        id:    "1"
+        body: {
+          "@timestamp": "2022-09-01",
+          "lines": [
+            {
+              "@timestamp": "2022-09-01",
+              "name": "foo",
+              "value": "1.2"
+            },
+            {
+              "@timestamp": "2022-09-01",
+              "name": "foo",
+              "value": "1.2"
+            },
+            {
+              "@timestamp": "2022-09-01",
+              "name": "bar",
+              "value": "2.3"
+            }
+          ]
+        }
+
+  - do:
+      indices.refresh:
+        index: [test]
+
+---
+"Nested, Composite, Top Hits":
+  - skip:
+      version: " - 8.5.99"
+      reason:  fixed in 8.6
+  - do:
+      catch: /Incompatible use of non-scorable and score-required aggregations/
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          size: 0
+          track_total_hits: -1
+          aggregations:
+            data:
+              nested:
+                path: "lines"
+              aggregations:
+                my_buckets:
+                  composite:
+                    size: 20
+                    sources:
+                      -
+                        prod_name:
+                          terms:
+                            field: "lines.name"
+                  aggregations:
+                    th:
+                      top_hits:
+                        size: 1
+---
+"Nested, Composite, Scripted Metric":
+  - skip:
+      version: " - 8.5.99"
+      reason:  fixed in 8.6
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          size: 0
+          track_total_hits: -1
+          aggregations:
+            data:
+              nested:
+                path: "lines"
+              aggregations:
+                my_buckets:
+                  composite:
+                    size: 20
+                    sources:
+                      -
+                        prod_name:
+                          terms:
+                            field: "lines.name"
+                  aggregations:
+                    catalog_price:
+                      scripted_metric:
+                        init_script:
+                          source: "state.transactions = []"
+                        map_script:
+                          source: "state.transactions.add(doc['lines.value'].value)"
+                        combine_script:
+                          source: "double sum = 0; for (t in state.transactions) { sum += t } return sum"
+                        reduce_script:
+                          source: "double sum = 0; for (a in states) { if (a != null) { sum += a } } return sum"
+
+  - match: {aggregations.data.doc_count: 3}
+  - length: { aggregations.data.my_buckets.buckets: 2 }
+  - match: { aggregations.data.my_buckets.buckets.0.key.prod_name: "bar" }
+  - match: { aggregations.data.my_buckets.buckets.0.doc_count: 1}
+  - match: { aggregations.data.my_buckets.buckets.0.catalog_price.value: 2.0}
+  - match: { aggregations.data.my_buckets.buckets.1.key.prod_name: "foo" }
+  - match: { aggregations.data.my_buckets.buckets.1.doc_count: 2}
+  - match: { aggregations.data.my_buckets.buckets.1.catalog_price.value: 2.0}
+---
+"Nested, Terms, Scripted Metric":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: test
+        body:
+          size: 0
+          track_total_hits: -1
+          aggregations:
+            data:
+              nested:
+                path: "lines"
+              aggregations:
+                my_buckets:
+                  terms:
+                    size: 20
+                    field: "lines.name"
+                  aggregations:
+                    catalog_price:
+                      scripted_metric:
+                        init_script:
+                          source: "state.transactions = []"
+                        map_script:
+                          source: "state.transactions.add(doc['lines.value'].value)"
+                        combine_script:
+                          source: "double sum = 0; for (t in state.transactions) { sum += t } return sum"
+                        reduce_script:
+                          source: "double sum = 0; for (a in states) { if (a != null) { sum += a } } return sum"
+
+  - match: {aggregations.data.doc_count: 3}
+  - length: { aggregations.data.my_buckets.buckets: 2 }
+  - match: { aggregations.data.my_buckets.buckets.0.key: "foo" }
+  - match: { aggregations.data.my_buckets.buckets.0.doc_count: 2}
+  - match: { aggregations.data.my_buckets.buckets.0.catalog_price.value: 2.0}
+  - match: { aggregations.data.my_buckets.buckets.1.key: "bar" }
+  - match: { aggregations.data.my_buckets.buckets.1.doc_count: 1}
+  - match: { aggregations.data.my_buckets.buckets.1.catalog_price.value: 2.0}

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/top_hits_nested_metric.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/top_hits_nested_metric.yml
@@ -10,6 +10,8 @@ setup:
             properties:
               users:
                 type: nested
+              text:
+                type: text
 
   - do:
       index:
@@ -19,6 +21,7 @@ setup:
         body: |
           {
             "group" : "fans",
+            "text": "one",
             "users" : [
               {
                 "first" : "John",
@@ -39,6 +42,7 @@ setup:
         body: |
           {
             "group" : "fans",
+            "text" : "two",
             "users" : [
               {
                 "first" : "Mark",
@@ -77,6 +81,28 @@ setup:
   - match: { aggregations.to-users.users.hits.hits.2._index: my-index }
   - match: { aggregations.to-users.users.hits.hits.2._nested.field: users }
   - match: { aggregations.to-users.users.hits.hits.2._nested.offset: 1 }
+
+---
+"top_hits with nested sorted by score":
+  - do:
+      search:
+        rest_total_hits_as_int: true
+        index: my-index
+        body:
+          query:
+            match:
+              text: "one"
+          aggs:
+            to-users:
+              nested:
+                path: users
+              aggs:
+                users:
+                  top_hits:
+                    size: 3
+  - match: { hits.total: 1 }
+  - length: { aggregations.to-users.users.hits.hits: 3 }
+
 
 ---
 "top_hits aggregation with nested documents and disabled _source":

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -582,6 +582,7 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
         }
         deferredCollectors.postCollection();
     }
+
     private static class DeferredScorable extends Scorable {
 
         public int doc;
@@ -608,6 +609,7 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
             return doc;
         }
     }
+
     /**
      * Replay the top buckets from the matching documents.
      */

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/composite/CompositeAggregator.java
@@ -37,6 +37,8 @@ import org.elasticsearch.common.Rounding;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.core.Strings;
 import org.elasticsearch.index.IndexSortConfig;
+import org.elasticsearch.logging.LogManager;
+import org.elasticsearch.logging.Logger;
 import org.elasticsearch.lucene.queries.SearchAfterSortedDocQuery;
 import org.elasticsearch.search.DocValueFormat;
 import org.elasticsearch.search.aggregations.AggregationExecutionContext;
@@ -585,9 +587,10 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
 
     private static class DeferredScorable extends Scorable {
 
-        public int doc;
+        private static final Logger LOGGER = LogManager.getLogger(DeferredScorable.class);
         private final DocIdSetIterator iterator;
         private final Scorer scorer;
+        public int doc;
 
         DeferredScorable(Scorer scorer) {
             this.scorer = scorer;
@@ -599,6 +602,8 @@ public final class CompositeAggregator extends BucketsAggregator implements Size
             if (iterator.docID() < doc) {
                 // TODO: check if doc is a root document
                 final int d = iterator.advance(doc);
+                // I think we should always throw here if d != doc; this would indicate that we're collecting a child document
+                // but getting the score for a parent document
                 assert d == doc;
             }
             return scorer.score();


### PR DESCRIPTION
This is a follow up to https://github.com/elastic/elasticsearch/pull/91220 exploring the patch @jpountz suggested in the discussion.  The top hits test needs to be reworked a bit for this behavior, and we need to add some hardening and comments to the deferred scorer I think, but this at least gives us a place to start tinkering with that.