### PR TITLE
Make ShardRoutingState#value final

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/ShardRoutingState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/ShardRoutingState.java
@@ -31,7 +31,7 @@ public enum ShardRoutingState {
      */
     RELOCATING((byte) 4);
 
-    private byte value;
+    private final byte value;
 
     ShardRoutingState(byte value) {
         this.value = value;


### PR DESCRIPTION
This makes `ShardRoutingState#value` final to make sure it is not accidentally changed.