### PR TITLE
[Test] Remove randomization for credentials protected remote connection

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterConnectionTests.java
@@ -302,7 +302,7 @@ public class RemoteClusterConnectionTests extends ESTestCase {
                 service.acceptIncomingRequests();
                 String clusterAlias = "test-cluster";
                 Settings settings = buildRandomSettings(clusterAlias, seedNodes);
-                try (RemoteClusterConnection connection = new RemoteClusterConnection(settings, clusterAlias, service, randomBoolean())) {
+                try (RemoteClusterConnection connection = new RemoteClusterConnection(settings, clusterAlias, service, false)) {
                     int numThreads = randomIntBetween(4, 10);
                     Thread[] threads = new Thread[numThreads];
                     CyclicBarrier barrier = new CyclicBarrier(numThreads + 1);


### PR DESCRIPTION
This PR removes the randomBoolean for whether the
remoteClusterConnection is credentials protected so that test does not occationally fail due to RCS remote cluster server not bootstrapped.

Removal of the randomization does not reduce the test coverage because the test is meant to encounter failures when attempting connection. So it should have failed before it even reaches the part when different remote cluster mode comes into play. However sometimes the connection does come through and it will fail because the remote cluster server is not actually configured. The fact that the connection comes through sometimes seems to be of its own bug. So removing the current randomization can potentially help reveal the underlying cause of why the connection sometimes does not fail. In addition, there are other tests in the class that dedicately test the new RCS remote connections.

Resolves: #96282
