### PR TITLE
[8.8] Mute watcher yaml test (#96290)

### DIFF
--- a/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/usage/10_basic.yml
+++ b/x-pack/plugin/watcher/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/watcher/usage/10_basic.yml
@@ -1,5 +1,8 @@
 ---
 "Test watcher usage stats output":
+  - skip:
+      version: "all"
+      reason: "AwaitsFix https://github.com/elastic/elasticsearch/issues/65547"
   - do:
       catch: missing
       watcher.delete_watch:


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Mute watcher yaml test (#96290)