### PR TITLE
[8.8] API rest compatibility for type parameter in geo_bounding_box query (#96317)

### DIFF
--- a/docs/changelog/96317.yaml
+++ b/docs/changelog/96317.yaml
@@ -1,0 +1,5 @@
+pr: 96317
+summary: API rest compatibility for type parameter in `geo_bounding_box` query
+area: Geo
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTestV7Compat/resources/rest-api-spec/test/search/10_geo_bounding_box.yml
+++ b/rest-api-spec/src/yamlRestTestV7Compat/resources/rest-api-spec/test/search/10_geo_bounding_box.yml
@@ -1,0 +1,80 @@
+---
+setup:
+  - skip:
+      version: "9.0.0 - "
+      reason: "compatible from 8.x to 7.x"
+      features:
+        - "headers"
+        - "warnings"
+  - do:
+      indices.create:
+        index: locations
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+          mappings:
+
+            properties:
+              location:
+                type: geo_point
+  - do:
+      bulk:
+        index: locations
+        refresh: true
+        body: |
+          {"index":{}}
+          {"location" : {"lat": 13.5, "lon" : 34.89}}
+          {"index":{}}
+          {"location" : {"lat": -7.9, "lon" : 120.78}}
+          {"index":{}}
+          {"location" : {"lat": 45.78, "lon" : -173.45}}
+          {"index":{}}
+          {"location" : {"lat": 32.45, "lon" : 45.6}}
+          {"index":{}}
+          {"location" : {"lat": -63.24, "lon" : 31.0}}
+          {"index":{}}
+          {"location" : {"lat": 0.0, "lon" : 0.0}}
+
+
+---
+"geo bounding box query not compatible":
+  - do:
+      catch: /failed to parse \[geo_bounding_box\] query. unexpected field \[type\]/
+      search:
+        index: locations
+        body:
+          query:
+            geo_bounding_box:
+              type : indexed
+              location:
+                top_left:
+                  lat: 10
+                  lon: -10
+                bottom_right:
+                  lat: -10
+                  lon: 10
+
+---
+"geo bounding box query compatible":
+  - do:
+      headers:
+        Content-Type: "application/vnd.elasticsearch+json;compatible-with=7"
+        Accept: "application/vnd.elasticsearch+json;compatible-with=7"
+      warnings:
+        - "Deprecated parameter [type] used, it should no longer be specified."
+      search:
+        index: locations
+        body:
+          query:
+            geo_bounding_box:
+              type : indexed
+              location:
+                top_left:
+                  lat: 10
+                  lon: -10
+                bottom_right:
+                  lat: -10
+                  lon: 10
+  - match: {hits.total.value: 1}
+

--- a/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/GeoBoundingBoxQueryBuilder.java
@@ -21,6 +21,8 @@ import org.elasticsearch.common.geo.ShapeRelation;
 import org.elasticsearch.common.geo.SpatialStrategy;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.logging.DeprecationLogger;
+import org.elasticsearch.core.RestApiVersion;
 import org.elasticsearch.geometry.Rectangle;
 import org.elasticsearch.geometry.utils.Geohash;
 import org.elasticsearch.index.mapper.GeoShapeQueryable;
@@ -42,11 +44,16 @@ import java.util.Objects;
 public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBoundingBoxQueryBuilder> {
     public static final String NAME = "geo_bounding_box";
 
+    private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(GeoBoundingBoxQueryBuilder.class);
+
+    private static final String TYPE_PARAMETER_DEPRECATION_MESSAGE = "Deprecated parameter [type] used, it should no longer be specified.";
+
     /**
      * The default value for ignore_unmapped.
      */
     public static final boolean DEFAULT_IGNORE_UNMAPPED = false;
 
+    private static final ParseField TYPE_FIELD = new ParseField("type").forRestApiVersion(RestApiVersion.equalTo(RestApiVersion.V_7));
     private static final ParseField VALIDATION_METHOD_FIELD = new ParseField("validation_method");
     private static final ParseField IGNORE_UNMAPPED_FIELD = new ParseField("ignore_unmapped");
 
@@ -349,14 +356,18 @@ public class GeoBoundingBoxQueryBuilder extends AbstractQueryBuilder<GeoBounding
                     validationMethod = GeoValidationMethod.fromString(parser.text());
                 } else if (IGNORE_UNMAPPED_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
                     ignoreUnmapped = parser.booleanValue();
-                } else {
-                    throw new ParsingException(
-                        parser.getTokenLocation(),
-                        "failed to parse [{}] query. unexpected field [{}]",
-                        NAME,
-                        currentFieldName
-                    );
-                }
+                } else if (parser.getRestApiVersion() == RestApiVersion.V_7
+                    && TYPE_FIELD.match(currentFieldName, parser.getDeprecationHandler())) {
+                        deprecationLogger.compatibleCritical("geo_bounding_box_type", TYPE_PARAMETER_DEPRECATION_MESSAGE);
+                        parser.text(); // ignore value
+                    } else {
+                        throw new ParsingException(
+                            parser.getTokenLocation(),
+                            "failed to parse [{}] query. unexpected field [{}]",
+                            NAME,
+                            currentFieldName
+                        );
+                    }
             }
         }
 


### PR DESCRIPTION
Backports the following commits to 8.8:
 - API rest compatibility for type parameter in geo_bounding_box query (#96317)