### PR TITLE
MockLogAppender should not always use common prefix for logger names

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/InternalTestCluster.java
@@ -386,9 +386,6 @@ public final class InternalTestCluster extends TestCluster {
         if (Strings.hasLength(System.getProperty("tests.es.logger.level"))) {
             builder.put("logger.level", System.getProperty("tests.es.logger.level"));
         }
-        if (Strings.hasLength(System.getProperty("es.logger.prefix"))) {
-            builder.put("logger.prefix", System.getProperty("es.logger.prefix"));
-        }
         // Default the watermarks to absurdly low to prevent the tests
         // from failing on nodes without enough disk space
         builder.put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), "1b");

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -33,8 +33,6 @@ import static org.hamcrest.Matchers.is;
  */
 public class MockLogAppender extends AbstractAppender {
 
-    private static final String COMMON_PREFIX = System.getProperty("es.logger.prefix", "org.elasticsearch.");
-
     private final List<WrappedLoggingExpectation> expectations;
 
     public MockLogAppender() {
@@ -79,7 +77,7 @@ public class MockLogAppender extends AbstractAppender {
 
         public AbstractEventExpectation(String name, String logger, Level level, String message) {
             this.name = name;
-            this.logger = getLoggerName(logger);
+            this.logger = logger;
             this.level = level;
             this.message = message;
             this.saw = false;
@@ -208,14 +206,6 @@ public class MockLogAppender extends AbstractAppender {
             assertThat(name, saw, equalTo(true));
         }
 
-    }
-
-    private static String getLoggerName(String name) {
-        if (name.startsWith("org.elasticsearch.")) {
-            name = name.substring("org.elasticsearch.".length());
-            return COMMON_PREFIX + name;
-        }
-        return name;
     }
 
     /**

--- a/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/MockLogAppender.java
@@ -213,8 +213,9 @@ public class MockLogAppender extends AbstractAppender {
     private static String getLoggerName(String name) {
         if (name.startsWith("org.elasticsearch.")) {
             name = name.substring("org.elasticsearch.".length());
+            return COMMON_PREFIX + name;
         }
-        return COMMON_PREFIX + name;
+        return name;
     }
 
     /**

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
@@ -68,8 +68,6 @@ public class WatcherScheduleEngineBenchmark {
         .build();
 
     public static void main(String[] args) throws Exception {
-        System.setProperty("es.logger.prefix", "");
-
         String[] engines = new String[] { "ticker", "scheduler" };
         int numWatches = 2000;
         int benchTime = 60000;


### PR DESCRIPTION
Only for the ones starting with org.elasticsearch. The rest (e.g., loggers in plugins' tests) can go through with their original names as they are.