### PR TITLE
Clean up `adjustSearchType` method

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -403,6 +403,12 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
     }
 
     static void adjustSearchType(SearchRequest searchRequest, boolean singleShard) {
+        // if there's a kNN search, always use DFS_QUERY_THEN_FETCH
+        if (searchRequest.hasKnnSearch()) {
+            searchRequest.searchType(DFS_QUERY_THEN_FETCH);
+            return;
+        }
+
         // optimize search type for cases where there is only one shard group to search on
         if (singleShard) {
             // if we only have one group, then we always want Q_T_F, no need for DFS, and no need to do THEN since we hit one shard
@@ -413,11 +419,6 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
         if (searchRequest.isSuggestOnly()) {
             searchRequest.requestCache(false);
             searchRequest.searchType(QUERY_THEN_FETCH);
-        }
-
-        // if there's a kNN search, always use DFS_QUERY_THEN_FETCH
-        if (searchRequest.hasKnnSearch()) {
-            searchRequest.searchType(DFS_QUERY_THEN_FETCH);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
+++ b/server/src/main/java/org/elasticsearch/action/search/TransportSearchAction.java
@@ -409,15 +409,16 @@ public class TransportSearchAction extends HandledTransportAction<SearchRequest,
             return;
         }
 
-        // optimize search type for cases where there is only one shard group to search on
-        if (singleShard) {
-            // if we only have one group, then we always want Q_T_F, no need for DFS, and no need to do THEN since we hit one shard
-            searchRequest.searchType(QUERY_THEN_FETCH);
-        }
-
         // if there's only suggest, disable request cache and always use QUERY_THEN_FETCH
         if (searchRequest.isSuggestOnly()) {
             searchRequest.requestCache(false);
+            searchRequest.searchType(QUERY_THEN_FETCH);
+            return;
+        }
+
+        // optimize search type for cases where there is only one shard group to search on
+        if (singleShard) {
+            // if we only have one group, then we always want Q_T_F, no need for DFS, and no need to do THEN since we hit one shard
             searchRequest.searchType(QUERY_THEN_FETCH);
         }
     }


### PR DESCRIPTION
This moves the knn check for adjusting search type to the top of the method instead of possibly "adjusting" the search type multiple times. Purely mechanical change for readability.