### PR TITLE
Universal Profiling: Remove cluster id from metrics mapping

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -33,9 +33,6 @@
         "@timestamp": {
           "type": "date",
           "format": "epoch_second"
-        },
-        "Elasticsearch.cluster.id": {
-          "type": "keyword"
         }
       }
     }


### PR DESCRIPTION
With this PR the cluster id is removed from the metrics mapping. It is redundant and doesn't need to be stored in the customer's cluster.