### PR TITLE
Chunk profiling stacktrace response

### DIFF
--- a/docs/changelog/96340.yaml
+++ b/docs/changelog/96340.yaml
@@ -1,0 +1,5 @@
+pr: 96340
+summary: Chunk profiling stacktrace response
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
+++ b/x-pack/plugin/profiler/src/internalClusterTest/java/org/elasticsearch/xpack/profiler/GetProfilingActionIT.java
@@ -7,8 +7,6 @@
 
 package org.elasticsearch.xpack.profiler;
 
-import org.elasticsearch.rest.RestStatus;
-
 import java.util.List;
 
 public class GetProfilingActionIT extends ProfilingTestCase {
@@ -20,7 +18,6 @@ public class GetProfilingActionIT extends ProfilingTestCase {
     public void testGetProfilingDataUnfiltered() throws Exception {
         GetProfilingRequest request = new GetProfilingRequest(1, null);
         GetProfilingResponse response = client().execute(GetProfilingAction.INSTANCE, request).get();
-        assertEquals(RestStatus.OK, response.status());
         assertEquals(1, response.getTotalFrames());
         assertNotNull(response.getStackTraces());
         StackTrace stackTrace = response.getStackTraces().get("QjoLteG7HX3VUUXr-J4kHQ");

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/RestGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/RestGetProfilingAction.java
@@ -9,8 +9,9 @@ package org.elasticsearch.xpack.profiler;
 import org.elasticsearch.client.internal.node.NodeClient;
 import org.elasticsearch.rest.BaseRestHandler;
 import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.action.RestActionListener;
 import org.elasticsearch.rest.action.RestCancellableNodeClient;
-import org.elasticsearch.rest.action.RestStatusToXContentListener;
+import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 
 import java.io.IOException;
 import java.util.List;
@@ -30,7 +31,7 @@ public class RestGetProfilingAction extends BaseRestHandler {
         request.applyContentParser(getProfilingRequest::parseXContent);
 
         return channel -> {
-            RestStatusToXContentListener<GetProfilingResponse> listener = new RestStatusToXContentListener<>(channel);
+            RestActionListener<GetProfilingResponse> listener = new RestChunkedToXContentListener<>(channel);
             RestCancellableNodeClient cancelClient = new RestCancellableNodeClient(client, request.getHttpChannel());
             cancelClient.execute(GetProfilingAction.INSTANCE, getProfilingRequest, listener);
         };

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -8,17 +8,13 @@
 package org.elasticsearch.xpack.profiler;
 
 import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.util.List;
 import java.util.Map;
-import java.util.function.Supplier;
 
 public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<GetProfilingResponse> {
-    private <T> T randomNullable(Supplier<T> v) {
-        return randomBoolean() ? v.get() : null;
-    }
-
     private <T> T randomNullable(T v) {
         return randomBoolean() ? v : null;
     }
@@ -59,5 +55,22 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
     @Override
     protected Writeable.Reader<GetProfilingResponse> instanceReader() {
         return GetProfilingResponse::new;
+    }
+
+    public void testChunking() {
+        AbstractChunkedSerializingTestCase.assertChunkCount(createTestInstance(), instance -> {
+            // start, end, total_frames
+            int chunks = 3;
+            chunks += size(instance.getExecutables());
+            chunks += size(instance.getStackFrames());
+            chunks += size(instance.getStackTraces());
+            chunks += size(instance.getStackTraceEvents());
+            return chunks;
+        });
+    }
+
+    private int size(Map<?, ?> m) {
+        // if there is a map, we also need to take into account start and end object
+        return m != null ? 2 + m.size() : 0;
     }
 }


### PR DESCRIPTION
With this commit we implement chunking for the get stacktraces API in the profiling plugin as typical response sizes are dozens of MB large.