### PR TITLE
Add risk_score  indexes for kibana_system_user

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStore.java
@@ -924,7 +924,8 @@ public class ReservedRolesStore implements BiConsumer<Set<String>, ActionListene
                         "logs-cloud_security_posture.vulnerabilities_latest-default*"
                     )
                     .privileges("create_index", "read", "index", "delete", IndicesAliasesAction.NAME, UpdateSettingsAction.NAME)
-                    .build() },
+                    .build(),
+                RoleDescriptor.IndicesPrivileges.builder().indices("risk-score.risk-*").privileges("all").build() },
             null,
             new ConfigurableClusterPrivilege[] {
                 new ManageApplicationPrivileges(Set.of("kibana-*")),

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1246,9 +1246,8 @@ public class ReservedRolesStoreTests extends ESTestCase {
             );
         });
 
-        Arrays.asList(
-            "risk-score.risk-score-" + randomAlphaOfLength(randomIntBetween(0, 13))
-        ).forEach(indexName -> assertAllIndicesAccessAllowed(kibanaRole, indexName));
+        Arrays.asList("risk-score.risk-score-" + randomAlphaOfLength(randomIntBetween(0, 13)))
+            .forEach(indexName -> assertAllIndicesAccessAllowed(kibanaRole, indexName));
     }
 
     public void testKibanaAdminRole() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1245,6 +1245,10 @@ public class ReservedRolesStoreTests extends ESTestCase {
                 is(true)
             );
         });
+
+        Arrays.asList(
+            "risk-score.risk-score-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+        ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
     }
 
     public void testKibanaAdminRole() {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1247,7 +1247,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
         });
 
         Arrays.asList(
-            "risk-score.risk-score-" + randomAlphaOfLength(randomIntBetween(0, 13)),
+            "risk-score.risk-score-" + randomAlphaOfLength(randomIntBetween(0, 13))
         ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -1248,7 +1248,7 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
         Arrays.asList(
             "risk-score.risk-score-" + randomAlphaOfLength(randomIntBetween(0, 13))
-        ).forEach(index -> assertAllIndicesAccessAllowed(kibanaRole, index));
+        ).forEach(indexName -> assertAllIndicesAccessAllowed(kibanaRole, indexName));
     }
 
     public void testKibanaAdminRole() {


### PR DESCRIPTION
It introduces,  the privileges for risk scores datastream indices for `kibana-system` user
Related PR: https://github.com/elastic/kibana/pull/158422