### PR TITLE
[Profiling] Rename lastprocessed into next_time (profiling-executables)

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
@@ -28,7 +28,7 @@
           "type": "date",
           "format": "epoch_second"
         },
-        "Symbolization.lastprocessed": {
+        "Symbolization.next_time": {
           "type": "date",
           "format": "epoch_second",
           "index": false


### PR DESCRIPTION
Used by the symbolizer only.
The new name reflects the new semantics of this field.