### PR TITLE
[DOCS] Fixes a typo in the stop transform API docs

### DIFF
--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -41,7 +41,7 @@ comma-separated list or a wildcard expression. To stop all {transforms}, use
 
 `allow_no_match`::
  (Optional, Boolean)
- include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
 
 `force`::
   (Optional, Boolean) Set to `true` to stop a failed {transform} or to 


### PR DESCRIPTION
Removes a space from the [stop transform API docs](https://www.elastic.co/guide/en/elasticsearch/reference/master/stop-transform.html#stop-transform-query-parms) that breaks the `include` statement.