### PR TITLE
[8.8] [DOCS] Fixes a typo in the stop transform API docs (#96358)

### DIFF
--- a/docs/reference/transform/apis/stop-transform.asciidoc
+++ b/docs/reference/transform/apis/stop-transform.asciidoc
@@ -41,7 +41,7 @@ comma-separated list or a wildcard expression. To stop all {transforms}, use
 
 `allow_no_match`::
  (Optional, Boolean)
- include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
+include::{es-repo-dir}/rest-api/common-parms.asciidoc[tag=allow-no-match-transforms2]
 
 `force`::
   (Optional, Boolean) Set to `true` to stop a failed {transform} or to 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Fixes a typo in the stop transform API docs (#96358)](https://github.com/elastic/elasticsearch/pull/96358)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)