### PR TITLE
[DOCS] Move 2048 dims 'experimental' warning inline

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -115,8 +115,9 @@ integer values between -128 to 127, inclusive for both indexing and searching.
 Number of vector dimensions. Can't exceed `1024` for indexed vectors
 (`"index": true`), or `2048` for non-indexed vectors.
 
-experimental::[]
-Number of dimensions for indexed vectors can be extended up to `2048`.
++
+experimental:[]
+The number of dimensions for indexed vectors can be extended up to `2048`.
 
 `index`::
 (Optional, Boolean)


### PR DESCRIPTION
The current statement that `dims` can be extended up to 2048 feels disconnected from the "experimental" warning just above it:

![image](https://github.com/elastic/elasticsearch/assets/9715543/0100047b-f108-43d7-9fa3-549a469f95f5)

This change moves that warning inline: 

![image](https://github.com/elastic/elasticsearch/assets/9715543/2566d3db-8f80-4434-8cba-19aad40b88be)
