### PR TITLE
add analytics_collections to enterprise search usage in docs test

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -413,6 +413,9 @@ GET /_xpack/usage
     "enabled": true,
     "search_applications" : {
       "count": 0
+    },
+    "analytics_collections": {
+      "count": 0
     }
   }
 }


### PR DESCRIPTION
adds the missing `analytics_collections` key to the response in `usage.asciidoc`. this was missed in https://github.com/elastic/elasticsearch/pull/96063 because these tests are currently skipped in snapshot builds[^1].

fixes #96344 

[^1]: https://github.com/elastic/elasticsearch/issues/95603#issuecomment-1535256381