### PR TITLE
Speed up SharedBytes.IO

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -731,7 +731,7 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
 
                 ensureOpen();
                 final SharedBytes.IO fileChannel = sharedBytes.getFileChannel(sharedBytesPos);
-                resources[0] = Releasables.releaseOnce(fileChannel::decRef);
+                resources[0] = Releasables.releaseOnce(fileChannel);
 
                 final ActionListener<Void> rangeListener = rangeListener(
                     rangeToRead,

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -12,9 +12,9 @@ import org.apache.logging.log4j.Logger;
 import org.elasticsearch.blobcache.BlobCacheUtils;
 import org.elasticsearch.blobcache.common.ByteBufferReference;
 import org.elasticsearch.common.unit.ByteSizeValue;
-import org.elasticsearch.common.util.concurrent.ConcurrentCollections;
 import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.IOUtils;
+import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
 import org.elasticsearch.env.NodeEnvironment;
@@ -27,7 +27,6 @@ import java.nio.channels.FileChannel;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
-import java.util.Map;
 import java.util.function.IntConsumer;
 import java.util.function.LongConsumer;
 
@@ -54,6 +53,9 @@ public class SharedBytes extends AbstractRefCounted {
         StandardOpenOption.CREATE };
 
     final int numRegions;
+
+    private final IO[] ios;
+
     final long regionSize;
 
     // TODO: for systems like Windows without true p-write/read support we should split this up into multiple channels since positional
@@ -82,6 +84,10 @@ public class SharedBytes extends AbstractRefCounted {
             }
         }
         this.path = cacheFile;
+        this.ios = new IO[numRegions];
+        for (int i = 0; i < numRegions; i++) {
+            ios[i] = new IO(i);
+        }
         this.writeBytes = writeBytes;
         this.readBytes = readBytes;
     }
@@ -215,27 +221,11 @@ public class SharedBytes extends AbstractRefCounted {
         }
     }
 
-    private final Map<Integer, IO> ios = ConcurrentCollections.newConcurrentMap();
-
     public IO getFileChannel(int sharedBytesPos) {
         assert fileChannel != null;
-        return ios.compute(sharedBytesPos, (p, io) -> {
-            if (io == null || io.tryIncRef() == false) {
-                final IO newIO;
-                boolean success = false;
-                incRef();
-                try {
-                    newIO = new IO(p);
-                    success = true;
-                } finally {
-                    if (success == false) {
-                        decRef();
-                    }
-                }
-                return newIO;
-            }
-            return io;
-        });
+        var res = ios[sharedBytesPos];
+        incRef();
+        return res;
     }
 
     long getPhysicalOffset(long chunkPosition) {
@@ -244,13 +234,11 @@ public class SharedBytes extends AbstractRefCounted {
         return physicalOffset;
     }
 
-    public final class IO extends AbstractRefCounted {
+    public final class IO implements Releasable {
 
-        private final int sharedBytesPos;
         private final long pageStart;
 
         private IO(final int sharedBytesPos) {
-            this.sharedBytesPos = sharedBytesPos;
             pageStart = getPhysicalOffset(sharedBytesPos);
         }
 
@@ -282,9 +270,8 @@ public class SharedBytes extends AbstractRefCounted {
         }
 
         @Override
-        protected void closeInternal() {
-            ios.remove(sharedBytesPos, this);
-            SharedBytes.this.decRef();
+        public void close() {
+            decRef();
         }
     }
 

--- a/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
+++ b/x-pack/plugin/blob-cache/src/test/java/org/elasticsearch/blobcache/shared/SharedBytesTests.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.blobcache.shared;
+
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.env.Environment;
+import org.elasticsearch.env.NodeEnvironment;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.node.Node;
+import org.elasticsearch.test.ESTestCase;
+
+import java.nio.file.Files;
+
+public class SharedBytesTests extends ESTestCase {
+
+    public void testReleasesFileCorrectly() throws Exception {
+        int regions = randomIntBetween(1, 10);
+        var nodeSettings = Settings.builder()
+            .put(Node.NODE_NAME_SETTING.getKey(), "node")
+            .put("path.home", createTempDir())
+            .putList(Environment.PATH_DATA_SETTING.getKey(), createTempDir().toString())
+            .build();
+        try (var nodeEnv = new NodeEnvironment(nodeSettings, TestEnvironment.newEnvironment(nodeSettings))) {
+            final SharedBytes sharedBytes = new SharedBytes(
+                regions,
+                randomIntBetween(1, 16) * 4096L,
+                nodeEnv,
+                ignored -> {},
+                ignored -> {}
+            );
+            final var sharedBytesPath = nodeEnv.nodeDataPaths()[0].resolve("shared_snapshot_cache");
+            assertTrue(Files.exists(sharedBytesPath));
+            SharedBytes.IO fileChannel = sharedBytes.getFileChannel(randomInt(regions - 1));
+            assertTrue(Files.exists(sharedBytesPath));
+            if (randomBoolean()) {
+                fileChannel.close();
+                assertTrue(Files.exists(sharedBytesPath));
+                sharedBytes.decRef();
+            } else {
+                sharedBytes.decRef();
+                assertTrue(Files.exists(sharedBytesPath));
+                fileChannel.close();
+            }
+            assertFalse(Files.exists(sharedBytesPath));
+        }
+    }
+}


### PR DESCRIPTION
This was way overengineered and not sure why I built it the way I originally did. We can just put the IO instances in an array of known size and have them live as long as the `SharedBytes` live. No need to constantly create and destroy them and contend on hot map regions whatsoever.
Also, as of right now there is no point in them having individual ref counts. We could probably do away with these in general but I think there's some merit to the API and if we eventually feel like we need to move the IO to mmap these would be a massive help so I didn't make any bigger changes here.
