### PR TITLE
Require DLM enabled in the mixed-cluster QA cluster

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -38,6 +38,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
       requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
+      requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.8.0")
     }
 
     tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -29,6 +29,7 @@ BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.9.0") &&
       nodes."${baseName}-1".setting 'node.roles', '["data_content", "data_hot"]'
     }
     nodes."${baseName}-2".setting 'node.roles', '["master"]'
+    requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.8.0")
   }
 
   tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask


### PR DESCRIPTION
This is an alternative way to #96390 of fixing the mixed-cluster test failures 
described in #96382 

Fixes #96382 
Fixes https://github.com/elastic/elasticsearch/issues/96383