### PR TITLE
Rank_feature field null_value test and small edits

### DIFF
--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldMapper.java
@@ -30,8 +30,10 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentParser.Token;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * A {@link FieldMapper} that exposes Lucene's {@link FeatureField}.
@@ -152,12 +154,13 @@ public class RankFeatureFieldMapper extends FieldMapper {
             if (format != null) {
                 throw new IllegalArgumentException("Field [" + name() + "] of type [" + typeName() + "] doesn't support formats.");
             }
-            return new SourceValueFetcher(name(), context) {
+            return sourceValueFetcher(context.isSourceEnabled() ? context.sourcePath(name()) : Collections.emptySet());
+        }
+
+        private SourceValueFetcher sourceValueFetcher(Set<String> sourcePaths) {
+            return new SourceValueFetcher(sourcePaths, nullValue) {
                 @Override
-                protected Float parseSourceValue(Object value) {
-                    if (value.equals("")) {
-                        return nullValue;
-                    }
+                protected Object parseSourceValue(Object value) {
                     return objectToFloat(value);
                 }
             };

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/RankFeatureFieldTypeTests.java
@@ -30,6 +30,6 @@ public class RankFeatureFieldTypeTests extends FieldTypeTestCase {
 
         assertEquals(List.of(3.14f), fetchSourceValue(mapper, 3.14));
         assertEquals(List.of(42.9f), fetchSourceValue(mapper, "42.9"));
-        assertEquals(List.of(2.0f), fetchSourceValue(mapper, ""));
+        assertEquals(List.of(2.0f), fetchSourceValue(mapper, null));
     }
 }

--- a/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_feature/20_null_value.yml
+++ b/modules/mapper-extras/src/yamlRestTest/resources/rest-api-spec/test/rank_feature/20_null_value.yml
@@ -1,12 +1,12 @@
 ---
-"Non positive null_vallue":
+"Non positive null_value":
 
   - skip:
       version: " - 8.8.99"
       reason: "null_value parameter was added in 8.9.0"
 
   - do:
-      catch: bad_request
+      catch: /\[null_value\] must be a positive normal float for field of type \[rank_feature\]/
       indices.create:
         index: test2
         body:
@@ -16,7 +16,7 @@
             properties:
               pagerank:
                 type: rank_feature
-                null_vallue: -3
+                null_value: -3
 
 ---
 "Search rank_feature with and without null_value":
@@ -35,7 +35,7 @@
             properties:
               pagerank:
                 type: rank_feature
-                null_value: 15
+                null_value: 100
               url_length:
                 type: rank_feature
 
@@ -55,9 +55,19 @@
           pagerank: null
           url_length: null
 
+  # can't index a field value equal to an empty string
+  - do:
+      catch: /failed to parse field \[pagerank\] of type \[rank_feature\] in document/
+      index:
+        index: test1
+        id: "wrong_document1"
+        body:
+          pagerank: ""
+
   - do:
       indices.refresh: {}
 
+  # docs with null values are absent in search results
   - do:
       search:
         index: test1
@@ -72,6 +82,7 @@
   - match:
       hits.hits.0._id: "1"
 
+  # docs with null values are present in search results
   - do:
       search:
         index: test1
@@ -79,6 +90,9 @@
           query:
             rank_feature:
               field: pagerank
+          fields:
+            - field: 'pagerank'
+            - field: 'url_length'
 
   - match:
       hits.total.value: 2
@@ -88,3 +102,8 @@
 
   - match:
       hits.hits.1._id: "1"
+
+  - match: { hits.hits.0._source.pagerank: null }
+  - match: { hits.hits.0.fields.pagerank.0: 100 }
+  - match: { hits.hits.0._source.url_length: null }
+  - is_false: hits.hits.0.fields.url_length


### PR DESCRIPTION
Correct and add more tests for adding null_value parameter 
for the rank_feature field.

Also make sure that ValueFetcher is using Mapper's `null_value`
parameter.

Relates to #95811, closes #95149