### PR TITLE
Fix lossy-conversions lint warnings

### DIFF
--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/CIDR.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/api/CIDR.java
@@ -66,8 +66,8 @@ public class CIDR {
         // Borrowed from Lucene
         for (int i = prefixLength; i < 8 * lower.length; i++) {
             int m = 1 << (7 - (i & 7));
-            lower[i >> 3] &= ~m;
-            upper[i >> 3] |= m;
+            lower[i >> 3] &= (byte) ~m;
+            upper[i >> 3] |= (byte) m;
         }
         return new Tuple<>(lower, upper);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/termvectors/GetTermVectorsIT.java
@@ -1017,7 +1017,7 @@ public class GetTermVectorsIT extends AbstractTermVectorsTestCase {
         List<Integer> shardIds = Arrays.stream(searchShardsResponse.getGroups()).map(s -> s.getShardId().id()).toList();
 
         // request termvectors of artificial document from each shard
-        int sumTotalTermFreq = 0;
+        long sumTotalTermFreq = 0;
         int sumDocFreq = 0;
         for (Integer shardId : shardIds) {
             TermVectorsResponse tvResponse = client().prepareTermVectors()

--- a/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/blocks/SimpleBlocksIT.java
@@ -369,7 +369,7 @@ public class SimpleBlocksIT extends ESIntegTestCase {
         ensureGreen(indexName);
 
         final APIBlock block = randomAddableBlock();
-        int nbDocs = 0;
+        long nbDocs = 0;
         try {
             try (BackgroundIndexer indexer = new BackgroundIndexer(indexName, client(), 1000)) {
                 indexer.setFailureAssertion(t -> {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexingPressureIT.java
@@ -103,7 +103,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
         final Releasable replicaRelease = blockReplicas(replicaThreadPool);
 
         final BulkRequest bulkRequest = new BulkRequest();
-        int totalRequestSize = 0;
+        long totalRequestSize = 0;
         for (int i = 0; i < 80; ++i) {
             IndexRequest request = new IndexRequest(INDEX_NAME).id(UUIDs.base64UUID())
                 .source(Collections.singletonMap("key", randomAlphaOfLength(50)));
@@ -235,7 +235,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
 
     public void testWriteCanBeRejectedAtCoordinatingLevel() throws Exception {
         final BulkRequest bulkRequest = new BulkRequest();
-        int totalRequestSize = 0;
+        long totalRequestSize = 0;
         for (int i = 0; i < 80; ++i) {
             IndexRequest request = new IndexRequest(INDEX_NAME).id(UUIDs.base64UUID())
                 .source(Collections.singletonMap("key", randomAlphaOfLength(50)));
@@ -300,7 +300,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
 
     public void testWriteCanBeRejectedAtPrimaryLevel() throws Exception {
         final BulkRequest bulkRequest = new BulkRequest();
-        int totalRequestSize = 0;
+        long totalRequestSize = 0;
         for (int i = 0; i < 80; ++i) {
             IndexRequest request = new IndexRequest(INDEX_NAME).id(UUIDs.base64UUID())
                 .source(Collections.singletonMap("key", randomAlphaOfLength(50)));
@@ -370,7 +370,7 @@ public class IndexingPressureIT extends ESIntegTestCase {
             int thresholdToStopSending = 800 * 1024;
 
             ArrayList<ActionFuture<IndexResponse>> responses = new ArrayList<>();
-            int totalRequestSize = 0;
+            long totalRequestSize = 0;
             while (totalRequestSize < thresholdToStopSending) {
                 IndexRequest request = new IndexRequest(INDEX_NAME).id(UUIDs.base64UUID())
                     .source(Collections.singletonMap("key", randomAlphaOfLength(500)));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -149,12 +149,12 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         assertFailures(searchRequest, RestStatus.INTERNAL_SERVER_ERROR, containsString(errMsg));
 
         NodesStatsResponse stats = client.admin().cluster().prepareNodesStats().setBreaker(true).get();
-        int breaks = 0;
+        long breaks = 0;
         for (NodeStats stat : stats.getNodes()) {
             CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.FIELDDATA);
             breaks += breakerStats.getTrippedCount();
         }
-        assertThat(breaks, greaterThanOrEqualTo(1));
+        assertThat(breaks, greaterThanOrEqualTo(1L));
     }
 
     public void testRamAccountingTermsEnum() throws Exception {
@@ -215,12 +215,12 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
         assertFailures(searchRequest, RestStatus.INTERNAL_SERVER_ERROR, containsString(errMsg));
 
         NodesStatsResponse stats = client.admin().cluster().prepareNodesStats().setBreaker(true).get();
-        int breaks = 0;
+        long breaks = 0;
         for (NodeStats stat : stats.getNodes()) {
             CircuitBreakerStats breakerStats = stat.getBreaker().getStats(CircuitBreaker.FIELDDATA);
             breaks += breakerStats.getTrippedCount();
         }
-        assertThat(breaks, greaterThanOrEqualTo(1));
+        assertThat(breaks, greaterThanOrEqualTo(1L));
     }
 
     public void testRequestBreaker() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -236,7 +236,7 @@ public class CloseIndexIT extends ESIntegTestCase {
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createIndex(indexName);
 
-        int nbDocs = 0;
+        long nbDocs = 0;
         try (BackgroundIndexer indexer = new BackgroundIndexer(indexName, client(), MAX_DOCS)) {
             indexer.setFailureAssertion(t -> assertException(t, indexName));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -300,7 +300,7 @@ public class HistogramIT extends ESIntegTestCase {
         assertThat(histo.getName(), equalTo("histo"));
         assertThat(histo.getBuckets().size(), equalTo(expectedNumberOfBuckets));
 
-        int docsCounted = 0;
+        long docsCounted = 0;
         for (int i = 0; i < expectedNumberOfBuckets; ++i) {
             Histogram.Bucket bucket = histo.getBuckets().get(i);
             assertThat(bucket, notNullValue());

--- a/server/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
+++ b/server/src/main/java/org/elasticsearch/common/RandomBasedUUIDGenerator.java
@@ -70,7 +70,7 @@ class RandomBasedUUIDGenerator implements UUIDGenerator {
          * The high field of th clock sequence multiplexed with the variant.
          * We set only the MSB of the variant*/
         randomBytes[8] &= 0x3f; /* clear the 2 most significant bits */
-        randomBytes[8] |= 0x80; /* set the variant (MSB is set)*/
+        randomBytes[8] |= (byte) 0x80; /* set the variant (MSB is set)*/
         return randomBytes;
     }
 }

--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -59,7 +59,7 @@ public class ByteArrayStreamInput extends StreamInput {
     }
 
     public void skipBytes(long count) {
-        pos += count;
+        pos += (int) count;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/network/CIDRUtils.java
+++ b/server/src/main/java/org/elasticsearch/common/network/CIDRUtils.java
@@ -63,8 +63,8 @@ public class CIDRUtils {
         // Borrowed from Lucene
         for (int i = prefixLength; i < 8 * lower.length; i++) {
             int m = 1 << (7 - (i & 7));
-            lower[i >> 3] &= ~m;
-            upper[i >> 3] |= m;
+            lower[i >> 3] &= (byte) ~m;
+            upper[i >> 3] |= (byte) m;
         }
         return new Tuple<>(lower, upper);
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/BinaryRangeUtil.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/BinaryRangeUtil.java
@@ -233,11 +233,11 @@ enum BinaryRangeUtil {
         }
 
         // write the header
-        encoded[0] |= sign << 7;
+        encoded[0] |= (byte) (sign << 7);
         if (sign > 0) {
-            encoded[0] |= numAdditionalBytes << 3;
+            encoded[0] |= (byte) (numAdditionalBytes << 3);
         } else {
-            encoded[0] |= (15 - numAdditionalBytes) << 3;
+            encoded[0] |= (byte) ((15 - numAdditionalBytes) << 3);
         }
         return encoded;
     }

--- a/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/IpScriptFieldType.java
@@ -198,8 +198,8 @@ public final class IpScriptFieldType extends AbstractScriptFieldType<IpFieldScri
         byte upper[] = addr.getAddress();
         for (int i = prefixLength; i < 8 * lower.length; i++) {
             int m = 1 << (7 - (i & 7));
-            lower[i >> 3] &= ~m;
-            upper[i >> 3] |= m;
+            lower[i >> 3] &= (byte) ~m;
+            upper[i >> 3] |= (byte) m;
         }
         // Force the terms into IPv6
         BytesRef lowerBytes = new BytesRef(InetAddressPoint.encode(InetAddressPoint.decode(lower)));

--- a/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/RangeFieldMapper.java
@@ -444,8 +444,8 @@ public class RangeFieldMapper extends FieldMapper {
         byte[] upper = lower.clone();
         for (int i = cidr.v2(); i < 8 * lower.length; i++) {
             int m = 1 << 7 - (i & 7);
-            lower[i >> 3] &= ~m;
-            upper[i >> 3] |= m;
+            lower[i >> 3] &= (byte) ~m;
+            upper[i >> 3] |= (byte) m;
         }
         try {
             return new Range(RangeType.IP, InetAddress.getByAddress(lower), InetAddress.getByAddress(upper), true, true);

--- a/server/src/main/java/org/elasticsearch/script/VectorScoreScriptUtils.java
+++ b/server/src/main/java/org/elasticsearch/script/VectorScoreScriptUtils.java
@@ -99,7 +99,7 @@ public class VectorScoreScriptUtils {
 
             if (normalizeQuery) {
                 for (int dim = 0; dim < this.queryVector.length; dim++) {
-                    this.queryVector[dim] /= queryMagnitude;
+                    this.queryVector[dim] /= (float) queryMagnitude;
                 }
             }
         }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/BestBucketsDeferringCollector.java
@@ -184,7 +184,7 @@ public class BestBucketsDeferringCollector extends DeferringBucketCollector {
                 final PackedLongValues.Iterator buckets = entry.buckets.iterator();
                 int doc = 0;
                 for (long i = 0, end = entry.docDeltas.size(); i < end; ++i) {
-                    doc += docDeltaIterator.next();
+                    doc += (int) docDeltaIterator.next();
                     final long bucket = buckets.next();
                     final long rebasedBucket = this.selectedBuckets.find(bucket);
                     if (rebasedBucket != -1) {

--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/range/IpRangeAggregationBuilder.java
@@ -128,8 +128,8 @@ public final class IpRangeAggregationBuilder extends ValuesSourceAggregationBuil
             byte upper[] = address.getAddress();
             for (int i = prefixLength; i < 8 * lower.length; i++) {
                 int m = 1 << (7 - (i & 7));
-                lower[i >> 3] &= ~m;
-                upper[i >> 3] |= m;
+                lower[i >> 3] &= (byte) ~m;
+                upper[i >> 3] |= (byte) m;
             }
             this.key = key;
             try {

--- a/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchPhaseControllerTests.java
@@ -489,7 +489,7 @@ public class SearchPhaseControllerTests extends ESTestCase {
         for (SearchPhaseResult shardResult : results.asList()) {
             TopDocs topDocs = shardResult.queryResult().topDocs().topDocs;
             assert topDocs.totalHits.relation == Relation.EQUAL_TO;
-            resultCount += topDocs.totalHits.value;
+            resultCount += (int) topDocs.totalHits.value;
         }
         return resultCount;
     }

--- a/server/src/test/java/org/elasticsearch/index/shard/StoreRecoveryTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/StoreRecoveryTests.java
@@ -89,7 +89,7 @@ public class StoreRecoveryTests extends ESTestCase {
         final long maxSeqNo = randomNonNegativeLong();
         final long maxUnsafeAutoIdTimestamp = randomNonNegativeLong();
         StoreRecovery.addIndices(indexStats, target, indexSort, dirs, maxSeqNo, maxUnsafeAutoIdTimestamp, null, 0, false, false);
-        int numFiles = 0;
+        long numFiles = 0;
         Predicate<String> filesFilter = (f) -> f.startsWith("segments") == false
             && f.equals("write.lock") == false
             && f.startsWith("extra") == false;

--- a/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/index/snapshots/blobstore/FileInfoTests.java
@@ -168,7 +168,7 @@ public class FileInfoTests extends ESTestCase {
         );
         int numBytes = 0;
         for (int i = 0; i < info.numberOfParts(); i++) {
-            numBytes += info.partBytes(i);
+            numBytes += (int) info.partBytes(i);
         }
         assertEquals(numBytes, 36);
 
@@ -179,7 +179,7 @@ public class FileInfoTests extends ESTestCase {
         );
         numBytes = 0;
         for (int i = 0; i < info.numberOfParts(); i++) {
-            numBytes += info.partBytes(i);
+            numBytes += (int) info.partBytes(i);
         }
         assertEquals(numBytes, 35);
         final int numIters = randomIntBetween(10, 100);
@@ -193,7 +193,7 @@ public class FileInfoTests extends ESTestCase {
             info = new BlobStoreIndexShardSnapshot.FileInfo("foo", metadata, ByteSizeValue.ofBytes(randomIntBetween(1, 1000)));
             numBytes = 0;
             for (int i = 0; i < info.numberOfParts(); i++) {
-                numBytes += info.partBytes(i);
+                numBytes += (int) info.partBytes(i);
             }
             assertEquals(numBytes, metadata.length());
         }

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -835,7 +835,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
                 System.arraycopy(fileData, 0, fileDataCopy, 0, fileData.length);
                 // Corrupt the file
                 for (int i = 0; i < randomIntBetween(1, fileDataCopy.length); i++) {
-                    fileDataCopy[i] ^= 0xFF;
+                    fileDataCopy[i] ^= (byte) 0xFF;
                 }
                 return new ByteArrayInputStream(fileDataCopy);
             }

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefixTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/prefix/InternalIpPrefixTests.java
@@ -101,7 +101,7 @@ public class InternalIpPrefixTests extends InternalMultiBucketAggregationTestCas
         int m = 0;
         int b = 0x80;
         for (int i = 0; i < prefixLength; i++) {
-            mask[m] |= b;
+            mask[m] |= (byte) b;
             b = b >> 1;
             if (b == 0) {
                 m++;

--- a/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/bucket/range/InternalBinaryRangeTests.java
@@ -91,7 +91,7 @@ public class InternalBinaryRangeTests extends InternalRangeTestCase<InternalBina
         for (Range.Bucket bucket : reduced.getBuckets()) {
             int expectedCount = 0;
             for (InternalBinaryRange input : inputs) {
-                expectedCount += input.getBuckets().get(pos).getDocCount();
+                expectedCount += (int) input.getBuckets().get(pos).getDocCount();
             }
             assertEquals(expectedCount, bucket.getDocCount());
             pos++;

--- a/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
+++ b/x-pack/plugin/ccr/src/main/java/org/elasticsearch/xpack/ccr/action/ShardChangesAction.java
@@ -557,7 +557,7 @@ public class ShardChangesAction extends ActionType<ShardChangesAction.Response> 
                 "not exposing operations from [" + fromSeqNo + "] greater than the global checkpoint [" + globalCheckpoint + "]"
             );
         }
-        int seenBytes = 0;
+        long seenBytes = 0;
         // - 1 is needed, because toSeqNo is inclusive
         long toSeqNo = Math.min(globalCheckpoint, (fromSeqNo + maxOperationCount) - 1);
         assert fromSeqNo <= toSeqNo : "invalid range from_seqno[" + fromSeqNo + "] > to_seqno[" + toSeqNo + "]";

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/BCrypt.java
@@ -1399,13 +1399,13 @@ public class BCrypt {
             c2 = char64(s.charAt(off++));
             if (c1 == -1 || c2 == -1) break;
             o = (byte) (c1 << 2);
-            o |= (c2 & 0x30) >> 4;
+            o |= (byte) ((c2 & 0x30) >> 4);
             rs.append((char) o);
             if (++olen >= maxolen || off >= slen) break;
             c3 = char64(s.charAt(off++));
             if (c3 == -1) break;
             o = (byte) ((c2 & 0x0f) << 4);
-            o |= (c3 & 0x3c) >> 2;
+            o |= (byte) ((c3 & 0x3c) >> 2);
             rs.append((char) o);
             if (++olen >= maxolen || off >= slen) break;
             c4 = char64(s.charAt(off++));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
@@ -169,7 +169,7 @@ public class StratifiedTrainTestSplitterTests extends ESTestCase {
 
         long expectedTotalTrainingCount = 0;
         for (long classCount : classCounts.values()) {
-            expectedTotalTrainingCount += (long) trainingFraction * classCount;
+            expectedTotalTrainingCount += (long) (trainingFraction * classCount);
         }
         assertThat(actualTotalTrainingCount, greaterThanOrEqualTo(expectedTotalTrainingCount - 2));
         assertThat(actualTotalTrainingCount, lessThanOrEqualTo(expectedTotalTrainingCount));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/traintestsplit/StratifiedTrainTestSplitterTests.java
@@ -169,7 +169,7 @@ public class StratifiedTrainTestSplitterTests extends ESTestCase {
 
         long expectedTotalTrainingCount = 0;
         for (long classCount : classCounts.values()) {
-            expectedTotalTrainingCount += trainingFraction * classCount;
+            expectedTotalTrainingCount += (long) trainingFraction * classCount;
         }
         assertThat(actualTotalTrainingCount, greaterThanOrEqualTo(expectedTotalTrainingCount - 2));
         assertThat(actualTotalTrainingCount, lessThanOrEqualTo(expectedTotalTrainingCount));

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene54/Lucene54DocValuesConsumer.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene54/Lucene54DocValuesConsumer.java
@@ -343,7 +343,7 @@ final class Lucene54DocValuesConsumer extends DocValuesConsumer implements Close
                 bits = 0;
             }
             if (v != null) {
-                bits |= 1 << (count & 7);
+                bits |= (byte) (1 << (count & 7));
             }
             count++;
         }

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/FST.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/FST.java
@@ -996,7 +996,7 @@ public final class FST<T> implements Accountable {
                 presenceIndex -= Byte.SIZE;
             }
             // Set the bit at presenceIndex to flag that the corresponding arc is present.
-            presenceBits |= 1 << presenceIndex;
+            presenceBits |= (byte) (1 << presenceIndex);
             previousLabel = label;
         }
         assert presenceIndex == (nodeIn.arcs[nodeIn.numArcs - 1].label - nodeIn.arcs[0].label) % 8;

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/ForwardBytesReader.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/ForwardBytesReader.java
@@ -44,7 +44,7 @@ final class ForwardBytesReader extends FST.BytesReader {
 
     @Override
     public void skipBytes(long count) {
-        pos += count;
+        pos += (int) count;
     }
 
     @Override

--- a/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/ReverseBytesReader.java
+++ b/x-pack/plugin/old-lucene-versions/src/main/java/org/elasticsearch/xpack/lucene/bwc/codecs/lucene70/fst/ReverseBytesReader.java
@@ -42,7 +42,7 @@ final class ReverseBytesReader extends FST.BytesReader {
 
     @Override
     public void skipBytes(long count) {
-        pos -= count;
+        pos -= (int) count;
     }
 
     @Override

--- a/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
+++ b/x-pack/plugin/snapshot-repo-test-kit/src/internalClusterTest/java/org/elasticsearch/repositories/blobstore/testkit/RepositoryAnalysisFailureIT.java
@@ -157,7 +157,7 @@ public class RepositoryAnalysisFailureIT extends AbstractSnapshotIntegTestCase {
                 final byte[] disruptedContents = actualContents == null ? null : Arrays.copyOf(actualContents, actualContents.length);
                 if (actualContents != null && countDown.countDown()) {
                     // CRC32 should always detect a single bit flip
-                    disruptedContents[Math.toIntExact(position + randomLongBetween(0, length - 1))] ^= 1 << between(0, 7);
+                    disruptedContents[Math.toIntExact(position + randomLongBetween(0, length - 1))] ^= (byte) (1 << between(0, 7));
                 }
                 return disruptedContents;
             }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/index/fielddata/TriangleTreeWriter.java
@@ -146,17 +146,17 @@ class TriangleTreeWriter {
 
         private void writeMetadata(StreamOutput out) throws IOException {
             byte metadata = 0;
-            metadata |= (left != null) ? (1 << 0) : 0;
-            metadata |= (right != null) ? (1 << 1) : 0;
+            metadata |= (byte) ((left != null) ? (1 << 0) : 0);
+            metadata |= (byte) ((right != null) ? (1 << 1) : 0);
             if (component.type == ShapeField.DecodedTriangle.TYPE.POINT) {
                 metadata |= (1 << 2);
             } else if (component.type == ShapeField.DecodedTriangle.TYPE.LINE) {
                 metadata |= (1 << 3);
-                metadata |= (component.ab) ? (1 << 4) : 0;
+                metadata |= (byte) ((component.ab) ? (1 << 4) : 0);
             } else {
-                metadata |= (component.ab) ? (1 << 4) : 0;
-                metadata |= (component.bc) ? (1 << 5) : 0;
-                metadata |= (component.ca) ? (1 << 6) : 0;
+                metadata |= (byte) ((component.ab) ? (1 << 4) : 0);
+                metadata |= (byte) ((component.bc) ? (1 << 5) : 0);
+                metadata |= (byte) ((component.ca) ? (1 << 6) : 0);
             }
             out.writeByte(metadata);
         }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeToCharProcessorTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/expression/function/scalar/datetime/DateTimeToCharProcessorTests.java
@@ -163,7 +163,7 @@ public class DateTimeToCharProcessorTests extends ESTestCase {
         int fractions = b.remainder(BigDecimal.ONE).movePointRight(9).intValueExact();
         int adjustment = 0;
         if (fractions < 0) {
-            fractions += 1e9;
+            fractions += (int) 1e9;
             adjustment = -1;
         }
         return dateTime((seconds + adjustment) * 1000).withNano(fractions);


### PR DESCRIPTION
JDK 20 has added a new javac lint warning for possible _lossy conversion_ in compound assignments - because of implicit type casts, e.g. 
  `warning: [lossy-conversions] implicit cast from int to byte in compound assignment is possibly lossy`

The change resolves all such warnings, by either widening the type of the left-hand operand, or explicitly casting the type of the right-hand operand. The changes are largely mechanical.

Resolving these issues allows to build with JDK 20 using JAVA_TOOLCHAIN_HOME.

FYI - The JDK issue that added the javac lint warning - https://bugs.openjdk.org/browse/JDK-8244681

closes #95839