### PR TITLE
Convert ThreadPool stats objects to records

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -97,6 +97,6 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
     }
 
     private static void waitForMaxActiveSnapshotThreads(final String node, final Matcher<Integer> matcher) throws Exception {
-        assertBusy(() -> assertThat(snapshotThreadPoolStats(node).getActive(), matcher), 30L, TimeUnit.SECONDS);
+        assertBusy(() -> assertThat(snapshotThreadPoolStats(node).active(), matcher), 30L, TimeUnit.SECONDS);
     }
 }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -311,7 +311,12 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
                 ifPresent(getOs()).toXContent(builder, params);
                 ifPresent(getProcess()).toXContent(builder, params);
                 ifPresent(getJvm()).toXContent(builder, params);
-                ifPresent(getThreadPool()).toXContent(builder, params);
+                return builder;
+            }),
+
+            ifPresent(getThreadPool()).toXContentChunked(outerParams),
+
+            Iterators.single((builder, params) -> {
                 ifPresent(getFs()).toXContent(builder, params);
                 return builder;
             }),

--- a/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/cat/RestThreadPoolAction.java
@@ -140,7 +140,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
         final Set<String> candidates = new HashSet<>();
         for (final NodeStats nodeStats : nodesStats.getNodes()) {
             for (final ThreadPoolStats.Stats threadPoolStats : nodeStats.getThreadPool()) {
-                candidates.add(threadPoolStats.getName());
+                candidates.add(threadPoolStats.name());
             }
         }
 
@@ -169,7 +169,7 @@ public class RestThreadPoolAction extends AbstractCatAction {
 
                 ThreadPoolStats threadPoolStats = stats.getThreadPool();
                 for (ThreadPoolStats.Stats threadPoolStat : threadPoolStats) {
-                    poolThreadStats.put(threadPoolStat.getName(), threadPoolStat);
+                    poolThreadStats.put(threadPoolStat.name(), threadPoolStat);
                 }
                 if (info != null) {
                     for (ThreadPool.Info threadPoolInfo : info.getInfo(ThreadPoolInfo.class)) {
@@ -222,13 +222,13 @@ public class RestThreadPoolAction extends AbstractCatAction {
 
                 table.addCell(entry.getKey());
                 table.addCell(poolInfo == null ? null : poolInfo.getThreadPoolType().getType());
-                table.addCell(poolStats == null ? null : poolStats.getActive());
-                table.addCell(poolStats == null ? null : poolStats.getThreads());
-                table.addCell(poolStats == null ? null : poolStats.getQueue());
+                table.addCell(poolStats == null ? null : poolStats.active());
+                table.addCell(poolStats == null ? null : poolStats.threads());
+                table.addCell(poolStats == null ? null : poolStats.queue());
                 table.addCell(maxQueueSize == null ? -1 : maxQueueSize);
-                table.addCell(poolStats == null ? null : poolStats.getRejected());
-                table.addCell(poolStats == null ? null : poolStats.getLargest());
-                table.addCell(poolStats == null ? null : poolStats.getCompleted());
+                table.addCell(poolStats == null ? null : poolStats.rejected());
+                table.addCell(poolStats == null ? null : poolStats.largest());
+                table.addCell(poolStats == null ? null : poolStats.completed());
                 table.addCell(core);
                 table.addCell(max);
                 table.addCell(size);

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
@@ -81,6 +81,7 @@ public record ThreadPoolStats(List<Stats> stats) implements Writeable, ChunkedTo
 
     public ThreadPoolStats {
         Collections.sort(stats);
+        stats = Collections.unmodifiableList(stats);
     }
 
     public ThreadPoolStats(StreamInput in) throws IOException {

--- a/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
+++ b/server/src/main/java/org/elasticsearch/threadpool/ThreadPoolStats.java
@@ -20,36 +20,16 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 
-public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<ThreadPoolStats.Stats> {
+public record ThreadPoolStats(List<Stats> stats) implements Writeable, ToXContentFragment, Iterable<ThreadPoolStats.Stats> {
 
-    public static class Stats implements Writeable, ToXContentFragment, Comparable<Stats> {
-
-        private final String name;
-        private final int threads;
-        private final int queue;
-        private final int active;
-        private final long rejected;
-        private final int largest;
-        private final long completed;
-
-        public Stats(String name, int threads, int queue, int active, long rejected, int largest, long completed) {
-            this.name = name;
-            this.threads = threads;
-            this.queue = queue;
-            this.active = active;
-            this.rejected = rejected;
-            this.largest = largest;
-            this.completed = completed;
-        }
+    public record Stats(String name, int threads, int queue, int active, long rejected, int largest, long completed)
+        implements
+            Writeable,
+            ToXContentFragment,
+            Comparable<Stats> {
 
         public Stats(StreamInput in) throws IOException {
-            name = in.readString();
-            threads = in.readInt();
-            queue = in.readInt();
-            active = in.readInt();
-            rejected = in.readLong();
-            largest = in.readInt();
-            completed = in.readLong();
+            this(in.readString(), in.readInt(), in.readInt(), in.readInt(), in.readLong(), in.readInt(), in.readLong());
         }
 
         @Override
@@ -61,34 +41,6 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
             out.writeLong(rejected);
             out.writeInt(largest);
             out.writeLong(completed);
-        }
-
-        public String getName() {
-            return this.name;
-        }
-
-        public int getThreads() {
-            return this.threads;
-        }
-
-        public int getQueue() {
-            return this.queue;
-        }
-
-        public int getActive() {
-            return this.active;
-        }
-
-        public long getRejected() {
-            return rejected;
-        }
-
-        public int getLargest() {
-            return largest;
-        }
-
-        public long getCompleted() {
-            return this.completed;
         }
 
         @Override
@@ -118,31 +70,28 @@ public class ThreadPoolStats implements Writeable, ToXContentFragment, Iterable<
 
         @Override
         public int compareTo(Stats other) {
-            if ((getName() == null) && (other.getName() == null)) {
+            if ((name() == null) && (other.name() == null)) {
                 return 0;
-            } else if ((getName() != null) && (other.getName() == null)) {
+            } else if ((name() != null) && (other.name() == null)) {
                 return 1;
-            } else if (getName() == null) {
+            } else if (name() == null) {
                 return -1;
             } else {
-                int compare = getName().compareTo(other.getName());
+                int compare = name().compareTo(other.name());
                 if (compare == 0) {
-                    compare = Integer.compare(getThreads(), other.getThreads());
+                    compare = Integer.compare(threads(), other.threads());
                 }
                 return compare;
             }
         }
     }
 
-    private List<Stats> stats;
-
-    public ThreadPoolStats(List<Stats> stats) {
+    public ThreadPoolStats {
         Collections.sort(stats);
-        this.stats = stats;
     }
 
     public ThreadPoolStats(StreamInput in) throws IOException {
-        stats = in.readList(Stats::new);
+        this(in.readList(Stats::new));
     }
 
     @Override

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -72,6 +72,7 @@ import org.elasticsearch.search.suggest.completion.CompletionStats;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.threadpool.ThreadPoolStats;
+import org.elasticsearch.threadpool.ThreadPoolStatsTests;
 import org.elasticsearch.transport.TransportActionStats;
 import org.elasticsearch.transport.TransportStats;
 import org.elasticsearch.xcontent.ToXContent;
@@ -82,7 +83,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
@@ -231,20 +231,10 @@ public class NodeStatsTests extends ESTestCase {
                 if (nodeStats.getThreadPool() == null) {
                     assertNull(deserializedNodeStats.getThreadPool());
                 } else {
-                    Iterator<ThreadPoolStats.Stats> threadPoolIterator = nodeStats.getThreadPool().iterator();
-                    Iterator<ThreadPoolStats.Stats> deserializedThreadPoolIterator = deserializedNodeStats.getThreadPool().iterator();
-                    while (threadPoolIterator.hasNext()) {
-                        ThreadPoolStats.Stats stats = threadPoolIterator.next();
-                        ThreadPoolStats.Stats deserializedStats = deserializedThreadPoolIterator.next();
-                        assertEquals(stats.name(), deserializedStats.name());
-                        assertEquals(stats.threads(), deserializedStats.threads());
-                        assertEquals(stats.active(), deserializedStats.active());
-                        assertEquals(stats.largest(), deserializedStats.largest());
-                        assertEquals(stats.completed(), deserializedStats.completed());
-                        assertEquals(stats.queue(), deserializedStats.queue());
-                        assertEquals(stats.rejected(), deserializedStats.rejected());
-                    }
+                    assertNotSame(nodeStats.getThreadPool(), deserializedNodeStats.getThreadPool());
+                    assertEquals(nodeStats.getThreadPool(), deserializedNodeStats.getThreadPool());
                 }
+
                 FsInfo fs = nodeStats.getFs();
                 FsInfo deserializedFs = deserializedNodeStats.getFs();
                 if (fs == null) {
@@ -467,34 +457,8 @@ public class NodeStatsTests extends ESTestCase {
                 if (ingestStats == null) {
                     assertNull(deserializedIngestStats);
                 } else {
-                    IngestStats.Stats totalStats = ingestStats.totalStats();
-                    assertEquals(totalStats.ingestCount(), deserializedIngestStats.totalStats().ingestCount());
-                    assertEquals(totalStats.ingestCurrent(), deserializedIngestStats.totalStats().ingestCurrent());
-                    assertEquals(totalStats.ingestFailedCount(), deserializedIngestStats.totalStats().ingestFailedCount());
-                    assertEquals(totalStats.ingestTimeInMillis(), deserializedIngestStats.totalStats().ingestTimeInMillis());
-                    assertEquals(ingestStats.pipelineStats().size(), deserializedIngestStats.pipelineStats().size());
-                    for (IngestStats.PipelineStat pipelineStat : ingestStats.pipelineStats()) {
-                        String pipelineId = pipelineStat.pipelineId();
-                        IngestStats.Stats deserializedPipelineStats = getPipelineStats(deserializedIngestStats.pipelineStats(), pipelineId);
-                        assertEquals(pipelineStat.stats().ingestFailedCount(), deserializedPipelineStats.ingestFailedCount());
-                        assertEquals(pipelineStat.stats().ingestTimeInMillis(), deserializedPipelineStats.ingestTimeInMillis());
-                        assertEquals(pipelineStat.stats().ingestCurrent(), deserializedPipelineStats.ingestCurrent());
-                        assertEquals(pipelineStat.stats().ingestCount(), deserializedPipelineStats.ingestCount());
-                        List<IngestStats.ProcessorStat> processorStats = ingestStats.processorStats().get(pipelineId);
-                        // intentionally validating identical order
-                        Iterator<IngestStats.ProcessorStat> it = deserializedIngestStats.processorStats().get(pipelineId).iterator();
-                        for (IngestStats.ProcessorStat processorStat : processorStats) {
-                            IngestStats.ProcessorStat deserializedProcessorStat = it.next();
-                            assertEquals(processorStat.stats().ingestFailedCount(), deserializedProcessorStat.stats().ingestFailedCount());
-                            assertEquals(
-                                processorStat.stats().ingestTimeInMillis(),
-                                deserializedProcessorStat.stats().ingestTimeInMillis()
-                            );
-                            assertEquals(processorStat.stats().ingestCurrent(), deserializedProcessorStat.stats().ingestCurrent());
-                            assertEquals(processorStat.stats().ingestCount(), deserializedProcessorStat.stats().ingestCount());
-                        }
-                        assertFalse(it.hasNext());
-                    }
+                    assertNotSame(ingestStats, deserializedIngestStats);
+                    assertEquals(ingestStats, deserializedIngestStats);
                 }
                 AdaptiveSelectionStats adaptiveStats = nodeStats.getAdaptiveSelectionStats();
                 AdaptiveSelectionStats deserializedAdaptiveStats = deserializedNodeStats.getAdaptiveSelectionStats();

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -236,13 +236,13 @@ public class NodeStatsTests extends ESTestCase {
                     while (threadPoolIterator.hasNext()) {
                         ThreadPoolStats.Stats stats = threadPoolIterator.next();
                         ThreadPoolStats.Stats deserializedStats = deserializedThreadPoolIterator.next();
-                        assertEquals(stats.getName(), deserializedStats.getName());
-                        assertEquals(stats.getThreads(), deserializedStats.getThreads());
-                        assertEquals(stats.getActive(), deserializedStats.getActive());
-                        assertEquals(stats.getLargest(), deserializedStats.getLargest());
-                        assertEquals(stats.getCompleted(), deserializedStats.getCompleted());
-                        assertEquals(stats.getQueue(), deserializedStats.getQueue());
-                        assertEquals(stats.getRejected(), deserializedStats.getRejected());
+                        assertEquals(stats.name(), deserializedStats.name());
+                        assertEquals(stats.threads(), deserializedStats.threads());
+                        assertEquals(stats.active(), deserializedStats.active());
+                        assertEquals(stats.largest(), deserializedStats.largest());
+                        assertEquals(stats.completed(), deserializedStats.completed());
+                        assertEquals(stats.queue(), deserializedStats.queue());
+                        assertEquals(stats.rejected(), deserializedStats.rejected());
                     }
                 }
                 FsInfo fs = nodeStats.getFs();

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardOperationPermitsTests.java
@@ -476,8 +476,8 @@ public class IndexShardOperationPermitsTests extends ESTestCase {
          */
         assertBusy(() -> {
             for (final ThreadPoolStats.Stats stats : threadPool.stats()) {
-                if (ThreadPool.Names.GENERIC.equals(stats.getName())) {
-                    assertThat("Expected no active threads in GENERIC pool", stats.getActive(), equalTo(0));
+                if (ThreadPool.Names.GENERIC.equals(stats.name())) {
+                    assertThat("Expected no active threads in GENERIC pool", stats.active(), equalTo(0));
                     return;
                 }
             }

--- a/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/IndexingMemoryControllerTests.java
@@ -410,7 +410,7 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
     ThreadPoolStats.Stats getRefreshThreadPoolStats() {
         final ThreadPoolStats stats = threadPool.stats();
         for (ThreadPoolStats.Stats s : stats) {
-            if (s.getName().equals(ThreadPool.Names.REFRESH)) {
+            if (s.name().equals(ThreadPool.Names.REFRESH)) {
                 return s;
             }
         }
@@ -468,12 +468,12 @@ public class IndexingMemoryControllerTests extends IndexShardTestCase {
         }
         assertBusy(() -> {
             ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
-            assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations - 1));
+            assertThat(stats.completed(), equalTo(beforeStats.completed() + iterations - 1));
         });
         refreshLatch.get().countDown(); // allow refresh
         assertBusy(() -> {
             ThreadPoolStats.Stats stats = getRefreshThreadPoolStats();
-            assertThat(stats.getCompleted(), equalTo(beforeStats.getCompleted() + iterations));
+            assertThat(stats.completed(), equalTo(beforeStats.completed() + iterations));
         });
         assertThat(shard.refreshStats().getTotal(), equalTo(refreshStats.getTotal() + 1));
         closeShards(shard);

--- a/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/InternalSnapshotsInfoServiceTests.java
@@ -398,12 +398,12 @@ public class InternalSnapshotsInfoServiceTests extends ESTestCase {
             final ThreadPoolStats threadPoolStats = clusterService.getClusterApplierService().threadPool().stats();
             ThreadPoolStats.Stats generic = null;
             for (ThreadPoolStats.Stats threadPoolStat : threadPoolStats) {
-                if (ThreadPool.Names.GENERIC.equals(threadPoolStat.getName())) {
+                if (ThreadPool.Names.GENERIC.equals(threadPoolStat.name())) {
                     generic = threadPoolStat;
                 }
             }
             assertThat(generic, notNullValue());
-            assertThat(generic.getActive(), equalTo(nbActive));
+            assertThat(generic.active(), equalTo(nbActive));
         }, 30L, TimeUnit.SECONDS);
     }
 

--- a/server/src/test/java/org/elasticsearch/threadpool/ESThreadPoolTestCase.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ESThreadPoolTestCase.java
@@ -26,7 +26,7 @@ public abstract class ESThreadPoolTestCase extends ESTestCase {
 
     protected final ThreadPoolStats.Stats stats(final ThreadPool threadPool, final String name) {
         for (final ThreadPoolStats.Stats stats : threadPool.stats()) {
-            if (name.equals(stats.getName())) {
+            if (name.equals(stats.name())) {
                 return stats;
             }
         }

--- a/server/src/test/java/org/elasticsearch/threadpool/FixedThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/FixedThreadPoolTests.java
@@ -72,7 +72,7 @@ public class FixedThreadPoolTests extends ESThreadPoolTestCase {
             block.countDown();
 
             assertThat(counter, equalTo(rejections));
-            assertThat(stats(threadPool, threadPoolName).getRejected(), equalTo(rejections));
+            assertThat(stats(threadPool, threadPoolName).rejected(), equalTo(rejections));
         } finally {
             terminateThreadPoolIfNeeded(threadPool);
         }

--- a/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ScalingThreadPoolTests.java
@@ -139,8 +139,8 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
                 });
             }
             final ThreadPoolStats.Stats stats = stats(threadPool, threadPoolName);
-            assertThat(stats.getQueue(), equalTo(numberOfTasks - size));
-            assertThat(stats.getLargest(), equalTo(size));
+            assertThat(stats.queue(), equalTo(numberOfTasks - size));
+            assertThat(stats.largest(), equalTo(size));
             latch.countDown();
             try {
                 taskLatch.await();
@@ -170,7 +170,7 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
                     }
                 });
             }
-            int threads = stats(threadPool, threadPoolName).getThreads();
+            int threads = stats(threadPool, threadPoolName).threads();
             assertEquals(128, threads);
             latch.countDown();
             // this while loop is the core of this test; if threads
@@ -181,7 +181,7 @@ public class ScalingThreadPoolTests extends ESThreadPoolTestCase {
             // down
             do {
                 spinForAtLeastOneMillisecond();
-            } while (stats(threadPool, threadPoolName).getThreads() > min);
+            } while (stats(threadPool, threadPoolName).threads() > min);
             try {
                 taskLatch.await();
             } catch (InterruptedException e) {

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
@@ -42,7 +42,7 @@ public class ThreadPoolStatsTests extends ESTestCase {
     }
 
     public void testSerialization() throws IOException {
-        var original = new ThreadPoolStats(randomList(2, this::randomStats));
+        var original = new ThreadPoolStats(randomList(2, ThreadPoolStatsTests::randomStats));
         var other = serialize(original);
 
         assertNotSame(original, other);
@@ -55,11 +55,11 @@ public class ThreadPoolStatsTests extends ESTestCase {
         return new ThreadPoolStats(out.bytes().streamInput());
     }
 
-    private ThreadPoolStats.Stats randomStats() {
+    public static ThreadPoolStats.Stats randomStats() {
         return randomStats(randomFrom(THREAD_POOL_TYPES.keySet()));
     }
 
-    private ThreadPoolStats.Stats randomStats(String name) {
+    public static ThreadPoolStats.Stats randomStats(String name) {
         return new ThreadPoolStats.Stats(
             name,
             randomMinusOneOrOther(),
@@ -72,6 +72,6 @@ public class ThreadPoolStatsTests extends ESTestCase {
     }
 
     private static int randomMinusOneOrOther() {
-        return randomBoolean() ? -1 : randomIntBetween(-1, Integer.MAX_VALUE);
+        return randomBoolean() ? -1 : randomIntBetween(0, Integer.MAX_VALUE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
@@ -10,102 +10,68 @@ package org.elasticsearch.threadpool;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.xcontent.ToXContent;
-import org.elasticsearch.xcontent.XContentBuilder;
-import org.elasticsearch.xcontent.XContentParser;
-import org.elasticsearch.xcontent.XContentType;
-import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.elasticsearch.threadpool.ThreadPool.THREAD_POOL_TYPES;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.equalTo;
 
 public class ThreadPoolStatsTests extends ESTestCase {
     public void testThreadPoolStatsSort() {
-        List<ThreadPoolStats.Stats> stats = new ArrayList<>();
-        stats.add(new ThreadPoolStats.Stats("z", -1, 0, 0, 0, 0, 0L));
-        stats.add(new ThreadPoolStats.Stats("m", 3, 0, 0, 0, 0, 0L));
-        stats.add(new ThreadPoolStats.Stats("m", 1, 0, 0, 0, 0, 0L));
-        stats.add(new ThreadPoolStats.Stats("d", -1, 0, 0, 0, 0, 0L));
-        stats.add(new ThreadPoolStats.Stats("m", 2, 0, 0, 0, 0, 0L));
-        stats.add(new ThreadPoolStats.Stats("t", -1, 0, 0, 0, 0, 0L));
-        stats.add(new ThreadPoolStats.Stats("a", -1, 0, 0, 0, 0, 0L));
+        var stats = List.of(
+            new ThreadPoolStats.Stats("z", -1, 0, 0, 0, 0, 0L),
+            new ThreadPoolStats.Stats("m", 3, 0, 0, 0, 0, 0L),
+            new ThreadPoolStats.Stats("m", 1, 0, 0, 0, 0, 0L),
+            new ThreadPoolStats.Stats("d", -1, 0, 0, 0, 0, 0L),
+            new ThreadPoolStats.Stats("m", 2, 0, 0, 0, 0, 0L),
+            new ThreadPoolStats.Stats("t", -1, 0, 0, 0, 0, 0L),
+            new ThreadPoolStats.Stats("a", -1, 0, 0, 0, 0, 0L)
+        );
 
-        List<ThreadPoolStats.Stats> copy = new ArrayList<>(stats);
+        var copy = new ArrayList<>(stats);
         Collections.sort(copy);
 
-        List<String> names = new ArrayList<>(copy.size());
-        for (ThreadPoolStats.Stats stat : copy) {
-            names.add(stat.name());
-        }
+        var names = copy.stream().map(ThreadPoolStats.Stats::name).toList();
         assertThat(names, contains("a", "d", "m", "m", "m", "t", "z"));
 
-        List<Integer> threads = new ArrayList<>(copy.size());
-        for (ThreadPoolStats.Stats stat : copy) {
-            threads.add(stat.threads());
-        }
+        var threads = copy.stream().map(ThreadPoolStats.Stats::threads).toList();
         assertThat(threads, contains(-1, -1, 1, 2, 3, -1, -1));
     }
 
-    public void testThreadPoolStatsToXContent() throws IOException {
-        try (BytesStreamOutput os = new BytesStreamOutput()) {
+    public void testSerialization() throws IOException {
+        var original = new ThreadPoolStats(randomList(2, this::randomStats));
+        var other = serialize(original);
 
-            List<ThreadPoolStats.Stats> stats = new ArrayList<>();
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.SEARCH, -1, 0, 0, 0, 0, 0L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.WARMER, -1, 0, 0, 0, 0, 0L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.GENERIC, -1, 0, 0, 0, 0, 0L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.FORCE_MERGE, -1, 0, 0, 0, 0, 0L));
-            stats.add(new ThreadPoolStats.Stats(ThreadPool.Names.SAME, -1, 0, 0, 0, 0, 0L));
+        assertNotSame(original, other);
+        assertEquals(original, other);
+    }
 
-            ThreadPoolStats threadPoolStats = new ThreadPoolStats(stats);
-            try (XContentBuilder builder = new XContentBuilder(XContentType.JSON.xContent(), os)) {
-                builder.startObject();
-                threadPoolStats.toXContent(builder, ToXContent.EMPTY_PARAMS);
-                builder.endObject();
-            }
+    private static ThreadPoolStats serialize(ThreadPoolStats stats) throws IOException {
+        var out = new BytesStreamOutput();
+        stats.writeTo(out);
+        return new ThreadPoolStats(out.bytes().streamInput());
+    }
 
-            try (XContentParser parser = createParser(JsonXContent.jsonXContent, os.bytes())) {
-                XContentParser.Token token = parser.currentToken();
-                assertNull(token);
+    private ThreadPoolStats.Stats randomStats() {
+        return randomStats(randomFrom(THREAD_POOL_TYPES.keySet()));
+    }
 
-                token = parser.nextToken();
-                assertThat(token, equalTo(XContentParser.Token.START_OBJECT));
+    private ThreadPoolStats.Stats randomStats(String name) {
+        return new ThreadPoolStats.Stats(
+            name,
+            randomMinusOneOrOther(),
+            randomMinusOneOrOther(),
+            randomMinusOneOrOther(),
+            randomMinusOneOrOther(),
+            randomMinusOneOrOther(),
+            randomMinusOneOrOther()
+        );
+    }
 
-                token = parser.nextToken();
-                assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
-                assertThat(parser.currentName(), equalTo(ThreadPoolStats.Fields.THREAD_POOL));
-
-                token = parser.nextToken();
-                assertThat(token, equalTo(XContentParser.Token.START_OBJECT));
-
-                token = parser.nextToken();
-                assertThat(token, equalTo(XContentParser.Token.FIELD_NAME));
-
-                List<String> names = new ArrayList<>();
-                while (token == XContentParser.Token.FIELD_NAME) {
-                    names.add(parser.currentName());
-
-                    token = parser.nextToken();
-                    assertThat(token, equalTo(XContentParser.Token.START_OBJECT));
-
-                    parser.skipChildren();
-                    token = parser.nextToken();
-                }
-                assertThat(
-                    names,
-                    contains(
-                        ThreadPool.Names.FORCE_MERGE,
-                        ThreadPool.Names.GENERIC,
-                        ThreadPool.Names.SAME,
-                        ThreadPool.Names.SEARCH,
-                        ThreadPool.Names.WARMER
-                    )
-                );
-            }
-        }
+    private static int randomMinusOneOrOther() {
+        return randomBoolean() ? -1 : randomIntBetween(-1, Integer.MAX_VALUE);
     }
 }

--- a/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/threadpool/ThreadPoolStatsTests.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
 
 public class ThreadPoolStatsTests extends ESTestCase {
-    public void testThreadPoolStatsSort() throws IOException {
+    public void testThreadPoolStatsSort() {
         List<ThreadPoolStats.Stats> stats = new ArrayList<>();
         stats.add(new ThreadPoolStats.Stats("z", -1, 0, 0, 0, 0, 0L));
         stats.add(new ThreadPoolStats.Stats("m", 3, 0, 0, 0, 0, 0L));
@@ -40,13 +40,13 @@ public class ThreadPoolStatsTests extends ESTestCase {
 
         List<String> names = new ArrayList<>(copy.size());
         for (ThreadPoolStats.Stats stat : copy) {
-            names.add(stat.getName());
+            names.add(stat.name());
         }
         assertThat(names, contains("a", "d", "m", "m", "m", "t", "z"));
 
         List<Integer> threads = new ArrayList<>(copy.size());
         for (ThreadPoolStats.Stats stat : copy) {
-            threads.add(stat.getThreads());
+            threads.add(stat.threads());
         }
         assertThat(threads, contains(-1, -1, 1, 2, 3, -1, -1));
     }

--- a/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/snapshots/AbstractSnapshotIntegTestCase.java
@@ -682,7 +682,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
 
     protected static ThreadPoolStats.Stats snapshotThreadPoolStats(final String node) {
         return StreamSupport.stream(internalCluster().getInstance(ThreadPool.class, node).stats().spliterator(), false)
-            .filter(threadPool -> threadPool.getName().equals(ThreadPool.Names.SNAPSHOT))
+            .filter(threadPool -> threadPool.name().equals(ThreadPool.Names.SNAPSHOT))
             .findFirst()
             .orElseThrow(() -> new AssertionError("Failed to find snapshot pool on node [" + node + "]"));
     }
@@ -690,7 +690,7 @@ public abstract class AbstractSnapshotIntegTestCase extends ESIntegTestCase {
     protected void awaitMasterFinishRepoOperations() throws Exception {
         logger.info("--> waiting for master to finish all repo operations on its SNAPSHOT pool");
         final String masterName = internalCluster().getMasterName();
-        assertBusy(() -> assertEquals(snapshotThreadPoolStats(masterName).getActive(), 0));
+        assertBusy(() -> assertEquals(snapshotThreadPoolStats(masterName).active(), 0));
     }
 
     protected List<String> createNSnapshots(String repoName, int count) throws Exception {

--- a/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
+++ b/x-pack/plugin/monitoring/src/internalClusterTest/java/org/elasticsearch/xpack/monitoring/integration/MonitoringIT.java
@@ -405,9 +405,9 @@ public class MonitoringIT extends ESSingleNodeTestCase {
                     boolean foundBulkThreads = false;
 
                     for (final ThreadPoolStats.Stats threadPoolStats : nodeStats.getThreadPool()) {
-                        if (WRITE.equals(threadPoolStats.getName())) {
+                        if (WRITE.equals(threadPoolStats.name())) {
                             foundBulkThreads = true;
-                            assertThat("Still some active _bulk threads!", threadPoolStats.getActive(), equalTo(0));
+                            assertThat("Still some active _bulk threads!", threadPoolStats.active(), equalTo(0));
                             break;
                         }
                     }

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/AbstractSearchableSnapshotsTestCase.java
@@ -254,8 +254,8 @@ public abstract class AbstractSearchableSnapshotsTestCase extends ESIndexInputTe
     protected static void assertThreadPoolNotBusy(ThreadPool threadPool) throws Exception {
         assertBusy(() -> {
             for (ThreadPoolStats.Stats stat : threadPool.stats()) {
-                assertEquals(stat.getActive(), 0);
-                assertEquals(stat.getQueue(), 0);
+                assertEquals(stat.active(), 0);
+                assertEquals(stat.queue(), 0);
             }
         }, 30L, TimeUnit.SECONDS);
     }

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/test/bench/WatcherScheduleEngineBenchmark.java
@@ -209,7 +209,7 @@ public class WatcherScheduleEngineBenchmark {
                     NodesStatsResponse response = client.admin().cluster().prepareNodesStats().setThreadPool(true).get();
                     for (NodeStats nodeStats : response.getNodes()) {
                         for (ThreadPoolStats.Stats threadPoolStats : nodeStats.getThreadPool()) {
-                            if ("watcher".equals(threadPoolStats.getName())) {
+                            if ("watcher".equals(threadPoolStats.name())) {
                                 stats.setWatcherThreadPoolStats(threadPoolStats);
                             }
                         }
@@ -345,8 +345,8 @@ public class WatcherScheduleEngineBenchmark {
                 "%10s | %13s | %12d | %13d \n",
                 name,
                 ByteSizeValue.ofBytes(avgHeapUsed),
-                watcherThreadPoolStats.getRejected(),
-                watcherThreadPoolStats.getCompleted()
+                watcherThreadPoolStats.rejected(),
+                watcherThreadPoolStats.completed()
             );
         }
 


### PR DESCRIPTION
As part of the creation of new cluster `_info/*` API, I'm converting some POJO objects to records. This PR also converts the object from normal XContent to the Chunked version, what is needed for the forthcoming PR