### PR TITLE
[Test] Include DLM actions only when feature flag is enabled (#96118)

### DIFF
--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -7,11 +7,16 @@
 
 package org.elasticsearch.xpack.security.operator;
 
+import org.elasticsearch.cluster.metadata.DataLifecycle;
+
+import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class Constants {
 
-    public static final Set<String> NON_OPERATOR_ACTIONS = Set.of(
+    public static final Set<String> NON_OPERATOR_ACTIONS = Stream.of(
         // "cluster:admin/autoscaling/delete_autoscaling_policy",
         "cluster:admin/autoscaling/get_autoscaling_capacity",
         "cluster:admin/autoscaling/get_autoscaling_policy",
@@ -102,7 +107,6 @@ public class Constants {
         "cluster:admin/xpack/application/search_application/get",
         "cluster:admin/xpack/application/search_application/list",
         "cluster:admin/xpack/application/search_application/put",
-        "cluster:admin/xpack/application/search_application/search",
         "cluster:admin/xpack/ccr/auto_follow_pattern/activate",
         "cluster:admin/xpack/ccr/auto_follow_pattern/delete",
         "cluster:admin/xpack/ccr/auto_follow_pattern/get",
@@ -399,10 +403,10 @@ public class Constants {
         "indices:admin/data_stream/migrate",
         "indices:admin/data_stream/modify",
         "indices:admin/data_stream/promote",
-        "indices:admin/dlm/delete",
-        "indices:admin/dlm/get",
-        "indices:admin/dlm/put",
-        "indices:admin/dlm/explain",
+        DataLifecycle.isEnabled() ? "indices:admin/dlm/delete" : null,
+        DataLifecycle.isEnabled() ? "indices:admin/dlm/get" : null,
+        DataLifecycle.isEnabled() ? "indices:admin/dlm/put" : null,
+        DataLifecycle.isEnabled() ? "indices:admin/dlm/explain" : null,
         "indices:admin/delete",
         "indices:admin/flush",
         "indices:admin/flush[s]",
@@ -473,6 +477,7 @@ public class Constants {
         "indices:data/read/sql/translate",
         "indices:data/read/sql/async/get", // org.elasticsearch.xpack.core.sql.SqlAsyncActionNames.SQL_ASYNC_GET_RESULT_ACTION_NAME
         "indices:data/read/tv",
+        "indices:data/read/xpack/application/search_application/search",
         "indices:data/read/xpack/ccr/shard_changes",
         "indices:data/read/xpack/enrich/coordinate_lookups",
         "indices:data/read/xpack/graph/explore",
@@ -514,5 +519,5 @@ public class Constants {
         "internal:cluster/formation/info",
         "internal:gateway/local/started_shards",
         "internal:admin/indices/prevalidate_shard_path"
-    );
+    ).filter(Objects::nonNull).collect(Collectors.toUnmodifiableSet());
 }

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/OperatorPrivilegesIT.java
@@ -94,7 +94,6 @@ public class OperatorPrivilegesIT extends ESRestTestCase {
         client().performRequest(mainRequest);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96105")
     @SuppressWarnings("unchecked")
     public void testEveryActionIsEitherOperatorOnlyOrNonOperator() throws IOException {
         final String message = "An action should be declared to be either operator-only in ["


### PR DESCRIPTION
Backport: #96118

This PR adds DLM feature flag checks when preparing the list of non-operator actions to ensure DLM actions are included only when the feature flag is enabled.

