### PR TITLE
Reduce indirection in AbstractRefCounted

### DIFF
--- a/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
+++ b/server/src/main/java/org/elasticsearch/bootstrap/Elasticsearch.java
@@ -24,6 +24,7 @@ import org.elasticsearch.common.network.IfConfig;
 import org.elasticsearch.common.settings.SecureSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.transport.BoundTransportAddress;
+import org.elasticsearch.core.AbstractRefCounted;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.SuppressForbidden;
 import org.elasticsearch.env.Environment;
@@ -181,6 +182,8 @@ class Elasticsearch {
         try {
             // ReferenceDocs class does nontrivial static initialization which should always succeed but load it now (before SM) to be sure
             MethodHandles.publicLookup().ensureInitialized(ReferenceDocs.class);
+            // AbstractRefCounted class uses MethodHandles.lookup during initialization, load it now (before SM) to be sure it succeeds
+            MethodHandles.publicLookup().ensureInitialized(AbstractRefCounted.class);
         } catch (IllegalAccessException unexpected) {
             throw new AssertionError(unexpected);
         }


### PR DESCRIPTION
Today `AbstractRefCounted` holds an `AtomicInteger` which holds the actual ref count, which is an extra heap object and means that acquiring/releasing refs always goes through that extra pointer lookup. We use this utility extensively, on some pretty hot paths, so with this commit we move to using a primitive `refCount` field with atomic operations via a `VarHandle`.