### PR TITLE
Fix tchar pattern in RestRequest

### DIFF
--- a/docs/changelog/96406.yaml
+++ b/docs/changelog/96406.yaml
@@ -1,0 +1,5 @@
+pr: 96406
+summary: Fix tchar pattern in `RestRequest`
+area: Infra/REST API
+type: bug
+issues: []

--- a/libs/x-content/src/main/java/org/elasticsearch/xcontent/ParsedMediaType.java
+++ b/libs/x-content/src/main/java/org/elasticsearch/xcontent/ParsedMediaType.java
@@ -27,7 +27,7 @@ public class ParsedMediaType {
     private final String subType;
     private final Map<String, String> parameters;
     // tchar pattern as defined by RFC7230 section 3.2.6
-    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-z0-9!#$%&'*+\\-.\\^_`|~]+");
+    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+\\-.\\^_`|~]+");
 
     private ParsedMediaType(String originalHeaderValue, String type, String subType, Map<String, String> parameters) {
         this.originalHeaderValue = originalHeaderValue;

--- a/libs/x-content/src/test/java/org/elasticsearch/xcontent/ParsedMediaTypeTests.java
+++ b/libs/x-content/src/test/java/org/elasticsearch/xcontent/ParsedMediaTypeTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.xcontent;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -106,6 +107,14 @@ public class ParsedMediaTypeTests extends ESTestCase {
         ParsedMediaType parsedMediaType = ParsedMediaType.parseMediaType(mediaType + randomFrom("", " ", ";", ";;", ";;;"));
         assertEquals("application/foo", parsedMediaType.mediaTypeWithoutParameters());
         assertEquals(Collections.emptyMap(), parsedMediaType.getParameters());
+    }
+
+    public void testMalformedMediaType() {
+        List<String> headers = List.of("a/b[", "a/b]", "a/b\\");
+        for (String header : headers) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> ParsedMediaType.parseMediaType(header));
+            assertThat(e.getMessage(), equalTo("invalid media-type [" + header + "]"));
+        }
     }
 
     public void testMalformedParameters() {

--- a/server/src/main/java/org/elasticsearch/rest/RestRequest.java
+++ b/server/src/main/java/org/elasticsearch/rest/RestRequest.java
@@ -48,7 +48,7 @@ import static org.elasticsearch.core.TimeValue.parseTimeValue;
 public class RestRequest implements ToXContent.Params {
 
     // tchar pattern as defined by RFC7230 section 3.2.6
-    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-z0-9!#$%&'*+\\-.\\^_`|~]+");
+    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+\\-.\\^_`|~]+");
 
     private static final AtomicLong requestIdGenerator = new AtomicLong();
 

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -201,6 +201,18 @@ public class RestRequestTests extends ESTestCase {
         assertThat(e.getMessage(), equalTo("Invalid media-type value on headers [Content-Type]"));
     }
 
+    public void testInvalidMediaTypeCharacter() {
+       List<String> headers = List.of("a/b[","a/b]","a/b\\");
+        for(String header : headers) {
+            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
+                () -> RestRequest.parseContentType(Collections.singletonList(header)));
+            assertThat(e.getMessage(),equalTo("invalid Content-Type header ["+header+"]"));
+        }
+
+
+
+    }
+
     public void testNoContentTypeHeader() {
         RestRequest contentRestRequest = contentRestRequest("", Collections.emptyMap(), Collections.emptyMap());
         assertNull(contentRestRequest.getXContentType());

--- a/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/RestRequestTests.java
@@ -202,15 +202,14 @@ public class RestRequestTests extends ESTestCase {
     }
 
     public void testInvalidMediaTypeCharacter() {
-       List<String> headers = List.of("a/b[","a/b]","a/b\\");
-        for(String header : headers) {
-            IllegalArgumentException e = expectThrows(IllegalArgumentException.class,
-                () -> RestRequest.parseContentType(Collections.singletonList(header)));
-            assertThat(e.getMessage(),equalTo("invalid Content-Type header ["+header+"]"));
+        List<String> headers = List.of("a/b[", "a/b]", "a/b\\");
+        for (String header : headers) {
+            IllegalArgumentException e = expectThrows(
+                IllegalArgumentException.class,
+                () -> RestRequest.parseContentType(Collections.singletonList(header))
+            );
+            assertThat(e.getMessage(), equalTo("invalid Content-Type header [" + header + "]"));
         }
-
-
-
     }
 
     public void testNoContentTypeHeader() {

--- a/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/content/ParsedMediaType.java
+++ b/x-pack/plugin/sql/sql-proto/src/main/java/org/elasticsearch/xpack/sql/proto/content/ParsedMediaType.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
  */
 class ParsedMediaType {
     // tchar pattern as defined by RFC7230 section 3.2.6
-    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-z0-9!#$%&'*+\\-.\\^_`|~]+");
+    private static final Pattern TCHAR_PATTERN = Pattern.compile("[a-zA-Z0-9!#$%&'*+\\-.\\^_`|~]+");
 
     private final String originalHeaderValue;
     private final String type;


### PR DESCRIPTION
in https://community.sonarsource.com/t/blog-post-regular-expressions-present-challenges-even-for-not-so-regular-developers/38304 
an author pointed out that Elasticsearch has a bug in its tchar regex.

_

> So now it should take you only one second to find a bug in this [Elasticsearch](https://github.com/elastic/elasticsearch) code which is commented "defined by RFC7230 section 3.2.6" for this expression:
> 
> ```
> Pattern.compile("[a-zA-z0-9!#$%&'*+\\-.\\^_`|~]+");
> ```
> 
> [Source (RestRequest.java)](https://github.com/elastic/elasticsearch/blob/fc5725597189a4ee36b265a8fb75fa616b63e41b/server/src/main/java/org/elasticsearch/rest/RestRequest.java#L61)

_

and indeed the `A-z` is a mistake and includes acciental `[`, `]`, `/` characters

This commits fixes this.

Just to explain why we validate this way:
the correct value of a content-type is a Media type  https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.5
a media-type is defined in https://www.rfc-editor.org/rfc/rfc7231#section-3.1.1.1 and uses token
and a token is defined in https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6
and it uses tchar defined in the same RFC


