### PR TITLE
Refactor header warning pattern to avoid stackoverflow

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -23,7 +23,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -41,7 +41,8 @@ public class HeaderWarning {
         "Elasticsearch-" + // warn agent
         "\\d+\\.\\d+\\.\\d+(?:-(?:alpha|beta|rc)\\d+)?(?:-SNAPSHOT)?-" + // warn agent
         "(?:[a-f0-9]{7}(?:[a-f0-9]{33})?|unknown) " + // warn agent
-        "\"(?<quotedStringValue>.*)\"( " + // quoted warning value, captured
+        // quoted warning value, captured. Do not add more greedy qualifiers later to avoid excessive backtracking
+        "\"(?<quotedStringValue>.*)\"( " +
         // quoted RFC 1123 date format
         "\"" + // opening quote
         "(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun), " + // weekday

--- a/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/HeaderWarning.java
@@ -66,7 +66,7 @@ public class HeaderWarning {
      * the individual chars from qdText can be validated using the set of chars
      * the \\\\|\\\\\" (escaped '\' 0x20 and '"' 0x5c) which is used for quoted-pair has to be validated as strings
      */
-    private static Set<Integer> qdTextChars = Stream.of(
+    private static BitSet qdTextChars = Stream.of(
         IntStream.of(0x09),// HTAB
         IntStream.of(0x20), // SPACE
         IntStream.of(0x21), // !
@@ -75,7 +75,7 @@ public class HeaderWarning {
         // excluding 0x5c '\' which has to be escaped
         IntStream.rangeClosed(0x5D, 0x7E),// ascii ]-~
         IntStream.rangeClosed(0x80, 0xFF)// obs-text -bear in mind it contains 0x85 new line. Which requires DOT_ALL flag
-    ).flatMapToInt(i -> i).boxed().collect(Collectors.toSet());
+    ).flatMapToInt(i -> i).collect(BitSet::new, BitSet::set, BitSet::or);
     public static final Pattern WARNING_XCONTENT_LOCATION_PATTERN = Pattern.compile("^\\[.*?]\\[-?\\d+:-?\\d+] ");
 
     /*
@@ -228,7 +228,7 @@ public class HeaderWarning {
     private static boolean matchesQuotedString(String qdtext) {
         qdtext = qdtext.replaceAll("\\\\\"", "");
         qdtext = qdtext.replaceAll("\\\\", "");
-        return qdtext.chars().allMatch(c -> qdTextChars.contains(c));
+        return qdtext.chars().allMatch(c -> qdTextChars.get(c));
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
@@ -335,4 +335,45 @@ public class HeaderWarningTests extends ESTestCase {
         assertThat(responses.get(0), containsString("\"legacy template [global] has index patterns"));
         assertThat(responses.get(0), containsString(Integer.toString(299)));
     }
+
+    public void testHeaderWarningValidation() {
+        ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
+        final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
+
+        HeaderWarning.addWarning(threadContexts, allPossibleChars());
+
+        // LoggerMessageFormat.format makes sure all not allowed chars are escaped
+        HeaderWarning.addWarning(threadContexts, "\"");
+        HeaderWarning.addWarning(threadContexts, "\\");
+        HeaderWarning.addWarning(threadContexts, allNotAllowedChars());
+    }
+
+    private String allNotAllowedChars() {
+        StringBuilder chars = new StringBuilder();
+        for (char c = 0; c < 256; c++) {
+            if (c < '\t' || ('\t' < c && c < 0x20) || c == 0x7f) {
+                chars.append(c);
+            }
+        }
+        return chars.toString();
+    }
+
+    private static String allPossibleChars() {
+        StringBuilder allPossibleChars = new StringBuilder();
+        allPossibleChars.append('\t');
+        allPossibleChars.append(' ');
+        allPossibleChars.append('!');
+        for (int i = 0x23; i <= 0x5b; i++) {
+            allPossibleChars.append((char) i);
+        }
+        for (int i = 0x5d; i <= 0x7e; i++) {
+            allPossibleChars.append((char) i);
+        }
+        for (int i = 0x80; i <= 0xff; i++) {
+            allPossibleChars.append((char) i);
+        }
+        allPossibleChars.append("\\");
+        allPossibleChars.append("\\\"");
+        return allPossibleChars.toString();
+    }
 }

--- a/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
+++ b/server/src/test/java/org/elasticsearch/common/logging/HeaderWarningTests.java
@@ -340,7 +340,7 @@ public class HeaderWarningTests extends ESTestCase {
         ThreadContext threadContext = new ThreadContext(Settings.EMPTY);
         final Set<ThreadContext> threadContexts = Collections.singleton(threadContext);
 
-        HeaderWarning.addWarning(threadContexts, allPossibleChars());
+        HeaderWarning.addWarning(threadContexts, allAllowedChars());
 
         // LoggerMessageFormat.format makes sure all not allowed chars are escaped
         HeaderWarning.addWarning(threadContexts, "\"");
@@ -358,7 +358,7 @@ public class HeaderWarningTests extends ESTestCase {
         return chars.toString();
     }
 
-    private static String allPossibleChars() {
+    private static String allAllowedChars() {
         StringBuilder allPossibleChars = new StringBuilder();
         allPossibleChars.append('\t');
         allPossibleChars.append(' ');

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -438,8 +438,7 @@ public class DoSection implements ExecutableSection {
             .collect(toCollection(LinkedHashSet::new));
         final Set<Pattern> expectedRegex = new LinkedHashSet<>(expectedWarningHeadersRegex);
         for (final String header : warningHeaders) {
-            final Matcher matcher = HeaderWarning.WARNING_HEADER_PATTERN.matcher(header);
-            final boolean matches = matcher.matches();
+            final boolean matches = HeaderWarning.warningHeaderPatternMatches(header);
             if (matches) {
                 final String message = HeaderWarning.extractWarningValueFromWarningHeader(header, true);
                 if (allowed.contains(message)) {

--- a/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
+++ b/test/yaml-rest-runner/src/main/java/org/elasticsearch/test/rest/yaml/section/DoSection.java
@@ -38,7 +38,6 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import static java.util.Collections.emptyList;


### PR DESCRIPTION
an alternative combined with * in a regex is causing a stackoverflow when parsing
very long inputs (stack size have to be linearly correlated to the warning length).

This commit refactors the warning value aka qdText as per rfc7230 into iterative approach

closes #95972