### PR TITLE
Move the registration of the aggregation collector manager to SearchContextAggregations

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/DefaultSearchContext.java
@@ -11,8 +11,6 @@ package org.elasticsearch.search;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.BoostQuery;
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.Query;
@@ -129,7 +127,6 @@ final class DefaultSearchContext extends SearchContext {
     private Profilers profilers;
 
     private final Map<String, SearchExtBuilder> searchExtBuilders = new HashMap<>();
-    private CollectorManager<Collector, Void> aggCollectorManager;
     private final SearchExecutionContext searchExecutionContext;
     private final FetchPhase fetchPhase;
 
@@ -761,16 +758,6 @@ final class DefaultSearchContext extends SearchContext {
     @Override
     public long getRelativeTimeInMillis() {
         return relativeTimeSupplier.getAsLong();
-    }
-
-    @Override
-    public CollectorManager<Collector, Void> getAggsCollectorManager() {
-        return aggCollectorManager;
-    }
-
-    @Override
-    public void registerAggsCollectorManager(CollectorManager<Collector, Void> collectorManager) {
-        this.aggCollectorManager = collectorManager;
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/AggregationPhase.java
@@ -56,9 +56,9 @@ public class AggregationPhase {
         }
         if (context.getProfilers() != null) {
             InternalProfileCollector profileCollector = new InternalProfileCollector(collector, CollectorResult.REASON_AGGREGATION);
-            context.registerAggsCollectorManager(new InternalProfileCollectorManager(profileCollector));
+            context.aggregations().registerAggsCollectorManager(new InternalProfileCollectorManager(profileCollector));
         } else {
-            context.registerAggsCollectorManager(new SingleThreadCollectorManager(collector));
+            context.aggregations().registerAggsCollectorManager(new SingleThreadCollectorManager(collector));
         }
     }
 
@@ -110,6 +110,5 @@ public class AggregationPhase {
 
         // disable aggregations so that they don't run on next pages in case of scrolling
         context.aggregations(null);
-        context.registerAggsCollectorManager(null);
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/aggregations/SearchContextAggregations.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/SearchContextAggregations.java
@@ -7,6 +7,9 @@
  */
 package org.elasticsearch.search.aggregations;
 
+import org.apache.lucene.search.Collector;
+import org.apache.lucene.search.CollectorManager;
+
 /**
  * The aggregation context that is part of the search context.
  */
@@ -14,6 +17,7 @@ public class SearchContextAggregations {
 
     private final AggregatorFactories factories;
     private Aggregator[] aggregators;
+    private CollectorManager<Collector, Void> aggCollectorManager;
 
     /**
      * Creates a new aggregation context with the parsed aggregator factories
@@ -37,5 +41,19 @@ public class SearchContextAggregations {
      */
     public void aggregators(Aggregator[] aggregators) {
         this.aggregators = aggregators;
+    }
+
+    /**
+     * Registers the collector to be run for the aggregations phase
+     */
+    public void registerAggsCollectorManager(CollectorManager<Collector, Void> aggCollectorManager) {
+        this.aggCollectorManager = aggCollectorManager;
+    }
+
+    /**
+     * Returns the collector to be run for the aggregations phase
+     */
+    public CollectorManager<Collector, Void> getAggsCollectorManager() {
+        return aggCollectorManager;
     }
 }

--- a/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/FilteredSearchContext.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.search.internal;
 
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
@@ -438,16 +436,6 @@ public abstract class FilteredSearchContext extends SearchContext {
     @Override
     public Profilers getProfilers() {
         return in.getProfilers();
-    }
-
-    @Override
-    public CollectorManager<Collector, Void> getAggsCollectorManager() {
-        return in.getAggsCollectorManager();
-    }
-
-    @Override
-    public void registerAggsCollectorManager(CollectorManager<Collector, Void> collectorManager) {
-        in.registerAggsCollectorManager(collectorManager);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/SearchContext.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.search.internal;
 
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
@@ -374,16 +372,6 @@ public abstract class SearchContext implements Releasable {
      * WARN: This is not the epoch time.
      */
     public abstract long getRelativeTimeInMillis();
-
-    /**
-     * Registers the collector to be run for the aggregations phase
-     */
-    public abstract void registerAggsCollectorManager(CollectorManager<Collector, Void> collectorManager);
-
-    /**
-     * Returns the collector to be run for the aggregations phase
-     */
-    public abstract CollectorManager<Collector, Void> getAggsCollectorManager();
 
     public abstract SearchExecutionContext getSearchExecutionContext();
 

--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -237,9 +237,9 @@ public class QueryPhase {
                     collector
                 );
             }
-            if (searchContext.getAggsCollectorManager() != null) {
+            if (searchContext.aggregations() != null) {
                 final Collector collector = collectorManager.newCollector();
-                final Collector aggsCollector = searchContext.getAggsCollectorManager().newCollector();
+                final Collector aggsCollector = searchContext.aggregations().getAggsCollectorManager().newCollector();
                 collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                     searchContext.getProfilers(),
                     new SingleThreadCollectorManager(MultiCollector.wrap(collector, aggsCollector)),

--- a/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
+++ b/server/src/main/java/org/elasticsearch/search/rank/RankSearchContext.java
@@ -8,8 +8,6 @@
 
 package org.elasticsearch.search.rank;
 
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
@@ -202,14 +200,6 @@ public class RankSearchContext extends SearchContext {
     @Override
     public long getRelativeTimeInMillis() {
         return parent.getRelativeTimeInMillis();
-    }
-
-    /**
-     * Aggregations are run as a separate query, so do not add any aggregations collectors.
-     */
-    @Override
-    public CollectorManager<Collector, Void> getAggsCollectorManager() {
-        return null;
     }
 
     /* ---- ALL METHODS ARE UNSUPPORTED BEYOND HERE ---- */
@@ -541,11 +531,6 @@ public class RankSearchContext extends SearchContext {
 
     @Override
     public void addFetchResult() {
-        throw new UnsupportedOperationException();
-    }
-
-    @Override
-    public void registerAggsCollectorManager(CollectorManager<Collector, Void> collectorManager) {
         throw new UnsupportedOperationException();
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/TestSearchContext.java
@@ -7,8 +7,6 @@
  */
 package org.elasticsearch.test;
 
-import org.apache.lucene.search.Collector;
-import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.FieldDoc;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TotalHits;
@@ -73,7 +71,6 @@ public class TestSearchContext extends SearchContext {
     boolean trackScores = false;
     int trackTotalHitsUpTo = SearchContext.DEFAULT_TRACK_TOTAL_HITS_UP_TO;
     RankShardContext rankShardContext;
-    CollectorManager<Collector, Void> aggCollectorManager;
     ContextIndexSearcher searcher;
     int from;
     int size;
@@ -524,16 +521,6 @@ public class TestSearchContext extends SearchContext {
     @Override
     public Profilers getProfilers() {
         return null; // no profiling
-    }
-
-    @Override
-    public CollectorManager<Collector, Void> getAggsCollectorManager() {
-        return aggCollectorManager;
-    }
-
-    @Override
-    public void registerAggsCollectorManager(CollectorManager<Collector, Void> collector) {
-        this.aggCollectorManager = collector;
     }
 
     @Override


### PR DESCRIPTION
We are currently using the SearchContext to hold a reference to the aggregation collector manager  but it is only set if the SearchContextAggregations is not null. Therefore it makes sense that we use that object to hold the reference. Note that we will probably remove this completely for concurrent search.

The complexity here is that we are (ab)using this registration on QueryPhaseTests. Looking into how we are using it I think this registration of collectors are not adding any extra testing so I have removed them. Therefore I am tagging this PR as search as that needs to be approved.

