### PR TITLE
Remove fair version of KeyedLock

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/KeyedLock.java
@@ -26,22 +26,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class KeyedLock<T> {
 
     private final ConcurrentMap<T, KeyLock> map = ConcurrentCollections.newConcurrentMapWithAggressiveConcurrency();
-    private final boolean fair;
-
-    /**
-     * Creates a new lock
-     * @param fair Use fair locking, ie threads get the lock in the order they requested it
-     */
-    public KeyedLock(boolean fair) {
-        this.fair = fair;
-    }
-
-    /**
-     * Creates a non-fair lock
-     */
-    public KeyedLock() {
-        this(false);
-    }
 
     /**
      * Acquires a lock for the given key. The key is compared by it's equals method not by object identity. The lock can be acquired
@@ -90,7 +74,7 @@ public final class KeyedLock<T> {
     }
 
     private ReleasableLock tryCreateNewLock(T key) {
-        KeyLock newLock = new KeyLock(fair);
+        KeyLock newLock = new KeyLock();
         newLock.lock();
         KeyLock keyLock = map.putIfAbsent(key, newLock);
         if (keyLock == null) {
@@ -140,8 +124,8 @@ public final class KeyedLock<T> {
 
     @SuppressWarnings("serial")
     private static final class KeyLock extends ReentrantLock {
-        KeyLock(boolean fair) {
-            super(fair);
+        KeyLock() {
+            super();
         }
 
         private final AtomicInteger count = new AtomicInteger(1);

--- a/server/src/test/java/org/elasticsearch/common/util/concurrent/KeyedLockTests.java
+++ b/server/src/test/java/org/elasticsearch/common/util/concurrent/KeyedLockTests.java
@@ -29,7 +29,7 @@ public class KeyedLockTests extends ESTestCase {
     public void testIfMapEmptyAfterLotsOfAcquireAndReleases() throws InterruptedException {
         ConcurrentHashMap<String, Integer> counter = new ConcurrentHashMap<>();
         ConcurrentHashMap<String, AtomicInteger> safeCounter = new ConcurrentHashMap<>();
-        KeyedLock<String> connectionLock = new KeyedLock<>(randomBoolean());
+        KeyedLock<String> connectionLock = new KeyedLock<>();
         String[] names = new String[randomIntBetween(1, 40)];
         for (int i = 0; i < names.length; i++) {
             names[i] = randomRealisticUnicodeOfLengthBetween(10, 20);


### PR DESCRIPTION
Before we optimize this further, lets make sure we don't have needless indirection here: No production code uses of the fair version exist and only one test case needed adjusting.
