### PR TITLE
[Profiling] Set index:true for Symbolization.next_time

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
@@ -31,7 +31,7 @@
         "Symbolization.next_time": {
           "type": "date",
           "format": "epoch_second",
-          "index": false
+          "index": true
         }
       }
     }


### PR DESCRIPTION
Since we `profiling-executables.Symbolization.next_time` as a query filter, set `index: true` for this field.