### PR TITLE
[8.8] Require DLM enabled in the mixed-cluster QA cluster (#96391)

### DIFF
--- a/qa/mixed-cluster/build.gradle
+++ b/qa/mixed-cluster/build.gradle
@@ -38,6 +38,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       setting 'path.repo', "${buildDir}/cluster/shared/repo/${baseName}"
       setting 'xpack.security.enabled', 'false'
       requiresFeature 'es.index_mode_feature_flag_registered', Version.fromString("8.0.0")
+      requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.8.0")
     }
 
     tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {

--- a/x-pack/qa/mixed-tier-cluster/build.gradle
+++ b/x-pack/qa/mixed-tier-cluster/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'elasticsearch.legacy-java-rest-test'
 apply plugin: 'elasticsearch.bwc-test'
 
+import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.VersionProperties
 import org.elasticsearch.gradle.internal.info.BuildParams
 import org.elasticsearch.gradle.testclusters.StandaloneRestIntegTestTask
@@ -29,6 +30,7 @@ BuildParams.bwcVersions.withWireCompatible(v -> v.onOrAfter("7.9.0") &&
       nodes."${baseName}-1".setting 'node.roles', '["data_content", "data_hot"]'
     }
     nodes."${baseName}-2".setting 'node.roles', '["master"]'
+    requiresFeature 'es.dlm_feature_flag_enabled', Version.fromString("8.8.0")
   }
 
   tasks.register("${baseName}#mixedClusterTest", StandaloneRestIntegTestTask) {


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Require DLM enabled in the mixed-cluster QA cluster (#96391)