### PR TITLE
Promptly fail recovery from snapshot

### DIFF
--- a/docs/changelog/96421.yaml
+++ b/docs/changelog/96421.yaml
@@ -1,0 +1,6 @@
+pr: 96421
+summary: Promptly fail recovery from snapshot
+area: Recovery
+type: bug
+issues:
+ - 95525

--- a/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetService.java
@@ -356,6 +356,11 @@ public class PeerRecoveryTargetService implements IndexEventListener {
         return recoverySettings.tryAcquireSnapshotDownloadPermits();
     }
 
+    // Visible for testing
+    public int ongoingRecoveryCount() {
+        return onGoingRecoveries.size();
+    }
+
     /**
      * Prepare the start recovery request.
      *


### PR DESCRIPTION
Recovering a blob from snapshot may take some time. If the recovery is cancelled during this time, there is no point in continuing, and indeed we must give up as soon as possible to avoid holding the shard lock for longer than necessary. This commit checks for cancellation on every read from the blob store, rather than just between blobs.

Closes #95525