### PR TITLE
Mention DLM in ignored docs test comments

### DIFF
--- a/x-pack/docs/build.gradle
+++ b/x-pack/docs/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.docs-test'
@@ -30,9 +29,11 @@ restResources {
   }
 }
 
-// TODO: Remove the following when RCS feature is released
-// The get-builtin-privileges doc test does not include the new cluster privilege for RCS
-// So we disable the test if the build is a snapshot where unreleased feature is enabled by default
+// TODO: Remove the following when the following features are released. These tests include new privileges only available under feature flags
+//  which require snapshot builds:
+// * RCS 2.0. cross_cluster_search is only available with untrusted_remote_cluster_feature_flag_registered set
+// * DLM. manage_dlm privilege is only available with dlm_feature_flag_enabled set
+// We disable these tests for snapshot builds to maintain release build coverage.
 tasks.named("yamlRestTest").configure {
   if (BuildParams.isSnapshotBuild()) {
     systemProperty 'tests.rest.blacklist', '*/get-builtin-privileges/*'

--- a/x-pack/plugin/build.gradle
+++ b/x-pack/plugin/build.gradle
@@ -66,9 +66,11 @@ if (BuildParams.isSnapshotBuild() == false) {
   // private key, these tests are blacklisted in non-snapshot test runs
   restTestBlacklist.addAll(['xpack/15_basic/*', 'license/20_put_license/*', 'license/30_enterprise_license/*'])
 
-  // TODO: Remove the following when RCS feature is released
-  // cross_cluster_search privilege is only available when untrusted_remote_cluster_feature_flag_registered is enabled
-  // which requires snapshot build
+  // TODO: Remove the following when the following features are released. These tests include new privileges only available under feature flags
+  //  which require snapshot builds:
+  // * RCS 2.0. cross_cluster_search is only available with untrusted_remote_cluster_feature_flag_registered set
+  // * DLM. manage_dlm privilege is only available with dlm_feature_flag_enabled set
+  // We disable these tests for snapshot builds to maintain release build coverage.
   restTestBlacklist.add('privileges/11_builtin/Test get builtin privileges')
   restTestBlacklist.add('api_key/50_cross_cluster/*')
 }
@@ -95,7 +97,10 @@ tasks.named("yamlRestTestV7CompatTransform").configure { task ->
     "vectors/10_dense_vector_basic/Deprecated function signature",
     "to support it, it would require to almost revert back the #48725 and complicate the code"
   )
-  task.skipTest("vectors/20_dense_vector_special_cases/Indexing of Dense vectors should error when dims don't match defined in the mapping", "Error message has changed")
+  task.skipTest(
+    "vectors/20_dense_vector_special_cases/Indexing of Dense vectors should error when dims don't match defined in the mapping",
+    "Error message has changed"
+  )
   task.skipTest("vectors/30_sparse_vector_basic/Cosine Similarity", "not supported for compatibility")
   task.skipTest("vectors/30_sparse_vector_basic/Deprecated function signature", "not supported for compatibility")
   task.skipTest("vectors/30_sparse_vector_basic/Dot Product", "not supported for compatibility")


### PR DESCRIPTION
Book-keeping PR to ensure that we don't prematurely un-ignore a doc tests suite. 