### PR TITLE
[8.8] [DOCS] Make 2028 dims 'experimental' warning inline (#96369)

### DIFF
--- a/docs/reference/mapping/types/dense-vector.asciidoc
+++ b/docs/reference/mapping/types/dense-vector.asciidoc
@@ -115,8 +115,9 @@ integer values between -128 to 127, inclusive for both indexing and searching.
 Number of vector dimensions. Can't exceed `1024` for indexed vectors
 (`"index": true`), or `2048` for non-indexed vectors.
 
-experimental::[]
-Number of dimensions for indexed vectors can be extended up to `2048`.
++
+experimental:[]
+The number of dimensions for indexed vectors can be extended up to `2048`.
 
 `index`::
 (Optional, Boolean)


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Make 2028 dims 'experimental' warning inline (#96369)