### PR TITLE
Count refs to index commit held by snapshot

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotIndexCommit.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotIndexCommit.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.apache.lucene.index.IndexCommit;
+import org.elasticsearch.common.util.concurrent.RunOnce;
+import org.elasticsearch.core.AbstractRefCounted;
+import org.elasticsearch.core.Nullable;
+import org.elasticsearch.index.engine.Engine;
+
+/**
+ * A (closeable) {@link IndexCommit} plus ref-counting to keep track of active users, and with the facility to drop the "main" initial ref
+ * early if the shard snapshot is aborted.
+ */
+public class SnapshotIndexCommit extends AbstractRefCounted {
+
+    private final Engine.IndexCommitRef commitRef;
+    private final Runnable releaseInitialRef;
+    @Nullable
+    private Exception closeException;
+
+    public SnapshotIndexCommit(Engine.IndexCommitRef commitRef) {
+        this.commitRef = commitRef;
+        this.releaseInitialRef = new RunOnce(this::decRef);
+    }
+
+    @Override
+    protected void closeInternal() {
+        assert closeException == null : closeException;
+        try {
+            commitRef.close();
+        } catch (Exception e) {
+            closeException = e;
+        }
+    }
+
+    /**
+     * Called after all other refs are released, to release the initial ref (if not already released) and re-throw any exception thrown
+     * when the inner {@link IndexCommit} was closed.
+     */
+    public void onCompletion() throws Exception {
+        releaseInitialRef.run();
+        assert hasReferences() == false;
+        // closeInternal happens-before here so no need for synchronization
+        if (closeException != null) {
+            throw closeException;
+        }
+    }
+
+    /**
+     * Called to abort the snapshot while it's running: release the initial ref (if not already released).
+     */
+    public void onAbort() {
+        releaseInitialRef.run();
+    }
+
+    public IndexCommit indexCommit() {
+        assert hasReferences();
+        return commitRef.getIndexCommit();
+    }
+}

--- a/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
+++ b/server/src/main/java/org/elasticsearch/repositories/blobstore/BlobStoreRepository.java
@@ -2712,7 +2712,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
                 indexCommitPointFiles = new ArrayList<>();
                 final Collection<String> fileNames;
                 final Store.MetadataSnapshot metadataFromStore;
-                try (Releasable ignored = incrementStoreRef(store, snapshotStatus, shardId)) {
+                try (Releasable ignored = context.withCommitRef()) {
                     // TODO apparently we don't use the MetadataSnapshot#.recoveryDiff(...) here but we should
                     try {
                         logger.trace("[{}] [{}] Loading store metadata using index commit [{}]", shardId, snapshotId, snapshotIndexCommit);
@@ -2924,15 +2924,6 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         for (int i = 0; i < noOfFilesToSnapshot; i++) {
             shardSnapshotTaskRunner.enqueueFileSnapshot(context, filesToSnapshot::poll, filesListener);
         }
-    }
-
-    private static Releasable incrementStoreRef(Store store, IndexShardSnapshotStatus snapshotStatus, ShardId shardId) {
-        if (store.tryIncRef() == false) {
-            snapshotStatus.ensureNotAborted();
-            assert false : "Store should not be closed concurrently unless snapshot is aborted";
-            throw new IndexShardSnapshotFailedException(shardId, "Store got closed concurrently");
-        }
-        return store::decRef;
     }
 
     private static boolean assertFileContentsMatchHash(
@@ -3439,7 +3430,7 @@ public abstract class BlobStoreRepository extends AbstractLifecycleComponent imp
         final BlobContainer shardContainer = shardContainer(indexId, shardId);
         final String file = fileInfo.physicalName();
         try (
-            Releasable ignored = BlobStoreRepository.incrementStoreRef(store, snapshotStatus, store.shardId());
+            Releasable ignored = context.withCommitRef();
             IndexInput indexInput = store.openVerifyingInput(file, IOContext.READONCE, fileInfo.metadata())
         ) {
             for (int i = 0; i < fileInfo.numberOfParts(); i++) {

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotShardsService.java
@@ -45,6 +45,7 @@ import org.elasticsearch.repositories.RepositoryShardId;
 import org.elasticsearch.repositories.ShardGeneration;
 import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.repositories.ShardSnapshotResult;
+import org.elasticsearch.repositories.SnapshotIndexCommit;
 import org.elasticsearch.repositories.SnapshotShardContext;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.TransportService;
@@ -374,7 +375,7 @@ public class SnapshotShardsService extends AbstractLifecycleComponent implements
                         indexShard.mapperService(),
                         snapshot.getSnapshotId(),
                         indexId,
-                        snapshotRef,
+                        new SnapshotIndexCommit(snapshotRef),
                         getShardStateId(indexShard, snapshotRef.getIndexCommit()),
                         snapshotStatus,
                         version,

--- a/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
@@ -71,13 +71,12 @@ public class SnapshotIndexCommitTests extends ESTestCase {
     }
 
     private SnapshotIndexCommit getSnapshotIndexCommit(boolean throwOnClose, AtomicBoolean isClosed) {
-        return new SnapshotIndexCommit(
-            new Engine.IndexCommitRef(null, () -> {
-                assertTrue(isClosed.compareAndSet(false, true));
-                if (throwOnClose) {
-                    throw new IOException("simulated");
-                }
-            }));
+        return new SnapshotIndexCommit(new Engine.IndexCommitRef(null, () -> {
+            assertTrue(isClosed.compareAndSet(false, true));
+            if (throwOnClose) {
+                throw new IOException("simulated");
+            }
+        }));
     }
 
     private void assertOnCompletionBehaviour(boolean throwOnClose, SnapshotIndexCommit indexCommitRef) throws Exception {

--- a/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.repositories;
+
+import org.elasticsearch.index.engine.Engine;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class SnapshotIndexCommitTests extends ESTestCase {
+
+    public void testCompleteAndCloseCleanly() throws Exception {
+        runCompleteTest(false);
+    }
+
+    public void testCompleteAndFailOnClose() throws Exception {
+        runCompleteTest(true);
+    }
+
+    public void testAbortAndCloseCleanly() throws Exception {
+        runAbortTest(false);
+    }
+
+    public void testAbortAndFailOnClose() throws Exception {
+        runAbortTest(true);
+    }
+
+    private void runCompleteTest(boolean throwOnClose) throws Exception {
+        final var isClosed = new AtomicBoolean();
+        final var indexCommitRef = getSnapshotIndexCommit(throwOnClose, isClosed);
+
+        assertFalse(isClosed.get());
+        if (randomBoolean()) {
+            assertTrue(indexCommitRef.tryIncRef());
+            indexCommitRef.decRef();
+        }
+
+        assertOnCompletionBehaviour(throwOnClose, indexCommitRef);
+
+        assertTrue(isClosed.get());
+        assertFalse(indexCommitRef.tryIncRef());
+
+        indexCommitRef.onAbort();
+        assertFalse(indexCommitRef.tryIncRef());
+    }
+
+    private void runAbortTest(boolean throwOnClose) throws Exception {
+        final var isClosed = new AtomicBoolean();
+        final var indexCommitRef = getSnapshotIndexCommit(throwOnClose, isClosed);
+
+        assertFalse(isClosed.get());
+        assertTrue(indexCommitRef.tryIncRef());
+
+        indexCommitRef.onAbort();
+        assertFalse(isClosed.get());
+
+        assertTrue(indexCommitRef.tryIncRef());
+        indexCommitRef.decRef();
+        indexCommitRef.decRef();
+
+        assertTrue(isClosed.get());
+
+        assertOnCompletionBehaviour(throwOnClose, indexCommitRef);
+    }
+
+    private SnapshotIndexCommit getSnapshotIndexCommit(boolean throwOnClose, AtomicBoolean isClosed) {
+        return new SnapshotIndexCommit(
+            new Engine.IndexCommitRef(null, () -> {
+                assertTrue(isClosed.compareAndSet(false, true));
+                if (throwOnClose) {
+                    throw new IOException("simulated");
+                }
+            }));
+    }
+
+    private void assertOnCompletionBehaviour(boolean throwOnClose, SnapshotIndexCommit indexCommitRef) throws Exception {
+        if (throwOnClose) {
+            assertEquals("simulated", expectThrows(IOException.class, indexCommitRef::onCompletion).getMessage());
+        } else {
+            indexCommitRef.onCompletion();
+        }
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/ShardSnapshotTaskRunnerTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/ShardSnapshotTaskRunnerTests.java
@@ -23,6 +23,7 @@ import org.elasticsearch.index.snapshots.blobstore.BlobStoreIndexShardSnapshot;
 import org.elasticsearch.index.store.Store;
 import org.elasticsearch.index.store.StoreFileMetadata;
 import org.elasticsearch.repositories.IndexId;
+import org.elasticsearch.repositories.SnapshotIndexCommit;
 import org.elasticsearch.repositories.SnapshotShardContext;
 import org.elasticsearch.snapshots.SnapshotId;
 import org.elasticsearch.test.DummyShardLock;
@@ -121,7 +122,7 @@ public class ShardSnapshotTaskRunnerTests extends ESTestCase {
             null,
             snapshotId,
             indexId,
-            new Engine.IndexCommitRef(null, () -> {}),
+            new SnapshotIndexCommit(new Engine.IndexCommitRef(null, () -> {})),
             null,
             IndexShardSnapshotStatus.newInitializing(null),
             Version.CURRENT,

--- a/server/src/test/java/org/elasticsearch/repositories/fs/FsRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/fs/FsRepositoryTests.java
@@ -49,6 +49,7 @@ import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.ShardGeneration;
 import org.elasticsearch.repositories.ShardSnapshotResult;
+import org.elasticsearch.repositories.SnapshotIndexCommit;
 import org.elasticsearch.repositories.SnapshotShardContext;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.snapshots.Snapshot;
@@ -108,7 +109,7 @@ public class FsRepositoryTests extends ESTestCase {
                     null,
                     snapshotId,
                     indexId,
-                    new Engine.IndexCommitRef(indexCommit, () -> {}),
+                    new SnapshotIndexCommit(new Engine.IndexCommitRef(indexCommit, () -> {})),
                     null,
                     snapshotStatus,
                     Version.CURRENT,
@@ -151,7 +152,7 @@ public class FsRepositoryTests extends ESTestCase {
                     null,
                     incSnapshotId,
                     indexId,
-                    new Engine.IndexCommitRef(incIndexCommit, () -> {}),
+                    new SnapshotIndexCommit(new Engine.IndexCommitRef(incIndexCommit, () -> {})),
                     null,
                     snapshotStatus2,
                     Version.CURRENT,

--- a/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/shard/IndexShardTestCase.java
@@ -73,6 +73,7 @@ import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.Repository;
 import org.elasticsearch.repositories.ShardGeneration;
 import org.elasticsearch.repositories.ShardSnapshotResult;
+import org.elasticsearch.repositories.SnapshotIndexCommit;
 import org.elasticsearch.repositories.SnapshotShardContext;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
 import org.elasticsearch.snapshots.Snapshot;
@@ -1054,7 +1055,7 @@ public abstract class IndexShardTestCase extends ESTestCase {
                     shard.mapperService(),
                     snapshot.getSnapshotId(),
                     indexId,
-                    indexCommitRef,
+                    new SnapshotIndexCommit(indexCommitRef),
                     null,
                     snapshotStatus,
                     Version.CURRENT,

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/snapshots/sourceonly/SourceOnlySnapshotShardTests.java
@@ -70,6 +70,7 @@ import org.elasticsearch.repositories.RepositoryData;
 import org.elasticsearch.repositories.ShardGeneration;
 import org.elasticsearch.repositories.ShardGenerations;
 import org.elasticsearch.repositories.ShardSnapshotResult;
+import org.elasticsearch.repositories.SnapshotIndexCommit;
 import org.elasticsearch.repositories.SnapshotShardContext;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
 import org.elasticsearch.repositories.blobstore.ESBlobStoreRepositoryIntegTestCase;
@@ -130,7 +131,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         shard.mapperService(),
                         snapshotId,
                         indexId,
-                        snapshotRef,
+                        new SnapshotIndexCommit(snapshotRef),
                         null,
                         indexShardSnapshotStatus,
                         Version.CURRENT,
@@ -172,7 +173,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         shard.mapperService(),
                         snapshotId,
                         indexId,
-                        snapshotRef,
+                        new SnapshotIndexCommit(snapshotRef),
                         null,
                         indexShardSnapshotStatus,
                         Version.CURRENT,
@@ -203,7 +204,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         shard.mapperService(),
                         snapshotId,
                         indexId,
-                        snapshotRef,
+                        new SnapshotIndexCommit(snapshotRef),
                         null,
                         indexShardSnapshotStatus,
                         Version.CURRENT,
@@ -234,7 +235,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         shard.mapperService(),
                         snapshotId,
                         indexId,
-                        snapshotRef,
+                        new SnapshotIndexCommit(snapshotRef),
                         null,
                         indexShardSnapshotStatus,
                         Version.CURRENT,
@@ -258,7 +259,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
         return "{ \"value\" : \"" + randomAlphaOfLength(10) + "\"}";
     }
 
-    public void testRestoreMinmal() throws IOException {
+    public void testRestoreMinimal() throws IOException {
         IndexShard shard = newStartedShard(true);
         int numInitialDocs = randomIntBetween(10, 100);
         for (int i = 0; i < numInitialDocs; i++) {
@@ -295,7 +296,7 @@ public class SourceOnlySnapshotShardTests extends IndexShardTestCase {
                         shard.mapperService(),
                         snapshotId,
                         indexId,
-                        snapshotRef,
+                        new SnapshotIndexCommit(snapshotRef),
                         null,
                         indexShardSnapshotStatus,
                         Version.CURRENT,

--- a/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/test/java/org/elasticsearch/xpack/searchablesnapshots/store/SearchableSnapshotDirectoryTests.java
@@ -82,6 +82,7 @@ import org.elasticsearch.indices.recovery.RecoverySettings;
 import org.elasticsearch.indices.recovery.RecoveryState;
 import org.elasticsearch.repositories.IndexId;
 import org.elasticsearch.repositories.ShardSnapshotResult;
+import org.elasticsearch.repositories.SnapshotIndexCommit;
 import org.elasticsearch.repositories.SnapshotShardContext;
 import org.elasticsearch.repositories.blobstore.BlobStoreRepository;
 import org.elasticsearch.repositories.blobstore.BlobStoreTestUtil;
@@ -627,7 +628,7 @@ public class SearchableSnapshotDirectoryTests extends AbstractSearchableSnapshot
                             null,
                             snapshotId,
                             indexId,
-                            new Engine.IndexCommitRef(indexCommit, () -> {}),
+                            new SnapshotIndexCommit(new Engine.IndexCommitRef(indexCommit, () -> {})),
                             null,
                             snapshotStatus,
                             Version.CURRENT,


### PR DESCRIPTION
Moves ref-counting onto the `SnapshotShardContext` to more clearly
prevent an aborted snapshot from interacting with the `Store`.

Relates #95316