### PR TITLE
Format message only when debug is enabled

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeReplacementAllocationDecider.java
@@ -34,8 +34,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
         if (replacementOngoing(allocation) == false) {
             return YES__NO_REPLACEMENTS;
         } else if (replacementFromSourceToTarget(allocation, shardRouting.currentNodeId(), node.node().getName())) {
-            return Decision.single(
-                Decision.Type.YES,
+            return allocation.decision(
+                Decision.YES,
                 NAME,
                 "node [%s] is replacing node [%s], and may receive shards from it",
                 shardRouting.currentNodeId(),
@@ -48,16 +48,16 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
                 return YES__RECONCILING;
             }
 
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "node [%s] is being replaced, and its shards may only be allocated to the replacement target [%s]",
                 shardRouting.currentNodeId(),
                 getReplacementName(allocation, shardRouting.currentNodeId())
             );
         } else if (isReplacementSource(allocation, node.nodeId())) {
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "node [%s] is being replaced by [%s], so no data may be allocated to it",
                 node.nodeId(),
@@ -73,8 +73,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
             }
 
             final SingleNodeShutdownMetadata shutdown = allocation.replacementTargetShutdowns().get(node.node().getName());
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "node [%s] is replacing the vacating node [%s], only data currently allocated to the source node "
                     + "may be allocated to it until the replacement is complete",
@@ -92,8 +92,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
         if (replacementOngoing(allocation) == false) {
             return YES__NO_REPLACEMENTS;
         } else if (isReplacementSource(allocation, node.nodeId())) {
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "node [%s] is being replaced by node [%s], so no data may remain on it",
                 node.nodeId(),
@@ -110,8 +110,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
             return YES__NO_REPLACEMENTS;
         } else if (isReplacementTargetName(allocation, node.getName())) {
             final SingleNodeShutdownMetadata shutdown = allocation.replacementTargetShutdowns().get(node.getName());
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "node [%s] is a node replacement target for node [%s], "
                     + "shards cannot auto expand to be on it until the replacement is complete",
@@ -119,8 +119,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
                 shutdown == null ? null : shutdown.getNodeId()
             );
         } else if (isReplacementSource(allocation, node.getId())) {
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "node [%s] is being replaced by [%s], shards cannot auto expand to be on it",
                 node.getId(),
@@ -134,16 +134,16 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
     @Override
     public Decision canForceAllocateDuringReplace(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         if (replacementFromSourceToTarget(allocation, shardRouting.currentNodeId(), node.node().getName())) {
-            return Decision.single(
-                Decision.Type.YES,
+            return allocation.decision(
+                Decision.YES,
                 NAME,
                 "node [%s] is being replaced by node [%s], and can be force vacated to the target",
                 shardRouting.currentNodeId(),
                 node.nodeId()
             );
         } else {
-            return Decision.single(
-                Decision.Type.NO,
+            return allocation.decision(
+                Decision.NO,
                 NAME,
                 "shard is not on the source of a node replacement relocated to the replacement target"
             );
@@ -153,8 +153,8 @@ public class NodeReplacementAllocationDecider extends AllocationDecider {
     @Override
     public Decision canAllocateReplicaWhenThereIsRetentionLease(ShardRouting shardRouting, RoutingNode node, RoutingAllocation allocation) {
         if (isReplacementTargetName(allocation, node.node().getName())) {
-            return Decision.single(
-                Decision.Type.YES,
+            return allocation.decision(
+                Decision.YES,
                 NAME,
                 "node [%s] is a node replacement target and can have a previously allocated replica re-allocated to it",
                 node.nodeId()


### PR DESCRIPTION
This change uses `allocation.decision` instead of `Decision.single` so that we are checking debug flag before formatting explanation message.
