### PR TITLE
Change test settings

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -451,7 +451,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             true,
             false,
             IntStream.range(0, nbDocs)
-                .mapToObj(i -> client().prepareIndex(indexName).setSource("foo", randomBoolean() ? "bar" : "baz"))
+                .mapToObj(i -> client().prepareIndex(indexName).setSource("foo", randomAlphaOfLength(1048)))
                 .collect(Collectors.toList())
         );
         refresh(indexName);
@@ -463,7 +463,9 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             // we compute the min across all the max shard sizes by node in order to
             // trigger the rate limiter in all nodes. We could just use the min shard size
             // but that would make this test too slow.
-            long rateLimitInBytes = getMaxShardSizeByNodeInBytes(indexName).values().stream().min(Long::compareTo).get();
+            // Update: setting rate limit at a 90% of minimax value above
+            long minimax = getMaxShardSizeByNodeInBytes(indexName).values().stream().min(Long::compareTo).get();
+            long rateLimitInBytes = (long) (0.9 * minimax);
             repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ofBytes(rateLimitInBytes));
         } else {
             repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ZERO);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -460,10 +460,11 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         final Settings.Builder repositorySettings = Settings.builder().put("location", randomRepoPath());
         final boolean useRateLimits = randomBoolean();
         if (useRateLimits) {
-            // we compute the min across all the max shard sizes by node in order to
+            // we compute the min across all the max shard (minimax) sizes by node in order to
             // trigger the rate limiter in all nodes. We could just use the min shard size
             // but that would make this test too slow.
-            // Update: setting rate limit at a 90% of minimax value above
+            // Setting rate limit at a 90% of minimax value to increase probability to engage rate limiting mechanism
+            // which is defined in RateLimitingInputStream (see details in https://github.com/elastic/elasticsearch/pull/96444)
             long minimax = getMaxShardSizeByNodeInBytes(indexName).values().stream().min(Long::compareTo).get();
             long rateLimitInBytes = (long) (0.9 * minimax);
             repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ofBytes(rateLimitInBytes));


### PR DESCRIPTION
Over past year there were 5 observed [failures](https://ci-stats.elastic.co/s/jenkins/app/discover#/?_g=h@00a189c&_a=h@01ee4fa) if the test. The test asserts non-zero cumulative rate limiting delay, simply speaking it checks if rate limiting is happening.

Rate limiting logic involves two components:`RateLimitingInputStream` (ES codebase)  and `RateLimiter` (Lucene codebase) where cumulative delay is collected behind `listener.onPause(pause)` in line 47 and then asserted in the test.
https://github.com/elastic/elasticsearch/blob/a92a647b9f17d1bddf5c707490a19482c273eda3/server/src/main/java/org/elasticsearch/index/snapshots/blobstore/RateLimitingInputStream.java#L44-L48

Rate limiting counter can remain eq to 0 **iff** there were no invocation of `listener.onPause`, meaning `pause` was eq 0.
The value is calculated on a fly by `RateLimiter`, if `startNS >= targetNS` condition does not hold, it returns 0. 
```
public long pause(long bytes) {

      long startNS = System.nanoTime();

      double secondsToPause = (bytes / 1024. / 1024.) / mbPerSec;

      long targetNS;

      // Sync'd to read + write lastNS:
      synchronized (this) {

        // Time we should sleep until; this is purely instantaneous
        // rate (just adds seconds onto the last time we had paused to);
        // maybe we should also offer decayed recent history one?
        targetNS = lastNS + (long) (1000000000 * secondsToPause);

        if (startNS >= targetNS) {
          // OK, current time is already beyond the target sleep time,
          // no pausing to do.

          // Set to startNS, not targetNS, to enforce the instant rate, not
          // the "averaaged over all history" rate:
          lastNS = startNS;
          return 0;
        }
```
Problem with this code is that `startNS = System.nanoTime()` is executed **after** the physical read from the stream happened. The only linking piece between (1) physical IO read and (2) `startNS` variable  is `secondsToPause` which tries to *estimate* the delay. If the arbitrary delay happens between (1) and (2) code returns ZERO. The failure is easy to reproduce by setting a breaking point on `startNS = System.nanoTime()` and passing it (thus simulating delay) - the test always fails.

To reduce likelihood of the failure I'm offering to tweak two available parameters in `secondsToPause = (bytes / 1024. / 1024.) / mbPerSec` formula - `bytes` and `mbPerSec`. By increasing the ratio, I expect to hold the `startNS >= targetNS` condition more often.

In my mind, the test is OK'ish itself by there is lack of control over RateLimiter component which prevents making the test better.

If we keep seeing failures, than we need to re-work way of asserting fact of rate limiting.   



Fix #94277