### PR TITLE
[8.7] Add known issue docs for #95114 (#96448)

### DIFF
--- a/docs/reference/release-notes/8.7.1.asciidoc
+++ b/docs/reference/release-notes/8.7.1.asciidoc
@@ -3,6 +3,19 @@
 
 Also see <<breaking-changes-8.7,Breaking changes in 8.7>>.
 
+[[known-issues-8.7.1]]
+[float]
+=== Known issues
+
+* `ArrayIndexOutOfBoundsException` may be thrown while creating a transport message
++
+Certain sequences of writes and seeks to the buffer used to create a transport
+message may encounter an alignment bug which results in an
+`ArrayIndexOutOfBoundsException`, preventing the transport message from being
+sent.
++
+This issue is fixed in 8.8.0.
+
 [[bug-8.7.1]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Add known issue docs for #95114 (#96448)