### PR TITLE
Enable the Panama Vector module

### DIFF
--- a/distribution/src/config/jvm.options
+++ b/distribution/src/config/jvm.options
@@ -54,6 +54,10 @@
 ## JVM temporary directory
 -Djava.io.tmpdir=${ES_TMPDIR}
 
+# Leverages accelerated vector hardware instructions; removing this may
+# result in less optimal vector performance
+20:--add-modules=jdk.incubator.vector
+
 ## heap dumps
 
 # generate a heap dump when an allocation from the Java heap fails; heap dumps

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ErrorPumpThread.java
@@ -16,6 +16,7 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 
 import static org.elasticsearch.bootstrap.BootstrapInfo.SERVER_READY_MARKER;
@@ -68,6 +69,9 @@ class ErrorPumpThread extends Thread {
         nonInterruptibleVoid(this::join);
     }
 
+    /** List of messages / lines to filter from the output. */
+    List<String> filter = List.of("WARNING: Using incubator modules: jdk.incubator.vector");
+
     @Override
     public void run() {
         try {
@@ -76,7 +80,7 @@ class ErrorPumpThread extends Thread {
                 if (line.isEmpty() == false && line.charAt(0) == SERVER_READY_MARKER) {
                     ready = true;
                     readyOrDead.countDown();
-                } else {
+                } else if (filter.contains(line) == false) {
                     writer.println(line);
                 }
             }

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
@@ -220,9 +220,6 @@ public class ServerProcess {
         // Special circumstances require some modules (not depended on by the main server module) to be explicitly added:
         command.add("--add-modules=jdk.net"); // needed to reflectively set extended socket options
         command.add("--add-modules=org.elasticsearch.preallocate"); // needed on boot layer as target to open java.io
-        if (disableIncubatorModule(jvmOptions) == false) {
-            command.add("--add-modules=jdk.incubator.vector"); // switches Lucene VectorUtil to the vectorized implementation
-        }
         command.add("-m");
         command.add("org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch");
 
@@ -231,18 +228,6 @@ public class ServerProcess {
         builder.redirectOutput(ProcessBuilder.Redirect.INHERIT);
 
         return processStarter.start(builder);
-    }
-
-    /** Tells whether to disable the incubating vector module - it's enabled by default on JDK 20. */
-    static boolean disableIncubatorModule(List<String> jvmOptions) {
-        if (Runtime.version().feature() != 20) {
-            // we currently only support JDK 20. Each JDK version should be enabled explicitly, as appropriate
-            return true;
-        }
-        if (jvmOptions.contains("-Des.disable.jdk.incubator.vector")) {
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
+++ b/distribution/tools/server-cli/src/main/java/org/elasticsearch/server/cli/ServerProcess.java
@@ -219,6 +219,7 @@ public class ServerProcess {
         command.add(esHome.resolve("lib").toString());
         // Special circumstances require some modules (not depended on by the main server module) to be explicitly added:
         command.add("--add-modules=jdk.net"); // needed to reflectively set extended socket options
+        command.add("--add-modules=jdk.incubator.vector"); // makes Lucene VectorUtil faster
         command.add("--add-modules=org.elasticsearch.preallocate"); // needed on boot layer as target to open java.io
         command.add("-m");
         command.add("org.elasticsearch.server/org.elasticsearch.bootstrap.Elasticsearch");

--- a/docs/changelog/96453.yaml
+++ b/docs/changelog/96453.yaml
@@ -2,4 +2,4 @@ pr: 96453
 summary: Leverage SIMD hardware instructions in Vector Search
 area: Vector Search
 type: enhancement
-issues: []
+issues: [96370]

--- a/docs/changelog/96453.yaml
+++ b/docs/changelog/96453.yaml
@@ -2,5 +2,4 @@ pr: 96453
 summary: Leverage SIMD hardware instructions in Vector Search
 area: Vector Search
 type: enhancement
-issues:
- - 96370
+issues: []

--- a/docs/changelog/96453.yaml
+++ b/docs/changelog/96453.yaml
@@ -1,0 +1,5 @@
+pr: 96453
+summary: Enable the Panama Vector module
+area: Vector Search
+type: enhancement
+issues: []

--- a/docs/changelog/96453.yaml
+++ b/docs/changelog/96453.yaml
@@ -1,5 +1,6 @@
 pr: 96453
-summary: Enable the Panama Vector module
+summary: Leverage SIMD hardware instructions in Vector Search
 area: Vector Search
 type: enhancement
-issues: []
+issues:
+ - 96370

--- a/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
+++ b/server/src/main/java/org/elasticsearch/common/logging/LogConfigurator.java
@@ -269,8 +269,9 @@ public class LogConfigurator {
                     LogManager.getLogger("stderr"),
                     Level.WARN,
                     // MMapDirectory messages come from Lucene, suggesting to users as a warning that they should enable preview features in
-                    // the JDK
-                    List.of("MMapDirectory")
+                    // the JDK. Vector logs come from Lucene too, but only if the used explicitly disables the Vector API - no point warning
+                    // in this case.
+                    List.of("MMapDirectory", "VectorUtilProvider", "WARNING: Java vector incubator module is not readable")
                 ),
                 false,
                 StandardCharsets.UTF_8


### PR DESCRIPTION
This change adds the jdk.incubator.vector module, so that we can enable the Panamaized vector utils in Lucene. https://github.com/apache/lucene/pull/12311

The module is added by default if running on JDK 20, which is the only current supported implementation in Lucene, but JDK 21 will likely come soon.

If for some reason this needs to be disable, just remove or otherwise comment out the `--add-modules=jdk.incubator.vector` line in the _jvm.options_.

The log output from Lucene shows the preferred vector bit width that is in operation.

relates #96370