### PR TITLE
[DOCS] Forward port 8.7.1 release notes

### DIFF
--- a/docs/reference/release-notes.asciidoc
+++ b/docs/reference/release-notes.asciidoc
@@ -7,6 +7,7 @@
 This section summarizes the changes in each release.
 
 * <<release-notes-8.8.0>>
+* <<release-notes-8.7.1>>
 * <<release-notes-8.7.0>>
 * <<release-notes-8.6.2>>
 * <<release-notes-8.6.1>>
@@ -42,6 +43,7 @@ This section summarizes the changes in each release.
 --
 
 include::release-notes/8.8.0.asciidoc[]
+include::release-notes/8.7.1.asciidoc[]
 include::release-notes/8.7.0.asciidoc[]
 include::release-notes/8.6.2.asciidoc[]
 include::release-notes/8.6.1.asciidoc[]

--- a/docs/reference/release-notes/8.7.1.asciidoc
+++ b/docs/reference/release-notes/8.7.1.asciidoc
@@ -1,0 +1,48 @@
+[[release-notes-8.7.1]]
+== {es} version 8.7.1
+
+Also see <<breaking-changes-8.7,Breaking changes in 8.7>>.
+
+[[bug-8.7.1]]
+[float]
+=== Bug fixes
+
+Allocation::
+* Compute balancer threshold based on max shard size {es-pull}95090[#95090]
+* Use applied state after `DiskThresholdMonitor` reroute {es-pull}94916[#94916]
+* Weaken node-replacement decider during reconciliation {es-pull}95070[#95070]
+
+ILM+SLM::
+* Downsample ILM action should skip non-time-series indices {es-pull}94835[#94835] (issue: {es-issue}93123[#93123])
+
+Ingest Node::
+* Fix async enrich execution prematurely releases enrich policy lock {es-pull}94702[#94702] (issue: {es-issue}94690[#94690])
+
+Network::
+* Fix off-by-one bug in `RecyclerBytesStreamOutput` {es-pull}95036[#95036]
+
+Recovery::
+* Async creation of `IndexShard` instances {es-pull}94545[#94545]
+
+Search::
+* Return 200 when closing empty PIT or scroll {es-pull}94708[#94708]
+
+Stats::
+* Fix _cluster/stats `.nodes.fs` deduplication {es-pull}94798[#94798] (issue: {es-issue}24472[#24472])
+* Fix `FsInfo` device deduplication {es-pull}94744[#94744]
+
+[[enhancement-8.7.1]]
+[float]
+=== Enhancements
+
+Authorization::
+* Reuse `FieldPermissionsCache` in Role parsing {es-pull}94931[#94931]
+
+[[upgrade-8.7.1]]
+[float]
+=== Upgrades
+
+Packaging::
+* Upgrade bundled JDK to Java 20 {es-pull}94600[#94600]
+
+

--- a/docs/reference/release-notes/8.7.1.asciidoc
+++ b/docs/reference/release-notes/8.7.1.asciidoc
@@ -3,6 +3,19 @@
 
 Also see <<breaking-changes-8.7,Breaking changes in 8.7>>.
 
+[[known-issues-8.7.1]]
+[float]
+=== Known issues
+
+* `ArrayIndexOutOfBoundsException` may be thrown while creating a transport message
++
+Certain sequences of writes and seeks to the buffer used to create a transport
+message may encounter an alignment bug which results in an
+`ArrayIndexOutOfBoundsException`, preventing the transport message from being
+sent.
++
+This issue is fixed in 8.8.0.
+
 [[bug-8.7.1]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Also includes #96448 which is how @DaveCTurner noticed that the forward port was missing in the first place.