### PR TITLE
Made the plugin return the exponent if it samples data.

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/EventsIndex.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/EventsIndex.java
@@ -23,7 +23,7 @@ public final class EventsIndex {
 
     private static final int MAX_EXPONENT = 11;
 
-    public static final EventsIndex FULL_INDEX = new EventsIndex(ALL_EVENTS, 1, 1);
+    public static final EventsIndex FULL_INDEX = new EventsIndex(ALL_EVENTS, 1, 0);
 
     // Start with counting the results in the index down-sampled by 5^6.
     // That is in the middle of our down-sampled indexes.

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -178,6 +178,9 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
+        // The sampling exponent as we use it in the code starts at 1, but "1" actually means
+        // "all the data", so logically it is exponent 0.
+        double samplingRate = Math.pow(0.2, samplingExponent - 1);
         if (error != null) {
             return Iterators.concat(
                 ChunkedToXContentHelper.startObject(),
@@ -192,8 +195,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
                 optional("executables", executables, ChunkedToXContentHelper::map),
                 optional("stack_trace_events", stackTraceEvents, ChunkedToXContentHelper::map),
                 Iterators.single((b, p) -> b.field("total_frames", totalFrames)),
-                Iterators.single((b, p) -> b.field("is_sampled", isSampled)),
-                Iterators.single((b, p) -> b.field("sampling_exponent", samplingExponent)),
+                Iterators.single((b, p) -> b.field("sampling_rate", samplingRate)),
                 ChunkedToXContentHelper.endObject()
             );
         }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -196,7 +196,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
                 Iterators.single((b, p) -> b.field("sampling_exponent", samplingExponent)),
                 ChunkedToXContentHelper.endObject()
             );
-        }
+       }
     }
 
     private <T> Iterator<? extends ToXContent> optional(

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -179,10 +179,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
         // Calculate the sample rate.
-        double samplingRate = 0.0;
-        if (samplingExponent != 0) {
-            samplingRate = Math.pow(0.2, samplingExponent);
-        }
+        final double samplingRate = samplingExponent == 0 ? 1.0 : Math.pow(0.2, samplingExponent);
         if (error != null) {
             return Iterators.concat(
                 ChunkedToXContentHelper.startObject(),

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -178,9 +178,11 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-        // The sampling exponent as we use it in the code starts at 1, but "1" actually means
-        // "all the data", so logically it is exponent 0.
-        double samplingRate = Math.pow(0.2, samplingExponent - 1);
+        // Calculate the sample rate.
+        double samplingRate = 0.0;
+        if (samplingExponent != 0) {
+            samplingRate = Math.pow(0.2, samplingExponent);
+        }
         if (error != null) {
             return Iterators.concat(
                 ChunkedToXContentHelper.startObject(),

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -32,6 +32,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
     @Nullable
     private final Map<String, Integer> stackTraceEvents;
     private final int totalFrames;
+    private final boolean isSampled;
+    private final int samplingExponent;
     @Nullable
     private final Exception error;
 
@@ -62,6 +64,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         this.executables = in.readBoolean() ? in.readMap(StreamInput::readString, StreamInput::readString) : null;
         this.stackTraceEvents = in.readBoolean() ? in.readMap(StreamInput::readString, StreamInput::readInt) : null;
         this.totalFrames = in.readInt();
+        this.isSampled = in.readBoolean();
+        this.samplingExponent = in.readInt();
         this.error = in.readBoolean() ? in.readException() : null;
     }
 
@@ -70,13 +74,15 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         Map<String, StackFrame> stackFrames,
         Map<String, String> executables,
         Map<String, Integer> stackTraceEvents,
-        int totalFrames
+        int totalFrames,
+        boolean isSampled,
+        int samplingExponent
     ) {
-        this(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, null);
+        this(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, isSampled, samplingExponent, null);
     }
 
     public GetProfilingResponse(Exception error) {
-        this(null, null, null, null, 0, error);
+        this(null, null, null, null, 0, false, 0, error);
     }
 
     private GetProfilingResponse(
@@ -85,6 +91,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         Map<String, String> executables,
         Map<String, Integer> stackTraceEvents,
         int totalFrames,
+        boolean isSampled,
+        int samplingExponent,
         Exception error
     ) {
         this.stackTraces = stackTraces;
@@ -92,6 +100,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         this.executables = executables;
         this.stackTraceEvents = stackTraceEvents;
         this.totalFrames = totalFrames;
+        this.isSampled = isSampled;
+        this.samplingExponent = samplingExponent;
         this.error = error;
     }
 
@@ -133,6 +143,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
             out.writeBoolean(false);
         }
         out.writeInt(totalFrames);
+        out.writeBoolean(isSampled);
+        out.writeInt(samplingExponent);
         if (error != null) {
             out.writeBoolean(true);
             out.writeException(error);
@@ -194,6 +206,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
             builder.endObject();
         }
         builder.field("total_frames", totalFrames);
+        builder.field("is_sampled", isSampled);
+        builder.field("sampling_exponent", samplingExponent);
         if (error != null) {
             builder.startObject("error");
             ElasticsearchException.generateThrowableXContent(builder, params, error);
@@ -213,6 +227,8 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
         }
         GetProfilingResponse response = (GetProfilingResponse) o;
         return totalFrames == response.totalFrames
+            && isSampled == response.isSampled
+            && samplingExponent == response.samplingExponent
             && Objects.equals(stackTraces, response.stackTraces)
             && Objects.equals(stackFrames, response.stackFrames)
             && Objects.equals(executables, response.executables)
@@ -222,6 +238,6 @@ public class GetProfilingResponse extends ActionResponse implements StatusToXCon
 
     @Override
     public int hashCode() {
-        return Objects.hash(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, error);
+        return Objects.hash(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, isSampled, samplingExponent, error);
     }
 }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -178,7 +178,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
 
     @Override
     public Iterator<? extends ToXContent> toXContentChunked(ToXContent.Params params) {
-       if (error != null) {
+        if (error != null) {
             return Iterators.concat(
                 ChunkedToXContentHelper.startObject(),
                 Iterators.single((b, p) -> ElasticsearchException.generateFailureXContent(b, params, error, true)),
@@ -196,7 +196,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
                 Iterators.single((b, p) -> b.field("sampling_exponent", samplingExponent)),
                 ChunkedToXContentHelper.endObject()
             );
-       }
+        }
     }
 
     private <T> Iterator<? extends ToXContent> optional(
@@ -205,7 +205,7 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
         BiFunction<String, Map<String, T>, Iterator<? extends ToXContent>> supplier
     ) {
         return (values != null) ? supplier.apply(name, values) : Collections.emptyIterator();
-   }
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -127,7 +127,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         long start = System.nanoTime();
         GetProfilingResponseBuilder responseBuilder = new GetProfilingResponseBuilder();
         int exp = eventsIndex.getExponent();
-        responseBuilder.setIsSampled(exp != 1);
+        responseBuilder.setIsSampled(exp != 0);
         responseBuilder.setSamplingExponent(exp);
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -126,6 +126,9 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
     ) {
         long start = System.nanoTime();
         GetProfilingResponseBuilder responseBuilder = new GetProfilingResponseBuilder();
+        int exp = eventsIndex.getExponent();
+        responseBuilder.setIsSampled(exp != 1);
+        responseBuilder.setSamplingExponent(exp);
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setQuery(request.getQuery())
@@ -413,6 +416,8 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         private Map<String, StackFrame> stackFrames;
         private Map<String, String> executables;
         private Map<String, Integer> stackTraceEvents;
+        private boolean isSampled;
+        private int samplingExponent;
         private Exception error;
 
         public void setStackTraces(Map<String, StackTrace> stackTraces) {
@@ -439,6 +444,14 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             return stackTraceEvents;
         }
 
+        public void setIsSampled(boolean isSampled) {
+            this.isSampled = isSampled;
+        }
+
+        public void setSamplingExponent(int exp) {
+            this.samplingExponent = exp;
+        }
+
         public void setError(Exception error) {
             this.error = error;
         }
@@ -447,7 +460,8 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             if (error != null) {
                 return new GetProfilingResponse(error);
             } else {
-                return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames);
+                return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames,
+                    isSampled, samplingExponent);
             }
         }
     }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -462,14 +462,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             if (error != null) {
                 return new GetProfilingResponse(error);
             } else {
-                return new GetProfilingResponse(
-                    stackTraces,
-                    stackFrames,
-                    executables,
-                    stackTraceEvents,
-                    totalFrames,
-                    samplingRate
-                );
+                return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, samplingRate);
             }
         }
     }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -126,6 +126,9 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
     ) {
         long start = System.nanoTime();
         GetProfilingResponseBuilder responseBuilder = new GetProfilingResponseBuilder();
+        int exp = eventsIndex.getExponent();
+        responseBuilder.setIsSampled(exp != 1);
+        responseBuilder.setSamplingExponent(exp);
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setQuery(request.getQuery())
@@ -421,6 +424,8 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         private Map<String, StackFrame> stackFrames;
         private Map<String, String> executables;
         private Map<String, Integer> stackTraceEvents;
+        private boolean isSampled;
+        private int samplingExponent;
         private Exception error;
 
         public void setStackTraces(Map<String, StackTrace> stackTraces) {
@@ -447,6 +452,14 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             return stackTraceEvents;
         }
 
+        public void setIsSampled(boolean isSampled) {
+            this.isSampled = isSampled;
+        }
+
+        public void setSamplingExponent(int exp) {
+            this.samplingExponent = exp;
+        }
+
         public void setError(Exception error) {
             this.error = error;
         }
@@ -455,7 +468,8 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             if (error != null) {
                 return new GetProfilingResponse(error);
             } else {
-                return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames);
+                return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames,
+                    isSampled, samplingExponent);
             }
         }
     }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -127,7 +127,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         long start = System.nanoTime();
         GetProfilingResponseBuilder responseBuilder = new GetProfilingResponseBuilder();
         int exp = eventsIndex.getExponent();
-        responseBuilder.setSamplingRate(eventsIndex.getSampleRate());
+        responseBuilder.setSampleRate(eventsIndex.getSampleRate());
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setQuery(request.getQuery())
@@ -450,7 +450,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             return stackTraceEvents;
         }
 
-        public void setSamplingRate(double rate) {
+        public void setSampleRate(double rate) {
             this.samplingRate = rate;
         }
 

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -127,8 +127,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         long start = System.nanoTime();
         GetProfilingResponseBuilder responseBuilder = new GetProfilingResponseBuilder();
         int exp = eventsIndex.getExponent();
-        responseBuilder.setIsSampled(exp != 0);
-        responseBuilder.setSamplingExponent(exp);
+        responseBuilder.setSamplingRate(eventsIndex.getSampleRate());
         client.prepareSearch(eventsIndex.getName())
             .setTrackTotalHits(false)
             .setQuery(request.getQuery())
@@ -424,8 +423,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
         private Map<String, StackFrame> stackFrames;
         private Map<String, String> executables;
         private Map<String, Integer> stackTraceEvents;
-        private boolean isSampled;
-        private int samplingExponent;
+        private double samplingRate;
         private Exception error;
 
         public void setStackTraces(Map<String, StackTrace> stackTraces) {
@@ -452,12 +450,8 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             return stackTraceEvents;
         }
 
-        public void setIsSampled(boolean isSampled) {
-            this.isSampled = isSampled;
-        }
-
-        public void setSamplingExponent(int exp) {
-            this.samplingExponent = exp;
+        public void setSamplingRate(double rate) {
+            this.samplingRate = rate;
         }
 
         public void setError(Exception error) {
@@ -474,8 +468,7 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
                     executables,
                     stackTraceEvents,
                     totalFrames,
-                    isSampled,
-                    samplingExponent
+                    samplingRate
                 );
             }
         }

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/TransportGetProfilingAction.java
@@ -468,8 +468,15 @@ public class TransportGetProfilingAction extends HandledTransportAction<GetProfi
             if (error != null) {
                 return new GetProfilingResponse(error);
             } else {
-                return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames,
-                    isSampled, samplingExponent);
+                return new GetProfilingResponse(
+                    stackTraces,
+                    stackFrames,
+                    executables,
+                    stackTraceEvents,
+                    totalFrames,
+                    isSampled,
+                    samplingExponent
+                );
             }
         }
     }

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -44,7 +44,7 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
         Map<String, String> executables = randomNullable(Map.of("QCCDqjSg3bMK1C4YRK6Tiw", "libc.so.6"));
         Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), randomIntBetween(1, 200)));
 
-        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames);
+        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, false, 1);
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -59,8 +59,8 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
 
     public void testChunking() {
         AbstractChunkedSerializingTestCase.assertChunkCount(createTestInstance(), instance -> {
-            // start, end, total_frames
-            int chunks = 3;
+            // start, end, total_frames, isSampling, exponent
+            int chunks = 5;
             chunks += size(instance.getExecutables());
             chunks += size(instance.getStackFrames());
             chunks += size(instance.getStackTraces());

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -59,8 +59,8 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
 
     public void testChunking() {
         AbstractChunkedSerializingTestCase.assertChunkCount(createTestInstance(), instance -> {
-            // start, end, total_frames, isSampling, exponent
-            int chunks = 5;
+            // start, end, total_frames, samplingrate
+            int chunks = 4;
             chunks += size(instance.getExecutables());
             chunks += size(instance.getStackFrames());
             chunks += size(instance.getStackTraces());

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -44,7 +44,7 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
         Map<String, String> executables = randomNullable(Map.of("QCCDqjSg3bMK1C4YRK6Tiw", "libc.so.6"));
         Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), randomIntBetween(1, 200)));
 
-        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, false, 1);
+        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, 1.0);
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/GetProfilingResponseTests.java
@@ -49,7 +49,7 @@ public class GetProfilingResponseTests extends AbstractWireSerializingTestCase<G
         Map<String, String> executables = randomNullable(Map.of("QCCDqjSg3bMK1C4YRK6Tiw", "libc.so.6"));
         Map<String, Integer> stackTraceEvents = randomNullable(Map.of(randomAlphaOfLength(12), randomIntBetween(1, 200)));
 
-        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames);
+        return new GetProfilingResponse(stackTraces, stackFrames, executables, stackTraceEvents, totalFrames, false, 1);
     }
 
     @Override

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/RestGetProfilingActionTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/RestGetProfilingActionTests.java
@@ -48,8 +48,7 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 0,
-                false,
-                0
+                1.0
             );
         });
         RestRequest profilingRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)
@@ -74,8 +73,7 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 0,
-                false,
-                0
+                0.0
             );
         });
         RestRequest profilingRequest = new FakeRestRequest.Builder(xContentRegistry()).withMethod(RestRequest.Method.POST)

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/RestGetProfilingActionTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/RestGetProfilingActionTests.java
@@ -47,6 +47,8 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                0,
+                false,
                 0
             );
         });
@@ -71,6 +73,8 @@ public class RestGetProfilingActionTests extends RestActionTestCase {
                 Collections.emptyMap(),
                 Collections.emptyMap(),
                 Collections.emptyMap(),
+                0,
+                false,
                 0
             );
         });


### PR DESCRIPTION
This change modifies the ES profiling plugin to also return information on whether a particular set of profiling events was subsampled, and the exponent of the sample.

The backend uses "stratified sampling", e.g. it stores events in different tiers with probability 0.2^0, 0.2^1, 0.2^2 (...), thinning out more and more. This means that any data obtained needs to be scaled accordingly, and the situations where data is extrapolated from sample needs to be made visible to the user.