### PR TITLE
Fix NPE when indexing a document that just has been deleted in a tsdb index

### DIFF
--- a/docs/changelog/96461.yaml
+++ b/docs/changelog/96461.yaml
@@ -1,0 +1,5 @@
+pr: 96461
+summary: Fix NPE when indexing a document that just has been deleted in a tsdb index
+area: TSDB
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
@@ -6,7 +6,7 @@
 
   - do:
       indices.create:
-        index: weather_sensors-dev
+        index: weather_sensors
         body:
           settings:
             index:
@@ -36,7 +36,7 @@
 
   - do:
       index:
-        index: weather_sensors-dev
+        index: weather_sensors
         body:
           "@timestamp": 2023-05-31T08:41:15.000Z
           sensor_id: SYKENET-000001
@@ -49,7 +49,7 @@
 
   - do:
       delete:
-        index: weather_sensors-dev
+        index: weather_sensors
         id: crxuhC8WO3aVdhvtAAABiHD35_g
   - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
   - match:   { result: deleted }
@@ -57,11 +57,11 @@
 
   - do:
       indices.flush:
-        index: weather_sensors-dev
+        index: weather_sensors
 
   - do:
       index:
-        index: weather_sensors-dev
+        index: weather_sensors
         body:
           "@timestamp": 2023-05-31T08:41:15.000Z
           sensor_id: SYKENET-000001

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
@@ -1,0 +1,73 @@
+---
+"basic tsdb delete":
+  - skip:
+      version: " - 8.8.99"
+      reason: fixed in 8.9.0
+
+  - do:
+      indices.create:
+        index: weather_sensors-dev
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [sensor_id, location]
+              time_series:
+                start_time: 2000-01-01T00:00:00.000Z
+                end_time: 2099-12-31T23:59:59.999Z
+              number_of_replicas: 0
+              number_of_shards: 1
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              humidity:
+                type: half_float
+                time_series_metric: gauge
+              location:
+                type: keyword
+                time_series_dimension: true
+              sensor_id:
+                type: keyword
+                time_series_dimension: true
+              temperature:
+                type: half_float
+                time_series_metric: gauge
+
+  - do:
+      index:
+        index: weather_sensors-dev
+        body:
+          "@timestamp": 2023-05-31T08:41:15.000Z
+          sensor_id: SYKENET-000001
+          location: swamp
+          temperature: 32.4
+          humidity: 88.9
+  - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
+  - match:   { result: created }
+  - match:   { _version: 1 }
+
+  - do:
+      delete:
+        index: weather_sensors-dev
+        id: crxuhC8WO3aVdhvtAAABiHD35_g
+  - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
+  - match:   { result: deleted }
+  - match:   { _version: 2 }
+
+  - do:
+      indices.flush:
+        index: weather_sensors-dev
+
+  - do:
+      index:
+        index: weather_sensors-dev
+        body:
+          "@timestamp": 2023-05-31T08:41:15.000Z
+          sensor_id: SYKENET-000001
+          location: swamp
+          temperature: 32.4
+          humidity: 88.9
+  - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
+  - match:   { result: created }
+  - match:   { _version: 3 }

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -94,7 +94,7 @@ final class PerThreadIDVersionAndSeqNoLookup {
         this.readerKey = readerKey;
 
         this.loadedTimestampRange = loadTimestampRange;
-        if (loadTimestampRange && reader.numDocs() != 0) {
+        if (loadTimestampRange && reader.getFieldInfos().fieldInfo(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD) != null) {
             PointValues tsPointValues = reader.getPointValues(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD);
             assert tsPointValues != null : "no timestamp field for reader:" + reader + " and parent:" + reader.getContext().parent.reader();
             minTimestamp = LongPoint.decodeDimension(tsPointValues.getMinPackedValue(), 0);

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -94,7 +94,7 @@ final class PerThreadIDVersionAndSeqNoLookup {
         this.readerKey = readerKey;
 
         this.loadedTimestampRange = loadTimestampRange;
-        if (loadTimestampRange) {
+        if (loadTimestampRange && reader.numDocs() != 0) {
             PointValues tsPointValues = reader.getPointValues(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD);
             assert tsPointValues != null : "no timestamp field for reader:" + reader + " and parent:" + reader.getContext().parent.reader();
             minTimestamp = LongPoint.decodeDimension(tsPointValues.getMinPackedValue(), 0);

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -94,6 +94,8 @@ final class PerThreadIDVersionAndSeqNoLookup {
         this.readerKey = readerKey;
 
         this.loadedTimestampRange = loadTimestampRange;
+        // Also check for the existence of the timestamp field, because sometimes a segment can only contain tombstone documents,
+        // which don't have any mapped fields (also not the timestamp field) and just some meta fields like _id, _seq_no etc.
         if (loadTimestampRange && reader.getFieldInfos().fieldInfo(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD) != null) {
             PointValues tsPointValues = reader.getPointValues(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD);
             assert tsPointValues != null : "no timestamp field for reader:" + reader + " and parent:" + reader.getContext().parent.reader();

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
@@ -164,5 +164,8 @@ public class VersionLookupTests extends ESTestCase {
         assertTrue(lookup.loadedTimestampRange);
         assertEquals(lookup.minTimestamp, 0L);
         assertEquals(lookup.maxTimestamp, Long.MAX_VALUE);
+        reader.close();
+        writer.close();
+        dir.close();
     }
 }

--- a/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/uid/VersionLookupTests.java
@@ -25,6 +25,7 @@ import org.elasticsearch.cluster.metadata.DataStream;
 import org.elasticsearch.common.lucene.Lucene;
 import org.elasticsearch.common.lucene.uid.VersionsAndSeqNoResolver.DocIdAndVersion;
 import org.elasticsearch.index.mapper.IdFieldMapper;
+import org.elasticsearch.index.mapper.ParsedDocument;
 import org.elasticsearch.index.mapper.SeqNoFieldMapper;
 import org.elasticsearch.index.mapper.VersionFieldMapper;
 import org.elasticsearch.test.ESTestCase;
@@ -151,5 +152,17 @@ public class VersionLookupTests extends ESTestCase {
         reader.close();
         writer.close();
         dir.close();
+    }
+
+    public void testLoadTimestampRangeWithDeleteTombstone() throws Exception {
+        Directory dir = newDirectory();
+        IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(Lucene.STANDARD_ANALYZER).setMergePolicy(NoMergePolicy.INSTANCE));
+        writer.addDocument(ParsedDocument.deleteTombstone("_id").docs().get(0));
+        DirectoryReader reader = DirectoryReader.open(writer);
+        LeafReaderContext segment = reader.leaves().get(0);
+        PerThreadIDVersionAndSeqNoLookup lookup = new PerThreadIDVersionAndSeqNoLookup(segment.reader(), IdFieldMapper.NAME, true);
+        assertTrue(lookup.loadedTimestampRange);
+        assertEquals(lookup.minTimestamp, 0L);
+        assertEquals(lookup.maxTimestamp, Long.MAX_VALUE);
     }
 }


### PR DESCRIPTION
Sometimes a segment only contains tombstone documents. In that case, loading min and max `@timestamp` field values can result into NPE. Because these documents don't have a `@timestamp` field.

This change fixes that by checking for the existence of the `@timestamp` field in the a segment's field infos.

Reproduction of the issue:

Create tsdb index:

```
PUT weather_sensors
{
    "mappings": {
        "properties": {
            "@timestamp": {
                "type": "date"
            },
            "humidity": {
                "type": "half_float",
                "time_series_metric": "gauge"
            },
            "location": {
                "type": "keyword",
                "time_series_dimension": true
            },
            "sensor_id": {
                "type": "keyword",
                "time_series_dimension": true
            },
            "temperature": {
                "type": "half_float",
                "time_series_metric": "gauge"
            }
        }
    },
    "settings": {
        "index": {
            "time_series": {
                "start_time": "2000-01-01T00:00:00.000Z",
                "end_time": "2099-12-31T23:59:59.999Z"
            },
            "routing_path": [
                "sensor_id",
                "location"
            ],
            "mode": "time_series",
            "codec": "best_compression",
            "number_of_shards": "1"
        }
    }
}
```

Index document:

```
POST weather_sensors/_doc
{
  "@timestamp": "2023-05-31T08:41:15.000Z",
  "sensor_id": "SYKENET-000001",
  "location": "swamp",
  "temperature": 32.4,
  "humidity": 88.9
}
```

Delete that document:

```
DELETE weather_sensors/_doc/crxuhC8WO3aVdhvtAAABiHD35_g
```

Index same document again:

```
POST weather_sensors/_doc
{
  "@timestamp": "2023-05-31T08:31:15.000Z",
  "sensor_id": "SYKENET-000001",
  "location": "swamp",
  "temperature": 42.4,
  "humidity": 88.9
}
```

Last api call results in the following error:

```
{
    "error": {
        "root_cause": [
            {
                "type": "null_pointer_exception",
                "reason": "Cannot invoke \"org.apache.lucene.index.CompositeReaderContext.reader()\" because \"org.apache.lucene.index.LeafReader.getContext().parent\" is null"
            }
        ],
        "type": "null_pointer_exception",
        "reason": "Cannot invoke \"org.apache.lucene.index.CompositeReaderContext.reader()\" because \"org.apache.lucene.index.LeafReader.getContext().parent\" is null"
    },
    "status": 500
}
```