### PR TITLE
[8.8] [Transform] Improve error message on transform `_update` conflict (#96432)

### DIFF
--- a/docs/changelog/96432.yaml
+++ b/docs/changelog/96432.yaml
@@ -1,0 +1,5 @@
+pr: 96432
+summary: Improve error message on transform `_update` conflict
+area: Transform
+type: bug
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformMessages.java
@@ -16,7 +16,8 @@ public class TransformMessages {
         "Timed out after [{0}] while waiting for transform [{1}] to stop";
     public static final String REST_STOP_TRANSFORM_WAIT_FOR_COMPLETION_INTERRUPT = "Interrupted while waiting for transform [{0}] to stop";
     public static final String REST_PUT_TRANSFORM_EXISTS = "Transform with id [{0}] already exists";
-    public static final String REST_UPDATE_TRANSFORM_CONFLICT = "Transform with id [{0}] got updated in the meantime. Please try again";
+    public static final String REST_UPDATE_TRANSFORM_CONFLICT =
+        "Cannot update transform id [{0}] due to a concurrent update conflict. Please retry.";
     public static final String REST_UNKNOWN_TRANSFORM = "Transform with id [{0}] could not be found";
     public static final String REST_STOP_TRANSFORM_WITHOUT_CONFIG =
         "Detected transforms with no config [{0}]. Use force to stop/delete them.";

--- a/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
+++ b/x-pack/plugin/transform/qa/single-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/transform/integration/TransformUpdateIT.java
@@ -221,7 +221,7 @@ public class TransformUpdateIT extends TransformRestTestCase {
                 assertThat(re.getResponse().getStatusLine().getStatusCode(), is(equalTo(409)));
                 assertThat(
                     re.getMessage(),
-                    containsString("Transform with id [" + transformId + "] got updated in the meantime. Please try again")
+                    containsString("Cannot update transform id [" + transformId + "] due to a concurrent update conflict. Please retry.")
                 );
             }
         }


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [Transform] Improve error message on transform `_update` conflict (#96432)