### PR TITLE
[8.8] Fix NPE when indexing a document that just has been deleted in a tsdb index (#96461)

### DIFF
--- a/docs/changelog/96461.yaml
+++ b/docs/changelog/96461.yaml
@@ -1,0 +1,5 @@
+pr: 96461
+summary: Fix NPE when indexing a document that just has been deleted in a tsdb index
+area: TSDB
+type: bug
+issues: []

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
@@ -1,8 +1,8 @@
 ---
 "basic tsdb delete":
   - skip:
-      version: " - 8.8.99"
-      reason: fixed in 8.9.0
+      version: " - 8.8.0"
+      reason: fixed in 8.8.1
 
   - do:
       indices.create:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/delete/70_tsdb.yml
@@ -1,0 +1,73 @@
+---
+"basic tsdb delete":
+  - skip:
+      version: " - 8.8.99"
+      reason: fixed in 8.9.0
+
+  - do:
+      indices.create:
+        index: weather_sensors
+        body:
+          settings:
+            index:
+              mode: time_series
+              routing_path: [sensor_id, location]
+              time_series:
+                start_time: 2000-01-01T00:00:00.000Z
+                end_time: 2099-12-31T23:59:59.999Z
+              number_of_replicas: 0
+              number_of_shards: 1
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              humidity:
+                type: half_float
+                time_series_metric: gauge
+              location:
+                type: keyword
+                time_series_dimension: true
+              sensor_id:
+                type: keyword
+                time_series_dimension: true
+              temperature:
+                type: half_float
+                time_series_metric: gauge
+
+  - do:
+      index:
+        index: weather_sensors
+        body:
+          "@timestamp": 2023-05-31T08:41:15.000Z
+          sensor_id: SYKENET-000001
+          location: swamp
+          temperature: 32.4
+          humidity: 88.9
+  - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
+  - match:   { result: created }
+  - match:   { _version: 1 }
+
+  - do:
+      delete:
+        index: weather_sensors
+        id: crxuhC8WO3aVdhvtAAABiHD35_g
+  - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
+  - match:   { result: deleted }
+  - match:   { _version: 2 }
+
+  - do:
+      indices.flush:
+        index: weather_sensors
+
+  - do:
+      index:
+        index: weather_sensors
+        body:
+          "@timestamp": 2023-05-31T08:41:15.000Z
+          sensor_id: SYKENET-000001
+          location: swamp
+          temperature: 32.4
+          humidity: 88.9
+  - match:   { _id: crxuhC8WO3aVdhvtAAABiHD35_g }
+  - match:   { result: created }
+  - match:   { _version: 3 }

--- a/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/uid/PerThreadIDVersionAndSeqNoLookup.java
@@ -94,7 +94,9 @@ final class PerThreadIDVersionAndSeqNoLookup {
         this.readerKey = readerKey;
 
         this.loadedTimestampRange = loadTimestampRange;
-        if (loadTimestampRange) {
+        // Also check for the existence of the timestamp field, because sometimes a segment can only contain tombstone documents,
+        // which don't have any mapped fields (also not the timestamp field) and just some meta fields like _id, _seq_no etc.
+        if (loadTimestampRange && reader.getFieldInfos().fieldInfo(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD) != null) {
             PointValues tsPointValues = reader.getPointValues(DataStream.TimestampField.FIXED_TIMESTAMP_FIELD);
             assert tsPointValues != null : "no timestamp field for reader:" + reader + " and parent:" + reader.getContext().parent.reader();
             minTimestamp = LongPoint.decodeDimension(tsPointValues.getMinPackedValue(), 0);


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix NPE when indexing a document that just has been deleted in a tsdb index (#96461)