### PR TITLE
Update to the latest form the `data_lifecycle` telemetry section

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -331,14 +331,12 @@ GET /_xpack/usage
   "data_lifecycle" : {
     "available": true,
     "enabled": true,
-    "lifecycle": {
-        "count": 0,
-        "default_rollover_used": true,
-        "retention": {
-            "minimum_millis": 0,
-            "maximum_millis": 0,
-            "average_millis": 0.0
-        }
+    "count": 0,
+    "default_rollover_used": true,
+    "retention": {
+        "minimum_millis": 0,
+        "maximum_millis": 0,
+        "average_millis": 0.0
     }
   },
   "data_tiers" : {


### PR DESCRIPTION
The docs about the `xpack/usage` had an outdated version of the `data_lifecycle` section. This test was ignored on snapshot builds and only took effect on release builds that's why we didn't see it sooner.

Closes #96471