### PR TITLE
Become candidate on publication failure

### DIFF
--- a/docs/changelog/96490.yaml
+++ b/docs/changelog/96490.yaml
@@ -1,0 +1,6 @@
+pr: 96490
+summary: Become candidate on publication failure
+area: Cluster Coordination
+type: bug
+issues:
+ - 96273

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/Coordinator.java
@@ -1548,6 +1548,9 @@ public class Coordinator extends AbstractLifecycleComponent implements ClusterSt
                     followersChecker.setCurrentNodes(publishNodes);
                     lagDetector.setTrackedNodes(publishNodes);
                     publication.start(followersChecker.getFaultyNodes());
+                } catch (Exception e) {
+                    assert currentPublication.isEmpty() : e; // should not fail after setting currentPublication
+                    becomeCandidate("publish");
                 } finally {
                     publicationContext.decRef();
                 }


### PR DESCRIPTION
If the publication fails before starting (e.g. due to one of the precondition checks in `CoordinationState#handleClientValue`) then we must explicitly stand down as leader.

Closes #96273