### PR TITLE
[8.8] [Enterprise Search] xpack/usage analytics collections count (#96063)

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
@@ -41,7 +41,7 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
     public EnterpriseSearchFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
         this.searchApplicationsUsage = in.readMap();
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_1)) {
             this.analyticsCollectionsUsage = in.readMap();
         } else {
             this.analyticsCollectionsUsage = Collections.emptyMap();
@@ -52,7 +52,7 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeGenericMap(searchApplicationsUsage);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_1)) {
             out.writeGenericMap(analyticsCollectionsUsage);
         }
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
@@ -15,28 +15,46 @@ import org.elasticsearch.xpack.core.XPackFeatureSet;
 import org.elasticsearch.xpack.core.XPackField;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 
 public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public static final String SEARCH_APPLICATIONS = "search_applications";
-    private final Map<String, Object> searchApplicationsStats;
+    public static final String ANALYTICS_COLLECTIONS = "analytics_collections";
+    public static final String COUNT = "count";
+    private final Map<String, Object> searchApplicationsUsage;
+    private final Map<String, Object> analyticsCollectionsUsage;
 
-    public EnterpriseSearchFeatureSetUsage(boolean available, boolean enabled, Map<String, Object> searchApplicationsStats) {
+    public EnterpriseSearchFeatureSetUsage(
+        boolean available,
+        boolean enabled,
+        Map<String, Object> searchApplicationsUsage,
+        Map<String, Object> analyticsCollectionsUsage
+    ) {
         super(XPackField.ENTERPRISE_SEARCH, available, enabled);
-        this.searchApplicationsStats = Objects.requireNonNull(searchApplicationsStats);
+        this.searchApplicationsUsage = Objects.requireNonNull(searchApplicationsUsage);
+        this.analyticsCollectionsUsage = Objects.requireNonNull(analyticsCollectionsUsage);
     }
 
     public EnterpriseSearchFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        this.searchApplicationsStats = in.readMap();
+        this.searchApplicationsUsage = in.readMap();
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+            this.analyticsCollectionsUsage = in.readMap();
+        } else {
+            this.analyticsCollectionsUsage = Collections.emptyMap();
+        }
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
-        out.writeGenericMap(searchApplicationsStats);
+        out.writeGenericMap(searchApplicationsUsage);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+            out.writeGenericMap(analyticsCollectionsUsage);
+        }
     }
 
     @Override
@@ -47,7 +65,8 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
     @Override
     protected void innerXContent(XContentBuilder builder, Params params) throws IOException {
         super.innerXContent(builder, params);
-        builder.field(SEARCH_APPLICATIONS, searchApplicationsStats);
+        builder.field(SEARCH_APPLICATIONS, searchApplicationsUsage);
+        builder.field(ANALYTICS_COLLECTIONS, analyticsCollectionsUsage);
     }
 
     @Override
@@ -55,15 +74,20 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         EnterpriseSearchFeatureSetUsage that = (EnterpriseSearchFeatureSetUsage) o;
-        return Objects.equals(searchApplicationsStats, that.searchApplicationsStats);
+        return Objects.equals(searchApplicationsUsage, that.searchApplicationsUsage)
+            && Objects.equals(analyticsCollectionsUsage, that.analyticsCollectionsUsage);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(searchApplicationsStats);
+        return Objects.hash(searchApplicationsUsage, analyticsCollectionsUsage);
     }
 
-    public Map<String, Object> getSearchApplicationsStats() {
-        return searchApplicationsStats;
+    public Map<String, Object> getSearchApplicationsUsage() {
+        return searchApplicationsUsage;
+    }
+
+    public Map<String, Object> getAnalyticsCollectionsUsage() {
+        return analyticsCollectionsUsage;
     }
 }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsageSerializingTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsageSerializingTests.java
@@ -19,19 +19,25 @@ public class EnterpriseSearchFeatureSetUsageSerializingTests extends AbstractWir
     @Override
     protected EnterpriseSearchFeatureSetUsage createTestInstance() {
         Map<String, Object> searchApplicationsStats = new HashMap<>();
-        searchApplicationsStats.put("count", randomLongBetween(0, 100000));
-        return new EnterpriseSearchFeatureSetUsage(true, true, searchApplicationsStats);
+        Map<String, Object> analyticsCollectionsStats = new HashMap<>();
+        searchApplicationsStats.put(EnterpriseSearchFeatureSetUsage.COUNT, randomLongBetween(0, 100000));
+        analyticsCollectionsStats.put(EnterpriseSearchFeatureSetUsage.COUNT, randomLongBetween(0, 100000));
+        return new EnterpriseSearchFeatureSetUsage(true, true, searchApplicationsStats, analyticsCollectionsStats);
     }
 
     @Override
     protected EnterpriseSearchFeatureSetUsage mutateInstance(EnterpriseSearchFeatureSetUsage instance) throws IOException {
-        long searchApplicationsCount = (long) instance.getSearchApplicationsStats().get("count");
+        long searchApplicationsCount = (long) instance.getSearchApplicationsUsage().get(EnterpriseSearchFeatureSetUsage.COUNT);
         searchApplicationsCount = randomValueOtherThan(searchApplicationsCount, () -> randomLongBetween(0, 100000));
+        long analyticsCollectionsCount = (long) instance.getAnalyticsCollectionsUsage().get(EnterpriseSearchFeatureSetUsage.COUNT);
+        analyticsCollectionsCount = randomValueOtherThan(analyticsCollectionsCount, () -> randomLongBetween(0, 100000));
 
         Map<String, Object> searchApplicationsStats = new HashMap<>();
+        Map<String, Object> analyticsCollectionsStats = new HashMap<>();
         searchApplicationsStats.put("count", searchApplicationsCount);
+        analyticsCollectionsStats.put("count", analyticsCollectionsCount);
 
-        return new EnterpriseSearchFeatureSetUsage(true, true, searchApplicationsStats);
+        return new EnterpriseSearchFeatureSetUsage(true, true, searchApplicationsStats, analyticsCollectionsStats);
     }
 
     @Override

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/100_usage.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/100_usage.yml
@@ -34,7 +34,8 @@ teardown:
     enterprise_search: {
       enabled: true,
       available: true,
-      search_applications: { count: 0 }
+      search_applications: { count: 0 },
+      analytics_collections: { count: 0 }
     }
   }
 
@@ -51,7 +52,8 @@ teardown:
     enterprise_search: {
       enabled: true,
       available: true,
-      search_applications: { count: 1 }
+      search_applications: { count: 1 },
+      analytics_collections: { count: 0 }
     }
   }
 
@@ -62,13 +64,18 @@ teardown:
           indices: [ "test-index1" ]
 
   - do:
+      search_application.put_behavioral_analytics:
+        name: test-analytics-collection
+
+  - do:
       xpack.usage: {}
 
   - match: {
     enterprise_search: {
       enabled: true,
       available: true,
-      search_applications: { count: 2 }
+      search_applications: { count: 2 },
+      analytics_collections: { count: 1 }
     }
   }
 
@@ -83,6 +90,23 @@ teardown:
     enterprise_search: {
       enabled: true,
       available: true,
-      search_applications: { count: 1 }
+      search_applications: { count: 1 },
+      analytics_collections: { count: 1 }
+    }
+  }
+
+  - do:
+      search_application.delete_behavioral_analytics:
+        name: test-analytics-collection
+
+  - do:
+      xpack.usage: {}
+
+  - match: {
+    enterprise_search: {
+      enabled: true,
+      available: true,
+      search_applications: { count: 1 },
+      analytics_collections: { count: 0 }
     }
   }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[Enterprise Search] xpack/usage analytics collections count (#96063)](https://github.com/elastic/elasticsearch/pull/96063)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)