### PR TITLE
[8.8] add analytics_collections to ent search usage test (#96385)

### DIFF
--- a/docs/reference/rest-api/usage.asciidoc
+++ b/docs/reference/rest-api/usage.asciidoc
@@ -413,6 +413,9 @@ GET /_xpack/usage
     "enabled": true,
     "search_applications" : {
       "count": 0
+    },
+    "analytics_collections": {
+      "count": 0
     }
   }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [add analytics_collections to ent search usage test (#96385)](https://github.com/elastic/elasticsearch/pull/96385)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)