### PR TITLE
Fix registry unsupported pipeline update

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/template/IndexTemplateRegistry.java
@@ -185,6 +185,10 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
             return;
         }
 
+        if (isClusterReady(event) == false) {
+            return;
+        }
+
         // if this node is newer than the master node, we probably need to add the template, which might be newer than the
         // template the master node has, so we need potentially add new templates despite being not the master node
         DiscoveryNode localNode = event.state().getNodes().getLocalNode();
@@ -195,6 +199,14 @@ public abstract class IndexTemplateRegistry implements ClusterStateListener {
             addTemplatesIfMissing(state);
             addIndexLifecyclePoliciesIfMissing(state);
         }
+    }
+
+    /**
+     * A method that can be overridden to add additional conditions to be satisfied
+     * before installing the template registry components.
+     */
+    protected boolean isClusterReady(ClusterChangedEvent event) {
+        return true;
     }
 
     /**

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -406,7 +406,6 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
         assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getIngestPipelines().size())));
     }
 
-
     public void testThatNothingIsInstalledWhenAllNodesAreNotUpdated() {
         DiscoveryNode updatedNode = TestDiscoveryNode.create("updatedNode");
         DiscoveryNode outdatedNode = TestDiscoveryNode.create("outdatedNode", ESTestCase.buildNewFakeTransportAddress(), Version.V_8_7_0);
@@ -425,7 +424,6 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
         registry.clusterChanged(event);
     }
-
 
     // -------------
 

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.application.analytics;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -404,6 +405,27 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
         registry.clusterChanged(event);
         assertBusy(() -> assertThat(calledTimes.get(), equalTo(registry.getIngestPipelines().size())));
     }
+
+
+    public void testThatNothingIsInstalledWhenAllNodesAreNotUpdated() {
+        DiscoveryNode updatedNode = TestDiscoveryNode.create("updatedNode");
+        DiscoveryNode outdatedNode = TestDiscoveryNode.create("outdatedNode", ESTestCase.buildNewFakeTransportAddress(), Version.V_8_7_0);
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .localNodeId("updatedNode")
+            .masterNodeId("updatedNode")
+            .add(updatedNode)
+            .add(outdatedNode)
+            .build();
+
+        client.setVerifier((a, r, l) -> {
+            fail("if some cluster mode are not updated to at least v.8.8.0 nothing should happen");
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
+        registry.clusterChanged(event);
+    }
+
 
     // -------------
 

--- a/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
+++ b/x-pack/plugin/stack/src/main/java/org/elasticsearch/xpack/stack/StackTemplateRegistry.java
@@ -9,7 +9,9 @@ package org.elasticsearch.xpack.stack;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.Version;
 import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.ClusterChangedEvent;
 import org.elasticsearch.cluster.metadata.ComponentTemplate;
 import org.elasticsearch.cluster.metadata.ComposableIndexTemplate;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -35,6 +37,9 @@ import java.util.stream.Stream;
 
 public class StackTemplateRegistry extends IndexTemplateRegistry {
     private static final Logger logger = LogManager.getLogger(StackTemplateRegistry.class);
+
+    // Current version of the registry requires all nodes to be at least 8.9.0.
+    public static final Version MIN_NODE_VERSION = Version.V_8_9_0;
 
     // The stack template registry version. This number must be incremented when we make changes
     // to built-in templates.
@@ -252,5 +257,14 @@ public class StackTemplateRegistry extends IndexTemplateRegistry {
         // are only installed via elected master node then the APIs are always
         // there and the ActionNotFoundTransportException errors are then prevented.
         return true;
+    }
+
+    @Override
+    protected boolean isClusterReady(ClusterChangedEvent event) {
+        // Ensure current version of the components are installed only once all nodes are updated to 8.9.0.
+        // This is necessary to prevent an error caused nby the usage of the ignore_missing_pipeline property
+        // in the pipeline processor, which has been introduced only in 8.9.0
+        Version minNodeVersion = event.state().nodes().getMinNodeVersion();
+        return minNodeVersion.onOrAfter(MIN_NODE_VERSION);
     }
 }

--- a/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
+++ b/x-pack/plugin/stack/src/test/java/org/elasticsearch/xpack/stack/StackTemplateRegistryTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.stack;
 
+import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -441,6 +442,25 @@ public class StackTemplateRegistryTests extends ESTestCase {
             Collections.singletonMap(StackTemplateRegistry.LOGS_INDEX_TEMPLATE_NAME, null),
             nodes
         );
+        registry.clusterChanged(event);
+    }
+
+    public void testThatNothingIsInstalledWhenAllNodesAreNotUpdated() {
+        DiscoveryNode updatedNode = TestDiscoveryNode.create("updatedNode");
+        DiscoveryNode outdatedNode = TestDiscoveryNode.create("outdatedNode", ESTestCase.buildNewFakeTransportAddress(), Version.V_8_8_0);
+        DiscoveryNodes nodes = DiscoveryNodes.builder()
+            .localNodeId("updatedNode")
+            .masterNodeId("updatedNode")
+            .add(updatedNode)
+            .add(outdatedNode)
+            .build();
+
+        client.setVerifier((a, r, l) -> {
+            fail("if some cluster mode are not updated to at least v.8.9.0 nothing should happen");
+            return null;
+        });
+
+        ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), nodes);
         registry.clusterChanged(event);
     }
 

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MLModelDeploymentsUpgradeIT.java
@@ -112,21 +112,10 @@ public class MLModelDeploymentsUpgradeIT extends AbstractUpgradeTestCase {
                     request.addParameter("wait_for_status", "yellow");
                     request.addParameter("timeout", "70s");
                 }));
-
-                // Workaround for an upgrade test failure where an ingest
-                // pipeline config cannot be parsed by older nodes:
-                // https://github.com/elastic/elasticsearch/issues/95766
-                //
-                // In version 8.3.1 ml stopped parsing the full ingest
-                // pipeline configuration so will avoid this problem.
-                // TODO remove this check once https://github.com/elastic/elasticsearch/issues/95766
-                // is resolved
-                if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_3_1)) {
-                    waitForDeploymentStarted(modelId);
-                    // attempt inference on new and old nodes multiple times
-                    for (int i = 0; i < 10; i++) {
-                        assertInfer(modelId);
-                    }
+                waitForDeploymentStarted(modelId);
+                // attempt inference on new and old nodes multiple times
+                for (int i = 0; i < 10; i++) {
+                    assertInfer(modelId);
                 }
             }
             case UPGRADED -> {

--- a/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
+++ b/x-pack/qa/rolling-upgrade/src/test/java/org/elasticsearch/upgrades/MlTrainedModelsUpgradeIT.java
@@ -74,19 +74,8 @@ public class MlTrainedModelsUpgradeIT extends AbstractUpgradeTestCase {
                     request.addParameter("timeout", "70s");
                 }));
                 List<String> modelIds = getTrainedModels();
-
-                // Workaround for an upgrade test failure where an ingest
-                // pipeline config cannot be parsed by older nodes:
-                // https://github.com/elastic/elasticsearch/issues/95766
-                //
-                // In version 8.3.1 ml stopped parsing the full ingest
-                // pipeline configuration so will avoid this problem.
-                // TODO remove this check once https://github.com/elastic/elasticsearch/issues/95766
-                // is resolved
-                if (UPGRADE_FROM_VERSION.onOrAfter(Version.V_8_3_1)) {
-                    // Test that stats are serializable and can be gathered
-                    getTrainedModelStats();
-                }
+                // Test that stats are serializable and can be gathered
+                getTrainedModelStats();
                 // Verify that the pipelines still work and inference is possible
                 testInfer(modelIds);
             }


### PR DESCRIPTION
## Closes: https://github.com/elastic/elasticsearch/issues/95766

The update tests were failing because pipeline are using new processor config that have been introduced recently.

- behavioral analytics pipeline is using the `ignore_missing` param of the `uri_parts` processor (introduced in `8.8.0`)
- log pipeline is using `ignore_missing_pipeline` param of the `pipeline` processor (introduced in `8.9.0`)

Both registry are now installed only when all the modes in the cluster are updated to the right version.