### PR TITLE
[8.8] Do not copy index.default_pipeline and index.final_pipeline (#96494)

### DIFF
--- a/docs/changelog/96494.yaml
+++ b/docs/changelog/96494.yaml
@@ -1,0 +1,6 @@
+pr: 96494
+summary: Do not copy `index.default_pipeline` and `index.final_pipeline`
+area: Rollup
+type: bug
+issues:
+ - 96478

--- a/x-pack/plugin/rollup/qa/rest/build.gradle
+++ b/x-pack/plugin/rollup/qa/rest/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 restResources {
   restApi {
-    include '_common', 'bulk', 'cluster', 'indices', 'search'
+    include '_common', 'bulk', 'cluster', 'indices', 'search', 'ingest.put_pipeline', 'ingest.delete_pipeline'
   }
 }
 

--- a/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/60_settings.yml
+++ b/x-pack/plugin/rollup/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/rollup/60_settings.yml
@@ -1,0 +1,100 @@
+---
+"Downsample index with pipeline":
+  - skip:
+      version: " - 8.4.99"
+      reason: "rollup renamed to downsample in 8.5.0"
+
+  - do:
+      ingest.put_pipeline:
+        id: "pipeline"
+        body: >
+          {
+            "processors": [
+             {
+               "set" : {
+                 "field" : "field",
+                 "value": 42
+               }
+              }
+            ]
+          }
+
+  - do:
+      indices.create:
+        index: test
+        body:
+          settings:
+            number_of_shards: 1
+            number_of_replicas: 0
+            index:
+              default_pipeline: "pipeline"
+              final_pipeline: "pipeline"
+              mode: time_series
+              routing_path: [metricset, k8s.pod.uid]
+              time_series:
+                start_time: 2021-04-28T00:00:00Z
+                end_time: 2021-04-29T00:00:00Z
+          mappings:
+            properties:
+              "@timestamp":
+                type: date
+              metricset:
+                type: keyword
+                time_series_dimension: true
+              value:
+                type: double
+                time_series_metric: gauge
+  - do:
+      bulk:
+        refresh: true
+        index: test
+        body:
+          - '{"index": {}}'
+          - '{"@timestamp": "2021-04-28T18:50:04.467Z", "metricset": "pod", "value": 10}'
+
+  - do:
+      search:
+        index: test
+        body:
+          query:
+            match_all: {}
+
+  - match: { hits.total.value: 1 }
+  - match: { hits.hits.0._source.field: 42 }
+
+  - do:
+      indices.put_settings:
+        index: test
+        body:
+          index.blocks.write: true
+
+  - do:
+      indices.downsample:
+        index: test
+        target_index: test-rollup
+        body: >
+          {
+            "fixed_interval": "1h"
+          }
+
+  - do:
+      indices.get_settings:
+        index: test
+
+  - match: { test.settings.index.default_pipeline: "pipeline" }
+  - match: { test.settings.index.final_pipeline: "pipeline" }
+
+  - do:
+      indices.get_settings:
+        index: test-rollup
+
+  - match: { test-rollup.settings.index.default_pipeline: null }
+  - match: { test-rollup.settings.index.final_pipeline: null }
+
+
+---
+teardown:
+  - do:
+      ingest.delete_pipeline:
+        id: "pipeline"
+        ignore: 404


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Do not copy index.default_pipeline and index.final_pipeline (#96494)