### PR TITLE
[Fleet] Add File Delivery index templates

### DIFF
--- a/x-pack/plugin/core/src/main/resources/fleet-filedelivery-data-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-filedelivery-data-ilm-policy.json
@@ -1,0 +1,25 @@
+{
+  "phases": {
+    "hot": {
+      "min_age": "0ms",
+      "actions": {
+        "rollover": {
+          "max_size": "10gb",
+          "max_age": "14d"
+        }
+      }
+    },
+    "delete": {
+      "min_age": "24d",
+      "actions": {
+        "delete": {
+          "delete_searchable_snapshot": true
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "policy for fleet deliverable files",
+    "managed": true
+  }
+}

--- a/x-pack/plugin/core/src/main/resources/fleet-filedelivery-data.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-filedelivery-data.json
@@ -1,0 +1,41 @@
+{
+  "index_patterns": [
+    ".fleet-filedelivery-data-*-*"
+  ],
+  "priority": 200,
+  "composed_of": [],
+  "_meta": {
+    "description": "fleet file delivery data index template",
+    "managed": true
+  },
+  "template" : {
+    "settings": {
+      "index.auto_expand_replicas": "0-1",
+      "index.hidden": true
+    },
+    "mappings": {
+      "_doc": {
+        "_meta": {
+          "version": "${xpack.fleet.template.version}"
+        },
+        "properties": {
+          "data": {
+            "type": "binary"
+          },
+          "bid": {
+            "type": "keyword"
+          },
+          "sha2": {
+            "type": "keyword",
+            "index": false
+          },
+          "last": {
+            "type": "boolean",
+            "index": false
+          }
+        }
+      }
+    }
+  },
+  "version": ${xpack.fleet.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/fleet-filedelivery-data.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-filedelivery-data.json
@@ -20,7 +20,8 @@
         },
         "properties": {
           "data": {
-            "type": "binary"
+            "type": "binary",
+            "store": true
           },
           "bid": {
             "type": "keyword"

--- a/x-pack/plugin/core/src/main/resources/fleet-filedelivery-meta-ilm-policy.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-filedelivery-meta-ilm-policy.json
@@ -1,0 +1,25 @@
+{
+  "phases": {
+    "hot": {
+      "min_age": "0ms",
+      "actions": {
+        "rollover": {
+          "max_size": "10gb",
+          "max_age": "30d"
+        }
+      }
+    },
+    "delete": {
+      "min_age": "90d",
+      "actions": {
+        "delete": {
+          "delete_searchable_snapshot": true
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "policy for fleet deliverable file metadata",
+    "managed": true
+  }
+}

--- a/x-pack/plugin/core/src/main/resources/fleet-filedelivery-meta.json
+++ b/x-pack/plugin/core/src/main/resources/fleet-filedelivery-meta.json
@@ -1,0 +1,60 @@
+{
+  "index_patterns": [
+    ".fleet-filedelivery-meta-*-*"
+  ],
+  "priority": 200,
+  "composed_of": [],
+  "_meta": {
+    "description": "fleet file delivery index template",
+    "managed": true
+  },
+  "template": {
+    "settings": {
+      "index.auto_expand_replicas": "0-1",
+      "index.hidden": true
+    },
+    "mappings": {
+      "_doc": {
+        "_meta": {
+          "version": "${xpack.fleet.template.version}"
+        },
+        "dynamic": false,
+        "properties": {
+          "agent_id": {
+            "type": "keyword"
+          },
+          "action_id": {
+            "type": "keyword"
+          },
+          "source": {
+            "type": "keyword"
+          },
+          "file": {
+            "properties": {
+              "Status": {
+                "type": "keyword"
+              },
+              "ChunkSize": {
+                "type": "integer"
+              },
+              "Compression": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "keyword"
+              },
+              "Meta": {
+                "properties": {
+                  "target_agents": {
+                    "type": "keyword"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "version": ${xpack.fleet.template.version}
+}

--- a/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
+++ b/x-pack/plugin/fleet/src/javaRestTest/java/org/elasticsearch/xpack/fleet/FleetSystemIndicesIT.java
@@ -103,6 +103,31 @@ public class FleetSystemIndicesIT extends ESRestTestCase {
         assertThat(responseBody, containsString("bid"));
     }
 
+    public void testCreationOfFleetFileDelivery() throws Exception {
+        Request request = new Request("PUT", ".fleet-filedelivery-meta-agent-00001");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        request = new Request("GET", ".fleet-filedelivery-meta-agent-00001/_mapping");
+        response = client().performRequest(request);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        assertThat(responseBody, not(containsString("xpack.fleet.template.version"))); // assert templating worked
+        assertThat(responseBody, containsString("action_id"));
+    }
+
+    public void testCreationOfFleetFileDeliveryData() throws Exception {
+        Request request = new Request("PUT", ".fleet-filedelivery-data-agent-00001");
+        Response response = client().performRequest(request);
+        assertEquals(200, response.getStatusLine().getStatusCode());
+
+        request = new Request("GET", ".fleet-filedelivery-data-agent-00001/_mapping");
+        response = client().performRequest(request);
+        String responseBody = EntityUtils.toString(response.getEntity());
+        assertThat(responseBody, not(containsString("xpack.fleet.template.version"))); // assert templating worked
+        assertThat(responseBody, containsString("data"));
+        assertThat(responseBody, containsString("bid"));
+    }
+
     public void testCreationOfFleetArtifacts() throws Exception {
         Request request = new Request("PUT", ".fleet-artifacts");
         Response response = client().performRequest(request);

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -42,7 +42,7 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
 
     public static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
         new IndexTemplateConfig(".fleet-files", "/fleet-files.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
-        new IndexTemplateConfig(".fleet-file-data", "/fleet-file-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE)
+        new IndexTemplateConfig(".fleet-file-data", "/fleet-file-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
         new IndexTemplateConfig(".fleet-filedelivery-meta", "/fleet-filedelivery-meta.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
         new IndexTemplateConfig(".fleet-filedelivery-data", "/fleet-filedelivery-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE)
     );

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -43,6 +43,8 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
     public static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
         new IndexTemplateConfig(".fleet-files", "/fleet-files.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
         new IndexTemplateConfig(".fleet-file-data", "/fleet-file-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE)
+        new IndexTemplateConfig(".fleet-filedelivery-meta", "/fleet-filedelivery-meta.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
+        new IndexTemplateConfig(".fleet-filedelivery-data", "/fleet-filedelivery-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE)
     );
 
     public FleetTemplateRegistry(

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -44,16 +44,16 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
         new IndexTemplateConfig(".fleet-files", "/fleet-files.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
         new IndexTemplateConfig(".fleet-file-data", "/fleet-file-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
         new IndexTemplateConfig(
-          ".fleet-filedelivery-meta",
-          "/fleet-filedelivery-meta.json",
-          INDEX_TEMPLATE_VERSION,
-          TEMPLATE_VERSION_VARIABLE
+            ".fleet-filedelivery-meta",
+            "/fleet-filedelivery-meta.json",
+            INDEX_TEMPLATE_VERSION,
+            TEMPLATE_VERSION_VARIABLE
         ),
         new IndexTemplateConfig(
-          ".fleet-filedelivery-data",
-          "/fleet-filedelivery-data.json",
-          INDEX_TEMPLATE_VERSION,
-          TEMPLATE_VERSION_VARIABLE
+            ".fleet-filedelivery-data",
+            "/fleet-filedelivery-data.json",
+            INDEX_TEMPLATE_VERSION,
+            TEMPLATE_VERSION_VARIABLE
         )
     );
 

--- a/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
+++ b/x-pack/plugin/fleet/src/main/java/org/elasticsearch/xpack/fleet/FleetTemplateRegistry.java
@@ -43,8 +43,18 @@ public class FleetTemplateRegistry extends IndexTemplateRegistry {
     public static final Map<String, ComposableIndexTemplate> COMPOSABLE_INDEX_TEMPLATE_CONFIGS = parseComposableTemplates(
         new IndexTemplateConfig(".fleet-files", "/fleet-files.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
         new IndexTemplateConfig(".fleet-file-data", "/fleet-file-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
-        new IndexTemplateConfig(".fleet-filedelivery-meta", "/fleet-filedelivery-meta.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE),
-        new IndexTemplateConfig(".fleet-filedelivery-data", "/fleet-filedelivery-data.json", INDEX_TEMPLATE_VERSION, TEMPLATE_VERSION_VARIABLE)
+        new IndexTemplateConfig(
+          ".fleet-filedelivery-meta",
+          "/fleet-filedelivery-meta.json",
+          INDEX_TEMPLATE_VERSION,
+          TEMPLATE_VERSION_VARIABLE
+        ),
+        new IndexTemplateConfig(
+          ".fleet-filedelivery-data",
+          "/fleet-filedelivery-data.json",
+          INDEX_TEMPLATE_VERSION,
+          TEMPLATE_VERSION_VARIABLE
+        )
     );
 
     public FleetTemplateRegistry(


### PR DESCRIPTION
Adds two new index templates (`.fleet-filedevliery-meta-*-*` and `.fleet-filedelivery-data-*-*`) for fleet usage, supporting a limited file-delivery feature through fleet.

This follows a similar path as #91413 with somewhat different usage patterns.