### PR TITLE
Short-circuit lock in SparseFileTracker.waitForRange

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -461,6 +461,7 @@ public class SparseFileTracker {
     private void maybeUpdateCompletePointer(Range gapRange) {
         assert Thread.holdsLock(mutex);
         if (gapRange.start == 0) {
+            assert complete <= gapRange.end;
             complete = gapRange.end;
         }
     }

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/common/SparseFileTracker.java
@@ -33,6 +33,12 @@ public class SparseFileTracker {
      */
     private final TreeSet<Range> ranges = new TreeSet<>(RANGE_START_COMPARATOR);
 
+    /**
+     * Number of bytes from the start of the file that are present as one continuous range without gaps. Used as an optimization in
+     * {@link #waitForRange(ByteRange, ByteRange, ActionListener)} to bypass expensive inspection of {@link #ranges} in some cases.
+     */
+    private volatile long complete = 0L;
+
     private final Object mutex = new Object();
 
     private final String description;
@@ -167,6 +173,14 @@ public class SparseFileTracker {
             );
         }
 
+        if (complete >= range.end()) {
+            listener.onResponse(null);
+            return List.of();
+        }
+        return doWaitForRange(range, subRange, listener);
+    }
+
+    private List<Gap> doWaitForRange(ByteRange range, ByteRange subRange, ActionListener<Void> listener) {
         final ActionListener<Void> wrappedListener = wrapWithAssertions(listener);
 
         final List<Gap> gaps = new ArrayList<>();
@@ -422,15 +436,19 @@ public class SparseFileTracker {
                 assert gapRange.end == nextRange.start : gapRange + " vs " + nextRange;
                 prevRange.end = nextRange.end;
                 ranges.remove(nextRange);
+                maybeUpdateCompletePointer(prevRange);
             } else if (mergeWithPrev) {
                 assert prevRange.isPending() == false : prevRange;
                 assert prevRange.end == gapRange.start : prevRange + " vs " + gapRange;
                 prevRange.end = gapRange.end;
+                maybeUpdateCompletePointer(prevRange);
             } else if (mergeWithNext) {
                 assert nextRange.isPending() == false : nextRange;
                 assert gapRange.end == nextRange.start : gapRange + " vs " + nextRange;
                 nextRange.start = gapRange.start;
+                maybeUpdateCompletePointer(nextRange);
             } else {
+                maybeUpdateCompletePointer(gapRange);
                 ranges.add(new Range(gapRange.start, gapRange.end, null));
             }
 
@@ -438,6 +456,13 @@ public class SparseFileTracker {
         }
 
         completionListener.onResponse(gapRange.end);
+    }
+
+    private void maybeUpdateCompletePointer(Range gapRange) {
+        assert Thread.holdsLock(mutex);
+        if (gapRange.start == 0) {
+            complete = gapRange.end;
+        }
     }
 
     private void onGapProgress(final Range gapRange, long value) {

--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBlobCacheService.java
@@ -761,40 +761,46 @@ public class SharedBlobCacheService<KeyType> implements Releasable {
                 );
                 final List<SparseFileTracker.Gap> gaps = tracker.waitForRange(rangeToWrite, rangeToRead, rangeListener);
 
-                for (SparseFileTracker.Gap gap : gaps) {
-                    executor.execute(new AbstractRunnable() {
-
-                        @Override
-                        protected void doRun() throws Exception {
-                            if (CacheFileRegion.this.tryIncRef() == false) {
-                                throw new AlreadyClosedException("Cache file channel has been released and closed");
-                            }
-                            try {
-                                ensureOpen();
-                                final long start = gap.start();
-                                assert regionOwners[sharedBytesPos].get() == CacheFileRegion.this;
-                                writer.fillCacheRange(
-                                    fileChannel,
-                                    physicalStartOffset() + gap.start(),
-                                    gap.start(),
-                                    gap.end() - gap.start(),
-                                    progress -> gap.onProgress(start + progress)
-                                );
-                                writeCount.increment();
-                            } finally {
-                                decRef();
-                            }
-                            gap.onCompletion();
-                        }
-
-                        @Override
-                        public void onFailure(Exception e) {
-                            gap.onFailure(e);
-                        }
-                    });
+                if (gaps.isEmpty() == false) {
+                    fillGaps(writer, executor, fileChannel, gaps);
                 }
             } catch (Exception e) {
                 releaseAndFail(listener, Releasables.wrap(resources), e);
+            }
+        }
+
+        private void fillGaps(RangeMissingHandler writer, Executor executor, SharedBytes.IO fileChannel, List<SparseFileTracker.Gap> gaps) {
+            for (SparseFileTracker.Gap gap : gaps) {
+                executor.execute(new AbstractRunnable() {
+
+                    @Override
+                    protected void doRun() throws Exception {
+                        if (CacheFileRegion.this.tryIncRef() == false) {
+                            throw new AlreadyClosedException("Cache file channel has been released and closed");
+                        }
+                        try {
+                            ensureOpen();
+                            final long start = gap.start();
+                            assert regionOwners[sharedBytesPos].get() == CacheFileRegion.this;
+                            writer.fillCacheRange(
+                                fileChannel,
+                                physicalStartOffset() + gap.start(),
+                                gap.start(),
+                                gap.end() - gap.start(),
+                                progress -> gap.onProgress(start + progress)
+                            );
+                            writeCount.increment();
+                        } finally {
+                            decRef();
+                        }
+                        gap.onCompletion();
+                    }
+
+                    @Override
+                    public void onFailure(Exception e) {
+                        gap.onFailure(e);
+                    }
+                });
             }
         }
 


### PR DESCRIPTION
Optimization for reading from fully cached (and a few other cases) regions without locking. This removes a bunch of allocations and a lock acquisition from fully-cached reads, bringing their performance closer to normal file system directory implementations.
Also rip apart this method and its caller a little to make profiling easier to interpret and maybe improve compilation of the hot fully-cached path.