### PR TITLE
lower required version for analytics usage to 8.8.1

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/application/EnterpriseSearchFeatureSetUsage.java
@@ -41,7 +41,7 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
     public EnterpriseSearchFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
         this.searchApplicationsUsage = in.readMap();
-        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_1)) {
             this.analyticsCollectionsUsage = in.readMap();
         } else {
             this.analyticsCollectionsUsage = Collections.emptyMap();
@@ -52,7 +52,7 @@ public class EnterpriseSearchFeatureSetUsage extends XPackFeatureSet.Usage {
     public void writeTo(StreamOutput out) throws IOException {
         super.writeTo(out);
         out.writeGenericMap(searchApplicationsUsage);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_9_0)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_8_1)) {
             out.writeGenericMap(analyticsCollectionsUsage);
         }
     }


### PR DESCRIPTION
brings main back in sync with change required for backport: https://github.com/elastic/elasticsearch/pull/96495/commits/5417569271215fc01a2cf6e27ca092dfb74344d1