### PR TITLE
Unmute FlattenedFieldSearchTests.testCardinalityAggregation

### DIFF
--- a/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSearchTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/flattened/FlattenedFieldSearchTests.java
@@ -209,7 +209,6 @@ public class FlattenedFieldSearchTests extends ESSingleNodeTestCase {
         assertHitCount(searchResponse, 0L);
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/86115")
     public void testCardinalityAggregation() throws IOException {
         int numDocs = randomIntBetween(2, 100);
         int precisionThreshold = randomIntBetween(0, 1 << randomInt(20));


### PR DESCRIPTION
This test failed because of https://github.com/elastic/elasticsearch/pull/85840 but the change was reverted in https://github.com/elastic/elasticsearch/pull/86237 and the test does not fail any more.

fixes https://github.com/elastic/elasticsearch/issues/86115