### PR TITLE
Cleanup RestoreSnapshotResponse

### DIFF
--- a/docs/changelog/96523.yaml
+++ b/docs/changelog/96523.yaml
@@ -1,0 +1,5 @@
+pr: 96523
+summary: Cleanup `RestoreSnapshotResponse`
+area: Snapshot/Restore
+type: tech debt
+issues: []

--- a/docs/changelog/96523.yaml
+++ b/docs/changelog/96523.yaml
@@ -1,5 +1,0 @@
-pr: 96523
-summary: Cleanup `RestoreSnapshotResponse`
-area: Snapshot/Restore
-type: tech debt
-issues: []

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/snapshots/restore/RestoreSnapshotResponseTests.java
@@ -8,38 +8,76 @@
 
 package org.elasticsearch.action.admin.cluster.snapshots.restore;
 
+import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.snapshots.RestoreInfo;
-import org.elasticsearch.test.AbstractXContentTestCase;
-import org.elasticsearch.xcontent.XContentParser;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 
-public class RestoreSnapshotResponseTests extends AbstractXContentTestCase<RestoreSnapshotResponse> {
+public class RestoreSnapshotResponseTests extends AbstractWireSerializingTestCase<RestoreSnapshotResponse> {
 
     @Override
     protected RestoreSnapshotResponse createTestInstance() {
-        if (randomBoolean()) {
-            String name = randomRealisticUnicodeOfCodepointLengthBetween(1, 30);
-            List<String> indices = new ArrayList<>();
-            indices.add("test0");
-            indices.add("test1");
-            int totalShards = randomIntBetween(1, 1000);
-            int successfulShards = randomIntBetween(0, totalShards);
-            return new RestoreSnapshotResponse(new RestoreInfo(name, indices, totalShards, successfulShards));
-        } else {
-            return new RestoreSnapshotResponse((RestoreInfo) null);
+        return new RestoreSnapshotResponse(randomBoolean() ? null : mutateRestoreInfo(null));
+    }
+
+    private RestoreInfo mutateRestoreInfo(RestoreInfo restoreInfo) {
+        if (restoreInfo == null) {
+            final var totalShards = between(1, 1000);
+            return new RestoreInfo(randomName(), randomIndices(), totalShards, between(0, totalShards));
         }
+        if (randomBoolean()) {
+            return null;
+        }
+
+        return switch (between(1, 4)) {
+            case 1 -> new RestoreInfo(
+                randomValueOtherThan(restoreInfo.name(), RestoreSnapshotResponseTests::randomName),
+                restoreInfo.indices(),
+                restoreInfo.totalShards(),
+                restoreInfo.successfulShards()
+            );
+            case 2 -> new RestoreInfo(
+                restoreInfo.name(),
+                randomValueOtherThan(restoreInfo.indices(), RestoreSnapshotResponseTests::randomIndices),
+                restoreInfo.totalShards(),
+                restoreInfo.successfulShards()
+            );
+            case 3 -> new RestoreInfo(
+                restoreInfo.name(),
+                restoreInfo.indices(),
+                randomValueOtherThan(
+                    restoreInfo.totalShards(),
+                    () -> between(restoreInfo.successfulShards(), Math.max(restoreInfo.totalShards() + 1, 1000))
+                ),
+                restoreInfo.successfulShards()
+            );
+            case 4 -> new RestoreInfo(
+                restoreInfo.name(),
+                restoreInfo.indices(),
+                restoreInfo.totalShards(),
+                randomValueOtherThan(restoreInfo.successfulShards(), () -> between(0, restoreInfo.totalShards()))
+            );
+            default -> throw new AssertionError("impossible");
+        };
+    }
+
+    private static List<String> randomIndices() {
+        return randomList(1, 10, () -> randomAlphaOfLength(10));
+    }
+
+    private static String randomName() {
+        return randomRealisticUnicodeOfCodepointLengthBetween(1, 30);
     }
 
     @Override
-    protected RestoreSnapshotResponse doParseInstance(XContentParser parser) throws IOException {
-        return RestoreSnapshotResponse.fromXContent(parser);
+    protected RestoreSnapshotResponse mutateInstance(RestoreSnapshotResponse instance) throws IOException {
+        return new RestoreSnapshotResponse(mutateRestoreInfo(instance.getRestoreInfo()));
     }
 
     @Override
-    protected boolean supportsUnknownFields() {
-        return true;
+    protected Writeable.Reader<RestoreSnapshotResponse> instanceReader() {
+        return RestoreSnapshotResponse::new;
     }
 }


### PR DESCRIPTION
- should have wire-protocol tests
- no need for an `XContent` parser any more
- fields can therefore be `final`