### PR TITLE
Fix range query coordinator rewrite issue

### DIFF
--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
@@ -334,7 +334,6 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         assertThat(e.getRootCause().getMessage(), containsString("Time series aggregations cannot be used inside global aggregation."));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96501")
     public void testStandAloneTimeSeriesAggWithMetricFilter() {
         boolean above = randomBoolean();
         int metric = randomIntBetween(0, numberOfMetrics - 1);
@@ -366,7 +365,6 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96487")
     public void testRetrievingHits() {
         Map.Entry<String, Double> filterMetric = randomMetricAndValue(data);
         double lowerVal = filterMetric.getValue() - randomDoubleBetween(0, 100000, true);

--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
@@ -11,6 +11,7 @@ package org.elasticsearch.aggregations.bucket;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.DocWriteRequest;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
@@ -523,6 +524,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         response = client().prepareSearch("test").setQuery(queryBuilder).setSize(10).addAggregation(timeSeries("by_ts")).get();
         assertSearchResponse(response);
 
+        assertAcked(client().admin().indices().delete(new DeleteIndexRequest("test")).actionGet());
     }
 
     public static TimeSeriesAggregationBuilder timeSeries(String name) {

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -453,7 +453,9 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
                 coordinatorRewriteContext
             );
         }
-
+        // If the field type is null or not of type DataFieldType then we have no idea whether this range query will match during
+        // coordinating rewrite. So we should return that it intersects, either the data node query rewrite or by actually running
+        // the query we know whether this range query actually matches.
         return MappedFieldType.Relation.INTERSECTS;
     }
 

--- a/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
+++ b/server/src/main/java/org/elasticsearch/index/query/RangeQueryBuilder.java
@@ -454,7 +454,7 @@ public class RangeQueryBuilder extends AbstractQueryBuilder<RangeQueryBuilder> i
             );
         }
 
-        return MappedFieldType.Relation.DISJOINT;
+        return MappedFieldType.Relation.INTERSECTS;
     }
 
     protected MappedFieldType.Relation getRelation(final SearchExecutionContext searchExecutionContext) throws IOException {

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -402,9 +402,12 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             boolean registerType
         ) throws IOException {
             this.nowInMillis = nowInMillis;
-            Environment env = InternalSettingsPreparer.prepareEnvironment(nodeSettings, emptyMap(), null, () -> {
-                throw new AssertionError("node.name must be set");
-            });
+            Environment env = InternalSettingsPreparer.prepareEnvironment(
+                nodeSettings,
+                emptyMap(),
+                null,
+                () -> { throw new AssertionError("node.name must be set"); }
+            );
             PluginsService pluginsService;
             pluginsService = new MockPluginsService(nodeSettings, env, plugins);
 
@@ -576,11 +579,7 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
                 parserConfiguration,
                 this.client,
                 () -> nowInMillis,
-                IndexLongFieldRange.UNKNOWN.extendWithShardRange(
-                    randomIntBetween(0, 2),
-                    randomIntBetween(2, 5),
-                    ShardLongFieldRange.of(min, max)
-                ),
+                IndexLongFieldRange.NO_SHARDS.extendWithShardRange(0, 1, ShardLongFieldRange.of(min, max)),
                 dateFieldType
             );
         }

--- a/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/AbstractBuilderTestCase.java
@@ -402,12 +402,9 @@ public abstract class AbstractBuilderTestCase extends ESTestCase {
             boolean registerType
         ) throws IOException {
             this.nowInMillis = nowInMillis;
-            Environment env = InternalSettingsPreparer.prepareEnvironment(
-                nodeSettings,
-                emptyMap(),
-                null,
-                () -> { throw new AssertionError("node.name must be set"); }
-            );
+            Environment env = InternalSettingsPreparer.prepareEnvironment(nodeSettings, emptyMap(), null, () -> {
+                throw new AssertionError("node.name must be set");
+            });
             PluginsService pluginsService;
             pluginsService = new MockPluginsService(nodeSettings, env, plugins);
 


### PR DESCRIPTION
If during the coordinator rewrite can't find the requested field we should assume that the query matches. So `MappedFieldType.Relation.INTERSECTS` should be returned instead of `MappedFieldType.Relation.DISJOINT`.

Closes #96487 and #96501

(marking as non-issue, this is a bug in unreleased code)