### PR TITLE
variable_width_histogram aggregation does not support concurrent execution

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/bucket/histogram/VariableWidthHistogramAggregationBuilder.java
@@ -137,6 +137,11 @@ public class VariableWidthHistogramAggregationBuilder extends ValuesSourceAggreg
     }
 
     @Override
+    public boolean supportsConcurrentExecution() {
+        return false;
+    }
+
+    @Override
     protected AggregationBuilder shallowCopy(AggregatorFactories.Builder factoriesBuilder, Map<String, Object> metaData) {
         return new VariableWidthHistogramAggregationBuilder(this, factoriesBuilder, metaData);
     }


### PR DESCRIPTION
variable_width_histogram aggregation might give different results depending if running sequentially or in concurrency mode, depending on the shard size. At the moment we are flagging those aggregations as not supporting concurrency. Set as non-issue as this work has not been released.

fixes https://github.com/elastic/elasticsearch/issues/96295