### PR TITLE
Suggest capturing a heap dump to diagnose high heap

### DIFF
--- a/docs/reference/how-to/fix-common-cluster-issues.asciidoc
+++ b/docs/reference/how-to/fix-common-cluster-issues.asciidoc
@@ -158,6 +158,8 @@ You can also use the <<cat-nodes,cat nodes API>> to get the current
 GET _cat/nodes?v=true&h=name,node*,heap*
 ----
 
+See <<high-jvm-memory-pressure>> for more details.
+
 To get the JVM memory usage for each circuit breaker, use the
 <<cluster-nodes-stats,node stats API>>.
 

--- a/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
+++ b/docs/reference/troubleshooting/common-issues/high-jvm-memory-pressure.asciidoc
@@ -27,9 +27,16 @@ collection.
 [timestamp_short_interval_from_last][INFO ][o.e.m.j.JvmGcMonitorService] [node_id] [gc][number] overhead, spent [21s] collecting in the last [40s]
 ----
 
+**Capture a JVM heap dump**
+
+To determine the exact reason for the high JVM memory pressure, capture a heap
+dump of the JVM while its memory usage is high.
+
 [discrete]
 [[reduce-jvm-memory-pressure]]
 ==== Reduce JVM memory pressure
+
+This section contains some common suggestions for reducing JVM memory pressure.
 
 **Reduce your shard count**
 


### PR DESCRIPTION
The `high-jvm-memory-pressure.html` troubleshooting docs give some suggestions, but vitally they omit the advice to capture a heap dump which is what we really need users to do if they want to understand their high heap usage. This commit adds a note to the docs to that effect.