### PR TITLE
Fix reading a byte after end of stream for ByteArrayStreamInput

### DIFF
--- a/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/ByteArrayStreamInput.java
@@ -33,6 +33,9 @@ public class ByteArrayStreamInput extends StreamInput {
 
     @Override
     public int read() throws IOException {
+        if (limit - pos <= 0) {
+            return -1;
+        }
         return readByte() & 0xFF;
     }
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/AbstractStreamTests.java
@@ -697,6 +697,19 @@ public abstract class AbstractStreamTests extends ESTestCase {
         assertImmutableListSerialization(List.of(1, 2, 3), StreamInput::readVInt, StreamOutput::writeVInt);
     }
 
+    public void testReadAfterReachingEndOfStream() throws IOException {
+        try (var output = new BytesStreamOutput()) {
+            int len = randomIntBetween(1, 16);
+            for (int i = 0; i < len; i++) {
+                output.writeByte(randomByte());
+            }
+            StreamInput input = getStreamInput(output.bytes());
+            input.readBytes(new byte[len], 0, len);
+
+            assertEquals(-1, input.read());
+        }
+    }
+
     private void assertSerialization(
         CheckedConsumer<StreamOutput, IOException> outputAssertions,
         CheckedConsumer<StreamInput, IOException> inputAssertions


### PR DESCRIPTION
If we call `read` on a stream after reached the end of it, we should return -1, instead of throwing ArrayIndexOfBoundException.
