### PR TITLE
Use explicit mapping instead of dynamic in Matrix Stats Rest Test

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
@@ -20,7 +20,7 @@ setup:
               "val3":
                 "type": "double"
               "vals":
-                "type": "double"
+                "type": "float"
 
   - do:
       indices.create:

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
@@ -19,6 +19,8 @@ setup:
                 "type": "double"
               "val3":
                 "type": "double"
+              "vals":
+                "type": "double"
 
   - do:
       indices.create:


### PR DESCRIPTION
Resolves https://github.com/elastic/elasticsearch/issues/95842

The above test failed, I believe, because we attempted to index a multi-value field using a dynamic mapping where the first value was a long and the second value was a double.  I was unable to perfectly reproduce the failure in the linked test (I believe it depends on multi node configuration and which document is the first to be indexed on a given node), but I was able to produce the same error message by slightly changing the test data (not committed), and the fix here resolved that failure.