### PR TITLE
[8.8] Use explicit mapping instead of dynamic in Matrix Stats Rest Test (#96531)

### DIFF
--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/matrix_stats_multi_value_field.yml
@@ -19,6 +19,8 @@ setup:
                 "type": "double"
               "val3":
                 "type": "double"
+              "vals":
+                "type": "float"
 
   - do:
       indices.create:


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Use explicit mapping instead of dynamic in Matrix Stats Rest Test (#96531)