### PR TITLE
Make one `Version` ctor public

### DIFF
--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * Script value class.
+ * Version value class.
  */
 public class Version implements ToXContentFragment, BytesRefProducer, Comparable<Version> {
     protected String version;

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
@@ -26,7 +26,7 @@ public class Version implements ToXContentFragment, BytesRefProducer, Comparable
         this.bytes = VersionEncoder.encodeVersion(version).bytesRef;
     }
 
-    protected Version(BytesRef bytes) {
+    public Version(BytesRef bytes) {
         this.version = VersionEncoder.decodeVersion(bytes).utf8ToString();
         this.bytes = bytes;
     }

--- a/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
+++ b/x-pack/plugin/mapper-version/src/main/java/org/elasticsearch/xpack/versionfield/Version.java
@@ -15,7 +15,7 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 
 /**
- * Version value class.
+ * Version value class, also exposed to scripting consumers.
  */
 public class Version implements ToXContentFragment, BytesRefProducer, Comparable<Version> {
     protected String version;


### PR DESCRIPTION
Make `org.elasticsearch.xpack.versionfield.Version` ctor taking a `BytesRef` argument public. Required for code having a `BytesRef`-encoded representation of the `Version`, in order to build an instance; the encoder/decoder aren't public either.
