### PR TITLE
Adds the _cluster object to the AsyncStatusResponse XContent when Clusters has a non-zero count total

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -132,12 +132,13 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_006 = registerTransportVersion(8_500_006, "7BB5621A-80AC-425F-BA88-75543C442F23");
     public static final TransportVersion V_8_500_007 = registerTransportVersion(8_500_007, "77261d43-4149-40af-89c5-7e71e0454fce");
     public static final TransportVersion V_8_500_008 = registerTransportVersion(8_500_008, "8884ab9d-94cd-4bac-aff8-01f2c394f47c");
+    public static final TransportVersion V_8_500_009 = registerTransportVersion(8_500_009, "35091358-fd41-4106-a6e2-d2a1315494c1");
 
     /**
      * Reference to the most recent transport version.
      * This should be the transport version with the highest id.
      */
-    public static final TransportVersion CURRENT = findCurrent(V_8_500_008);
+    public static final TransportVersion CURRENT = findCurrent(V_8_500_009);
 
     /**
      * Reference to the earliest compatible transport version to this version of the codebase.

--- a/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
+++ b/x-pack/plugin/async-search/src/main/java/org/elasticsearch/xpack/search/MutableSearchResponse.java
@@ -241,6 +241,11 @@ class MutableSearchResponse {
      * @return response representing the status of async search
      */
     synchronized AsyncStatusResponse toStatusResponse(String asyncExecutionId, long startTime, long expirationTime) {
+        SearchResponse.Clusters clustersInStatus = null;
+        if (clusters != null && clusters.getTotal() > 0) {
+            // include clusters in the status if present and not Clusters.EMPTY (the case for local searches only)
+            clustersInStatus = clusters;
+        }
         if (finalResponse != null) {
             return new AsyncStatusResponse(
                 asyncExecutionId,
@@ -252,7 +257,8 @@ class MutableSearchResponse {
                 finalResponse.getSuccessfulShards(),
                 finalResponse.getSkippedShards(),
                 finalResponse.getShardFailures() != null ? finalResponse.getShardFailures().length : 0,
-                finalResponse.status()
+                finalResponse.status(),
+                clustersInStatus
             );
         }
         if (failure != null) {
@@ -266,7 +272,8 @@ class MutableSearchResponse {
                 successfulShards,
                 skippedShards,
                 queryFailures == null ? 0 : queryFailures.nonNullLength(),
-                ExceptionsHelper.status(ExceptionsHelper.unwrapCause(failure))
+                ExceptionsHelper.status(ExceptionsHelper.unwrapCause(failure)),
+                clustersInStatus
             );
         }
         return new AsyncStatusResponse(
@@ -279,7 +286,8 @@ class MutableSearchResponse {
             successfulShards,
             skippedShards,
             queryFailures == null ? 0 : queryFailures.nonNullLength(),
-            null  // for a still running search, completion status is null
+            null,  // for a still running search, completion status is null
+            clustersInStatus
         );
     }
 

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -8,14 +8,17 @@
 package org.elasticsearch.xpack.search;
 
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.search.ShardSearchFailure;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.Writeable;
 import org.elasticsearch.common.xcontent.XContentHelper;
 import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.internal.InternalSearchResponse;
 import org.elasticsearch.test.AbstractWireSerializingTestCase;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
 import org.elasticsearch.xcontent.XContentType;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
 import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
 
 import java.io.IOException;
@@ -167,5 +170,164 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             response.toXContent(builder, ToXContent.EMPTY_PARAMS);
             assertEquals(XContentHelper.stripWhitespace(expectedJson), Strings.toString(builder));
         }
+    }
+
+    public void testGetStatusFromStoredSearchRandomizedInputs() {
+        String searchId = randomSearchId();
+        AsyncSearchResponse asyncSearchResponse = AsyncSearchResponseTests.randomAsyncSearchResponse(
+            searchId,
+            AsyncSearchResponseTests.randomSearchResponse()
+        );
+
+        if (asyncSearchResponse.getSearchResponse() == null
+            && asyncSearchResponse.getFailure() == null
+            && asyncSearchResponse.isRunning() == false) {
+            // if no longer running, the search should have recorded either a failure or a search response
+            // if not an Exception should be thrown
+            expectThrows(
+                IllegalStateException.class,
+                () -> AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId)
+            );
+        } else {
+            AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
+            assertNotNull(statusFromStoredSearch);
+            if (statusFromStoredSearch.isRunning()) {
+                assertNull(
+                    "completion_status should only be present if search is no longer running",
+                    statusFromStoredSearch.getCompletionStatus()
+                );
+            } else {
+                assertNotNull(
+                    "completion_status should be present if search is no longer running",
+                    statusFromStoredSearch.getCompletionStatus()
+                );
+            }
+        }
+    }
+
+    public void testGetStatusFromStoredSearchFailureScenario() {
+        String searchId = randomSearchId();
+        Exception error = new IllegalArgumentException("dummy");
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, null, error, true, false, 100, 200);
+        AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
+        assertNotNull(statusFromStoredSearch);
+        assertEquals(statusFromStoredSearch.getCompletionStatus(), RestStatus.BAD_REQUEST);
+        assertTrue(statusFromStoredSearch.isPartial());
+        assertNull(statusFromStoredSearch.getClusters());
+        assertEquals(0, statusFromStoredSearch.getTotalShards());
+        assertEquals(0, statusFromStoredSearch.getSuccessfulShards());
+        assertEquals(0, statusFromStoredSearch.getSkippedShards());
+    }
+
+    public void testGetStatusFromStoredSearchFailedShardsScenario() {
+        String searchId = randomSearchId();
+
+        long tookInMillis = randomNonNegativeLong();
+        int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
+        int successfulShards = randomIntBetween(0, totalShards);
+        int skippedShards = randomIntBetween(0, successfulShards);
+        InternalSearchResponse internalSearchResponse = InternalSearchResponse.EMPTY_WITH_TOTAL_HITS;
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(100, 99, 1, 99, false);
+        SearchResponse searchResponse = new SearchResponse(
+            internalSearchResponse,
+            null,
+            totalShards,
+            successfulShards,
+            skippedShards,
+            tookInMillis,
+            new ShardSearchFailure[] { new ShardSearchFailure(new RuntimeException("foo")) },
+            clusters
+        );
+
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
+        assertNotNull(statusFromStoredSearch);
+        assertEquals(1, statusFromStoredSearch.getFailedShards());
+        assertEquals(statusFromStoredSearch.getCompletionStatus(), RestStatus.OK);
+    }
+
+    public void testGetStatusFromStoredSearchWithEmptyClustersSuccessfullyCompleted() {
+        String searchId = randomSearchId();
+
+        long tookInMillis = randomNonNegativeLong();
+        int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
+        int successfulShards = randomIntBetween(0, totalShards);
+        int skippedShards = randomIntBetween(0, successfulShards);
+        InternalSearchResponse internalSearchResponse = InternalSearchResponse.EMPTY_WITH_TOTAL_HITS;
+        SearchResponse searchResponse = new SearchResponse(
+            internalSearchResponse,
+            null,
+            totalShards,
+            successfulShards,
+            skippedShards,
+            tookInMillis,
+            ShardSearchFailure.EMPTY_ARRAY,
+            SearchResponse.Clusters.EMPTY
+        );
+
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
+        assertNotNull(statusFromStoredSearch);
+        assertEquals(statusFromStoredSearch.getCompletionStatus(), RestStatus.OK);
+        assertNull(statusFromStoredSearch.getClusters());
+    }
+
+    public void testGetStatusFromStoredSearchWithNonEmptyClustersSuccessfullyCompleted() {
+        String searchId = randomSearchId();
+
+        long tookInMillis = randomNonNegativeLong();
+        int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
+        int successfulShards = randomIntBetween(0, totalShards);
+        int skippedShards = randomIntBetween(0, successfulShards);
+        InternalSearchResponse internalSearchResponse = InternalSearchResponse.EMPTY_WITH_TOTAL_HITS;
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(100, 99, 1, 99, false);
+        SearchResponse searchResponse = new SearchResponse(
+            internalSearchResponse,
+            null,
+            totalShards,
+            successfulShards,
+            skippedShards,
+            tookInMillis,
+            ShardSearchFailure.EMPTY_ARRAY,
+            clusters
+        );
+
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, false, 100, 200);
+        AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
+        assertNotNull(statusFromStoredSearch);
+        assertEquals(0, statusFromStoredSearch.getFailedShards());
+        assertEquals(statusFromStoredSearch.getCompletionStatus(), RestStatus.OK);
+        assertEquals(100, statusFromStoredSearch.getClusters().getTotal());
+    }
+
+    public void testGetStatusFromStoredSearchWithNonEmptyClustersStillRunning() {
+        String searchId = randomSearchId();
+
+        long tookInMillis = randomNonNegativeLong();
+        int totalShards = randomIntBetween(1, Integer.MAX_VALUE);
+        int successfulShards = randomIntBetween(0, totalShards);
+        int skippedShards = randomIntBetween(0, successfulShards);
+        InternalSearchResponse internalSearchResponse = InternalSearchResponse.EMPTY_WITH_TOTAL_HITS;
+        SearchResponse.Clusters clusters = new SearchResponse.Clusters(100, 2, 3, 99, true);
+        SearchResponse searchResponse = new SearchResponse(
+            internalSearchResponse,
+            null,
+            totalShards,
+            successfulShards,
+            skippedShards,
+            tookInMillis,
+            ShardSearchFailure.EMPTY_ARRAY,
+            clusters
+        );
+
+        boolean isRunning = true;
+        AsyncSearchResponse asyncSearchResponse = new AsyncSearchResponse(searchId, searchResponse, null, false, isRunning, 100, 200);
+        AsyncStatusResponse statusFromStoredSearch = AsyncStatusResponse.getStatusFromStoredSearch(asyncSearchResponse, 100, searchId);
+        assertNotNull(statusFromStoredSearch);
+        assertEquals(0, statusFromStoredSearch.getFailedShards());
+        assertNull("completion_status should not be present if still running", statusFromStoredSearch.getCompletionStatus());
+        assertEquals(100, statusFromStoredSearch.getClusters().getTotal());
+        assertEquals(2, statusFromStoredSearch.getClusters().getSuccessful());
+        assertEquals(3, statusFromStoredSearch.getClusters().getSkipped());
     }
 }

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/AsyncStatusResponseTests.java
@@ -69,6 +69,12 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
         boolean isRunning = instance.isRunning() == false;
         boolean isPartial = isRunning ? randomBoolean() : false;
         RestStatus completionStatus = isRunning ? null : randomBoolean() ? RestStatus.OK : RestStatus.SERVICE_UNAVAILABLE;
+        SearchResponse.Clusters clusters = switch (randomIntBetween(0, 3)) {
+            case 1 -> SearchResponse.Clusters.EMPTY;
+            case 2 -> new SearchResponse.Clusters(1, 1, 0);
+            case 3 -> new SearchResponse.Clusters(4, 1, 0, 3, true);
+            default -> null;  // case 0
+        };
         return new AsyncStatusResponse(
             instance.getId(),
             isRunning,
@@ -80,7 +86,7 @@ public class AsyncStatusResponseTests extends AbstractWireSerializingTestCase<As
             instance.getSkippedShards(),
             instance.getFailedShards(),
             completionStatus,
-            null
+            clusters
         );
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncStatusResponse.java
@@ -150,7 +150,7 @@ public class AsyncStatusResponse extends ActionResponse implements SearchStatusR
         out.writeVInt(successfulShards);
         out.writeVInt(skippedShards);
         out.writeVInt(failedShards);
-        if (isRunning == false) { /// MP: Hmm, is this going to be a problem? Why is this not writeOptionalString?
+        if (isRunning == false) {
             RestStatus.writeTo(out, completionStatus);
         }
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_009)) {


### PR DESCRIPTION
During a cross cluster search, the `_cluster` object in the SearchResponse will have a non-zero `total` count and thus is useful status information for the user. That information is included in the `_async_search/<id>` endpoint already because it is part of the underlying SearchResponse.

However, that information is not present in the `_async_search/status/<id>` endpoint, since that does not show the SearchResponse details. With a cross-cluster search this is useful information to understand (1) how many clusters are being searched; (2) whether they are successful or skipped, so it is being added in this commit.

When an async search is performed against the local cluster only , the `_cluster` object will not be present in the AsyncStatusResponse, since it is not informative (TransportSearchAction uses Clusters.EMPTY for executeLocalSearch).