### PR TITLE
Differentiate qa project group ids from in production projects

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,10 +3,6 @@ org.gradle.parallel=true
 # We need to declare --add-exports to make spotless working seamlessly with jdk16
 org.gradle.jvmargs=-XX:+HeapDumpOnOutOfMemoryError -Xss2m  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
 
-# Disable duplicate project id detection
-# See https://docs.gradle.org/current/userguide/upgrading_version_6.html#duplicate_project_names_may_cause_publication_to_fail
-systemProp.org.gradle.dependency.duplicate.project.detection=false
-
 # Enforce the build to fail on deprecated gradle api usage
 systemProp.org.gradle.warning.mode=fail
 

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -47,6 +47,7 @@ subprojects {
 
 // helper method to calculate unique group id for qa projects and
 // use org.elasticsearch.plugin for all productive projects
+// generates e.g. for path `x-pack:plugin:ccr:qa:rest` the project group id `org.elasticsearch.plugin.ccr.qa`
 def xpackProjectGroup(String path) {
   return path.contains(":qa:") ?
     'org.elasticsearch' + path.substring(":x-pack".length(), path.lastIndexOf(":")).replace(":", ".") :

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -20,7 +20,7 @@ subprojects {
     }
   }
 
-  group = path.contains(":qa:") ? 'org.elasticsearch.plugin.qa' : 'org.elasticsearch.plugin'
+  group = xpackProjectGroup(path)
 
   // helper method to find the path to a module
   ext.xpackModule = { String moduleName -> ":x-pack:plugin:${moduleName}" }
@@ -44,3 +44,12 @@ subprojects {
     project.ext.noticeFile.set(xpackRootProject.file('NOTICE.txt'))
   }
 }
+
+// helper method to calculate unique group id for qa projects and
+// use org.elasticsearch.plugin for all productive projects
+def xpackProjectGroup(String path) {
+  return path.contains(":qa:") ?
+    'org.elasticsearch' + path.substring(":x-pack".length(), path.lastIndexOf(":")).replace(":", ".") :
+    'org.elasticsearch.plugin'
+}
+

--- a/x-pack/build.gradle
+++ b/x-pack/build.gradle
@@ -20,7 +20,8 @@ subprojects {
     }
   }
 
-  group = 'org.elasticsearch.plugin'
+  group = path.contains(":qa:") ? 'org.elasticsearch.plugin.qa' : 'org.elasticsearch.plugin'
+
   // helper method to find the path to a module
   ext.xpackModule = { String moduleName -> ":x-pack:plugin:${moduleName}" }
 


### PR DESCRIPTION
We need to avoid duplicate GADs of gradle subprojects as we have duplicates otherwise.

Ideally we have a notion of a qa project or internal use project mold into our gradle logic. but for now thats probably enough. in the non xpack modules and plugin folder we workaround this issue by only applying the groupId for direct child projects