### PR TITLE
SQL: Fix translation of queries involving Version vals

### DIFF
--- a/docs/changelog/96540.yaml
+++ b/docs/changelog/96540.yaml
@@ -1,0 +1,6 @@
+pr: 96540
+summary: Fix translation of queries involving Version vals
+area: SQL
+type: bug
+issues:
+ - 96509

--- a/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
+++ b/x-pack/plugin/ql/src/main/java/org/elasticsearch/xpack/ql/planner/ExpressionTranslators.java
@@ -54,6 +54,7 @@ import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.ql.type.DataTypes;
 import org.elasticsearch.xpack.ql.util.Check;
 import org.elasticsearch.xpack.ql.util.CollectionUtils;
+import org.elasticsearch.xpack.versionfield.Version;
 
 import java.time.OffsetTime;
 import java.time.ZoneId;
@@ -64,6 +65,8 @@ import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
+
+import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
 
 public final class ExpressionTranslators {
 
@@ -289,6 +292,12 @@ public final class ExpressionTranslators {
                 }
                 format = formatter.pattern();
                 isDateLiteralComparison = true;
+            } else if (field.dataType() == VERSION) {
+                // VersionStringFieldMapper#indexedValueForSearch() only accepts as input String or BytesRef with the String (i.e. not
+                // encoded) representation of the version as it'll do the encoding itself.
+                if (value instanceof Version version) {
+                    value = version.toString();
+                }
             }
 
             ZoneId zoneId = null;
@@ -391,14 +400,14 @@ public final class ExpressionTranslators {
 
         private static Query translate(In in, TranslatorHandler handler) {
             FieldAttribute field = checkIsFieldAttribute(in.value());
-            boolean isDateTimeComparison = DataTypes.isDateTime(field.dataType());
+            boolean needsTypeSpecificValueHandling = DataTypes.isDateTime(field.dataType()) || field.dataType() == VERSION;
 
             Set<Object> terms = new LinkedHashSet<>();
             List<Query> queries = new ArrayList<>();
 
             for (Expression rhs : in.list()) {
                 if (DataTypes.isNull(rhs.dataType()) == false) {
-                    if (isDateTimeComparison) {
+                    if (needsTypeSpecificValueHandling) {
                         // delegates to BinaryComparisons translator to ensure consistent handling of date and time values
                         Query query = BinaryComparisons.translate(new Equals(in.source(), in.value(), rhs, in.zoneId()), handler);
 

--- a/x-pack/plugin/sql/qa/server/src/main/resources/version.csv-spec
+++ b/x-pack/plugin/sql/qa/server/src/main/resources/version.csv-spec
@@ -382,6 +382,38 @@ SELECT * FROM apps WHERE '1.2.0' < '1.11.0'::version ORDER BY id LIMIT 1;
 
 ;
 
+filterByVersionEquality
+SELECT id, version FROM apps WHERE version = '2.12.0'::version;
+
+      id:i     |    version:s
+---------------+---------------
+4              |2.12.0
+;
+
+filterByVersionInequality
+SELECT id, version FROM apps WHERE version > '2.12'::version;
+
+      id:i     |    version:s
+---------------+---------------
+4              |2.12.0
+6              |5.2.9
+7              |5.2.9-SNAPSHOT
+9              |bad
+10             |5.2.9
+14             |5.2.9
+;
+
+filterByVersionIn
+SELECT id, version FROM apps WHERE version IN ('2.12.0'::version, '5.2.9'::version);
+
+      id:i     |    version:s
+---------------+---------------
+4              |2.12.0
+6              |5.2.9
+10             |5.2.9
+14             |5.2.9
+;
+
 groupByVersionHaving
 SELECT max(id) as idx, version FROM apps GROUP BY version HAVING idx = 14;
 


### PR DESCRIPTION
This will change the value used in queries involving Version types, updating it from the Version value to the expected string representation.

Closes #96509.