### PR TITLE
Additional redact processor license check tests

### DIFF
--- a/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestServiceTests.java
@@ -888,7 +888,7 @@ public class IngestServiceTests extends ESTestCase {
         assertThat(pipelines.get(1).getId(), equalTo("_id2"));
     }
 
-    public void testValidate() throws Exception {
+    public void testValidateProcessorTypeOnAllNodes() throws Exception {
         IngestService ingestService = createWithProcessors();
         PutPipelineRequest putRequest = new PutPipelineRequest("_id", new BytesArray("""
             {


### PR DESCRIPTION
Followup to #95477 / #95928

Nothing especially notable, just adds a few more tests of the behavior for the redact processors' license checking, as well as the behavior in the `IngestService` around when `processor.extraValidation()` is called.