### PR TITLE
Increment TransportVersions by gaps of 100

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -130,12 +130,13 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_005 = registerTransportVersion(8_500_005, "65370d2a-d936-4383-a2e0-8403f708129b");
     public static final TransportVersion V_8_500_006 = registerTransportVersion(8_500_006, "7BB5621A-80AC-425F-BA88-75543C442F23");
     public static final TransportVersion V_8_500_007 = registerTransportVersion(8_500_007, "77261d43-4149-40af-89c5-7e71e0454fce");
+    public static final TransportVersion V_8_500_100 = registerTransportVersion(8_500_100, "e3f7c171-5b6c-4989-8d0a-c23100fd92f9");
 
     /**
      * Reference to the most recent transport version.
      * This should be the transport version with the highest id.
      */
-    public static final TransportVersion CURRENT = V_8_500_007;
+    public static final TransportVersion CURRENT = V_8_500_100;
 
     /**
      * Reference to the earliest compatible transport version to this version of the codebase.

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -167,8 +167,12 @@ public class TransportVersionTests extends ESTestCase {
         }
     }
 
-    public void testCURRENTIsLatest() {
+    public void testCurrentIsLatest() {
         assertThat(Collections.max(TransportVersion.getAllVersions()), is(TransportVersion.CURRENT));
+    }
+
+    public void testCurrentIncrementGap() {
+        assertThat(TransportVersion.CURRENT.id() % 100, equalTo(0));
     }
 
     public void testToString() {

--- a/server/src/test/java/org/elasticsearch/TransportVersionTests.java
+++ b/server/src/test/java/org/elasticsearch/TransportVersionTests.java
@@ -172,7 +172,8 @@ public class TransportVersionTests extends ESTestCase {
     }
 
     public void testCurrentIncrementGap() {
-        assertThat(TransportVersion.CURRENT.id() % 100, equalTo(0));
+        assertThat("Transport must be incremented by multiples of 100",
+            TransportVersion.CURRENT.id() % 100, equalTo(0));
     }
 
     public void testToString() {


### PR DESCRIPTION
This commit bumps TransportVersion to a multiple of 100 and adds a test to ensure future TransportVersion constants maintain this increment. The gap ensures serverless has room for its own transport version ids.