### PR TITLE
Correct the typo from `my_app` to `my-app` in the Put Search Application doc

### DIFF
--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -91,7 +91,7 @@ PUT _application/search_application/my-app?create
 ----
 // TEST[skip:TBD]
 
-The following example creates or updates an existing Search Application called `my_app`:
+The following example creates or updates an existing Search Application called `my-app`:
 
 [source,console]
 ----


### PR DESCRIPTION
The term `my-app` is used in both the preceding and following text and sample code, so this typo `my_app` should be corrected.