### PR TITLE
Streamline AsyncShardFetch#getNumberOfInFlightFetches

### DIFF
--- a/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
+++ b/server/src/main/java/org/elasticsearch/gateway/AsyncShardFetch.java
@@ -68,6 +68,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     private final Set<String> nodesToIgnore = new HashSet<>();
     private final AtomicLong round = new AtomicLong();
     private boolean closed;
+    private volatile int fetchingCount;
 
     @SuppressWarnings("unchecked")
     protected AsyncShardFetch(
@@ -81,6 +82,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
         this.type = type;
         this.shardId = Objects.requireNonNull(shardId);
         this.customDataPath = Objects.requireNonNull(customDataPath);
+        this.fetchingCount = 0;
         this.action = (Lister<BaseNodesResponse<T>, T>) action;
     }
 
@@ -92,14 +94,8 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     /**
      * Returns the number of async fetches that are currently ongoing.
      */
-    public synchronized int getNumberOfInFlightFetches() {
-        int count = 0;
-        for (NodeEntry<T> nodeEntry : cache.values()) {
-            if (nodeEntry.isFetching()) {
-                count++;
-            }
-        }
-        return count;
+    public int getNumberOfInFlightFetches() {
+        return fetchingCount;
     }
 
     /**
@@ -122,6 +118,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
             final long fetchingRound = round.incrementAndGet();
             for (NodeEntry<T> nodeEntry : nodesToFetch) {
                 nodeEntry.markAsFetching(fetchingRound);
+                fetchingCount++;
             }
             DiscoveryNode[] discoNodesToFetch = nodesToFetch.stream()
                 .map(NodeEntry::getNodeId)
@@ -131,7 +128,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
         }
 
         // if we are still fetching, return null to indicate it
-        if (hasAnyNodeFetching(cache)) {
+        if (hasAnyNodeFetching()) {
             return new FetchResult<>(shardId, null, emptySet());
         } else {
             // nothing to fetch, yay, build the return value
@@ -209,6 +206,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
                         // if the entry is there, for the right fetching round and not marked as failed already, process it
                         logger.trace("{} marking {} as done for [{}], result is [{}]", shardId, nodeEntry.getNodeId(), type, response);
                         nodeEntry.doneFetching(response);
+                        fetchingCount--;
                     }
                 }
             }
@@ -236,6 +234,7 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
                             || unwrappedCause instanceof ReceiveTimeoutTransportException
                             || unwrappedCause instanceof ElasticsearchTimeoutException) {
                             nodeEntry.restartFetching();
+                            fetchingCount--;
                         } else {
                             logger.warn(
                                 () -> new ParameterizedMessage(
@@ -247,12 +246,14 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
                                 failure
                             );
                             nodeEntry.doneFetching(failure.getCause());
+                            fetchingCount--;
                         }
                     }
                 }
             }
         }
         reroute(shardId, "post_response");
+        assert assertFetchingCountConsistent();
     }
 
     /**
@@ -264,7 +265,11 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
      * Clear cache for node, ensuring next fetch will fetch a fresh copy.
      */
     synchronized void clearCacheForNode(String nodeId) {
-        cache.remove(nodeId);
+        NodeEntry<T> nodeEntry = cache.remove(nodeId);
+        if (nodeEntry != null && nodeEntry.fetching) {
+            fetchingCount--;
+        }
+        assert assertFetchingCountConsistent();
     }
 
     /**
@@ -280,7 +285,18 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
             }
         }
         // remove nodes that are not longer part of the data nodes set
-        shardCache.keySet().removeIf(nodeId -> nodes.nodeExists(nodeId) == false);
+        for (Iterator<Map.Entry<String, NodeEntry<T>>> iterator = shardCache.entrySet().iterator(); iterator.hasNext();) {
+            Map.Entry<String, NodeEntry<T>> entry = iterator.next();
+            String nodeId = entry.getKey();
+            NodeEntry<T> nodeEntry = entry.getValue();
+            if (nodes.nodeExists(nodeId) == false) {
+                if (nodeEntry.fetching) {
+                    fetchingCount--;
+                }
+                iterator.remove();
+            }
+        }
+        assert assertFetchingCountConsistent();
     }
 
     /**
@@ -300,13 +316,8 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
     /**
      * Are there any nodes that are fetching data?
      */
-    private boolean hasAnyNodeFetching(Map<String, NodeEntry<T>> shardCache) {
-        for (NodeEntry<T> nodeEntry : shardCache.values()) {
-            if (nodeEntry.isFetching()) {
-                return true;
-            }
-        }
-        return false;
+    private boolean hasAnyNodeFetching() {
+        return fetchingCount != 0;
     }
 
     /**
@@ -464,5 +475,11 @@ public abstract class AsyncShardFetch<T extends BaseNodeResponse> implements Rel
         long getFetchingRound() {
             return fetchingRound;
         }
+    }
+
+    private boolean assertFetchingCountConsistent() {
+        assert Thread.holdsLock(this);
+        assert fetchingCount == cache.values().stream().filter(NodeEntry::isFetching).count();
+        return true;
     }
 }

--- a/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
+++ b/server/src/test/java/org/elasticsearch/gateway/AsyncShardFetchTests.java
@@ -200,6 +200,7 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         // no fetched data, 2 requests still on going
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(2));
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
 
@@ -215,6 +216,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         // no more ongoing requests, we should fetch the data
         assertThat(test.reroute.get(), equalTo(2));
         fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(2));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
@@ -228,6 +230,7 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         // no fetched data, 2 requests still on going
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(2));
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
 
@@ -236,12 +239,14 @@ public class AsyncShardFetchTests extends ESTestCase {
         assertThat(test.reroute.get(), equalTo(1));
         fetchData = test.fetchData(nodes, emptySet());
         assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
 
         // fire the second simulation, this should allow us to get the data
         test.fireSimulationAndWait(node2.getId());
         assertThat(test.reroute.get(), equalTo(2));
         // since one of those failed, we should only have one entry
         fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
@@ -286,6 +291,7 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         // no fetched data, request still on going
         AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
         assertThat(fetchData.hasData(), equalTo(false));
         assertThat(test.reroute.get(), equalTo(0));
 
@@ -294,12 +300,14 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         // verify we get back right data from node
         fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
 
         // second fetch gets same data
         fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1));
@@ -311,6 +319,7 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         // no fetched data, new request on going
         fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
         assertThat(fetchData.hasData(), equalTo(false));
 
         test.fireSimulationAndWait(node1.getId());
@@ -318,9 +327,46 @@ public class AsyncShardFetchTests extends ESTestCase {
 
         // verify we get new data back
         fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
         assertThat(fetchData.hasData(), equalTo(true));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1_2));
+    }
+
+    public void testTwoNodesRemoveOne() throws Exception {
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(node1).add(node2).build();
+        test.addSimulation(node1.getId(), response1);
+        test.addSimulation(node2.getId(), response2);
+
+        // no fetched data, 2 requests still on going
+        AsyncShardFetch.FetchResult<Response> fetchData = test.fetchData(nodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(2));
+        assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.reroute.get(), equalTo(0));
+
+        // remove node1 that are no longer part of the data nodes set
+        DiscoveryNodes newNodes = DiscoveryNodes.builder().add(node2).build();
+        fetchData = test.fetchData(newNodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
+        assertThat(fetchData.hasData(), equalTo(false));
+
+        // fire the first response, but data1 removed
+        test.fireSimulationAndWait(node1.getId());
+        // there is still another on going request, so no data
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
+        fetchData = test.fetchData(nodes, emptySet());
+        assertThat(fetchData.hasData(), equalTo(false));
+
+        // fire the second simulation, this should allow us to get the data
+        test.fireSimulationAndWait(node2.getId());
+        // no more ongoing requests, we should fetch the data
+        assertThat(test.reroute.get(), equalTo(2));
+        fetchData = test.fetchData(newNodes, emptySet());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
+        assertThat(fetchData.hasData(), equalTo(true));
+        // only node2 in the fetchData
+        assertThat(fetchData.getData().size(), equalTo(1));
+        assertThat(fetchData.getData().get(node2), sameInstance(response2));
     }
 
     public void testConcurrentRequestAndClearCache() throws Exception {
@@ -333,7 +379,9 @@ public class AsyncShardFetchTests extends ESTestCase {
         assertThat(test.reroute.get(), equalTo(0));
 
         // clear cache while request is still on going, before it is processed
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
         test.clearCacheForNode(node1.getId());
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
 
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(1));
@@ -344,6 +392,7 @@ public class AsyncShardFetchTests extends ESTestCase {
         // verify still no fetched data, request still on going
         fetchData = test.fetchData(nodes, emptySet());
         assertThat(fetchData.hasData(), equalTo(false));
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(1));
 
         test.fireSimulationAndWait(node1.getId());
         assertThat(test.reroute.get(), equalTo(2));
@@ -351,9 +400,9 @@ public class AsyncShardFetchTests extends ESTestCase {
         // verify we get new data back
         fetchData = test.fetchData(nodes, emptySet());
         assertThat(fetchData.hasData(), equalTo(true));
+        assertThat(test.getNumberOfInFlightFetches(), equalTo(0));
         assertThat(fetchData.getData().size(), equalTo(1));
         assertThat(fetchData.getData().get(node1), sameInstance(response1_2));
-
     }
 
     static class TestFetch extends AsyncShardFetch<Response> {


### PR DESCRIPTION
Avoids an O(#nodes) iteration by tracking the number of fetches directly.

Backport of #93632 to 7.17