### PR TITLE
[8.8] fix typo, `my-app` -> `my_app` (#96543)

### DIFF
--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -91,7 +91,7 @@ PUT _application/search_application/my-app?create
 ----
 // TEST[skip:TBD]
 
-The following example creates or updates an existing Search Application called `my_app`:
+The following example creates or updates an existing Search Application called `my-app`:
 
 [source,console]
 ----


### PR DESCRIPTION
Backports the following commits to 8.8:
 - fix typo, `my-app` -> `my_app` (#96543)