### PR TITLE
Make RefCountingRunnable.AcquiredRef lighter

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/RefCountingRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RefCountingRunnable.java
@@ -87,6 +87,9 @@ public final class RefCountingRunnable implements Releasable {
      */
     public Releasable acquire() {
         if (refCounted.tryIncRef()) {
+            // All refs are considered equal so there's no real need to allocate a new object here, although note that this deviates
+            // (subtly) from the docs for Closeable#close() which indicate that it should be idempotent. But only if assertions are
+            // disabled, and if assertions are enabled then we are asserting that we never double-close these things anyway.
             return Releasables.assertOnce(this);
         }
         assert false : ALREADY_CLOSED_MESSAGE;

--- a/server/src/main/java/org/elasticsearch/action/support/RefCountingRunnable.java
+++ b/server/src/main/java/org/elasticsearch/action/support/RefCountingRunnable.java
@@ -69,12 +69,11 @@ public final class RefCountingRunnable implements Releasable {
     private final RefCounted refCounted;
     private final AtomicBoolean originalRefReleased = new AtomicBoolean();
 
-    private class AcquiredRef implements Releasable {
-        private final AtomicBoolean released = new AtomicBoolean();
+    private class AcquiredRef extends AtomicBoolean implements Releasable {
 
         @Override
         public void close() {
-            releaseRef(released);
+            releaseRef(this);
         }
 
         @Override

--- a/server/src/test/java/org/elasticsearch/action/support/RefCountingListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/RefCountingListenerTests.java
@@ -180,7 +180,7 @@ public class RefCountingListenerTests extends ESTestCase {
                 expectedMessage = RefCountingRunnable.ALREADY_CLOSED_MESSAGE;
             } else {
                 throwingRunnable = refs::close;
-                expectedMessage = "already closed";
+                expectedMessage = "invalid decRef call: already closed";
             }
 
             assertEquals(expectedMessage, expectThrows(AssertionError.class, throwingRunnable).getMessage());

--- a/server/src/test/java/org/elasticsearch/action/support/RefCountingRunnableTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/RefCountingRunnableTests.java
@@ -169,7 +169,7 @@ public class RefCountingRunnableTests extends ESTestCase {
                 expectedMessage = RefCountingRunnable.ALREADY_CLOSED_MESSAGE;
             } else {
                 throwingRunnable = refs::close;
-                expectedMessage = "already closed";
+                expectedMessage = "invalid decRef call: already closed";
             }
 
             assertEquals(expectedMessage, expectThrows(AssertionError.class, throwingRunnable).getMessage());


### PR DESCRIPTION
Just a small improvement saving some allocations when this may be hot. Found from benchmarking blob cache.
