### PR TITLE
Update NodeShutdownAllocationDecider javadoc.

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -19,7 +19,7 @@ import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
  * An allocation decider that prevents shards from being allocated to a node that is in the process of shutting down.
  *
  * No shards can be allocated to or remain on a node which is shutting down for removal.
- * Shard can be allocated or remain on the node scheduled for a restart.
+ * Shards can be allocated to or remain on a node scheduled for a restart.
  */
 public class NodeShutdownAllocationDecider extends AllocationDecider {
 

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/decider/NodeShutdownAllocationDecider.java
@@ -16,12 +16,10 @@ import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.routing.allocation.RoutingAllocation;
 
 /**
- * An allocation decider that prevents shards from being allocated to a
- * node that is in the process of shutting down.
+ * An allocation decider that prevents shards from being allocated to a node that is in the process of shutting down.
  *
- * In short: No shards can be allocated to, or remain on, a node which is
- * shutting down for removal. Primary shards cannot be allocated to, or remain
- * on, a node which is shutting down for restart.
+ * No shards can be allocated to or remain on a node which is shutting down for removal.
+ * Shard can be allocated or remain on the node scheduled for a restart.
  */
 public class NodeShutdownAllocationDecider extends AllocationDecider {
 


### PR DESCRIPTION
This change updates NodeShutdownAllocationDecider docs to remove details about primary shard handling during restart that are not implemented.
