### PR TITLE
Refactor away a DiscoveryNodeUtils.create method to the builder

### DIFF
--- a/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
+++ b/modules/transport-netty4/src/test/java/org/elasticsearch/transport/netty4/SimpleNetty4TransportTests.java
@@ -200,20 +200,16 @@ public class SimpleNetty4TransportTests extends AbstractSimpleTransportTestCase 
             socket.bind(getLocalEphemeral(), 1);
             socket.setReuseAddress(true);
 
-            DiscoveryNode first = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
-            DiscoveryNode second = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode first = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
+            DiscoveryNode second = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(
                 1,

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterStateDiffIT.java
@@ -57,7 +57,6 @@ import java.util.Map;
 import java.util.Set;
 
 import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.cluster.metadata.AliasMetadata.newAliasMetadataBuilder;
 import static org.elasticsearch.cluster.routing.RandomShardRoutingMutator.randomChange;
@@ -212,7 +211,7 @@ public class ClusterStateDiffIT extends ESIntegTestCase {
     }
 
     private DiscoveryNode randomNode(String nodeId) {
-        return DiscoveryNodeUtils.create(nodeId, buildNewFakeTransportAddress(), emptyMap(), emptySet(), randomVersion(random()));
+        return DiscoveryNodeUtils.builder(nodeId).roles(emptySet()).version(randomVersion(random())).build();
     }
 
     /**

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/info/NodeInfoTests.java
@@ -17,7 +17,6 @@ import org.elasticsearch.monitor.os.OsInfo;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.VersionUtils;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
@@ -38,13 +37,7 @@ public class NodeInfoTests extends ESTestCase {
             Version.CURRENT,
             TransportVersion.CURRENT,
             Build.CURRENT,
-            DiscoveryNodeUtils.create(
-                "test_node",
-                buildNewFakeTransportAddress(),
-                emptyMap(),
-                emptySet(),
-                VersionUtils.randomVersion(random())
-            ),
+            DiscoveryNodeUtils.builder("test_node").roles(emptySet()).version(VersionUtils.randomVersion(random())).build(),
             null,
             null,
             null,

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStatsTests.java
@@ -86,7 +86,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.IntStream;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.test.AbstractChunkedSerializingTestCase.assertChunkCount;
 import static org.elasticsearch.threadpool.ThreadPoolStatsTests.randomStats;
@@ -676,13 +675,10 @@ public class NodeStatsTests extends ESTestCase {
     }
 
     public static NodeStats createNodeStats() {
-        DiscoveryNode node = DiscoveryNodeUtils.create(
-            "test_node",
-            buildNewFakeTransportAddress(),
-            emptyMap(),
-            emptySet(),
-            VersionUtils.randomVersion(random())
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("test_node")
+            .roles(emptySet())
+            .version(VersionUtils.randomVersion(random()))
+            .build();
         NodeIndicesStats nodeIndicesStats = null;
         if (frequently()) {
             final Index indexTest = new Index("test", "_na_");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/NodeVersionAllocationDeciderTests.java
@@ -63,7 +63,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.shuffle;
 import static org.elasticsearch.cluster.routing.RoutingNodesHelper.shardsWithState;
 import static org.elasticsearch.cluster.routing.ShardRoutingState.INITIALIZING;
@@ -310,20 +309,14 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
         ShardId shard1 = new ShardId("test1", "_na_", 0);
         ShardId shard2 = new ShardId("test2", "_na_", 0);
         final DiscoveryNode newNode = DiscoveryNodeUtils.builder("newNode").roles(MASTER_DATA_ROLES).build();
-        final DiscoveryNode oldNode1 = DiscoveryNodeUtils.create(
-            "oldNode1",
-            buildNewFakeTransportAddress(),
-            emptyMap(),
-            MASTER_DATA_ROLES,
-            VersionUtils.getPreviousVersion()
-        );
-        final DiscoveryNode oldNode2 = DiscoveryNodeUtils.create(
-            "oldNode2",
-            buildNewFakeTransportAddress(),
-            emptyMap(),
-            MASTER_DATA_ROLES,
-            VersionUtils.getPreviousVersion()
-        );
+        final DiscoveryNode oldNode1 = DiscoveryNodeUtils.builder("oldNode1")
+            .roles(MASTER_DATA_ROLES)
+            .version(VersionUtils.getPreviousVersion())
+            .build();
+        final DiscoveryNode oldNode2 = DiscoveryNodeUtils.builder("oldNode2")
+            .roles(MASTER_DATA_ROLES)
+            .version(VersionUtils.getPreviousVersion())
+            .build();
         AllocationId allocationId1P = AllocationId.newInitializing();
         AllocationId allocationId1R = AllocationId.newInitializing();
         AllocationId allocationId2P = AllocationId.newInitializing();
@@ -421,20 +414,14 @@ public class NodeVersionAllocationDeciderTests extends ESAllocationTestCase {
 
     public void testRestoreDoesNotAllocateSnapshotOnOlderNodes() {
         final DiscoveryNode newNode = DiscoveryNodeUtils.builder("newNode").roles(MASTER_DATA_ROLES).build();
-        final DiscoveryNode oldNode1 = DiscoveryNodeUtils.create(
-            "oldNode1",
-            buildNewFakeTransportAddress(),
-            emptyMap(),
-            MASTER_DATA_ROLES,
-            VersionUtils.getPreviousVersion()
-        );
-        final DiscoveryNode oldNode2 = DiscoveryNodeUtils.create(
-            "oldNode2",
-            buildNewFakeTransportAddress(),
-            emptyMap(),
-            MASTER_DATA_ROLES,
-            VersionUtils.getPreviousVersion()
-        );
+        final DiscoveryNode oldNode1 = DiscoveryNodeUtils.builder("oldNode1")
+            .roles(MASTER_DATA_ROLES)
+            .version(VersionUtils.getPreviousVersion())
+            .build();
+        final DiscoveryNode oldNode2 = DiscoveryNodeUtils.builder("oldNode2")
+            .roles(MASTER_DATA_ROLES)
+            .version(VersionUtils.getPreviousVersion())
+            .build();
 
         final Snapshot snapshot = new Snapshot("rep1", new SnapshotId("snp1", UUIDs.randomBase64UUID()));
         final IndexId indexId = new IndexId("test", UUIDs.randomBase64UUID(random()));

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StartRecoveryRequestTests.java
@@ -25,7 +25,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Collections;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.test.VersionUtils.randomVersion;
 import static org.hamcrest.Matchers.equalTo;
@@ -45,8 +44,8 @@ public class StartRecoveryRequestTests extends ESTestCase {
         final StartRecoveryRequest outRequest = new StartRecoveryRequest(
             new ShardId("test", "_na_", 0),
             UUIDs.randomBase64UUID(),
-            DiscoveryNodeUtils.create("a", buildNewFakeTransportAddress(), emptyMap(), emptySet(), targetNodeVersion),
-            DiscoveryNodeUtils.create("b", buildNewFakeTransportAddress(), emptyMap(), emptySet(), targetNodeVersion),
+            DiscoveryNodeUtils.builder("a").roles(emptySet()).version(targetNodeVersion).build(),
+            DiscoveryNodeUtils.builder("b").roles(emptySet()).version(targetNodeVersion).build(),
             metadataSnapshot,
             randomBoolean(),
             randomNonNegativeLong(),

--- a/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
+++ b/server/src/test/java/org/elasticsearch/nodesinfo/NodeInfoStreamingTests.java
@@ -48,7 +48,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static org.elasticsearch.xcontent.XContentFactory.jsonBuilder;
 import static org.hamcrest.core.IsEqual.equalTo;
@@ -105,13 +104,10 @@ public class NodeInfoStreamingTests extends ESTestCase {
 
     private static NodeInfo createNodeInfo() {
         Build build = Build.CURRENT;
-        DiscoveryNode node = DiscoveryNodeUtils.create(
-            "test_node",
-            buildNewFakeTransportAddress(),
-            emptyMap(),
-            emptySet(),
-            VersionUtils.randomVersion(random())
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("test_node")
+            .roles(emptySet())
+            .version(VersionUtils.randomVersion(random()))
+            .build();
         Settings settings = randomBoolean() ? null : Settings.builder().put("test", "setting").build();
         OsInfo osInfo = null;
         if (randomBoolean()) {

--- a/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/SniffConnectionStrategyTests.java
@@ -1023,10 +1023,9 @@ public class SniffConnectionStrategyTests extends ESTestCase {
 
     public void testGetNodePredicateNodeVersion() {
         TransportAddress address = new TransportAddress(TransportAddress.META_ADDRESS, 0);
-        Set<DiscoveryNodeRole> roles = DiscoveryNodeRole.roles();
         Predicate<DiscoveryNode> nodePredicate = SniffConnectionStrategy.getNodePredicate(Settings.EMPTY);
         Version version = VersionUtils.randomVersion(random());
-        DiscoveryNode node = DiscoveryNodeUtils.create("id", address, Collections.emptyMap(), roles, version);
+        DiscoveryNode node = DiscoveryNodeUtils.builder("id").address(address).version(version).build();
         assertThat(nodePredicate.test(node), equalTo(Version.CURRENT.isCompatible(version)));
     }
 

--- a/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/TransportServiceHandshakeTests.java
@@ -129,13 +129,11 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             VersionUtils.randomVersionBetween(random(), Version.CURRENT.minimumCompatibilityVersion(), Version.CURRENT),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "",
-            transportServiceB.getLocalNode().getAddress(),
-            emptyMap(),
-            emptySet(),
-            Version.CURRENT.minimumCompatibilityVersion()
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
+            .address(transportServiceB.getLocalNode().getAddress())
+            .roles(emptySet())
+            .version(Version.CURRENT.minimumCompatibilityVersion())
+            .build();
         try (
             Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
                 transportServiceA,
@@ -168,13 +166,11 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             Version.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "",
-            transportServiceB.getLocalNode().getAddress(),
-            emptyMap(),
-            emptySet(),
-            Version.CURRENT.minimumCompatibilityVersion()
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
+            .address(transportServiceB.getLocalNode().getAddress())
+            .roles(emptySet())
+            .version(Version.CURRENT.minimumCompatibilityVersion())
+            .build();
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> {
             try (
                 Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
@@ -209,13 +205,11 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             VersionUtils.getPreviousVersion(Version.CURRENT.minimumCompatibilityVersion()),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "",
-            transportServiceB.getLocalNode().getAddress(),
-            emptyMap(),
-            emptySet(),
-            Version.CURRENT.minimumCompatibilityVersion()
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
+            .address(transportServiceB.getLocalNode().getAddress())
+            .roles(emptySet())
+            .version(Version.CURRENT.minimumCompatibilityVersion())
+            .build();
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> {
             try (
                 Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
@@ -258,13 +252,11 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             Version.CURRENT.minimumCompatibilityVersion(),
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "",
-            transportServiceB.getLocalNode().getAddress(),
-            emptyMap(),
-            emptySet(),
-            Version.CURRENT.minimumCompatibilityVersion()
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
+            .address(transportServiceB.getLocalNode().getAddress())
+            .roles(emptySet())
+            .version(Version.CURRENT.minimumCompatibilityVersion())
+            .build();
         expectThrows(ConnectTransportException.class, () -> {
             try (
                 Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(
@@ -296,13 +288,11 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             Version.CURRENT,
             TransportService.NOOP_TRANSPORT_INTERCEPTOR
         );
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            randomAlphaOfLength(10),
-            transportServiceB.getLocalNode().getAddress(),
-            emptyMap(),
-            emptySet(),
-            transportServiceB.getLocalNode().getVersion()
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder(randomAlphaOfLength(10))
+            .address(transportServiceB.getLocalNode().getAddress())
+            .roles(emptySet())
+            .version(transportServiceB.getLocalNode().getVersion())
+            .build();
         ConnectTransportException ex = expectThrows(
             ConnectTransportException.class,
             () -> AbstractSimpleTransportTestCase.connectToNode(transportServiceA, discoveryNode, TestProfiles.LIGHT_PROFILE)
@@ -334,13 +324,11 @@ public class TransportServiceHandshakeTests extends ESTestCase {
             Version.CURRENT,
             transportInterceptorB
         );
-        final DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "",
-            transportServiceB.getLocalNode().getAddress(),
-            emptyMap(),
-            emptySet(),
-            Version.CURRENT.minimumCompatibilityVersion()
-        );
+        final DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("")
+            .address(transportServiceB.getLocalNode().getAddress())
+            .roles(emptySet())
+            .version(Version.CURRENT.minimumCompatibilityVersion())
+            .build();
         TransportSerializationException ex = expectThrows(TransportSerializationException.class, () -> {
             try (
                 Transport.Connection connection = AbstractSimpleTransportTestCase.openConnection(

--- a/test/framework/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/cluster/node/DiscoveryNodeUtils.java
@@ -41,16 +41,6 @@ public class DiscoveryNodeUtils {
     }
 
     public static DiscoveryNode create(
-        String id,
-        TransportAddress address,
-        Map<String, String> attributes,
-        Set<DiscoveryNodeRole> roles,
-        Version version
-    ) {
-        return builder(id).address(address).attributes(attributes).roles(roles).version(version).build();
-    }
-
-    public static DiscoveryNode create(
         String nodeName,
         String nodeId,
         TransportAddress address,

--- a/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/transport/AbstractSimpleTransportTestCase.java
@@ -2306,13 +2306,11 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         try (ServerSocket socket = new MockServerSocket()) {
             socket.bind(getLocalEphemeral(), 1);
             socket.setReuseAddress(true);
-            DiscoveryNode dummy = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode dummy = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(
                 1,
@@ -2335,13 +2333,11 @@ public abstract class AbstractSimpleTransportTestCase extends ESTestCase {
         try (ServerSocket socket = new MockServerSocket()) {
             socket.bind(getLocalEphemeral(), 1);
             socket.setReuseAddress(true);
-            DiscoveryNode dummy = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode dummy = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
             Thread t = new Thread() {
                 @Override
                 public void run() {

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/InternalExecutePolicyActionTests.java
@@ -18,7 +18,6 @@ import org.junit.Before;
 
 import java.util.Set;
 
-import static java.util.Collections.emptyMap;
 import static org.hamcrest.Matchers.either;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
@@ -121,6 +120,6 @@ public class InternalExecutePolicyActionTests extends ESTestCase {
     }
 
     private static DiscoveryNode newNode(String nodeId, Set<DiscoveryNodeRole> roles, Version version) {
-        return DiscoveryNodeUtils.create(nodeId, buildNewFakeTransportAddress(), emptyMap(), roles, version);
+        return DiscoveryNodeUtils.builder(nodeId).roles(roles).version(version).build();
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/TokenServiceTests.java
@@ -102,6 +102,7 @@ import java.util.Base64;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import javax.crypto.SecretKey;
 
@@ -1077,13 +1078,10 @@ public class TokenServiceTests extends ESTestCase {
     ) {
         final ClusterState currentState = clusterService.state();
         final DiscoveryNodes.Builder discoBuilder = DiscoveryNodes.builder(currentState.getNodes());
-        final DiscoveryNode anotherDataNode = DiscoveryNodeUtils.create(
-            "another_data_node#" + version,
-            buildNewFakeTransportAddress(),
-            Collections.emptyMap(),
-            Collections.singleton(DiscoveryNodeRole.DATA_ROLE),
-            version
-        );
+        final DiscoveryNode anotherDataNode = DiscoveryNodeUtils.builder("another_data_node#" + version)
+            .roles(Set.of(DiscoveryNodeRole.DATA_ROLE))
+            .version(version)
+            .build();
         discoBuilder.add(anotherDataNode);
         final ClusterState.Builder newStateBuilder = ClusterState.builder(currentState);
         newStateBuilder.nodes(discoBuilder);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/transport/netty4/SimpleSecurityNetty4ServerTransportTests.java
@@ -854,13 +854,11 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                     IOUtils.closeWhileHandlingException(acceptedSocket);
                 }
             }).start();
-            DiscoveryNode dummy = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode dummy = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(
                 1,
@@ -896,13 +894,11 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
                     throw new AssertionError(e);
                 }
             }).start();
-            DiscoveryNode dummy = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode dummy = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
             ConnectionProfile.Builder builder = new ConnectionProfile.Builder();
             builder.addConnections(
                 1,
@@ -933,13 +929,11 @@ public class SimpleSecurityNetty4ServerTransportTests extends AbstractSimpleTran
         try (ServerSocket socket = serverSocketFactory.createServerSocket()) {
             socket.bind(getLocalEphemeral(), 1);
             socket.setReuseAddress(true);
-            DiscoveryNode dummy = DiscoveryNodeUtils.create(
-                "TEST",
-                new TransportAddress(socket.getInetAddress(), socket.getLocalPort()),
-                emptyMap(),
-                emptySet(),
-                version0
-            );
+            DiscoveryNode dummy = DiscoveryNodeUtils.builder("TEST")
+                .address(new TransportAddress(socket.getInetAddress(), socket.getLocalPort()))
+                .roles(emptySet())
+                .version(version0)
+                .build();
             Thread t = new Thread(() -> {
                 try (Socket accept = SocketAccess.doPrivileged(socket::accept)) {
                     // A read call will execute the ssl handshake

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformNodesTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformNodesTests.java
@@ -28,9 +28,8 @@ import org.elasticsearch.xpack.core.transform.transforms.TransformTaskParams;
 
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
+import java.util.Set;
 
-import static java.util.Collections.emptyMap;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE;
 import static org.elasticsearch.cluster.node.DiscoveryNodeRole.TRANSFORM_ROLE;
 import static org.elasticsearch.persistent.PersistentTasksCustomMetadata.INITIAL_ASSIGNMENT;
@@ -307,6 +306,6 @@ public class TransformNodesTests extends ESTestCase {
     }
 
     private static DiscoveryNode newDiscoveryNode(String id, Version version, DiscoveryNodeRole... roles) {
-        return DiscoveryNodeUtils.create(id, buildNewFakeTransportAddress(), emptyMap(), new HashSet<>(Arrays.asList(roles)), version);
+        return DiscoveryNodeUtils.builder(id).roles(Set.of(roles)).version(version).build();
     }
 }

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformPersistentTasksExecutorTests.java
@@ -45,9 +45,7 @@ import org.elasticsearch.xpack.transform.transforms.scheduling.TransformSchedule
 
 import java.time.Clock;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
@@ -289,12 +287,10 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             nodes.add(
                 DiscoveryNodeUtils.builder("dedicated-transform-node")
                     .roles(
-                        new HashSet<>(
-                            Arrays.asList(
-                                DiscoveryNodeRole.MASTER_ROLE,
-                                DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
-                                DiscoveryNodeRole.TRANSFORM_ROLE
-                            )
+                        Set.of(
+                            DiscoveryNodeRole.MASTER_ROLE,
+                            DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
+                            DiscoveryNodeRole.TRANSFORM_ROLE
                         )
                     )
                     .build()
@@ -303,20 +299,17 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
 
         if (pastDataNode) {
             nodes.add(
-                DiscoveryNodeUtils.create(
-                    "past-data-node-1",
-                    buildNewFakeTransportAddress(),
-                    Collections.emptyMap(),
-                    new HashSet<>(
-                        Arrays.asList(
+                DiscoveryNodeUtils.builder("past-data-node-1")
+                    .roles(
+                        Set.of(
                             DiscoveryNodeRole.DATA_ROLE,
                             DiscoveryNodeRole.MASTER_ROLE,
                             DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
                             DiscoveryNodeRole.TRANSFORM_ROLE
                         )
-                    ),
-                    Version.V_7_7_0
-                )
+                    )
+                    .version(Version.V_7_7_0)
+                    .build()
             );
         }
 
@@ -324,25 +317,17 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
             nodes.add(
                 DiscoveryNodeUtils.builder("current-data-node-with-2-tasks")
                     .roles(
-                        new HashSet<>(
-                            Arrays.asList(
-                                DiscoveryNodeRole.DATA_ROLE,
-                                DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
-                                DiscoveryNodeRole.TRANSFORM_ROLE
-                            )
-                        )
+                        Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE, DiscoveryNodeRole.TRANSFORM_ROLE)
                     )
                     .build()
             )
                 .add(
                     DiscoveryNodeUtils.builder("current-data-node-with-1-tasks")
                         .roles(
-                            new HashSet<>(
-                                Arrays.asList(
-                                    DiscoveryNodeRole.MASTER_ROLE,
-                                    DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
-                                    DiscoveryNodeRole.TRANSFORM_ROLE
-                                )
+                            Set.of(
+                                DiscoveryNodeRole.MASTER_ROLE,
+                                DiscoveryNodeRole.REMOTE_CLUSTER_CLIENT_ROLE,
+                                DiscoveryNodeRole.TRANSFORM_ROLE
                             )
                         )
                         .build()
@@ -352,11 +337,7 @@ public class TransformPersistentTasksExecutorTests extends ESTestCase {
         if (transformLocalOnlyNodes) {
             nodes.add(
                 DiscoveryNodeUtils.builder("current-data-node-with-0-tasks-transform-remote-disabled")
-                    .roles(
-                        new HashSet<>(
-                            Arrays.asList(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.TRANSFORM_ROLE)
-                        )
-                    )
+                    .roles(Set.of(DiscoveryNodeRole.DATA_ROLE, DiscoveryNodeRole.MASTER_ROLE, DiscoveryNodeRole.TRANSFORM_ROLE))
                     .build()
             );
         }


### PR DESCRIPTION
Remove the `DiscoveryNodeUtils.create(String, TransportAddress, Map, Set, Version)` method and change to the builder.

These changes have been done mechanically.