### PR TITLE
Refactor some uses of DiscoveryNodeUtils.create to the builder

### DIFF
--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTests.java
@@ -106,11 +106,9 @@ public class TransportBulkActionTests extends ESTestCase {
     public void setUp() throws Exception {
         super.setUp();
         threadPool = new TestThreadPool(getClass().getName());
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "node",
-            ESTestCase.buildNewFakeTransportAddress(),
-            VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("node")
+            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .build();
         clusterService = createClusterService(threadPool, discoveryNode);
         CapturingTransport capturingTransport = new CapturingTransport();
         transportService = capturingTransport.createTransportService(

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionTookTests.java
@@ -76,11 +76,9 @@ public class TransportBulkActionTookTests extends ESTestCase {
     @Before
     public void setUp() throws Exception {
         super.setUp();
-        DiscoveryNode discoveryNode = DiscoveryNodeUtils.create(
-            "node",
-            ESTestCase.buildNewFakeTransportAddress(),
-            VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
-        );
+        DiscoveryNode discoveryNode = DiscoveryNodeUtils.builder("node")
+            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .build();
         clusterService = createClusterService(threadPool, discoveryNode);
     }
 

--- a/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchQueryThenFetchAsyncActionTests.java
@@ -260,8 +260,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         int numConcurrent = randomIntBetween(1, 4);
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode newVersionNode = DiscoveryNodeUtils.create("node1", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode oldVersionNode = DiscoveryNodeUtils.create("node2", buildNewFakeTransportAddress(), oldVersion);
+        DiscoveryNode newVersionNode = DiscoveryNodeUtils.builder("node1").version(newVersion).build();
+        DiscoveryNode oldVersionNode = DiscoveryNodeUtils.builder("node2").version(oldVersion).build();
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(newVersionNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(oldVersionNode));
 
@@ -360,8 +360,8 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         AtomicInteger successfulOps = new AtomicInteger();
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode newVersionNode = DiscoveryNodeUtils.create("node1", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode oldVersionNode = DiscoveryNodeUtils.create("node2", buildNewFakeTransportAddress(), oldVersion);
+        DiscoveryNode newVersionNode = DiscoveryNodeUtils.builder("node1").version(newVersion).build();
+        DiscoveryNode oldVersionNode = DiscoveryNodeUtils.builder("node2").version(oldVersion).build();
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(newVersionNode));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(oldVersionNode));
 
@@ -502,9 +502,9 @@ public class SearchQueryThenFetchAsyncActionTests extends ESTestCase {
         AtomicInteger successfulOps = new AtomicInteger();
 
         Map<String, Transport.Connection> lookup = new ConcurrentHashMap<>();
-        DiscoveryNode newVersionNode1 = DiscoveryNodeUtils.create("node1", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode newVersionNode2 = DiscoveryNodeUtils.create("node2", buildNewFakeTransportAddress(), newVersion);
-        DiscoveryNode oldVersionNode = DiscoveryNodeUtils.create("node3", buildNewFakeTransportAddress(), oldVersion);
+        DiscoveryNode newVersionNode1 = DiscoveryNodeUtils.builder("node1").version(newVersion).build();
+        DiscoveryNode newVersionNode2 = DiscoveryNodeUtils.builder("node2").version(newVersion).build();
+        DiscoveryNode oldVersionNode = DiscoveryNodeUtils.builder("node3").version(oldVersion).build();
         lookup.put("node1", new SearchAsyncActionTests.MockConnection(newVersionNode1));
         lookup.put("node2", new SearchAsyncActionTests.MockConnection(newVersionNode2));
         lookup.put("node3", new SearchAsyncActionTests.MockConnection(oldVersionNode));

--- a/server/src/test/java/org/elasticsearch/cluster/action/index/MappingUpdatedActionTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/action/index/MappingUpdatedActionTests.java
@@ -128,9 +128,7 @@ public class MappingUpdatedActionTests extends ESTestCase {
     }
 
     public void testSendUpdateMappingUsingAutoPutMappingAction() {
-        DiscoveryNodes nodes = DiscoveryNodes.builder()
-            .add(DiscoveryNodeUtils.create("first", buildNewFakeTransportAddress(), Version.V_7_9_0))
-            .build();
+        DiscoveryNodes nodes = DiscoveryNodes.builder().add(DiscoveryNodeUtils.builder("first").version(Version.V_7_9_0).build()).build();
         ClusterState clusterState = ClusterState.builder(new ClusterName("_name")).nodes(nodes).build();
         ClusterService clusterService = mock(ClusterService.class);
         when(clusterService.state()).thenReturn(clusterState);

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/NodeJoinExecutorTests.java
@@ -106,10 +106,8 @@ public class NodeJoinExecutorTests extends ESTestCase {
     public void testPreventJoinClusterWithUnsupportedNodeVersions() {
         DiscoveryNodes.Builder builder = DiscoveryNodes.builder();
         final Version version = randomCompatibleVersion(random(), Version.CURRENT);
-        builder.add(DiscoveryNodeUtils.create(UUIDs.base64UUID(), buildNewFakeTransportAddress(), version));
-        builder.add(
-            DiscoveryNodeUtils.create(UUIDs.base64UUID(), buildNewFakeTransportAddress(), randomCompatibleVersion(random(), version))
-        );
+        builder.add(DiscoveryNodeUtils.builder(UUIDs.base64UUID()).version(version).build());
+        builder.add(DiscoveryNodeUtils.builder(UUIDs.base64UUID()).version(randomCompatibleVersion(random(), version)).build());
         DiscoveryNodes nodes = builder.build();
 
         final Version maxNodeVersion = nodes.getMaxNodeVersion();

--- a/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/PublicationTransportHandlerTests.java
@@ -222,11 +222,9 @@ public class PublicationTransportHandlerTests extends ESTestCase {
 
             final List<DiscoveryNode> allNodes = new ArrayList<>();
             while (allNodes.size() < 10) {
-                var node = DiscoveryNodeUtils.create(
-                    "node-" + allNodes.size(),
-                    buildNewFakeTransportAddress(),
-                    VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
-                );
+                var node = DiscoveryNodeUtils.builder("node-" + allNodes.size())
+                    .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+                    .build();
                 allNodes.add(node);
                 nodeTransports.put(
                     node,
@@ -355,11 +353,9 @@ public class PublicationTransportHandlerTests extends ESTestCase {
         final var completed = new AtomicBoolean();
 
         final var localNode = DiscoveryNodeUtils.create("localNode");
-        final var otherNode = DiscoveryNodeUtils.create(
-            "otherNode",
-            buildNewFakeTransportAddress(),
-            VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
-        );
+        final var otherNode = DiscoveryNodeUtils.builder("otherNode")
+            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .build();
         for (final var discoveryNode : List.of(localNode, otherNode)) {
             final var transport = new MockTransport() {
                 @Override

--- a/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/rest/action/document/RestIndexActionTests.java
@@ -86,11 +86,7 @@ public class RestIndexActionTests extends RestActionTestCase {
             .build();
         clusterStateSupplier.set(
             ClusterState.builder(ClusterName.DEFAULT)
-                .nodes(
-                    DiscoveryNodes.builder()
-                        .add(DiscoveryNodeUtils.create("test", buildNewFakeTransportAddress(), minClusterVersion))
-                        .build()
-                )
+                .nodes(DiscoveryNodes.builder().add(DiscoveryNodeUtils.builder("test").version(minClusterVersion).build()).build())
                 .build()
         );
         dispatchRequest(autoIdRequest);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/SecurityTests.java
@@ -370,11 +370,9 @@ public class SecurityTests extends ESTestCase {
     }
 
     public void testJoinValidatorForFIPSOnAllowedLicense() throws Exception {
-        DiscoveryNode node = DiscoveryNodeUtils.create(
-            "foo",
-            buildNewFakeTransportAddress(),
-            VersionUtils.randomVersionBetween(random(), null, Version.CURRENT)
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("foo")
+            .version(VersionUtils.randomVersionBetween(random(), null, Version.CURRENT))
+            .build();
         Metadata.Builder builder = Metadata.builder();
         License license = TestUtils.generateSignedLicense(
             randomFrom(License.OperationMode.ENTERPRISE, License.OperationMode.PLATINUM, License.OperationMode.TRIAL).toString(),
@@ -397,11 +395,9 @@ public class SecurityTests extends ESTestCase {
     }
 
     public void testJoinValidatorForFIPSOnForbiddenLicense() throws Exception {
-        DiscoveryNode node = DiscoveryNodeUtils.create(
-            "foo",
-            buildNewFakeTransportAddress(),
-            VersionUtils.randomVersionBetween(random(), null, Version.CURRENT)
-        );
+        DiscoveryNode node = DiscoveryNodeUtils.builder("foo")
+            .version(VersionUtils.randomVersionBetween(random(), null, Version.CURRENT))
+            .build();
         Metadata.Builder builder = Metadata.builder();
         final String forbiddenLicenseType = randomFrom(
             List.of(License.OperationMode.values())
@@ -455,7 +451,7 @@ public class SecurityTests extends ESTestCase {
             .numberOfShards(1)
             .numberOfReplicas(0)
             .build();
-        DiscoveryNode existingOtherNode = DiscoveryNodeUtils.create("bar", buildNewFakeTransportAddress(), version);
+        DiscoveryNode existingOtherNode = DiscoveryNodeUtils.builder("bar").version(version).build();
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder().add(existingOtherNode).build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT)
             .nodes(discoveryNodes)
@@ -469,11 +465,9 @@ public class SecurityTests extends ESTestCase {
         BiConsumer<DiscoveryNode, ClusterState> joinValidator = security.getJoinValidator();
         assertNotNull(joinValidator);
         DiscoveryNode node = DiscoveryNodeUtils.create("foo");
-        DiscoveryNode existingOtherNode = DiscoveryNodeUtils.create(
-            "bar",
-            buildNewFakeTransportAddress(),
-            VersionUtils.randomCompatibleVersion(random(), Version.CURRENT)
-        );
+        DiscoveryNode existingOtherNode = DiscoveryNodeUtils.builder("bar")
+            .version(VersionUtils.randomCompatibleVersion(random(), Version.CURRENT))
+            .build();
         DiscoveryNodes discoveryNodes = DiscoveryNodes.builder().add(existingOtherNode).build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).nodes(discoveryNodes).build();
         joinValidator.accept(node, clusterState);

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/action/filter/SecurityActionFilterTests.java
@@ -96,7 +96,7 @@ public class SecurityActionFilterTests extends ESTestCase {
         ClusterState state = mock(ClusterState.class);
         DiscoveryNodes nodes = DiscoveryNodes.builder()
             .add(DiscoveryNodeUtils.create("id1"))
-            .add(DiscoveryNodeUtils.create("id2", buildNewFakeTransportAddress(), Version.CURRENT.minimumCompatibilityVersion()))
+            .add(DiscoveryNodeUtils.builder("id2").version(Version.CURRENT.minimumCompatibilityVersion()).build())
             .build();
         when(state.nodes()).thenReturn(nodes);
 

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/WatcherLifeCycleServiceTests.java
@@ -620,6 +620,6 @@ public class WatcherLifeCycleServiceTests extends ESTestCase {
     }
 
     private static DiscoveryNode newNode(String nodeName, Version version) {
-        return DiscoveryNodeUtils.create(nodeName, ESTestCase.buildNewFakeTransportAddress(), version);
+        return DiscoveryNodeUtils.builder(nodeName).version(version).build();
     }
 }


### PR DESCRIPTION
Refactor some uses of `DiscoveryNodeUtils.create(String, TransportAddress, Version)` to the builder.

These changes have all been done mechanically.