### PR TITLE
Synonyms API - DELETE Request

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/synonyms.delete.json
@@ -1,0 +1,32 @@
+{
+  "synonyms.delete": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/delete-synonyms.html",
+      "description": "Deletes a synonym set"
+    },
+    "stability": "experimental",
+    "visibility": "feature_flag",
+    "feature_flag": "es.synonyms_feature_flag_enabled",
+    "headers": {
+      "accept": [
+        "application/json"
+      ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/_synonyms/{synonyms_set}",
+          "methods": [
+            "DELETE"
+          ],
+          "parts": {
+            "synonyms_set": {
+              "type": "string",
+              "description": "The name of the synonyms set to be deleted"
+            }
+          }
+        }
+      ]
+    }
+  }
+}

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -21,6 +21,11 @@ setup:
   - match:
       acknowledged: true
 
+  - do:
+      catch: missing
+      synonyms.get:
+        synonyms_set: test-get-synonyms
+
 ---
 "Delete synonyms set - not found":
   - do:

--- a/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
+++ b/rest-api-spec/src/yamlRestTest/resources/rest-api-spec/test/synonyms/30_synonyms_delete.yml
@@ -1,0 +1,57 @@
+setup:
+  - skip:
+      version: " - 8.8.99"
+      reason: Introduced in 8.9.0
+  - do:
+      synonyms.put:
+        synonyms_set: test-get-synonyms
+        body:
+          synonyms_set:
+            - synonyms: "hello, hi"
+              id: "test-id-1"
+            - synonyms: "bye => goodbye"
+              id: "test-id-2"
+
+---
+"Delete synonyms set":
+  - do:
+      synonyms.delete:
+        synonyms_set: test-get-synonyms
+
+  - match:
+      acknowledged: true
+
+---
+"Delete synonyms set - not found":
+  - do:
+      catch: missing
+      synonyms.delete:
+        synonyms_set: unknown-synonym-set
+
+---
+"Delete synonyms set - does not impact other synonym sets":
+  - do:
+      synonyms.put:
+        synonyms_set: test-other-synonyms
+        body:
+          synonyms_set:
+            - synonyms: "hola, hi"
+              id: "test-other-1"
+            - synonyms: "test => check"
+              id: "test-other-2"
+  - do:
+      synonyms.delete:
+        synonyms_set: test-get-synonyms
+
+  - do:
+      synonyms.get:
+        synonyms_set: test-other-synonyms
+
+  - match:
+      count: 2
+  - match:
+      synonyms_set:
+        - synonyms: "hola, hi"
+          id: "test-other-1"
+        - synonyms: "test => check"
+          id: "test-other-2"

--- a/server/src/main/java/org/elasticsearch/action/ActionModule.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionModule.java
@@ -249,8 +249,10 @@ import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.AutoCreateIndex;
 import org.elasticsearch.action.support.DestructiveOperations;
 import org.elasticsearch.action.support.TransportAction;
+import org.elasticsearch.action.synonyms.DeleteSynonymsAction;
 import org.elasticsearch.action.synonyms.GetSynonymsAction;
 import org.elasticsearch.action.synonyms.PutSynonymsAction;
+import org.elasticsearch.action.synonyms.TransportDeleteSynonymsAction;
 import org.elasticsearch.action.synonyms.TransportGetSynonymsAction;
 import org.elasticsearch.action.synonyms.TransportPutSynonymsAction;
 import org.elasticsearch.action.termvectors.MultiTermVectorsAction;
@@ -436,6 +438,7 @@ import org.elasticsearch.rest.action.search.RestKnnSearchAction;
 import org.elasticsearch.rest.action.search.RestMultiSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchAction;
 import org.elasticsearch.rest.action.search.RestSearchScrollAction;
+import org.elasticsearch.rest.action.synonyms.RestDeleteSynonymsAction;
 import org.elasticsearch.rest.action.synonyms.RestGetSynonymsAction;
 import org.elasticsearch.rest.action.synonyms.RestPutSynonymsAction;
 import org.elasticsearch.synonyms.SynonymsAPI;
@@ -783,6 +786,7 @@ public class ActionModule extends AbstractModule {
         if (SynonymsAPI.isEnabled()) {
             actions.register(PutSynonymsAction.INSTANCE, TransportPutSynonymsAction.class);
             actions.register(GetSynonymsAction.INSTANCE, TransportGetSynonymsAction.class);
+            actions.register(DeleteSynonymsAction.INSTANCE, TransportDeleteSynonymsAction.class);
         }
 
         return unmodifiableMap(actions.getRegistry());
@@ -997,6 +1001,7 @@ public class ActionModule extends AbstractModule {
         if (SynonymsAPI.isEnabled()) {
             registerHandler.accept(new RestPutSynonymsAction());
             registerHandler.accept(new RestGetSynonymsAction());
+            registerHandler.accept(new RestDeleteSynonymsAction());
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymsAction.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.action.synonyms;
 
+import org.apache.logging.log4j.util.Strings;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionType;
@@ -35,9 +36,11 @@ public class DeleteSynonymsAction extends ActionType<AcknowledgedResponse> {
             this.synonymsSetId = in.readString();
         }
 
-        public Request(String SynonymsSetId) {
-            Objects.requireNonNull(SynonymsSetId, "Synonym set ID cannot be null");
-            this.synonymsSetId = SynonymsSetId;
+        public Request(String synonymsSetId) {
+            if (Strings.isBlank(synonymsSetId)) {
+                throw new IllegalArgumentException("Synonym set ID cannot be null or blank");
+            }
+            this.synonymsSetId = synonymsSetId;
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/DeleteSynonymsAction.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class DeleteSynonymsAction extends ActionType<AcknowledgedResponse> {
+
+    public static final DeleteSynonymsAction INSTANCE = new DeleteSynonymsAction();
+    public static final String NAME = "cluster:admin/synonyms/delete";
+
+    public DeleteSynonymsAction() {
+        super(NAME, AcknowledgedResponse::readFrom);
+    }
+
+    public static class Request extends ActionRequest {
+        private final String synonymsSetId;
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            this.synonymsSetId = in.readString();
+        }
+
+        public Request(String SynonymsSetId) {
+            Objects.requireNonNull(SynonymsSetId, "Synonym set ID cannot be null");
+            this.synonymsSetId = SynonymsSetId;
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeString(synonymsSetId);
+        }
+
+        public String synonymsSetId() {
+            return synonymsSetId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return Objects.equals(synonymsSetId, request.synonymsSetId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(synonymsSetId);
+        }
+    }
+}

--- a/server/src/main/java/org/elasticsearch/action/synonyms/TransportDeleteSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/synonyms/TransportDeleteSynonymsAction.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.HandledTransportAction;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.synonyms.SynonymsManagementAPIService;
+import org.elasticsearch.tasks.Task;
+import org.elasticsearch.transport.TransportService;
+
+public class TransportDeleteSynonymsAction extends HandledTransportAction<DeleteSynonymsAction.Request, AcknowledgedResponse> {
+
+    private final SynonymsManagementAPIService synonymsManagementAPIService;
+
+    @Inject
+    public TransportDeleteSynonymsAction(TransportService transportService, ActionFilters actionFilters, Client client) {
+        super(DeleteSynonymsAction.NAME, transportService, actionFilters, DeleteSynonymsAction.Request::new);
+
+        this.synonymsManagementAPIService = new SynonymsManagementAPIService(client);
+    }
+
+    @Override
+    protected void doExecute(Task task, DeleteSynonymsAction.Request request, ActionListener<AcknowledgedResponse> listener) {
+        synonymsManagementAPIService.deleteSynonymsSet(request.synonymsSetId(), listener);
+    }
+}

--- a/server/src/main/java/org/elasticsearch/rest/action/synonyms/RestDeleteSynonymsAction.java
+++ b/server/src/main/java/org/elasticsearch/rest/action/synonyms/RestDeleteSynonymsAction.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.rest.action.synonyms;
+
+import org.elasticsearch.action.synonyms.DeleteSynonymsAction;
+import org.elasticsearch.client.internal.node.NodeClient;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.Scope;
+import org.elasticsearch.rest.ServerlessScope;
+import org.elasticsearch.rest.action.RestToXContentListener;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.elasticsearch.rest.RestRequest.Method.DELETE;
+
+@ServerlessScope(Scope.PUBLIC)
+public class RestDeleteSynonymsAction extends BaseRestHandler {
+
+    @Override
+    public String getName() {
+        return "synonyms_delete_action";
+    }
+
+    @Override
+    public List<Route> routes() {
+        return List.of(new Route(DELETE, "/_synonyms/{synonymsSet}"));
+    }
+
+    @Override
+    protected RestChannelConsumer prepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
+        DeleteSynonymsAction.Request request = new DeleteSynonymsAction.Request(restRequest.param("synonymsSet"));
+        return channel -> client.execute(DeleteSynonymsAction.INSTANCE, request, new RestToXContentListener<>(channel));
+    }
+}

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -160,10 +160,6 @@ public class SynonymsManagementAPIService {
     }
 
     public void putSynonymsSet(String resourceName, SynonymRule[] synonymsSet, ActionListener<UpdateSynonymsResult> listener) {
-
-        // TODO Add synonym rules validation
-
-        // Delete synonyms set if it existed previously. Avoid catching an index not found error by ignoring unavailable indices
         deleteSynonymSetRules(resourceName, listener.delegateFailure((deleteByQueryResponseListener, bulkByScrollResponse) -> {
             boolean created = bulkByScrollResponse.getDeleted() == 0;
             final List<BulkItemResponse.Failure> bulkFailures = bulkByScrollResponse.getBulkFailures();
@@ -217,7 +213,7 @@ public class SynonymsManagementAPIService {
         // Delete synonyms set if it existed previously. Avoid catching an index not found error by ignoring unavailable indices
         DeleteByQueryRequest dbqRequest = new DeleteByQueryRequest(SYNONYMS_ALIAS_NAME).setQuery(
             QueryBuilders.termQuery(SYNONYMS_SET_FIELD, resourceName)
-        ).setIndicesOptions(IndicesOptions.fromOptions(true, true, false, false));
+        ).setRefresh(true).setIndicesOptions(IndicesOptions.fromOptions(true, true, false, false));
 
         client.execute(DeleteByQueryAction.INSTANCE, dbqRequest, listener);
     }

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.synonyms;
 
-import org.apache.logging.log4j.core.appender.rolling.action.Action;
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
@@ -166,52 +165,51 @@ public class SynonymsManagementAPIService {
 
         // Delete synonyms set if it existed previously. Avoid catching an index not found error by ignoring unavailable indices
         deleteSynonymSetRules(resourceName, listener.delegateFailure((deleteByQueryResponseListener, bulkByScrollResponse) -> {
-                boolean created = bulkByScrollResponse.getDeleted() == 0;
-                final List<BulkItemResponse.Failure> bulkFailures = bulkByScrollResponse.getBulkFailures();
-                if (bulkFailures.isEmpty() == false) {
-                    listener.onFailure(
-                        new ElasticsearchException(
-                            "Error updating synonyms: "
-                                + bulkFailures.stream().map(BulkItemResponse.Failure::getMessage).collect(Collectors.joining("\n"))
-                        )
-                    );
-                }
+            boolean created = bulkByScrollResponse.getDeleted() == 0;
+            final List<BulkItemResponse.Failure> bulkFailures = bulkByScrollResponse.getBulkFailures();
+            if (bulkFailures.isEmpty() == false) {
+                listener.onFailure(
+                    new ElasticsearchException(
+                        "Error updating synonyms: "
+                            + bulkFailures.stream().map(BulkItemResponse.Failure::getMessage).collect(Collectors.joining("\n"))
+                    )
+                );
+            }
 
-                // Insert as bulk requests
-                BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
-                try {
-                    for (SynonymRule synonymRule : synonymsSet) {
-                        try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
-                            builder.startObject();
-                            {
-                                builder.field(SYNONYMS_FIELD, synonymRule.synonyms());
-                                builder.field(SYNONYMS_SET_FIELD, resourceName);
-                            }
-                            builder.endObject();
-
-                            final IndexRequest indexRequest = new IndexRequest(SYNONYMS_ALIAS_NAME).opType(DocWriteRequest.OpType.INDEX)
-                                .source(builder);
-                            indexRequest.id(internalSynonymRuleId(resourceName, synonymRule));
-                            bulkRequestBuilder.add(indexRequest);
+            // Insert as bulk requests
+            BulkRequestBuilder bulkRequestBuilder = client.prepareBulk();
+            try {
+                for (SynonymRule synonymRule : synonymsSet) {
+                    try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
+                        builder.startObject();
+                        {
+                            builder.field(SYNONYMS_FIELD, synonymRule.synonyms());
+                            builder.field(SYNONYMS_SET_FIELD, resourceName);
                         }
+                        builder.endObject();
+
+                        final IndexRequest indexRequest = new IndexRequest(SYNONYMS_ALIAS_NAME).opType(DocWriteRequest.OpType.INDEX)
+                            .source(builder);
+                        indexRequest.id(internalSynonymRuleId(resourceName, synonymRule));
+                        bulkRequestBuilder.add(indexRequest);
                     }
-                } catch (IOException ex) {
-                    listener.onFailure(ex);
                 }
+            } catch (IOException ex) {
+                listener.onFailure(ex);
+            }
 
-                bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
-                    .execute(deleteByQueryResponseListener.delegateFailure((bulkResponseListener, bulkResponse) -> {
-                        if (bulkResponse.hasFailures() == false) {
-                            UpdateSynonymsResult result = created ? UpdateSynonymsResult.CREATED : UpdateSynonymsResult.UPDATED;
-                            bulkResponseListener.onResponse(result);
-                        } else {
-                            bulkResponseListener.onFailure(
-                                new ElasticsearchException("Couldn't update synonyms: " + bulkResponse.buildFailureMessage())
-                            );
-                        }
-                    }));
-            })
-        );
+            bulkRequestBuilder.setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
+                .execute(deleteByQueryResponseListener.delegateFailure((bulkResponseListener, bulkResponse) -> {
+                    if (bulkResponse.hasFailures() == false) {
+                        UpdateSynonymsResult result = created ? UpdateSynonymsResult.CREATED : UpdateSynonymsResult.UPDATED;
+                        bulkResponseListener.onResponse(result);
+                    } else {
+                        bulkResponseListener.onFailure(
+                            new ElasticsearchException("Couldn't update synonyms: " + bulkResponse.buildFailureMessage())
+                        );
+                    }
+                }));
+        }));
     }
 
     // Deletes a synonym set rules, using the supplied listener
@@ -223,6 +221,7 @@ public class SynonymsManagementAPIService {
 
         client.execute(DeleteByQueryAction.INSTANCE, dbqRequest, listener);
     }
+
     public void deleteSynonymsSet(String resourceName, ActionListener<AcknowledgedResponse> listener) {
         deleteSynonymSetRules(resourceName, listener.delegateFailure((l, bulkByScrollResponse) -> {
             if (bulkByScrollResponse.getDeleted() == 0) {

--- a/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymsActionRequestSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymsActionRequestSerializingTests.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.action.synonyms;
+
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+
+import java.io.IOException;
+
+public class DeleteSynonymsActionRequestSerializingTests extends AbstractWireSerializingTestCase<DeleteSynonymsAction.Request> {
+
+    @Override
+    protected Writeable.Reader<DeleteSynonymsAction.Request> instanceReader() {
+        return DeleteSynonymsAction.Request::new;
+    }
+
+    @Override
+    protected DeleteSynonymsAction.Request createTestInstance() {
+        return new DeleteSynonymsAction.Request(
+            randomIdentifier()
+        );
+    }
+
+    @Override
+    protected DeleteSynonymsAction.Request mutateInstance(DeleteSynonymsAction.Request instance) throws IOException {
+        return randomValueOtherThan(instance, this::createTestInstance);
+    }
+}

--- a/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymsActionRequestSerializingTests.java
+++ b/server/src/test/java/org/elasticsearch/action/synonyms/DeleteSynonymsActionRequestSerializingTests.java
@@ -22,9 +22,7 @@ public class DeleteSynonymsActionRequestSerializingTests extends AbstractWireSer
 
     @Override
     protected DeleteSynonymsAction.Request createTestInstance() {
-        return new DeleteSynonymsAction.Request(
-            randomIdentifier()
-        );
+        return new DeleteSynonymsAction.Request(randomIdentifier());
     }
 
     @Override

--- a/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
+++ b/x-pack/plugin/security/qa/operator-privileges-tests/src/javaRestTest/java/org/elasticsearch/xpack/security/operator/Constants.java
@@ -67,6 +67,7 @@ public class Constants {
         "cluster:admin/script_language/get",
         "cluster:admin/scripts/painless/context",
         "cluster:admin/scripts/painless/execute",
+        "cluster:admin/synonyms/delete",
         "cluster:admin/synonyms/get",
         "cluster:admin/synonyms/put",
         "cluster:admin/settings/update",


### PR DESCRIPTION
Adds a DELETE request for a synonym set:

`DELETE /_synonyms/<synonym_set_id>`

Response:

```json
{
    "acknowledged": true
}
```

This request deletes all synonym rules in a synonym set. If no synonym rules are found, a not found error is thrown, as the synonym set did not exist previously.
