### PR TITLE
Fix lost exception in SnapshotIndexCommit

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
@@ -74,9 +74,7 @@ public final class SnapshotShardContext extends DelegatingActionListener<ShardSn
 
             @Override
             public void onFailure(Exception e) {
-                commitRef.onCompletion(listener.map(ignored -> {
-                    throw e;
-                }));
+                commitRef.onCompletion(listener.map(ignored -> { throw e; }));
             }
         });
         this.store = store;

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
@@ -66,30 +66,7 @@ public final class SnapshotShardContext extends DelegatingActionListener<ShardSn
         final long snapshotStartTime,
         ActionListener<ShardSnapshotResult> listener
     ) {
-        super(new ActionListener<>() {
-            @Override
-            public void onResponse(ShardSnapshotResult shardSnapshotResult) {
-                commitRef.onCompletion(listener.map(ignored -> shardSnapshotResult));
-            }
-
-            @Override
-            public void onFailure(Exception e) {
-                commitRef.onCompletion(new ActionListener<>() {
-                    @Override
-                    public void onResponse(Void unused) {
-                        listener.onFailure(e);
-                    }
-
-                    @Override
-                    public void onFailure(Exception e2) {
-                        if (e2 != e) {
-                            e.addSuppressed(e2);
-                        }
-                        listener.onFailure(e);
-                    }
-                });
-            }
-        });
+        super(commitRef.closingBefore(listener));
         this.store = store;
         this.mapperService = mapperService;
         this.snapshotId = snapshotId;

--- a/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
+++ b/server/src/main/java/org/elasticsearch/repositories/SnapshotShardContext.java
@@ -74,7 +74,20 @@ public final class SnapshotShardContext extends DelegatingActionListener<ShardSn
 
             @Override
             public void onFailure(Exception e) {
-                commitRef.onCompletion(listener.map(ignored -> { throw e; }));
+                commitRef.onCompletion(new ActionListener<>() {
+                    @Override
+                    public void onResponse(Void unused) {
+                        listener.onFailure(e);
+                    }
+
+                    @Override
+                    public void onFailure(Exception e2) {
+                        if (e2 != e) {
+                            e.addSuppressed(e2);
+                        }
+                        listener.onFailure(e);
+                    }
+                });
             }
         });
         this.store = store;

--- a/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
@@ -8,7 +8,9 @@
 
 package org.elasticsearch.repositories;
 
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.core.Nullable;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.test.ESTestCase;
 
@@ -19,31 +21,21 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SnapshotIndexCommitTests extends ESTestCase {
 
-    public void testCompleteAndCloseCleanly() throws Exception {
-        runCompleteTest(false);
+    public void testComplete() throws Exception {
+        runCompleteTest(false, null);
+        runCompleteTest(true, null);
+        runCompleteTest(false, new ElasticsearchException("outer"));
+        runCompleteTest(true, new ElasticsearchException("outer"));
     }
 
-    public void testCompleteAndFailOnClose() throws Exception {
-        runCompleteTest(true);
+    public void testAbort() throws Exception {
+        runAbortTest(false, null);
+        runAbortTest(true, null);
+        runAbortTest(false, new ElasticsearchException("outer"));
+        runAbortTest(true, new ElasticsearchException("outer"));
     }
 
-    public void testAbortAndCloseCleanly() throws Exception {
-        runAbortTest(false);
-    }
-
-    public void testAbortAndFailOnClose() throws Exception {
-        runAbortTest(true);
-    }
-
-    public void testConcurrentAbortAndCompleteCleanly() throws Exception {
-        runConcurrentTest(false);
-    }
-
-    public void testConcurrentAbortAndCompleteWithFailOnClose() throws Exception {
-        runConcurrentTest(true);
-    }
-
-    private void runCompleteTest(boolean throwOnClose) throws Exception {
+    private void runCompleteTest(boolean throwOnClose, @Nullable Exception outerException) throws Exception {
         final var isClosed = new AtomicBoolean();
         final var indexCommitRef = getSnapshotIndexCommit(throwOnClose, isClosed);
 
@@ -53,7 +45,7 @@ public class SnapshotIndexCommitTests extends ESTestCase {
             indexCommitRef.decRef();
         }
 
-        assertOnCompletionBehaviour(throwOnClose, indexCommitRef);
+        assertOnCompletionBehaviour(throwOnClose, outerException, indexCommitRef);
 
         assertTrue(isClosed.get());
         assertFalse(indexCommitRef.tryIncRef());
@@ -62,7 +54,7 @@ public class SnapshotIndexCommitTests extends ESTestCase {
         assertFalse(indexCommitRef.tryIncRef());
     }
 
-    private void runAbortTest(boolean throwOnClose) throws Exception {
+    private void runAbortTest(boolean throwOnClose, @Nullable Exception outerException) throws Exception {
         final var isClosed = new AtomicBoolean();
         final var indexCommitRef = getSnapshotIndexCommit(throwOnClose, isClosed);
 
@@ -78,18 +70,19 @@ public class SnapshotIndexCommitTests extends ESTestCase {
 
         assertTrue(isClosed.get());
 
-        assertOnCompletionBehaviour(throwOnClose, indexCommitRef);
+        assertOnCompletionBehaviour(throwOnClose, outerException, indexCommitRef);
     }
 
     private void runConcurrentTest(boolean throwOnClose) throws Exception {
         final var isClosed = new AtomicBoolean();
         final var indexCommitRef = getSnapshotIndexCommit(throwOnClose, isClosed);
+        final var completeFuture = new PlainActionFuture<String>();
+        final var closingActionListener = indexCommitRef.closingBefore(completeFuture);
 
-        final var completeFuture = new PlainActionFuture<Void>();
         final var barrier = new CyclicBarrier(2);
         final var completeThread = new Thread(() -> {
             safeAwait(barrier);
-            indexCommitRef.onCompletion(completeFuture);
+            closingActionListener.onResponse("success");
         });
         completeThread.start();
 
@@ -102,7 +95,7 @@ public class SnapshotIndexCommitTests extends ESTestCase {
         completeThread.join();
         abortThread.join();
 
-        assertOnCompletionFuture(throwOnClose, completeFuture);
+        assertOnCompletionFuture(throwOnClose, null, completeFuture);
     }
 
     private SnapshotIndexCommit getSnapshotIndexCommit(boolean throwOnClose, AtomicBoolean isClosed) {
@@ -114,18 +107,37 @@ public class SnapshotIndexCommitTests extends ESTestCase {
         }));
     }
 
-    private void assertOnCompletionBehaviour(boolean throwOnClose, SnapshotIndexCommit indexCommitRef) throws Exception {
-        final var future = new PlainActionFuture<Void>();
-        indexCommitRef.onCompletion(future);
-        assertOnCompletionFuture(throwOnClose, future);
+    private void assertOnCompletionBehaviour(boolean throwOnClose, @Nullable Exception outerException, SnapshotIndexCommit indexCommitRef)
+        throws Exception {
+        final var future = new PlainActionFuture<String>();
+        if (outerException == null) {
+            indexCommitRef.closingBefore(future).onResponse("success");
+        } else {
+            indexCommitRef.closingBefore(future).onFailure(outerException);
+        }
+        assertOnCompletionFuture(throwOnClose, outerException, future);
     }
 
-    private void assertOnCompletionFuture(boolean throwOnClose, PlainActionFuture<Void> completionFuture) throws Exception {
+    private void assertOnCompletionFuture(
+        boolean throwOnClose,
+        @Nullable Exception outerException,
+        PlainActionFuture<String> completionFuture
+    ) throws Exception {
         assertTrue(completionFuture.isDone());
-        if (throwOnClose) {
-            assertEquals("simulated", expectThrows(ExecutionException.class, IOException.class, completionFuture::get).getMessage());
+        if (outerException == null) {
+            if (throwOnClose) {
+                assertEquals("simulated", expectThrows(ExecutionException.class, IOException.class, completionFuture::get).getMessage());
+            } else {
+                assertEquals("success", completionFuture.get());
+            }
         } else {
-            completionFuture.get();
+            assertSame(outerException, expectThrows(ExecutionException.class, Exception.class, completionFuture::get));
+            if (throwOnClose) {
+                assertEquals(1, outerException.getSuppressed().length);
+                assertEquals("simulated", outerException.getSuppressed()[0].getMessage());
+            } else {
+                assertEquals(0, outerException.getSuppressed().length);
+            }
         }
     }
 

--- a/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/SnapshotIndexCommitTests.java
@@ -8,10 +8,14 @@
 
 package org.elasticsearch.repositories;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.index.engine.Engine;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class SnapshotIndexCommitTests extends ESTestCase {
@@ -30,6 +34,14 @@ public class SnapshotIndexCommitTests extends ESTestCase {
 
     public void testAbortAndFailOnClose() throws Exception {
         runAbortTest(true);
+    }
+
+    public void testConcurrentAbortAndCompleteCleanly() throws Exception {
+        runConcurrentTest(false);
+    }
+
+    public void testConcurrentAbortAndCompleteWithFailOnClose() throws Exception {
+        runConcurrentTest(true);
     }
 
     private void runCompleteTest(boolean throwOnClose) throws Exception {
@@ -70,6 +82,35 @@ public class SnapshotIndexCommitTests extends ESTestCase {
         assertOnCompletionBehaviour(throwOnClose, indexCommitRef);
     }
 
+    private void runConcurrentTest(boolean throwOnClose) throws Exception {
+        final var isClosed = new AtomicBoolean();
+        final var indexCommitRef = getSnapshotIndexCommit(throwOnClose, isClosed);
+
+        final var closeFuture = new PlainActionFuture<Void>();
+        final var barrier = new CyclicBarrier(2);
+        final var closeThread = new Thread(() -> {
+            safeAwait(barrier);
+            indexCommitRef.onCompletion(closeFuture);
+        });
+        closeThread.start();
+
+        final var abortThread = new Thread(() -> {
+            safeAwait(barrier);
+            indexCommitRef.onAbort();
+        });
+        abortThread.start();
+
+        closeThread.join();
+        abortThread.join();
+
+        assertTrue(closeFuture.isDone());
+        if (throwOnClose) {
+            assertEquals("simulated", expectThrows(ExecutionException.class, IOException.class, closeFuture::get).getMessage());
+        } else {
+            closeFuture.get();
+        }
+    }
+
     private SnapshotIndexCommit getSnapshotIndexCommit(boolean throwOnClose, AtomicBoolean isClosed) {
         return new SnapshotIndexCommit(new Engine.IndexCommitRef(null, () -> {
             assertTrue(isClosed.compareAndSet(false, true));
@@ -81,10 +122,14 @@ public class SnapshotIndexCommitTests extends ESTestCase {
 
     private void assertOnCompletionBehaviour(boolean throwOnClose, SnapshotIndexCommit indexCommitRef) throws Exception {
         if (throwOnClose) {
-            assertEquals("simulated", expectThrows(IOException.class, indexCommitRef::onCompletion).getMessage());
+            assertEquals("simulated", expectThrows(IOException.class, () -> getOnCompletionResult(indexCommitRef)).getMessage());
         } else {
-            indexCommitRef.onCompletion();
+            getOnCompletionResult(indexCommitRef);
         }
+    }
+
+    private static void getOnCompletionResult(SnapshotIndexCommit indexCommitRef) throws Exception {
+        PlainActionFuture.<Void, Exception>get(indexCommitRef::onCompletion, 0, TimeUnit.NANOSECONDS);
     }
 
 }


### PR DESCRIPTION
The claimed happens-before relationship is not quite sufficient to avoid the need for synchronization, so this commit fixes the behaviour of `SnapshotIndexCommit` when completed and aborted concurrently.

Relates #96426