### PR TITLE
Fix a typo in LocalClusterSpec

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalClusterSpec.java
@@ -195,7 +195,7 @@ public class LocalClusterSpec implements ClusterSpec {
         }
 
         public boolean hasRole(String role) {
-            return getSetting("node.roles", "[]").contains("search");
+            return getSetting("node.roles", "[]").contains(role);
         }
 
         /**


### PR DESCRIPTION
Fix a typo in LocalClusterSpec to use actual parameter instead of hard-coded value.