### PR TITLE
update docs for vector tile and geohex

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -226,9 +226,7 @@ Defaults to `5`.
 aggregation.
 
 `geohex`::
-<<search-aggregations-bucket-geohexgrid-aggregation,`geohex_grid`>> aggregation.
-If you specify this value, the `<field>` must be a <<geo-point,`geo_point`>>
-field.
+<<search-aggregations-bucket-geohexgrid-aggregation,`geohex_grid`>> aggregation.ß
 ====
 // end::grid-agg[]
 

--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -222,8 +222,7 @@ Defaults to `5`.
 [%collapsible%open]
 ====
 `geotile` (Default)::
-<<search-aggregations-bucket-geotilegrid-aggregation,`geotile_grid`>>
-aggregation.
+<<search-aggregations-bucket-geotilegrid-aggregation,`geotile_grid`>> aggregation.
 
 `geohex`::
 <<search-aggregations-bucket-geohexgrid-aggregation,`geohex_grid`>> aggregation.

--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -226,7 +226,7 @@ Defaults to `5`.
 aggregation.
 
 `geohex`::
-<<search-aggregations-bucket-geohexgrid-aggregation,`geohex_grid`>> aggregation.ß
+<<search-aggregations-bucket-geohexgrid-aggregation,`geohex_grid`>> aggregation.
 ====
 // end::grid-agg[]
 


### PR DESCRIPTION
geohex aggregation is now supported since Elasticsearch 8.7 for geo_shape fields so update docs accordingly.