### PR TITLE
[8.8] update docs for vector tile and geohex (#96595)

### DIFF
--- a/docs/reference/search/search-vector-tile-api.asciidoc
+++ b/docs/reference/search/search-vector-tile-api.asciidoc
@@ -222,13 +222,10 @@ Defaults to `5`.
 [%collapsible%open]
 ====
 `geotile` (Default)::
-<<search-aggregations-bucket-geotilegrid-aggregation,`geotile_grid`>>
-aggregation.
+<<search-aggregations-bucket-geotilegrid-aggregation,`geotile_grid`>> aggregation.
 
 `geohex`::
 <<search-aggregations-bucket-geohexgrid-aggregation,`geohex_grid`>> aggregation.
-If you specify this value, the `<field>` must be a <<geo-point,`geo_point`>>
-field.
 ====
 // end::grid-agg[]
 


### PR DESCRIPTION
Backports the following commits to 8.8:
 - update docs for vector tile and geohex (#96595)