### PR TITLE
Fix threading comments in CancellableFanOut

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/CancellableFanOut.java
+++ b/server/src/main/java/org/elasticsearch/action/support/CancellableFanOut.java
@@ -40,7 +40,7 @@ public abstract class CancellableFanOut<Item, ItemResponse, FinalResponse> {
      * @param itemsIterator The items over which to fan out. Iterated on the calling thread.
      * @param listener      A listener for the final response, which is completed after all the fanned-out actions have completed. It is not
      *                      completed promptly on cancellation. Completed on the thread that handles the final per-item response (or
-     *                      the calling thread if there are no items).
+     *                      the calling thread if there are no items), or on the cancelling thread if cancelled.
      */
     public final void run(@Nullable Task task, Iterator<Item> itemsIterator, ActionListener<FinalResponse> listener) {
 
@@ -74,7 +74,9 @@ public abstract class CancellableFanOut<Item, ItemResponse, FinalResponse> {
         try (var refs = new RefCountingRunnable(() -> {
             // When all sub-tasks are complete, pass the result from resultListener to the outer listener.
             resultListenerCompleter.run();
-            // resultListener is always complete by this point, so the outer listener is completed on this thread
+            // If not cancelled then resultListener is always complete by this point so the outer listener is completed on this thread.
+            // If it's being concurrently cancelled then the outer listener may be completed with the TaskCancelledException on the
+            // cancelling thread.
             resultListener.addListener(listener);
         })) {
             while (itemsIterator.hasNext()) {

--- a/server/src/test/java/org/elasticsearch/action/support/CancellableFanOutTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/CancellableFanOutTests.java
@@ -203,7 +203,7 @@ public class CancellableFanOutTests extends ESTestCase {
             @Override
             protected String onCompletion() {
                 assertEquals(items.size(), itemsProcessed.get());
-                assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread));
+                assertThat(Thread.currentThread().getName(), isProcessorThread);
                 if (randomBoolean()) {
                     return "finished";
                 } else {
@@ -214,7 +214,7 @@ public class CancellableFanOutTests extends ESTestCase {
             @Override
             public void onResponse(String s) {
                 assertEquals(items.size(), itemsProcessed.get());
-                assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread));
+                assertThat(Thread.currentThread().getName(), isProcessorThread);
                 assertEquals("finished", s);
                 completionLatch.countDown();
             }
@@ -225,7 +225,7 @@ public class CancellableFanOutTests extends ESTestCase {
                     assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread, isCancelThread));
                 } else {
                     assertEquals(items.size(), itemsProcessed.get());
-                    assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread));
+                    assertThat(Thread.currentThread().getName(), isProcessorThread);
                     assertThat(e, instanceOf(ElasticsearchException.class));
                     assertEquals("onCompletion", e.getMessage());
                 }

--- a/server/src/test/java/org/elasticsearch/action/support/CancellableFanOutTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/CancellableFanOutTests.java
@@ -17,12 +17,24 @@ import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ReachabilityChecker;
-import org.hamcrest.Matchers;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.oneOf;
+import static org.hamcrest.Matchers.startsWith;
 
 public class CancellableFanOutTests extends ESTestCase {
 
@@ -47,7 +59,7 @@ public class CancellableFanOutTests extends ESTestCase {
 
             @Override
             protected void onItemResponse(String item, String itemResponse) {
-                assertThat(item, Matchers.oneOf("a", "c"));
+                assertThat(item, oneOf("a", "c"));
                 assertEquals(item + "-response", itemResponse);
                 counter += 1;
             }
@@ -129,5 +141,105 @@ public class CancellableFanOutTests extends ESTestCase {
         assertTrue(itemListeners.isEmpty());
         assertTrue(future.isDone());
         expectThrows(TaskCancelledException.class, future::actionGet);
+    }
+
+    public void testConcurrency() throws InterruptedException {
+
+        final var isTestThread = startsWith("TEST-");
+        final var isProcessorThread = startsWith("processor-thread-");
+        final var isCancelThread = equalTo("cancel-thread");
+        assertThat(Thread.currentThread().getName(), isTestThread);
+
+        final var items = List.of("a", "b", "c");
+        final var processorThreads = new Thread[items.size()];
+        final var queue = new LinkedBlockingQueue<Runnable>();
+        final var barrier = new CyclicBarrier(processorThreads.length + 1);
+        for (int i = 0; i < processorThreads.length; i++) {
+            processorThreads[i] = new Thread(() -> {
+                try {
+                    assertThat(Thread.currentThread().getName(), isProcessorThread);
+                    final var item = Objects.requireNonNull(queue.poll(10, TimeUnit.SECONDS));
+                    safeAwait(barrier);
+                    item.run();
+                } catch (Exception e) {
+                    throw new AssertionError(e);
+                }
+            }, "processor-thread-" + i);
+            processorThreads[i].start();
+        }
+
+        final var task = new CancellableTask(1, "test", "test", "", TaskId.EMPTY_TASK_ID, Map.of());
+
+        final var cancelThread = new Thread(() -> {
+            assertThat(Thread.currentThread().getName(), isCancelThread);
+            safeAwait(barrier);
+            TaskCancelHelper.cancel(task, "test");
+        }, "cancel-thread");
+        cancelThread.start();
+
+        final var itemsProcessed = new AtomicInteger();
+        final var completionLatch = new CountDownLatch(1);
+        new CancellableFanOut<String, String, String>() {
+            @Override
+            protected void sendItemRequest(String s, ActionListener<String> listener) {
+                queue.add(
+                    randomBoolean() ? () -> listener.onResponse(s) : () -> listener.onFailure(new ElasticsearchException("sendItemRequest"))
+                );
+            }
+
+            @Override
+            protected void onItemResponse(String s, String response) {
+                assertThat(Thread.currentThread().getName(), isProcessorThread);
+                assertEquals(s, response);
+                assertThat(itemsProcessed.incrementAndGet(), lessThanOrEqualTo(items.size()));
+            }
+
+            @Override
+            protected void onItemFailure(String s, Exception e) {
+                assertThat(Thread.currentThread().getName(), isProcessorThread);
+                assertThat(e, instanceOf(ElasticsearchException.class));
+                assertEquals("sendItemRequest", e.getMessage());
+                assertThat(itemsProcessed.incrementAndGet(), lessThanOrEqualTo(items.size()));
+            }
+
+            @Override
+            protected String onCompletion() {
+                assertEquals(items.size(), itemsProcessed.get());
+                assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread, isTestThread));
+                if (randomBoolean()) {
+                    return "finished";
+                } else {
+                    throw new ElasticsearchException("onCompletion");
+                }
+            }
+        }.run(task, items.iterator(), new ActionListener<>() {
+            @Override
+            public void onResponse(String s) {
+                assertEquals(items.size(), itemsProcessed.get());
+                assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread, isTestThread));
+                assertEquals("finished", s);
+                completionLatch.countDown();
+            }
+
+            @Override
+            public void onFailure(Exception e) {
+                if (e instanceof TaskCancelledException) {
+                    assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread, isTestThread, isCancelThread));
+                } else {
+                    assertEquals(items.size(), itemsProcessed.get());
+                    assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread, isTestThread));
+                    assertThat(e, instanceOf(ElasticsearchException.class));
+                    assertEquals("onCompletion", e.getMessage());
+                }
+                completionLatch.countDown();
+            }
+        });
+
+        safeAwait(completionLatch);
+
+        cancelThread.join();
+        for (Thread processorThread : processorThreads) {
+            processorThread.join();
+        }
     }
 }


### PR DESCRIPTION
Similar to #96571, a concurrent cancel/completion may complete the final listener on the cancelling thread which disagrees with the comments in this area. Fixes the comments and adds a test showing the behaviour.