### PR TITLE
The get data stream api incorrectly prints warning log for upgraded tsdb data streams

### DIFF
--- a/docs/changelog/96606.yaml
+++ b/docs/changelog/96606.yaml
@@ -1,0 +1,6 @@
+pr: 96606
+summary: The get data stream api incorrectly prints warning log for upgraded tsdb
+  data streams
+area: TSDB
+type: bug
+issues: []

--- a/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
+++ b/modules/data-streams/src/main/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportAction.java
@@ -29,7 +29,6 @@ import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexMode;
-import org.elasticsearch.index.IndexSettings;
 import org.elasticsearch.indices.SystemDataStreamDescriptor;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.tasks.Task;


### PR DESCRIPTION
Invoking the get data stream api on an upgrade tsdb data stream (which has normal and tsbd indices) can result in a warning log incorrectly be logged. This warning is logged as part of computing the temporal ranges of a tsdb data stream. This warning log indicates that tsdb backing indices are overlapping, but this isn't true. For normal indices, this api picked `-9999-01-01T00:00:00Z` as start time and `9999-12-31T23:59:59.999Z` as end time. This will overlap with any tsdb backing index. Instead, the normal indices should be skipped for computing the temporal ranges.

The following can incorrectlu be logged for upgraded tsdb data streams: `[instance-0000000074] previous backing index [-9999-01-01T00:00:00Z/9999-12-31T23:59:59.999Z] range is colliding with current backing index range [-9999-01-01T00:00:00Z/9999-12-31T23:59:59.999Z]` This change addresses this. Note that in tests an assertion would trip before the log gets printed.