### PR TITLE
Reduce copying in TransportGetShardSnapshotAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/repositories/IndexSnapshotsService.java
+++ b/server/src/main/java/org/elasticsearch/repositories/IndexSnapshotsService.java
@@ -47,6 +47,8 @@ public class IndexSnapshotsService {
         ShardId shardId,
         ActionListener<Optional<ShardSnapshotInfo>> originalListener
     ) {
+        assert repositoryName != null;
+
         final ActionListener<Optional<ShardSnapshotInfo>> listener = originalListener.delegateResponse((delegate, err) -> {
             delegate.onFailure(
                 new RepositoryException(repositoryName, "Unable to find the latest snapshot for shard [" + shardId + "]", err)

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -68,6 +68,7 @@ import org.elasticsearch.test.InternalSettingsPlugin;
 import org.elasticsearch.test.MockLogAppender;
 import org.elasticsearch.test.junit.annotations.TestLogging;
 import org.elasticsearch.test.transport.MockTransportService;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.transport.Transport;
 import org.elasticsearch.transport.TransportChannel;
 import org.elasticsearch.transport.TransportResponse;
@@ -877,6 +878,53 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
             assertThat(newReplicaRepo.totalBytesRead.get(), is(greaterThan(0L)));
             assertThat(newReplicaRepo.totalBytesRead.get(), is(lessThanOrEqualTo(snapshotSizeForIndex)));
         }
+    }
+
+    public void testUsesNewestSnapshot() throws Exception {
+        internalCluster().ensureAtLeastNumDataNodes(2);
+
+        String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
+        createIndex(indexName, indexSettings(1, 0).put(IndexService.GLOBAL_CHECKPOINT_SYNC_INTERVAL_SETTING.getKey(), "1s").build());
+
+        int numDocs = randomIntBetween(300, 1000);
+        indexDocs(indexName, 0, numDocs);
+
+        String oldSnapshotRepo = "old-snapshot-repo";
+        createRepo(oldSnapshotRepo, TestRepositoryPlugin.INSTRUMENTED_TYPE);
+        final var oldSnapshotInfo = createSnapshot(oldSnapshotRepo, "old-snapshot", Collections.singletonList(indexName));
+        assertThat(oldSnapshotInfo.startTime(), lessThanOrEqualTo(oldSnapshotInfo.endTime()));
+
+        indexDocs(indexName, numDocs, 1);
+        final var forceMergeResponse = indicesAdmin().prepareForceMerge(indexName).setMaxNumSegments(1).setFlush(true).get();
+        assertEquals(1, forceMergeResponse.getTotalShards());
+        assertEquals(1, forceMergeResponse.getSuccessfulShards());
+
+        // wait for time to pass
+        assertBusy(
+            () -> internalCluster().getInstances(ThreadPool.class)
+                .forEach(tp -> assertThat(tp.absoluteTimeInMillis(), greaterThan(oldSnapshotInfo.endTime())))
+        );
+
+        String newSnapshotRepo;
+        if (randomBoolean()) {
+            newSnapshotRepo = "new-snapshot-repo";
+            createRepo(newSnapshotRepo, TestRepositoryPlugin.INSTRUMENTED_TYPE);
+        } else {
+            newSnapshotRepo = oldSnapshotRepo;
+        }
+        final var newSnapshotInfo = createSnapshot(newSnapshotRepo, "latest-snapshot", Collections.singletonList(indexName));
+        assertThat(newSnapshotInfo.startTime(), greaterThan(oldSnapshotInfo.endTime()));
+
+        setReplicaCount(1, indexName);
+
+        ensureGreen(indexName);
+        assertDocumentsAreEqual(indexName, numDocs + 1);
+
+        RecoveryState recoveryState = getLatestPeerRecoveryStateForShard(indexName, 0);
+        String currentPrimary = recoveryState.getSourceNode().getName();
+        String replica = recoveryState.getTargetNode().getName();
+        assertPeerRecoveryWasSuccessful(recoveryState, currentPrimary, replica);
+        assertEquals(recoveryState.getIndex().recoveredBytes(), recoveryState.getIndex().recoveredFromSnapshotBytes());
     }
 
     public void testDisabledSnapshotBasedRecoveryUsesSourceFiles() throws Exception {


### PR DESCRIPTION
Simplifies `TransportGetShardSnapshotAction` by removing all the intermediate data structures. With this change we just iterate over the specified repositories and collect the results in their final form directly.