### PR TITLE
Uses a factory method for IngestStats serialization

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/node/stats/NodeStats.java
@@ -107,7 +107,7 @@ public class NodeStats extends BaseNodeResponse implements ChunkedToXContent {
         scriptStats = in.readOptionalWriteable(ScriptStats::new);
         scriptCacheStats = scriptStats != null ? scriptStats.toScriptCacheStats() : null;
         discoveryStats = in.readOptionalWriteable(DiscoveryStats::new);
-        ingestStats = in.readOptionalWriteable(IngestStats::new);
+        ingestStats = in.readOptionalWriteable(IngestStats::read);
         adaptiveSelectionStats = in.readOptionalWriteable(AdaptiveSelectionStats::new);
         indexingPressureStats = in.readOptionalWriteable(IndexingPressureStats::new);
     }

--- a/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/ingest/IngestStatsTests.java
@@ -9,7 +9,6 @@
 package org.elasticsearch.ingest;
 
 import org.elasticsearch.common.io.stream.BytesStreamOutput;
-import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.test.ESTestCase;
 
 import java.io.IOException;
@@ -161,10 +160,10 @@ public class IngestStatsTests extends ESTestCase {
     }
 
     private static IngestStats serialize(IngestStats stats) throws IOException {
-        BytesStreamOutput out = new BytesStreamOutput();
+        var out = new BytesStreamOutput();
         stats.writeTo(out);
-        StreamInput in = out.bytes().streamInput();
-        return new IngestStats(in);
+        var in = out.bytes().streamInput();
+        return IngestStats.read(in);
     }
 
     private static void assertIngestStats(IngestStats ingestStats, IngestStats serializedStats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetTrainedModelsStatsAction.java
@@ -123,7 +123,7 @@ public class GetTrainedModelsStatsAction extends ActionType<GetTrainedModelsStat
                 } else {
                     modelSizeStats = null;
                 }
-                ingestStats = new IngestStats(in);
+                ingestStats = IngestStats.read(in);
                 pipelineCount = in.readVInt();
                 inferenceStats = in.readOptionalWriteable(InferenceStats::new);
                 if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_0_0)) {


### PR DESCRIPTION
While converting the `IngestStats` object to a record (PR #96217), I used a trick that uses Tuples and static methods instead of using a factory method, what's clearer and simple.
