### PR TITLE
Create float type family

### DIFF
--- a/docs/changelog/96625.yaml
+++ b/docs/changelog/96625.yaml
@@ -1,0 +1,6 @@
+pr: 96625
+summary: Create float type family
+area: Mapping
+type: enhancement
+issues:
+ - 67723

--- a/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
+++ b/modules/mapper-extras/src/main/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldMapper.java
@@ -244,6 +244,11 @@ public class ScaledFloatFieldMapper extends FieldMapper {
         }
 
         @Override
+        public String familyTypeName() {
+            return NumberFieldMapper.NumberType.FLOAT.typeName();
+        }
+
+        @Override
         public boolean mayExistInIndex(SearchExecutionContext context) {
             return context.fieldExistsInIndex(name());
         }

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/ScaledFloatFieldTypeTests.java
@@ -176,6 +176,12 @@ public class ScaledFloatFieldTypeTests extends FieldTypeTestCase {
         assertEquals(10 / ft.getScalingFactor(), ft.valueForDisplay(10L));
     }
 
+    public void testFieldFamilyTypeIsReportedCorrectly() {
+        ScaledFloatFieldMapper.ScaledFloatFieldType ft = new ScaledFloatFieldMapper.ScaledFloatFieldType("scaled_float", 0.1);
+        var expectedFamilyType = NumberFieldMapper.NumberType.FLOAT.typeName();
+        assertEquals(expectedFamilyType, ft.familyTypeName());
+    }
+
     public void testFieldData() throws IOException {
         double scalingFactor = 0.1 + randomDouble() * 100;
         Directory dir = newDirectory();

--- a/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/NumberFieldMapper.java
@@ -327,6 +327,11 @@ public class NumberFieldMapper extends FieldMapper {
             }
 
             @Override
+            public String familyTypeName() {
+                return NumberFieldMapper.NumberType.FLOAT.typeName();
+            }
+
+            @Override
             public Query termQuery(String field, Object value, boolean isIndexed) {
                 float v = parseToFloat(value);
                 if (isIndexed) {
@@ -1219,6 +1224,10 @@ public class NumberFieldMapper extends FieldMapper {
             return name;
         }
 
+        public String familyTypeName() {
+            return typeName();
+        }
+
         /** Get the associated numeric type */
         public final NumericType numericType() {
             return numericType;
@@ -1519,6 +1528,11 @@ public class NumberFieldMapper extends FieldMapper {
         @Override
         public String typeName() {
             return type.name;
+        }
+
+        @Override
+        public String familyTypeName() {
+            return this.type.familyTypeName();
         }
 
         /**

--- a/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFilterTests.java
+++ b/server/src/test/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesFilterTests.java
@@ -19,6 +19,34 @@ import java.util.function.Predicate;
 
 public class FieldCapabilitiesFilterTests extends MapperServiceTestCase {
 
+    /**
+     * Tests that the field family type is returned instead of the actual field type.
+     * `half_float` is chosen arbitrarily for this purpose.
+     */
+    public void testFieldFamilyTypeIsReturned() throws IOException {
+        MapperService mapperService = createMapperService("""
+            {
+              "_doc": {
+                "properties": {
+                  "field1": { "type": "half_float"}
+                }
+              }
+            }
+            """);
+        SearchExecutionContext sec = createSearchExecutionContext(mapperService);
+
+        Map<String, IndexFieldCapabilities> response = FieldCapabilitiesFetcher.retrieveFieldCaps(
+            sec,
+            new String[] { "*" },
+            new String[] {},
+            Strings.EMPTY_ARRAY,
+            f -> true
+        );
+
+        var expectedFamilyType = "float";
+        assertEquals(expectedFamilyType, response.get("field1").getType());
+    }
+
     public void testExcludeNestedFields() throws IOException {
         MapperService mapperService = createMapperService("""
             { "_doc" : {

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -10,8 +10,6 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
-import jdk.jfr.Description;
-
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
@@ -747,14 +745,14 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
         }
     }
 
-    public void testFieldFamilyTypeIsReportedCorrectly(){
+    public void testFieldFamilyTypeIsReportedCorrectly() {
         for (NumberFieldMapper.NumberType type : NumberFieldMapper.NumberType.values()) {
             NumberFieldMapper.NumberFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", type);
             var floatFamilyTypes = Set.of(NumberType.FLOAT.typeName(), NumberType.HALF_FLOAT.typeName());
-            if (floatFamilyTypes.contains(fieldType.typeName())){
+            if (floatFamilyTypes.contains(fieldType.typeName())) {
                 assertEquals(NumberType.FLOAT.typeName(), type.familyTypeName());
-            }else{
-                assertEquals(type.typeName(),type.familyTypeName());
+            } else {
+                assertEquals(type.typeName(), type.familyTypeName());
             }
         }
     }

--- a/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
+++ b/server/src/test/java/org/elasticsearch/index/mapper/NumberFieldTypeTests.java
@@ -10,6 +10,8 @@ package org.elasticsearch.index.mapper;
 
 import com.carrotsearch.randomizedtesting.generators.RandomPicks;
 
+import jdk.jfr.Description;
+
 import org.apache.lucene.document.Document;
 import org.apache.lucene.document.DoublePoint;
 import org.apache.lucene.document.FloatPoint;
@@ -57,6 +59,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 import static java.util.Collections.emptyMap;
@@ -740,6 +743,18 @@ public class NumberFieldTypeTests extends FieldTypeTestCase {
                 b.rawField("field", new ByteArrayInputStream(value.toString().getBytes("UTF-8")), XContentType.JSON);
             } else {
                 b.field("field", value);
+            }
+        }
+    }
+
+    public void testFieldFamilyTypeIsReportedCorrectly(){
+        for (NumberFieldMapper.NumberType type : NumberFieldMapper.NumberType.values()) {
+            NumberFieldMapper.NumberFieldType fieldType = new NumberFieldMapper.NumberFieldType("field", type);
+            var floatFamilyTypes = Set.of(NumberType.FLOAT.typeName(), NumberType.HALF_FLOAT.typeName());
+            if (floatFamilyTypes.contains(fieldType.typeName())){
+                assertEquals(NumberType.FLOAT.typeName(), type.familyTypeName());
+            }else{
+                assertEquals(type.typeName(),type.familyTypeName());
             }
         }
     }


### PR DESCRIPTION
This PR combines `float`, `half_float`, and `scaled_float` into the same field type family. 

Relates to https://github.com/elastic/elasticsearch/pull/58483

Closes https://github.com/elastic/elasticsearch/issues/67723
