### PR TITLE
Mute AbstractHttpServerTransportTests.testForceClosesOpenChannels

### DIFF
--- a/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
+++ b/server/src/test/java/org/elasticsearch/http/AbstractHttpServerTransportTests.java
@@ -1101,6 +1101,7 @@ public class AbstractHttpServerTransportTests extends ESTestCase {
         }
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96632")
     public void testForceClosesOpenChannels() {
         try (TestHttpServerTransport transport = new TestHttpServerTransport(gracePeriod(1_000))) {
             transport.bindServer();


### PR DESCRIPTION
Skips `AbstractHttpServerTransportTests.testForceClosesOpenChannels`

Refs: #96632