### PR TITLE
Enable parallelizable knn query execution in DfsPhase

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -10,12 +10,12 @@ package org.elasticsearch.search.dfs;
 
 import org.apache.lucene.index.Term;
 import org.apache.lucene.search.CollectionStatistics;
-import org.apache.lucene.search.Collector;
 import org.apache.lucene.search.CollectorManager;
 import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.ScoreMode;
 import org.apache.lucene.search.TermStatistics;
+import org.apache.lucene.search.TopDocs;
 import org.apache.lucene.search.TopScoreDocCollector;
 import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
@@ -27,7 +27,6 @@ import org.elasticsearch.search.profile.query.CollectorResult;
 import org.elasticsearch.search.profile.query.InternalProfileCollector;
 import org.elasticsearch.search.profile.query.InternalProfileCollectorManager;
 import org.elasticsearch.search.profile.query.QueryProfiler;
-import org.elasticsearch.search.query.SingleThreadCollectorManager;
 import org.elasticsearch.search.rescore.RescoreContext;
 import org.elasticsearch.search.vectors.KnnSearchBuilder;
 import org.elasticsearch.search.vectors.KnnVectorQueryBuilder;
@@ -178,19 +177,28 @@ public class DfsPhase {
         List<DfsKnnResults> knnResults = new ArrayList<>(knnVectorQueryBuilders.size());
         for (int i = 0; i < knnSearch.size(); i++) {
             Query knnQuery = searchExecutionContext.toQuery(knnVectorQueryBuilders.get(i)).query();
-            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(knnSearch.get(i).k(), Integer.MAX_VALUE);
-            CollectorManager<Collector, Void> collectorManager = new SingleThreadCollectorManager(topScoreDocCollector);
-            if (context.getProfilers() != null) {
+            if (context.getProfilers() == null) {
+                // without profiling enabled we use a CollectorManager that supports parallelized execution
+                CollectorManager<TopScoreDocCollector, TopDocs> collectorManager = TopScoreDocCollector.createSharedManager(
+                    knnSearch.get(i).k(),
+                    null,
+                    Integer.MAX_VALUE
+                );
+                TopDocs topDocs = context.searcher().search(knnQuery, collectorManager);
+                knnResults.add(new DfsKnnResults(topDocs.scoreDocs));
+            } else {
+                TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(knnSearch.get(i).k(), Integer.MAX_VALUE);
+                // This assumes the execution is single threaded
+                // TODO will we later have to set the executor based on whether profiler is set or not?
                 InternalProfileCollectorManager ipcm = new InternalProfileCollectorManager(
-                    new InternalProfileCollector(collectorManager.newCollector(), CollectorResult.REASON_SEARCH_TOP_HITS)
+                    new InternalProfileCollector(topScoreDocCollector, CollectorResult.REASON_SEARCH_TOP_HITS)
                 );
                 QueryProfiler knnProfiler = context.getProfilers().getDfsProfiler().addQueryProfiler(ipcm);
-                collectorManager = ipcm;
                 // Set the current searcher profiler to gather query profiling information for gathering top K docs
                 context.searcher().setProfiler(knnProfiler);
+                context.searcher().search(knnQuery, ipcm);
+                knnResults.add(new DfsKnnResults(topScoreDocCollector.topDocs().scoreDocs));
             }
-            context.searcher().search(knnQuery, collectorManager);
-            knnResults.add(new DfsKnnResults(topScoreDocCollector.topDocs().scoreDocs));
         }
         // Set profiler back after running KNN searches
         if (context.getProfilers() != null) {


### PR DESCRIPTION
Currently, the collector manager used when executing the knn query in the DfsPhase uses a single-thred-only CollectorManager. In preparation of switching to parallelized execution this change swaps this for a parallelizable CollectorManager for cases where profiling is not enabled. This will only take noticeable effect once we also use multi-threaded executor though. For the profiling case we will still use the single threaded mode. This might be changed in a follow up.
