### PR TITLE
Disable bwc tests in preparation for DLM updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,9 +135,9 @@ tasks.register("verifyVersions") {
  * after the backport of the backcompat code is complete.
  */
 
-boolean bwc_tests_enabled = true
+boolean bwc_tests_enabled = false
 // place a PR link here when committing bwc changes:
-String bwc_tests_disabled_issue = ""
+String bwc_tests_disabled_issue = "https://github.com/elastic/elasticsearch/pull/96583"
 if (bwc_tests_enabled == false) {
   if (bwc_tests_disabled_issue.isEmpty()) {
     throw new GradleException("bwc_tests_disabled_issue must be set when bwc_tests_enabled == false")


### PR DESCRIPTION
Due to https://github.com/elastic/elasticsearch/pull/96583 and https://github.com/elastic/elasticsearch/pull/96623