### PR TITLE
Ensure Map.remove() is only called if it will actually remove something

### DIFF
--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
@@ -85,7 +85,9 @@ public class ExecutableIndexAction extends ExecutableAction<IndexAction> {
             }
         }
 
-        data = mutableMap(data);
+        if (data.containsKey(INDEX_FIELD) || data.containsKey(TYPE_FIELD) || data.containsKey(ID_FIELD)) {
+            data = mutableMap(data);
+        }
 
         IndexRequest indexRequest = new IndexRequest();
         if (action.refreshPolicy != null) {
@@ -226,8 +228,9 @@ public class ExecutableIndexAction extends ExecutableAction<IndexAction> {
      * Extracts the specified field out of data map, or alternative falls back to the action value
      */
     private String getField(String actionId, String watchId, String name, Map<String, Object> data, String fieldName, String defaultValue) {
-        Object obj = data.remove(fieldName);
-        if (obj != null) {
+        Object obj;
+        // map may be immutable - only try to remove if it's actually there
+        if (data.containsKey(fieldName) && (obj = data.remove(fieldName)) != null) {
             if (defaultValue != null) {
                 throw illegalState(
                     "could not execute action [{}] of watch [{}]. "

--- a/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
+++ b/x-pack/plugin/watcher/src/main/java/org/elasticsearch/xpack/watcher/actions/index/ExecutableIndexAction.java
@@ -85,9 +85,8 @@ public class ExecutableIndexAction extends ExecutableAction<IndexAction> {
             }
         }
 
-        if (data.containsKey(INDEX_FIELD) || data.containsKey(TYPE_FIELD) || data.containsKey(ID_FIELD)) {
-            data = mutableMap(data);
-        }
+        data = mutableMap(data);
+
         IndexRequest indexRequest = new IndexRequest();
         if (action.refreshPolicy != null) {
             indexRequest.setRefreshPolicy(action.refreshPolicy);


### PR DESCRIPTION
This issue was brought up by #96646

The problem here is that, although there is code to check if the map is likely to be modified, and then makes it mutable, the mutable check is not hit if the keys do not exist. But then it still tried to call `remove` on it.

Immutable maps point-blank throw `UnsupportedOperationException` on modification operations, even if the method would not actually cause any modifications. So it needs to check if the removal will actually modify anything, before calling it.