### PR TITLE
Bump minimum targetCompatibility of java version checker to 1.8

### DIFF
--- a/distribution/tools/java-version-checker/build.gradle
+++ b/distribution/tools/java-version-checker/build.gradle
@@ -5,7 +5,7 @@ sourceSets {
 }
 
 tasks.named(sourceSets.unsupportedJdkVersionEntrypoint.compileJavaTaskName).configure {
-  targetCompatibility = JavaVersion.VERSION_1_7
+  targetCompatibility = JavaVersion.VERSION_1_8
 }
 
 tasks.named("jar") {


### PR DESCRIPTION
Bump the minimum targetCompatibility of java version checker to 1.8 ( from 1.7 ).

JDK 20 has removed support for source and target 1.7 in javac [1], so to successfully build with JDK 20 (through JAVA_TOOLCHAIN_HOME), we can no longer specify targetCompatibility = JavaVersion.VERSION_1_7, for the java version checker.

The idea of the java version checker is to successfully run with "older" JDK's, but I think that 1.8 is presently more than sufficient. While we still don't "support" compiling with JDK 20, it is good to keep the project up to date, so we can more easily experiment with recent JDK's. 

[1] https://bugs.openjdk.org/browse/JDK-8173605