### PR TITLE
Add beta label to Behavioral Analytics API reference

### DIFF
--- a/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
@@ -2,6 +2,8 @@
 [[delete-analytics-collection]]
 === Delete Analytics Collection
 
+beta::[]
+
 ++++
 <titleabbrev>Delete Analytics Collection</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/index.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/index.asciidoc
@@ -1,6 +1,8 @@
 [[behavioral-analytics-apis]]
 == Behavioral Analytics APIs
 
+beta::[]
+
 ++++
 <titleabbrev>Behavioral Analytics APIs</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
@@ -2,6 +2,8 @@
 [[list-analytics-collection]]
 === List Analytics Collections
 
+beta::[]
+
 ++++
 <titleabbrev>List Analytics Collections</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -2,6 +2,8 @@
 [[post-analytics-collection-event]]
 === Post Event to an Analytics Collection
 
+beta::[]
+
 ++++
 <titleabbrev>Post Analytics Collection Event</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
@@ -2,6 +2,8 @@
 [[put-analytics-collection]]
 === Put Analytics Collection
 
+beta::[]
+
 ++++
 <titleabbrev>Put Analytics Collection</titleabbrev>
 ++++


### PR DESCRIPTION
Updates the documentation with the beta notification in the API reference for behavioral analytics.

<img width="892" alt="Screenshot 2023-06-07 at 13 50 45" src="https://github.com/elastic/elasticsearch/assets/16032709/aa1292de-e6ca-4ad8-850b-0107473a2fe8">

