### PR TITLE
Implement #isShutdown on Deterministic Queue ExecutorService

### DIFF
--- a/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
+++ b/test/framework/src/main/java/org/elasticsearch/common/util/concurrent/DeterministicTaskQueue.java
@@ -249,7 +249,7 @@ public class DeterministicTaskQueue {
 
                 @Override
                 public boolean isShutdown() {
-                    throw new UnsupportedOperationException();
+                    return false;
                 }
 
                 @Override


### PR DESCRIPTION
This is sometimes called via
org.elasticsearch.indices.recovery.RecoverySourceHandler#closeOnGenericThreadPool and causes the failure fixed here.
Since we don't support shutting down the deterministic queue might as well return `false` here.

closes #96449
