### PR TITLE
[8.8] Add beta label to Behavioral Analytics API reference (#96657)

### DIFF
--- a/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/delete-analytics-collection.asciidoc
@@ -2,6 +2,8 @@
 [[delete-analytics-collection]]
 === Delete Analytics Collection
 
+beta::[]
+
 ++++
 <titleabbrev>Delete Analytics Collection</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/index.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/index.asciidoc
@@ -1,6 +1,8 @@
 [[behavioral-analytics-apis]]
 == Behavioral Analytics APIs
 
+beta::[]
+
 ++++
 <titleabbrev>Behavioral Analytics APIs</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/list-analytics-collection.asciidoc
@@ -2,6 +2,8 @@
 [[list-analytics-collection]]
 === List Analytics Collections
 
+beta::[]
+
 ++++
 <titleabbrev>List Analytics Collections</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/post-analytics-collection-event.asciidoc
@@ -2,6 +2,8 @@
 [[post-analytics-collection-event]]
 === Post Event to an Analytics Collection
 
+beta::[]
+
 ++++
 <titleabbrev>Post Analytics Collection Event</titleabbrev>
 ++++

--- a/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
+++ b/docs/reference/behavioral-analytics/apis/put-analytics-collection.asciidoc
@@ -2,6 +2,8 @@
 [[put-analytics-collection]]
 === Put Analytics Collection
 
+beta::[]
+
 ++++
 <titleabbrev>Put Analytics Collection</titleabbrev>
 ++++


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Add beta label to Behavioral Analytics API reference (#96657)