### PR TITLE
Disable DLM completely in 8.8.1 and onwards

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataLifecycle.java
@@ -65,7 +65,7 @@ public class DataLifecycle implements SimpleDiffable<DataLifecycle>, ToXContentO
     }
 
     public static boolean isEnabled() {
-        return DLM_FEATURE_FLAG.isEnabled();
+        return false;
     }
 
     @Nullable


### PR DESCRIPTION
We disabled the serialisation code for DLM in 8.8.1 and onwards in the 8.8.x line
however the DLM service could still be enabled via the feature
flag. 

This could mean that if the master `8.8.1` node has DLM enabled
it could save index/component templates in the cluster state
but not be able to send them over the wire to other `8.8.1` nodes.
(note that cluster state local persistence is based on XCONTENT 
representation)

As feature flags are just for testing this shouldn't be a problem in
production systems, however it feels a bit awkward and unexpected.

This proposes hardcoding DLM as disabled in `8.8.1` and onwards.