### PR TITLE
speed up the process in LuceneVerifyingIndexOutput

### DIFF
--- a/docs/changelog/96670.yaml
+++ b/docs/changelog/96670.yaml
@@ -1,0 +1,4 @@
+pr: 96670
+summary: speed up the process in LuceneVerifyingIndexOutput
+area: Store
+type: enhancement

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -1259,13 +1259,14 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
         @Override
         public void writeBytes(byte[] b, int offset, int length) throws IOException {
             final int directWriteLength = Math.toIntExact(checksumPosition > this.writtenBytes ? Math.min(checksumPosition - this.writtenBytes, length) : 0);
-            out.writeBytes(b, offset, directWriteLength);
+            out.writeBytes(b, offset, directWriteLength); // direct write through parts before the checksum position
             this.writtenBytes += directWriteLength;
             final int leftLength = length - directWriteLength;
             final int leftOffset = offset + directWriteLength;
+
             final long writtenBytes = this.writtenBytes;
             this.writtenBytes += leftLength;
-            if (this.writtenBytes > checksumPosition) {
+            if (this.writtenBytes > checksumPosition) { // we are writing parts of the checksum....
                 if (writtenBytes == checksumPosition) {
                     readAndCompareChecksum();
                 }


### PR DESCRIPTION
As mentioned in [#96614](https://github.com/elastic/elasticsearch/issues/96614), The feature will be helpful to speedup the file chunk write process when there are a lot of small files to be recovery or restored. The Comparison Experimentation Based on NIO FS show that the speedup is 10 times.

       * Comparison Experimentation
       * Before optimization: chunk size 512KB, write times 10000, total cost time: 270827ms, avg cost time: 27.0827ms
       * After optimization: chunk size 512KB, write times 10000, total cost time: 11603ms, avg cost time: 1.1603ms
