### PR TITLE
Load synonyms from system index for analyzers

### DIFF
--- a/modules/analysis-common/build.gradle
+++ b/modules/analysis-common/build.gradle
@@ -5,6 +5,8 @@
  * in compliance with, at your election, the Elastic License 2.0 or the Server
  * Side Public License, v 1.
  */
+import org.elasticsearch.gradle.Version
+
 apply plugin: 'elasticsearch.legacy-yaml-rest-test'
 apply plugin: 'elasticsearch.legacy-yaml-rest-compat-test'
 apply plugin: 'elasticsearch.internal-cluster-test'
@@ -17,8 +19,14 @@ esplugin {
 
 restResources {
   restApi {
-    include '_common', 'indices', 'index', 'cluster', 'search', 'nodes', 'bulk', 'termvectors', 'explain', 'count'
+    include '_common', 'indices', 'index', 'cluster', 'search', 'nodes', 'bulk', 'termvectors', 'explain', 'count', 'synonyms.put'
   }
+}
+
+testClusters.configureEach {
+  module ':modules:reindex'
+  module ':modules:mapper-extras'
+  requiresFeature 'es.synonyms_feature_flag_enabled', Version.fromString("8.9.0")
 }
 
 dependencies {

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java
@@ -129,6 +129,7 @@ import org.elasticsearch.plugins.ScriptPlugin;
 import org.elasticsearch.repositories.RepositoriesService;
 import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
+import org.elasticsearch.synonyms.SynonymsManagementAPIService;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
 import org.elasticsearch.watcher.ResourceWatcherService;
@@ -151,6 +152,8 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
     private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(CommonAnalysisPlugin.class);
 
     private final SetOnce<ScriptService> scriptServiceHolder = new SetOnce<>();
+    private final SetOnce<SynonymsManagementAPIService> synonymsManagementServiceHolder = new SetOnce<>();
+    private final SetOnce<ThreadPool> threadPoolHolder = new SetOnce<>();
 
     @Override
     public Collection<Object> createComponents(
@@ -169,6 +172,8 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         AllocationService allocationService
     ) {
         this.scriptServiceHolder.set(scriptService);
+        this.synonymsManagementServiceHolder.set(new SynonymsManagementAPIService(client));
+        this.threadPoolHolder.set(threadPool);
         return Collections.emptyList();
     }
 
@@ -332,8 +337,25 @@ public class CommonAnalysisPlugin extends Plugin implements AnalysisPlugin, Scri
         filters.put("sorani_normalization", SoraniNormalizationFilterFactory::new);
         filters.put("stemmer_override", requiresAnalysisSettings(StemmerOverrideTokenFilterFactory::new));
         filters.put("stemmer", StemmerTokenFilterFactory::new);
-        filters.put("synonym", requiresAnalysisSettings(SynonymTokenFilterFactory::new));
-        filters.put("synonym_graph", requiresAnalysisSettings(SynonymGraphTokenFilterFactory::new));
+        filters.put(
+            "synonym",
+            requiresAnalysisSettings(
+                (i, e, n, s) -> new SynonymTokenFilterFactory(i, e, n, s, synonymsManagementServiceHolder.get(), threadPoolHolder.get())
+            )
+        );
+        filters.put(
+            "synonym_graph",
+            requiresAnalysisSettings(
+                (i, e, n, s) -> new SynonymGraphTokenFilterFactory(
+                    i,
+                    e,
+                    n,
+                    s,
+                    synonymsManagementServiceHolder.get(),
+                    threadPoolHolder.get()
+                )
+            )
+        );
         filters.put("trim", TrimTokenFilterFactory::new);
         filters.put("truncate", requiresAnalysisSettings(TruncateTokenFilterFactory::new));
         filters.put("unique", UniqueTokenFilterFactory::new);

--- a/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
+++ b/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/SynonymGraphTokenFilterFactory.java
@@ -19,14 +19,23 @@ import org.elasticsearch.index.analysis.AnalysisMode;
 import org.elasticsearch.index.analysis.CharFilterFactory;
 import org.elasticsearch.index.analysis.TokenFilterFactory;
 import org.elasticsearch.index.analysis.TokenizerFactory;
+import org.elasticsearch.synonyms.SynonymsManagementAPIService;
+import org.elasticsearch.threadpool.ThreadPool;
 
 import java.util.List;
 import java.util.function.Function;
 
 public class SynonymGraphTokenFilterFactory extends SynonymTokenFilterFactory {
 
-    SynonymGraphTokenFilterFactory(IndexSettings indexSettings, Environment env, String name, Settings settings) {
-        super(indexSettings, env, name, settings);
+    SynonymGraphTokenFilterFactory(
+        IndexSettings indexSettings,
+        Environment env,
+        String name,
+        Settings settings,
+        SynonymsManagementAPIService synonymsManagementAPIService,
+        ThreadPool threadPool
+    ) {
+        super(indexSettings, env, name, settings, synonymsManagementAPIService, threadPool);
     }
 
     @Override

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PredicateTokenScriptFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/PredicateTokenScriptFilterTests.java
@@ -9,6 +9,12 @@
 package org.elasticsearch.analysis.common;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.support.AbstractClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -23,6 +29,7 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTokenStreamTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
 
 import java.io.IOException;
@@ -58,9 +65,9 @@ public class PredicateTokenScriptFilterTests extends ESTokenStreamTestCase {
                 return (FactoryType) factory;
             }
         };
-
+        Client client = new MockClient(Settings.EMPTY, null);
         CommonAnalysisPlugin plugin = new CommonAnalysisPlugin();
-        plugin.createComponents(null, null, null, null, scriptService, null, null, null, null, null, null, Tracer.NOOP, null);
+        plugin.createComponents(client, null, null, null, scriptService, null, null, null, null, null, null, Tracer.NOOP, null);
         AnalysisModule module = new AnalysisModule(
             TestEnvironment.newEnvironment(settings),
             Collections.singletonList(plugin),
@@ -74,6 +81,22 @@ public class PredicateTokenScriptFilterTests extends ESTokenStreamTestCase {
             assertAnalyzesTo(analyzer, "Oh what a wonderful thing to be", new String[] { "Oh", "what", "to", "be" });
         }
 
+    }
+
+    private class MockClient extends AbstractClient {
+        MockClient(Settings settings, ThreadPool threadPool) {
+            super(settings, threadPool);
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {}
     }
 
 }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/ScriptedConditionTokenFilterTests.java
@@ -9,6 +9,12 @@
 package org.elasticsearch.analysis.common;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.client.internal.support.AbstractClient;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.env.Environment;
@@ -23,6 +29,7 @@ import org.elasticsearch.script.ScriptContext;
 import org.elasticsearch.script.ScriptService;
 import org.elasticsearch.test.ESTokenStreamTestCase;
 import org.elasticsearch.test.IndexSettingsModule;
+import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.tracing.Tracer;
 
 import java.util.Collections;
@@ -58,9 +65,9 @@ public class ScriptedConditionTokenFilterTests extends ESTokenStreamTestCase {
                 return (FactoryType) factory;
             }
         };
-
+        Client client = new MockClient(Settings.EMPTY, null);
         CommonAnalysisPlugin plugin = new CommonAnalysisPlugin();
-        plugin.createComponents(null, null, null, null, scriptService, null, null, null, null, null, null, Tracer.NOOP, null);
+        plugin.createComponents(client, null, null, null, scriptService, null, null, null, null, null, null, Tracer.NOOP, null);
         AnalysisModule module = new AnalysisModule(
             TestEnvironment.newEnvironment(settings),
             Collections.singletonList(plugin),
@@ -74,6 +81,22 @@ public class ScriptedConditionTokenFilterTests extends ESTokenStreamTestCase {
             assertAnalyzesTo(analyzer, "Vorsprung Durch Technik", new String[] { "Vorsprung", "Durch", "TECHNIK" });
         }
 
+    }
+
+    private class MockClient extends AbstractClient {
+        MockClient(Settings settings, ThreadPool threadPool) {
+            super(settings, threadPool);
+        }
+
+        @Override
+        public void close() {}
+
+        @Override
+        protected <Request extends ActionRequest, Response extends ActionResponse> void doExecute(
+            ActionType<Response> action,
+            Request request,
+            ActionListener<Response> listener
+        ) {}
     }
 
 }

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/SynonymsAnalysisTests.java
@@ -268,7 +268,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         for (String factory : bypassingFactories) {
             TokenFilterFactory tff = plugin.getTokenFilters().get(factory).get(idxSettings, null, factory, settings);
             TokenizerFactory tok = new KeywordTokenizerFactory(idxSettings, null, "keyword", settings);
-            SynonymTokenFilterFactory stff = new SynonymTokenFilterFactory(idxSettings, null, "synonym", settings);
+            SynonymTokenFilterFactory stff = new SynonymTokenFilterFactory(idxSettings, null, "synonym", settings, null, null);
             Analyzer analyzer = SynonymTokenFilterFactory.buildSynonymAnalyzer(
                 tok,
                 Collections.emptyList(),
@@ -338,7 +338,7 @@ public class SynonymsAnalysisTests extends ESTestCase {
         for (String factory : disallowedFactories) {
             TokenFilterFactory tff = plugin.getTokenFilters().get(factory).get(idxSettings, null, factory, settings);
             TokenizerFactory tok = new KeywordTokenizerFactory(idxSettings, null, "keyword", settings);
-            SynonymTokenFilterFactory stff = new SynonymTokenFilterFactory(idxSettings, null, "synonym", settings);
+            SynonymTokenFilterFactory stff = new SynonymTokenFilterFactory(idxSettings, null, "synonym", settings, null, null);
 
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,

--- a/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/70_synonyms_from_index.yml
+++ b/modules/analysis-common/src/yamlRestTest/resources/rest-api-spec/test/analysis-common/70_synonyms_from_index.yml
@@ -1,0 +1,100 @@
+---
+"Load synonyms from index for an analyzer":
+  - skip:
+      version: " - 8.8.99"
+      reason: Loading synonyms from index is introduced in 8.9.0
+  - do:
+      synonyms.put:
+        synonyms_set: set1
+        body:
+          synonyms_set:
+            - synonyms: "hello, hi"
+            - synonyms: "bye => goodbye"
+
+  - match: { result: "created" }
+
+  - do:
+      indices.create:
+        index: my_index
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+            analysis:
+              filter:
+                my_synonym_filter:
+                  type: synonym
+                  synonyms_set: set1
+                  updateable : true
+              analyzer:
+                my_analyzer:
+                  type: custom
+                  tokenizer: standard
+                  filter: [ lowercase, my_synonym_filter ]
+          mappings:
+            properties:
+              my_field:
+                type: text
+                search_analyzer: my_analyzer
+
+  - do:
+      bulk:
+        refresh: true
+        body:
+          - '{"index": {"_index": "my_index", "_id": "1"}}'
+          - '{"my_field": "hello"}'
+          - '{"index": {"_index": "my_index", "_id": "2"}}'
+          - '{"my_field": "goodbye"}'
+
+  - do:
+      search:
+        index: my_index
+        body:
+          query:
+            match:
+              my_field:
+                query: hi
+  - match: { hits.total.value: 1 }
+
+  - do:
+      search:
+        index: my_index
+        body:
+          query:
+            match:
+              my_field:
+                query: bye
+  - match: { hits.total.value: 1 }
+
+
+---
+"Fail loading synonyms from index if synonyms_set doesn't exist":
+  - skip:
+      version: " - 8.8.99"
+      reason: Loading synonyms from index is introduced in 8.9.0
+
+  - do:
+      indices.create:
+        index: my_index
+        body:
+          settings:
+            index:
+              number_of_shards: 1
+            analysis:
+              filter:
+                my_synonym_filter:
+                  type: synonym
+                  synonyms_set: set_missing
+                  updateable: true
+              analyzer:
+                my_analyzer:
+                  type: custom
+                  tokenizer: standard
+                  filter: [ lowercase, my_synonym_filter ]
+          mappings:
+            properties:
+              my_field:
+                type: text
+                search_analyzer: my_analyzer
+  - match: { acknowledged: true }
+  - match: { shards_acknowledged: false }


### PR DESCRIPTION
- Create a new option of "synonyms_set" for synonym set filter that specifies which synonyms set to be loaded from the system ".synonyms" index
- On index creation for this option load synonyms set  from index
- If synonyms set doesn't exist, index creation request still succeeds, but shards are not allocated, so the cluster state will be read.

Note: this is a temporary solution, as:
- No check is done on master node, as fake synonyms are provided
- On shard on index creation we use a blocking operation in the cluster applier thread
