### PR TITLE
Rename service that upgrades system index mappings

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
@@ -36,7 +36,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 import static org.hamcrest.Matchers.equalTo;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 0)
-public class SystemIndexManagerIT extends ESIntegTestCase {
+public class SystemIndexMappingUpdateServiceIT extends ESIntegTestCase {
 
     @Before
     public void beforeEach() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/put/TransportUpdateSettingsAction.java
@@ -39,7 +39,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import static org.elasticsearch.indices.SystemIndexManager.MANAGED_SYSTEM_INDEX_SETTING_UPDATE_ALLOWLIST;
+import static org.elasticsearch.indices.SystemIndexMappingUpdateService.MANAGED_SYSTEM_INDEX_SETTING_UPDATE_ALLOWLIST;
 
 public class TransportUpdateSettingsAction extends AcknowledgedTransportMasterNodeAction<UpdateSettingsRequest> {
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SystemIndexMetadataUpgradeService.java
@@ -18,6 +18,7 @@ import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.AbstractRunnable;
 import org.elasticsearch.core.SuppressForbidden;
+import org.elasticsearch.indices.SystemIndexMappingUpdateService;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.threadpool.ThreadPool;
 
@@ -28,7 +29,7 @@ import java.util.Map;
 /**
  * A service responsible for updating the metadata used by system indices.
  *
- * Mapping updates are handled by {@link org.elasticsearch.indices.SystemIndexManager}.
+ * Mapping updates are handled by {@link SystemIndexMappingUpdateService}.
  */
 public class SystemIndexMetadataUpgradeService implements ClusterStateListener {
 

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -83,6 +83,9 @@ import java.util.Set;
  * API will fail. (See <a href="https://github.com/elastic/elasticsearch/pull/86707">PR #86707</a>) However, auto-creating the index by
  * writing a document to it will succeed. (See <a href="https://github.com/elastic/elasticsearch/pull/77045">PR #77045</a>)
  *
+ * <p>The mappings for managed system indices are automatically upgraded when all nodes in the cluster are compatible with the
+ * descriptor's mappings. See {@link SystemIndexMappingUpdateService} for details.
+ *
  * <p>We hope to remove the currently deprecated forms of access to system indices in a future release. A newly added system index with
  * no backwards-compatibility requirements may opt into our desired behavior by setting isNetNew to true. A "net new system index"
  * strictly enforces its allowed product origins, and cannot be accessed by any REST API request that lacks a correct product header.

--- a/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
+++ b/server/src/main/java/org/elasticsearch/indices/SystemIndexDescriptor.java
@@ -14,6 +14,7 @@ import org.apache.lucene.util.automaton.Operations;
 import org.elasticsearch.Version;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.Metadata;
+import org.elasticsearch.cluster.metadata.SystemIndexMetadataUpgradeService;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.lucene.RegExp;
 import org.elasticsearch.common.settings.Settings;
@@ -39,8 +40,7 @@ import java.util.Set;
  * <p>Any index name that matches a descriptor’s index pattern belongs to the descriptor. For example, if a descriptor had a pattern of
  * {@code ".example-index-*"}, then indices named {@code ".example-index-1"}, {@code ".example-index-reindex"}, and {@code
  * ".example-index-old"} would all belong to the descriptor. If a node gains a new system index descriptor after an upgrade, then matching
- * indices will automatically be marked as system indices (see
- * {@link org.elasticsearch.cluster.metadata.SystemIndexMetadataUpgradeService}).
+ * indices will automatically be marked as system indices (see {@link SystemIndexMetadataUpgradeService}).
  *
  * <p>SystemIndexDescriptor index patterns must begin with a "{@code .}" character. Index patterns also have a "gotcha": the pattern
  * definitions may look like the standard Elasticsearch multi-target syntax but the underlying implementation is different. Index

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -128,7 +128,7 @@ import org.elasticsearch.indices.ExecutorSelector;
 import org.elasticsearch.indices.IndicesModule;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.ShardLimitValidator;
-import org.elasticsearch.indices.SystemIndexManager;
+import org.elasticsearch.indices.SystemIndexMappingUpdateService;
 import org.elasticsearch.indices.SystemIndices;
 import org.elasticsearch.indices.analysis.AnalysisModule;
 import org.elasticsearch.indices.breaker.BreakerSettings;
@@ -658,7 +658,7 @@ public class Node implements Closeable {
                 .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
 
             if (DiscoveryNode.isMasterNode(settings)) {
-                clusterService.addListener(new SystemIndexManager(systemIndices, client));
+                clusterService.addListener(new SystemIndexMappingUpdateService(systemIndices, client));
                 clusterService.addListener(new TransportVersionsFixupListener(clusterService, client.admin().cluster(), threadPool));
             }
 

--- a/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceTests.java
@@ -36,7 +36,7 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.CheckedConsumer;
 import org.elasticsearch.index.Index;
 import org.elasticsearch.index.shard.ShardId;
-import org.elasticsearch.indices.SystemIndexManager.UpgradeStatus;
+import org.elasticsearch.indices.SystemIndexMappingUpdateService.UpgradeStatus;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class SystemIndexManagerTests extends ESTestCase {
+public class SystemIndexMappingUpdateServiceTests extends ESTestCase {
 
     private static final ClusterName CLUSTER_NAME = new ClusterName("security-index-manager-tests");
     private static final ClusterState EMPTY_CLUSTER_STATE = new ClusterState.Builder(CLUSTER_NAME).build();
@@ -110,7 +110,7 @@ public class SystemIndexManagerTests extends ESTestCase {
                 new SystemIndices.Feature("index 2", "index 2 feature", List.of(d2))
             )
         );
-        SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
+        SystemIndexMappingUpdateService manager = new SystemIndexMappingUpdateService(systemIndices, client);
 
         final List<SystemIndexDescriptor> eligibleDescriptors = manager.getEligibleDescriptors(
             Metadata.builder()
@@ -154,7 +154,7 @@ public class SystemIndexManagerTests extends ESTestCase {
             )
         );
         ;
-        SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
+        SystemIndexMappingUpdateService manager = new SystemIndexMappingUpdateService(systemIndices, client);
 
         final List<SystemIndexDescriptor> eligibleDescriptors = manager.getEligibleDescriptors(
             Metadata.builder().put(getIndexMetadata(d2, d2.getMappings(), 6, IndexMetadata.State.OPEN)).build()
@@ -169,7 +169,10 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerSkipsClosedIndices() {
         final ClusterState.Builder clusterStateBuilder = createClusterState(IndexMetadata.State.CLOSE);
-        assertThat(SystemIndexManager.getUpgradeStatus(clusterStateBuilder.build(), DESCRIPTOR), equalTo(UpgradeStatus.CLOSED));
+        assertThat(
+            SystemIndexMappingUpdateService.getUpgradeStatus(clusterStateBuilder.build(), DESCRIPTOR),
+            equalTo(UpgradeStatus.CLOSED)
+        );
     }
 
     /**
@@ -177,7 +180,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerSkipsIndicesWithRedStatus() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(markShardsUnavailable(createClusterState()), DESCRIPTOR),
+            SystemIndexMappingUpdateService.getUpgradeStatus(markShardsUnavailable(createClusterState()), DESCRIPTOR),
             equalTo(UpgradeStatus.UNHEALTHY)
         );
     }
@@ -188,7 +191,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerSkipsIndicesWithOutdatedFormat() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(markShardsAvailable(createClusterState(5)), DESCRIPTOR),
+            SystemIndexMappingUpdateService.getUpgradeStatus(markShardsAvailable(createClusterState(5)), DESCRIPTOR),
             equalTo(UpgradeStatus.NEEDS_UPGRADE)
         );
     }
@@ -198,7 +201,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerSkipsIndicesWithUpToDateMappings() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(markShardsAvailable(createClusterState()), DESCRIPTOR),
+            SystemIndexMappingUpdateService.getUpgradeStatus(markShardsAvailable(createClusterState()), DESCRIPTOR),
             equalTo(UpgradeStatus.UP_TO_DATE)
         );
     }
@@ -208,7 +211,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerProcessesIndicesWithOutdatedMappings() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(
+            SystemIndexMappingUpdateService.getUpgradeStatus(
                 markShardsAvailable(createClusterState(Strings.toString(getMappings("1.0.0")))),
                 DESCRIPTOR
             ),
@@ -221,7 +224,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerProcessesIndicesWithNullMetadata() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(
+            SystemIndexMappingUpdateService.getUpgradeStatus(
                 markShardsAvailable(createClusterState(Strings.toString(getMappings(builder -> {})))),
                 DESCRIPTOR
             ),
@@ -234,7 +237,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerProcessesIndicesWithNullVersionMetadata() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(
+            SystemIndexMappingUpdateService.getUpgradeStatus(
                 markShardsAvailable(createClusterState(Strings.toString(getMappings((String) null)))),
                 DESCRIPTOR
             ),
@@ -247,7 +250,7 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testManagerSubmitsPutRequest() {
         SystemIndices systemIndices = new SystemIndices(List.of(FEATURE));
-        SystemIndexManager manager = new SystemIndexManager(systemIndices, client);
+        SystemIndexMappingUpdateService manager = new SystemIndexMappingUpdateService(systemIndices, client);
 
         manager.clusterChanged(event(markShardsAvailable(createClusterState(Strings.toString(getMappings("1.0.0"))))));
 
@@ -259,13 +262,16 @@ public class SystemIndexManagerTests extends ESTestCase {
      */
     public void testCanHandleIntegerMetaVersion() {
         assertThat(
-            SystemIndexManager.getUpgradeStatus(markShardsAvailable(createClusterState(Strings.toString(getMappings(3)))), DESCRIPTOR),
+            SystemIndexMappingUpdateService.getUpgradeStatus(
+                markShardsAvailable(createClusterState(Strings.toString(getMappings(3)))),
+                DESCRIPTOR
+            ),
             equalTo(UpgradeStatus.NEEDS_MAPPINGS_UPDATE)
         );
     }
 
     private static ClusterState.Builder createClusterState() {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings());
+        return createClusterState(SystemIndexMappingUpdateServiceTests.DESCRIPTOR.getMappings());
     }
 
     private static ClusterState.Builder createClusterState(String mappings) {
@@ -273,7 +279,7 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     private static ClusterState.Builder createClusterState(IndexMetadata.State state) {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings(), 6, state);
+        return createClusterState(SystemIndexMappingUpdateServiceTests.DESCRIPTOR.getMappings(), 6, state);
     }
 
     private static ClusterState.Builder createClusterState(String mappings, IndexMetadata.State state) {
@@ -281,11 +287,11 @@ public class SystemIndexManagerTests extends ESTestCase {
     }
 
     private static ClusterState.Builder createClusterState(int format) {
-        return createClusterState(SystemIndexManagerTests.DESCRIPTOR.getMappings(), format, IndexMetadata.State.OPEN);
+        return createClusterState(SystemIndexMappingUpdateServiceTests.DESCRIPTOR.getMappings(), format, IndexMetadata.State.OPEN);
     }
 
     private static ClusterState.Builder createClusterState(String mappings, int format, IndexMetadata.State state) {
-        IndexMetadata.Builder indexMeta = getIndexMetadata(SystemIndexManagerTests.DESCRIPTOR, mappings, format, state);
+        IndexMetadata.Builder indexMeta = getIndexMetadata(SystemIndexMappingUpdateServiceTests.DESCRIPTOR, mappings, format, state);
 
         Metadata.Builder metadataBuilder = new Metadata.Builder();
         metadataBuilder.put(indexMeta);


### PR DESCRIPTION
We have two classes that listen to cluster state and modify system indices. One of them is the sensibly-named `SystemIndexMetadataUpgradeService`, which modifies `IndexMetadata` for system indices. The other was previously called `SystemIndexManager`, which is too generic a name, since it specifically handles mapping upgrades. Here, we rename it `SystemIndexMappingUpdateService`.

We don't need to combine these classes right now, since they listen for different circumstances: we can upgrade index metadata even when we're in a mixed-version cluster, but we only upgrade mappings when all nodes have the same version.