### PR TITLE
Add method for registering a SettingsProvider for keystore settings

### DIFF
--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/AbstractLocalSpecBuilder.java
@@ -178,6 +178,12 @@ public abstract class AbstractLocalSpecBuilder<T extends LocalSpecBuilder<?>> im
         return cast(this);
     }
 
+    @Override
+    public T keystore(SettingsProvider settingsProvider) {
+        this.keystoreProviders.add(settingsProvider);
+        return cast(this);
+    }
+
     public List<SettingsProvider> getKeystoreProviders() {
         return inherit(() -> parent.getKeystoreProviders(), keystoreProviders);
     }

--- a/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
+++ b/test/test-clusters/src/main/java/org/elasticsearch/test/cluster/local/LocalSpecBuilder.java
@@ -97,6 +97,11 @@ interface LocalSpecBuilder<T extends LocalSpecBuilder<?>> {
     T keystore(String key, Supplier<String> supplier, Predicate<LocalNodeSpec> predicate);
 
     /**
+     * Register a {@link SettingsProvider} for keystore settings.
+     */
+    T keystore(SettingsProvider settingsProvider);
+
+    /**
      * Sets the security setting keystore password.
      */
     T keystorePassword(String password);


### PR DESCRIPTION
Add a method to `LocalClusterBuilder` for providing a `SettingsProvider` for secure keystore settings in test clusters.