### PR TITLE
Fix CancellableFanOutTests#testConcurrency

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/support/CancellableFanOut.java
+++ b/server/src/main/java/org/elasticsearch/action/support/CancellableFanOut.java
@@ -151,8 +151,8 @@ public abstract class CancellableFanOut<Item, ItemResponse, FinalResponse> {
     protected abstract void onItemFailure(Item item, Exception e);
 
     /**
-     * Called when responses for all items have been processed, on the thread that processed the last per-item response. Not called if the
-     * task is cancelled.
+     * Called when responses for all items have been processed, on the thread that processed the last per-item response or possibly the
+     * thread which called {@link #run} if all items were processed before {@link #run} returns. Not called if the task is cancelled.
      * <p>
      * Note that it's easy to accidentally capture another reference to this class when implementing this method, and that will prevent the
      * early release of any accumulated results. Beware of lambdas, and test carefully.

--- a/server/src/test/java/org/elasticsearch/action/support/CancellableFanOutTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/CancellableFanOutTests.java
@@ -17,6 +17,7 @@ import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskId;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.ReachabilityChecker;
+import org.hamcrest.Matcher;
 
 import java.util.HashMap;
 import java.util.List;
@@ -143,10 +144,16 @@ public class CancellableFanOutTests extends ESTestCase {
         expectThrows(TaskCancelledException.class, future::actionGet);
     }
 
+    private static void assertCurrentThread(Matcher<String> matcher) {
+        assertThat(Thread.currentThread().getName(), matcher);
+    }
+
     public void testConcurrency() throws InterruptedException {
 
         final var isProcessorThread = startsWith("processor-thread-");
         final var isCancelThread = equalTo("cancel-thread");
+        final var isTestThread = startsWith("TEST-");
+        assertCurrentThread(isTestThread);
 
         final var items = randomList(1, 3, () -> randomAlphaOfLength(5));
         final var processorThreads = new Thread[items.size()];
@@ -155,7 +162,7 @@ public class CancellableFanOutTests extends ESTestCase {
         for (int i = 0; i < processorThreads.length; i++) {
             processorThreads[i] = new Thread(() -> {
                 try {
-                    assertThat(Thread.currentThread().getName(), isProcessorThread);
+                    assertCurrentThread(isProcessorThread);
                     final var item = Objects.requireNonNull(queue.poll(10, TimeUnit.SECONDS));
                     safeAwait(barrier);
                     item.run();
@@ -169,7 +176,7 @@ public class CancellableFanOutTests extends ESTestCase {
         final var task = new CancellableTask(1, "test", "test", "", TaskId.EMPTY_TASK_ID, Map.of());
 
         final var cancelThread = new Thread(() -> {
-            assertThat(Thread.currentThread().getName(), isCancelThread);
+            assertCurrentThread(isCancelThread);
             safeAwait(barrier);
             TaskCancelHelper.cancel(task, "test");
         }, "cancel-thread");
@@ -187,14 +194,14 @@ public class CancellableFanOutTests extends ESTestCase {
 
             @Override
             protected void onItemResponse(String s, String response) {
-                assertThat(Thread.currentThread().getName(), isProcessorThread);
+                assertCurrentThread(isProcessorThread);
                 assertEquals(s, response);
                 assertThat(itemsProcessed.incrementAndGet(), lessThanOrEqualTo(items.size()));
             }
 
             @Override
             protected void onItemFailure(String s, Exception e) {
-                assertThat(Thread.currentThread().getName(), isProcessorThread);
+                assertCurrentThread(isProcessorThread);
                 assertThat(e, instanceOf(ElasticsearchException.class));
                 assertEquals("sendItemRequest", e.getMessage());
                 assertThat(itemsProcessed.incrementAndGet(), lessThanOrEqualTo(items.size()));
@@ -203,7 +210,7 @@ public class CancellableFanOutTests extends ESTestCase {
             @Override
             protected String onCompletion() {
                 assertEquals(items.size(), itemsProcessed.get());
-                assertThat(Thread.currentThread().getName(), isProcessorThread);
+                assertCurrentThread(anyOf(isTestThread, isProcessorThread));
                 if (randomBoolean()) {
                     return "finished";
                 } else {
@@ -214,7 +221,7 @@ public class CancellableFanOutTests extends ESTestCase {
             @Override
             public void onResponse(String s) {
                 assertEquals(items.size(), itemsProcessed.get());
-                assertThat(Thread.currentThread().getName(), isProcessorThread);
+                assertCurrentThread(anyOf(isTestThread, isProcessorThread));
                 assertEquals("finished", s);
                 completionLatch.countDown();
             }
@@ -222,10 +229,10 @@ public class CancellableFanOutTests extends ESTestCase {
             @Override
             public void onFailure(Exception e) {
                 if (e instanceof TaskCancelledException) {
-                    assertThat(Thread.currentThread().getName(), anyOf(isProcessorThread, isCancelThread));
+                    assertCurrentThread(anyOf(isTestThread, isProcessorThread, isCancelThread));
                 } else {
                     assertEquals(items.size(), itemsProcessed.get());
-                    assertThat(Thread.currentThread().getName(), isProcessorThread);
+                    assertCurrentThread(anyOf(isTestThread, isProcessorThread));
                     assertThat(e, instanceOf(ElasticsearchException.class));
                     assertEquals("onCompletion", e.getMessage());
                 }


### PR DESCRIPTION
The completion may also happen on the calling thread. Weakens the assertion and updates the docs to match.

Closes #96688