### PR TITLE
[8.8] Fix iteration of empty percentiles throwing Null Pointer Exception (#96668)

### DIFF
--- a/docs/changelog/96668.yaml
+++ b/docs/changelog/96668.yaml
@@ -1,0 +1,6 @@
+pr: 96668
+summary: Fix iteration of empty percentiles throwing Null Pointer Exception
+area: Aggregations
+type: bug
+issues:
+ - 96626

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalHDRPercentiles.java
@@ -21,6 +21,8 @@ import org.elasticsearch.xcontent.XContentBuilder;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -28,6 +30,7 @@ import java.util.zip.DataFormatException;
 
 abstract class AbstractInternalHDRPercentiles extends InternalNumericMetricsAggregation.MultiValue {
 
+    protected static final Iterator<Percentile> EMPTY_ITERATOR = Collections.emptyIterator();
     private static final DoubleHistogram EMPTY_HISTOGRAM_THREE_DIGITS = new DoubleHistogram(3);
     private static final DoubleHistogram EMPTY_HISTOGRAM_ZERO_DIGITS = new EmptyDoubleHdrHistogram();
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/AbstractInternalTDigestPercentiles.java
@@ -19,11 +19,15 @@ import org.elasticsearch.xcontent.XContentBuilder;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
 abstract class AbstractInternalTDigestPercentiles extends InternalNumericMetricsAggregation.MultiValue {
+
+    protected static final Iterator<Percentile> EMPTY_ITERATOR = Collections.emptyIterator();
 
     // NOTE: using compression = 1.0 empty histograms will track just about 5 centroids.
     // This reduces the amount of data to serialize and deserialize.

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentileRanks.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.DocValueFormat;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles implements PercentileRanks {
     public static final String NAME = "hdr_percentile_ranks";
@@ -43,6 +44,9 @@ public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles i
 
     @Override
     public Iterator<Percentile> iterator() {
+        if (state == null) {
+            return EMPTY_ITERATOR;
+        }
         return new Iter(keys, state);
     }
 
@@ -93,7 +97,7 @@ public class InternalHDRPercentileRanks extends AbstractInternalHDRPercentiles i
 
         public Iter(double[] values, DoubleHistogram state) {
             this.values = values;
-            this.state = state;
+            this.state = Objects.requireNonNull(state);
             i = 0;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentiles.java
@@ -14,6 +14,7 @@ import org.elasticsearch.search.DocValueFormat;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles implements Percentiles {
     public static final String NAME = "hdr_percentiles";
@@ -43,6 +44,9 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
 
     @Override
     public Iterator<Percentile> iterator() {
+        if (state == null) {
+            return EMPTY_ITERATOR;
+        }
         return new Iter(keys, state);
     }
 
@@ -83,7 +87,7 @@ public class InternalHDRPercentiles extends AbstractInternalHDRPercentiles imple
 
         public Iter(double[] percents, DoubleHistogram state) {
             this.percents = percents;
-            this.state = state;
+            this.state = Objects.requireNonNull(state);
             i = 0;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentileRanks.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.DocValueFormat;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPercentiles implements PercentileRanks {
     public static final String NAME = "tdigest_percentile_ranks";
@@ -42,6 +43,9 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
 
     @Override
     public Iterator<Percentile> iterator() {
+        if (state == null) {
+            return EMPTY_ITERATOR;
+        }
         return new Iter(keys, state);
     }
 
@@ -89,7 +93,7 @@ public class InternalTDigestPercentileRanks extends AbstractInternalTDigestPerce
 
         public Iter(double[] values, TDigestState state) {
             this.values = values;
-            this.state = state;
+            this.state = Objects.requireNonNull(state);
             i = 0;
         }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentiles.java
@@ -13,6 +13,7 @@ import org.elasticsearch.search.DocValueFormat;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentiles implements Percentiles {
     public static final String NAME = "tdigest_percentiles";
@@ -42,6 +43,9 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
 
     @Override
     public Iterator<Percentile> iterator() {
+        if (state == null) {
+            return EMPTY_ITERATOR;
+        }
         return new Iter(keys, state);
     }
 
@@ -79,7 +83,7 @@ public class InternalTDigestPercentiles extends AbstractInternalTDigestPercentil
 
         public Iter(double[] percents, TDigestState state) {
             this.percents = percents;
-            this.state = state;
+            this.state = Objects.requireNonNull(state);
             i = 0;
         }
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesRanksTests.java
@@ -30,9 +30,13 @@ public class InternalHDRPercentilesRanksTests extends InternalPercentilesRanksTe
         boolean keyed,
         DocValueFormat format,
         double[] percents,
-        double[] values
+        double[] values,
+        boolean empty
     ) {
 
+        if (empty) {
+            return new InternalHDRPercentileRanks(name, percents, null, keyed, format, metadata);
+        }
         final DoubleHistogram state = new DoubleHistogram(3);
         Arrays.stream(values).forEach(state::recordValue);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalHDRPercentilesTests.java
@@ -31,8 +31,13 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
         boolean keyed,
         DocValueFormat format,
         double[] percents,
-        double[] values
+        double[] values,
+        boolean empty
     ) {
+
+        if (empty) {
+            return new InternalHDRPercentiles(name, percents, null, keyed, format, metadata);
+        }
 
         final DoubleHistogram state = new DoubleHistogram(3);
         Arrays.stream(values).forEach(state::recordValue);
@@ -76,7 +81,15 @@ public class InternalHDRPercentilesTests extends InternalPercentilesTestCase<Int
             values[i] = randomDouble();
         }
 
-        InternalHDRPercentiles aggregation = createTestInstance("test", emptyMap(), false, randomNumericDocValueFormat(), percents, values);
+        InternalHDRPercentiles aggregation = createTestInstance(
+            "test",
+            emptyMap(),
+            false,
+            randomNumericDocValueFormat(),
+            percents,
+            values,
+            false
+        );
 
         Iterator<Percentile> iterator = aggregation.iterator();
         Iterator<String> nameIterator = aggregation.valueNames().iterator();

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesRanksTests.java
@@ -29,8 +29,12 @@ public class InternalTDigestPercentilesRanksTests extends InternalPercentilesRan
         boolean keyed,
         DocValueFormat format,
         double[] percents,
-        double[] values
+        double[] values,
+        boolean empty
     ) {
+        if (empty) {
+            return new InternalTDigestPercentileRanks(name, percents, null, keyed, format, metadata);
+        }
         final TDigestState state = new TDigestState(100);
         Arrays.stream(values).forEach(state::add);
 

--- a/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
+++ b/server/src/test/java/org/elasticsearch/search/aggregations/metrics/InternalTDigestPercentilesTests.java
@@ -30,8 +30,12 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
         boolean keyed,
         DocValueFormat format,
         double[] percents,
-        double[] values
+        double[] values,
+        boolean empty
     ) {
+        if (empty) {
+            return new InternalTDigestPercentiles(name, percents, null, keyed, format, metadata);
+        }
         final TDigestState state = new TDigestState(100);
         Arrays.stream(values).forEach(state::add);
 
@@ -126,7 +130,8 @@ public class InternalTDigestPercentilesTests extends InternalPercentilesTestCase
             false,
             randomNumericDocValueFormat(),
             percents,
-            values
+            values,
+            false
         );
 
         Iterator<Percentile> iterator = aggregation.iterator();


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Fix iteration of empty percentiles throwing Null Pointer Exception (#96668)