### PR TITLE
The unit tests can still have DLM enabled

### DIFF
--- a/modules/dlm/build.gradle
+++ b/modules/dlm/build.gradle
@@ -1,4 +1,3 @@
-import org.elasticsearch.gradle.Version
 import org.elasticsearch.gradle.internal.info.BuildParams
 
 apply plugin: 'elasticsearch.internal-es-plugin'
@@ -15,3 +14,9 @@ dependencies {
 }
 
 addQaCheckDependencies(project)
+
+if (BuildParams.isSnapshotBuild() == false) {
+  tasks.named("test").configure {
+    systemProperty 'es.dlm_feature_flag_enabled', 'true'
+  }
+}


### PR DESCRIPTION
We need to enable DLM for unit tests for non-snapshot (stable) builds

Fixes #96687 