### PR TITLE
Refactor some uses of MapBuilder to JCL maps

### DIFF
--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/event/AnalyticsEventFactoryTests.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.application.analytics.event;
 
 import org.elasticsearch.common.bytes.BytesReference;
-import org.elasticsearch.common.collect.MapBuilder;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xcontent.XContentType;
 import org.elasticsearch.xpack.application.analytics.action.PostAnalyticsEventAction;
@@ -79,7 +78,7 @@ public class AnalyticsEventFactoryTests extends ESTestCase {
     }
 
     private static BytesReference toRequestPayload(AnalyticsEvent event) throws IOException {
-        MapBuilder<String, Object> requestPayloadBuilder = MapBuilder.newMapBuilder(event.payloadAsMap());
+        Map<String, Object> requestPayloadBuilder = new HashMap<>(event.payloadAsMap());
 
         @SuppressWarnings("unchecked")
         Map<String, String> eventSessionData = (Map<String, String>) event.payloadAsMap().get(SESSION_FIELD.getPreferredName());
@@ -92,7 +91,7 @@ public class AnalyticsEventFactoryTests extends ESTestCase {
 
         requestPayloadBuilder.put(SESSION_FIELD.getPreferredName(), requestSessionData);
 
-        return convertMapToJson(requestPayloadBuilder.map());
+        return convertMapToJson(requestPayloadBuilder);
     }
 
     public void testFromPayloadSearchClickEvent() throws IOException {

--- a/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
+++ b/x-pack/plugin/identity-provider/src/main/java/org/elasticsearch/xpack/idp/saml/idp/SamlIdentityProvider.java
@@ -11,7 +11,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.util.Maps;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProvider;
 import org.elasticsearch.xpack.idp.saml.sp.SamlServiceProviderResolver;
@@ -21,12 +21,12 @@ import org.opensaml.saml.saml2.metadata.ContactPersonTypeEnumeration;
 import org.opensaml.security.x509.X509Credential;
 
 import java.net.URL;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Stream;
 
 /**
  * SAML 2.0 configuration information about this IdP
@@ -183,15 +183,13 @@ public class SamlIdentityProvider {
     }
 
     public static class ContactInfo {
-        static final Map<String, ContactPersonTypeEnumeration> TYPES = Collections.unmodifiableMap(
-            MapBuilder.newMapBuilder(new LinkedHashMap<String, ContactPersonTypeEnumeration>())
-                .put(ContactPersonTypeEnumeration.ADMINISTRATIVE.toString(), ContactPersonTypeEnumeration.ADMINISTRATIVE)
-                .put(ContactPersonTypeEnumeration.BILLING.toString(), ContactPersonTypeEnumeration.BILLING)
-                .put(ContactPersonTypeEnumeration.SUPPORT.toString(), ContactPersonTypeEnumeration.SUPPORT)
-                .put(ContactPersonTypeEnumeration.TECHNICAL.toString(), ContactPersonTypeEnumeration.TECHNICAL)
-                .put(ContactPersonTypeEnumeration.OTHER.toString(), ContactPersonTypeEnumeration.OTHER)
-                .map()
-        );
+        static final Map<String, ContactPersonTypeEnumeration> TYPES = Stream.of(
+            ContactPersonTypeEnumeration.ADMINISTRATIVE,
+            ContactPersonTypeEnumeration.BILLING,
+            ContactPersonTypeEnumeration.SUPPORT,
+            ContactPersonTypeEnumeration.TECHNICAL,
+            ContactPersonTypeEnumeration.OTHER
+        ).collect(Maps.toUnmodifiableOrderedMap(ContactPersonTypeEnumeration::toString, Function.identity()));
 
         public final ContactPersonTypeEnumeration type;
         public final String givenName;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlSpMetadataBuilder.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/saml/SamlSpMetadataBuilder.java
@@ -7,7 +7,7 @@
 package org.elasticsearch.xpack.security.authc.saml;
 
 import org.elasticsearch.common.Strings;
-import org.elasticsearch.common.collect.MapBuilder;
+import org.elasticsearch.common.util.Maps;
 import org.opensaml.saml.common.xml.SAMLConstants;
 import org.opensaml.saml.saml2.metadata.AssertionConsumerService;
 import org.opensaml.saml.saml2.metadata.AttributeConsumingService;
@@ -60,7 +60,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * Constructs SAML Metadata to describe a <em>Service Provider</em>.
@@ -393,15 +395,13 @@ public class SamlSpMetadataBuilder {
     }
 
     public static class ContactInfo {
-        static final Map<String, ContactPersonTypeEnumeration> TYPES = MapBuilder.<String, ContactPersonTypeEnumeration>newMapBuilder(
-            new LinkedHashMap<>()
-        )
-            .put(ContactPersonTypeEnumeration.ADMINISTRATIVE.toString(), ContactPersonTypeEnumeration.ADMINISTRATIVE)
-            .put(ContactPersonTypeEnumeration.BILLING.toString(), ContactPersonTypeEnumeration.BILLING)
-            .put(ContactPersonTypeEnumeration.SUPPORT.toString(), ContactPersonTypeEnumeration.SUPPORT)
-            .put(ContactPersonTypeEnumeration.TECHNICAL.toString(), ContactPersonTypeEnumeration.TECHNICAL)
-            .put(ContactPersonTypeEnumeration.OTHER.toString(), ContactPersonTypeEnumeration.OTHER)
-            .map();
+        static final Map<String, ContactPersonTypeEnumeration> TYPES = Stream.of(
+            ContactPersonTypeEnumeration.ADMINISTRATIVE,
+            ContactPersonTypeEnumeration.BILLING,
+            ContactPersonTypeEnumeration.SUPPORT,
+            ContactPersonTypeEnumeration.TECHNICAL,
+            ContactPersonTypeEnumeration.OTHER
+        ).collect(Maps.toUnmodifiableOrderedMap(ContactPersonTypeEnumeration::toString, Function.identity()));
 
         public final ContactPersonTypeEnumeration type;
         public final String givenName;

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -121,6 +121,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.util.Collections.emptyMap;
+import static java.util.Map.entry;
 import static org.elasticsearch.common.util.set.Sets.newHashSet;
 import static org.elasticsearch.test.ActionListenerUtils.anyActionListener;
 import static org.elasticsearch.xpack.core.security.test.TestRestrictedIndices.RESTRICTED_INDICES;
@@ -1109,17 +1110,12 @@ public class RBACEngineTests extends ESTestCase {
             containsInAnyOrder(
                 ResourcePrivileges.builder("user/hawkeye/name")
                     .addPrivileges(
-                        Map.of(
-                            "DATA:read/user/*",
-                            true,
-                            "ACTION:" + action1,
-                            true,
-                            "ACTION:" + action2,
-                            false,
-                            action1,
-                            true,
-                            action2,
-                            false
+                        Map.ofEntries(
+                            entry("DATA:read/user/*", true),
+                            entry("ACTION:" + action1, true),
+                            entry("ACTION:" + action2, false),
+                            entry(action1, true),
+                            entry(action2, false)
                         )
                     )
                     .build()

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/RBACEngineTests.java
@@ -110,7 +110,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
@@ -693,32 +692,12 @@ public class RBACEngineTests extends ESTestCase {
             response.getDetails().index().values(),
             containsInAnyOrder(
                 ResourcePrivileges.builder("apache-2016-12")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new TreeMap<String, Boolean>())
-                            .put("create_doc", true)
-                            .put("index", true)
-                            .put("delete", true)
-                            .map()
-                    )
+                    .addPrivileges(Map.of("create_doc", true, "index", true, "delete", true))
                     .build(),
                 ResourcePrivileges.builder("apache-2017-01")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new TreeMap<String, Boolean>())
-                            .put("create_doc", true)
-                            .put("index", true)
-                            .put("delete", false)
-                            .map()
-                    )
+                    .addPrivileges(Map.of("create_doc", true, "index", true, "delete", false))
                     .build(),
-                ResourcePrivileges.builder("other")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new TreeMap<String, Boolean>())
-                            .put("create_doc", true)
-                            .put("index", false)
-                            .put("delete", false)
-                            .map()
-                    )
-                    .build()
+                ResourcePrivileges.builder("other").addPrivileges(Map.of("create_doc", true, "index", false, "delete", false)).build()
             )
         );
 
@@ -743,22 +722,10 @@ public class RBACEngineTests extends ESTestCase {
             response.getDetails().index().values(),
             containsInAnyOrder(
                 ResourcePrivileges.builder("apache-2016-12")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new TreeMap<String, Boolean>())
-                            .put("create_doc", true)
-                            .put("create", true)
-                            .put("index", true)
-                            .map()
-                    )
+                    .addPrivileges(Map.of("create_doc", true, "create", true, "index", true))
                     .build(),
                 ResourcePrivileges.builder("apache-2017-01")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new TreeMap<String, Boolean>())
-                            .put("create_doc", true)
-                            .put("create", true)
-                            .put("index", true)
-                            .map()
-                    )
+                    .addPrivileges(Map.of("create_doc", true, "create", true, "index", true))
                     .build()
             )
         );
@@ -785,11 +752,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getDetails().index().values(), Matchers.iterableWithSize(1));
         assertThat(
             response.getDetails().index().values(),
-            containsInAnyOrder(
-                ResourcePrivileges.builder(prePatternPrefix)
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).map())
-                    .build()
-            )
+            containsInAnyOrder(ResourcePrivileges.builder(prePatternPrefix).addPrivileges(Map.of("index", false)).build())
         );
 
         String matchesPatternPrefix = XPackPlugin.ASYNC_RESULTS_INDEX.substring(0, patternPrefix.length() + 1);
@@ -803,11 +766,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getDetails().index().values(), Matchers.iterableWithSize(1));
         assertThat(
             response.getDetails().index().values(),
-            containsInAnyOrder(
-                ResourcePrivileges.builder(matchesPatternPrefix + "*")
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).map())
-                    .build()
-            )
+            containsInAnyOrder(ResourcePrivileges.builder(matchesPatternPrefix + "*").addPrivileges(Map.of("index", true)).build())
         );
         response = hasPrivileges(
             IndicesPrivileges.builder().indices(matchesPatternPrefix + "*").allowRestrictedIndices(true).privileges("index").build(),
@@ -819,11 +778,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getDetails().index().values(), Matchers.iterableWithSize(1));
         assertThat(
             response.getDetails().index().values(),
-            containsInAnyOrder(
-                ResourcePrivileges.builder(matchesPatternPrefix + "*")
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).map())
-                    .build()
-            )
+            containsInAnyOrder(ResourcePrivileges.builder(matchesPatternPrefix + "*").addPrivileges(Map.of("index", false)).build())
         );
         response = hasPrivileges(
             IndicesPrivileges.builder().indices(matchesPatternPrefix).allowRestrictedIndices(randomBoolean()).privileges("index").build(),
@@ -835,11 +790,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getDetails().index().values(), Matchers.iterableWithSize(1));
         assertThat(
             response.getDetails().index().values(),
-            containsInAnyOrder(
-                ResourcePrivileges.builder(matchesPatternPrefix)
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).map())
-                    .build()
-            )
+            containsInAnyOrder(ResourcePrivileges.builder(matchesPatternPrefix).addPrivileges(Map.of("index", true)).build())
         );
 
         final String restrictedIndexMatchingWildcard = XPackPlugin.ASYNC_RESULTS_INDEX + randomAlphaOfLengthBetween(0, 2);
@@ -858,9 +809,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(
             response.getDetails().index().values(),
             containsInAnyOrder(
-                ResourcePrivileges.builder(restrictedIndexMatchingWildcard + "*")
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).map())
-                    .build()
+                ResourcePrivileges.builder(restrictedIndexMatchingWildcard + "*").addPrivileges(Map.of("index", false)).build()
             )
         );
         response = hasPrivileges(
@@ -878,9 +827,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(
             response.getDetails().index().values(),
             containsInAnyOrder(
-                ResourcePrivileges.builder(restrictedIndexMatchingWildcard + "*")
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).map())
-                    .build()
+                ResourcePrivileges.builder(restrictedIndexMatchingWildcard + "*").addPrivileges(Map.of("index", false)).build()
             )
         );
         response = hasPrivileges(
@@ -897,11 +844,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getDetails().index().values(), Matchers.iterableWithSize(1));
         assertThat(
             response.getDetails().index().values(),
-            containsInAnyOrder(
-                ResourcePrivileges.builder(restrictedIndexMatchingWildcard)
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).map())
-                    .build()
-            )
+            containsInAnyOrder(ResourcePrivileges.builder(restrictedIndexMatchingWildcard).addPrivileges(Map.of("index", false)).build())
         );
 
         role = Role.builder(RESTRICTED_INDICES, "role")
@@ -922,11 +865,7 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(response.getDetails().index().values(), Matchers.iterableWithSize(1));
         assertThat(
             response.getDetails().index().values(),
-            containsInAnyOrder(
-                ResourcePrivileges.builder(matchesPatternPrefix + "*")
-                    .addPrivileges(MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).map())
-                    .build()
-            )
+            containsInAnyOrder(ResourcePrivileges.builder(matchesPatternPrefix + "*").addPrivileges(Map.of("index", true)).build())
         );
     }
 
@@ -956,17 +895,10 @@ public class RBACEngineTests extends ESTestCase {
             response.getDetails().index().values(),
             containsInAnyOrder(
                 ResourcePrivileges.builder(".secret-non-restricted") // matches ".sec*" but not ".security*"
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", false).map()
-                    )
+                    .addPrivileges(Map.of("index", true, "monitor", false))
                     .build(),
                 ResourcePrivileges.builder(explicitRestrictedIndex) // matches both ".sec*" and ".security*"
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("index", restrictedIndexPermission)
-                            .put("monitor", restrictedMonitorPermission)
-                            .map()
-                    )
+                    .addPrivileges(Map.of("index", restrictedIndexPermission, "monitor", restrictedMonitorPermission))
                     .build()
             )
         );
@@ -988,17 +920,10 @@ public class RBACEngineTests extends ESTestCase {
             response.getDetails().index().values(),
             containsInAnyOrder(
                 ResourcePrivileges.builder(".secret-non-restricted") // matches ".sec*" but not ".security*"
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", false).map()
-                    )
+                    .addPrivileges(Map.of("index", true, "monitor", false))
                     .build(),
                 ResourcePrivileges.builder(explicitRestrictedIndex) // matches both ".sec*" and ".security*"
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("index", restrictedIndexPermission)
-                            .put("monitor", restrictedMonitorPermission)
-                            .map()
-                    )
+                    .addPrivileges(Map.of("index", restrictedIndexPermission, "monitor", restrictedMonitorPermission))
                     .build()
             )
         );
@@ -1022,16 +947,8 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(
             response.getDetails().index().values(),
             containsInAnyOrder(
-                ResourcePrivileges.builder(".sec*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", false).map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder(".security*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", true).map()
-                    )
-                    .build()
+                ResourcePrivileges.builder(".sec*").addPrivileges(Map.of("index", true, "monitor", false)).build(),
+                ResourcePrivileges.builder(".security*").addPrivileges(Map.of("index", true, "monitor", true)).build()
             )
         );
 
@@ -1046,16 +963,8 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(
             response.getDetails().index().values(),
             containsInAnyOrder(
-                ResourcePrivileges.builder(".sec*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).put("monitor", false).map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder(".security*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", false).put("monitor", true).map()
-                    )
-                    .build()
+                ResourcePrivileges.builder(".sec*").addPrivileges(Map.of("index", false, "monitor", false)).build(),
+                ResourcePrivileges.builder(".security*").addPrivileges(Map.of("index", false, "monitor", true)).build()
             )
         );
 
@@ -1076,16 +985,8 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(
             response.getDetails().index().values(),
             containsInAnyOrder(
-                ResourcePrivileges.builder(".sec*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", false).map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder(".security*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", true).map()
-                    )
-                    .build()
+                ResourcePrivileges.builder(".sec*").addPrivileges(Map.of("index", true, "monitor", false)).build(),
+                ResourcePrivileges.builder(".security*").addPrivileges(Map.of("index", true, "monitor", true)).build()
             )
         );
 
@@ -1100,16 +1001,8 @@ public class RBACEngineTests extends ESTestCase {
         assertThat(
             response.getDetails().index().values(),
             containsInAnyOrder(
-                ResourcePrivileges.builder(".sec*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", false).map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder(".security*")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>()).put("index", true).put("monitor", false).map()
-                    )
-                    .build()
+                ResourcePrivileges.builder(".sec*").addPrivileges(Map.of("index", true, "monitor", false)).build(),
+                ResourcePrivileges.builder(".security*").addPrivileges(Map.of("index", true, "monitor", false)).build()
             )
         );
     }
@@ -1162,42 +1055,10 @@ public class RBACEngineTests extends ESTestCase {
             Strings.collectionToCommaDelimitedString(app1),
             app1,
             containsInAnyOrder(
-                ResourcePrivileges.builder("foo/1")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", true)
-                            .put("write", false)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder("foo/bar/2")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", true)
-                            .put("write", false)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder("foo/bar/baz")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", true)
-                            .put("write", true)
-                            .put("all", true)
-                            .map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder("baz/bar/foo")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", false)
-                            .put("write", false)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build()
+                ResourcePrivileges.builder("foo/1").addPrivileges(Map.of("read", true, "write", false, "all", false)).build(),
+                ResourcePrivileges.builder("foo/bar/2").addPrivileges(Map.of("read", true, "write", false, "all", false)).build(),
+                ResourcePrivileges.builder("foo/bar/baz").addPrivileges(Map.of("read", true, "write", true, "all", true)).build(),
+                ResourcePrivileges.builder("baz/bar/foo").addPrivileges(Map.of("read", false, "write", false, "all", false)).build()
             )
         );
         final Collection<ResourcePrivileges> app2 = response.getDetails().application().get("app2");
@@ -1206,42 +1067,10 @@ public class RBACEngineTests extends ESTestCase {
             Strings.collectionToCommaDelimitedString(app2),
             app2,
             containsInAnyOrder(
-                ResourcePrivileges.builder("foo/1")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", false)
-                            .put("write", false)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder("foo/bar/2")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", true)
-                            .put("write", true)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder("foo/bar/baz")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", true)
-                            .put("write", true)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build(),
-                ResourcePrivileges.builder("baz/bar/foo")
-                    .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("read", false)
-                            .put("write", true)
-                            .put("all", false)
-                            .map()
-                    )
-                    .build()
+                ResourcePrivileges.builder("foo/1").addPrivileges(Map.of("read", false, "write", false, "all", false)).build(),
+                ResourcePrivileges.builder("foo/bar/2").addPrivileges(Map.of("read", true, "write", true, "all", false)).build(),
+                ResourcePrivileges.builder("foo/bar/baz").addPrivileges(Map.of("read", true, "write", true, "all", false)).build(),
+                ResourcePrivileges.builder("baz/bar/foo").addPrivileges(Map.of("read", false, "write", true, "all", false)).build()
             )
         );
     }
@@ -1280,13 +1109,18 @@ public class RBACEngineTests extends ESTestCase {
             containsInAnyOrder(
                 ResourcePrivileges.builder("user/hawkeye/name")
                     .addPrivileges(
-                        MapBuilder.newMapBuilder(new LinkedHashMap<String, Boolean>())
-                            .put("DATA:read/user/*", true)
-                            .put("ACTION:" + action1, true)
-                            .put("ACTION:" + action2, false)
-                            .put(action1, true)
-                            .put(action2, false)
-                            .map()
+                        Map.of(
+                            "DATA:read/user/*",
+                            true,
+                            "ACTION:" + action1,
+                            true,
+                            "ACTION:" + action2,
+                            false,
+                            action1,
+                            true,
+                            action2,
+                            false
+                        )
                     )
                     .build()
             )


### PR DESCRIPTION
Replace uses of `newMapBuilder(Map)` with pure JCL maps