### PR TITLE
[8.8] Debug ccr connection failure in docs build (#96699)

### DIFF
--- a/docs/build.gradle
+++ b/docs/build.gradle
@@ -65,6 +65,13 @@ testClusters.matching { it.name == "yamlRestTest"}.configureEach {
     keystorePassword 'keystore-password'
   }
 
+  // debug ccr test failures:
+  // https://github.com/elastic/elasticsearch/issues/95678
+  // https://github.com/elastic/elasticsearch/issues/94359
+  // https://github.com/elastic/elasticsearch/issues/96561
+  setting 'logger.org.elasticsearch.transport.SniffConnectionStrategy', 'DEBUG'
+  setting 'logger.org.elasticsearch.transport.RemoteClusterService', 'DEBUG'
+
   // enable regexes in painless so our tests don't complain about example snippets that use them
   setting 'script.painless.regex.enabled', 'true'
   setting 'xpack.security.enabled', 'false'


### PR DESCRIPTION
Backports the following commits to 8.8:
 - Debug ccr connection failure in docs build (#96699)