### PR TITLE
Fix GetDataStreamsTransportActionTests#testGetTimeSeriesMixedDataStream test

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
@@ -199,7 +199,6 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96672")
     public void testGetTimeSeriesMixedDataStream() {
         Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
         String dataStream1 = "ds-1";
@@ -230,6 +229,10 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
             systemIndices,
             ClusterSettings.createBuiltInClusterSettings()
         );
+
+        var name1 = DataStream.getDefaultBackingIndexName("ds-1", 1, now.toEpochMilli());
+        var name2 = DataStream.getDefaultBackingIndexName("ds-1", 2, now.toEpochMilli());
+        var name3 = DataStream.getDefaultBackingIndexName("ds-1", 3, now.toEpochMilli());
         assertThat(
             response.getDataStreams(),
             contains(
@@ -237,7 +240,7 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
                     transformedMatch(d -> d.getDataStream().getName(), equalTo(dataStream1)),
                     transformedMatch(
                         d -> d.getDataStream().getIndices().stream().map(Index::getName).toList(),
-                        contains(".ds-ds-1-2023.06.06-000001", ".ds-ds-1-2023.06.06-000002", ".ds-ds-1-2023.06.06-000003")
+                        contains(name1, name2, name3)
                     ),
                     transformedMatch(d -> d.getTimeSeries().temporalRanges(), contains(new Tuple<>(twoHoursAgo, twoHoursAhead)))
                 )


### PR DESCRIPTION
The name of backing indices was based on fixed dates.

Closes #96672