### PR TITLE
[DOCS] Remove leftover experimental tag for knn search

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -483,7 +483,6 @@ A boost value greater than `1.0` increases the score. A boost value between
 `0` and `1.0` decreases the score.
 ====
 
-experimental::[]
 [[search-api-knn]]
 `knn`::
 (Optional, object or array of objects)


### PR DESCRIPTION
Knn search was made GA in Elasticsearch 8.5, see #91065 . This commit removes a leftover experimental marking from the search docs.