### PR TITLE
[DOCS] Fixes field name in text_expansion query

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -242,7 +242,7 @@ GET my-index/_search
       "should": [
         {
           "text_expansion": { 
-            "ml.token": {
+            "ml.tokens": {
               "model_text": "How to avoid muscle soreness after running?",
               "model_id": ".elser_model_1",
               "boost": 1 <2>


### PR DESCRIPTION
## Overview

This PR fixes the compound query example on the text_expansion docs page.


### Preview

[Compound query example](https://elasticsearch_96724.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-elser.html#text-expansion-compound-query) 