### PR TITLE
[8.5] [DOCS] Remove leftover experimental tag for knn search (#96722)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -480,7 +480,6 @@ A boost value greater than `1.0` increases the score. A boost value between
 `0` and `1.0` decreases the score.
 ====
 
-experimental::[]
 [[search-api-knn]]
 `knn`::
 (Optional, object) Defines the <<approximate-knn, approximate kNN search>> to


### PR DESCRIPTION
Backports the following commits to 8.5:
 - [DOCS] Remove leftover experimental tag for knn search (#96722)