### PR TITLE
[8.7] [DOCS] Remove leftover experimental tag for knn search (#96722)

### DIFF
--- a/docs/reference/search/search.asciidoc
+++ b/docs/reference/search/search.asciidoc
@@ -480,7 +480,6 @@ A boost value greater than `1.0` increases the score. A boost value between
 `0` and `1.0` decreases the score.
 ====
 
-experimental::[]
 [[search-api-knn]]
 `knn`::
 (Optional, object or array of objects)


### PR DESCRIPTION
Backports the following commits to 8.7:
 - [DOCS] Remove leftover experimental tag for knn search (#96722)