### PR TITLE
[8.8] [DOCS] Fixes field name in text_expansion query. (#96724)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -242,7 +242,7 @@ GET my-index/_search
       "should": [
         {
           "text_expansion": { 
-            "ml.token": {
+            "ml.tokens": {
               "model_text": "How to avoid muscle soreness after running?",
               "model_id": ".elser_model_1",
               "boost": 1 <2>


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Fixes field name in text_expansion query. (#96724)