### PR TITLE
[DOCS] Removes the technical preview admonition from query_vector_builder docs

### DIFF
--- a/docs/reference/search/search-your-data/knn-search.asciidoc
+++ b/docs/reference/search/search-your-data/knn-search.asciidoc
@@ -334,8 +334,6 @@ calculated on the combined set of `knn` and `query` matches.
 [[semantic-search]]
 ==== Perform semantic search
 
-experimental[]
-
 kNN search enables you to perform semantic search by using a previously deployed
 {ml-docs}/ml-nlp-search-compare.html#ml-nlp-text-embedding[text embedding model].
 Instead of literal matching on search terms, semantic search retrieves results


### PR DESCRIPTION
## Overview

This PR removes the technical preview admonition from the `Perform semantic search` section of the kNN search docs as the `query_vector_builder` query becomes GA in 8.9.