### PR TITLE
[ML] Ensure inference queue is cleared after shutdown

### DIFF
--- a/docs/changelog/96738.yaml
+++ b/docs/changelog/96738.yaml
@@ -1,5 +1,5 @@
 pr: 96738
-summary: Ensure inference queue is cleared after shutdown
+summary: Ensure NLP model inference queue is always cleared after shutdown or failure
 area: Machine Learning
 type: bug
 issues: []

--- a/docs/changelog/96738.yaml
+++ b/docs/changelog/96738.yaml
@@ -1,0 +1,5 @@
+pr: 96738
+summary: Ensure inference queue is cleared after shutdown
+area: Machine Learning
+type: bug
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -446,7 +446,14 @@ public class DeploymentManager {
             isStopped = true;
             resultProcessor.stop();
             stateStreamer.cancel();
-            priorityProcessWorker.shutdown();
+
+            if (priorityProcessWorker.isShutdown()) {
+                // most likely there was a crash or exception that caused the
+                // thread to stop. Notify any waiting requests in the work queue
+                priorityProcessWorker.notifyQueueRunnables();
+            } else {
+                priorityProcessWorker.shutdown();
+            }
             killProcessIfPresent();
             if (nlpTaskProcessor.get() != null) {
                 nlpTaskProcessor.get().close();

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/pytorch/PriorityProcessWorkerExecutorService.java
@@ -81,6 +81,7 @@ public class PriorityProcessWorkerExecutorService extends AbstractProcessWorkerE
         if (isShutdown()) {
             EsRejectedExecutionException rejected = new EsRejectedExecutionException(processName + " worker service has shutdown", true);
             command.onRejection(rejected);
+            notifyQueueRunnables();
             return;
         }
 
@@ -93,6 +94,10 @@ public class PriorityProcessWorkerExecutorService extends AbstractProcessWorkerE
 
         // PriorityBlockingQueue::offer always returns true
         queue.offer(new OrderedRunnable(priority, tieBreaker, contextHolder.preserveContext(command)));
+        if (isShutdown()) {
+            // the worker shutdown during this function
+            notifyQueueRunnables();
+        }
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/process/AbstractProcessWorkerExecutorService.java
@@ -117,7 +117,18 @@ public abstract class AbstractProcessWorkerExecutorService<T extends Runnable> e
         }
     }
 
-    protected synchronized void notifyQueueRunnables() {
+    /**
+     * Drains the queue of runnables and notifies each as either
+     * a rejected execution or failure.
+     *
+     * Although public this method should be used with caution.
+     * It should only be called _after_ the worker has shutdown.
+     *
+     * The method is synchronised to protect concurrent calls.
+     */
+    public synchronized void notifyQueueRunnables() {
+        assert isShutdown() : "Queue runnables should only be drained and notified after the worker is shutdown";
+
         if (queue.isEmpty() == false) {
             List<Runnable> notExecuted = new ArrayList<>();
             queue.drainTo(notExecuted);


### PR DESCRIPTION
If an inference request is inserted into the work queue after the queue has shutdown the request will never get processed causing it to hang. When adding to the work queue there is a small window after the `is shutdown` check where the the work item is added but the worker thread may have stopped. In addition, any processed requests are notified when the deployment is stopped.