### PR TITLE
Add trim filter to allowed normalizer filters in docs

### DIFF
--- a/docs/reference/analysis/normalizers.asciidoc
+++ b/docs/reference/analysis/normalizers.asciidoc
@@ -11,7 +11,7 @@ following: `arabic_normalization`, `asciifolding`, `bengali_normalization`,
 `cjk_width`, `decimal_digit`, `elision`, `german_normalization`,
 `hindi_normalization`, `indic_normalization`, `lowercase`,
 `persian_normalization`, `scandinavian_folding`, `serbian_normalization`,
-`sorani_normalization`, `uppercase`.
+`sorani_normalization`, `trim`, `uppercase`.
 
 Elasticsearch ships with a `lowercase` built-in normalizer. For other forms of
 normalization a custom configuration is required.


### PR DESCRIPTION
The `trim` filter is allowed to be used in normalizers. This appears to have been added
with https://github.com/elastic/elasticsearch/pull/27758. This change adds this filter
to the relevant docs.