### PR TITLE
Change tech preview to beta

### DIFF
--- a/docs/reference/search-application/apis/delete-search-application.asciidoc
+++ b/docs/reference/search-application/apis/delete-search-application.asciidoc
@@ -2,7 +2,7 @@
 [[delete-search-application]]
 === Delete Search Application
 
-preview::[]
+beta::[]
 
 ++++
 <titleabbrev>Delete Search Application</titleabbrev>

--- a/docs/reference/search-application/apis/get-search-application.asciidoc
+++ b/docs/reference/search-application/apis/get-search-application.asciidoc
@@ -2,7 +2,7 @@
 [[get-search-application]]
 === Get Search Application
 
-preview::[]
+beta::[]
 
 ++++
 <titleabbrev>Get Search Application</titleabbrev>

--- a/docs/reference/search-application/apis/index.asciidoc
+++ b/docs/reference/search-application/apis/index.asciidoc
@@ -1,7 +1,7 @@
 [[search-application-apis]]
 == Search Application APIs
 
-preview::[]
+beta::[]
 
 ++++
 <titleabbrev>Search Application APIs</titleabbrev>

--- a/docs/reference/search-application/apis/list-search-applications.asciidoc
+++ b/docs/reference/search-application/apis/list-search-applications.asciidoc
@@ -2,7 +2,7 @@
 [[list-search-applications]]
 === List Search Applications
 
-preview::[]
+beta::[]
 
 ++++
 <titleabbrev>List Search Applications</titleabbrev>

--- a/docs/reference/search-application/apis/put-search-application.asciidoc
+++ b/docs/reference/search-application/apis/put-search-application.asciidoc
@@ -2,7 +2,7 @@
 [[put-search-application]]
 === Put Search Application
 
-preview::[]
+beta::[]
 
 ++++
 <titleabbrev>Put Search Application</titleabbrev>

--- a/docs/reference/search-application/apis/search-application-search.asciidoc
+++ b/docs/reference/search-application/apis/search-application-search.asciidoc
@@ -2,7 +2,7 @@
 [[search-application-search]]
 === Search Application Search
 
-preview::[]
+beta::[]
 
 ++++
 <titleabbrev>Search Application Search</titleabbrev>


### PR DESCRIPTION
This pr changes the label from **Tech Preview** to **Beta** in the documentation of elasticsearch.

Issue: https://github.com/elastic/enterprise-search-team/issues/4726
