### PR TITLE
Fix SearchableSnapshotsIntegTests.testMaxRestoreBytesPerSecIsUsed

### DIFF
--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -476,9 +476,6 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             repositorySettings.put(MAX_RESTORE_BYTES_PER_SEC.getKey(), ByteSizeValue.ofBytes(rateLimitInBytes));
         } else {
             repositorySettings.put(MAX_RESTORE_BYTES_PER_SEC.getKey(), ByteSizeValue.ZERO);
-        }
-
-        if (useRateLimits == false) {
             // Disable rate limiter which is defined in RecoverySettings
             // BlobStoreRepository#maybeRateLimitRestores uses two rate limiters and a single callback listener
             // which is asserted in this test. Both rate limiter should be switched off

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -448,8 +448,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
 
-        Settings.Builder indexSettings = indexSettingsNoReplicas(between(1, 3))
-            .put(INDEX_SOFT_DELETES_SETTING.getKey(), true);
+        Settings.Builder indexSettings = indexSettingsNoReplicas(between(1, 3)).put(INDEX_SOFT_DELETES_SETTING.getKey(), true);
 
         assertAcked(prepareCreate(indexName, indexSettings));
 
@@ -479,7 +478,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             repositorySettings.put(MAX_RESTORE_BYTES_PER_SEC.getKey(), ByteSizeValue.ZERO);
         }
 
-        if ( useRateLimits == false ) {
+        if (useRateLimits == false) {
             // Disable rate limiter which is defined in RecoverySettings
             // BlobStoreRepository#maybeRateLimitRestores uses two rate limiters and a single callback listener
             // which is asserted in this test. Both rate limiter should be switched off
@@ -525,7 +524,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             }
         }
 
-        if ( useRateLimits == false ) {
+        if (useRateLimits == false) {
             // compensate setting change from above
             updateClusterSettings(Settings.builder().putNull(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()));
         }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -75,6 +75,8 @@ import java.util.stream.IntStream;
 import static org.elasticsearch.cluster.metadata.IndexMetadata.INDEX_NUMBER_OF_SHARDS_SETTING;
 import static org.elasticsearch.index.IndexSettings.INDEX_SOFT_DELETES_SETTING;
 import static org.elasticsearch.index.query.QueryBuilders.matchQuery;
+import static org.elasticsearch.indices.recovery.RecoverySettings.INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING;
+import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.MAX_RESTORE_BYTES_PER_SEC;
 import static org.elasticsearch.repositories.blobstore.BlobStoreRepository.READONLY_SETTING_KEY;
 import static org.elasticsearch.snapshots.SearchableSnapshotsSettings.SEARCHABLE_SNAPSHOT_STORE_TYPE;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
@@ -445,7 +447,12 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         final String repositoryName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
 
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
-        assertAcked(prepareCreate(indexName, indexSettingsNoReplicas(between(1, 3)).put(INDEX_SOFT_DELETES_SETTING.getKey(), true)));
+
+        Settings.Builder indexSettings = indexSettingsNoReplicas(between(1, 3))
+            .put(INDEX_SOFT_DELETES_SETTING.getKey(), true);
+
+        assertAcked(prepareCreate(indexName, indexSettings));
+
         final int nbDocs = between(10, 50);
         indexRandom(
             true,
@@ -467,10 +474,18 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             // which is defined in RateLimitingInputStream (see details in https://github.com/elastic/elasticsearch/pull/96444)
             long minimax = getMaxShardSizeByNodeInBytes(indexName).values().stream().min(Long::compareTo).get();
             long rateLimitInBytes = (long) (0.9 * minimax);
-            repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ofBytes(rateLimitInBytes));
+            repositorySettings.put(MAX_RESTORE_BYTES_PER_SEC.getKey(), ByteSizeValue.ofBytes(rateLimitInBytes));
         } else {
-            repositorySettings.put("max_restore_bytes_per_sec", ByteSizeValue.ZERO);
+            repositorySettings.put(MAX_RESTORE_BYTES_PER_SEC.getKey(), ByteSizeValue.ZERO);
         }
+
+        if ( useRateLimits == false ) {
+            // Disable rate limiter which is defined in RecoverySettings
+            // BlobStoreRepository#maybeRateLimitRestores uses two rate limiters and a single callback listener
+            // which is asserted in this test. Both rate limiter should be switched off
+            updateClusterSettings(Settings.builder().put(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey(), ByteSizeValue.ZERO));
+        }
+
         createRepository(repositoryName, "fs", repositorySettings);
 
         final String restoredIndexName = randomBoolean() ? indexName : randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
@@ -508,6 +523,11 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                     useRateLimits ? greaterThan(0L) : equalTo(0L)
                 );
             }
+        }
+
+        if ( useRateLimits == false ) {
+            // compensate setting change from above
+            updateClusterSettings(Settings.builder().putNull(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()));
         }
 
         assertAcked(client().admin().indices().prepareDelete(restoredIndexName));


### PR DESCRIPTION
For root cause analysis see https://github.com/elastic/elasticsearch/issues/94277#issuecomment-1585477427

Fix #94277