### PR TITLE
Include targetNodeName in shutdown metadata toString()

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/SingleNodeShutdownMetadata.java
@@ -271,6 +271,9 @@ public class SingleNodeShutdownMetadata extends AbstractDiffable<SingleNodeShutd
         if (allocationDelay != null) {
             stringBuilder.append(", allocationDelay=[").append(allocationDelay).append("]");
         }
+        if (targetNodeName != null) {
+            stringBuilder.append(", targetNodeName=[").append(targetNodeName).append("]");
+        }
         stringBuilder.append("}");
         return stringBuilder.toString();
     }


### PR DESCRIPTION
Reporting the `targetNodeName` was added to `main` in #78727 but omitted from the backport in #78865. This commit adds the missing field to the `toString()` response.