### PR TITLE
[DOCS] Fixes transform scheduled_now documentation

### DIFF
--- a/docs/reference/transform/apis/schedule-now-transform.asciidoc
+++ b/docs/reference/transform/apis/schedule-now-transform.asciidoc
@@ -21,7 +21,7 @@ Instantly runs a {transform} to process data.
 * Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
 
-[schedule-now-transform-desc]]
+[[schedule-now-transform-desc]]
 == {api-description-title}
 
 When you run this API, processing for the next checkpoint is started immediately 

--- a/docs/reference/transform/apis/schedule-now-transform.asciidoc
+++ b/docs/reference/transform/apis/schedule-now-transform.asciidoc
@@ -24,10 +24,11 @@ in the `transform_admin` built-in role.
 [schedule-now-transform-desc]]
 == {api-description-title}
 
-When you run this API, the {transform} processes the new data instantly,
-without waiting for the configured `frequency` interval.
-Subsequently, the transform will be processed again at
-`now + frequency` unless the API is called again in the meantime.
+When you run this API, processing for the next checkpoint is started immediately 
+without waiting for the configured `frequency` interval. The API returns 
+immediately, data processing happens in the background. Subsequently, the 
+{transform} will be processed again at `now + frequency` unless the API is 
+called again in the meantime.
 
 [[schedule-now-transform-path-parms]]
 == {api-path-parms-title}


### PR DESCRIPTION
## Overview

The initial docs for `schedule_now` might make an impression that the transform processes the data instantly after calling the API. In reality, the process starts immediately, but data processing can take more time than a moment. This PR makes the docs more precise to normalize expectations.

It also fixes a section ID.

### Preview

[Transform schedule now](https://elasticsearch_96766.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/schedule-now-transform.html#_description_22)