### PR TITLE
[8.8] [DOCS] Fixes transform scheduled_now documentation (#96766)

### DIFF
--- a/docs/reference/transform/apis/schedule-now-transform.asciidoc
+++ b/docs/reference/transform/apis/schedule-now-transform.asciidoc
@@ -21,13 +21,14 @@ Instantly runs a {transform} to process data.
 * Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
 
-[schedule-now-transform-desc]]
+[[schedule-now-transform-desc]]
 == {api-description-title}
 
-When you run this API, the {transform} processes the new data instantly,
-without waiting for the configured `frequency` interval.
-Subsequently, the transform will be processed again at
-`now + frequency` unless the API is called again in the meantime.
+When you run this API, processing for the next checkpoint is started immediately 
+without waiting for the configured `frequency` interval. The API returns 
+immediately, data processing happens in the background. Subsequently, the 
+{transform} will be processed again at `now + frequency` unless the API is 
+called again in the meantime.
 
 [[schedule-now-transform-path-parms]]
 == {api-path-parms-title}


### PR DESCRIPTION
Backports the following commits to 8.8:
 - [DOCS] Fixes transform scheduled_now documentation (#96766)