### PR TITLE
Cleanup dead code in Translog + TranslogWriter

### DIFF
--- a/server/src/main/java/org/elasticsearch/index/translog/Translog.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/Translog.java
@@ -10,7 +10,6 @@ package org.elasticsearch.index.translog;
 
 import org.apache.lucene.store.AlreadyClosedException;
 import org.elasticsearch.TransportVersion;
-import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.UUIDs;
 import org.elasticsearch.common.bytes.BytesReference;
 import org.elasticsearch.common.io.DiskIoBufferPool;
@@ -23,7 +22,6 @@ import org.elasticsearch.common.lucene.uid.Versions;
 import org.elasticsearch.common.util.BigArrays;
 import org.elasticsearch.common.util.concurrent.ReleasableLock;
 import org.elasticsearch.core.IOUtils;
-import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Releasable;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.index.IndexSettings;
@@ -1866,16 +1864,6 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         return createEmptyTranslog(location, initialGlobalCheckpoint, shardId, channelFactory, primaryTerm);
     }
 
-    static String createEmptyTranslog(
-        Path location,
-        long initialGlobalCheckpoint,
-        ShardId shardId,
-        ChannelFactory channelFactory,
-        long primaryTerm
-    ) throws IOException {
-        return createEmptyTranslog(location, shardId, initialGlobalCheckpoint, primaryTerm, null, channelFactory);
-    }
-
     /**
      * Creates a new empty translog within the specified {@code location} that contains the given {@code initialGlobalCheckpoint},
      * {@code primaryTerm} and {@code translogUUID}.
@@ -1888,26 +1876,23 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
      * @param shardId                 the {@link ShardId}
      * @param initialGlobalCheckpoint the global checkpoint to initialize the translog with
      * @param primaryTerm             the shard's primary term to initialize the translog with
-     * @param translogUUID            the unique identifier to initialize the translog with
-     * @param factory                 a {@link ChannelFactory} used to open translog files
+     * @param channelFactory          a {@link ChannelFactory} used to open translog files
      * @return the translog's unique identifier
      * @throws IOException if something went wrong during translog creation
      */
-    public static String createEmptyTranslog(
-        final Path location,
-        final ShardId shardId,
-        final long initialGlobalCheckpoint,
-        final long primaryTerm,
-        @Nullable final String translogUUID,
-        @Nullable final ChannelFactory factory
+    static String createEmptyTranslog(
+        Path location,
+        long initialGlobalCheckpoint,
+        ShardId shardId,
+        ChannelFactory channelFactory,
+        long primaryTerm
     ) throws IOException {
         IOUtils.rm(location);
         Files.createDirectories(location);
 
         final long generation = 1L;
         final long minTranslogGeneration = 1L;
-        final ChannelFactory channelFactory = factory != null ? factory : FileChannel::open;
-        final String uuid = Strings.hasLength(translogUUID) ? translogUUID : UUIDs.randomBase64UUID();
+        final String uuid = UUIDs.randomBase64UUID();
         final Path checkpointFile = location.resolve(CHECKPOINT_FILE_NAME);
         final Path translogFile = location.resolve(getFilename(generation));
         final Checkpoint checkpoint = Checkpoint.emptyTranslogCheckpoint(0, generation, initialGlobalCheckpoint, minTranslogGeneration);
@@ -1938,4 +1923,5 @@ public class Translog extends AbstractIndexShardComponent implements IndexShardC
         writer.close();
         return uuid;
     }
+
 }

--- a/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
+++ b/server/src/main/java/org/elasticsearch/index/translog/TranslogWriter.java
@@ -169,7 +169,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                 initialGlobalCheckpoint,
                 initialMinTranslogGen
             );
-            writeCheckpoint(checkpointChannel, checkpointFile, checkpoint);
+            Checkpoint.write(checkpointChannel, checkpointFile, checkpoint);
             final LongSupplier writerGlobalCheckpointSupplier;
             if (Assertions.ENABLED) {
                 writerGlobalCheckpointSupplier = () -> {
@@ -507,7 +507,7 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
                         if (lastSyncedCheckpoint.offset != checkpointToSync.offset) {
                             channel.force(false);
                         }
-                        writeCheckpoint(checkpointChannel, checkpointPath, checkpointToSync);
+                        Checkpoint.write(checkpointChannel, checkpointPath, checkpointToSync);
                     } catch (final Exception ex) {
                         closeWithTragicEvent(ex);
                         throw ex;
@@ -611,11 +611,6 @@ public class TranslogWriter extends BaseTranslogReader implements Closeable {
         // we don't have to have a lock here because we only write ahead to the file, so all writes has been complete
         // for the requested location.
         Channels.readFromFileChannelWithEofException(channel, position, targetBuffer);
-    }
-
-    private static void writeCheckpoint(final FileChannel fileChannel, final Path checkpointFile, final Checkpoint checkpoint)
-        throws IOException {
-        Checkpoint.write(fileChannel, checkpointFile, checkpoint);
     }
 
     /**


### PR DESCRIPTION
Inline one unused override and remove one noop indirection method to shorten another PR and clean up a little in isolation.
