### PR TITLE
Disable ccs-rolling-upgrade-remote-cluster in fips, refs: #96134

### DIFF
--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -59,6 +59,9 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     doFirst {
       localCluster.get().nextNodeToNextVersion()
     }
+    if (BuildParams.inFipsJvm) {
+      enabled = false
+    }
   }
 
   tasks.register("${baseName}#oneThirdUpgraded", StandaloneRestIntegTestTask) {

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -52,9 +52,7 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
     }
 
-    if (BuildParams.inFipsJvm) {
-      enabled = false
-    }
+    onlyIf("FIPS mode disabled") { BuildParams.inFipsJvm == false }
   }
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {

--- a/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
+++ b/qa/ccs-rolling-upgrade-remote-cluster/build.gradle
@@ -51,6 +51,10 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
       nonInputProperties.systemProperty('tests.rest.cluster', localCluster.map(c -> c.allHttpSocketURI.join(",")))
       nonInputProperties.systemProperty('tests.rest.remote_cluster', remoteCluster.map(c -> c.allHttpSocketURI.join(",")))
     }
+
+    if (BuildParams.inFipsJvm) {
+      enabled = false
+    }
   }
 
   tasks.register("${baseName}#oldClusterTest", StandaloneRestIntegTestTask) {
@@ -58,9 +62,6 @@ BuildParams.bwcVersions.withWireCompatible { bwcVersion, baseName ->
     mustRunAfter("precommit")
     doFirst {
       localCluster.get().nextNodeToNextVersion()
-    }
-    if (BuildParams.inFipsJvm) {
-      enabled = false
     }
   }
 


### PR DESCRIPTION
This test has been failing for months in fips.  Disabling until it can be investigated.

See: #96134