### PR TITLE
Fixing GeoIpDownloaderStatsAction$NodeResponse serialization by defensively copying inputs

### DIFF
--- a/docs/changelog/96777.yaml
+++ b/docs/changelog/96777.yaml
@@ -1,0 +1,7 @@
+pr: 96777
+summary: Fixing `GeoIpDownloaderStatsAction$NodeResponse` serialization by defensively
+  copying inputs
+area: Ingest Node
+type: bug
+issues:
+ - 96438

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsAction.java
@@ -178,9 +178,9 @@ public class GeoIpDownloaderStatsAction extends ActionType<GeoIpDownloaderStatsA
         ) {
             super(node);
             this.stats = stats;
-            this.databases = databases;
-            this.filesInTemp = filesInTemp;
-            this.configDatabases = configDatabases;
+            this.databases = Set.copyOf(databases);
+            this.filesInTemp = Set.copyOf(filesInTemp);
+            this.configDatabases = Set.copyOf(configDatabases);
         }
 
         public GeoIpDownloaderStats getStats() {

--- a/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsActionNodeResponseTests.java
+++ b/modules/ingest-geoip/src/test/java/org/elasticsearch/ingest/geoip/stats/GeoIpDownloaderStatsActionNodeResponseTests.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.ingest.geoip.stats;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.not;
+
+public class GeoIpDownloaderStatsActionNodeResponseTests extends ESTestCase {
+
+    public void testInputsAreDefensivelyCopied() {
+        DiscoveryNode node = DiscoveryNodeUtils.create("id");
+        Set<String> databases = new HashSet<>(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
+        Set<String> files = new HashSet<>(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
+        Set<String> configDatabases = new HashSet<>(randomList(10, () -> randomAlphaOfLengthBetween(5, 10)));
+        GeoIpDownloaderStatsAction.NodeResponse nodeResponse = new GeoIpDownloaderStatsAction.NodeResponse(
+            node,
+            GeoIpDownloaderStatsSerializingTests.createRandomInstance(),
+            databases,
+            files,
+            configDatabases
+        );
+        assertThat(nodeResponse.getDatabases(), equalTo(databases));
+        assertThat(nodeResponse.getFilesInTemp(), equalTo(files));
+        assertThat(nodeResponse.getConfigDatabases(), equalTo(configDatabases));
+        databases.add(randomAlphaOfLength(20));
+        files.add(randomAlphaOfLength(20));
+        configDatabases.add(randomAlphaOfLength(20));
+        assertThat(nodeResponse.getDatabases(), not(equalTo(databases)));
+        assertThat(nodeResponse.getFilesInTemp(), not(equalTo(files)));
+        assertThat(nodeResponse.getConfigDatabases(), not(equalTo(configDatabases)));
+    }
+}


### PR DESCRIPTION
We don't currently make a defensive copy of the inputs to the GeoIpDownloaderStatsAction$NodeResponse constructor. Some of those inputs are subject to change when a geoip database is reloaded. That can cause serialization to break (because the serialization code assumes that the contents of the Sets are not changing during serialization. This PR makes an immutable copy of the Sets in NodeResponse to prevent this.
Before this fix, we would occasionally see failures like this:
```
Caused by: java.lang.IllegalStateException: Message not fully read (response) for requestId [192], handler [org.elasticsearch.transport.TransportService$ContextRestoreResponseHandler/org.elasticsearch.action.ActionListenerResponseHandler@94f41f2/org.elasticsearch.action.ActionListenerImplementations$RunAfterActionListener/notifyOnce[[cluster:monitor/ingest/geoip/stats][{node_s1}{MYbBzhJ9SD6YeT3etp8llQ}{uPItn9j_Qv-nonD-byDXBw}{node_s1}{127.0.0.1}{127.0.0.1:19541}{cdfhilrstw}{8.9.0}]]/release[refCounted[org.elasticsearch.action.support.CancellableFanOut$$Lambda$3163/0x00000008019064e8@b3aa1b5]]], error [false]; resetting
```
I was able to force this to reproduce reliably by artificially putting a 2-second sleep into the serialization code (StreamOutput.writeCollection) between when the size of the collection is read and when the values are written. With this fix I have been unable to reproduce it.

Closes #96438