### PR TITLE
Check that the step retries value is not null

### DIFF
--- a/docs/changelog/96788.yaml
+++ b/docs/changelog/96788.yaml
@@ -1,0 +1,5 @@
+pr: 96788
+summary: Check that the step retries value is not null
+area: ILM+SLM
+type: bug
+issues: []

--- a/docs/changelog/96788.yaml
+++ b/docs/changelog/96788.yaml
@@ -1,5 +1,0 @@
-pr: 96788
-summary: Check that the step retries value is not null
-area: ILM+SLM
-type: bug
-issues: []

--- a/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
+++ b/x-pack/plugin/ilm/src/main/java/org/elasticsearch/xpack/ilm/IlmHealthIndicatorService.java
@@ -416,9 +416,10 @@ public class IlmHealthIndicatorService implements HealthIndicatorService {
 
         @Override
         public boolean test(Long now, IndexMetadata indexMetadata) {
+            var failedStepRetryCount = indexMetadata.getLifecycleExecutionState().failedStepRetryCount();
             return step.equals(indexMetadata.getLifecycleExecutionState().step())
                 && (maxTimeOn.compareTo(RuleConfig.getElapsedTime(now, indexMetadata.getLifecycleExecutionState().stepTime())) < 0
-                    || indexMetadata.getLifecycleExecutionState().failedStepRetryCount() > maxRetries);
+                    || (failedStepRetryCount != null && failedStepRetryCount > maxRetries));
         }
     }
 }


### PR DESCRIPTION
Avoid generating an NPE when using the value of
`ILMStep.failedStepRetryCount`.
