### PR TITLE
Rename project id property for profiling events

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
@@ -9,7 +9,7 @@
         "refresh_interval": "10s",
         "sort": {
           "field": [
-            "service.name",
+            "profiling.project.id",
             "@timestamp",
             "orchestrator.resource.name",
             "container.name",
@@ -29,7 +29,7 @@
           "type": "keyword",
           "index": true
         },
-        "service.name": {
+        "profiling.project.id": {
           "type": "keyword"
         },
         "@timestamp": {


### PR DESCRIPTION
With this commit we rename the property `service.name` to `profiling.project.id` for profiling events.