### PR TITLE
[Profiling] Require POST to retrieve stacktraces

### DIFF
--- a/docs/changelog/96790.yaml
+++ b/docs/changelog/96790.yaml
@@ -1,0 +1,5 @@
+pr: 96790
+summary: "[Profiling] Require POST to retrieve stacktraces"
+area: Application
+type: enhancement
+issues: []

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/RestGetProfilingAction.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/RestGetProfilingAction.java
@@ -16,13 +16,12 @@ import org.elasticsearch.rest.action.RestChunkedToXContentListener;
 import java.io.IOException;
 import java.util.List;
 
-import static org.elasticsearch.rest.RestRequest.Method.GET;
 import static org.elasticsearch.rest.RestRequest.Method.POST;
 
 public class RestGetProfilingAction extends BaseRestHandler {
     @Override
     public List<Route> routes() {
-        return List.of(new Route(GET, "/_profiling/stacktraces"), new Route(POST, "/_profiling/stacktraces"));
+        return List.of(new Route(POST, "/_profiling/stacktraces"));
     }
 
     @Override


### PR DESCRIPTION
Previously we have allowed either `GET` or `POST` to retrieve stacktraces. This leniency can be confusing and is also not required. Therefore we support only `POST` now.