### PR TITLE
Fix get synonyms set bug when system index has not been created

### DIFF
--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -178,7 +178,7 @@ public class SynonymsManagementAPIService {
                 @Override
                 public void onFailure(Exception e) {
                     if (e instanceof IndexNotFoundException) {
-                        listener.onFailure(new ResourceNotFoundException(resourceName));
+                        listener.onFailure(new ResourceNotFoundException("Synonym set [" + resourceName + "] not found"));
                         return;
                     }
                     listener.onFailure(e);

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -161,17 +161,29 @@ public class SynonymsManagementAPIService {
             .setSize(size)
             .setPreference(Preference.LOCAL.type())
             .setTrackTotalHits(true)
-            .execute(listener.delegateFailure((searchResponseListener, searchResponse) -> {
-                final long totalSynonymRules = searchResponse.getHits().getTotalHits().value;
-                if (totalSynonymRules == 0) {
-                    listener.onFailure(new ResourceNotFoundException("Synonym set [" + resourceName + "] not found"));
-                    return;
+            .execute(new ActionListener<>() {
+                @Override
+                public void onResponse(SearchResponse searchResponse) {
+                    final long totalSynonymRules = searchResponse.getHits().getTotalHits().value;
+                    if (totalSynonymRules == 0) {
+                        listener.onFailure(new ResourceNotFoundException("Synonym set [" + resourceName + "] not found"));
+                        return;
+                    }
+                    final SynonymRule[] synonymRules = Arrays.stream(searchResponse.getHits().getHits())
+                        .map(SynonymsManagementAPIService::hitToSynonymRule)
+                        .toArray(SynonymRule[]::new);
+                    listener.onResponse(new PagedResult<>(totalSynonymRules, synonymRules));
                 }
-                final SynonymRule[] synonymRules = Arrays.stream(searchResponse.getHits().getHits())
-                    .map(SynonymsManagementAPIService::hitToSynonymRule)
-                    .toArray(SynonymRule[]::new);
-                listener.onResponse(new PagedResult<>(totalSynonymRules, synonymRules));
-            }));
+
+                @Override
+                public void onFailure(Exception e) {
+                    if (e instanceof IndexNotFoundException) {
+                        listener.onFailure(new ResourceNotFoundException(resourceName));
+                        return;
+                    }
+                    listener.onFailure(e);
+                }
+            });
     }
 
     private static SynonymRule hitToSynonymRule(SearchHit hit) {


### PR DESCRIPTION
Synonyms set system index could not have been created yet - we need to transform the `IndexNotFoundException` that is returned in this case into a `ResourceNotFoundException`