### PR TITLE
Unwrap exceptions looking for IndexNotFoundExceptions in their causes

### DIFF
--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.synonyms;
 
 import org.elasticsearch.ElasticsearchException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
@@ -143,7 +144,8 @@ public class SynonymsManagementAPIService {
 
                 @Override
                 public void onFailure(Exception e) {
-                    if (e instanceof IndexNotFoundException) {
+                    final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                    if (cause instanceof IndexNotFoundException) {
                         // If System index has not been created yet, no synonym sets have been stored
                         listener.onResponse(new PagedResult<>(0L, new SynonymSetSummary[0]));
                         return;
@@ -177,7 +179,8 @@ public class SynonymsManagementAPIService {
 
                 @Override
                 public void onFailure(Exception e) {
-                    if (e instanceof IndexNotFoundException) {
+                    final Throwable cause = ExceptionsHelper.unwrapCause(e);
+                    if (cause instanceof IndexNotFoundException) {
                         listener.onFailure(new ResourceNotFoundException("Synonym set [" + resourceName + "] not found"));
                         return;
                     }

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/SearchApplicationIndexService.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.application.search;
 
 import org.elasticsearch.ElasticsearchParseException;
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
@@ -229,8 +230,9 @@ public class SearchApplicationIndexService {
             public void onFailure(Exception e) {
                 // Convert index not found failure from the alias API into an illegal argument
                 Exception failException = e;
-                if (e instanceof IndexNotFoundException) {
-                    failException = new IllegalArgumentException(e.getMessage(), e);
+                Throwable cause = ExceptionsHelper.unwrapCause(e);
+                if (cause instanceof IndexNotFoundException) {
+                    failException = new IllegalArgumentException(cause.getMessage(), cause);
                 }
                 listener.onFailure(failException);
             }
@@ -495,8 +497,9 @@ public class SearchApplicationIndexService {
 
         @Override
         public void onFailure(Exception e) {
-            if (e instanceof IndexNotFoundException) {
-                delegate.onFailure(new ResourceNotFoundException(resourceName, e));
+            Throwable cause = ExceptionsHelper.unwrapCause(e);
+            if (cause instanceof IndexNotFoundException) {
+                delegate.onFailure(new ResourceNotFoundException(resourceName));
                 return;
             }
             delegate.onFailure(e);


### PR DESCRIPTION
Follow up to [this comment](https://github.com/elastic/elasticsearch/pull/96791#discussion_r1228019190). Unwraps exception prior to checking for an `IndexNotFoundException`.