### PR TITLE
Dry up checking current state before waiting for new state in ClusterStateObserver

### DIFF
--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -207,14 +207,8 @@ public class ClusterStateObserver {
             listener.onNewClusterState(initialState);
             return;
         }
-        ClusterStateObserver observer = new ClusterStateObserver(clusterService, timeout, logger, threadContext);
-        // set observed state and check it again in case it changed concurrently
-        ClusterState state = observer.setAndGetObservedState();
-        if (initialState != state && statePredicate.test(state)) {
-            listener.onNewClusterState(state);
-        } else {
-            observer.waitForNextChange(listener, statePredicate);
-        }
+        ClusterStateObserver observer = new ClusterStateObserver(initialState, clusterService, timeout, logger, threadContext);
+        observer.waitForNextChange(listener, statePredicate);
     }
 
     class ObserverClusterStateListener implements TimeoutClusterStateListener {

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterStateObserver.java
@@ -182,6 +182,41 @@ public class ClusterStateObserver {
         }
     }
 
+    /**
+     * Waits for the cluster state to match a given predicate. Unlike {@link #waitForNextChange} this method checks whether the current
+     * state matches the predicate first and resolves the listener directly if it matches without waiting for another cluster state update.
+     *
+     * @param clusterService cluster service
+     * @param threadContext  thread context to resolve listener in
+     * @param listener       listener to resolve once state matches the predicate
+     * @param statePredicate predicate the cluster state has to match
+     * @param timeout        timeout for the wait or {@code null} for no timeout
+     * @param logger         logger to use for logging observer messages
+     */
+    public static void waitForState(
+        ClusterService clusterService,
+        ThreadContext threadContext,
+        Listener listener,
+        Predicate<ClusterState> statePredicate,
+        @Nullable TimeValue timeout,
+        Logger logger
+    ) {
+        final ClusterState initialState = clusterService.state();
+        if (statePredicate.test(initialState)) {
+            // short-cut in case the state matches the predicate already
+            listener.onNewClusterState(initialState);
+            return;
+        }
+        ClusterStateObserver observer = new ClusterStateObserver(clusterService, timeout, logger, threadContext);
+        // set observed state and check it again in case it changed concurrently
+        ClusterState state = observer.setAndGetObservedState();
+        if (initialState != state && statePredicate.test(state)) {
+            listener.onNewClusterState(state);
+        } else {
+            observer.waitForNextChange(listener, statePredicate);
+        }
+    }
+
     class ObserverClusterStateListener implements TimeoutClusterStateListener {
 
         @Override

--- a/server/src/test/java/org/elasticsearch/cluster/ClusterStateObserverTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/ClusterStateObserverTests.java
@@ -8,14 +8,17 @@
 
 package org.elasticsearch.cluster;
 
+import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNodes;
 import org.elasticsearch.cluster.service.ClusterApplierService;
+import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.core.TimeValue;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.hamcrest.Matchers.containsString;
@@ -63,6 +66,30 @@ public class ClusterStateObserverTests extends ESTestCase {
         });
 
         assertTrue(listenerAdded.get());
+    }
+
+    public void testWaitForState() throws Exception {
+        final ClusterState clusterState = ClusterState.builder(new ClusterName("test")).nodes(DiscoveryNodes.builder()).build();
+        final ClusterService clusterService = mock(ClusterService.class);
+        when(clusterService.state()).thenReturn(clusterState);
+        final PlainActionFuture<ClusterState> future = PlainActionFuture.newFuture();
+        ClusterStateObserver.waitForState(clusterService, new ThreadContext(Settings.EMPTY), new ClusterStateObserver.Listener() {
+            @Override
+            public void onNewClusterState(ClusterState state) {
+                future.onResponse(state);
+            }
+
+            @Override
+            public void onClusterServiceClose() {
+                fail("should not be called");
+            }
+
+            @Override
+            public void onTimeout(TimeValue timeout) {
+                fail("should not be called");
+            }
+        }, cs -> cs == clusterState, null, logger);
+        assertSame(clusterState, future.get(0L, TimeUnit.NANOSECONDS));
     }
 
 }

--- a/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/ClusterServiceUtils.java
@@ -194,15 +194,11 @@ public class ClusterServiceUtils {
 
     public static void awaitClusterState(Logger logger, Predicate<ClusterState> statePredicate, ClusterService clusterService)
         throws Exception {
-        final ClusterStateObserver observer = new ClusterStateObserver(
+        final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
+        ClusterStateObserver.waitForState(
             clusterService,
-            null,
-            logger,
-            clusterService.getClusterApplierService().threadPool().getThreadContext()
-        );
-        if (statePredicate.test(observer.setAndGetObservedState()) == false) {
-            final PlainActionFuture<Void> future = PlainActionFuture.newFuture();
-            observer.waitForNextChange(new ClusterStateObserver.Listener() {
+            clusterService.getClusterApplierService().threadPool().getThreadContext(),
+            new ClusterStateObserver.Listener() {
                 @Override
                 public void onNewClusterState(ClusterState state) {
                     future.onResponse(null);
@@ -217,9 +213,12 @@ public class ClusterServiceUtils {
                 public void onTimeout(TimeValue timeout) {
                     assert false : "onTimeout called with no timeout set";
                 }
-            }, statePredicate);
-            future.get(30L, TimeUnit.SECONDS);
-        }
+            },
+            statePredicate,
+            null,
+            logger
+        );
+        future.get(30L, TimeUnit.SECONDS);
     }
 
     public static void awaitNoPendingTasks(ClusterService clusterService) {


### PR DESCRIPTION
Drying up this logic across a few use cases and adding a test that describes the behaviour.
