### PR TITLE
[Profiling] Use more stable index names internally

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexManager.java
@@ -26,6 +26,7 @@ import org.elasticsearch.xpack.core.ClientHelper;
 
 import java.io.Closeable;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -216,12 +217,7 @@ public class ProfilingIndexManager implements ClusterStateListener, Closeable {
         }
 
         private String indexPrefix() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(".");
-            sb.append(name);
-            sb.append("-v");
-            sb.append(ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION);
-            return sb.toString();
+            return String.format(Locale.ROOT, ".%s-v%03d", name, ProfilingIndexTemplateRegistry.INDEX_TEMPLATE_VERSION);
         }
 
         @Override

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/KvIndexResolverTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/KvIndexResolverTests.java
@@ -45,7 +45,7 @@ public class KvIndexResolverTests extends ESTestCase {
 
     public void testResolveSingleIndex() {
         String indexPattern = "profiling-stacktraces";
-        Index[] concreteIndices = new Index[] { idx(".profiling-stacktraces-v1-000001") };
+        Index[] concreteIndices = new Index[] { idx(".profiling-stacktraces-v001-000001") };
         when(mockIndexResolver.concreteIndices(any(), eq(IndicesOptions.STRICT_EXPAND_OPEN), eq(indexPattern))).thenReturn(concreteIndices);
 
         List<Index> resolvedIndices = resolver.resolve(ClusterState.EMPTY_STATE, indexPattern, Instant.MIN, Instant.MAX);
@@ -55,9 +55,9 @@ public class KvIndexResolverTests extends ESTestCase {
 
     public void testResolveRangeOfIndices() {
         String indexPattern = "profiling-stacktraces";
-        Index stGen1 = idx(".profiling-stacktraces-v1-000001");
-        Index stGen2 = idx(".profiling-stacktraces-v1-000002");
-        Index stGen3 = idx(".profiling-stacktraces-v1-000003");
+        Index stGen1 = idx(".profiling-stacktraces-v001-000001");
+        Index stGen2 = idx(".profiling-stacktraces-v001-000002");
+        Index stGen3 = idx(".profiling-stacktraces-v001-000003");
         Index[] concreteIndices = new Index[] { stGen1, stGen2, stGen3 };
         when(mockIndexResolver.concreteIndices(any(), eq(IndicesOptions.STRICT_EXPAND_OPEN), eq(indexPattern))).thenReturn(concreteIndices);
 
@@ -93,9 +93,9 @@ public class KvIndexResolverTests extends ESTestCase {
 
     public void testResolveRangeOfIndicesAtBoundary() {
         String indexPattern = "profiling-stacktraces";
-        Index stGen1 = idx(".profiling-stacktraces-v1-000001");
-        Index stGen2 = idx(".profiling-stacktraces-v1-000002");
-        Index stGen3 = idx(".profiling-stacktraces-v1-000003");
+        Index stGen1 = idx(".profiling-stacktraces-v001-000001");
+        Index stGen2 = idx(".profiling-stacktraces-v001-000002");
+        Index stGen3 = idx(".profiling-stacktraces-v001-000003");
         Index[] concreteIndices = new Index[] { stGen1, stGen2, stGen3 };
         when(mockIndexResolver.concreteIndices(any(), eq(IndicesOptions.STRICT_EXPAND_OPEN), eq(indexPattern))).thenReturn(concreteIndices);
 
@@ -145,8 +145,8 @@ public class KvIndexResolverTests extends ESTestCase {
 
     public void testResolveAllIndices() {
         String indexPattern = "profiling-stacktraces";
-        Index stV1 = idx(".profiling-stacktraces-v1-000001");
-        Index stV2 = idx(".profiling-stacktraces-v2-000001");
+        Index stV1 = idx(".profiling-stacktraces-v001-000001");
+        Index stV2 = idx(".profiling-stacktraces-v002-000001");
         Index[] concreteIndices = new Index[] { stV1, stV2 };
         when(mockIndexResolver.concreteIndices(any(), eq(IndicesOptions.STRICT_EXPAND_OPEN), eq(indexPattern))).thenReturn(concreteIndices);
 


### PR DESCRIPTION
With this commit we change the version component of profiling indices from `vN` to `vNNN`. This allows for more stable index names when the version numbers changes and aligns with best practices aligned by other teams (e.g. ML). In the future it will help to sort indices by generation lexicographically (e.g. `v010` will be sorted before `v009` in a descending sort).