### PR TITLE
[ML] make inference model definitions writeable

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/MlInferenceNamedXContentProvider.java
@@ -613,6 +613,12 @@ public class MlInferenceNamedXContentProvider implements NamedXContentProvider {
             )
         );
 
+        // Inference model
+        namedWriteables.add(new NamedWriteableRegistry.Entry(InferenceModel.class, TreeInferenceModel.NAME, TreeInferenceModel::new));
+        namedWriteables.add(
+            new NamedWriteableRegistry.Entry(InferenceModel.class, EnsembleInferenceModel.NAME, EnsembleInferenceModel::new)
+        );
+
         // Output Aggregator
         namedWriteables.add(
             new NamedWriteableRegistry.Entry(OutputAggregator.class, WeightedSum.NAME.getPreferredName(), WeightedSum::new)

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/InferenceModel.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/trainedmodel/inference/InferenceModel.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.ml.inference.trainedmodel.inference;
 
 import org.apache.lucene.util.Accountable;
+import org.elasticsearch.common.io.stream.NamedWriteable;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.xpack.core.ml.inference.results.InferenceResults;
 import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
@@ -16,7 +17,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.TargetType;
 
 import java.util.Map;
 
-public interface InferenceModel extends Accountable {
+public interface InferenceModel extends Accountable, NamedWriteable {
 
     static double[] extractFeatures(String[] featureNames, Map<String, Object> fields) {
         double[] features = new double[featureNames.length];


### PR DESCRIPTION
Model inference definitions are currently not serializable between nodes. 

However, it is required for future LTR work that inference optimized models be serializable from the coordinator -> data nodes. 

This adds wire serialization code for our ensemble and tree inference models. From a user perspective, this change does nothing.