### PR TITLE
Fix dependency info generation to skip org.elasticsearch

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoTask.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/DependenciesInfoTask.java
@@ -217,15 +217,7 @@ public class DependenciesInfoTask extends ConventionTask {
     }
 
     private IllegalStateException missingInfo(String group, String name, String infoFileSuffix, String reason) {
-        return new IllegalStateException(
-            "Unable to find "
-                + infoFileSuffix
-                + " file for dependency "
-                + group
-                + ":"
-                + name
-                + " "
-                + reason);
+        return new IllegalStateException("Unable to find " + infoFileSuffix + " file for dependency " + group + ":" + name + " " + reason);
     }
 
     protected File getDependencyInfoFile(final String group, final String name, final String infoFileSuffix) {


### PR DESCRIPTION
This commit fixes an edge case in dependency info generation, much like in #96355 for dependency licenses check, where an Elasticsearch dependency may show not show up as a project dependency as is the case with serverless. Additionally this fixes the dependency info task to properly work when the licenses dir is missing if there are no dependencies.
