### PR TITLE
Adding a known issue about the ingest attachment processor causing cluster instability

### DIFF
--- a/docs/reference/release-notes/8.4.0.asciidoc
+++ b/docs/reference/release-notes/8.4.0.asciidoc
@@ -30,6 +30,16 @@ affected node.
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+// tag::ingest-processor-log4j-cluster-instability-known-issue[]
+* When the {ref}/attachment.html[ingest attachment processor] is used, the
+interaction of https://tika.apache.org/[Tika] with log4j 2.18.0 (introduced
+in 8.4.0) and higher results in excessive logging. This logging is so
+excessive that it can lead to cluster instability, to the point where the
+is unusable and all nodes must be restarted. (issue: {es-issue}93878[#93878])
++
+To resolve the issue, upgrade to 8.7.0 or higher.
+// end::ingest-processor-log4j-cluster-instability-known-issue[]
+
 [[bug-8.4.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.0.asciidoc
+++ b/docs/reference/release-notes/8.4.0.asciidoc
@@ -32,10 +32,11 @@ include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
 // tag::ingest-processor-log4j-cluster-instability-known-issue[]
 * When the {ref}/attachment.html[ingest attachment processor] is used, the
-interaction of https://tika.apache.org/[Tika] with log4j 2.18.0 (introduced
-in 8.4.0) and higher results in excessive logging. This logging is so
+interaction of https://tika.apache.org/[Tika] with log4j 2.18.0 and higher
+(introduced in {es} 8.4.0) results in excessive logging. This logging is so
 excessive that it can lead to cluster instability, to the point where the
-is unusable and all nodes must be restarted. (issue: {es-issue}93878[#93878])
+cluster is unusable and nodes must be restarted. (issue: {es-issue}91964[#91964]).
+This issue is fixed in {es} 8.7.0 ({es-pull}93878[#93878])
 +
 To resolve the issue, upgrade to 8.7.0 or higher.
 // end::ingest-processor-log4j-cluster-instability-known-issue[]

--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -17,7 +17,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.4.1]]
 [float]

--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -17,6 +17,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.4.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -26,7 +26,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.4.2]]
 [float]

--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -26,6 +26,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.4.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -17,6 +17,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.4.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -17,7 +17,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.4.3]]
 [float]

--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -20,6 +20,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[breaking-8.5.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -20,7 +20,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[breaking-8.5.0]]
 [float]

--- a/docs/reference/release-notes/8.5.1.asciidoc
+++ b/docs/reference/release-notes/8.5.1.asciidoc
@@ -13,6 +13,9 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.5.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.1.asciidoc
+++ b/docs/reference/release-notes/8.5.1.asciidoc
@@ -14,7 +14,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.5.1]]
 [float]

--- a/docs/reference/release-notes/8.5.2.asciidoc
+++ b/docs/reference/release-notes/8.5.2.asciidoc
@@ -13,6 +13,9 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.5.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.2.asciidoc
+++ b/docs/reference/release-notes/8.5.2.asciidoc
@@ -14,7 +14,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.5.2]]
 [float]

--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -13,7 +13,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.5.3]]
 [float]

--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -12,6 +12,9 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.5.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -11,7 +11,7 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 // tag::reconciliation-imbalance-known-issue[]
 * Shard rebalancing may temporarily unbalance cluster

--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -11,6 +11,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 // tag::reconciliation-imbalance-known-issue[]
 * Shard rebalancing may temporarily unbalance cluster
 +

--- a/docs/reference/release-notes/8.6.1.asciidoc
+++ b/docs/reference/release-notes/8.6.1.asciidoc
@@ -9,7 +9,7 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.6.1]]
 [float]

--- a/docs/reference/release-notes/8.6.1.asciidoc
+++ b/docs/reference/release-notes/8.6.1.asciidoc
@@ -9,6 +9,8 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.6.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.2.asciidoc
+++ b/docs/reference/release-notes/8.6.2.asciidoc
@@ -9,6 +9,8 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 
+include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.6.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.2.asciidoc
+++ b/docs/reference/release-notes/8.6.2.asciidoc
@@ -9,7 +9,7 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 
-include::8.4.0.asciidoc[ingest-processor-log4j-cluster-instability-known-issue]
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
 
 [[bug-8.6.2]]
 [float]


### PR DESCRIPTION
This adds a known issue in our 8.4-8.6 release notes about the known issue fixed by #93878.