### PR TITLE
Universal Profiling: Rename project.id field to profiling.project.id

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -7,7 +7,7 @@
         "refresh_interval": "10s",
         "sort": {
           "field": [
-            "project.id",
+            "profiling.project.id",
             "@timestamp",
             "host.id"
           ]
@@ -24,7 +24,7 @@
           "type": "keyword",
           "index": true
         },
-        "project.id": {
+        "profiling.project.id": {
           "type": "keyword"
         },
         "host.id": {


### PR DESCRIPTION
For profiling-metrics data stream.