### PR TITLE
Simplify Profilers class

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/profile/Profilers.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/Profilers.java
@@ -21,16 +21,13 @@ import java.util.Collections;
 /** Wrapper around all the profilers that makes management easier. */
 public final class Profilers {
 
-    private final ContextIndexSearcher searcher;
     private final QueryProfiler queryProfiler;
     private final AggregationProfiler aggProfiler = new AggregationProfiler();
     private DfsProfiler dfsProfiler;
 
     public Profilers(ContextIndexSearcher searcher) {
-        this.searcher = searcher;
-        QueryProfiler profiler = new QueryProfiler();
-        searcher.setProfiler(profiler);
-        queryProfiler = profiler;
+        this.queryProfiler = new QueryProfiler();
+        searcher.setProfiler(this.queryProfiler);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/search/profile/Profilers.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/Profilers.java
@@ -16,45 +16,28 @@ import org.elasticsearch.search.profile.dfs.DfsProfiler;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
 import org.elasticsearch.search.profile.query.QueryProfiler;
 
-import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 /** Wrapper around all the profilers that makes management easier. */
 public final class Profilers {
 
     private final ContextIndexSearcher searcher;
-    private final List<QueryProfiler> queryProfilers = new ArrayList<>();
+    private final QueryProfiler queryProfiler;
     private final AggregationProfiler aggProfiler = new AggregationProfiler();
     private DfsProfiler dfsProfiler;
 
     public Profilers(ContextIndexSearcher searcher) {
         this.searcher = searcher;
-        addQueryProfiler();
-    }
-
-    /**
-     * Begin profiling a new query.
-     */
-    public QueryProfiler addQueryProfiler() {
         QueryProfiler profiler = new QueryProfiler();
         searcher.setProfiler(profiler);
-        queryProfilers.add(profiler);
-        return profiler;
+        queryProfiler = profiler;
     }
 
     /**
      * Get the profiler for the query we are currently processing.
      */
     public QueryProfiler getCurrentQueryProfiler() {
-        return queryProfilers.get(queryProfilers.size() - 1);
-    }
-
-    /**
-     * The list of all {@link QueryProfiler}s created so far.
-     */
-    public List<QueryProfiler> getQueryProfilers() {
-        return Collections.unmodifiableList(queryProfilers);
+        return queryProfiler;
     }
 
     public AggregationProfiler getAggregationProfiler() {
@@ -68,7 +51,6 @@ public final class Profilers {
         if (dfsProfiler == null) {
             dfsProfiler = new DfsProfiler();
         }
-
         return dfsProfiler;
     }
 
@@ -83,16 +65,12 @@ public final class Profilers {
      * Build the results for the query phase.
      */
     public SearchProfileQueryPhaseResult buildQueryPhaseResults() {
-        List<QueryProfileShardResult> queryResults = new ArrayList<>(queryProfilers.size());
-        for (QueryProfiler queryProfiler : queryProfilers) {
-            QueryProfileShardResult result = new QueryProfileShardResult(
-                queryProfiler.getTree(),
-                queryProfiler.getRewriteTime(),
-                queryProfiler.getCollector()
-            );
-            queryResults.add(result);
-        }
+        QueryProfileShardResult result = new QueryProfileShardResult(
+            queryProfiler.getTree(),
+            queryProfiler.getRewriteTime(),
+            queryProfiler.getCollector()
+        );
         AggregationProfileShardResult aggResults = new AggregationProfileShardResult(aggProfiler.getTree());
-        return new SearchProfileQueryPhaseResult(queryResults, aggResults);
+        return new SearchProfileQueryPhaseResult(Collections.singletonList(result), aggResults);
     }
 }


### PR DESCRIPTION
In its current form, the Profilers class doesn't need to hold a list of query profilers because it appears only one can be set at a time. This change removes this for better readability.