### PR TITLE
Introduce a filtered collector manager

### DIFF
--- a/docs/changelog/96824.yaml
+++ b/docs/changelog/96824.yaml
@@ -1,0 +1,5 @@
+pr: 96824
+summary: Introduce a filtered collector manager
+area: Search
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
@@ -73,7 +73,6 @@ public class FilteredCollector implements Collector {
         CollectorManager<C, T> collectorManager,
         Weight filter
     ) {
-        AtomicInteger counter = new AtomicInteger(0);
         return new CollectorManager<>() {
             @Override
             public FilteredCollector newCollector() throws IOException {

--- a/server/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
+++ b/server/src/main/java/org/elasticsearch/common/lucene/search/FilteredCollector.java
@@ -21,7 +21,6 @@ import org.elasticsearch.common.lucene.Lucene;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Collector that wraps another collector and collects only documents that match the provided filter.

--- a/server/src/test/java/org/elasticsearch/common/lucene/search/FilteredCollectorTests.java
+++ b/server/src/test/java/org/elasticsearch/common/lucene/search/FilteredCollectorTests.java
@@ -41,7 +41,7 @@ public class FilteredCollectorTests extends ESTestCase {
         super.setUp();
         directory = newDirectory();
         RandomIndexWriter writer = new RandomIndexWriter(random(), directory, newIndexWriterConfig());
-        numDocs = randomIntBetween(10, 100);
+        numDocs = randomIntBetween(900, 1000);
         for (int i = 0; i < numDocs; i++) {
             Document doc = new Document();
             doc.add(new StringField("field1", "value", Field.Store.NO));
@@ -64,19 +64,19 @@ public class FilteredCollectorTests extends ESTestCase {
 
     public void testFiltering() throws IOException {
         {
-            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(1, 100);
+            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(1, 1000);
             searcher.search(new MatchAllDocsQuery(), topScoreDocCollector);
             assertEquals(numDocs, topScoreDocCollector.topDocs().totalHits.value);
         }
         {
-            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(1, 100);
+            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(1, 1000);
             TermQuery termQuery = new TermQuery(new Term("field2", "value"));
             Weight filterWeight = termQuery.createWeight(searcher, ScoreMode.TOP_DOCS, 1f);
             searcher.search(new MatchAllDocsQuery(), new FilteredCollector(topScoreDocCollector, filterWeight));
             assertEquals(1, topScoreDocCollector.topDocs().totalHits.value);
         }
         {
-            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(1, 100);
+            TopScoreDocCollector topScoreDocCollector = TopScoreDocCollector.create(1, 1000);
             TermQuery termQuery = new TermQuery(new Term("field1", "value"));
             Weight filterWeight = termQuery.createWeight(searcher, ScoreMode.TOP_DOCS, 1f);
             searcher.search(new MatchAllDocsQuery(), new FilteredCollector(topScoreDocCollector, filterWeight));
@@ -100,12 +100,13 @@ public class FilteredCollectorTests extends ESTestCase {
     }
 
     public void testManager() throws IOException {
-        CollectorManager<TopScoreDocCollector, TopDocs> topDocsManager = TopScoreDocCollector.createSharedManager(1, null, 100);
         {
+            CollectorManager<TopScoreDocCollector, TopDocs> topDocsManager = TopScoreDocCollector.createSharedManager(1, null, 1000);
             TopDocs topDocs = searcher.search(new MatchAllDocsQuery(), topDocsManager);
             assertEquals(numDocs, topDocs.totalHits.value);
         }
         {
+            CollectorManager<TopScoreDocCollector, TopDocs> topDocsManager = TopScoreDocCollector.createSharedManager(1, null, 1000);
             TermQuery termQuery = new TermQuery(new Term("field2", "value"));
             Weight filterWeight = termQuery.createWeight(searcher, ScoreMode.TOP_DOCS, 1f);
             CollectorManager<FilteredCollector, TopDocs> filteredManager = FilteredCollector.createManager(topDocsManager, filterWeight);
@@ -113,6 +114,7 @@ public class FilteredCollectorTests extends ESTestCase {
             assertEquals(1, topDocs.totalHits.value);
         }
         {
+            CollectorManager<TopScoreDocCollector, TopDocs> topDocsManager = TopScoreDocCollector.createSharedManager(1, null, 1000);
             TermQuery termQuery = new TermQuery(new Term("field1", "value"));
             Weight filterWeight = termQuery.createWeight(searcher, ScoreMode.TOP_DOCS, 1f);
             CollectorManager<FilteredCollector, TopDocs> filteredManager = FilteredCollector.createManager(topDocsManager, filterWeight);


### PR DESCRIPTION
In order to add support for inter-segment search concurrency, we need to implement collector managers for all of our custom collectors.

This PR introduces a collector manager that is based on `FilteredCollector`, used when a post_filter is provided as part of a search request.

Note that the collector manager is not yet integrated in the query phase.