### PR TITLE
Add ActionType#toString

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/ActionType.java
+++ b/server/src/main/java/org/elasticsearch/action/ActionType.java
@@ -58,4 +58,9 @@ public class ActionType<Response extends ActionResponse> {
     public int hashCode() {
         return name.hashCode();
     }
+
+    @Override
+    public String toString() {
+        return name;
+    }
 }


### PR DESCRIPTION
Today if you call an unknown client action you get an exception whose message includes the result of the default `Object#toString()` for the `ActionType` in question, which doesn't really help. This commit implements a more useful `toString()`.