### PR TITLE
Add assertion message to SharedBytes#copyToCacheFileAligned

### DIFF
--- a/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
+++ b/x-pack/plugin/blob-cache/src/main/java/org/elasticsearch/blobcache/shared/SharedBytes.java
@@ -158,7 +158,7 @@ public class SharedBytes extends AbstractRefCounted {
             long bytesWritten = positionalWrite(fc, fileChannelPos + bytesCopied, buf);
             bytesCopied += bytesWritten;
             final long adjustedBytesCopied = bytesCopied - adjustment; // adjust to not break RangeFileTracker
-            assert adjustedBytesCopied == length;
+            assert adjustedBytesCopied == length : adjustedBytesCopied + " vs " + length;
             progressUpdater.accept(adjustedBytesCopied);
         }
     }


### PR DESCRIPTION
I saw this assertion trip once, and the lack of message meant the problem wasn't obvious. This commit adds a message.