### PR TITLE
Introduce StatelessPrimaryRelocationAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/recovery/StatelessPrimaryRelocationAction.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/StatelessPrimaryRelocationAction.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.recovery;
+
+import org.elasticsearch.action.ActionRequest;
+import org.elasticsearch.action.ActionRequestValidationException;
+import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.ActionType;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.index.shard.ShardId;
+
+import java.io.IOException;
+import java.util.Objects;
+
+public class StatelessPrimaryRelocationAction {
+
+    public static final ActionType<ActionResponse.Empty> INSTANCE = new ActionType<>(
+        "internal:index/shard/recovery/stateless_primary_relocation",
+        in -> ActionResponse.Empty.INSTANCE
+    );
+
+    public static class Request extends ActionRequest {
+
+        private final long recoveryId;
+        private final ShardId shardId;
+        private final DiscoveryNode targetNode;
+        private final String targetAllocationId;
+
+        public Request(long recoveryId, ShardId shardId, DiscoveryNode targetNode, String targetAllocationId) {
+            this.recoveryId = recoveryId;
+            this.shardId = shardId;
+            this.targetNode = targetNode;
+            this.targetAllocationId = targetAllocationId;
+        }
+
+        public Request(StreamInput in) throws IOException {
+            super(in);
+            recoveryId = in.readVLong();
+            shardId = new ShardId(in);
+            targetNode = new DiscoveryNode(in);
+            targetAllocationId = in.readString();
+        }
+
+        @Override
+        public ActionRequestValidationException validate() {
+            return null;
+        }
+
+        @Override
+        public void writeTo(StreamOutput out) throws IOException {
+            super.writeTo(out);
+            out.writeVLong(recoveryId);
+            shardId.writeTo(out);
+            targetNode.writeTo(out);
+            out.writeString(targetAllocationId);
+        }
+
+        public long recoveryId() {
+            return recoveryId;
+        }
+
+        public ShardId shardId() {
+            return shardId;
+        }
+
+        public DiscoveryNode targetNode() {
+            return targetNode;
+        }
+
+        public String targetAllocationId() {
+            return targetAllocationId;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            Request request = (Request) o;
+            return recoveryId == request.recoveryId
+                && shardId.equals(request.shardId)
+                && targetNode.equals(request.targetNode)
+                && targetAllocationId.equals(request.targetAllocationId);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(recoveryId, shardId, targetNode, targetAllocationId);
+        }
+    }
+}

--- a/server/src/test/java/org/elasticsearch/indices/recovery/StatelessPrimaryRelocationActionTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/StatelessPrimaryRelocationActionTests.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.indices.recovery;
+
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
+import org.elasticsearch.common.UUIDs;
+import org.elasticsearch.common.io.stream.Writeable;
+import org.elasticsearch.index.shard.ShardId;
+import org.elasticsearch.index.shard.ShardIdTests;
+import org.elasticsearch.test.AbstractWireSerializingTestCase;
+import org.elasticsearch.test.ESTestCase;
+
+import java.io.IOException;
+
+public class StatelessPrimaryRelocationActionTests extends AbstractWireSerializingTestCase<StatelessPrimaryRelocationAction.Request> {
+
+    @Override
+    protected Writeable.Reader<StatelessPrimaryRelocationAction.Request> instanceReader() {
+        return StatelessPrimaryRelocationAction.Request::new;
+    }
+
+    @Override
+    protected StatelessPrimaryRelocationAction.Request createTestInstance() {
+        return new StatelessPrimaryRelocationAction.Request(
+            randomNonNegativeLong(),
+            new ShardId(randomIdentifier(), UUIDs.randomBase64UUID(), randomIntBetween(0, 99)),
+            newDiscoveryNode(),
+            UUIDs.randomBase64UUID()
+        );
+    }
+
+    private static DiscoveryNode newDiscoveryNode() {
+        return DiscoveryNodeUtils.builder("test").ephemeralId(UUIDs.randomBase64UUID()).build();
+    }
+
+    @Override
+    protected StatelessPrimaryRelocationAction.Request mutateInstance(StatelessPrimaryRelocationAction.Request instance)
+        throws IOException {
+        return switch (between(1, 4)) {
+            case 1 -> new StatelessPrimaryRelocationAction.Request(
+                randomValueOtherThan(instance.recoveryId(), ESTestCase::randomNonNegativeLong),
+                instance.shardId(),
+                instance.targetNode(),
+                instance.targetAllocationId()
+            );
+            case 2 -> new StatelessPrimaryRelocationAction.Request(
+                instance.recoveryId(),
+                ShardIdTests.mutate(instance.shardId()),
+                instance.targetNode(),
+                instance.targetAllocationId()
+            );
+            case 3 -> new StatelessPrimaryRelocationAction.Request(
+                instance.recoveryId(),
+                instance.shardId(),
+                randomValueOtherThan(instance.targetNode(), StatelessPrimaryRelocationActionTests::newDiscoveryNode),
+                instance.targetAllocationId()
+            );
+            case 4 -> new StatelessPrimaryRelocationAction.Request(
+                instance.recoveryId(),
+                instance.shardId(),
+                instance.targetNode(),
+                randomValueOtherThan(instance.targetAllocationId(), UUIDs::randomBase64UUID)
+            );
+            default -> throw new AssertionError("impossible");
+        };
+    }
+}


### PR DESCRIPTION
This action is needed by a dependent module, although we can't use it in the main codebase until the changes to the dependent module are merged. This commit adds it to the main codebase without using it anywhere. A future commit will add the missing usages.