### PR TITLE
[8.8] [DOCS] Adds size parameter to reindex call in ELSER tutorial. (#96820)

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -126,7 +126,8 @@ pipeline that uses ELSER as the inference model.
 POST _reindex?wait_for_completion=false
 {
   "source": {
-    "index": "test-data"
+    "index": "test-data",
+    "size": 50 <1>
   },
   "dest": {
     "index": "my-index",
@@ -135,6 +136,9 @@ POST _reindex?wait_for_completion=false
 }
 ----
 // TEST[skip:TBD]
+<1> The default batch size for reindexing is 1000. Reducing `size` to a smaller 
+number makes the update of the reindexing process quicker which enables you to 
+follow the progress closely and detect errors early.
 
 The call returns a task ID to monitor the progress:
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.8`:
 - [[DOCS] Adds size parameter to reindex call in ELSER tutorial. (#96820)](https://github.com/elastic/elasticsearch/pull/96820)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)