### PR TITLE
Introduce minimum score collector manager

### DIFF
--- a/docs/changelog/96834.yaml
+++ b/docs/changelog/96834.yaml
@@ -1,0 +1,5 @@
+pr: 96834
+summary: Introduce minimum score collector manager
+area: Search
+type: enhancement
+issues: []


### PR DESCRIPTION
In order to add support for inter-segment search concurrency, we need to implement collector managers for all of our custom collectors.

This PR introduces a collector manager that is based on MinimumScoreCollector, used when a min_score is provided as part of a search request.

Note that the collector manager is not yet integrated in the query phase.