### PR TITLE
[Profiling] Enforce hot tier for K/V indices

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hot-tier.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hot-tier.json
@@ -1,0 +1,10 @@
+{
+  "template": {
+    "settings": {
+      "index": {
+        "routing.allocation.include._tier_preference": "data_hot"
+      }
+    }
+  },
+  "version": ${xpack.profiling.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-executables.json
@@ -4,7 +4,8 @@
   ],
   "composed_of": [
     "profiling-executables",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-hot-tier"
   ],
   "priority": 100,
   "_meta": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-stackframes.json
@@ -4,7 +4,8 @@
   ],
   "composed_of": [
     "profiling-stackframes",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-hot-tier"
   ],
   "priority": 100,
   "_meta": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-stacktraces.json
@@ -4,7 +4,8 @@
   ],
   "composed_of": [
     "profiling-stacktraces",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-hot-tier"
   ],
   "priority": 100,
   "_meta": {

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-symbols-global.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-symbols-global.json
@@ -4,7 +4,8 @@
   ],
   "composed_of": [
     "profiling-symbols",
-    "profiling-ilm"
+    "profiling-ilm",
+    "profiling-hot-tier"
   ],
   "template": {
     "settings": {

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
@@ -110,6 +110,12 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
                 PROFILING_TEMPLATE_VERSION_VARIABLE
             ),
             new IndexTemplateConfig(
+                "profiling-hot-tier",
+                "/org/elasticsearch/xpack/profiler/component-template/profiling-hot-tier.json",
+                INDEX_TEMPLATE_VERSION,
+                PROFILING_TEMPLATE_VERSION_VARIABLE
+            ),
+            new IndexTemplateConfig(
                 "profiling-metrics",
                 "/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json",
                 INDEX_TEMPLATE_VERSION,


### PR DESCRIPTION
Regular indices are allocated on the `content` tier by default (see also the
[docs](https://www.elastic.co/guide/en/elasticsearch/reference/8.8/migrate-index-allocation-filters.html#stop-setting-custom-hot-attribute)). However, we want to define a lifecycle for K/V indices that matches those of regular datastreams. Therefore we enforce initial allocation of K/V indices on the hot tier.