### PR TITLE
[8.7] Adding a known issue to the release notes about the ingest attachment processor causing cluster instability (#96811)

### DIFF
--- a/docs/reference/release-notes/8.4.0.asciidoc
+++ b/docs/reference/release-notes/8.4.0.asciidoc
@@ -30,6 +30,17 @@ affected node.
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+// tag::ingest-processor-log4j-cluster-instability-known-issue[]
+* When the {ref}/attachment.html[ingest attachment processor] is used, the
+interaction of https://tika.apache.org/[Tika] with log4j 2.18.0 and higher
+(introduced in {es} 8.4.0) results in excessive logging. This logging is so
+excessive that it can lead to cluster instability, to the point where the
+cluster is unusable and nodes must be restarted. (issue: {es-issue}91964[#91964]).
+This issue is fixed in {es} 8.7.0 ({es-pull}93878[#93878])
++
+To resolve the issue, upgrade to 8.7.0 or higher.
+// end::ingest-processor-log4j-cluster-instability-known-issue[]
+
 [[bug-8.4.0]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.1.asciidoc
+++ b/docs/reference/release-notes/8.4.1.asciidoc
@@ -17,6 +17,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.4.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.2.asciidoc
+++ b/docs/reference/release-notes/8.4.2.asciidoc
@@ -26,6 +26,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.4.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.4.3.asciidoc
+++ b/docs/reference/release-notes/8.4.3.asciidoc
@@ -17,6 +17,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.4.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.0.asciidoc
+++ b/docs/reference/release-notes/8.5.0.asciidoc
@@ -20,6 +20,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[breaking-8.5.0]]
 [float]
 === Breaking changes

--- a/docs/reference/release-notes/8.5.1.asciidoc
+++ b/docs/reference/release-notes/8.5.1.asciidoc
@@ -13,6 +13,9 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.5.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.2.asciidoc
+++ b/docs/reference/release-notes/8.5.2.asciidoc
@@ -13,6 +13,9 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.5.2]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.5.3.asciidoc
+++ b/docs/reference/release-notes/8.5.3.asciidoc
@@ -12,6 +12,9 @@ include::8.4.0.asciidoc[tag=ml-pre-7-datafeeds-known-issue]
 include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
+
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.5.3]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.0.asciidoc
+++ b/docs/reference/release-notes/8.6.0.asciidoc
@@ -11,6 +11,8 @@ include::8.4.0.asciidoc[tag=file-based-settings-deadlock-known-issue]
 
 include::8.0.0.asciidoc[tag=jackson-filtering-bug]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 // tag::reconciliation-imbalance-known-issue[]
 * Shard rebalancing may temporarily unbalance cluster
 +

--- a/docs/reference/release-notes/8.6.1.asciidoc
+++ b/docs/reference/release-notes/8.6.1.asciidoc
@@ -9,6 +9,8 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.6.1]]
 [float]
 === Bug fixes

--- a/docs/reference/release-notes/8.6.2.asciidoc
+++ b/docs/reference/release-notes/8.6.2.asciidoc
@@ -9,6 +9,8 @@ Also see <<breaking-changes-8.6,Breaking changes in 8.6>>.
 
 include::8.6.0.asciidoc[tag=reconciliation-imbalance-known-issue]
 
+include::8.4.0.asciidoc[tag=ingest-processor-log4j-cluster-instability-known-issue]
+
 [[bug-8.6.2]]
 [float]
 === Bug fixes


### PR DESCRIPTION
Backports the following commits to 8.7:
 - Adding a known issue to the release notes about the ingest attachment processor causing cluster instability (#96811)