### PR TITLE
Remove the fast-fail code in AsyncResultsService.getSearchResponseFromTask

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
@@ -120,13 +120,8 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
     ) {
         try {
             final Task task = store.getTaskAndCheckAuthentication(taskManager, searchId, asyncTaskClass);
-            if (task == null) {
+            if (task == null || task.isCancelled()) {
                 getSearchResponseFromIndex(searchId, request, nowInMillis, listener);
-                return;
-            }
-
-            if (task.isCancelled()) {
-                listener.onFailure(new ResourceNotFoundException(searchId.getEncoded()));
                 return;
             }
 


### PR DESCRIPTION
getSearchResponseFromTask assumes that if a task is cancelled, it should immediately give up with a ResourceNotFoundException.

This is unnecessary and undesirable for two reasons:

1. In the case of a task being cancelled via the Task API, the `getSearchResponseFromIndex` call will still work and return useful information about the cancelled search, rather than an uninformative "resource_not_found_exception" response.

2. In the case where the async-search task is cancelled by doing a `DELETE _async_search` call, then `getSearchResponseFromIndex` will fail, but it fails with the same ResourceNotFoundException that the code was already using in its "fail-fast" if branch.

Thus removing this code makes the response better in the case where the search was cancelled via the Task API and has the same result when the async-search was cancelled via a DELETE action.