### PR TITLE
Uses `ClusterSettings` instead of Node `Settings` in `HealthMetadataService`

### DIFF
--- a/docs/changelog/96843.yaml
+++ b/docs/changelog/96843.yaml
@@ -1,0 +1,6 @@
+pr: 96843
+summary: Uses `ClusterSettings` instead of Node `Settings` in `HealthMetadataService`
+area: Health
+type: bug
+issues:
+ - 96219

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -24,7 +24,6 @@ import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 
@@ -60,10 +59,10 @@ public class HealthMetadataService {
     // us from checking the cluster state before the cluster state is initialized
     private volatile boolean isMaster = false;
 
-    private HealthMetadataService(ClusterService clusterService, Settings settings) {
+    private HealthMetadataService(ClusterService clusterService) {
         this.clusterService = clusterService;
         this.clusterStateListener = this::updateOnClusterStateChange;
-        this.enabled = ENABLED_SETTING.get(settings);
+        this.enabled = clusterService.getClusterSettings().get(ENABLED_SETTING);
         this.taskQueue = clusterService.createTaskQueue(
             "health metadata service",
             Priority.NORMAL,
@@ -71,8 +70,8 @@ public class HealthMetadataService {
         );
     }
 
-    public static HealthMetadataService create(ClusterService clusterService, Settings settings) {
-        HealthMetadataService healthMetadataService = new HealthMetadataService(clusterService, settings);
+    public static HealthMetadataService create(ClusterService clusterService) {
+        HealthMetadataService healthMetadataService = new HealthMetadataService(clusterService);
         healthMetadataService.registerListeners();
         return healthMetadataService;
     }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1033,7 +1033,7 @@ public class Node implements Closeable {
                 threadPool,
                 systemIndices
             );
-            HealthMetadataService healthMetadataService = HealthMetadataService.create(clusterService, settings);
+            HealthMetadataService healthMetadataService = HealthMetadataService.create(clusterService);
             LocalHealthMonitor localHealthMonitor = LocalHealthMonitor.create(settings, clusterService, nodeService, threadPool, client);
             HealthInfoCache nodeHealthOverview = HealthInfoCache.create(clusterService);
             HealthApiStats healthApiStats = new HealthApiStats();


### PR DESCRIPTION
While we built the first version of `HealthMetadata` object, we use the `Settings` object, which has the Node's settings. Due to this we always used the default values of the settings. This makes that every time a new master was selected, the initial `HealthMetadata` was built with the default values instead of the settings configured by the user.

closes #96219 