### PR TITLE
Refactor asserts in MetadataTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -38,8 +38,6 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
-import org.elasticsearch.test.LambdaMatchers;
-import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -78,8 +76,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
-import static org.hamcrest.Matchers.hasEntry;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
@@ -332,33 +328,21 @@ public class MetadataTests extends ESTestCase {
         Exception ex = expectThrows(IllegalArgumentException.class, () -> metadata.resolveIndexRouting("0", "alias1"));
         assertThat(
             ex.getMessage(),
-            is(
-                "Alias [alias1] has index routing associated with it [1], "
-                    + "and was provided with routing value [0], rejecting operation"
-            )
+            is("Alias [alias1] has index routing associated with it [1], and was provided with routing value [0], rejecting operation")
         );
-
 
         // alias with invalid index routing.
         ex = expectThrows(IllegalArgumentException.class, () -> metadata.resolveIndexRouting(null, "alias2"));
-            assertThat(
-                ex.getMessage(),
-                is(
-                    "index/alias [alias2] provided with routing value [1,2] that"
-                        + " resolved to several routing values, rejecting operation"
-                )
-            );
-
+        assertThat(
+            ex.getMessage(),
+            is("index/alias [alias2] provided with routing value [1,2] that resolved to several routing values, rejecting operation")
+        );
 
         ex = expectThrows(IllegalArgumentException.class, () -> metadata.resolveIndexRouting("1", "alias2"));
-            assertThat(
-                ex.getMessage(),
-                is(
-                    "index/alias [alias2] provided with routing value [1,2] that"
-                        + " resolved to several routing values, rejecting operation"
-                )
-            );
-
+        assertThat(
+            ex.getMessage(),
+            is("index/alias [alias2] provided with routing value [1,2] that resolved to several routing values, rejecting operation")
+        );
 
         IndexMetadata.Builder builder2 = IndexMetadata.builder("index2")
             .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataTests.java
@@ -38,6 +38,8 @@ import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.plugins.MapperPlugin;
 import org.elasticsearch.test.AbstractChunkedSerializingTestCase;
 import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.test.LambdaMatchers;
+import org.elasticsearch.test.MapMatcher;
 import org.elasticsearch.test.VersionUtils;
 import org.elasticsearch.xcontent.ToXContent;
 import org.elasticsearch.xcontent.XContentBuilder;
@@ -45,6 +47,7 @@ import org.elasticsearch.xcontent.XContentParser;
 import org.elasticsearch.xcontent.json.JsonXContent;
 
 import java.io.IOException;
+import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -66,12 +69,19 @@ import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createBack
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.createFirstBackingIndex;
 import static org.elasticsearch.cluster.metadata.DataStreamTestHelper.newInstance;
 import static org.elasticsearch.cluster.metadata.Metadata.Builder.assertDataStreams;
+import static org.elasticsearch.test.LambdaMatchers.transformedItemsMatch;
+import static org.hamcrest.Matchers.aMapWithSize;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
@@ -97,7 +107,7 @@ public class MetadataTests extends ESTestCase {
         {
             GetAliasesRequest request = new GetAliasesRequest();
             Map<String, List<AliasMetadata>> aliases = metadata.findAliases(request.aliases(), Strings.EMPTY_ARRAY);
-            assertThat(aliases.size(), equalTo(0));
+            assertThat(aliases, anEmptyMap());
         }
         {
             final GetAliasesRequest request;
@@ -109,40 +119,33 @@ public class MetadataTests extends ESTestCase {
                 request.replaceAliases(Strings.EMPTY_ARRAY);
             }
             Map<String, List<AliasMetadata>> aliases = metadata.findAliases(request.aliases(), new String[] { "index" });
-            assertThat(aliases.size(), equalTo(1));
+            assertThat(aliases, aMapWithSize(1));
             List<AliasMetadata> aliasMetadataList = aliases.get("index");
-            assertThat(aliasMetadataList.size(), equalTo(2));
-            assertThat(aliasMetadataList.get(0).alias(), equalTo("alias1"));
-            assertThat(aliasMetadataList.get(1).alias(), equalTo("alias2"));
+            assertThat(aliasMetadataList, transformedItemsMatch(AliasMetadata::alias, contains("alias1", "alias2")));
         }
         {
             GetAliasesRequest request = new GetAliasesRequest("alias*");
             Map<String, List<AliasMetadata>> aliases = metadata.findAliases(request.aliases(), new String[] { "index" });
-            assertThat(aliases.size(), equalTo(1));
+            assertThat(aliases, aMapWithSize(1));
             List<AliasMetadata> aliasMetadataList = aliases.get("index");
-            assertThat(aliasMetadataList.size(), equalTo(2));
-            assertThat(aliasMetadataList.get(0).alias(), equalTo("alias1"));
-            assertThat(aliasMetadataList.get(1).alias(), equalTo("alias2"));
+            assertThat(aliasMetadataList, transformedItemsMatch(AliasMetadata::alias, contains("alias1", "alias2")));
         }
         {
             GetAliasesRequest request = new GetAliasesRequest("alias1");
             Map<String, List<AliasMetadata>> aliases = metadata.findAliases(request.aliases(), new String[] { "index" });
-            assertThat(aliases.size(), equalTo(1));
+            assertThat(aliases, aMapWithSize(1));
             List<AliasMetadata> aliasMetadataList = aliases.get("index");
-            assertThat(aliasMetadataList.size(), equalTo(1));
-            assertThat(aliasMetadataList.get(0).alias(), equalTo("alias1"));
+            assertThat(aliasMetadataList, transformedItemsMatch(AliasMetadata::alias, contains("alias1")));
         }
         {
             Map<String, List<AliasMetadata>> aliases = metadata.findAllAliases(new String[] { "index" });
-            assertThat(aliases.size(), equalTo(1));
+            assertThat(aliases, aMapWithSize(1));
             List<AliasMetadata> aliasMetadataList = aliases.get("index");
-            assertThat(aliasMetadataList.size(), equalTo(2));
-            assertThat(aliasMetadataList.get(0).alias(), equalTo("alias1"));
-            assertThat(aliasMetadataList.get(1).alias(), equalTo("alias2"));
+            assertThat(aliasMetadataList, transformedItemsMatch(AliasMetadata::alias, contains("alias1", "alias2")));
         }
         {
             Map<String, List<AliasMetadata>> aliases = metadata.findAllAliases(Strings.EMPTY_ARRAY);
-            assertThat(aliases.size(), equalTo(0));
+            assertThat(aliases, anEmptyMap());
         }
     }
 
@@ -159,8 +162,7 @@ public class MetadataTests extends ESTestCase {
             .build();
         GetAliasesRequest request = new GetAliasesRequest().aliases("*", "-alias1");
         List<AliasMetadata> aliases = metadata.findAliases(request.aliases(), new String[] { "index" }).get("index");
-        assertThat(aliases.size(), equalTo(1));
-        assertThat(aliases.get(0).alias(), equalTo("alias2"));
+        assertThat(aliases, transformedItemsMatch(AliasMetadata::alias, contains("alias2")));
     }
 
     public void testFindDataStreams() {
@@ -171,11 +173,11 @@ public class MetadataTests extends ESTestCase {
 
         List<Index> allIndices = new ArrayList<>(result.indices);
         allIndices.addAll(result.backingIndices);
-        String[] concreteIndices = allIndices.stream().map(Index::getName).toList().toArray(new String[] {});
+        String[] concreteIndices = allIndices.stream().map(Index::getName).toArray(String[]::new);
         Map<String, DataStream> dataStreams = result.metadata.findDataStreams(concreteIndices);
-        assertThat(dataStreams.size(), equalTo(numBackingIndices));
+        assertThat(dataStreams, aMapWithSize(numBackingIndices));
         for (Index backingIndex : result.backingIndices) {
-            assertThat(dataStreams.containsKey(backingIndex.getName()), is(true));
+            assertThat(dataStreams, hasKey(backingIndex.getName()));
             assertThat(dataStreams.get(backingIndex.getName()).getName(), equalTo(dataStreamName));
         }
     }
@@ -194,9 +196,7 @@ public class MetadataTests extends ESTestCase {
             .build();
         GetAliasesRequest request = new GetAliasesRequest().aliases("a*", "-*b", "b*");
         List<AliasMetadata> aliases = metadata.findAliases(request.aliases(), new String[] { "index" }).get("index");
-        assertThat(aliases.size(), equalTo(2));
-        assertThat(aliases.get(0).alias(), equalTo("aa"));
-        assertThat(aliases.get(1).alias(), equalTo("bb"));
+        assertThat(aliases, transformedItemsMatch(AliasMetadata::alias, contains("aa", "bb")));
     }
 
     public void testAliasCollidingWithAnExistingIndex() {
@@ -231,12 +231,9 @@ public class MetadataTests extends ESTestCase {
             });
             metadataBuilder.put(indexBuilder);
         }
-        try {
-            metadataBuilder.build();
-            fail("exception should have been thrown");
-        } catch (IllegalStateException e) {
-            assertThat(e.getMessage(), startsWith("index, alias, and data stream names need to be unique"));
-        }
+
+        Exception e = expectThrows(IllegalStateException.class, metadataBuilder::build);
+        assertThat(e.getMessage(), startsWith("index, alias, and data stream names need to be unique"));
     }
 
     public void testValidateAliasWriteOnly() {
@@ -319,37 +316,31 @@ public class MetadataTests extends ESTestCase {
         Metadata metadata = Metadata.builder().put(builder).build();
 
         // no alias, no index
-        assertEquals(metadata.resolveIndexRouting(null, null), null);
+        assertNull(metadata.resolveIndexRouting(null, null));
         assertEquals(metadata.resolveIndexRouting("0", null), "0");
 
         // index, no alias
-        assertEquals(metadata.resolveIndexRouting(null, "index"), null);
+        assertNull(metadata.resolveIndexRouting(null, "index"));
         assertEquals(metadata.resolveIndexRouting("0", "index"), "0");
 
         // alias with no index routing
-        assertEquals(metadata.resolveIndexRouting(null, "alias0"), null);
+        assertNull(metadata.resolveIndexRouting(null, "alias0"));
         assertEquals(metadata.resolveIndexRouting("0", "alias0"), "0");
 
         // alias with index routing.
         assertEquals(metadata.resolveIndexRouting(null, "alias1"), "1");
-        try {
-            metadata.resolveIndexRouting("0", "alias1");
-            fail("should fail");
-        } catch (IllegalArgumentException ex) {
-            assertThat(
-                ex.getMessage(),
-                is(
-                    "Alias [alias1] has index routing associated with it [1], "
-                        + "and was provided with routing value [0], rejecting operation"
-                )
-            );
-        }
+        Exception ex = expectThrows(IllegalArgumentException.class, () -> metadata.resolveIndexRouting("0", "alias1"));
+        assertThat(
+            ex.getMessage(),
+            is(
+                "Alias [alias1] has index routing associated with it [1], "
+                    + "and was provided with routing value [0], rejecting operation"
+            )
+        );
+
 
         // alias with invalid index routing.
-        try {
-            metadata.resolveIndexRouting(null, "alias2");
-            fail("should fail");
-        } catch (IllegalArgumentException ex) {
+        ex = expectThrows(IllegalArgumentException.class, () -> metadata.resolveIndexRouting(null, "alias2"));
             assertThat(
                 ex.getMessage(),
                 is(
@@ -357,12 +348,9 @@ public class MetadataTests extends ESTestCase {
                         + " resolved to several routing values, rejecting operation"
                 )
             );
-        }
 
-        try {
-            metadata.resolveIndexRouting("1", "alias2");
-            fail("should fail");
-        } catch (IllegalArgumentException ex) {
+
+        ex = expectThrows(IllegalArgumentException.class, () -> metadata.resolveIndexRouting("1", "alias2"));
             assertThat(
                 ex.getMessage(),
                 is(
@@ -370,7 +358,7 @@ public class MetadataTests extends ESTestCase {
                         + " resolved to several routing values, rejecting operation"
                 )
             );
-        }
+
 
         IndexMetadata.Builder builder2 = IndexMetadata.builder("index2")
             .settings(Settings.builder().put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT))
@@ -404,15 +392,15 @@ public class MetadataTests extends ESTestCase {
         Metadata metadata = Metadata.builder().put(builder).build();
 
         // no alias, no index
-        assertEquals(metadata.resolveWriteIndexRouting(null, null), null);
+        assertNull(metadata.resolveWriteIndexRouting(null, null));
         assertEquals(metadata.resolveWriteIndexRouting("0", null), "0");
 
         // index, no alias
-        assertEquals(metadata.resolveWriteIndexRouting(null, "index"), null);
+        assertNull(metadata.resolveWriteIndexRouting(null, "index"));
         assertEquals(metadata.resolveWriteIndexRouting("0", "index"), "0");
 
         // alias with no index routing
-        assertEquals(metadata.resolveWriteIndexRouting(null, "alias0"), null);
+        assertNull(metadata.resolveWriteIndexRouting(null, "alias0"));
         assertEquals(metadata.resolveWriteIndexRouting("0", "alias0"), "0");
 
         // alias with index routing.
@@ -467,9 +455,7 @@ public class MetadataTests extends ESTestCase {
             JsonXContent.contentBuilder().startObject().startObject("meta-data").field("random", "value").endObject().endObject()
         );
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
-            Metadata.Builder.fromXContent(parser);
-            fail();
-        } catch (IllegalArgumentException e) {
+            Exception e = expectThrows(IllegalArgumentException.class, () -> Metadata.Builder.fromXContent(parser));
             assertEquals("Unexpected field [random]", e.getMessage());
         }
     }
@@ -479,9 +465,7 @@ public class MetadataTests extends ESTestCase {
             JsonXContent.contentBuilder().startObject().startObject("index_name").field("random", "value").endObject().endObject()
         );
         try (XContentParser parser = createParser(JsonXContent.jsonXContent, metadata)) {
-            IndexMetadata.Builder.fromXContent(parser);
-            fail();
-        } catch (IllegalArgumentException e) {
+            Exception e = expectThrows(IllegalArgumentException.class, () -> IndexMetadata.Builder.fromXContent(parser));
             assertEquals("Unexpected field [random]", e.getMessage());
         }
     }
@@ -631,7 +615,7 @@ public class MetadataTests extends ESTestCase {
                 MapperPlugin.NOOP_FIELD_FILTER,
                 onNextIndexCalls::incrementAndGet
             );
-            assertEquals(0, mappings.size());
+            assertThat(mappings, anEmptyMap());
             assertThat(onNextIndexCalls.get(), equalTo(0));
         }
         {
@@ -641,7 +625,7 @@ public class MetadataTests extends ESTestCase {
                 MapperPlugin.NOOP_FIELD_FILTER,
                 onNextIndexCalls::incrementAndGet
             );
-            assertEquals(1, mappings.size());
+            assertThat(mappings, aMapWithSize(1));
             assertIndexMappingsNotFiltered(mappings, "index1");
             assertThat(onNextIndexCalls.get(), equalTo(1));
         }
@@ -652,7 +636,7 @@ public class MetadataTests extends ESTestCase {
                 MapperPlugin.NOOP_FIELD_FILTER,
                 onNextIndexCalls::incrementAndGet
             );
-            assertEquals(2, mappings.size());
+            assertThat(mappings, aMapWithSize(2));
             assertIndexMappingsNotFiltered(mappings, "index1");
             assertIndexMappingsNotFiltered(mappings, "index2");
             assertThat(onNextIndexCalls.get(), equalTo(2));
@@ -728,39 +712,26 @@ public class MetadataTests extends ESTestCase {
             assertNotNull(docMapping);
 
             Map<String, Object> sourceAsMap = docMapping.getSourceAsMap();
-            assertEquals(3, sourceAsMap.size());
-            assertTrue(sourceAsMap.containsKey("_routing"));
-            assertTrue(sourceAsMap.containsKey("_source"));
+            assertThat(sourceAsMap.keySet(), containsInAnyOrder("properties", "_routing", "_source"));
 
             Map<String, Object> typeProperties = (Map<String, Object>) sourceAsMap.get("properties");
-            assertEquals(6, typeProperties.size());
-            assertTrue(typeProperties.containsKey("birth"));
-            assertTrue(typeProperties.containsKey("ip"));
-            assertTrue(typeProperties.containsKey("suggest"));
+            assertThat(typeProperties.keySet(), containsInAnyOrder("name", "address", "birth", "ip", "suggest", "properties"));
 
             Map<String, Object> name = (Map<String, Object>) typeProperties.get("name");
-            assertNotNull(name);
-            assertEquals(1, name.size());
+            assertThat(name.keySet(), containsInAnyOrder("properties"));
             Map<String, Object> nameProperties = (Map<String, Object>) name.get("properties");
-            assertNotNull(nameProperties);
-            assertEquals(0, nameProperties.size());
+            assertThat(nameProperties, anEmptyMap());
 
             Map<String, Object> address = (Map<String, Object>) typeProperties.get("address");
-            assertNotNull(address);
-            assertEquals(2, address.size());
-            assertTrue(address.containsKey("type"));
+            assertThat(address.keySet(), containsInAnyOrder("type", "properties"));
             Map<String, Object> addressProperties = (Map<String, Object>) address.get("properties");
-            assertNotNull(addressProperties);
-            assertEquals(2, addressProperties.size());
+            assertThat(addressProperties.keySet(), containsInAnyOrder("street", "area"));
             assertLeafs(addressProperties, "street", "area");
 
             Map<String, Object> properties = (Map<String, Object>) typeProperties.get("properties");
-            assertNotNull(properties);
-            assertEquals(2, properties.size());
-            assertTrue(properties.containsKey("type"));
+            assertThat(properties.keySet(), containsInAnyOrder("type", "properties"));
             Map<String, Object> propertiesProperties = (Map<String, Object>) properties.get("properties");
-            assertNotNull(propertiesProperties);
-            assertEquals(2, propertiesProperties.size());
+            assertThat(propertiesProperties.keySet(), containsInAnyOrder("key", "value"));
             assertLeafs(propertiesProperties, "key");
             assertMultiField(propertiesProperties, "value", "keyword");
         }
@@ -776,28 +747,22 @@ public class MetadataTests extends ESTestCase {
             assertIndexMappingsNoFields(mappings, "index2");
             MappingMetadata mappingMetadata = mappings.get("index3");
             Map<String, Object> sourceAsMap = mappingMetadata.getSourceAsMap();
-            assertEquals(3, sourceAsMap.size());
-            assertTrue(sourceAsMap.containsKey("_routing"));
-            assertTrue(sourceAsMap.containsKey("_source"));
+            assertThat(sourceAsMap.keySet(), containsInAnyOrder("_routing", "_source", "properties"));
             Map<String, Object> typeProperties = (Map<String, Object>) sourceAsMap.get("properties");
-            assertNotNull(typeProperties);
-            assertEquals(1, typeProperties.size());
+            assertThat(typeProperties.keySet(), containsInAnyOrder("properties"));
             Map<String, Object> properties = (Map<String, Object>) typeProperties.get("properties");
-            assertNotNull(properties);
-            assertEquals(2, properties.size());
-            assertTrue(properties.containsKey("type"));
+            assertThat(properties.keySet(), containsInAnyOrder("type", "properties"));
             Map<String, Object> propertiesProperties = (Map<String, Object>) properties.get("properties");
-            assertNotNull(propertiesProperties);
-            assertEquals(2, propertiesProperties.size());
+            assertThat(propertiesProperties.keySet(), containsInAnyOrder("key", "value"));
             Map<String, Object> key = (Map<String, Object>) propertiesProperties.get("key");
-            assertEquals(1, key.size());
+            assertThat(key.keySet(), containsInAnyOrder("properties"));
             Map<String, Object> keyProperties = (Map<String, Object>) key.get("properties");
-            assertEquals(1, keyProperties.size());
+            assertThat(keyProperties.keySet(), containsInAnyOrder("keyword"));
             assertLeafs(keyProperties, "keyword");
             Map<String, Object> value = (Map<String, Object>) propertiesProperties.get("value");
-            assertEquals(1, value.size());
+            assertThat(value.keySet(), containsInAnyOrder("properties"));
             Map<String, Object> valueProperties = (Map<String, Object>) value.get("properties");
-            assertEquals(1, valueProperties.size());
+            assertThat(valueProperties.keySet(), containsInAnyOrder("keyword"));
             assertLeafs(valueProperties, "keyword");
         }
 
@@ -864,11 +829,9 @@ public class MetadataTests extends ESTestCase {
         MappingMetadata docMapping = mappings.get(index);
         assertNotNull(docMapping);
         Map<String, Object> sourceAsMap = docMapping.getSourceAsMap();
-        assertEquals(3, sourceAsMap.size());
-        assertTrue(sourceAsMap.containsKey("_routing"));
-        assertTrue(sourceAsMap.containsKey("_source"));
+        assertThat(sourceAsMap.keySet(), containsInAnyOrder("_routing", "_source", "properties"));
         Map<String, Object> typeProperties = (Map<String, Object>) sourceAsMap.get("properties");
-        assertEquals(0, typeProperties.size());
+        assertThat(typeProperties, anEmptyMap());
     }
 
     @SuppressWarnings("unchecked")
@@ -877,62 +840,46 @@ public class MetadataTests extends ESTestCase {
         assertNotNull(docMapping);
 
         Map<String, Object> sourceAsMap = docMapping.getSourceAsMap();
-        assertEquals(3, sourceAsMap.size());
-        assertTrue(sourceAsMap.containsKey("_routing"));
-        assertTrue(sourceAsMap.containsKey("_source"));
+        assertThat(sourceAsMap.keySet(), containsInAnyOrder("_routing", "_source", "properties"));
 
         Map<String, Object> typeProperties = (Map<String, Object>) sourceAsMap.get("properties");
-        assertEquals(7, typeProperties.size());
-        assertTrue(typeProperties.containsKey("birth"));
-        assertTrue(typeProperties.containsKey("age"));
-        assertTrue(typeProperties.containsKey("ip"));
-        assertTrue(typeProperties.containsKey("suggest"));
+        assertThat(typeProperties.keySet(), containsInAnyOrder("name", "address", "birth", "age", "ip", "suggest", "properties"));
 
         Map<String, Object> name = (Map<String, Object>) typeProperties.get("name");
-        assertNotNull(name);
-        assertEquals(1, name.size());
+        assertThat(name.keySet(), containsInAnyOrder("properties"));
         Map<String, Object> nameProperties = (Map<String, Object>) name.get("properties");
-        assertNotNull(nameProperties);
-        assertEquals(2, nameProperties.size());
+        assertThat(nameProperties.keySet(), containsInAnyOrder("first", "last"));
         assertLeafs(nameProperties, "first", "last");
 
         Map<String, Object> address = (Map<String, Object>) typeProperties.get("address");
-        assertNotNull(address);
-        assertEquals(2, address.size());
-        assertTrue(address.containsKey("type"));
+        assertThat(address.keySet(), containsInAnyOrder("type", "properties"));
         Map<String, Object> addressProperties = (Map<String, Object>) address.get("properties");
-        assertNotNull(addressProperties);
-        assertEquals(3, addressProperties.size());
+        assertThat(addressProperties.keySet(), containsInAnyOrder("street", "location", "area"));
         assertLeafs(addressProperties, "street", "location", "area");
 
         Map<String, Object> properties = (Map<String, Object>) typeProperties.get("properties");
-        assertNotNull(properties);
-        assertEquals(2, properties.size());
-        assertTrue(properties.containsKey("type"));
+        assertThat(properties.keySet(), containsInAnyOrder("type", "properties"));
         Map<String, Object> propertiesProperties = (Map<String, Object>) properties.get("properties");
-        assertNotNull(propertiesProperties);
-        assertEquals(2, propertiesProperties.size());
+        assertThat(propertiesProperties.keySet(), containsInAnyOrder("key", "value"));
         assertMultiField(propertiesProperties, "key", "keyword");
         assertMultiField(propertiesProperties, "value", "keyword");
     }
 
     @SuppressWarnings("unchecked")
     public static void assertLeafs(Map<String, Object> properties, String... fields) {
+        assertThat(properties.keySet(), hasItems(fields));
         for (String field : fields) {
-            assertTrue(properties.containsKey(field));
             Map<String, Object> fieldProp = (Map<String, Object>) properties.get(field);
-            assertNotNull(fieldProp);
-            assertFalse(fieldProp.containsKey("properties"));
-            assertFalse(fieldProp.containsKey("fields"));
+            assertThat(fieldProp, not(hasKey("properties")));
+            assertThat(fieldProp, not(hasKey("fields")));
         }
     }
 
     public static void assertMultiField(Map<String, Object> properties, String field, String... subFields) {
-        assertTrue(properties.containsKey(field));
+        assertThat(properties, hasKey(field));
         @SuppressWarnings("unchecked")
         Map<String, Object> fieldProp = (Map<String, Object>) properties.get(field);
-        assertNotNull(fieldProp);
-        assertTrue(fieldProp.containsKey("fields"));
+        assertThat(fieldProp, hasKey("fields"));
         @SuppressWarnings("unchecked")
         Map<String, Object> subFieldsDef = (Map<String, Object>) fieldProp.get("fields");
         assertLeafs(subFieldsDef, subFields);
@@ -1127,7 +1074,7 @@ public class MetadataTests extends ESTestCase {
 
         b.put(newInstance(dataStreamName, backingIndices, lastBackingIndexNum, null));
         Metadata metadata = b.build();
-        assertThat(metadata.dataStreams().size(), equalTo(1));
+        assertThat(metadata.dataStreams().keySet(), containsInAnyOrder(dataStreamName));
         assertThat(metadata.dataStreams().get(dataStreamName).getName(), equalTo(dataStreamName));
     }
 
@@ -1150,7 +1097,7 @@ public class MetadataTests extends ESTestCase {
 
             assertThat(value.isHidden(), is(false));
             assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
-            assertThat(value.getIndices().size(), equalTo(ds.getIndices().size()));
+            assertThat(value.getIndices(), hasSize(ds.getIndices().size()));
             assertThat(value.getWriteIndex().getName(), equalTo(DataStream.getDefaultBackingIndexName(name, ds.getGeneration())));
         }
     }
@@ -1169,7 +1116,7 @@ public class MetadataTests extends ESTestCase {
         b.put("a3", "d1", null, null);
 
         Metadata metadata = b.build();
-        assertThat(metadata.dataStreams().size(), equalTo(4));
+        assertThat(metadata.dataStreams(), aMapWithSize(4));
         IndexAbstraction value = metadata.getIndicesLookup().get("d1");
         assertThat(value, notNullValue());
         assertThat(value.getType(), equalTo(IndexAbstraction.Type.DATA_STREAM));
@@ -1278,13 +1225,13 @@ public class MetadataTests extends ESTestCase {
         CreateIndexResult result = createIndices(numIndices, numBackingIndices, dataStreamName);
 
         SortedMap<String, IndexAbstraction> indicesLookup = result.metadata.getIndicesLookup();
-        assertThat(indicesLookup.size(), equalTo(result.indices.size() + result.backingIndices.size() + 1));
+        assertThat(indicesLookup, aMapWithSize(result.indices.size() + result.backingIndices.size() + 1));
         for (Index index : result.indices) {
-            assertTrue(indicesLookup.containsKey(index.getName()));
+            assertThat(indicesLookup, hasKey(index.getName()));
             assertNull(indicesLookup.get(index.getName()).getParentDataStream());
         }
         for (Index index : result.backingIndices) {
-            assertTrue(indicesLookup.containsKey(index.getName()));
+            assertThat(indicesLookup, hasKey(index.getName()));
             assertNotNull(indicesLookup.get(index.getName()).getParentDataStream());
             assertThat(indicesLookup.get(index.getName()).getParentDataStream().getName(), equalTo(dataStreamName));
         }
@@ -2076,7 +2023,7 @@ public class MetadataTests extends ESTestCase {
             }
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size()));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size()));
         assertThat(
             metadata.indices().values().stream().map(IndexMetadata::mapping).collect(Collectors.toSet()),
             hasSize(metadata.getMappingsByHash().size())
@@ -2096,7 +2043,7 @@ public class MetadataTests extends ESTestCase {
             );
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size()));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size()));
         assertThat(metadata.getMappingsByHash().get(mapping.getSha256()), equalTo(entry));
 
         // Remove index and ensure mapping cache stays the same
@@ -2105,7 +2052,7 @@ public class MetadataTests extends ESTestCase {
             mb.remove("index-" + numIndices);
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size()));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size()));
         assertThat(metadata.getMappingsByHash().get(mapping.getSha256()), equalTo(entry));
 
         // Update a mapping of an index:
@@ -2117,7 +2064,7 @@ public class MetadataTests extends ESTestCase {
             mb.put(IndexMetadata.builder(luckyIndex).putMapping(updatedMapping));
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size() + 1));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size() + 1));
         assertThat(metadata.getMappingsByHash().get(luckyIndex.mapping().getSha256()), equalTo(entry));
         assertThat(metadata.getMappingsByHash().get(updatedMapping.getSha256()), equalTo(updatedMapping));
 
@@ -2127,7 +2074,7 @@ public class MetadataTests extends ESTestCase {
             mb.remove(luckyIndex.getIndex().getName());
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size()));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size()));
         assertThat(metadata.getMappingsByHash().get(updatedMapping.getSha256()), nullValue());
 
         // Add an index with new mapping and then later remove it:
@@ -2143,7 +2090,7 @@ public class MetadataTests extends ESTestCase {
             );
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size() + 1));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size() + 1));
         assertThat(metadata.getMappingsByHash().get(newMapping.getSha256()), equalTo(newMapping));
 
         {
@@ -2151,7 +2098,7 @@ public class MetadataTests extends ESTestCase {
             mb.remove("index-" + numIndices);
             metadata = mb.build();
         }
-        assertThat(metadata.getMappingsByHash().size(), equalTo(randomMappingDefinitions.size()));
+        assertThat(metadata.getMappingsByHash(), aMapWithSize(randomMappingDefinitions.size()));
         assertThat(metadata.getMappingsByHash().get(newMapping.getSha256()), nullValue());
     }
 
@@ -2292,7 +2239,7 @@ public class MetadataTests extends ESTestCase {
         // we check for global state changes, or in the fields excluded from the global state check.
         var unclassifiedFields = Arrays.stream(Metadata.class.getDeclaredFields())
             .filter(f -> Modifier.isStatic(f.getModifiers()) == false)
-            .map(f -> f.getName())
+            .map(Field::getName)
             .filter(n -> (checkedForGlobalStateChanges.contains(n) || excludedFromGlobalStateCheck.contains(n)) == false)
             .collect(Collectors.toSet());
         assertThat(unclassifiedFields, empty());


### PR DESCRIPTION
Use more idiomatic asserts that provide better error messages