### PR TITLE
Fix CoordinationDiagnosticsServiceIT leaving broken global state

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsServiceIT.java
@@ -22,6 +22,7 @@ import org.elasticsearch.test.disruption.NetworkDisruption;
 import org.elasticsearch.test.transport.MockTransportService;
 import org.elasticsearch.threadpool.Scheduler;
 import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
 import org.junit.Before;
 
 import java.io.IOException;
@@ -50,8 +51,8 @@ public class CoordinationDiagnosticsServiceIT extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
     }
 
-    @Before
-    private void restoreDefaultInitialDelay() {
+    @After
+    public void restoreDefaultInitialDelay() {
         CoordinationDiagnosticsService.remoteRequestInitialDelay = new TimeValue(10, TimeUnit.SECONDS);
     }
 


### PR DESCRIPTION
Found this trying to debug some tests. We were not restoring the default initial delay properly. This caused all tests after this class to run with a 0 delay which introduced a very visible amount of contention on the scheduled executor (as in tens of seconds of blocking for internal cluster tests in :server).
