### PR TITLE
Dry up some spots around map reading from StreamInput

### DIFF
--- a/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSelectorPipelineAggregationBuilder.java
+++ b/modules/aggregations/src/main/java/org/elasticsearch/aggregations/pipeline/BucketSelectorPipelineAggregationBuilder.java
@@ -48,7 +48,7 @@ public class BucketSelectorPipelineAggregationBuilder extends AbstractPipelineAg
      */
     public BucketSelectorPipelineAggregationBuilder(StreamInput in) throws IOException {
         super(in, NAME);
-        bucketsPathsMap = in.readMap(StreamInput::readString, StreamInput::readString);
+        bucketsPathsMap = in.readMap(StreamInput::readString);
         script = new Script(in);
         gapPolicy = GapPolicy.readFrom(in);
     }

--- a/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
+++ b/modules/ingest-common/src/main/java/org/elasticsearch/ingest/common/GrokProcessorGetAction.java
@@ -98,7 +98,7 @@ public class GrokProcessorGetAction extends ActionType<GrokProcessorGetAction.Re
 
         Response(StreamInput in) throws IOException {
             super(in);
-            grokPatterns = in.readMap(StreamInput::readString, StreamInput::readString);
+            grokPatterns = in.readMap(StreamInput::readString);
         }
 
         public Map<String, String> getGrokPatterns() {

--- a/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
+++ b/modules/ingest-geoip/src/main/java/org/elasticsearch/ingest/geoip/GeoIpTaskState.java
@@ -67,10 +67,7 @@ class GeoIpTaskState implements PersistentTaskState, VersionedNamedWriteable {
     }
 
     GeoIpTaskState(StreamInput input) throws IOException {
-        databases = input.readImmutableMap(StreamInput::readString, in -> {
-            long lastUpdate = in.readLong();
-            return new Metadata(lastUpdate, in.readVInt(), in.readVInt(), in.readString(), in.readLong());
-        });
+        databases = input.readImmutableMap(in -> new Metadata(in.readLong(), in.readVInt(), in.readVInt(), in.readString(), in.readLong()));
     }
 
     public GeoIpTaskState put(String name, Metadata metadata) {

--- a/server/src/main/java/org/elasticsearch/ElasticsearchException.java
+++ b/server/src/main/java/org/elasticsearch/ElasticsearchException.java
@@ -145,8 +145,8 @@ public class ElasticsearchException extends RuntimeException implements ToXConte
     public ElasticsearchException(StreamInput in) throws IOException {
         super(in.readOptionalString(), in.readException());
         readStackTrace(this, in);
-        headers.putAll(in.readMapOfLists(StreamInput::readString, StreamInput::readString));
-        metadata.putAll(in.readMapOfLists(StreamInput::readString, StreamInput::readString));
+        headers.putAll(in.readMapOfLists(StreamInput::readString));
+        metadata.putAll(in.readMapOfLists(StreamInput::readString));
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/allocation/DesiredBalanceResponse.java
@@ -61,7 +61,7 @@ public class DesiredBalanceResponse extends ActionResponse implements ChunkedToX
             in.getTransportVersion().onOrAfter(CLUSTER_BALANCE_STATS_VERSION)
                 ? ClusterBalanceStats.readFrom(in)
                 : ClusterBalanceStats.EMPTY,
-            in.readImmutableMap(StreamInput::readString, v -> v.readImmutableMap(StreamInput::readVInt, DesiredShards::from)),
+            in.readImmutableMap(v -> v.readImmutableMap(StreamInput::readVInt, DesiredShards::from)),
             in.getTransportVersion().onOrAfter(CLUSTER_INFO_VERSION) ? new ClusterInfo(in) : ClusterInfo.EMPTY
         );
     }

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/shards/ClusterSearchShardsResponse.java
@@ -30,7 +30,7 @@ public class ClusterSearchShardsResponse extends ActionResponse implements ToXCo
         super(in);
         groups = in.readArray(ClusterSearchShardsGroup::new, ClusterSearchShardsGroup[]::new);
         nodes = in.readArray(DiscoveryNode::new, DiscoveryNode[]::new);
-        indicesAndFilters = in.readMap(StreamInput::readString, AliasFilter::readFrom);
+        indicesAndFilters = in.readMap(AliasFilter::readFrom);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/GetSnapshotsResponse.java
@@ -94,7 +94,7 @@ public class GetSnapshotsResponse extends ActionResponse implements ChunkedToXCo
     public GetSnapshotsResponse(StreamInput in) throws IOException {
         this.snapshots = in.readImmutableList(SnapshotInfo::readFrom);
         if (in.getTransportVersion().onOrAfter(GetSnapshotsRequest.MULTIPLE_REPOSITORIES_SUPPORT_ADDED)) {
-            final Map<String, ElasticsearchException> failedResponses = in.readMap(StreamInput::readString, StreamInput::readException);
+            final Map<String, ElasticsearchException> failedResponses = in.readMap(StreamInput::readException);
             this.failures = Collections.unmodifiableMap(failedResponses);
             this.next = in.readOptionalString();
         } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/shard/GetShardSnapshotResponse.java
@@ -34,7 +34,7 @@ public class GetShardSnapshotResponse extends ActionResponse {
     GetShardSnapshotResponse(StreamInput in) throws IOException {
         super(in);
         this.latestShardSnapshot = in.readOptionalWriteable(ShardSnapshotInfo::new);
-        this.repositoryFailures = in.readMap(StreamInput::readString, RepositoryException::new);
+        this.repositoryFailures = in.readMap(RepositoryException::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/SearchUsageStats.java
@@ -51,8 +51,8 @@ public final class SearchUsageStats implements Writeable, ToXContentFragment {
     }
 
     public SearchUsageStats(StreamInput in) throws IOException {
-        this.queries = in.readMap(StreamInput::readString, StreamInput::readLong);
-        this.sections = in.readMap(StreamInput::readString, StreamInput::readLong);
+        this.queries = in.readMap(StreamInput::readLong);
+        this.sections = in.readMap(StreamInput::readLong);
         this.totalSearchCount = in.readVLong();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/alias/get/GetAliasesResponse.java
@@ -32,7 +32,7 @@ public class GetAliasesResponse extends ActionResponse {
     public GetAliasesResponse(StreamInput in) throws IOException {
         super(in);
         aliases = in.readImmutableOpenMap(StreamInput::readString, i -> i.readList(AliasMetadata::new));
-        dataStreamAliases = in.readMap(StreamInput::readString, in1 -> in1.readList(DataStreamAlias::new));
+        dataStreamAliases = in.readMap(in1 -> in1.readList(DataStreamAlias::new));
     }
 
     public Map<String, List<AliasMetadata>> getAliases() {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/ReloadAnalyzersResponse.java
@@ -45,7 +45,7 @@ public class ReloadAnalyzersResponse extends BroadcastResponse {
 
     public ReloadAnalyzersResponse(StreamInput in) throws IOException {
         super(in);
-        this.reloadDetails = in.readMap(StreamInput::readString, ReloadDetails::new);
+        this.reloadDetails = in.readMap(ReloadDetails::new);
     }
 
     public ReloadAnalyzersResponse(

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/AnalyzeIndexDiskUsageResponse.java
@@ -34,7 +34,7 @@ public final class AnalyzeIndexDiskUsageResponse extends BroadcastResponse {
 
     AnalyzeIndexDiskUsageResponse(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap(StreamInput::readString, IndexDiskUsageStats::new);
+        stats = in.readMap(IndexDiskUsageStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/diskusage/IndexDiskUsageStats.java
@@ -55,7 +55,7 @@ public final class IndexDiskUsageStats implements ToXContentFragment, Writeable 
     }
 
     public IndexDiskUsageStats(StreamInput in) throws IOException {
-        this.fields = new HashMap<>(in.readMap(StreamInput::readString, PerFieldDiskUsage::new));
+        this.fields = new HashMap<>(in.readMap(PerFieldDiskUsage::new));
         this.indexSizeInBytes = in.readVLong();
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetFieldMappingsResponse.java
@@ -51,7 +51,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
 
     GetFieldMappingsResponse(StreamInput in) throws IOException {
         super(in);
-        mappings = in.readImmutableMap(StreamInput::readString, mapIn -> {
+        mappings = in.readImmutableMap(mapIn -> {
             if (mapIn.getTransportVersion().before(TransportVersion.V_8_0_0)) {
                 int typesSize = mapIn.readVInt();
                 assert typesSize == 1 || typesSize == 0 : "Expected 0 or 1 types but got " + typesSize;
@@ -60,10 +60,7 @@ public class GetFieldMappingsResponse extends ActionResponse implements ToXConte
                 }
                 mapIn.readString(); // type
             }
-            return mapIn.readImmutableMap(
-                StreamInput::readString,
-                inpt -> new FieldMappingMetadata(inpt.readString(), inpt.readBytesReference())
-            );
+            return mapIn.readImmutableMap(inpt -> new FieldMappingMetadata(inpt.readString(), inpt.readBytesReference()));
         });
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/mapping/get/GetMappingsResponse.java
@@ -40,7 +40,7 @@ public class GetMappingsResponse extends ActionResponse implements ChunkedToXCon
 
     GetMappingsResponse(StreamInput in) throws IOException {
         super(in);
-        mappings = in.readImmutableMap(StreamInput::readString, in.getTransportVersion().before(TransportVersion.V_8_0_0) ? i -> {
+        mappings = in.readImmutableMap(in.getTransportVersion().before(TransportVersion.V_8_0_0) ? i -> {
             int mappingCount = i.readVInt();
             assert mappingCount == 1 || mappingCount == 0 : "Expected 0 or 1 mappings but got " + mappingCount;
             if (mappingCount == 1) {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/recovery/RecoveryResponse.java
@@ -32,7 +32,7 @@ public class RecoveryResponse extends BaseBroadcastResponse implements ChunkedTo
 
     public RecoveryResponse(StreamInput in) throws IOException {
         super(in);
-        shardRecoveryStates = in.readMapOfLists(StreamInput::readString, RecoveryState::readRecoveryState);
+        shardRecoveryStates = in.readMapOfLists(RecoveryState::readRecoveryState);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsResponse.java
@@ -40,8 +40,8 @@ public class GetSettingsResponse extends ActionResponse implements ChunkedToXCon
 
     public GetSettingsResponse(StreamInput in) throws IOException {
         super(in);
-        indexToSettings = in.readImmutableMap(StreamInput::readString, Settings::readSettingsFromStream);
-        indexToDefaultSettings = in.readImmutableMap(StreamInput::readString, Settings::readSettingsFromStream);
+        indexToSettings = in.readImmutableMap(Settings::readSettingsFromStream);
+        indexToDefaultSettings = in.readImmutableMap(Settings::readSettingsFromStream);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shards/IndicesShardStoresResponse.java
@@ -245,10 +245,7 @@ public class IndicesShardStoresResponse extends ActionResponse implements Chunke
 
     public IndicesShardStoresResponse(StreamInput in) throws IOException {
         super(in);
-        storeStatuses = in.readImmutableMap(
-            StreamInput::readString,
-            i -> i.readImmutableMap(StreamInput::readInt, j -> j.readImmutableList(StoreStatus::new))
-        );
+        storeStatuses = in.readImmutableMap(i -> i.readImmutableMap(StreamInput::readInt, j -> j.readImmutableList(StoreStatus::new)));
         failures = in.readImmutableList(Failure::readFailure);
     }
 

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/FieldUsageStatsResponse.java
@@ -35,7 +35,7 @@ public class FieldUsageStatsResponse extends ChunkedBroadcastResponse {
 
     FieldUsageStatsResponse(StreamInput in) throws IOException {
         super(in);
-        stats = in.readMap(StreamInput::readString, i -> i.readList(FieldUsageShardResponse::new));
+        stats = in.readMap(i -> i.readList(FieldUsageShardResponse::new));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsResponse.java
@@ -52,8 +52,8 @@ public class IndicesStatsResponse extends ChunkedBroadcastResponse {
         super(in);
         shards = in.readArray(ShardStats::new, ShardStats[]::new);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_1_0)) {
-            indexHealthMap = in.readMap(StreamInput::readString, ClusterHealthStatus::readFrom);
-            indexStateMap = in.readMap(StreamInput::readString, IndexMetadata.State::readFrom);
+            indexHealthMap = in.readMap(ClusterHealthStatus::readFrom);
+            indexStateMap = in.readMap(IndexMetadata.State::readFrom);
         } else {
             indexHealthMap = Map.of();
             indexStateMap = Map.of();

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComponentTemplateAction.java
@@ -120,7 +120,7 @@ public class GetComponentTemplateAction extends ActionType<GetComponentTemplateA
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            componentTemplates = in.readMap(StreamInput::readString, ComponentTemplate::new);
+            componentTemplates = in.readMap(ComponentTemplate::new);
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_007)) {
                 rolloverConfiguration = in.readOptionalWriteable(RolloverConfiguration::new);
             } else {

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/template/get/GetComposableIndexTemplateAction.java
@@ -122,7 +122,7 @@ public class GetComposableIndexTemplateAction extends ActionType<GetComposableIn
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            indexTemplates = in.readMap(StreamInput::readString, ComposableIndexTemplate::new);
+            indexTemplates = in.readMap(ComposableIndexTemplate::new);
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_007)) {
                 rolloverConfiguration = in.readOptionalWriteable(RolloverConfiguration::new);
             } else {

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilities.java
@@ -244,7 +244,7 @@ public class FieldCapabilities implements Writeable, ToXContentObject {
             this.nonDimensionIndices = null;
             this.metricConflictsIndices = null;
         }
-        meta = in.readMap(StreamInput::readString, i -> i.readSet(StreamInput::readString));
+        meta = in.readMap(i -> i.readSet(StreamInput::readString));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesIndexResponse.java
@@ -47,7 +47,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
 
     FieldCapabilitiesIndexResponse(StreamInput in) throws IOException {
         this.indexName = in.readString();
-        this.responseMap = in.readMap(StreamInput::readString, IndexFieldCapabilities::new);
+        this.responseMap = in.readMap(IndexFieldCapabilities::new);
         this.canMatch = in.readBoolean();
         this.originVersion = in.getTransportVersion();
         if (in.getTransportVersion().onOrAfter(MAPPING_HASH_VERSION)) {
@@ -71,7 +71,7 @@ final class FieldCapabilitiesIndexResponse implements Writeable {
         implements
             Writeable {
         GroupByMappingHash(StreamInput in) throws IOException {
-            this(in.readStringList(), in.readString(), in.readMap(StreamInput::readString, IndexFieldCapabilities::new));
+            this(in.readStringList(), in.readString(), in.readMap(IndexFieldCapabilities::new));
         }
 
         @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/FieldCapabilitiesResponse.java
@@ -76,7 +76,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
     public FieldCapabilitiesResponse(StreamInput in) throws IOException {
         super(in);
         indices = in.readStringArray();
-        this.responseMap = in.readMap(StreamInput::readString, FieldCapabilitiesResponse::readField);
+        this.responseMap = in.readMap(FieldCapabilitiesResponse::readField);
         this.indexResponses = FieldCapabilitiesIndexResponse.readList(in);
         this.failures = in.readList(FieldCapabilitiesFailure::new);
     }
@@ -136,7 +136,7 @@ public class FieldCapabilitiesResponse extends ActionResponse implements Chunked
     }
 
     private static Map<String, FieldCapabilities> readField(StreamInput in) throws IOException {
-        return in.readMap(StreamInput::readString, FieldCapabilities::new);
+        return in.readMap(FieldCapabilities::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
+++ b/server/src/main/java/org/elasticsearch/action/fieldcaps/IndexFieldCapabilities.java
@@ -75,7 +75,7 @@ public class IndexFieldCapabilities implements Writeable {
             this.isDimension = false;
             this.metricType = null;
         }
-        this.meta = in.readMap(StreamInput::readString, StreamInput::readString);
+        this.meta = in.readMap(StreamInput::readString);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/index/IndexRequest.java
@@ -159,7 +159,7 @@ public class IndexRequest extends ReplicatedWriteRequest<IndexRequest> implement
             requireAlias = false;
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0)) {
-            dynamicTemplates = in.readMap(StreamInput::readString, StreamInput::readString);
+            dynamicTemplates = in.readMap(StreamInput::readString);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchContextId.java
@@ -93,7 +93,7 @@ public final class SearchContextId {
             final TransportVersion version = TransportVersion.readVersion(in);
             in.setTransportVersion(version);
             final Map<ShardId, SearchContextIdForNode> shards = in.readMap(ShardId::new, SearchContextIdForNode::new);
-            final Map<String, AliasFilter> aliasFilters = in.readMap(StreamInput::readString, AliasFilter::readFrom);
+            final Map<String, AliasFilter> aliasFilters = in.readMap(AliasFilter::readFrom);
             if (in.available() > 0) {
                 throw new IllegalArgumentException("Not all bytes were read");
             }

--- a/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchRequest.java
@@ -268,7 +268,7 @@ public class SearchRequest extends ActionRequest implements IndicesRequest.Repla
             minCompatibleShardNode = null;
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-            waitForCheckpoints = in.readMap(StreamInput::readString, StreamInput::readLongArray);
+            waitForCheckpoints = in.readMap(StreamInput::readLongArray);
             waitForCheckpointsTimeout = in.readTimeValue();
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_4_0)) {

--- a/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
+++ b/server/src/main/java/org/elasticsearch/action/search/SearchShardsResponse.java
@@ -49,7 +49,7 @@ public final class SearchShardsResponse extends ActionResponse {
         super(in);
         this.groups = in.readList(SearchShardsGroup::new);
         this.nodes = in.readList(DiscoveryNode::new);
-        this.aliasFilters = in.readMap(StreamInput::readString, AliasFilter::readFrom);
+        this.aliasFilters = in.readMap(AliasFilter::readFrom);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
+++ b/server/src/main/java/org/elasticsearch/action/termvectors/TermVectorsFields.java
@@ -131,7 +131,7 @@ public final class TermVectorsFields extends Fields {
             hasTermStatistic = header.readBoolean();
             hasFieldStatistic = header.readBoolean();
             hasScores = header.readBoolean();
-            fieldMap = header.readMap(StreamInput::readString, StreamInput::readVLong);
+            fieldMap = header.readMap(StreamInput::readVLong);
         }
         // reference to the term vector data
         this.termVectors = termVectors;

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterInfo.java
@@ -84,9 +84,9 @@ public class ClusterInfo implements ToXContentFragment, Writeable {
     }
 
     public ClusterInfo(StreamInput in) throws IOException {
-        this.leastAvailableSpaceUsage = in.readImmutableMap(StreamInput::readString, DiskUsage::new);
-        this.mostAvailableSpaceUsage = in.readImmutableMap(StreamInput::readString, DiskUsage::new);
-        this.shardSizes = in.readImmutableMap(StreamInput::readString, StreamInput::readLong);
+        this.leastAvailableSpaceUsage = in.readImmutableMap(DiskUsage::new);
+        this.mostAvailableSpaceUsage = in.readImmutableMap(DiskUsage::new);
+        this.shardSizes = in.readImmutableMap(StreamInput::readLong);
         this.shardDataSetSizes = in.getTransportVersion().onOrAfter(DATA_SET_SIZE_SIZE_VERSION)
             ? in.readImmutableMap(ShardId::new, StreamInput::readLong)
             : Map.of();

--- a/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
+++ b/server/src/main/java/org/elasticsearch/cluster/ClusterState.java
@@ -908,7 +908,7 @@ public class ClusterState implements ChunkedToXContent, Diffable<ClusterState> {
         builder.routingTable = RoutingTable.readFrom(in);
         builder.nodes = DiscoveryNodes.readFrom(in, localNode);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_8_0)) {
-            builder.transportVersions(in.readMap(StreamInput::readString, TransportVersion::readVersion));
+            builder.transportVersions(in.readMap(TransportVersion::readVersion));
         } else {
             // this clusterstate is from a pre-8.8.0 node
             // infer the versions from discoverynodes for now

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/ClusterFormationFailureHelper.java
@@ -206,7 +206,7 @@ public class ClusterFormationFailureHelper {
             this(
                 in.readStringList(),
                 new DiscoveryNode(in),
-                in.readMap(StreamInput::readString, DiscoveryNode::new),
+                in.readMap(DiscoveryNode::new),
                 in.readLong(),
                 in.readLong(),
                 new VotingConfiguration(in),

--- a/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
+++ b/server/src/main/java/org/elasticsearch/cluster/coordination/CoordinationDiagnosticsService.java
@@ -1291,7 +1291,7 @@ public class CoordinationDiagnosticsService implements ClusterStateListener {
 
         private static Map<String, String> readClusterFormationStates(StreamInput in) throws IOException {
             if (in.readBoolean()) {
-                return in.readMap(StreamInput::readString, StreamInput::readString);
+                return in.readMap(StreamInput::readString);
             } else {
                 return Map.of();
             }

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComponentTemplateMetadata.java
@@ -59,7 +59,7 @@ public class ComponentTemplateMetadata implements Metadata.Custom {
     }
 
     public ComponentTemplateMetadata(StreamInput in) throws IOException {
-        this.componentTemplates = in.readMap(StreamInput::readString, ComponentTemplate::new);
+        this.componentTemplates = in.readMap(ComponentTemplate::new);
     }
 
     public Map<String, ComponentTemplate> componentTemplates() {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/ComposableIndexTemplateMetadata.java
@@ -60,7 +60,7 @@ public class ComposableIndexTemplateMetadata implements Metadata.Custom {
     }
 
     public ComposableIndexTemplateMetadata(StreamInput in) throws IOException {
-        this.indexTemplates = in.readMap(StreamInput::readString, ComposableIndexTemplate::new);
+        this.indexTemplates = in.readMap(ComposableIndexTemplate::new);
     }
 
     public static ComposableIndexTemplateMetadata fromXContent(XContentParser parser) throws IOException {

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DataStreamAlias.java
@@ -168,7 +168,7 @@ public class DataStreamAlias implements SimpleDiffable<DataStreamAlias>, ToXCont
         this.dataStreams = in.readStringList();
         this.writeDataStream = in.readOptionalString();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)) {
-            this.dataStreamToFilterMap = in.readMap(StreamInput::readString, CompressedXContent::readCompressedString);
+            this.dataStreamToFilterMap = in.readMap(CompressedXContent::readCompressedString);
         } else {
             this.dataStreamToFilterMap = new HashMap<>();
             CompressedXContent filter = in.readBoolean() ? CompressedXContent.readCompressedString(in) : null;

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/DiffableStringMap.java
@@ -89,7 +89,7 @@ public class DiffableStringMap extends AbstractMap<String, String> implements Di
 
     public static Diff<DiffableStringMap> readDiffFrom(StreamInput in) throws IOException {
         final List<String> deletes = in.readStringList();
-        final Map<String, String> upserts = in.readMap(StreamInput::readString, StreamInput::readString);
+        final Map<String, String> upserts = in.readMap(StreamInput::readString);
         return getDiff(deletes, upserts);
     }
 

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/NodesShutdownMetadata.java
@@ -74,7 +74,7 @@ public class NodesShutdownMetadata implements Metadata.Custom {
     }
 
     public NodesShutdownMetadata(StreamInput in) throws IOException {
-        this(in.readImmutableMap(StreamInput::readString, SingleNodeShutdownMetadata::new));
+        this(in.readImmutableMap(SingleNodeShutdownMetadata::new));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
+++ b/server/src/main/java/org/elasticsearch/cluster/metadata/Template.java
@@ -145,7 +145,7 @@ public class Template implements SimpleDiffable<Template>, ToXContentObject {
             this.mappings = null;
         }
         if (in.readBoolean()) {
-            this.aliases = in.readMap(StreamInput::readString, AliasMetadata::new);
+            this.aliases = in.readMap(AliasMetadata::new);
         } else {
             this.aliases = null;
         }

--- a/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
+++ b/server/src/main/java/org/elasticsearch/cluster/routing/allocation/allocator/ClusterBalanceStats.java
@@ -60,10 +60,7 @@ public record ClusterBalanceStats(Map<String, TierBalanceStats> tiers, Map<Strin
     }
 
     public static ClusterBalanceStats readFrom(StreamInput in) throws IOException {
-        return new ClusterBalanceStats(
-            in.readImmutableMap(StreamInput::readString, TierBalanceStats::readFrom),
-            in.readImmutableMap(StreamInput::readString, NodeBalanceStats::readFrom)
-        );
+        return new ClusterBalanceStats(in.readImmutableMap(TierBalanceStats::readFrom), in.readImmutableMap(NodeBalanceStats::readFrom));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
+++ b/server/src/main/java/org/elasticsearch/common/FieldMemoryStats.java
@@ -39,7 +39,7 @@ public final class FieldMemoryStats implements Writeable, Iterable<Map.Entry<Str
      * Creates a new FieldMemoryStats instance from a stream
      */
     public FieldMemoryStats(StreamInput input) throws IOException {
-        stats = input.readMap(StreamInput::readString, StreamInput::readVLong);
+        stats = input.readMap(StreamInput::readVLong);
     }
 
     /**

--- a/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
+++ b/server/src/main/java/org/elasticsearch/common/io/stream/StreamInput.java
@@ -619,6 +619,13 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
+     * Same as {@link #readMap(Writeable.Reader, Writeable.Reader)} but always reading string keys.
+     */
+    public <V> Map<String, V> readMap(Writeable.Reader<V> valueReader) throws IOException {
+        return readMap(StreamInput::readString, valueReader, Maps::newHashMapWithExpectedSize);
+    }
+
+    /**
      * If the returned map contains any entries it will be mutable. If it is empty it might be immutable.
      */
     public <K, V> Map<K, V> readMap(Writeable.Reader<K> keyReader, Writeable.Reader<V> valueReader) throws IOException {
@@ -645,28 +652,18 @@ public abstract class StreamInput extends InputStream {
     }
 
     /**
-     * Read a {@link Map} of {@code K}-type keys to {@code V}-type {@link List}s.
+     * Read a {@link Map} of string keys to {@code V}-type {@link List}s.
      * <pre><code>
-     * Map&lt;String, List&lt;String&gt;&gt; map = in.readMapOfLists(StreamInput::readString, StreamInput::readString);
+     * Map&lt;String, List&lt;String&gt;&gt; map = in.readMapOfLists(StreamInput::readString);
      * </code></pre>
      * If the map or a list in it contains any elements it will be mutable, otherwise either the empty map or empty lists it contains
      * might be immutable.
      *
-     * @param keyReader The key reader
      * @param valueReader The value reader
      * @return Never {@code null}.
      */
-    public <K, V> Map<K, List<V>> readMapOfLists(final Writeable.Reader<K> keyReader, final Writeable.Reader<V> valueReader)
-        throws IOException {
-        final int size = readArraySize();
-        if (size == 0) {
-            return Collections.emptyMap();
-        }
-        final Map<K, List<V>> map = Maps.newMapWithExpectedSize(size);
-        for (int i = 0; i < size; ++i) {
-            map.put(keyReader.read(this), readList(valueReader));
-        }
-        return map;
+    public <V> Map<String, List<V>> readMapOfLists(final Writeable.Reader<V> valueReader) throws IOException {
+        return readMap(i -> i.readList(valueReader));
     }
 
     /**
@@ -696,6 +693,13 @@ public abstract class StreamInput extends InputStream {
     @SuppressWarnings("unchecked")
     public Map<String, Object> readMap() throws IOException {
         return (Map<String, Object>) readGenericValue();
+    }
+
+    /**
+     * Same as {@link #readMap(Writeable.Reader, Writeable.Reader)} but always reading string keys.
+     */
+    public <V> Map<String, V> readImmutableMap(Writeable.Reader<V> valueReader) throws IOException {
+        return readImmutableMap(StreamInput::readString, valueReader);
     }
 
     /**
@@ -762,7 +766,7 @@ public abstract class StreamInput extends InputStream {
                 : readOrderedMap(StreamInput::readString, StreamInput::readGenericValue);
             case 10 -> getTransportVersion().onOrAfter(TransportVersion.V_8_7_0)
                 ? readMap(StreamInput::readGenericValue, StreamInput::readGenericValue)
-                : readMap(StreamInput::readString, StreamInput::readGenericValue);
+                : readMap(StreamInput::readGenericValue);
             case 11 -> readByte();
             case 12 -> readDate();
             case 13 ->

--- a/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/KeyStoreWrapper.java
@@ -179,7 +179,7 @@ public class KeyStoreWrapper implements SecureSettings {
         formatVersion = input.readInt();
         hasPassword = input.readBoolean();
         dataBytes = input.readOptionalByteArray();
-        entries.set(input.readMap(StreamInput::readString, Entry::new));
+        entries.set(input.readMap(Entry::new));
         closed = input.readBoolean();
     }
 

--- a/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/LocallyMountedSecrets.java
@@ -252,7 +252,7 @@ public class LocallyMountedSecrets implements SecureSettings {
          */
         public static LocalFileSecrets readFrom(StreamInput in) throws IOException {
             assert in.getTransportVersion() == TransportVersion.current();
-            return new LocalFileSecrets(in.readMap(StreamInput::readString, StreamInput::readByteArray), ReservedStateVersion.readFrom(in));
+            return new LocalFileSecrets(in.readMap(StreamInput::readByteArray), ReservedStateVersion.readFrom(in));
         }
 
         /**

--- a/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
+++ b/server/src/main/java/org/elasticsearch/common/util/concurrent/ThreadContext.java
@@ -463,8 +463,8 @@ public final class ThreadContext implements Writeable {
     }
 
     public static Tuple<Map<String, String>, Map<String, Set<String>>> readHeadersFromStream(StreamInput in) throws IOException {
-        final Map<String, String> requestHeaders = in.readMap(StreamInput::readString, StreamInput::readString);
-        final Map<String, Set<String>> responseHeaders = in.readMap(StreamInput::readString, input -> {
+        final Map<String, String> requestHeaders = in.readMap(StreamInput::readString);
+        final Map<String, Set<String>> responseHeaders = in.readMap(input -> {
             final int size = input.readVInt();
             if (size == 0) {
                 return Collections.emptySet();

--- a/server/src/main/java/org/elasticsearch/health/node/HealthInfo.java
+++ b/server/src/main/java/org/elasticsearch/health/node/HealthInfo.java
@@ -23,7 +23,7 @@ public record HealthInfo(Map<String, DiskHealthInfo> diskInfoByNode) implements 
     public static final HealthInfo EMPTY_HEALTH_INFO = new HealthInfo(Map.of());
 
     public HealthInfo(StreamInput input) throws IOException {
-        this(input.readMap(StreamInput::readString, DiskHealthInfo::new));
+        this(input.readMap(DiskHealthInfo::new));
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/engine/CommitStats.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/CommitStats.java
@@ -38,7 +38,7 @@ public final class CommitStats implements Writeable, ToXContentFragment {
     }
 
     CommitStats(StreamInput in) throws IOException {
-        userData = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
+        userData = in.readImmutableMap(StreamInput::readString);
         generation = in.readLong();
         id = in.readOptionalString();
         numDocs = in.readInt();

--- a/server/src/main/java/org/elasticsearch/index/engine/Segment.java
+++ b/server/src/main/java/org/elasticsearch/index/engine/Segment.java
@@ -60,7 +60,7 @@ public class Segment implements Writeable {
         }
         segmentSort = readSegmentSort(in);
         if (in.readBoolean()) {
-            attributes = in.readMap(StreamInput::readString, StreamInput::readString);
+            attributes = in.readMap(StreamInput::readString);
         } else {
             attributes = null;
         }

--- a/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
+++ b/server/src/main/java/org/elasticsearch/index/fielddata/FieldDataStats.java
@@ -52,7 +52,6 @@ public class FieldDataStats implements Writeable, ToXContentFragment {
             Map<String, GlobalOrdinalsStats.GlobalOrdinalFieldStats> fieldGlobalOrdinalsStats = null;
             if (in.readBoolean()) {
                 fieldGlobalOrdinalsStats = in.readMap(
-                    StreamInput::readString,
                     in1 -> new GlobalOrdinalsStats.GlobalOrdinalFieldStats(in1.readVLong(), in1.readVLong())
                 );
             }

--- a/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/FieldUsageStats.java
@@ -52,7 +52,7 @@ public class FieldUsageStats implements ToXContentObject, Writeable {
     }
 
     public FieldUsageStats(StreamInput in) throws IOException {
-        stats = in.readMap(StreamInput::readString, PerFieldUsageStats::new);
+        stats = in.readMap(PerFieldUsageStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
+++ b/server/src/main/java/org/elasticsearch/index/search/stats/SearchStats.java
@@ -297,7 +297,7 @@ public class SearchStats implements Writeable, ToXContentFragment {
         totalStats = Stats.readStats(in);
         openContexts = in.readVLong();
         if (in.readBoolean()) {
-            groupStats = in.readMap(StreamInput::readString, Stats::readStats);
+            groupStats = in.readMap(Stats::readStats);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
+++ b/server/src/main/java/org/elasticsearch/index/seqno/ReplicationTracker.java
@@ -1583,7 +1583,7 @@ public class ReplicationTracker extends AbstractIndexShardComponent implements L
 
         public PrimaryContext(StreamInput in) throws IOException {
             clusterStateVersion = in.readVLong();
-            checkpoints = in.readMap(StreamInput::readString, CheckpointState::new);
+            checkpoints = in.readMap(CheckpointState::new);
             routingTable = IndexShardRoutingTable.Builder.readFrom(in).build();
         }
 

--- a/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
+++ b/server/src/main/java/org/elasticsearch/index/shard/IndexingStats.java
@@ -270,7 +270,7 @@ public class IndexingStats implements Writeable, ToXContentFragment {
         totalStats = new Stats(in);
         if (in.getTransportVersion().before(TransportVersion.V_8_0_0)) {
             if (in.readBoolean()) {
-                Map<String, Stats> typeStats = in.readMap(StreamInput::readString, Stats::new);
+                Map<String, Stats> typeStats = in.readMap(Stats::new);
                 assert typeStats.size() == 1;
                 assert typeStats.containsKey(MapperService.SINGLE_MAPPING_NAME);
             }

--- a/server/src/main/java/org/elasticsearch/index/store/Store.java
+++ b/server/src/main/java/org/elasticsearch/index/store/Store.java
@@ -860,7 +860,7 @@ public class Store extends AbstractIndexShardComponent implements Closeable, Ref
 
         public static MetadataSnapshot readFrom(StreamInput in) throws IOException {
             final Map<String, StoreFileMetadata> metadata = in.readMapValues(StoreFileMetadata::new, StoreFileMetadata::name);
-            final var commitUserData = in.readMap(StreamInput::readString, StreamInput::readString);
+            final var commitUserData = in.readMap(StreamInput::readString);
             final var numDocs = in.readLong();
 
             if (metadata.size() == 0 && commitUserData.size() == 0 && numDocs == 0) {

--- a/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
+++ b/server/src/main/java/org/elasticsearch/monitor/jvm/JvmInfo.java
@@ -280,7 +280,7 @@ public class JvmInfo implements ReportingService.Info {
         }
         bootClassPath = in.readString();
         classPath = in.readString();
-        systemProperties = in.readMap(StreamInput::readString, StreamInput::readString);
+        systemProperties = in.readMap(StreamInput::readString);
         mem = new Mem(in);
         gcCollectors = in.readStringArray();
         memoryPools = in.readStringArray();

--- a/server/src/main/java/org/elasticsearch/node/AdaptiveSelectionStats.java
+++ b/server/src/main/java/org/elasticsearch/node/AdaptiveSelectionStats.java
@@ -42,8 +42,8 @@ public class AdaptiveSelectionStats implements Writeable, ToXContentFragment {
     }
 
     public AdaptiveSelectionStats(StreamInput in) throws IOException {
-        this.clientOutgoingConnections = in.readMap(StreamInput::readString, StreamInput::readLong);
-        this.nodeComputedStats = in.readMap(StreamInput::readString, ResponseCollectorService.ComputedNodeStats::new);
+        this.clientOutgoingConnections = in.readMap(StreamInput::readLong);
+        this.nodeComputedStats = in.readMap(ResponseCollectorService.ComputedNodeStats::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
+++ b/server/src/main/java/org/elasticsearch/persistent/PersistentTasksCustomMetadata.java
@@ -532,7 +532,7 @@ public final class PersistentTasksCustomMetadata extends AbstractNamedDiffable<M
 
     public PersistentTasksCustomMetadata(StreamInput in) throws IOException {
         lastAllocationId = in.readLong();
-        tasks = in.readMap(StreamInput::readString, PersistentTask::new);
+        tasks = in.readMap(PersistentTask::new);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoriesStats.java
@@ -29,7 +29,7 @@ public class RepositoriesStats implements Writeable, ToXContentFragment {
 
     public RepositoriesStats(StreamInput in) throws IOException {
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_011)) {
-            repositoryThrottlingStats = in.readMap(StreamInput::readString, ThrottlingStats::new);
+            repositoryThrottlingStats = in.readMap(ThrottlingStats::new);
         } else {
             repositoryThrottlingStats = new HashMap<>();
         }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryInfo.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryInfo.java
@@ -56,7 +56,7 @@ public final class RepositoryInfo implements Writeable, ToXContentFragment {
         this.ephemeralId = in.readString();
         this.name = in.readString();
         this.type = in.readString();
-        this.location = in.readMap(StreamInput::readString, StreamInput::readString);
+        this.location = in.readMap(StreamInput::readString);
         this.startedAt = in.readLong();
         this.stoppedAt = in.readOptionalLong();
     }

--- a/server/src/main/java/org/elasticsearch/repositories/RepositoryStats.java
+++ b/server/src/main/java/org/elasticsearch/repositories/RepositoryStats.java
@@ -29,7 +29,7 @@ public class RepositoryStats implements Writeable {
     }
 
     public RepositoryStats(StreamInput in) throws IOException {
-        this.requestCounts = in.readMap(StreamInput::readString, StreamInput::readLong);
+        this.requestCounts = in.readMap(StreamInput::readLong);
     }
 
     public RepositoryStats merge(RepositoryStats otherStats) {

--- a/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
+++ b/server/src/main/java/org/elasticsearch/script/ScriptLanguagesInfo.java
@@ -83,7 +83,7 @@ public class ScriptLanguagesInfo implements ToXContentObject, Writeable {
 
     public ScriptLanguagesInfo(StreamInput in) throws IOException {
         typesAllowed = in.readSet(StreamInput::readString);
-        languageContexts = in.readMap(StreamInput::readString, sin -> sin.readSet(StreamInput::readString));
+        languageContexts = in.readMap(sin -> sin.readSet(StreamInput::readString));
     }
 
     @SuppressWarnings("unchecked")

--- a/server/src/main/java/org/elasticsearch/search/SearchHit.java
+++ b/server/src/main/java/org/elasticsearch/search/SearchHit.java
@@ -157,8 +157,8 @@ public final class SearchHit implements Writeable, ToXContentObject, Iterable<Do
             explanation = readExplanation(in);
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_8_0)) {
-            documentFields.putAll(in.readMap(StreamInput::readString, DocumentField::new));
-            metaFields.putAll(in.readMap(StreamInput::readString, DocumentField::new));
+            documentFields.putAll(in.readMap(DocumentField::new));
+            metaFields.putAll(in.readMap(DocumentField::new));
         } else {
             Map<String, DocumentField> fields = readFields(in);
             fields.forEach(

--- a/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/support/MultiValuesSourceAggregationBuilder.java
@@ -97,7 +97,7 @@ public abstract class MultiValuesSourceAggregationBuilder<AB extends MultiValues
      */
     @SuppressWarnings("unchecked")
     private void read(StreamInput in) throws IOException {
-        fields = in.readMap(StreamInput::readString, MultiValuesSourceFieldConfig::new);
+        fields = in.readMap(MultiValuesSourceFieldConfig::new);
         userValueTypeHint = in.readOptionalWriteable(ValueType::readFromStream);
         format = in.readOptionalString();
     }

--- a/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/ProfileResult.java
@@ -74,9 +74,9 @@ public final class ProfileResult implements Writeable, ToXContentObject {
         this.type = in.readString();
         this.description = in.readString();
         this.nodeTime = in.readLong();
-        breakdown = in.readMap(StreamInput::readString, StreamInput::readLong);
+        breakdown = in.readMap(StreamInput::readLong);
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_9_0)) {
-            debug = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
+            debug = in.readMap(StreamInput::readGenericValue);
         } else {
             debug = Map.of();
         }

--- a/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/SearchProfileResults.java
@@ -46,13 +46,10 @@ public final class SearchProfileResults implements Writeable, ToXContentFragment
 
     public SearchProfileResults(StreamInput in) throws IOException {
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_16_0)) {
-            shardResults = in.readMap(StreamInput::readString, SearchProfileShardResult::new);
+            shardResults = in.readMap(SearchProfileShardResult::new);
         } else {
             // Before 8.0.0 we only send the query phase result
-            shardResults = in.readMap(
-                StreamInput::readString,
-                i -> new SearchProfileShardResult(new SearchProfileQueryPhaseResult(i), null)
-            );
+            shardResults = in.readMap(i -> new SearchProfileShardResult(new SearchProfileQueryPhaseResult(i), null));
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
+++ b/server/src/main/java/org/elasticsearch/snapshots/SnapshotInfo.java
@@ -515,10 +515,7 @@ public final class SnapshotInfo implements Comparable<SnapshotInfo>, ToXContentF
         final Map<String, Object> userMetadata = in.readMap();
         final List<String> dataStreams = in.readImmutableStringList();
         final List<SnapshotFeatureInfo> featureStates = in.readImmutableList(SnapshotFeatureInfo::new);
-        final Map<String, IndexSnapshotDetails> indexSnapshotDetails = in.readImmutableMap(
-            StreamInput::readString,
-            IndexSnapshotDetails::new
-        );
+        final Map<String, IndexSnapshotDetails> indexSnapshotDetails = in.readImmutableMap(IndexSnapshotDetails::new);
         return new SnapshotInfo(
             snapshot,
             indices,

--- a/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
+++ b/server/src/main/java/org/elasticsearch/tasks/TaskInfo.java
@@ -72,7 +72,7 @@ public record TaskInfo(
             in.readBoolean(),
             in.readBoolean(),
             TaskId.readFromStream(in),
-            in.readMap(StreamInput::readString, StreamInput::readString)
+            in.readMap(StreamInput::readString)
         );
     }
 

--- a/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
+++ b/server/src/main/java/org/elasticsearch/upgrades/FeatureMigrationResults.java
@@ -69,14 +69,14 @@ public class FeatureMigrationResults implements Metadata.Custom {
     }
 
     public FeatureMigrationResults(StreamInput in) throws IOException {
-        this.featureStatuses = in.readMap(StreamInput::readString, SingleFeatureMigrationResult::new);
+        this.featureStatuses = in.readMap(SingleFeatureMigrationResult::new);
     }
 
     @Override
     public void writeTo(StreamOutput out) throws IOException {
         out.writeMap(
             featureStatuses,
-            (StreamOutput outStream, String featureName) -> outStream.writeString(featureName),
+            StreamOutput::writeString,
             (StreamOutput outStream, SingleFeatureMigrationResult featureStatus) -> featureStatus.writeTo(outStream)
         );
     }

--- a/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/BytesStreamsTests.java
@@ -562,7 +562,7 @@ public class BytesStreamsTests extends ESTestCase {
 
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
 
-        final Map<String, List<String>> loaded = in.readMapOfLists(StreamInput::readString, StreamInput::readString);
+        final Map<String, List<String>> loaded = in.readMapOfLists(StreamInput::readString);
 
         assertThat(loaded.size(), equalTo(expected.size()));
 

--- a/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
+++ b/server/src/test/java/org/elasticsearch/common/io/stream/RecyclerBytesStreamOutputTests.java
@@ -602,7 +602,7 @@ public class RecyclerBytesStreamOutputTests extends ESTestCase {
 
         final StreamInput in = StreamInput.wrap(BytesReference.toBytes(out.bytes()));
 
-        final Map<String, List<String>> loaded = in.readMapOfLists(StreamInput::readString, StreamInput::readString);
+        final Map<String, List<String>> loaded = in.readMapOfLists(StreamInput::readString);
 
         assertThat(loaded.size(), equalTo(expected.size()));
 

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/NodeSeekStats.java
@@ -31,7 +31,7 @@ public class NodeSeekStats extends BaseNodeResponse implements ToXContentFragmen
 
     public NodeSeekStats(StreamInput in) throws IOException {
         super(in);
-        this.seeks = in.readMap(StreamInput::readString, (s -> s.readList(ShardSeekStats::new)));
+        this.seeks = in.readMap(s -> s.readList(ShardSeekStats::new));
     }
 
     @Override

--- a/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/ShardSeekStats.java
+++ b/test/external-modules/seek-tracking-directory/src/main/java/org/elasticsearch/test/seektracker/ShardSeekStats.java
@@ -20,7 +20,7 @@ import java.util.Map;
 public record ShardSeekStats(String shard, Map<String, Long> seeksPerFile) implements Writeable, ToXContentObject {
 
     public ShardSeekStats(StreamInput in) throws IOException {
-        this(in.readString(), in.readMap(StreamInput::readString, StreamInput::readLong));
+        this(in.readString(), in.readMap(StreamInput::readLong));
     }
 
     @Override

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/stringstats/InternalStringStats.java
@@ -93,7 +93,7 @@ public class InternalStringStats extends InternalAggregation {
         totalLength = in.readVLong();
         minLength = in.readVInt();
         maxLength = in.readVInt();
-        charOccurrences = in.readMap(StreamInput::readString, StreamInput::readLong);
+        charOccurrences = in.readMap(StreamInput::readLong);
     }
 
     @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/action/GetAutoscalingCapacityAction.java
@@ -85,7 +85,7 @@ public class GetAutoscalingCapacityAction extends ActionType<GetAutoscalingCapac
 
         public Response(final StreamInput in) throws IOException {
             super(in);
-            results = new TreeMap<>(in.readMap(StreamInput::readString, AutoscalingDeciderResults::new));
+            results = new TreeMap<>(in.readMap(AutoscalingDeciderResults::new));
         }
 
         @Override

--- a/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
+++ b/x-pack/plugin/autoscaling/src/main/java/org/elasticsearch/xpack/autoscaling/capacity/AutoscalingDeciderResults.java
@@ -64,7 +64,7 @@ public class AutoscalingDeciderResults implements ToXContentObject, Writeable {
         this.currentNodes = in.readSet(DiscoveryNode::new)
             .stream()
             .collect(Collectors.toCollection(() -> new TreeSet<>(DISCOVERY_NODE_COMPARATOR)));
-        this.results = new TreeMap<>(in.readMap(StreamInput::readString, AutoscalingDeciderResult::new));
+        this.results = new TreeMap<>(in.readMap(AutoscalingDeciderResult::new));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/DataTiersFeatureSetUsage.java
@@ -32,7 +32,7 @@ public class DataTiersFeatureSetUsage extends XPackFeatureSet.Usage {
 
     public DataTiersFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        this.tierStats = in.readMap(StreamInput::readString, TierSpecificStats::new);
+        this.tierStats = in.readMap(TierSpecificStats::new);
     }
 
     public DataTiersFeatureSetUsage(Map<String, TierSpecificStats> tierStats) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowMetadata.java
@@ -106,9 +106,9 @@ public class AutoFollowMetadata extends AbstractNamedDiffable<Metadata.Custom> i
 
     public AutoFollowMetadata(StreamInput in) throws IOException {
         this(
-            in.readMap(StreamInput::readString, AutoFollowPattern::readFrom),
-            in.readMapOfLists(StreamInput::readString, StreamInput::readString),
-            in.readMap(StreamInput::readString, valIn -> valIn.readMap(StreamInput::readString, StreamInput::readString))
+            in.readMap(AutoFollowPattern::readFrom),
+            in.readMapOfLists(StreamInput::readString),
+            in.readMap(valIn -> valIn.readMap(StreamInput::readString))
         );
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/AutoFollowStats.java
@@ -124,10 +124,8 @@ public class AutoFollowStats implements Writeable, ToXContentObject {
         numberOfFailedFollowIndices = in.readVLong();
         numberOfFailedRemoteClusterStateRequests = in.readVLong();
         numberOfSuccessfulFollowIndices = in.readVLong();
-        recentAutoFollowErrors = new TreeMap<>(
-            in.readMap(StreamInput::readString, in1 -> new Tuple<>(in1.readZLong(), in1.readException()))
-        );
-        autoFollowedClusters = new TreeMap<>(in.readMap(StreamInput::readString, AutoFollowedCluster::new));
+        recentAutoFollowErrors = new TreeMap<>(in.readMap(in1 -> new Tuple<>(in1.readZLong(), in1.readException())));
+        autoFollowedClusters = new TreeMap<>(in.readMap(AutoFollowedCluster::new));
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/GetAutoFollowPatternAction.java
@@ -88,7 +88,7 @@ public class GetAutoFollowPatternAction extends ActionType<GetAutoFollowPatternA
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            autoFollowPatterns = in.readMap(StreamInput::readString, AutoFollowPattern::readFrom);
+            autoFollowPatterns = in.readMap(AutoFollowPattern::readFrom);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTask.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ccr/action/ShardFollowTask.java
@@ -122,7 +122,7 @@ public class ShardFollowTask extends ImmutableFollowParameters implements Persis
         this.remoteCluster = remoteCluster;
         this.followShardId = followShardId;
         this.leaderShardId = leaderShardId;
-        this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
+        this.headers = in.readImmutableMap(StreamInput::readString);
     }
 
     public String getRemoteCluster() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/enrich/EnrichMetadata.java
@@ -65,7 +65,7 @@ public final class EnrichMetadata extends AbstractNamedDiffable<Metadata.Custom>
     private final Map<String, EnrichPolicy> policies;
 
     public EnrichMetadata(StreamInput in) throws IOException {
-        this(in.readMap(StreamInput::readString, EnrichPolicy::new));
+        this(in.readMap(EnrichPolicy::new));
     }
 
     public EnrichMetadata(Map<String, EnrichPolicy> policies) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/IndexLifecycleFeatureSetUsage.java
@@ -105,7 +105,7 @@ public class IndexLifecycleFeatureSetUsage extends XPackFeatureSet.Usage {
         }
 
         public PolicyStats(StreamInput in) throws IOException {
-            this.phaseStats = in.readMap(StreamInput::readString, PhaseStats::new);
+            this.phaseStats = in.readMap(PhaseStats::new);
             this.indicesManaged = in.readVInt();
         }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/LifecyclePolicy.java
@@ -101,7 +101,7 @@ public class LifecyclePolicy implements SimpleDiffable<LifecyclePolicy>, ToXCont
     public LifecyclePolicy(StreamInput in) throws IOException {
         type = in.readNamedWriteable(LifecycleType.class);
         name = in.readString();
-        phases = in.readImmutableMap(StreamInput::readString, Phase::new);
+        phases = in.readImmutableMap(Phase::new);
         this.metadata = in.readMap();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/EstimateModelMemoryAction.java
@@ -74,8 +74,8 @@ public class EstimateModelMemoryAction extends ActionType<EstimateModelMemoryAct
         public Request(StreamInput in) throws IOException {
             super(in);
             this.analysisConfig = in.readBoolean() ? new AnalysisConfig(in) : null;
-            this.overallCardinality = in.readMap(StreamInput::readString, StreamInput::readVLong);
-            this.maxBucketCardinality = in.readMap(StreamInput::readString, StreamInput::readVLong);
+            this.overallCardinality = in.readMap(StreamInput::readVLong);
+            this.maxBucketCardinality = in.readMap(StreamInput::readVLong);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/action/GetDatafeedRunningStateAction.java
@@ -161,7 +161,7 @@ public class GetDatafeedRunningStateAction extends ActionType<GetDatafeedRunning
 
         public Response(StreamInput in) throws IOException {
             super(in);
-            datafeedRunningState = in.readMap(StreamInput::readString, RunningState::new);
+            datafeedRunningState = in.readMap(RunningState::new);
         }
 
         public Response(Map<String, RunningState> runtimeStateMap) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/datafeed/DatafeedConfig.java
@@ -295,7 +295,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
         }
         this.scrollSize = in.readOptionalVInt();
         this.chunkingConfig = in.readOptionalWriteable(ChunkingConfig::new);
-        this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
+        this.headers = in.readImmutableMap(StreamInput::readString);
         delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
         maxEmptySearches = in.readOptionalVInt();
         indicesOptions = IndicesOptions.readIndicesOptions(in);
@@ -808,7 +808,7 @@ public class DatafeedConfig implements SimpleDiffable<DatafeedConfig>, ToXConten
             }
             this.scrollSize = in.readOptionalVInt();
             this.chunkingConfig = in.readOptionalWriteable(ChunkingConfig::new);
-            this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
+            this.headers = in.readImmutableMap(StreamInput::readString);
             delayedDataCheckConfig = in.readOptionalWriteable(DelayedDataCheckConfig::new);
             maxEmptySearches = in.readOptionalVInt();
             if (in.readBoolean()) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/dataframe/DataFrameAnalyticsConfig.java
@@ -186,7 +186,7 @@ public class DataFrameAnalyticsConfig implements ToXContentObject, Writeable {
         this.analysis = in.readNamedWriteable(DataFrameAnalysis.class);
         this.analyzedFields = in.readOptionalWriteable(FetchSourceContext::readFrom);
         this.modelMemoryLimit = in.readOptionalWriteable(ByteSizeValue::readFrom);
-        this.headers = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
+        this.headers = in.readImmutableMap(StreamInput::readString);
         this.createTime = in.readOptionalInstant();
         this.version = in.readBoolean() ? Version.readVersion(in) : null;
         this.allowLazyStart = in.readBoolean();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/TrainedModelConfig.java
@@ -256,7 +256,7 @@ public class TrainedModelConfig implements ToXContentObject, Writeable {
         modelSize = in.readVLong();
         estimatedOperations = in.readVLong();
         licenseLevel = License.OperationMode.parse(in.readString());
-        this.defaultFieldMap = in.readBoolean() ? in.readImmutableMap(StreamInput::readString, StreamInput::readString) : null;
+        this.defaultFieldMap = in.readBoolean() ? in.readImmutableMap(StreamInput::readString) : null;
 
         this.inferenceConfig = in.readOptionalNamedWriteable(InferenceConfig.class);
         if (in.getTransportVersion().onOrAfter(VERSION_3RD_PARTY_CONFIG_ADDED)) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/FrequencyEncoding.java
@@ -86,7 +86,7 @@ public class FrequencyEncoding implements LenientlyParsedPreProcessor, StrictlyP
     public FrequencyEncoding(StreamInput in) throws IOException {
         this.field = in.readString();
         this.featureName = in.readString();
-        this.frequencyMap = in.readImmutableMap(StreamInput::readString, StreamInput::readDouble);
+        this.frequencyMap = in.readImmutableMap(StreamInput::readDouble);
         this.custom = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/OneHotEncoding.java
@@ -74,7 +74,7 @@ public class OneHotEncoding implements LenientlyParsedPreProcessor, StrictlyPars
 
     public OneHotEncoding(StreamInput in) throws IOException {
         this.field = in.readString();
-        this.hotMap = Collections.unmodifiableMap(new TreeMap<>(in.readMap(StreamInput::readString, StreamInput::readString)));
+        this.hotMap = Collections.unmodifiableMap(new TreeMap<>(in.readMap(StreamInput::readString)));
         this.custom = in.readBoolean();
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/inference/preprocessing/TargetMeanEncoding.java
@@ -90,7 +90,7 @@ public class TargetMeanEncoding implements LenientlyParsedPreProcessor, Strictly
     public TargetMeanEncoding(StreamInput in) throws IOException {
         this.field = in.readString();
         this.featureName = in.readString();
-        this.meanMap = in.readImmutableMap(StreamInput::readString, StreamInput::readDouble);
+        this.meanMap = in.readImmutableMap(StreamInput::readDouble);
         this.defaultValue = in.readDouble();
         this.custom = in.readBoolean();
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/job/config/RuleScope.java
@@ -68,7 +68,7 @@ public class RuleScope implements ToXContentObject, Writeable {
     }
 
     public RuleScope(StreamInput in) throws IOException {
-        scope = in.readMap(StreamInput::readString, FilterRef::new);
+        scope = in.readMap(FilterRef::new);
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/stats/CountAccumulator.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ml/stats/CountAccumulator.java
@@ -37,7 +37,7 @@ public class CountAccumulator implements Writeable {
     }
 
     public CountAccumulator(StreamInput in) throws IOException {
-        this.counts = in.readMap(StreamInput::readString, StreamInput::readLong);
+        this.counts = in.readMap(StreamInput::readLong);
     }
 
     public void merge(CountAccumulator other) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupCapsAction.java
@@ -116,7 +116,7 @@ public class GetRollupCapsAction extends ActionType<GetRollupCapsAction.Response
         }
 
         Response(StreamInput in) throws IOException {
-            jobs = in.readImmutableMap(StreamInput::readString, RollableIndexCaps::new);
+            jobs = in.readImmutableMap(RollableIndexCaps::new);
         }
 
         public Map<String, RollableIndexCaps> getJobs() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/GetRollupIndexCapsAction.java
@@ -145,7 +145,7 @@ public class GetRollupIndexCapsAction extends ActionType<GetRollupIndexCapsActio
         }
 
         Response(StreamInput in) throws IOException {
-            jobs = in.readMap(StreamInput::readString, RollableIndexCaps::new);
+            jobs = in.readMap(RollableIndexCaps::new);
         }
 
         public Map<String, RollableIndexCaps> getJobs() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/action/RollupJobCaps.java
@@ -70,7 +70,7 @@ public class RollupJobCaps implements Writeable, ToXContentObject {
         this.jobID = in.readString();
         this.rollupIndex = in.readString();
         this.indexPattern = in.readString();
-        this.fieldCapLookup = in.readMap(StreamInput::readString, RollupFieldCaps::new);
+        this.fieldCapLookup = in.readMap(RollupFieldCaps::new);
     }
 
     public Map<String, RollupFieldCaps> getFieldCaps() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJob.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/rollup/job/RollupJob.java
@@ -57,7 +57,7 @@ public class RollupJob implements SimpleDiffable<RollupJob>, PersistentTaskParam
 
     public RollupJob(StreamInput in) throws IOException {
         this.config = new RollupJobConfig(in);
-        headers = in.readMap(StreamInput::readString, StreamInput::readString);
+        headers = in.readMap(StreamInput::readString);
     }
 
     public RollupJobConfig getConfig() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/apikey/BulkUpdateApiKeyResponse.java
@@ -37,7 +37,7 @@ public final class BulkUpdateApiKeyResponse extends ActionResponse implements To
         super(in);
         this.updated = in.readStringList();
         this.noops = in.readStringList();
-        this.errorDetails = in.readMap(StreamInput::readString, StreamInput::readException);
+        this.errorDetails = in.readMap(StreamInput::readException);
     }
 
     public List<String> getUpdated() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/privilege/PutPrivilegesResponse.java
@@ -27,7 +27,7 @@ public final class PutPrivilegesResponse extends ActionResponse implements ToXCo
 
     public PutPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
-        this.created = in.readImmutableMap(StreamInput::readString, StreamInput::readStringList);
+        this.created = in.readImmutableMap(StreamInput::readStringList);
     }
 
     public PutPrivilegesResponse(Map<String, List<String>> created) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/GetProfilesResponse.java
@@ -32,7 +32,7 @@ public class GetProfilesResponse extends ActionResponse implements ToXContentObj
     public GetProfilesResponse(StreamInput in) throws IOException {
         super(in);
         this.profiles = in.readImmutableList(Profile::new);
-        this.errors = in.readMap(StreamInput::readString, StreamInput::readException);
+        this.errors = in.readMap(StreamInput::readException);
     }
 
     public List<Profile> getProfiles() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SuggestProfilesRequest.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/profile/SuggestProfilesRequest.java
@@ -140,7 +140,7 @@ public class SuggestProfilesRequest extends ActionRequest {
 
         public Hint(StreamInput in) throws IOException {
             this.uids = in.readStringList();
-            this.labels = in.readMapOfLists(StreamInput::readString, StreamInput::readString);
+            this.labels = in.readMapOfLists(StreamInput::readString);
         }
 
         public List<String> getUids() {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/GetUsersResponse.java
@@ -45,7 +45,7 @@ public class GetUsersResponse extends ActionResponse implements ToXContentObject
         }
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_5_0)) {
             if (in.readBoolean()) {
-                profileUidLookup = in.readMap(StreamInput::readString, StreamInput::readString);
+                profileUidLookup = in.readMap(StreamInput::readString);
             } else {
                 profileUidLookup = null;
             }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/HasPrivilegesResponse.java
@@ -40,9 +40,9 @@ public class HasPrivilegesResponse extends ActionResponse implements ToXContentO
     public HasPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
         completeMatch = in.readBoolean();
-        cluster = in.readMap(StreamInput::readString, StreamInput::readBoolean);
+        cluster = in.readMap(StreamInput::readBoolean);
         index = readResourcePrivileges(in);
-        application = in.readMap(StreamInput::readString, HasPrivilegesResponse::readResourcePrivileges);
+        application = in.readMap(HasPrivilegesResponse::readResourcePrivileges);
         username = in.readString();
     }
 
@@ -119,7 +119,7 @@ public class HasPrivilegesResponse extends ActionResponse implements ToXContentO
         final Set<ResourcePrivileges> set = new TreeSet<>(Comparator.comparing(o -> o.getResource()));
         for (int i = 0; i < count; i++) {
             final String index = in.readString();
-            final Map<String, Boolean> privileges = in.readMap(StreamInput::readString, StreamInput::readBoolean);
+            final Map<String, Boolean> privileges = in.readMap(StreamInput::readBoolean);
             set.add(ResourcePrivileges.builder(index).addPrivileges(privileges).build());
         }
         return set;

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/action/user/ProfileHasPrivilegesResponse.java
@@ -27,7 +27,7 @@ public class ProfileHasPrivilegesResponse extends ActionResponse implements ToXC
     public ProfileHasPrivilegesResponse(StreamInput in) throws IOException {
         super(in);
         this.hasPrivilegeUids = in.readSet(StreamInput::readString);
-        this.errors = in.readMap(StreamInput::readString, StreamInput::readException);
+        this.errors = in.readMap(StreamInput::readException);
     }
 
     public ProfileHasPrivilegesResponse(Set<String> hasPrivilegeUids, Map<String, Exception> errors) {

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleMetadata.java
@@ -93,7 +93,7 @@ public class SnapshotLifecycleMetadata implements Metadata.Custom {
     }
 
     public SnapshotLifecycleMetadata(StreamInput in) throws IOException {
-        this.snapshotConfigurations = in.readMap(StreamInput::readString, SnapshotLifecyclePolicyMetadata::new);
+        this.snapshotConfigurations = in.readMap(SnapshotLifecyclePolicyMetadata::new);
         this.operationMode = in.readEnum(OperationMode.class);
         this.slmStats = new SnapshotLifecycleStats(in);
     }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotLifecycleStats.java
@@ -98,7 +98,7 @@ public class SnapshotLifecycleStats implements Writeable, ToXContentObject {
     }
 
     public SnapshotLifecycleStats(StreamInput in) throws IOException {
-        this.policyStats = new ConcurrentHashMap<>(in.readMap(StreamInput::readString, SnapshotPolicyStats::new));
+        this.policyStats = new ConcurrentHashMap<>(in.readMap(SnapshotPolicyStats::new));
         this.retentionRunCount.inc(in.readVLong());
         this.retentionFailedCount.inc(in.readVLong());
         this.retentionTimedOut.inc(in.readVLong());

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/textstructure/structurefinder/TextStructure.java
@@ -237,7 +237,7 @@ public class TextStructure implements ToXContentObject, Writeable {
         needClientTimezone = in.readBoolean();
         mappings = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap()));
         ingestPipeline = in.readBoolean() ? Collections.unmodifiableMap(in.readMap()) : null;
-        fieldStats = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap(StreamInput::readString, FieldStats::new)));
+        fieldStats = Collections.unmodifiableSortedMap(new TreeMap<>(in.readMap(FieldStats::new)));
         explanation = in.readImmutableList(StreamInput::readString);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/TransformFeatureSetUsage.java
@@ -31,8 +31,8 @@ public class TransformFeatureSetUsage extends Usage {
 
     public TransformFeatureSetUsage(StreamInput in) throws IOException {
         super(in);
-        this.transformCountByState = in.readMap(StreamInput::readString, StreamInput::readLong);
-        this.transformCountByFeature = in.readMap(StreamInput::readString, StreamInput::readLong);
+        this.transformCountByState = in.readMap(StreamInput::readLong);
+        this.transformCountByFeature = in.readMap(StreamInput::readLong);
         this.accumulatedStats = new TransformIndexerStats(in);
     }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformAction.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/action/ValidateTransformAction.java
@@ -105,7 +105,7 @@ public class ValidateTransformAction extends ActionType<ValidateTransformAction.
         }
 
         public Response(StreamInput in) throws IOException {
-            this.destIndexMappings = in.readMap(StreamInput::readString, StreamInput::readString);
+            this.destIndexMappings = in.readMap(StreamInput::readString);
         }
 
         @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NodeAttributes.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/NodeAttributes.java
@@ -83,7 +83,7 @@ public class NodeAttributes implements ToXContentObject, Writeable {
         this.name = in.readString();
         this.ephemeralId = in.readString();
         this.transportAddress = in.readString();
-        this.attributes = in.readImmutableMap(StreamInput::readString, StreamInput::readString);
+        this.attributes = in.readImmutableMap(StreamInput::readString);
     }
 
     /**

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfig.java
@@ -247,7 +247,7 @@ public class TransformConfig implements SimpleDiffable<TransformConfig>, Writeab
         source = new SourceConfig(in);
         dest = new DestConfig(in);
         frequency = in.readOptionalTimeValue();
-        setHeaders(in.readMap(StreamInput::readString, StreamInput::readString));
+        setHeaders(in.readMap(StreamInput::readString));
         pivotConfig = in.readOptionalWriteable(PivotConfig::new);
         latestConfig = in.readOptionalWriteable(LatestConfig::new);
         description = in.readOptionalString();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/transform/transforms/TransformConfigUpdate.java
@@ -114,7 +114,7 @@ public class TransformConfigUpdate implements Writeable {
         description = in.readOptionalString();
         syncConfig = in.readOptionalNamedWriteable(SyncConfig.class);
         if (in.readBoolean()) {
-            setHeaders(in.readMap(StreamInput::readString, StreamInput::readString));
+            setHeaders(in.readMap(StreamInput::readString));
         }
         settings = in.readOptionalWriteable(SettingsConfig::new);
         metadata = in.readMap();

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/watcher/watch/WatchStatus.java
@@ -72,7 +72,7 @@ public class WatchStatus implements ToXContentObject, Writeable {
             executionState = ExecutionState.resolve(in.readString());
         }
         if (in.readBoolean()) {
-            headers = in.readMap(StreamInput::readString, StreamInput::readString);
+            headers = in.readMap(StreamInput::readString);
         } else {
             headers = Collections.emptyMap();
         }

--- a/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
+++ b/x-pack/plugin/deprecation/src/main/java/org/elasticsearch/xpack/deprecation/DeprecationInfoAction.java
@@ -153,13 +153,13 @@ public class DeprecationInfoAction extends ActionType<DeprecationInfoAction.Resp
             super(in);
             clusterSettingsIssues = in.readList(DeprecationIssue::new);
             nodeSettingsIssues = in.readList(DeprecationIssue::new);
-            indexSettingsIssues = in.readMapOfLists(StreamInput::readString, DeprecationIssue::new);
+            indexSettingsIssues = in.readMapOfLists(DeprecationIssue::new);
             if (in.getTransportVersion().before(TransportVersion.V_7_11_0)) {
                 List<DeprecationIssue> mlIssues = in.readList(DeprecationIssue::new);
                 pluginSettingsIssues = new HashMap<>();
                 pluginSettingsIssues.put("ml_settings", mlIssues);
             } else {
-                pluginSettingsIssues = in.readMapOfLists(StreamInput::readString, DeprecationIssue::new);
+                pluginSettingsIssues = in.readMapOfLists(DeprecationIssue::new);
             }
         }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/action/PostAnalyticsEventAction.java
@@ -90,7 +90,7 @@ public class PostAnalyticsEventAction extends ActionType<PostAnalyticsEventActio
             this.eventTime = in.readLong();
             this.xContentType = in.readEnum(XContentType.class);
             this.payload = in.readBytesReference();
-            this.headers = in.readMap(StreamInput::readString, StreamInput::readStringList);
+            this.headers = in.readMap(StreamInput::readStringList);
             this.clientAddress = in.readOptionalString();
         }
 

--- a/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
+++ b/x-pack/plugin/eql/src/main/java/org/elasticsearch/xpack/eql/action/EqlSearchResponse.java
@@ -257,7 +257,7 @@ public class EqlSearchResponse extends ActionResponse implements ToXContentObjec
             id = in.readString();
             source = in.readBytesReference();
             if (in.getTransportVersion().onOrAfter(TransportVersion.V_7_13_0) && in.readBoolean()) {
-                fetchFields = in.readMap(StreamInput::readString, DocumentField::new);
+                fetchFields = in.readMap(DocumentField::new);
             } else {
                 fetchFields = null;
             }

--- a/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineResponse.java
+++ b/x-pack/plugin/logstash/src/main/java/org/elasticsearch/xpack/logstash/action/GetPipelineResponse.java
@@ -29,7 +29,7 @@ public class GetPipelineResponse extends ActionResponse implements ToXContentObj
 
     public GetPipelineResponse(StreamInput in) throws IOException {
         super(in);
-        this.pipelines = in.readMap(StreamInput::readString, StreamInput::readBytesReference);
+        this.pipelines = in.readMap(StreamInput::readBytesReference);
     }
 
     public Map<String, BytesReference> pipelines() {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetCollector.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/FrequentItemSetCollector.java
@@ -59,7 +59,7 @@ public final class FrequentItemSetCollector {
         }
 
         public FrequentItemSet(StreamInput in) throws IOException {
-            this.fields = in.readMapOfLists(StreamInput::readString, StreamInput::readGenericValue);
+            this.fields = in.readMapOfLists(StreamInput::readGenericValue);
             this.docCount = in.readVLong();
             this.support = in.readDouble();
         }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilder.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/inference/InferencePipelineAggregationBuilder.java
@@ -166,7 +166,7 @@ public class InferencePipelineAggregationBuilder extends AbstractPipelineAggrega
     ) throws IOException {
         super(in, NAME);
         modelId = in.readString();
-        bucketPathMap = in.readMap(StreamInput::readString, StreamInput::readString);
+        bucketPathMap = in.readMap(StreamInput::readString);
         inferenceConfig = in.readOptionalNamedWriteable(InferenceConfigUpdate.class);
         this.modelLoadingService = modelLoadingService;
         this.model = null;

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregation.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/aggs/kstest/InternalKSTestAggregation.java
@@ -30,7 +30,7 @@ public class InternalKSTestAggregation extends InternalAggregation {
 
     public InternalKSTestAggregation(StreamInput in) throws IOException {
         super(in);
-        this.modeValues = in.readMap(StreamInput::readString, StreamInput::readDouble);
+        this.modeValues = in.readMap(StreamInput::readDouble);
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/ModelAliasMetadata.java
@@ -83,7 +83,7 @@ public class ModelAliasMetadata implements Metadata.Custom {
     }
 
     public ModelAliasMetadata(StreamInput in) throws IOException {
-        this.modelAliases = in.readImmutableMap(StreamInput::readString, ModelAliasEntry::new);
+        this.modelAliases = in.readImmutableMap(ModelAliasEntry::new);
     }
 
     public Map<String, ModelAliasEntry> modelAliases() {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/aggs/frequentitemsets/mr/InternalItemSetMapReduceAggregationTests.java
@@ -72,7 +72,7 @@ public class InternalItemSetMapReduceAggregationTests extends InternalAggregatio
             }
 
             WordCounts(StreamInput in) throws IOException {
-                this.frequencies = in.readMap(StreamInput::readString, StreamInput::readLong);
+                this.frequencies = in.readMap(StreamInput::readLong);
             }
 
             @Override

--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/GetProfilingResponse.java
@@ -37,7 +37,6 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
     public GetProfilingResponse(StreamInput in) throws IOException {
         this.stackTraces = in.readBoolean()
             ? in.readMap(
-                StreamInput::readString,
                 i -> new StackTrace(
                     i.readList(StreamInput::readInt),
                     i.readList(StreamInput::readString),
@@ -48,7 +47,6 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
             : null;
         this.stackFrames = in.readBoolean()
             ? in.readMap(
-                StreamInput::readString,
                 i -> new StackFrame(
                     i.readList(StreamInput::readString),
                     i.readList(StreamInput::readString),
@@ -57,8 +55,8 @@ public class GetProfilingResponse extends ActionResponse implements ChunkedToXCo
                 )
             )
             : null;
-        this.executables = in.readBoolean() ? in.readMap(StreamInput::readString, StreamInput::readString) : null;
-        this.stackTraceEvents = in.readBoolean() ? in.readMap(StreamInput::readString, StreamInput::readInt) : null;
+        this.executables = in.readBoolean() ? in.readMap(StreamInput::readString) : null;
+        this.stackTraceEvents = in.readBoolean() ? in.readMap(StreamInput::readInt) : null;
         this.totalFrames = in.readInt();
         this.samplingRate = in.readDouble();
     }


### PR DESCRIPTION
Mostly the keys we read are strings, lets add an overload for that to save some code and maybe help the compiler make better decisions. Also readMapOfLists an be way simplified, no point in duplicating the map reading code here just to save one capturing lambda, there's not hot code that benefits from this.
