### PR TITLE
Remove redundant event loop shutdown check in Netty4TcpChannel

### DIFF
--- a/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
+++ b/modules/transport-netty4/src/main/java/org/elasticsearch/transport/netty4/Netty4TcpChannel.java
@@ -20,7 +20,6 @@ import org.elasticsearch.common.util.concurrent.ListenableFuture;
 import org.elasticsearch.core.IOUtils;
 import org.elasticsearch.core.Releasables;
 import org.elasticsearch.transport.TcpChannel;
-import org.elasticsearch.transport.TransportException;
 
 import java.net.InetSocketAddress;
 
@@ -163,10 +162,6 @@ public class Netty4TcpChannel implements TcpChannel {
     @Override
     public void sendMessage(BytesReference reference, ActionListener<Void> listener) {
         channel.writeAndFlush(Netty4Utils.toByteBuf(reference), addPromise(listener, channel));
-
-        if (channel.eventLoop().isShutdown()) {
-            listener.onFailure(new TransportException("Cannot send message, event loop is shutting down."));
-        }
     }
 
     public Channel getNettyChannel() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -671,7 +671,6 @@ public class SearchScrollIT extends ESIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/95759")
     public void testRestartDataNodesDuringScrollSearch() throws Exception {
         final String dataNode = internalCluster().startDataOnlyNode();
         createIndex("demo", indexSettings(1, 0).put("index.routing.allocation.include._name", dataNode).build());


### PR DESCRIPTION
This check isn't necessary any longer. We safely close all channels before shutting down the even loop groups so we can not run into the situation that a listener passed to `writeAndFlush` isn't completed. We also don't have this check on the http channel sending. -> remove the check that can cause a bug by double invoking the listener when the event loop concurrently closes.

closes #95759
