### PR TITLE
Add brute force approach to GeoHashGridTiler

### DIFF
--- a/docs/changelog/96863.yaml
+++ b/docs/changelog/96863.yaml
@@ -1,0 +1,5 @@
+pr: 96863
+summary: Add brute force approach to `GeoHashGridTiler`
+area: Geo
+type: enhancement
+issues: []


### PR DESCRIPTION
Currently we always resolve the tiler using recursion which is not optimal when a geometry only touches a few hashes. This PR adds the logic to use brute force approach when it is appropriate very much the shame way we do it in  GeoTileGridTiler.

Quick check shows that an aggregation that was timing out (>30s) now takes 4 seconds.