### PR TITLE
Prevent redundant failing of shards during recovery engine exceptions

### DIFF
--- a/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
+++ b/server/src/main/java/org/elasticsearch/indices/cluster/IndicesClusterStateService.java
@@ -931,6 +931,10 @@ public class IndicesClusterStateService extends AbstractLifecycleComponent imple
         @Override
         public void accept(final IndexShard.ShardFailure shardFailure) {
             final ShardRouting shardRouting = shardFailure.routing();
+            if (shardRouting.initializing()) {
+                // no need to fail the shard here during recovery, the recovery code will take care of failing it
+                return;
+            }
             threadPool.generic().execute(() -> {
                 synchronized (IndicesClusterStateService.this) {
                     failAndRemoveShard(


### PR DESCRIPTION
If a recovery ran into an engine exception, we would fail the shard both from the logic adjusted here (through a call from the engine to fail the shard) as well as through the recovery code that makes sure a failed recovery always leads to removing the shard.
This lead to a test failure since the engine exception and the exception sent from the recovery failure differ. It is highly unlikely that the exception by the changed logic is sent before the one sent by the recovery failure so mostly this code just does a redundant round of failing during recovery.
It seems safe to me to just short-circuit the failure handling for recoverying shards here to get a deterministic failure and avoid needless tasks on generic as well as redundant shard failure messages.

closes #95626
