### PR TITLE
[Profiling] Don't map new fields by default

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-events.json
@@ -24,6 +24,7 @@
       "_source": {
         "enabled": false
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-executables.json
@@ -13,6 +13,7 @@
       "_source": {
         "mode": "synthetic"
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-hosts.json
@@ -19,6 +19,7 @@
       "_source": {
         "enabled": true
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword"
@@ -31,7 +32,6 @@
           "format": "epoch_second"
         },
         "profiling": {
-          "dynamic": false,
           "properties": {
             "project.id": {
               "type": "keyword"
@@ -160,7 +160,6 @@
           }
         },
         "ec2": {
-          "dynamic": false,
           "properties": {
             "ami_id": {
               "type": "keyword"
@@ -224,7 +223,6 @@
           }
         },
         "azure": {
-          "dynamic": false,
           "properties": {
             "compute.sku": {
               "type": "keyword"
@@ -268,7 +266,6 @@
           }
         },
         "gce": {
-          "dynamic": false,
           "properties": {
             "instance.id": {
               "type": "keyword"

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -19,6 +19,12 @@
       "_source": {
         "enabled": false
       },
+      /*
+       We intentionally allow dynamic mappings for metrics. Which metrics are added is guarded by
+       the collector and we want to allow adding new metrics over time. As this is a datastream,
+       which will age and eventually be deleted, schema evolution is not a major concern here.
+       */
+      "dynamic": true,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -19,7 +19,6 @@
       "_source": {
         "enabled": false
       },
-      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-metrics.json
@@ -19,6 +19,7 @@
       "_source": {
         "enabled": false
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stackframes.json
@@ -21,6 +21,7 @@
       "_source": {
         "enabled": true
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-stacktraces.json
@@ -19,6 +19,7 @@
       "_source": {
         "mode": "synthetic"
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/component-template/profiling-symbols.json
@@ -17,6 +17,7 @@
       "_source": {
         "enabled": true
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-returnpads-private.json
@@ -19,6 +19,7 @@
       "_source": {
         "enabled": true
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-executables.json
@@ -15,6 +15,7 @@
       "_source": {
         "mode": "synthetic"
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/profiler/index-template/profiling-sq-leafframes.json
@@ -15,6 +15,7 @@
       "_source": {
         "mode": "synthetic"
       },
+      "dynamic": false,
       "properties": {
         "ecs.version": {
           "type": "keyword",


### PR DESCRIPTION
With this commit we set the mapping parameter `dynamic` to `false` for all profiling-related indices / index templates. Previously we were relying on the default behavior which would have mapped new fields dynamically. This is problematic for schema evolution. With this change we will still accept documents with additional fields but they will not be automatically added to the mappings.