### PR TITLE
[ML] Audit inference process crash events

### DIFF
--- a/docs/changelog/96877.yaml
+++ b/docs/changelog/96877.yaml
@@ -1,0 +1,5 @@
+pr: 96877
+summary: Audit inference process crash events
+area: Machine Learning
+type: enhancement
+issues: []

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/MachineLearning.java
@@ -951,7 +951,8 @@ public class MachineLearning extends Plugin
                 NativeController nativeController = NativeController.makeNativeController(
                     clusterService.getNodeName(),
                     environment,
-                    xContentRegistry
+                    xContentRegistry,
+                    systemAuditor
                 );
                 autodetectProcessFactory = new NativeAutodetectProcessFactory(
                     environment,
@@ -1075,7 +1076,14 @@ public class MachineLearning extends Plugin
         );
         this.modelLoadingService.set(modelLoadingService);
         this.deploymentManager.set(
-            new DeploymentManager(client, xContentRegistry, threadPool, pyTorchProcessFactory, getMaxModelDeploymentsPerNode())
+            new DeploymentManager(
+                client,
+                xContentRegistry,
+                threadPool,
+                pyTorchProcessFactory,
+                getMaxModelDeploymentsPerNode(),
+                inferenceAuditor
+            )
         );
 
         // Data frame analytics components

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManager.java
@@ -469,8 +469,8 @@ public class DeploymentManager {
         }
 
         private void onProcessCrash(String reason) {
-            String msg = "[" + task.getDeploymentId() + "] inference process crashed due to reason [" + task.getDeploymentId() + "]";
-            logger.error(msg);
+            String msg = "inference process crashed due to reason [" + reason + "]";
+            logger.error("[{}] {}", task.getDeploymentId(), msg);
             processContextByAllocation.remove(task.getId());
             isStopped = true;
             resultProcessor.stop();
@@ -479,8 +479,8 @@ public class DeploymentManager {
             if (nlpTaskProcessor.get() != null) {
                 nlpTaskProcessor.get().close();
             }
-            task.setFailed("inference process crashed due to reason [" + reason + "]");
-            auditor.error(task.getDeploymentId(), msg);
+            task.setFailed(msg);
+            auditor.error(task.getDeploymentId(), "inference process crashed");
         }
 
         void loadModel(TrainedModelLocation modelLocation, ActionListener<Boolean> listener) {

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/inference/deployment/DeploymentManagerTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.xpack.core.ml.inference.trainedmodel.InferenceConfig;
 import org.elasticsearch.xpack.ml.inference.pytorch.PriorityProcessWorkerExecutorService;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchProcessFactory;
 import org.elasticsearch.xpack.ml.inference.pytorch.process.PyTorchResultProcessor;
+import org.elasticsearch.xpack.ml.notifications.InferenceAuditor;
 import org.junit.After;
 import org.junit.Before;
 
@@ -77,7 +78,8 @@ public class DeploymentManagerTests extends ESTestCase {
             mock(NamedXContentRegistry.class),
             tp,
             mock(PyTorchProcessFactory.class),
-            10
+            10,
+            mock(InferenceAuditor.class)
         );
 
         PriorityProcessWorkerExecutorService priorityExecutorService = new PriorityProcessWorkerExecutorService(


### PR DESCRIPTION
When the inference process crashes, a message is logged but the event is not visible in the UI so the cause of the failure is not immediately apparent. This change uses the system auditor to notify the unexpected termination message when the named pipes connecting the process close and the `child process terminated by signal X` message from the `NativeController` (Linux & macOS). 

The `NativeController` class starts a thread from within its ctor, in theory that thread may try to access parts of the class that are not visible yet. I've moved the initialisation to a factory method. 