### PR TITLE
Remove create parameter from put query ruleset API call

### DIFF
--- a/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.put.json
+++ b/rest-api-spec/src/main/resources/rest-api-spec/api/query_ruleset.put.json
@@ -31,12 +31,6 @@
         }
       ]
     },
-    "params": {
-      "create": {
-        "type": "boolean",
-        "description": "If true, requires that a query_ruleset with the specified resource_id does not already exist. (default: false)"
-      }
-    },
     "body": {
       "description": "The query ruleset configuration, including `rules`",
       "required": true

--- a/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/200_query_ruleset_put.yml
+++ b/x-pack/plugin/ent-search/qa/rest/src/yamlRestTest/resources/rest-api-spec/test/entsearch/200_query_ruleset_put.yml
@@ -37,7 +37,6 @@
 'Create Query Ruleset - Resource already exists':
   - do:
       query_ruleset.put:
-        create: true
         ruleset_id: test-query-ruleset-recreating
         body:
           ruleset_id: 'test-query-ruleset-recreating'
@@ -55,9 +54,7 @@
   - match: { result: 'created' }
 
   - do:
-      catch: conflict
       query_ruleset.put:
-        create: true
         ruleset_id: test-query-ruleset-recreating
         body:
           ruleset_id: 'test-query-ruleset-recreating'
@@ -72,7 +69,7 @@
               ids:
                 - 'id2'
 
-  - match: { error.type: 'version_conflict_engine_exception' }
+  - match: { result: 'updated' }
 
 ---
 'Create Query Ruleset - Insufficient privilege':
@@ -84,7 +81,6 @@
       headers: { Authorization: "Basic ZW50c2VhcmNoLXVzZXI6ZW50c2VhcmNoLXVzZXItcGFzc3dvcmQ=" }  # user
       query_ruleset.put:
         ruleset_id: forbidden-query-ruleset
-        create: true
         body:
           ruleset_id: 'forbidden-query-ruleset'
           rules:

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/QueryRulesIndexService.java
@@ -207,15 +207,13 @@ public class QueryRulesIndexService {
      * Creates or updates the {@link QueryRuleset} in the underlying index.
      *
      * @param queryRuleset The query ruleset object.
-     * @param create If true, a query ruleset with the specified unique identifier must not already exist
      * @param listener The action listener to invoke on response/failure.
      */
-    public void putQueryRuleset(QueryRuleset queryRuleset, boolean create, ActionListener<IndexResponse> listener) {
+    public void putQueryRuleset(QueryRuleset queryRuleset, ActionListener<IndexResponse> listener) {
         try {
-            DocWriteRequest.OpType opType = (create ? DocWriteRequest.OpType.CREATE : DocWriteRequest.OpType.INDEX);
             final IndexRequest indexRequest = new IndexRequest(QUERY_RULES_ALIAS_NAME).opType(DocWriteRequest.OpType.INDEX)
                 .id(queryRuleset.id())
-                .opType(opType)
+                .opType(DocWriteRequest.OpType.INDEX)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(queryRuleset.toXContent(jsonBuilder(), ToXContent.EMPTY_PARAMS));
             clientWithOrigin.index(indexRequest, listener);

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetAction.java
@@ -41,22 +41,18 @@ public class PutQueryRulesetAction extends ActionType<PutQueryRulesetAction.Resp
     public static class Request extends ActionRequest {
 
         private final QueryRuleset queryRuleset;
-        private final boolean create;
 
         public Request(StreamInput in) throws IOException {
             super(in);
             this.queryRuleset = new QueryRuleset(in);
-            this.create = in.readBoolean();
         }
 
-        public Request(QueryRuleset queryRuleset, boolean create) {
+        public Request(QueryRuleset queryRuleset) {
             this.queryRuleset = queryRuleset;
-            this.create = create;
         }
 
-        public Request(String rulesetId, boolean create, BytesReference content, XContentType contentType) {
+        public Request(String rulesetId, BytesReference content, XContentType contentType) {
             this.queryRuleset = QueryRuleset.fromXContentBytes(rulesetId, content, contentType);
-            this.create = create;
         }
 
         @Override
@@ -79,15 +75,10 @@ public class PutQueryRulesetAction extends ActionType<PutQueryRulesetAction.Resp
         public void writeTo(StreamOutput out) throws IOException {
             super.writeTo(out);
             queryRuleset.writeTo(out);
-            out.writeBoolean(create);
         }
 
         public QueryRuleset queryRuleset() {
             return queryRuleset;
-        }
-
-        public boolean create() {
-            return create;
         }
 
         @Override
@@ -95,12 +86,12 @@ public class PutQueryRulesetAction extends ActionType<PutQueryRulesetAction.Resp
             if (this == o) return true;
             if (o == null || getClass() != o.getClass()) return false;
             Request request = (Request) o;
-            return create == request.create && Objects.equals(queryRuleset, request.queryRuleset);
+            return Objects.equals(queryRuleset, request.queryRuleset);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(queryRuleset, create);
+            return Objects.hash(queryRuleset);
         }
     }
 

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/RestPutQueryRulesetAction.java
@@ -42,7 +42,6 @@ public class RestPutQueryRulesetAction extends EnterpriseSearchBaseRestHandler {
     protected RestChannelConsumer innerPrepareRequest(RestRequest restRequest, NodeClient client) throws IOException {
         PutQueryRulesetAction.Request request = new PutQueryRulesetAction.Request(
             restRequest.param("ruleset_id"),
-            restRequest.paramAsBoolean("create", false),
             restRequest.content(),
             restRequest.getXContentType()
         );

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TransportPutQueryRulesetAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/rules/action/TransportPutQueryRulesetAction.java
@@ -29,8 +29,7 @@ public class TransportPutQueryRulesetAction extends HandledTransportAction<PutQu
     @Override
     protected void doExecute(Task task, PutQueryRulesetAction.Request request, ActionListener<PutQueryRulesetAction.Response> listener) {
         QueryRuleset queryRuleset = request.queryRuleset();
-        boolean create = request.create();
-        systemIndexService.putQueryRuleset(queryRuleset, create, listener.map(r -> new PutQueryRulesetAction.Response(r.getResult())));
+        systemIndexService.putQueryRuleset(queryRuleset, listener.map(r -> new PutQueryRulesetAction.Response(r.getResult())));
 
     }
 }

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestSerializingTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/rules/action/PutQueryRulesetActionRequestSerializingTests.java
@@ -20,7 +20,7 @@ public class PutQueryRulesetActionRequestSerializingTests extends AbstractWireSe
 
     @Override
     protected PutQueryRulesetAction.Request createTestInstance() {
-        return new PutQueryRulesetAction.Request(SearchApplicationTestUtils.randomQueryRuleset(), randomBoolean());
+        return new PutQueryRulesetAction.Request(SearchApplicationTestUtils.randomQueryRuleset());
     }
 
     @Override


### PR DESCRIPTION
Removes the `create` parameter from the Put Query Ruleset API call. 

For more context see [this GitHub thread](https://github.com/elastic/elasticsearch/pull/96812/files#r1229861599). 
