### PR TITLE
Add .search indices for enterprise search managment

### DIFF
--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/service/ElasticServiceAccounts.java
@@ -31,6 +31,7 @@ final class ElasticServiceAccounts {
                 RoleDescriptor.IndicesPrivileges.builder()
                     .indices(
                         "search-*",
+                        ".search-acl-filter-*",
                         ".elastic-analytics-collections",
                         ".ent-search-*",
                         ".monitoring-ent-search-*",


### PR DESCRIPTION
Part of https://github.com/elastic/enterprise-search-team/issues/4304

We introduced a new index pattern for Enterprise Search connectors for indices that are prefixed with `.search-acl-filter-*`, so we need to ensure that our native connectors in Elastic Cloud have permissions to create and manage those indices.