### PR TITLE
Correct rare-terms default precision in docs

### DIFF
--- a/docs/reference/aggregations/bucket/rare-terms-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/rare-terms-aggregation.asciidoc
@@ -79,7 +79,7 @@ A `rare_terms` aggregation looks like this in isolation:
 |`field` |The field we wish to find rare terms in |Required |
 |`max_doc_count` |The maximum number of documents a term should appear in. |Optional |`1`
 |`precision` |The precision of the internal CuckooFilters. Smaller precision leads to
-better approximation, but higher memory usage. Cannot be smaller than `0.00001` |Optional |`0.01`
+better approximation, but higher memory usage. Cannot be smaller than `0.00001` |Optional |`0.001`
 |`include` |Terms that should be included in the aggregation|Optional |
 |`exclude` |Terms that should be excluded from the aggregation|Optional |
 |`missing` |The value that should be used if a document does not have the field being aggregated|Optional |


### PR DESCRIPTION
Noticed that 1 of the 5 mentions of the default value of rare-terms aggregation precision was wrong. 4/5 mentions claim 0.001, which the code agrees with at https://github.com/elastic/elasticsearch/blob/main/server/src/main/java/org/elasticsearch/search/aggregations/bucket/terms/RareTermsAggregationBuilder.java#L73

This corrects the remaining mention, which is the first mention, and the one in the table of parameters, so most likely to be read and assumed by users.