### PR TITLE
Rework and expand QueryPhaseTests

### DIFF
--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -45,6 +45,7 @@ import org.apache.lucene.search.MatchNoDocsQuery;
 import org.apache.lucene.search.MultiTermQuery;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryCachingPolicy;
 import org.apache.lucene.search.ScoreDoc;
 import org.apache.lucene.search.Sort;
 import org.apache.lucene.search.SortField;
@@ -96,7 +97,6 @@ import static org.hamcrest.Matchers.arrayWithSize;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
-import static org.hamcrest.Matchers.in;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.lessThan;
 import static org.mockito.Mockito.mock;
@@ -104,37 +104,46 @@ import static org.mockito.Mockito.when;
 
 public class QueryPhaseTests extends IndexShardTestCase {
 
+    private Directory dir;
+    private IndexReader reader;
     private IndexShard indexShard;
 
     @Override
     public void setUp() throws Exception {
         super.setUp();
+        dir = newDirectory();
         indexShard = newShard(true);
     }
 
     @Override
     public void tearDown() throws Exception {
         super.tearDown();
+        if (reader != null) {
+            reader.close();
+        }
+        dir.close();
         closeShards(indexShard);
     }
 
-    private void countTestCase(Query query, IndexReader reader, boolean shouldCollectSearch, boolean shouldCollectCount) throws Exception {
-        ContextIndexSearcher searcher = shouldCollectSearch ? newContextSearcher(reader) : newEarlyTerminationContextSearcher(reader, 0);
+    private TestSearchContext createContext(ContextIndexSearcher searcher, Query query) {
         TestSearchContext context = new TestSearchContext(null, indexShard, searcher);
-        context.parsedQuery(new ParsedQuery(query));
-        context.setSize(0);
         context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
+        context.parsedQuery(new ParsedQuery(query));
+        return context;
+    }
+
+    private void countTestCase(Query query, IndexReader reader, boolean shouldCollectSearch, boolean shouldCollectCount) throws Exception {
+        ContextIndexSearcher searcher = shouldCollectSearch ? newContextSearcher(reader) : noCollectionContextSearcher(reader);
+        TestSearchContext context = createContext(searcher, query);
+        context.setSize(0);
 
         QueryPhase.addCollectorsAndSearch(context);
 
-        ContextIndexSearcher countSearcher = shouldCollectCount
-            ? newContextSearcher(reader)
-            : newEarlyTerminationContextSearcher(reader, 0);
+        ContextIndexSearcher countSearcher = shouldCollectCount ? newContextSearcher(reader) : noCollectionContextSearcher(reader);
         assertEquals(countSearcher.count(query), context.queryResult().topDocs().topDocs.totalHits.value);
     }
 
     private void countTestCase(boolean withDeletions) throws Exception {
-        Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig().setMergePolicy(NoMergePolicy.INSTANCE);
         RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
         final int numDocs = scaledRandomIntBetween(100, 200);
@@ -159,7 +168,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         if (withDeletions) {
             w.deleteDocuments(new Term("delete", "yes"));
         }
-        final IndexReader reader = w.getReader();
+        reader = w.getReader();
         Query matchAll = new MatchAllDocsQuery();
         Query matchAllCsq = new ConstantScoreQuery(matchAll);
         Query tq = new TermQuery(new Term("foo", "bar"));
@@ -180,9 +189,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
         countTestCase(feqCsq, reader, withDeletions, true);
         countTestCase(dvOnlyfeq, reader, true, true);
         countTestCase(bq, reader, true, true);
-        reader.close();
         w.close();
-        dir.close();
     }
 
     public void testCountWithoutDeletions() throws Exception {
@@ -193,141 +200,137 @@ public class QueryPhaseTests extends IndexShardTestCase {
         countTestCase(true);
     }
 
-    public void testPostFilterDisablesCountOptimization() throws Exception {
-        Directory dir = newDirectory();
-        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
-        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
-        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
-        Document doc = new Document();
-        w.addDocument(doc);
-        w.close();
-
-        IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newEarlyTerminationContextSearcher(reader, 0));
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-        context.setSize(10);
-
-        QueryPhase.addCollectorsAndSearch(context);
-        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-
-        context.setSearcher(newContextSearcher(reader));
-        context.parsedPostFilter(new ParsedQuery(new MatchNoDocsQuery()));
-        QueryPhase.addCollectorsAndSearch(context);
-        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-
-        context.setSize(0);
-        QueryPhase.executeQuery(context);
-        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-        reader.close();
-        dir.close();
+    private int indexDocs() throws IOException {
+        return indexDocs(newIndexWriterConfig());
     }
 
-    public void testTerminateAfterWithFilter() throws Exception {
-        Directory dir = newDirectory();
-        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
-        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
-        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
-        Document doc = new Document();
-        for (int i = 0; i < 10; i++) {
-            doc.add(new StringField("foo", Integer.toString(i), Store.NO));
-        }
-        w.addDocument(doc);
-        w.close();
-
-        IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-        context.terminateAfter(1);
-        context.setSize(10);
-        for (int i = 0; i < 10; i++) {
-            context.parsedPostFilter(new ParsedQuery(new TermQuery(new Term("foo", Integer.toString(i)))));
-            QueryPhase.addCollectorsAndSearch(context);
-            assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
-            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
-        }
-        reader.close();
-        dir.close();
-    }
-
-    public void testMinScoreDisablesCountOptimization() throws Exception {
-        Directory dir = newDirectory();
-        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
-        IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
-        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
-        Document doc = new Document();
-        w.addDocument(doc);
-        w.close();
-
-        IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newEarlyTerminationContextSearcher(reader, 0));
-        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-        context.setSize(0);
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        QueryPhase.addCollectorsAndSearch(context);
-        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-
-        context.minimumScore(100);
-        QueryPhase.addCollectorsAndSearch(context);
-        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-
-        context.setSize(10);
-        QueryPhase.executeQuery(context);
-        assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
-
-        reader.close();
-        dir.close();
-    }
-
-    public void testQueryCapturesThreadPoolStats() throws Exception {
-        Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig();
+    private int indexDocs(IndexWriterConfig iwc) throws IOException {
         RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
         final int numDocs = scaledRandomIntBetween(100, 200);
         for (int i = 0; i < numDocs; ++i) {
-            w.addDocument(new Document());
+            Document doc = new Document();
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "bar", Store.NO));
+            }
+            if (randomBoolean()) {
+                doc.add(new StringField("foo", "baz", Store.NO));
+            }
+            doc.add(new NumericDocValuesField("rank", numDocs - i));
+            w.addDocument(doc);
         }
         w.close();
-        IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
+        reader = DirectoryReader.open(dir);
+        return numDocs;
+    }
 
+    public void testPostFilterDisablesHitCountShortcut() throws Exception {
+        int numDocs = indexDocs();
+        {
+            TestSearchContext context = createContext(noCollectionContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(0);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertEquals(numDocs, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            context.setSize(10);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertEquals(numDocs, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+        {
+            // FilteredCollector does not propagate Weight#count, hence it forces collection despite
+            // the inner TotalHitCountCollector can shortcut
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(0);
+            context.parsedPostFilter(new ParsedQuery(new MatchNoDocsQuery()));
+            QueryPhase.executeQuery(context);
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+        {
+            // shortcutTotalHitCount is disabled for filter collectors, hence we collect until track_total_hits
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(10);
+            context.parsedPostFilter(new ParsedQuery(new MatchNoDocsQuery()));
+            QueryPhase.addCollectorsAndSearch(context);
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+    }
+
+    public void testTerminateAfterWithFilter() throws Exception {
+        indexDocs();
+        TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+        context.terminateAfter(1);
+        context.setSize(10);
+        context.parsedPostFilter(new ParsedQuery(new TermQuery(new Term("foo", "bar"))));
+        QueryPhase.addCollectorsAndSearch(context);
+        assertEquals(1, context.queryResult().topDocs().topDocs.totalHits.value);
+        assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+    }
+
+    public void testMinScoreDisablesHitCountShortcut() throws Exception {
+        int numDocs = indexDocs();
+        {
+            TestSearchContext context = createContext(noCollectionContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(0);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertEquals(numDocs, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            context.setSize(10);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertEquals(numDocs, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+        {
+            // MinimumScoreCollector does not propagate Weight#count, hence it forces collection despite
+            // the inner TotalHitCountCollector can shortcut
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(0);
+            context.minimumScore(100);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+        {
+            // shortcutTotalHitCount is disabled for filter collectors, hence we collect until track_total_hits
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(10);
+            context.minimumScore(100);
+            QueryPhase.executeQuery(context);
+            assertEquals(0, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
+        }
+    }
+
+    public void testQueryCapturesThreadPoolStats() throws Exception {
+        indexDocs();
+        TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
         QueryPhase.addCollectorsAndSearch(context);
         QuerySearchResult results = context.queryResult();
         assertThat(results.serviceTimeEWMA(), greaterThanOrEqualTo(0L));
         assertThat(results.nodeQueueSize(), greaterThanOrEqualTo(0));
-        reader.close();
-        dir.close();
     }
 
     public void testInOrderScrollOptimization() throws Exception {
-        Directory dir = newDirectory();
         final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
         IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
-        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
-        final int numDocs = scaledRandomIntBetween(100, 200);
-        for (int i = 0; i < numDocs; ++i) {
-            w.addDocument(new Document());
-        }
-        w.close();
-        IndexReader reader = DirectoryReader.open(dir);
+        int numDocs = indexDocs(iwc);
+
         ScrollContext scrollContext = new ScrollContext();
         TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader), scrollContext);
+        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
         context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
         context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
         scrollContext.lastEmittedDoc = null;
         scrollContext.maxScore = Float.NaN;
         scrollContext.totalHits = null;
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
         int size = randomIntBetween(2, 5);
         context.setSize(size);
 
@@ -338,35 +341,25 @@ public class QueryPhaseTests extends IndexShardTestCase {
         assertThat(context.terminateAfter(), equalTo(0));
         assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
 
-        context.setSearcher(newEarlyTerminationContextSearcher(reader, size));
+        context.setSearcher(earlyTerminationContextSearcher(reader, size));
         QueryPhase.addCollectorsAndSearch(context);
         assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
         assertThat(context.queryResult().getTotalHits().value, equalTo((long) numDocs));
         assertEquals(TotalHits.Relation.EQUAL_TO, context.queryResult().topDocs().topDocs.totalHits.relation);
         assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0].doc, greaterThanOrEqualTo(size));
-        reader.close();
-        dir.close();
     }
 
-    public void testTerminateAfterEarlyTermination() throws Exception {
-        Directory dir = newDirectory();
-        IndexWriterConfig iwc = newIndexWriterConfig();
-        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
-        final int numDocs = scaledRandomIntBetween(100, 200);
-        for (int i = 0; i < numDocs; ++i) {
-            Document doc = new Document();
-            if (randomBoolean()) {
-                doc.add(new StringField("foo", "bar", Store.NO));
-            }
-            if (randomBoolean()) {
-                doc.add(new StringField("foo", "baz", Store.NO));
-            }
-            doc.add(new NumericDocValuesField("rank", numDocs - i));
-            w.addDocument(doc);
-        }
-        w.close();
-        final IndexReader reader = DirectoryReader.open(dir);
-        // TotalHitCountCollector can shortcut count until the terminate_after
+    /**
+     * Test the terminate after functionality when no hits are collected (size is set to 0) and the total hit count is
+     * shortcut by {@link org.apache.lucene.search.TotalHitCountCollector} using {@link Weight#count(LeafReaderContext)}.
+     * A match all query is used to leverage the hit count shortcut as it enables retrieving the count from the index statistics.
+     */
+    public void testTerminateAfterSize0HitCountShortcut() throws Exception {
+        int numDocs = indexDocs();
+        // TotalHitCountCollector (used when size==0) shortcuts total hit count (using Weight#count) segment by segment.
+        // EarlyTerminatingCollector checks whether the threshold is reached at the beginning of each leaf collection.
+        // That's why the returned total hit count may be higher than terminate_after (or track_total_hits), yet lower
+        // than the number of docs depending on number of segments and documents distribution.
         IntUnaryOperator countDocUpTo = terminateAfter -> {
             int total = 0;
             for (LeafReaderContext leaf : reader.leaves()) {
@@ -377,22 +370,71 @@ public class QueryPhaseTests extends IndexShardTestCase {
             }
             return total;
         };
-
         {
-            TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-            context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-            context.setSize(1);
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 1), new MatchAllDocsQuery());
             context.terminateAfter(1);
-            BooleanQuery bq = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
-                .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
-                .build();
-            context.parsedQuery(new ParsedQuery(bq));
+            context.setSize(0);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) countDocUpTo.applyAsInt(1)));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+        // test interaction between trackTotalHits and terminateAfter
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            context.terminateAfter(10);
+            context.setSize(0);
+            context.trackTotalHitsUpTo(-1);
             QueryPhase.executeQuery(context);
             assertTrue(context.queryResult().terminatedEarly());
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            context.terminateAfter(10);
+            context.setSize(0);
+            // track total hits is lower than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(1, 9));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            // given that total hit count does not require collection, the early terminating collector that wraps the total hit count
+            // collector does not early terminate. The overall search, and consequently the total hit count collection, will early
+            // terminate based on the terminate_after value
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) countDocUpTo.applyAsInt(10)));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 10), new MatchAllDocsQuery());
+            context.terminateAfter(10);
+            context.setSize(0);
+            // track total hits is greater than terminate_after but lower than the number of docs
+            context.trackTotalHitsUpTo(randomIntBetween(11, 1000));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) countDocUpTo.applyAsInt(10)));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+    }
 
+    /**
+     * Test the terminate after functionality when no hits are collected (size is set to 0) and the
+     * total hit count cannot be shortcut using {@link Weight#count(LeafReaderContext)}.
+     * We use a boolean query with two optional clauses, which makes it impossible to shortcut the total hit count. This test also
+     * requires disabling the query cache otherwise the count could be cached from previous runs and cause different behaviour.
+     */
+    public void testTerminateAfterSize0NoHitCountShortcut() throws Exception {
+        indexDocs();
+        BooleanQuery bq = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+            .build();
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            context.terminateAfter(1);
             context.setSize(0);
             QueryPhase.executeQuery(context);
             assertTrue(context.queryResult().terminatedEarly());
@@ -400,39 +442,64 @@ public class QueryPhaseTests extends IndexShardTestCase {
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
         }
-
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-
-        context.terminateAfter(numDocs);
+        // test interaction between trackTotalHits and terminateAfter
         {
+            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            context.terminateAfter(10);
+            context.setSize(0);
+            context.trackTotalHitsUpTo(-1);
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            context.terminateAfter(10);
+            context.setSize(0);
+            // track total hits is lower than terminate_after
+            int trackTotalHits = randomIntBetween(1, 9);
+            context.trackTotalHitsUpTo(trackTotalHits);
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) trackTotalHits));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), bq);
+            context.terminateAfter(10);
+            context.setSize(0);
+            // track total hits is higher than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(11, 1000));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(10L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
+        }
+    }
+
+    /**
+     * Test the terminate after functionality when hits are collected (size is greater than 0) and the
+     * total hit count is shortcut using {@link TopDocsCollectorManagerFactory#shortcutTotalHitCount(IndexReader, Query)}
+     * A match all query is used to leverage the hit count shortcut as it enables retrieving the count from the index statistics.
+     */
+    public void testTerminateAfterWithHitsHitCountShortcut() throws Exception {
+        int numDocs = indexDocs();
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.terminateAfter(numDocs);
             context.setSize(10);
             QueryPhase.executeQuery(context);
             assertFalse(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(10));
         }
-
-        context.terminateAfter(1);
-        long countDocs = countDocUpTo.applyAsInt(1);
         {
-            context.setSize(1);
-            QueryPhase.addCollectorsAndSearch(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
-
-            context.setSize(0);
-            QueryPhase.addCollectorsAndSearch(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(countDocs));
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
-        }
-
-        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 1), new MatchAllDocsQuery());
+            context.terminateAfter(1);
             context.setSize(1);
             QueryPhase.addCollectorsAndSearch(context);
             assertTrue(context.queryResult().terminatedEarly());
@@ -440,140 +507,201 @@ public class QueryPhaseTests extends IndexShardTestCase {
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
         }
+        // test interaction between trackTotalHits and terminateAfter
         {
-            context.setSize(1);
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
+            context.terminateAfter(7);
+            context.setSize(10);
+            context.trackTotalHitsUpTo(-1);
             QueryPhase.executeQuery(context);
             assertTrue(context.queryResult().terminatedEarly());
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
-        }
-        {
-            context.setSize(0);
-            QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            // TotalHitCountCollector counts num docs in the first leaf
-            int numDocsInFirstLeaf = reader.leaves().get(0).reader().numDocs();
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocsInFirstLeaf));
-            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
-        }
-
-        // tests with trackTotalHits and terminateAfter
-        context.terminateAfter(10);
-        context.setSize(0);
-        for (int trackTotalHits : new int[] { -1, 3, 76, 100 }) {
-            context.trackTotalHitsUpTo(trackTotalHits);
-            QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            if (trackTotalHits == -1) {
-                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
-                assertThat(
-                    context.queryResult().topDocs().topDocs.totalHits.relation,
-                    equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO)
-                );
-            } else {
-                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) countDocUpTo.applyAsInt(10)));
-                assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            }
-            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(0));
-        }
-
-        context.terminateAfter(7);
-        context.setSize(10);
-        for (int trackTotalHits : new int[] { -1, 3, 75, 100 }) {
-            context.trackTotalHitsUpTo(trackTotalHits);
-            QueryPhase.executeQuery(context);
-            assertTrue(context.queryResult().terminatedEarly());
-            if (trackTotalHits == -1) {
-                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
-                assertThat(
-                    context.queryResult().topDocs().topDocs.totalHits.relation,
-                    equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO)
-                );
-            } else {
-                assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
-                assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-            }
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
         }
-        reader.close();
-        dir.close();
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
+            context.terminateAfter(7);
+            // size is greater than terminate_after
+            context.setSize(10);
+            // track_total_hits is lower than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(1, 6));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
+            context.terminateAfter(7);
+            // size is lower than terminate_after
+            context.setSize(5);
+            // track_total_hits is also lower than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(1, 6));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(5));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), new MatchAllDocsQuery());
+            context.terminateAfter(7);
+            context.setSize(10);
+            // track_total_hits is greater than terminate_after yet lower than the number of documents
+            context.trackTotalHitsUpTo(randomIntBetween(8, 1000));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+        }
+    }
+
+    /**
+     * Test the terminate after functionality when hits are collected (size is greater than 0) and the
+     * total hit count cannot be shortcut using {@link TopDocsCollectorManagerFactory#shortcutTotalHitCount(IndexReader, Query)}.
+     * We use a boolean query which the shortcutTotalHitCount does not shortcut the hit count for.
+     */
+    public void testTerminateAfterWithHitsNoHitCountShortcut() throws Exception {
+        indexDocs();
+        BooleanQuery bq = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.SHOULD)
+            .add(new TermQuery(new Term("foo", "baz")), Occur.SHOULD)
+            .build();
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 1), bq);
+            context.terminateAfter(1);
+            context.setSize(1);
+            QueryPhase.addCollectorsAndSearch(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(1L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+        }
+        // test interaction between trackTotalHits and terminateAfter
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), bq);
+            context.terminateAfter(7);
+            context.setSize(10);
+            context.trackTotalHitsUpTo(-1);
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(0L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), bq);
+            context.terminateAfter(7);
+            // size is greater than terminate_after
+            context.setSize(10);
+            // track_total_hits is lower than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(1, 6));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(7L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), bq);
+            context.terminateAfter(7);
+            // size is lower than terminate_after
+            context.setSize(5);
+            // track_total_hits is lower than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(1, 6));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            // MultiCollector ignores calls to setMinCompetitiveScore, hence we effectively don't early terminate tracking total hits
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(7L));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(5));
+        }
+        {
+            TestSearchContext context = createContext(earlyTerminationContextSearcher(reader, 7), bq);
+            context.terminateAfter(7);
+            // size is greater than terminate_after
+            context.setSize(10);
+            // track_total_hits is also greater than terminate_after
+            context.trackTotalHitsUpTo(randomIntBetween(8, 1000));
+            QueryPhase.executeQuery(context);
+            assertTrue(context.queryResult().terminatedEarly());
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(7L));
+            // TODO this looks off, it should probably be GREATER_THAN_OR_EQUAL_TO
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(7));
+        }
     }
 
     public void testIndexSortingEarlyTermination() throws Exception {
-        Directory dir = newDirectory();
         final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
         IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
-        RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
-        final int numDocs = scaledRandomIntBetween(100, 200);
-        for (int i = 0; i < numDocs; ++i) {
-            Document doc = new Document();
-            if (randomBoolean()) {
-                doc.add(new StringField("foo", "bar", Store.NO));
-            }
-            if (randomBoolean()) {
-                doc.add(new StringField("foo", "baz", Store.NO));
-            }
-            doc.add(new NumericDocValuesField("rank", numDocs - i));
-            w.addDocument(doc);
-        }
-        w.close();
-
-        final IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-        context.parsedQuery(new ParsedQuery(new MatchAllDocsQuery()));
-        context.setSize(1);
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
-        context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
-
-        QueryPhase.addCollectorsAndSearch(context);
-        assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
-        assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
-        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
-        assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
-        FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
-        assertThat(fieldDoc.fields[0], equalTo(1));
-
+        int numDocs = indexDocs(iwc);
         {
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(1);
+            context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+            QueryPhase.addCollectorsAndSearch(context);
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
+            assertThat(fieldDoc.fields[0], equalTo(1));
+        }
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(1);
+            context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
             context.parsedPostFilter(new ParsedQuery(new MinDocQuery(1)));
             QueryPhase.addCollectorsAndSearch(context);
             assertNull(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(numDocs - 1L));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
             assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
-            context.parsedPostFilter(null);
-
+        }
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(1);
+            context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
             QueryPhase.executeQuery(context);
             assertNull(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
             assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
         }
-
         {
-            context.setSearcher(newEarlyTerminationContextSearcher(reader, 1));
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(1);
+            context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
+            context.setSearcher(earlyTerminationContextSearcher(reader, 1));
             context.trackTotalHitsUpTo(SearchContext.TRACK_TOTAL_HITS_DISABLED);
             QueryPhase.addCollectorsAndSearch(context);
             assertNull(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
             assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
-
+        }
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), new MatchAllDocsQuery());
+            context.setSize(1);
+            context.sort(new SortAndFormats(sort, new DocValueFormat[] { DocValueFormat.RAW }));
             QueryPhase.addCollectorsAndSearch(context);
             assertNull(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(1));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs[0], instanceOf(FieldDoc.class));
+            FieldDoc fieldDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[0];
             assertThat(fieldDoc.fields[0], anyOf(equalTo(1), equalTo(2)));
         }
-        reader.close();
-        dir.close();
     }
 
     public void testIndexSortScrollOptimization() throws Exception {
-        Directory dir = newDirectory();
         final Sort indexSort = new Sort(new SortField("rank", SortField.Type.INT), new SortField("tiebreaker", SortField.Type.INT));
         IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(indexSort);
         RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
@@ -588,8 +716,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
             w.forceMerge(randomIntBetween(1, 10));
         }
         w.close();
+        reader = DirectoryReader.open(dir);
 
-        final IndexReader reader = DirectoryReader.open(dir);
         List<SortAndFormats> searchSortAndFormats = new ArrayList<>();
         searchSortAndFormats.add(new SortAndFormats(indexSort, new DocValueFormat[] { DocValueFormat.RAW, DocValueFormat.RAW }));
         // search sort is a prefix of the index sort
@@ -613,7 +741,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
             int sizeMinus1 = context.queryResult().topDocs().topDocs.scoreDocs.length - 1;
             FieldDoc lastDoc = (FieldDoc) context.queryResult().topDocs().topDocs.scoreDocs[sizeMinus1];
 
-            context.setSearcher(newEarlyTerminationContextSearcher(reader, 10));
+            context.setSearcher(earlyTerminationContextSearcher(reader, 10));
             QueryPhase.addCollectorsAndSearch(context);
             assertNull(context.queryResult().terminatedEarly());
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
@@ -634,12 +762,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
                 break;
             }
         }
-        reader.close();
-        dir.close();
     }
 
     public void testDisableTopScoreCollection() throws Exception {
-        Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig(new StandardAnalyzer());
         RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
         Document doc = new Document();
@@ -653,34 +778,36 @@ public class QueryPhaseTests extends IndexShardTestCase {
             w.addDocument(doc);
         }
         w.close();
+        reader = DirectoryReader.open(dir);
 
-        IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
         Query q = new SpanNearQuery.Builder("title", true).addClause(new SpanTermQuery(new Term("title", "foo")))
             .addClause(new SpanTermQuery(new Term("title", "bar")))
             .build();
-
-        context.parsedQuery(new ParsedQuery(q));
-        context.setSize(3);
-        context.trackTotalHitsUpTo(3);
-        TopDocsCollectorManagerFactory topDocsContext = TopDocsCollectorManagerFactory.createTopDocsCollectorFactory(context, false);
-        assertEquals(topDocsContext.collector().scoreMode(), org.apache.lucene.search.ScoreMode.COMPLETE);
-        QueryPhase.executeQuery(context);
-        assertEquals(5, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.EQUAL_TO);
-        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
-
-        context.sort(new SortAndFormats(new Sort(new SortField("other", SortField.Type.INT)), new DocValueFormat[] { DocValueFormat.RAW }));
-        topDocsContext = TopDocsCollectorManagerFactory.createTopDocsCollectorFactory(context, false);
-        assertEquals(topDocsContext.collector().scoreMode(), org.apache.lucene.search.ScoreMode.TOP_DOCS);
-        QueryPhase.executeQuery(context);
-        assertEquals(5, context.queryResult().topDocs().topDocs.totalHits.value);
-        assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
-        assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
-
-        reader.close();
-        dir.close();
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), q);
+            context.setSize(3);
+            context.trackTotalHitsUpTo(3);
+            TopDocsCollectorManagerFactory topDocsContext = TopDocsCollectorManagerFactory.createTopDocsCollectorFactory(context, false);
+            assertEquals(topDocsContext.collector().scoreMode(), org.apache.lucene.search.ScoreMode.COMPLETE);
+            QueryPhase.executeQuery(context);
+            assertEquals(5, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.EQUAL_TO);
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
+        }
+        {
+            TestSearchContext context = createContext(newContextSearcher(reader), q);
+            context.setSize(3);
+            context.trackTotalHitsUpTo(3);
+            context.sort(
+                new SortAndFormats(new Sort(new SortField("other", SortField.Type.INT)), new DocValueFormat[] { DocValueFormat.RAW })
+            );
+            TopDocsCollectorManagerFactory topDocsContext = TopDocsCollectorManagerFactory.createTopDocsCollectorFactory(context, false);
+            assertEquals(topDocsContext.collector().scoreMode(), org.apache.lucene.search.ScoreMode.TOP_DOCS);
+            QueryPhase.executeQuery(context);
+            assertEquals(5, context.queryResult().topDocs().topDocs.totalHits.value);
+            assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(3));
+            assertEquals(context.queryResult().topDocs().topDocs.totalHits.relation, TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO);
+        }
     }
 
     public void testNumericSortOptimization() throws Exception {
@@ -693,7 +820,6 @@ public class QueryPhaseTests extends IndexShardTestCase {
         when(searchExecutionContext.getFieldType(fieldNameDate)).thenReturn(fieldTypeDate);
         // enough docs to have a tree with several leaf nodes
         final int numDocs = atLeast(3500 * 2);
-        Directory dir = newDirectory();
         IndexWriter writer = new IndexWriter(dir, new IndexWriterConfig(null));
         long startLongValue = randomLongBetween(-10000000L, 10000000L);
         long longValue = startLongValue;
@@ -711,8 +837,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
             if (i % 3500 == 0) writer.flush();
         }
         writer.close();
-
-        final IndexReader reader = DirectoryReader.open(dir);
+        reader = DirectoryReader.open(dir);
 
         final SortField sortFieldLong = new SortField(fieldNameLong, SortField.Type.LONG);
         final SortField sortFieldDate = new SortField(fieldNameDate, SortField.Type.LONG);
@@ -729,15 +854,11 @@ public class QueryPhaseTests extends IndexShardTestCase {
         final SortAndFormats formatsDateLong = new SortAndFormats(sortDateLong, new DocValueFormat[] { dvFormatDate, DocValueFormat.RAW });
 
         Query q = LongPoint.newRangeQuery(fieldNameLong, startLongValue, startLongValue + numDocs);
-        final ParsedQuery query = new ParsedQuery(q);
-        final SearchShardTask task = new SearchShardTask(123L, "", "", "", null, Collections.emptyMap());
 
         // 1. Test sort optimization on long field
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             searchContext.sort(formatsLong);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.trackTotalHitsUpTo(10);
             searchContext.setSize(10);
             QueryPhase.addCollectorsAndSearch(searchContext);
@@ -747,14 +868,12 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
         // 2. Test sort optimization on long field with after
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             int afterDoc = (int) randomLongBetween(0, 30);
             long afterValue = startLongValue + afterDoc;
             FieldDoc after = new FieldDoc(afterDoc, Float.NaN, new Long[] { afterValue });
             searchContext.searchAfter(after);
             searchContext.sort(formatsLong);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.trackTotalHitsUpTo(10);
             searchContext.setSize(10);
             QueryPhase.addCollectorsAndSearch(searchContext);
@@ -767,10 +886,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
         // 3. Test sort optimization on long field + date field
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             searchContext.sort(formatsLongDate);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.trackTotalHitsUpTo(10);
             searchContext.setSize(10);
             QueryPhase.addCollectorsAndSearch(searchContext);
@@ -780,10 +897,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
         // 4. Test sort optimization on date field
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             searchContext.sort(formatsDate);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.trackTotalHitsUpTo(10);
             searchContext.setSize(10);
             QueryPhase.addCollectorsAndSearch(searchContext);
@@ -793,23 +908,19 @@ public class QueryPhaseTests extends IndexShardTestCase {
 
         // 5. Test sort optimization on date field + long field
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             searchContext.sort(formatsDateLong);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.trackTotalHitsUpTo(10);
             searchContext.setSize(10);
             QueryPhase.addCollectorsAndSearch(searchContext);
             assertTrue(searchContext.sort().sort.getSort()[0].getOptimizeSortWithPoints());
-            assertSortResults(searchContext.queryResult().topDocs().topDocs, (long) numDocs, true);
+            assertSortResults(searchContext.queryResult().topDocs().topDocs, numDocs, true);
         }
 
         // 6. Test sort optimization on when from > 0 and size = 0
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             searchContext.sort(formatsLong);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.trackTotalHitsUpTo(10);
             searchContext.from(5);
             searchContext.setSize(0);
@@ -817,20 +928,16 @@ public class QueryPhaseTests extends IndexShardTestCase {
             assertTrue(searchContext.sort().sort.getSort()[0].getOptimizeSortWithPoints());
             assertThat(searchContext.queryResult().topDocs().topDocs.scoreDocs, arrayWithSize(0));
             assertThat(searchContext.queryResult().topDocs().topDocs.totalHits.value, equalTo((long) numDocs));
+            assertThat(searchContext.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.EQUAL_TO));
         }
 
         // 7. Test that sort optimization doesn't break a case where from = 0 and size= 0
         {
-            TestSearchContext searchContext = new TestSearchContext(searchExecutionContext, indexShard, newContextSearcher(reader));
+            TestSearchContext searchContext = createContext(newContextSearcher(reader), q);
             searchContext.sort(formatsLong);
-            searchContext.parsedQuery(query);
-            searchContext.setTask(task);
             searchContext.setSize(0);
             QueryPhase.addCollectorsAndSearch(searchContext);
         }
-
-        reader.close();
-        dir.close();
     }
 
     public void testMaxScoreQueryVisitor() {
@@ -889,7 +996,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     // assert score docs are in order and their number is as expected
-    private void assertSortResults(TopDocs topDocs, long totalNumDocs, boolean isDoubleSort) {
+    private static void assertSortResults(TopDocs topDocs, long totalNumDocs, boolean isDoubleSort) {
         assertEquals(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO, topDocs.totalHits.relation);
         assertThat(topDocs.totalHits.value, lessThan(totalNumDocs)); // we collected less docs than total number
         long cur1, cur2;
@@ -910,7 +1017,6 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     public void testMinScore() throws Exception {
-        Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig();
         RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
         for (int i = 0; i < 10; i++) {
@@ -920,54 +1026,41 @@ public class QueryPhaseTests extends IndexShardTestCase {
             w.addDocument(doc);
         }
         w.close();
+        reader = DirectoryReader.open(dir);
 
-        IndexReader reader = DirectoryReader.open(dir);
-        TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-        context.parsedQuery(
-            new ParsedQuery(
-                new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
-                    .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
-                    .build()
-            )
-        );
+        BooleanQuery booleanQuery = new BooleanQuery.Builder().add(new TermQuery(new Term("foo", "bar")), Occur.MUST)
+            .add(new TermQuery(new Term("filter", "f1")), Occur.SHOULD)
+            .build();
+        TestSearchContext context = createContext(newContextSearcher(reader), booleanQuery);
         context.minimumScore(0.01f);
-        context.setTask(new SearchShardTask(123L, "", "", "", null, Collections.emptyMap()));
         context.setSize(1);
         context.trackTotalHitsUpTo(5);
 
         QueryPhase.addCollectorsAndSearch(context);
         assertEquals(10, context.queryResult().topDocs().topDocs.totalHits.value);
-
-        reader.close();
-        dir.close();
     }
 
     public void testCancellationDuringRewrite() throws IOException {
-        try (Directory dir = newDirectory(); RandomIndexWriter w = new RandomIndexWriter(random(), dir, newIndexWriterConfig())) {
-
-            for (int i = 0; i < 10; i++) {
-                Document doc = new Document();
-                doc.add(new StringField("foo", "a".repeat(i), Store.NO));
-                w.addDocument(doc);
-            }
-            w.flush();
-            w.close();
-
-            try (IndexReader reader = DirectoryReader.open(dir)) {
-                TestSearchContext context = new TestSearchContext(null, indexShard, newContextSearcher(reader));
-                PrefixQuery prefixQuery = new PrefixQuery(new Term("foo", "a"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
-                context.parsedQuery(new ParsedQuery(prefixQuery));
-                SearchShardTask task = new SearchShardTask(randomLong(), "transport", "", "", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
-                TaskCancelHelper.cancel(task, "simulated");
-                context.setTask(task);
-                context.searcher().addQueryCancellation(task::ensureNotCancelled);
-                expectThrows(TaskCancelledException.class, context::rewrittenQuery);
-            }
+        RandomIndexWriter w = new RandomIndexWriter(random(), dir, newIndexWriterConfig());
+        for (int i = 0; i < 10; i++) {
+            Document doc = new Document();
+            doc.add(new StringField("foo", "a".repeat(i), Store.NO));
+            w.addDocument(doc);
         }
+        w.flush();
+        w.close();
+
+        reader = DirectoryReader.open(dir);
+        PrefixQuery prefixQuery = new PrefixQuery(new Term("foo", "a"), MultiTermQuery.SCORING_BOOLEAN_REWRITE);
+        TestSearchContext context = createContext(newContextSearcher(reader), prefixQuery);
+        SearchShardTask task = new SearchShardTask(randomLong(), "transport", "", "", TaskId.EMPTY_TASK_ID, Collections.emptyMap());
+        TaskCancelHelper.cancel(task, "simulated");
+        context.setTask(task);
+        context.searcher().addQueryCancellation(task::ensureNotCancelled);
+        expectThrows(TaskCancelledException.class, context::rewrittenQuery);
     }
 
     public void testRank() throws IOException {
-        Directory dir = newDirectory();
         IndexWriterConfig iwc = newIndexWriterConfig();
         RandomIndexWriter w = new RandomIndexWriter(random(), dir, iwc);
         for (int i = 0; i < 10; i++) {
@@ -977,9 +1070,9 @@ public class QueryPhaseTests extends IndexShardTestCase {
             w.addDocument(doc);
         }
         w.close();
+        reader = DirectoryReader.open(dir);
 
         final List<Query> executed = new ArrayList<>();
-        IndexReader reader = DirectoryReader.open(dir);
         ContextIndexSearcher searcher = new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
@@ -1035,59 +1128,61 @@ public class QueryPhaseTests extends IndexShardTestCase {
         QueryPhase.executeRank(context);
         assertEquals(context.rewrittenQuery(), executed.get(0));
         assertEquals(queries, executed.subList(1, executed.size()));
-
-        reader.close();
-        dir.close();
     }
+
+    private static final QueryCachingPolicy NEVER_CACHE_POLICY = new QueryCachingPolicy() {
+        @Override
+        public void onUse(Query query) {}
+
+        @Override
+        public boolean shouldCache(Query query) {
+            return false;
+        }
+    };
 
     private static ContextIndexSearcher newContextSearcher(IndexReader reader) throws IOException {
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
+            NEVER_CACHE_POLICY,
             true
         );
     }
 
-    private static ContextIndexSearcher newEarlyTerminationContextSearcher(IndexReader reader, int size) throws IOException {
+    private static ContextIndexSearcher noCollectionContextSearcher(IndexReader reader) throws IOException {
+        return earlyTerminationContextSearcher(reader, 0);
+    }
+
+    private static ContextIndexSearcher earlyTerminationContextSearcher(IndexReader reader, int size) throws IOException {
         return new ContextIndexSearcher(
             reader,
             IndexSearcher.getDefaultSimilarity(),
             IndexSearcher.getDefaultQueryCache(),
-            IndexSearcher.getDefaultQueryCachingPolicy(),
+            NEVER_CACHE_POLICY,
             true
         ) {
 
             @Override
             public void search(List<LeafReaderContext> leaves, Weight weight, Collector collector) throws IOException {
-                final Collector in = new AssertingEarlyTerminationFilterCollector(collector, size);
+                final Collector in = new FilterCollector(collector) {
+                    @Override
+                    public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
+                        final LeafCollector in = super.getLeafCollector(context);
+                        return new FilterLeafCollector(in) {
+                            int collected;
+
+                            @Override
+                            public void collect(int doc) throws IOException {
+                                assert collected <= size : "should not collect more than " + size + " doc per segment, got " + collected;
+                                ++collected;
+                                super.collect(doc);
+                            }
+                        };
+                    }
+                };
                 super.search(leaves, weight, in);
             }
         };
-    }
-
-    private static class AssertingEarlyTerminationFilterCollector extends FilterCollector {
-        private final int size;
-
-        AssertingEarlyTerminationFilterCollector(Collector in, int size) {
-            super(in);
-            this.size = size;
-        }
-
-        @Override
-        public LeafCollector getLeafCollector(LeafReaderContext context) throws IOException {
-            final LeafCollector in = super.getLeafCollector(context);
-            return new FilterLeafCollector(in) {
-                int collected;
-
-                @Override
-                public void collect(int doc) throws IOException {
-                    assert collected <= size : "should not collect more than " + size + " doc per segment, got " + collected;
-                    ++collected;
-                    super.collect(doc);
-                }
-            };
-        }
     }
 }

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -319,7 +319,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
     }
 
     public void testInOrderScrollOptimization() throws Exception {
-        final Sort sort = new Sort(new SortField("rank", SortField.Type.INT));
+        final Sort sort = new Sort(new SortField("not_present", SortField.Type.INT));
         IndexWriterConfig iwc = newIndexWriterConfig().setIndexSort(sort);
         int numDocs = indexDocs(iwc);
 
@@ -355,7 +355,7 @@ public class QueryPhaseTests extends IndexShardTestCase {
      * A match all query is used to leverage the hit count shortcut as it enables retrieving the count from the index statistics.
      */
     public void testTerminateAfterSize0HitCountShortcut() throws Exception {
-        int numDocs = indexDocs();
+        indexDocs();
         // TotalHitCountCollector (used when size==0) shortcuts total hit count (using Weight#count) segment by segment.
         // EarlyTerminatingCollector checks whether the threshold is reached at the beginning of each leaf collection.
         // That's why the returned total hit count may be higher than terminate_after (or track_total_hits), yet lower

--- a/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/search/query/QueryPhaseTests.java
@@ -613,7 +613,8 @@ public class QueryPhaseTests extends IndexShardTestCase {
             context.trackTotalHitsUpTo(randomIntBetween(1, 6));
             QueryPhase.executeQuery(context);
             assertTrue(context.queryResult().terminatedEarly());
-            // MultiCollector ignores calls to setMinCompetitiveScore, hence we effectively don't early terminate tracking total hits
+            // MultiCollector ignores calls to setMinCompetitiveScore, because one collector is TOP_DOCS and the other TOP_SCORES,
+            // hence we effectively don't early terminate tracking total hits
             assertThat(context.queryResult().topDocs().topDocs.totalHits.value, equalTo(7L));
             assertThat(context.queryResult().topDocs().topDocs.totalHits.relation, equalTo(TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO));
             assertThat(context.queryResult().topDocs().topDocs.scoreDocs.length, equalTo(5));


### PR DESCRIPTION
There are a number of issues with the current tests included in QueryPhaseTests that this commit addresses:
- many scenarios tested in the same single test method that can be split up into multiple test methods
- the search context is shared across subsequent test sections, and modified for each scenarios, which makes it hard to follow exactly what scenario each section tests
- some scenarios are tested multiple times
- code duplication around indexing docs

The added code coverage revolves around support for terminate_after, which was only tested in combination with the scenario where total hit count can be shortcut. Added scenario where it cannot be shortcut.