### PR TITLE
Fix cluster bootstrap warning incorrectly emitted for discovery.type:…

### DIFF
--- a/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/coordination/ClusterBootstrapServiceTests.java
@@ -735,6 +735,27 @@ public class ClusterBootstrapServiceTests extends ESTestCase {
             }
 
             mockAppender.assertAllExpectationsMatched();
+
+            mockAppender.addExpectation(
+                new MockLogAppender.SeenEventExpectation(
+                    "bootstrapped node message if discovery type is single node ",
+                    ClusterBootstrapService.class.getCanonicalName(),
+                    Level.INFO,
+                    "this node is locked into single-node cluster UUID [test-uuid]"
+                )
+            );
+
+            new ClusterBootstrapService(
+                Settings.builder().put(DiscoveryModule.DISCOVERY_TYPE_SETTING.getKey(), DiscoveryModule.SINGLE_NODE_DISCOVERY_TYPE).build(),
+                transportService,
+                Collections::emptyList,
+                () -> false,
+                vc -> {
+                    throw new AssertionError("should not be called");
+                }
+            ).logBootstrapState(Metadata.builder().clusterUUID("test-uuid").clusterUUIDCommitted(true).build());
+
+            mockAppender.assertAllExpectationsMatched();
         }
     }
 }


### PR DESCRIPTION
Update incorrect periodic warning log to a single info log for discovery.type: single-node in report inappropriate
bootstrap config.
Closes #96874