### PR TITLE
given phase2 snapshot end seq no on RecoverySourceHandler

### DIFF
--- a/docs/changelog/96894.yaml
+++ b/docs/changelog/96894.yaml
@@ -1,0 +1,5 @@
+pr: 96894
+summary: Create translog snapshot with given an end seq no on phase2
+area: Recovery
+type: enhancement
+issues: []

--- a/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
+++ b/server/src/main/java/org/elasticsearch/indices/recovery/RecoverySourceHandler.java
@@ -316,7 +316,7 @@ public class RecoverySourceHandler {
                     final Translog.Snapshot phase2Snapshot = shard.newChangesSnapshot(
                         "peer-recovery",
                         startingSeqNo,
-                        Long.MAX_VALUE,
+                        Math.max(endingSeqNo, startingSeqNo),
                         false,
                         false,
                         true


### PR DESCRIPTION
In the phase2 stage of peer recovery, primary shard will send translog range from start seq no(replica request contains) to end seq no(primary shard max seq no). However we create translog snapshot without given end seq no, the snapshot maybe cause unnecessary scanning.