### PR TITLE
Adjust version extension signature

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -147,7 +147,9 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
             if (versionExtension == null) {
                 return fallback;
             }
-            return new TransportVersion(versionExtension.getCurrentTransportVersionId());
+            var version = versionExtension.getCurrentTransportVersion();
+            assert version.onOrAfter(fallback);
+            return version;
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
+++ b/server/src/main/java/org/elasticsearch/internal/VersionExtension.java
@@ -8,6 +8,8 @@
 
 package org.elasticsearch.internal;
 
+import org.elasticsearch.TransportVersion;
+
 import java.util.ServiceLoader;
 
 /**
@@ -15,11 +17,11 @@ import java.util.ServiceLoader;
  */
 public interface VersionExtension {
     /**
-     * Returns the version id of the current transport version.
-     * Note this cannot return a TransportVersion object because it needs to be
-     * called during static initialization of TransportVersion.
+     * Returns the {@link TransportVersion} that Elasticsearch should use.
+     * <p>
+     * This must be at least equal to the latest version found in {@link TransportVersion} V_* constants.
      */
-    int getCurrentTransportVersionId();
+    TransportVersion getCurrentTransportVersion();
 
     /**
      * Loads a single VersionExtension, or returns {@code null} if none are found.


### PR DESCRIPTION
Now that TransportVersion.current() is lazily evaluated, version extensions can return fully formed TransportVersion objects. This commit adjusts the signature of the extension to return TransportVersion instead of its id. It also adds some validation that the version returned doesn't try to downgrade to a version lower than what is known in server constants.
