### PR TITLE
Use a long to properly track added samples

### DIFF
--- a/docs/changelog/96912.yaml
+++ b/docs/changelog/96912.yaml
@@ -2,4 +2,5 @@ pr: 96912
 summary: Use a long to properly track added samples
 area: Aggregations
 type: bug
-issues: []
+issues:
+ - 96911

--- a/docs/changelog/96912.yaml
+++ b/docs/changelog/96912.yaml
@@ -1,0 +1,5 @@
+pr: 96912
+summary: Use a long to properly track added samples
+area: Aggregations
+type: bug
+issues: []

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/SortingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/SortingDigest.java
@@ -52,11 +52,11 @@ public class SortingDigest extends AbstractTDigest {
 
     @Override
     public void add(List<? extends TDigest> others) {
-        int valuesToAddCount = 0;
+        long valuesToAddCount = 0;
         for (TDigest other : others) {
             valuesToAddCount += other.size();
         }
-        values.ensureCapacity(valuesToAddCount + values.size());
+        reserve(valuesToAddCount);
 
         for (TDigest other : others) {
             for (Centroid centroid : other.centroids()) {

--- a/libs/tdigest/src/test/java/org/elasticsearch/tdigest/ScaleFunctionTests.java
+++ b/libs/tdigest/src/test/java/org/elasticsearch/tdigest/ScaleFunctionTests.java
@@ -60,21 +60,18 @@ public class ScaleFunctionTests extends ESTestCase {
                     double k0 = k.k(0, compression, n);
                     int m = 0;
                     for (int i = 0; i < n;) {
-                        double cnt = 1;
-                        while (i + cnt < n && k.k((i + cnt + 1) / (n - 1), compression, n) - k0 < 1) {
+                        int cnt = 1;
+                        while (i + cnt < n && k.k((i + cnt + 1.0) / (n - 1.0), compression, n) - k0 < 1) {
                             cnt++;
                         }
-                        double size = n * max(k.max(i / (n - 1), compression, n), k.max((i + cnt) / (n - 1), compression, n));
+                        double size = n * max(k.max(i / (n - 1), compression, n), k.max((i + cnt) / (n - 1.0), compression, n));
 
                         // check that we didn't cross the midline (which makes the size limit very conservative)
                         double left = i - (n - 1) / 2;
                         double right = i + cnt - (n - 1) / 2;
                         boolean sameSide = left * right > 0;
                         if (k.toString().endsWith("NO_NORM") == false && sameSide) {
-                            assertTrue(
-                                String.format(Locale.ROOT, "%s %.0f %.0f %.3f vs %.3f @ %.3f", k, compression, n, cnt, size, i / (n - 1)),
-                                cnt == 1 || cnt <= max(1.1 * size, size + 1)
-                            );
+                            assertTrue(cnt == 1 || cnt <= max(1.1 * size, size + 1));
                         }
                         i += cnt;
                         k0 = k.k(i / (n - 1), compression, n);


### PR DESCRIPTION
This helps avoid warnings around implicit conversions from long to integer values in SortingDigest.

Related to #95903

Fixes #96911