### PR TITLE
Dry up listeners that assert no failure in tests

### DIFF
--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/RetentionLeaseIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.seqno;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.routing.ShardRouting;
@@ -603,7 +604,7 @@ public class RetentionLeaseIT extends ESIntegTestCase {
     }
 
     private static ActionListener<ReplicationResponse> countDownLatchListener(CountDownLatch latch) {
-        return ActionListener.wrap(r -> latch.countDown(), RetentionLeaseIT::failWithException);
+        return ActionTestUtils.assertNoFailureListener(r -> latch.countDown());
     }
 
 }

--- a/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/cluster/reroute/ClusterRerouteTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.action.admin.cluster.reroute;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.ESAllocationTestCase;
@@ -83,9 +84,7 @@ public class ClusterRerouteTests extends ESAllocationTestCase {
         ClusterState clusterState = createInitialClusterState(allocationService);
 
         var responseRef = new AtomicReference<ClusterRerouteResponse>();
-        var responseActionListener = ActionListener.<ClusterRerouteResponse>wrap(responseRef::set, exception -> {
-            throw new AssertionError("Should not fail in test", exception);
-        });
+        var responseActionListener = ActionTestUtils.assertNoFailureListener(responseRef::set);
 
         var request = new ClusterRerouteRequest().dryRun(true);
         var task = new TransportClusterRerouteAction.ClusterRerouteResponseAckedClusterStateUpdateTask(

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/close/TransportVerifyShardBeforeCloseActionTests.java
@@ -155,10 +155,10 @@ public class TransportVerifyShardBeforeCloseActionTests extends ESTestCase {
             taskId
         );
         final PlainActionFuture<Void> res = PlainActionFuture.newFuture();
-        action.shardOperationOnPrimary(request, indexShard, ActionListener.wrap(r -> {
+        action.shardOperationOnPrimary(request, indexShard, res.delegateFailureAndWrap((l, r) -> {
             assertNotNull(r);
-            res.onResponse(null);
-        }, res::onFailure));
+            l.onResponse(null);
+        }));
         try {
             res.get();
         } catch (InterruptedException e) {

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/get/GetIndexActionTests.java
@@ -84,14 +84,11 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
             getIndexAction,
             null,
             defaultsRequest,
-            ActionListener.wrap(
+            ActionTestUtils.assertNoFailureListener(
                 defaultsResponse -> assertNotNull(
                     "index.refresh_interval should be set as we are including defaults",
                     defaultsResponse.getSetting(indexName, "index.refresh_interval")
-                ),
-                exception -> {
-                    throw new AssertionError(exception);
-                }
+                )
             )
         );
     }
@@ -102,14 +99,11 @@ public class GetIndexActionTests extends ESSingleNodeTestCase {
             getIndexAction,
             null,
             noDefaultsRequest,
-            ActionListener.wrap(
+            ActionTestUtils.assertNoFailureListener(
                 noDefaultsResponse -> assertNull(
                     "index.refresh_interval should be null as it was never set",
                     noDefaultsResponse.getSetting(indexName, "index.refresh_interval")
-                ),
-                exception -> {
-                    throw new AssertionError(exception);
-                }
+                )
             )
         );
     }

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/settings/get/GetSettingsActionTests.java
@@ -105,21 +105,31 @@ public class GetSettingsActionTests extends ESTestCase {
 
     public void testIncludeDefaults() {
         GetSettingsRequest noDefaultsRequest = new GetSettingsRequest().indices(indexName);
-        ActionTestUtils.execute(getSettingsAction, null, noDefaultsRequest, ActionListener.wrap(noDefaultsResponse -> {
-            assertNull(
-                "index.refresh_interval should be null as it was never set",
-                noDefaultsResponse.getSetting(indexName, "index.refresh_interval")
-            );
-        }, exception -> { throw new AssertionError(exception); }));
+        ActionTestUtils.execute(
+            getSettingsAction,
+            null,
+            noDefaultsRequest,
+            ActionTestUtils.assertNoFailureListener(
+                noDefaultsResponse -> assertNull(
+                    "index.refresh_interval should be null as it was never set",
+                    noDefaultsResponse.getSetting(indexName, "index.refresh_interval")
+                )
+            )
+        );
 
         GetSettingsRequest defaultsRequest = new GetSettingsRequest().indices(indexName).includeDefaults(true);
 
-        ActionTestUtils.execute(getSettingsAction, null, defaultsRequest, ActionListener.wrap(defaultsResponse -> {
-            assertNotNull(
-                "index.refresh_interval should be set as we are including defaults",
-                defaultsResponse.getSetting(indexName, "index.refresh_interval")
-            );
-        }, exception -> { throw new AssertionError(exception); }));
+        ActionTestUtils.execute(
+            getSettingsAction,
+            null,
+            defaultsRequest,
+            ActionTestUtils.assertNoFailureListener(
+                defaultsResponse -> assertNotNull(
+                    "index.refresh_interval should be set as we are including defaults",
+                    defaultsResponse.getSetting(indexName, "index.refresh_interval")
+                )
+            )
+        );
 
     }
 
@@ -127,7 +137,7 @@ public class GetSettingsActionTests extends ESTestCase {
         GetSettingsRequest defaultsRequest = new GetSettingsRequest().indices(indexName)
             .includeDefaults(true)
             .names("index.refresh_interval");
-        ActionTestUtils.execute(getSettingsAction, null, defaultsRequest, ActionListener.wrap(defaultsResponse -> {
+        ActionTestUtils.execute(getSettingsAction, null, defaultsRequest, ActionTestUtils.assertNoFailureListener(defaultsResponse -> {
             assertNotNull(
                 "index.refresh_interval should be set as we are including defaults",
                 defaultsResponse.getSetting(indexName, "index.refresh_interval")
@@ -140,7 +150,7 @@ public class GetSettingsActionTests extends ESTestCase {
                 "index.warmer.enabled should be null as this query is filtered",
                 defaultsResponse.getSetting(indexName, "index.warmer.enabled")
             );
-        }, exception -> { throw new AssertionError(exception); }));
+        }));
     }
 
     static class Resolver extends IndexNameExpressionResolver {

--- a/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/bulk/TransportBulkActionIngestTests.java
@@ -238,12 +238,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         IndexRequest indexRequest = new IndexRequest("index").id("id");
         indexRequest.source(Collections.emptyMap());
         bulkRequest.add(indexRequest);
-        ActionTestUtils.execute(
-            action,
-            null,
-            bulkRequest,
-            ActionListener.wrap(response -> {}, exception -> { throw new AssertionError(exception); })
-        );
+        ActionTestUtils.execute(action, null, bulkRequest, ActionTestUtils.assertNoFailureListener(response -> {}));
         assertTrue(action.isExecuted);
         verifyNoMoreInteractions(ingestService);
     }
@@ -251,9 +246,7 @@ public class TransportBulkActionIngestTests extends ESTestCase {
     public void testSingleItemBulkActionIngestSkipped() throws Exception {
         IndexRequest indexRequest = new IndexRequest("index").id("id");
         indexRequest.source(Collections.emptyMap());
-        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionListener.wrap(response -> {}, exception -> {
-            throw new AssertionError(exception);
-        }));
+        ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, ActionTestUtils.assertNoFailureListener(response -> {}));
         assertTrue(action.isExecuted);
         verifyNoMoreInteractions(ingestService);
     }
@@ -403,10 +396,10 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         bulkRequest.add(indexRequest);
         BulkResponse bulkResponse = mock(BulkResponse.class);
         AtomicBoolean responseCalled = new AtomicBoolean(false);
-        ActionListener<BulkResponse> listener = ActionListener.wrap(response -> {
+        ActionListener<BulkResponse> listener = ActionTestUtils.assertNoFailureListener(response -> {
             responseCalled.set(true);
             assertSame(bulkResponse, response);
-        }, e -> { throw new AssertionError(e); });
+        });
         ActionTestUtils.execute(action, null, bulkRequest, listener);
 
         // should not have executed ingest locally
@@ -443,10 +436,10 @@ public class TransportBulkActionIngestTests extends ESTestCase {
         indexRequest.setPipeline("testpipeline");
         IndexResponse indexResponse = mock(IndexResponse.class);
         AtomicBoolean responseCalled = new AtomicBoolean(false);
-        ActionListener<IndexResponse> listener = ActionListener.wrap(response -> {
+        ActionListener<IndexResponse> listener = ActionTestUtils.assertNoFailureListener(response -> {
             responseCalled.set(true);
             assertSame(indexResponse, response);
-        }, e -> { throw new AssertionError(e); });
+        });
         ActionTestUtils.execute(singleItemBulkWriteAction, null, indexRequest, listener);
 
         // should not have executed ingest locally

--- a/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/CanMatchPreFilterSearchPhaseTests.java
@@ -13,6 +13,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
 import org.elasticsearch.action.search.CanMatchNodeResponse.ResponseOrFailure;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.DataStream;
@@ -150,10 +151,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             null,
             true,
             EMPTY_CONTEXT_PROVIDER,
-            ActionListener.wrap(iter -> {
+            ActionTestUtils.assertNoFailureListener(iter -> {
                 result.set(iter);
                 latch.countDown();
-            }, e -> { throw new AssertionError(e); })
+            })
         );
 
         canMatchPhase.start();
@@ -248,10 +249,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             null,
             true,
             EMPTY_CONTEXT_PROVIDER,
-            ActionListener.wrap(iter -> {
+            ActionTestUtils.assertNoFailureListener(iter -> {
                 result.set(iter);
                 latch.countDown();
-            }, e -> { throw new AssertionError(e); })
+            })
         );
 
         canMatchPhase.start();
@@ -341,10 +342,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 null,
                 true,
                 EMPTY_CONTEXT_PROVIDER,
-                ActionListener.wrap(iter -> {
+                ActionTestUtils.assertNoFailureListener(iter -> {
                     result.set(iter);
                     latch.countDown();
-                }, e -> { throw new AssertionError(e); })
+                })
             );
 
             canMatchPhase.start();
@@ -443,10 +444,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
                 null,
                 true,
                 EMPTY_CONTEXT_PROVIDER,
-                ActionListener.wrap(iter -> {
+                ActionTestUtils.assertNoFailureListener(iter -> {
                     result.set(iter);
                     latch.countDown();
-                }, e -> { throw new AssertionError(e); })
+                })
             );
 
             canMatchPhase.start();
@@ -816,10 +817,10 @@ public class CanMatchPreFilterSearchPhaseTests extends ESTestCase {
             null,
             true,
             contextProvider,
-            ActionListener.wrap(iter -> {
+            ActionTestUtils.assertNoFailureListener(iter -> {
                 result.set(iter);
                 latch.countDown();
-            }, e -> { throw new AssertionError(e); })
+            })
         );
 
         canMatchPhase.start();

--- a/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/SearchAsyncActionTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.action.search;
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -63,9 +64,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         int numShards = 10;
 
         AtomicReference<SearchResponse> searchResponse = new AtomicReference<>();
-        ActionListener<SearchResponse> responseListener = ActionListener.wrap(searchResponse::set, (e) -> {
-            throw new AssertionError("unexpected", e);
-        });
+        ActionListener<SearchResponse> responseListener = ActionTestUtils.assertNoFailureListener(searchResponse::set);
         DiscoveryNode primaryNode = DiscoveryNodeUtils.create("node_1");
         DiscoveryNode replicaNode = DiscoveryNodeUtils.create("node_2");
 
@@ -180,10 +179,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         }
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean searchPhaseDidRun = new AtomicBoolean(false);
-        ActionListener<SearchResponse> responseListener = ActionListener.wrap(
-            response -> {},
-            (e) -> { throw new AssertionError("unexpected", e); }
-        );
+        ActionListener<SearchResponse> responseListener = ActionTestUtils.assertNoFailureListener(response -> {});
         DiscoveryNode primaryNode = DiscoveryNodeUtils.create("node_1");
         // for the sake of this test we place the replica on the same node. ie. this is not a mistake since we limit per node now
         DiscoveryNode replicaNode = DiscoveryNodeUtils.create("node_1");
@@ -281,11 +277,8 @@ public class SearchAsyncActionTests extends ESTestCase {
         request.allowPartialSearchResults(true);
         request.setMaxConcurrentShardRequests(randomIntBetween(1, 100));
         AtomicReference<TestSearchResponse> response = new AtomicReference<>();
-        ActionListener<SearchResponse> responseListener = ActionListener.wrap(
-            searchResponse -> response.set((TestSearchResponse) searchResponse),
-            (e) -> {
-                throw new AssertionError("unexpected", e);
-            }
+        ActionListener<SearchResponse> responseListener = ActionTestUtils.assertNoFailureListener(
+            searchResponse -> response.set((TestSearchResponse) searchResponse)
         );
         DiscoveryNode primaryNode = DiscoveryNodeUtils.create("node_1");
         DiscoveryNode replicaNode = DiscoveryNodeUtils.create("node_2");
@@ -519,10 +512,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         request.setMaxConcurrentShardRequests(numConcurrent);
         int numShards = randomIntBetween(5, 10);
         AtomicBoolean searchPhaseDidRun = new AtomicBoolean(false);
-        ActionListener<SearchResponse> responseListener = ActionListener.wrap(
-            response -> {},
-            (e) -> { throw new AssertionError("unexpected", e); }
-        );
+        ActionListener<SearchResponse> responseListener = ActionTestUtils.assertNoFailureListener(response -> {});
         DiscoveryNode primaryNode = DiscoveryNodeUtils.create("node_1");
         // for the sake of this test we place the replica on the same node. ie. this is not a mistake since we limit per node now
         DiscoveryNode replicaNode = DiscoveryNodeUtils.create("node_1");
@@ -616,9 +606,7 @@ public class SearchAsyncActionTests extends ESTestCase {
         request.allowPartialSearchResults(true);
 
         AtomicReference<SearchResponse> searchResponse = new AtomicReference<>();
-        ActionListener<SearchResponse> responseListener = ActionListener.wrap(searchResponse::set, (e) -> {
-            throw new AssertionError("unexpected", e);
-        });
+        ActionListener<SearchResponse> responseListener = ActionTestUtils.assertNoFailureListener(searchResponse::set);
         DiscoveryNode primaryNode = DiscoveryNodeUtils.create("node_1");
 
         final int numUnavailableSkippedShards = randomIntBetween(1, 10);

--- a/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/TransportSearchActionTests.java
@@ -22,6 +22,7 @@ import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsGroup;
 import org.elasticsearch.action.admin.cluster.shards.ClusterSearchShardsResponse;
 import org.elasticsearch.action.support.ActionFilter;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.replication.ClusterStateCreationUtils;
 import org.elasticsearch.client.internal.node.NodeClient;
@@ -583,7 +584,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 SetOnce<Tuple<SearchRequest, ActionListener<SearchResponse>>> setOnce = new SetOnce<>();
                 AtomicReference<SearchResponse> response = new AtomicReference<>();
                 LatchedActionListener<SearchResponse> listener = new LatchedActionListener<>(
-                    ActionListener.wrap(response::set, e -> fail("no failures expected")),
+                    ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
                 TransportSearchAction.ccsRemoteReduce(
@@ -721,7 +722,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 SetOnce<Tuple<SearchRequest, ActionListener<SearchResponse>>> setOnce = new SetOnce<>();
                 AtomicReference<SearchResponse> response = new AtomicReference<>();
                 LatchedActionListener<SearchResponse> listener = new LatchedActionListener<>(
-                    ActionListener.wrap(response::set, e -> fail("no failures expected")),
+                    ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
                 TransportSearchAction.ccsRemoteReduce(
@@ -774,7 +775,7 @@ public class TransportSearchActionTests extends ESTestCase {
                 SetOnce<Tuple<SearchRequest, ActionListener<SearchResponse>>> setOnce = new SetOnce<>();
                 AtomicReference<SearchResponse> response = new AtomicReference<>();
                 LatchedActionListener<SearchResponse> listener = new LatchedActionListener<>(
-                    ActionListener.wrap(response::set, e -> fail("no failures expected")),
+                    ActionTestUtils.assertNoFailureListener(response::set),
                     latch
                 );
                 TransportSearchAction.ccsRemoteReduce(
@@ -847,7 +848,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     skippedClusters,
                     remoteIndicesByCluster,
                     service,
-                    new LatchedActionListener<>(ActionListener.wrap(response::set, e -> fail("no failures expected")), latch)
+                    new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
                 awaitLatch(latch, 5, TimeUnit.SECONDS);
                 assertEquals(0, skippedClusters.get());
@@ -951,7 +952,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     skippedClusters,
                     remoteIndicesByCluster,
                     service,
-                    new LatchedActionListener<>(ActionListener.wrap(response::set, e -> fail("no failures expected")), latch)
+                    new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
                 awaitLatch(latch, 5, TimeUnit.SECONDS);
                 assertNotNull(response.get());
@@ -996,7 +997,7 @@ public class TransportSearchActionTests extends ESTestCase {
                     skippedClusters,
                     remoteIndicesByCluster,
                     service,
-                    new LatchedActionListener<>(ActionListener.wrap(response::set, e -> fail("no failures expected")), latch)
+                    new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(response::set), latch)
                 );
                 awaitLatch(latch, 5, TimeUnit.SECONDS);
                 assertEquals(0, skippedClusters.get());

--- a/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/SubscribableListenerTests.java
@@ -78,7 +78,7 @@ public class SubscribableListenerTests extends ESTestCase {
         var expectedResponse = new Object();
 
         IntFunction<ActionListener<Object>> listenerFactory = i -> ActionListener.runAfter(
-            ActionListener.wrap(o -> assertSame(o, expectedResponse), e -> fail()),
+            ActionTestUtils.assertNoFailureListener(o -> assertSame(o, expectedResponse)),
             new OrderAssertingRunnable(i, order)
         );
 

--- a/server/src/test/java/org/elasticsearch/client/internal/OriginSettingClientTests.java
+++ b/server/src/test/java/org/elasticsearch/client/internal/OriginSettingClientTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.bulk.BulkRequest;
 import org.elasticsearch.action.search.ClearScrollRequest;
 import org.elasticsearch.action.search.SearchRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.test.client.NoOpClient;
@@ -53,8 +54,8 @@ public class OriginSettingClientTests extends ESTestCase {
     }
 
     private <T> ActionListener<T> listenerThatAssertsOriginNotSet(ThreadContext threadContext) {
-        return ActionListener.wrap(r -> { assertNull(threadContext.getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME)); }, e -> {
-            fail("didn't expect to fail but: " + e);
-        });
+        return ActionTestUtils.assertNoFailureListener(
+            r -> assertNull(threadContext.getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME))
+        );
     }
 }

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexTemplateServiceTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.alias.Alias;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.MetadataIndexTemplateService.PutRequest;
@@ -1640,10 +1641,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             "good",
             TimeValue.timeValueSeconds(5),
             ct,
-            ActionListener.wrap(r -> ctLatch.countDown(), e -> {
-                logger.error("unexpected error", e);
-                fail("unexpected error");
-            })
+            ActionTestUtils.assertNoFailureListener(r -> ctLatch.countDown())
         );
         ctLatch.await(5, TimeUnit.SECONDS);
         InvalidIndexTemplateException e = expectThrows(InvalidIndexTemplateException.class, () -> {
@@ -2449,10 +2447,7 @@ public class MetadataIndexTemplateServiceTests extends ESSingleNodeTestCase {
             "foo",
             TimeValue.timeValueSeconds(5),
             ct,
-            ActionListener.wrap(r -> ctLatch.countDown(), e -> {
-                logger.error("unexpected error", e);
-                fail("unexpected error");
-            })
+            ActionTestUtils.assertNoFailureListener(r -> ctLatch.countDown())
         );
         ctLatch.await(5, TimeUnit.SECONDS);
         InvalidIndexTemplateException e = expectThrows(InvalidIndexTemplateException.class, () -> {

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationActionListenerTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/AllocationActionListenerTests.java
@@ -9,6 +9,7 @@
 package org.elasticsearch.cluster.routing.allocation.allocator;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -25,9 +26,10 @@ public class AllocationActionListenerTests extends ESTestCase {
 
     public void testShouldDelegateWhenBothComplete() {
         var completed = new AtomicBoolean(false);
-        var listener = new AllocationActionListener<AcknowledgedResponse>(ActionListener.wrap(ignore -> completed.set(true), exception -> {
-            throw new AssertionError("Should not fail in test");
-        }), createEmptyThreadContext());
+        var listener = new AllocationActionListener<AcknowledgedResponse>(
+            ActionTestUtils.assertNoFailureListener(ignore -> completed.set(true)),
+            createEmptyThreadContext()
+        );
 
         listener.clusterStateUpdate().onResponse(AcknowledgedResponse.TRUE);
         listener.reroute().onResponse(null);
@@ -37,9 +39,10 @@ public class AllocationActionListenerTests extends ESTestCase {
 
     public void testShouldNotDelegateWhenOnlyOneComplete() {
         var completed = new AtomicBoolean(false);
-        var listener = new AllocationActionListener<AcknowledgedResponse>(ActionListener.wrap(ignore -> completed.set(true), exception -> {
-            throw new AssertionError("Should not fail in test");
-        }), createEmptyThreadContext());
+        var listener = new AllocationActionListener<AcknowledgedResponse>(
+            ActionTestUtils.assertNoFailureListener(ignore -> completed.set(true)),
+            createEmptyThreadContext()
+        );
 
         if (randomBoolean()) {
             listener.clusterStateUpdate().onResponse(AcknowledgedResponse.TRUE);
@@ -75,10 +78,10 @@ public class AllocationActionListenerTests extends ESTestCase {
 
         var header = new AtomicReference<String>();
         var responseHeaders = new AtomicReference<List<String>>();
-        var listener = new AllocationActionListener<>(ActionListener.wrap(ignore -> {
+        var listener = new AllocationActionListener<>(ActionTestUtils.assertNoFailureListener(ignore -> {
             header.set(context.getHeader("header"));
             responseHeaders.set(context.getResponseHeaders().get("header"));
-        }, exception -> { throw new AssertionError("Should not fail in test"); }), context);
+        }), context);
 
         // this header should be ignored as it is added after context is captured
         context.addResponseHeader("header", "2");

--- a/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/routing/allocation/allocator/DesiredBalanceShardsAllocatorTests.java
@@ -11,6 +11,7 @@ package org.elasticsearch.cluster.routing.allocation.allocator;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.ClusterInfo;
 import org.elasticsearch.cluster.ClusterName;
@@ -172,9 +173,11 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
                             .addAsNew(indexMetadata)
                     )
                     .build();
-                return allocationService.reroute(newState, "test", ActionListener.wrap(response -> listenerCalled.set(true), exception -> {
-                    throw new AssertionError("should not happen in test", exception);
-                }));
+                return allocationService.reroute(
+                    newState,
+                    "test",
+                    ActionTestUtils.assertNoFailureListener(response -> listenerCalled.set(true))
+                );
             }
 
             @Override
@@ -376,7 +379,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
                             .addAsNew(indexMetadata)
                     )
                     .build();
-                return allocationService.reroute(newState, "test", ActionListener.wrap(response -> {
+                return allocationService.reroute(newState, "test", ActionTestUtils.assertNoFailureListener(response -> {
                     assertThat(
                         "All shards should be initializing by the time listener is called",
                         clusterService.state().getRoutingTable().index(indexName).primaryShardsUnassigned(),
@@ -384,7 +387,7 @@ public class DesiredBalanceShardsAllocatorTests extends ESAllocationTestCase {
                     );
                     assertThat(reconciliations.get(), equalTo(1));
                     listenersCalled.countDown();
-                }, exception -> { throw new AssertionError("Should not happen in test", exception); }));
+                }));
             }
 
             @Override

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseBackgroundSyncActionTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.seqno;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
@@ -154,7 +153,7 @@ public class RetentionLeaseBackgroundSyncActionTests extends ESTestCase {
         verify(indexShard).persistRetentionLeases();
         // the result should indicate success
         final AtomicBoolean success = new AtomicBoolean();
-        result.runPostReplicaActions(ActionListener.wrap(r -> success.set(true), e -> fail(e.toString())));
+        result.runPostReplicaActions(ActionTestUtils.assertNoFailureListener(r -> success.set(true)));
         assertTrue(success.get());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseStatsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.index.seqno;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.index.IndexSettings;
@@ -41,7 +42,7 @@ public class RetentionLeaseStatsTests extends ESSingleNodeTestCase {
             final long retainingSequenceNumber = randomLongBetween(0, Long.MAX_VALUE);
             final String source = randomAlphaOfLength(8);
             final CountDownLatch latch = new CountDownLatch(1);
-            final ActionListener<ReplicationResponse> listener = ActionListener.wrap(r -> latch.countDown(), e -> fail(e.toString()));
+            final ActionListener<ReplicationResponse> listener = ActionTestUtils.assertNoFailureListener(r -> latch.countDown());
             currentRetentionLeases.put(id, primary.addRetentionLease(id, retainingSequenceNumber, source, listener));
             latch.await();
         }

--- a/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
+++ b/server/src/test/java/org/elasticsearch/index/seqno/RetentionLeaseSyncActionTests.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.index.seqno;
 
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
 import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
@@ -149,7 +148,7 @@ public class RetentionLeaseSyncActionTests extends ESTestCase {
         verify(indexShard).persistRetentionLeases();
         // the result should indicate success
         final AtomicBoolean success = new AtomicBoolean();
-        result.runPostReplicaActions(ActionListener.wrap(r -> success.set(true), e -> fail(e.toString())));
+        result.runPostReplicaActions(ActionTestUtils.assertNoFailureListener(r -> success.set(true)));
         assertTrue(success.get());
     }
 

--- a/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
+++ b/server/src/test/java/org/elasticsearch/index/shard/IndexShardTests.java
@@ -34,6 +34,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -2862,10 +2863,10 @@ public class IndexShardTests extends IndexShardTestCase {
                     maxSeqNoOfUpdatesOrDeletes,
                     retentionLeases,
                     mappingVersion,
-                    ActionListener.wrap(r -> {
+                    listener.delegateFailureAndWrap((l, r) -> {
                         assertFalse(replica.isSyncNeeded());
-                        listener.onResponse(r);
-                    }, listener::onFailure)
+                        l.onResponse(r);
+                    })
                 );
             }
         }, true, true);
@@ -2986,11 +2987,11 @@ public class IndexShardTests extends IndexShardTestCase {
                     maxSeqNoOfUpdatesOrDeletes,
                     retentionLeases,
                     mappingVersion,
-                    ActionListener.wrap(checkpoint -> {
-                        listener.onResponse(checkpoint);
+                    listener.delegateFailureAndWrap((l, checkpoint) -> {
+                        l.onResponse(checkpoint);
                         // Shard should now be active since we did recover:
                         assertTrue(replica.isActive());
-                    }, listener::onFailure)
+                    })
                 );
             }
         }, false, true);
@@ -3025,10 +3026,10 @@ public class IndexShardTests extends IndexShardTestCase {
             // we're only checking that listeners are called when the engine is open, before there is no point
             @Override
             public void prepareForTranslogOperations(int totalTranslogOps, ActionListener<Void> listener) {
-                super.prepareForTranslogOperations(totalTranslogOps, ActionListener.wrap(r -> {
+                super.prepareForTranslogOperations(totalTranslogOps, listener.delegateFailureAndWrap((l, r) -> {
                     assertListenerCalled.accept(replica);
-                    listener.onResponse(r);
-                }, listener::onFailure));
+                    l.onResponse(r);
+                }));
             }
 
             @Override
@@ -3048,19 +3049,19 @@ public class IndexShardTests extends IndexShardTestCase {
                     maxSeqNoOfUpdatesOrDeletes,
                     retentionLeases,
                     mappingVersion,
-                    ActionListener.wrap(r -> {
+                    listener.delegateFailureAndWrap((l, r) -> {
                         assertListenerCalled.accept(replica);
-                        listener.onResponse(r);
-                    }, listener::onFailure)
+                        l.onResponse(r);
+                    })
                 );
             }
 
             @Override
             public void finalizeRecovery(long globalCheckpoint, long trimAboveSeqNo, ActionListener<Void> listener) {
-                super.finalizeRecovery(globalCheckpoint, trimAboveSeqNo, ActionListener.wrap(r -> {
+                super.finalizeRecovery(globalCheckpoint, trimAboveSeqNo, listener.delegateFailureAndWrap((l, r) -> {
                     assertListenerCalled.accept(replica);
-                    listener.onResponse(r);
-                }, listener::onFailure));
+                    l.onResponse(r);
+                }));
             }
         }, false, true);
 
@@ -4341,7 +4342,7 @@ public class IndexShardTests extends IndexShardTestCase {
             shard.getOperationPrimaryTerm(),
             shard.getLastKnownGlobalCheckpoint(),
             0L,
-            ActionListener.wrap(r -> {
+            ActionTestUtils.assertNoFailureListener(r -> {
                 try (r) {
                     Translog.Snapshot snapshot = TestTranslog.newSnapshotFromOperations(operations);
                     final DocumentParsingException error = expectThrows(
@@ -4352,7 +4353,7 @@ public class IndexShardTests extends IndexShardTestCase {
                 } finally {
                     engineResetLatch.countDown();
                 }
-            }, e -> { throw new AssertionError(e); }),
+            }),
             TimeValue.timeValueMinutes(1)
         );
         engineResetLatch.await();

--- a/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/indices/recovery/PeerRecoveryTargetServiceTests.java
@@ -14,9 +14,9 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.IOContext;
 import org.apache.lucene.store.IndexInput;
 import org.apache.lucene.store.OutputStreamIndexOutput;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -153,9 +153,7 @@ public class PeerRecoveryTargetServiceTests extends IndexShardTestCase {
                             r.content(),
                             r.lastChunk(),
                             r.totalTranslogOps(),
-                            ActionListener.wrap(ignored -> {}, e -> {
-                                throw new AssertionError(e);
-                            })
+                            ActionTestUtils.assertNoFailureListener(ignored -> {})
                         );
                     }
                 } catch (Exception e) {

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -29,6 +29,7 @@ import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.search.SearchShardTask;
 import org.elasticsearch.action.search.SearchType;
 import org.elasticsearch.action.search.TransportSearchAction;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
@@ -1139,7 +1140,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         );
         Thread currentThread = Thread.currentThread();
         // we still make sure can match is executed on the network thread
-        service.canMatch(req, ActionListener.wrap(r -> assertSame(Thread.currentThread(), currentThread), e -> fail("unexpected")));
+        service.canMatch(req, ActionTestUtils.assertNoFailureListener(r -> assertSame(Thread.currentThread(), currentThread)));
     }
 
     public void testAggContextGetsMatchAll() throws IOException {

--- a/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
+++ b/server/src/test/java/org/elasticsearch/snapshots/SnapshotResiliencyTests.java
@@ -1377,7 +1377,7 @@ public class SnapshotResiliencyTests extends ESTestCase {
     }
 
     private static <T> void continueOrDie(ListenableFuture<T> listener, CheckedConsumer<T, Exception> onResponse) {
-        listener.addListener(ActionListener.wrap(onResponse, e -> { throw new AssertionError(e); }));
+        listener.addListener(ActionTestUtils.assertNoFailureListener(onResponse));
     }
 
     public NodeClient client() {

--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterServiceTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.TransportVersion;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.OriginalIndices;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
@@ -710,7 +711,7 @@ public class RemoteClusterServiceTests extends ESTestCase {
     }
 
     private ActionListener<Void> connectionListener(final CountDownLatch latch) {
-        return ActionListener.wrap(x -> latch.countDown(), x -> fail());
+        return ActionTestUtils.assertNoFailureListener(x -> latch.countDown());
     }
 
     public void testCollectNodes() throws InterruptedException, IOException {

--- a/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/index/replication/ESIndexLevelReplicationTestCase.java
@@ -189,9 +189,7 @@ public abstract class ESIndexLevelReplicationTestCase extends IndexShardTestCase
             (_shardId, primaryAllocationId, primaryTerm, retentionLeases) -> syncRetentionLeases(
                 _shardId,
                 retentionLeases,
-                ActionListener.wrap(r -> {}, e -> {
-                    throw new AssertionError("failed to background sync retention lease", e);
-                })
+                ActionTestUtils.assertNoFailureListener(r -> {})
             )
         );
 

--- a/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
+++ b/x-pack/plugin/ccr/src/internalClusterTest/java/org/elasticsearch/xpack/ccr/CcrRetentionLeaseIT.java
@@ -8,7 +8,6 @@
 package org.elasticsearch.xpack.ccr;
 
 import org.elasticsearch.ElasticsearchException;
-import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.action.admin.cluster.snapshots.restore.RestoreSnapshotRequest;
 import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
@@ -17,6 +16,7 @@ import org.elasticsearch.action.admin.indices.stats.IndicesStatsRequest;
 import org.elasticsearch.action.admin.indices.stats.IndicesStatsResponse;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.broadcast.BroadcastResponse;
@@ -459,10 +459,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                             final IndexShard primary = getLeaderCluster().getInstance(IndicesService.class, primaryShardNodeName)
                                 .getShardOrNull(removeRequest.getShardId());
                             final CountDownLatch latch = new CountDownLatch(1);
-                            primary.removeRetentionLease(
-                                retentionLeaseId,
-                                ActionListener.wrap(r -> latch.countDown(), e -> fail(e.toString()))
-                            );
+                            primary.removeRetentionLease(retentionLeaseId, ActionTestUtils.assertNoFailureListener(r -> latch.countDown()));
                             try {
                                 latch.await();
                             } catch (final InterruptedException e) {
@@ -879,7 +876,7 @@ public class CcrRetentionLeaseIT extends CcrIntegTestCase {
                                 logger.info("--> removing retention lease [{}] on the leader", retentionLeaseId);
                                 primary.removeRetentionLease(
                                     retentionLeaseId,
-                                    ActionListener.wrap(r -> innerLatch.countDown(), e -> fail(e.toString()))
+                                    ActionTestUtils.assertNoFailureListener(r -> innerLatch.countDown())
                                 );
                                 logger.info(
                                     "--> waiting for the removed retention lease [{}] to be synced on the leader",

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardFollowTaskReplicationTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.admin.indices.flush.FlushRequest;
 import org.elasticsearch.action.bulk.BulkItemResponse;
 import org.elasticsearch.action.delete.DeleteRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.replication.PostWriteRefresh;
 import org.elasticsearch.action.support.replication.ReplicationResponse;
@@ -713,7 +714,7 @@ public class ShardFollowTaskReplicationTests extends ESIndexLevelReplicationTest
                     retentionLeaseId,
                     followerGlobalCheckpoint.getAsLong(),
                     "ccr",
-                    ActionListener.wrap(response::onResponse, e -> fail(e.toString()))
+                    ActionTestUtils.assertNoFailureListener(response::onResponse)
                 );
                 response.actionGet();
                 return threadPool.scheduleWithFixedDelay(

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowEngineIndexShardTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/index/engine/FollowEngineIndexShardTests.java
@@ -10,6 +10,7 @@ import org.apache.lucene.store.IOContext;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.cluster.node.DiscoveryNode;
 import org.elasticsearch.cluster.node.DiscoveryNodeUtils;
@@ -98,10 +99,10 @@ public class FollowEngineIndexShardTests extends IndexShardTestCase {
         );
 
         final CountDownLatch latch = new CountDownLatch(1);
-        ActionListener<Releasable> actionListener = ActionListener.wrap(releasable -> {
+        ActionListener<Releasable> actionListener = ActionTestUtils.assertNoFailureListener(releasable -> {
             releasable.close();
             latch.countDown();
-        }, e -> { assert false : "expected no exception, but got [" + e.getMessage() + "]"; });
+        });
         indexShard.acquirePrimaryOperationPermit(actionListener, ThreadPool.Names.GENERIC);
         latch.await();
         assertThat(indexShard.getLocalCheckpoint(), equalTo(seqNoBeforeGap));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ClientHelperTests.java
@@ -16,6 +16,7 @@ import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -64,11 +65,11 @@ public class ClientHelperTests extends ESTestCase {
         final String headerValue = randomAlphaOfLengthBetween(4, 16);
         final String origin = randomAlphaOfLengthBetween(4, 16);
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<ClusterHealthResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<ClusterHealthResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertNull(threadContext.getTransient(ClientHelper.ACTION_ORIGIN_TRANSIENT_NAME));
             assertEquals(headerValue, threadContext.getHeader(headerName));
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         final ClusterHealthRequest request = new ClusterHealthRequest();
         threadContext.putHeader(headerName, headerValue);
@@ -95,11 +96,11 @@ public class ClientHelperTests extends ESTestCase {
         final String headerValue = randomAlphaOfLengthBetween(4, 16);
         final String origin = randomAlphaOfLengthBetween(4, 16);
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<ClusterHealthResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<ClusterHealthResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertNull(threadContext.getTransient(ClientHelper.ACTION_ORIGIN_TRANSIENT_NAME));
             assertEquals(headerValue, threadContext.getHeader(headerName));
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertEquals(origin, threadContext.getTransient(ClientHelper.ACTION_ORIGIN_TRANSIENT_NAME));
@@ -127,11 +128,11 @@ public class ClientHelperTests extends ESTestCase {
         final String headerValue = randomAlphaOfLengthBetween(4, 16);
         final String origin = randomAlphaOfLengthBetween(4, 16);
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<ClusterHealthResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<ClusterHealthResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertNull(threadContext.getTransient(ClientHelper.ACTION_ORIGIN_TRANSIENT_NAME));
             assertEquals(headerValue, threadContext.getHeader(headerName));
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertEquals(origin, threadContext.getTransient(ClientHelper.ACTION_ORIGIN_TRANSIENT_NAME));
@@ -155,10 +156,10 @@ public class ClientHelperTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<SearchResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<SearchResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertTrue(threadContext.getHeaders().isEmpty());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertTrue(threadContext.getHeaders().isEmpty());
@@ -183,10 +184,10 @@ public class ClientHelperTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<SearchResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<SearchResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertTrue(threadContext.getHeaders().isEmpty());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertTrue(threadContext.getHeaders().isEmpty());
@@ -214,10 +215,10 @@ public class ClientHelperTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<SearchResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<SearchResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertTrue(threadContext.getHeaders().isEmpty());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertThat(threadContext.getHeaders().size(), equalTo(2));

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/LocalStateCompositeXPackPlugin.java
@@ -735,16 +735,16 @@ public class LocalStateCompositeXPackPlugin extends XPackPlugin
 
         GroupedActionListener<ResetFeatureStateResponse.ResetFeatureStateStatus> allListeners = new GroupedActionListener<>(
             systemPlugins.size(),
-            ActionListener.wrap(listenerResults -> {
+            finalListener.delegateFailureAndWrap((delegate, listenerResults) -> {
                 // If the clean-up produced only one result, use that to pass along. In most
                 // cases it should be 1-1 mapping of feature to response. Passing back success
                 // prevents us from writing validation tests on this API.
                 if (listenerResults != null && listenerResults.size() == 1) {
-                    finalListener.onResponse(listenerResults.stream().findFirst().get());
+                    delegate.onResponse(listenerResults.stream().findFirst().get());
                 } else {
-                    finalListener.onResponse(ResetFeatureStateStatus.success(getFeatureName()));
+                    delegate.onResponse(ResetFeatureStateStatus.success(getFeatureName()));
                 }
-            }, finalListener::onFailure)
+            })
         );
         systemPlugins.forEach(plugin -> plugin.cleanUpFeature(clusterService, client, allListeners));
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/IteratingActionListenerTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/IteratingActionListenerTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.common;
 
 import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.test.ESTestCase;
@@ -46,13 +47,15 @@ public class IteratingActionListenerTests extends ESTestCase {
             }
         };
 
-        IteratingActionListener<Object, Object> iteratingListener = new IteratingActionListener<>(ActionListener.wrap((object) -> {
-            assertNotNull(object);
-            assertThat(object, sameInstance(items.get(numberOfIterations - 1)));
-        }, (e) -> {
-            logger.error("unexpected exception", e);
-            fail("exception should not have been thrown");
-        }), consumer, items, new ThreadContext(Settings.EMPTY));
+        IteratingActionListener<Object, Object> iteratingListener = new IteratingActionListener<>(
+            ActionTestUtils.assertNoFailureListener(object -> {
+                assertNotNull(object);
+                assertThat(object, sameInstance(items.get(numberOfIterations - 1)));
+            }),
+            consumer,
+            items,
+            new ThreadContext(Settings.EMPTY)
+        );
         iteratingListener.run();
 
         // we never really went async, its all chained together so verify this for sanity
@@ -81,15 +84,17 @@ public class IteratingActionListenerTests extends ESTestCase {
             }
         };
 
-        IteratingActionListener<Object, Object> iteratingListener = new IteratingActionListener<>(ActionListener.wrap((object) -> {
-            assertNotNull(object);
-            assertThat(object, sameInstance(items.get(numberOfIterations - 1)));
-            assertEquals("bar", threadContext.getHeader("foo"));
-            assertEquals("listener", threadContext.getHeader("outside"));
-        }, (e) -> {
-            logger.error("unexpected exception", e);
-            fail("exception should not have been thrown");
-        }), consumer, items, threadContext);
+        IteratingActionListener<Object, Object> iteratingListener = new IteratingActionListener<>(
+            ActionTestUtils.assertNoFailureListener(object -> {
+                assertNotNull(object);
+                assertThat(object, sameInstance(items.get(numberOfIterations - 1)));
+                assertEquals("bar", threadContext.getHeader("foo"));
+                assertEquals("listener", threadContext.getHeader("outside"));
+            }),
+            consumer,
+            items,
+            threadContext
+        );
         iteratingListener.run();
 
         // we never really went async, its all chained together so verify this for sanity
@@ -99,11 +104,9 @@ public class IteratingActionListenerTests extends ESTestCase {
     }
 
     public void testIterationEmptyList() {
-        IteratingActionListener<Object, Object> listener = new IteratingActionListener<>(ActionListener.wrap(Assert::assertNull, (e) -> {
-            logger.error("unexpected exception", e);
-            fail("exception should not have been thrown");
-        }),
-            (listValue, iteratingListener) -> { fail("consumer should not have been called!!!"); },
+        IteratingActionListener<Object, Object> listener = new IteratingActionListener<>(
+            ActionTestUtils.assertNoFailureListener(Assert::assertNull),
+            (listValue, iteratingListener) -> fail("consumer should not have been called!!!"),
             Collections.emptyList(),
             new ThreadContext(Settings.EMPTY)
         );
@@ -171,16 +174,20 @@ public class IteratingActionListenerTests extends ESTestCase {
             return randomResult;
         };
 
-        IteratingActionListener<Object, Object> iteratingListener = new IteratingActionListener<>(ActionListener.wrap((object) -> {
-            assertNotNull(object);
-            assertNotNull(originalObject.get());
-            assertThat(object, sameInstance(result.get()));
-            assertThat(object, not(sameInstance(originalObject.get())));
-            assertThat(originalObject.get(), sameInstance(items.get(iterations.get() - 1)));
-        }, (e) -> {
-            logger.error("unexpected exception", e);
-            fail("exception should not have been thrown");
-        }), consumer, items, new ThreadContext(Settings.EMPTY), responseFunction, iterationPredicate);
+        IteratingActionListener<Object, Object> iteratingListener = new IteratingActionListener<>(
+            ActionTestUtils.assertNoFailureListener(object -> {
+                assertNotNull(object);
+                assertNotNull(originalObject.get());
+                assertThat(object, sameInstance(result.get()));
+                assertThat(object, not(sameInstance(originalObject.get())));
+                assertThat(originalObject.get(), sameInstance(items.get(iterations.get() - 1)));
+            }),
+            consumer,
+            items,
+            new ThreadContext(Settings.EMPTY),
+            responseFunction,
+            iterationPredicate
+        );
         iteratingListener.run();
 
         // we never really went async, its all chained together so verify this for sanity

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/common/validation/RemoteClusterMinimumVersionValidationTests.java
@@ -8,7 +8,7 @@
 package org.elasticsearch.xpack.core.common.validation;
 
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.transport.NoSuchRemoteClusterException;
 import org.elasticsearch.xpack.core.common.validation.SourceDestValidator.Context;
@@ -57,7 +57,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
-            ActionListener.wrap(ctx -> assertThat(ctx.getValidationException(), is(nullValue())), e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(ctx -> assertThat(ctx.getValidationException(), is(nullValue())))
         );
     }
 
@@ -67,7 +67,7 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
-            ActionListener.wrap(ctx -> assertThat(ctx.getValidationException(), is(nullValue())), e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(ctx -> assertThat(ctx.getValidationException(), is(nullValue())))
         );
     }
 
@@ -77,15 +77,14 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
-            ActionListener.wrap(
+            ActionTestUtils.assertNoFailureListener(
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
                     contains(
                         "remote clusters are expected to run at least version [7.11.0] (reason: [some reason]), "
                             + "but the following clusters were too old: [cluster-A (7.10.2)]"
                     )
-                ),
-                e -> fail(e.getMessage())
+                )
             )
         );
     }
@@ -96,15 +95,14 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(Version.V_7_11_2, REASON);
         validation.validate(
             context,
-            ActionListener.wrap(
+            ActionTestUtils.assertNoFailureListener(
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
                     contains(
                         "remote clusters are expected to run at least version [7.11.2] (reason: [some reason]), "
                             + "but the following clusters were too old: [cluster-A (7.10.2), cluster-B (7.11.0)]"
                     )
-                ),
-                e -> fail(e.getMessage())
+                )
             )
         );
     }
@@ -116,9 +114,8 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
-            ActionListener.wrap(
-                ctx -> assertThat(ctx.getValidationException().validationErrors(), contains("no such remote cluster: [cluster-D]")),
-                e -> fail(e.getMessage())
+            ActionTestUtils.assertNoFailureListener(
+                ctx -> assertThat(ctx.getValidationException().validationErrors(), contains("no such remote cluster: [cluster-D]"))
             )
         );
     }
@@ -130,12 +127,11 @@ public class RemoteClusterMinimumVersionValidationTests extends ESTestCase {
         SourceDestValidation validation = new RemoteClusterMinimumVersionValidation(MIN_EXPECTED_VERSION, REASON);
         validation.validate(
             context,
-            ActionListener.wrap(
+            ActionTestUtils.assertNoFailureListener(
                 ctx -> assertThat(
                     ctx.getValidationException().validationErrors(),
                     contains("Error resolving remote source: some-other-problem")
-                ),
-                e -> fail(e.getMessage())
+                )
             )
         );
     }

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/ml/job/persistence/ElasticsearchMappingsTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingAction;
 import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.support.master.MasterNodeRequest;
 import org.elasticsearch.client.internal.Client;
@@ -38,6 +39,7 @@ import org.elasticsearch.xpack.core.ml.job.process.autodetect.state.TimingStats;
 import org.elasticsearch.xpack.core.ml.job.results.CategoryDefinition;
 import org.elasticsearch.xpack.core.ml.job.results.ReservedFieldNames;
 import org.elasticsearch.xpack.core.ml.job.results.Result;
+import org.junit.Assert;
 import org.mockito.ArgumentCaptor;
 
 import java.io.BufferedInputStream;
@@ -197,7 +199,7 @@ public class ElasticsearchMappingsTests extends ESTestCase {
             client,
             clusterState,
             MasterNodeRequest.DEFAULT_MASTER_NODE_TIMEOUT,
-            ActionListener.wrap(ok -> assertTrue(ok), e -> fail(e.toString()))
+            ActionTestUtils.assertNoFailureListener(Assert::assertTrue)
         );
 
         ArgumentCaptor<PutMappingRequest> requestCaptor = ArgumentCaptor.forClass(PutMappingRequest.class);

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AbstractEqlBlockingIntegTestCase.java
@@ -213,7 +213,7 @@ public abstract class AbstractEqlBlockingIntegTestCase extends AbstractEqlIntegT
                             task,
                             action,
                             request,
-                            ActionListener.wrap(resp -> executorService.execute(() -> actionWrapper.accept(resp)), listener::onFailure)
+                            listener.delegateFailureAndWrap((l, resp) -> executorService.execute(() -> actionWrapper.accept(resp)))
                         );
                     } else {
                         chain.proceed(task, action, request, listener);

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/assembler/SequenceSpecTests.java
@@ -11,11 +11,11 @@ import com.carrotsearch.randomizedtesting.annotations.ParametersFactory;
 
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.SearchResponseSections;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.common.breaker.NoopCircuitBreaker;
 import org.elasticsearch.common.document.DocumentField;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -49,7 +49,6 @@ import static java.util.Collections.emptyList;
 import static java.util.Collections.emptyMap;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.common.logging.LoggerMessageFormat.format;
 import static org.elasticsearch.index.query.QueryBuilders.matchAllQuery;
 import static org.elasticsearch.xpack.eql.EqlTestUtils.booleanArrayOf;
@@ -281,7 +280,7 @@ public class SequenceSpecTests extends ESTestCase {
         TumblingWindow window = new TumblingWindow(testClient, criteria, null, matcher, Collections.emptyList());
 
         // finally make the assertion at the end of the listener
-        window.execute(wrap(this::checkResults, ex -> { throw ExceptionsHelper.convertToRuntime(ex); }));
+        window.execute(ActionTestUtils.assertNoFailureListener(this::checkResults));
     }
 
     private void checkResults(Payload payload) {

--- a/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
+++ b/x-pack/plugin/eql/src/test/java/org/elasticsearch/xpack/eql/execution/sequence/CircuitBreakerTests.java
@@ -9,7 +9,6 @@ package org.elasticsearch.xpack.eql.execution.sequence;
 
 import org.apache.lucene.search.TotalHits;
 import org.apache.lucene.search.TotalHits.Relation;
-import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
@@ -24,6 +23,7 @@ import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.SearchResponse.Clusters;
 import org.elasticsearch.action.search.SearchResponseSections;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.common.ParsingException;
 import org.elasticsearch.common.breaker.CircuitBreaker;
 import org.elasticsearch.common.breaker.CircuitBreakingException;
@@ -144,7 +144,7 @@ public class CircuitBreakerTests extends ESTestCase {
             CIRCUIT_BREAKER
         );
         TumblingWindow window = new TumblingWindow(client, criteria, null, matcher, Collections.emptyList());
-        window.execute(wrap(p -> {}, ex -> { throw ExceptionsHelper.convertToRuntime(ex); }));
+        window.execute(ActionTestUtils.assertNoFailureListener(p -> {}));
 
         CIRCUIT_BREAKER.startBreaking();
 
@@ -155,7 +155,7 @@ public class CircuitBreakerTests extends ESTestCase {
 
         CIRCUIT_BREAKER.stopBreaking();
 
-        window.execute(wrap(p -> {}, ex -> { throw ExceptionsHelper.convertToRuntime(ex); }));
+        window.execute(ActionTestUtils.assertNoFailureListener(p -> {}));
     }
 
     public void testCircuitBreakerSequenceMatcher() {
@@ -223,7 +223,7 @@ public class CircuitBreakerTests extends ESTestCase {
                 eqlCircuitBreaker
             );
             TumblingWindow window = new TumblingWindow(eqlClient, criteria, null, matcher, Collections.emptyList());
-            window.execute(wrap(p -> {}, ex -> {}));
+            window.execute(ActionListener.noop());
 
             assertTrue(esClient.searchRequestsRemainingCount() == 0); // ensure all the search requests have been asked for
             assertEquals(0, eqlCircuitBreaker.getTrippedCount()); // the circuit breaker shouldn't trip

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -191,9 +191,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         final PlainActionFuture<Set<SamlServiceProviderDocument>> future = new PlainActionFuture<>();
         serviceProviderIndex.findAll(
             assertListenerIsOnlyCalledOnce(
-                ActionListener.wrap(
-                    set -> future.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet())),
-                    future::onFailure
+                future.delegateFailureAndWrap(
+                    (f, set) -> f.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet()))
                 )
             )
         );
@@ -223,9 +222,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         serviceProviderIndex.readDocument(
             doc.docId,
             assertListenerIsOnlyCalledOnce(
-                ActionListener.wrap(
-                    info -> serviceProviderIndex.deleteDocument(info.version, WriteRequest.RefreshPolicy.IMMEDIATE, future),
-                    future::onFailure
+                future.delegateFailureAndWrap(
+                    (f, info) -> serviceProviderIndex.deleteDocument(info.version, WriteRequest.RefreshPolicy.IMMEDIATE, f)
                 )
             )
         );
@@ -243,9 +241,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
         serviceProviderIndex.findByEntityId(
             entityId,
             assertListenerIsOnlyCalledOnce(
-                ActionListener.wrap(
-                    set -> future.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet())),
-                    future::onFailure
+                future.delegateFailureAndWrap(
+                    (f, set) -> f.onResponse(set.stream().map(doc -> doc.document.get()).collect(Collectors.toUnmodifiableSet()))
                 )
             )
         );

--- a/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecyclePolicyClientTests.java
+++ b/x-pack/plugin/ilm/src/test/java/org/elasticsearch/xpack/ilm/LifecyclePolicyClientTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
@@ -41,10 +42,10 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<SearchResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<SearchResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertTrue(threadContext.getHeaders().isEmpty());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertTrue(threadContext.getHeaders().isEmpty());
@@ -77,10 +78,10 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<SearchResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<SearchResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertTrue(threadContext.getHeaders().isEmpty());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertTrue(threadContext.getHeaders().isEmpty());
@@ -116,10 +117,10 @@ public class LifecyclePolicyClientTests extends ESTestCase {
         when(threadPool.getThreadContext()).thenReturn(threadContext);
 
         final CountDownLatch latch = new CountDownLatch(2);
-        final ActionListener<SearchResponse> listener = ActionListener.wrap(v -> {
+        final ActionListener<SearchResponse> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertTrue(threadContext.getHeaders().isEmpty());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         doAnswer(invocationOnMock -> {
             assertThat(threadContext.getHeaders().size(), equalTo(2));

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/MachineLearningTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml;
 
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
@@ -74,11 +75,7 @@ public class MachineLearningTests extends ESTestCase {
         try (MachineLearning machineLearning = createTrialLicensedMachineLearning(Settings.EMPTY)) {
 
             SetOnce<Map<String, Object>> response = new SetOnce<>();
-            machineLearning.prepareForIndicesMigration(
-                clusterService,
-                client,
-                ActionListener.wrap(response::set, e -> fail(e.getMessage()))
-            );
+            machineLearning.prepareForIndicesMigration(clusterService, client, ActionTestUtils.assertNoFailureListener(response::set));
 
             assertThat(response.get(), equalTo(Collections.singletonMap("already_in_upgrade_mode", false)));
             verify(client).execute(
@@ -91,7 +88,7 @@ public class MachineLearningTests extends ESTestCase {
                 response.get(),
                 clusterService,
                 client,
-                ActionListener.wrap(ESTestCase::assertTrue, e -> fail(e.getMessage()))
+                ActionTestUtils.assertNoFailureListener(ESTestCase::assertTrue)
             );
 
             verify(client).execute(
@@ -116,11 +113,7 @@ public class MachineLearningTests extends ESTestCase {
         try (MachineLearning machineLearning = createTrialLicensedMachineLearning(Settings.EMPTY)) {
 
             SetOnce<Map<String, Object>> response = new SetOnce<>();
-            machineLearning.prepareForIndicesMigration(
-                clusterService,
-                client,
-                ActionListener.wrap(response::set, e -> fail(e.getMessage()))
-            );
+            machineLearning.prepareForIndicesMigration(clusterService, client, ActionTestUtils.assertNoFailureListener(response::set));
 
             assertThat(response.get(), equalTo(Collections.singletonMap("already_in_upgrade_mode", true)));
             verifyNoMoreInteractions(client);
@@ -129,7 +122,7 @@ public class MachineLearningTests extends ESTestCase {
                 response.get(),
                 clusterService,
                 client,
-                ActionListener.wrap(ESTestCase::assertTrue, e -> fail(e.getMessage()))
+                ActionTestUtils.assertNoFailureListener(ESTestCase::assertTrue)
             );
 
             // Neither pre nor post should have called any action

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportDeleteExpiredDataActionTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.test.ESTestCase;
@@ -87,9 +88,8 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
         List<MlDataRemover> removers = Stream.generate(DummyDataRemover::new).limit(numRemovers).collect(Collectors.toList());
 
         AtomicBoolean succeeded = new AtomicBoolean();
-        ActionListener<DeleteExpiredDataAction.Response> finalListener = ActionListener.wrap(
-            response -> succeeded.set(response.isDeleted()),
-            e -> fail(e.getMessage())
+        ActionListener<DeleteExpiredDataAction.Response> finalListener = ActionTestUtils.assertNoFailureListener(
+            response -> succeeded.set(response.isDeleted())
         );
 
         BooleanSupplier isTimedOutSupplier = () -> false;
@@ -108,9 +108,8 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
         List<MlDataRemover> removers = Stream.generate(DummyDataRemover::new).limit(numRemovers).collect(Collectors.toList());
 
         AtomicBoolean succeeded = new AtomicBoolean();
-        ActionListener<DeleteExpiredDataAction.Response> finalListener = ActionListener.wrap(
-            response -> succeeded.set(response.isDeleted()),
-            e -> fail(e.getMessage())
+        ActionListener<DeleteExpiredDataAction.Response> finalListener = ActionTestUtils.assertNoFailureListener(
+            response -> succeeded.set(response.isDeleted())
         );
 
         BooleanSupplier isTimedOutSupplier = () -> (removersRemaining.getAndDecrement() <= 0);
@@ -137,9 +136,8 @@ public class TransportDeleteExpiredDataActionTests extends ESTestCase {
         List<MlDataRemover> removers = Stream.generate(DummyDataRemover::new).limit(numRemovers).collect(Collectors.toList());
 
         AtomicBoolean succeeded = new AtomicBoolean();
-        ActionListener<DeleteExpiredDataAction.Response> finalListener = ActionListener.wrap(
-            response -> succeeded.set(response.isDeleted()),
-            e -> fail(e.getMessage())
+        ActionListener<DeleteExpiredDataAction.Response> finalListener = ActionTestUtils.assertNoFailureListener(
+            response -> succeeded.set(response.isDeleted())
         );
 
         BooleanSupplier isTimedOutSupplier = () -> (removersRemaining.getAndDecrement() <= 0);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/action/TransportFinalizeJobExecutionActionTests.java
@@ -9,6 +9,7 @@ package org.elasticsearch.xpack.ml.action;
 
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.action.update.UpdateAction;
 import org.elasticsearch.client.internal.Client;
@@ -72,7 +73,7 @@ public class TransportFinalizeJobExecutionActionTests extends ESTestCase {
 
         FinalizeJobExecutionAction.Request request = new FinalizeJobExecutionAction.Request(new String[] { "job1", "job2" });
         AtomicReference<AcknowledgedResponse> ack = new AtomicReference<>();
-        action.masterOperation(null, request, clusterState, ActionListener.wrap(ack::set, e -> assertNull(e.getMessage())));
+        action.masterOperation(null, request, clusterState, ActionTestUtils.assertNoFailureListener(ack::set));
 
         assertTrue(ack.get().isAcknowledged());
         verify(client, times(2)).execute(eq(UpdateAction.INSTANCE), any(), any());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/DatafeedJobBuilderTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.ml.datafeed;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -121,12 +122,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         DatafeedConfig.Builder datafeed = DatafeedRunnerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         AtomicBoolean wasHandlerCalled = new AtomicBoolean(false);
-        ActionListener<DatafeedJob> datafeedJobHandler = ActionListener.wrap(datafeedJob -> {
+        ActionListener<DatafeedJob> datafeedJobHandler = ActionTestUtils.assertNoFailureListener(datafeedJob -> {
             assertThat(datafeedJob.isRunning(), is(true));
             assertThat(datafeedJob.isIsolated(), is(false));
             assertThat(datafeedJob.lastEndTimeMs(), is(nullValue()));
             wasHandlerCalled.compareAndSet(false, true);
-        }, e -> fail());
+        });
 
         DatafeedContext datafeedContext = DatafeedContext.builder()
             .setDatafeedConfig(datafeed.build())
@@ -151,12 +152,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         DatafeedConfig.Builder datafeed = DatafeedRunnerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         AtomicBoolean wasHandlerCalled = new AtomicBoolean(false);
-        ActionListener<DatafeedJob> datafeedJobHandler = ActionListener.wrap(datafeedJob -> {
+        ActionListener<DatafeedJob> datafeedJobHandler = ActionTestUtils.assertNoFailureListener(datafeedJob -> {
             assertThat(datafeedJob.isRunning(), is(true));
             assertThat(datafeedJob.isIsolated(), is(false));
             assertThat(datafeedJob.lastEndTimeMs(), equalTo(7_200_000L));
             wasHandlerCalled.compareAndSet(false, true);
-        }, e -> fail());
+        });
 
         DatafeedContext datafeedContext = DatafeedContext.builder()
             .setDatafeedConfig(datafeed.build())
@@ -181,12 +182,12 @@ public class DatafeedJobBuilderTests extends ESTestCase {
         DatafeedConfig.Builder datafeed = DatafeedRunnerTests.createDatafeedConfig("datafeed1", jobBuilder.getId());
 
         AtomicBoolean wasHandlerCalled = new AtomicBoolean(false);
-        ActionListener<DatafeedJob> datafeedJobHandler = ActionListener.wrap(datafeedJob -> {
+        ActionListener<DatafeedJob> datafeedJobHandler = ActionTestUtils.assertNoFailureListener(datafeedJob -> {
             assertThat(datafeedJob.isRunning(), is(true));
             assertThat(datafeedJob.isIsolated(), is(false));
             assertThat(datafeedJob.lastEndTimeMs(), equalTo(7_199_999L));
             wasHandlerCalled.compareAndSet(false, true);
-        }, e -> fail());
+        });
 
         DatafeedContext datafeedContext = DatafeedContext.builder()
             .setDatafeedConfig(datafeed.build())

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/datafeed/extractor/DataExtractorFactoryTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.Maps;
@@ -136,9 +137,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
         jobBuilder.setDataDescription(dataDescription);
         DatafeedConfig datafeedConfig = DatafeedRunnerTests.createDatafeedConfig("datafeed1", "foo").build();
 
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
-            e -> fail()
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -159,9 +159,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
         DatafeedConfig.Builder datafeedConfig = DatafeedRunnerTests.createDatafeedConfig("datafeed1", "foo");
         datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
 
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
-            e -> fail()
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -182,9 +181,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
         DatafeedConfig.Builder datafeedConfig = DatafeedRunnerTests.createDatafeedConfig("datafeed1", "foo");
         datafeedConfig.setChunkingConfig(ChunkingConfig.newOff());
 
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ScrollDataExtractorFactory.class)),
-            e -> fail()
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ScrollDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -209,9 +207,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 .addAggregator(AggregationBuilders.histogram("time").interval(300000).subAggregation(maxTime).field("time"))
         );
 
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
-            e -> fail()
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -237,9 +234,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
                 .addAggregator(AggregationBuilders.histogram("time").interval(300000).subAggregation(maxTime).field("time"))
         );
 
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(AggregationDataExtractorFactory.class)),
-            e -> fail()
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(AggregationDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -265,9 +261,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
         );
         datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
 
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
-            e -> fail()
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -344,9 +339,9 @@ public class DataExtractorFactoryTests extends ESTestCase {
                         .field("time")
                 )
         );
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(dataExtractorFactory -> {
-            assertThat(dataExtractorFactory, instanceOf(RollupDataExtractorFactory.class));
-        }, e -> fail());
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(RollupDataExtractorFactory.class))
+        );
         DataExtractorFactory.create(
             client,
             datafeedConfig.build(),
@@ -381,9 +376,9 @@ public class DataExtractorFactoryTests extends ESTestCase {
         );
 
         // Test with remote index, aggregation, and no chunking
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(dataExtractorFactory -> {
-            assertThat(dataExtractorFactory, instanceOf(AggregationDataExtractorFactory.class));
-        }, e -> fail());
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(AggregationDataExtractorFactory.class))
+        );
         DataExtractorFactory.create(
             client,
             datafeedConfig.build(),
@@ -395,9 +390,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
 
         // Test with remote index, aggregation, and chunking
         datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
-        listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
-            e -> fail()
+        listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
         );
         DataExtractorFactory.create(
             client,
@@ -413,9 +407,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
         datafeedConfig.setIndices(Collections.singletonList("cluster_two:my_index"));
         datafeedConfig.setChunkingConfig(ChunkingConfig.newOff());
 
-        listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ScrollDataExtractorFactory.class)),
-            e -> fail()
+        listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ScrollDataExtractorFactory.class))
         );
 
         DataExtractorFactory.create(
@@ -429,9 +422,8 @@ public class DataExtractorFactoryTests extends ESTestCase {
 
         // Test with remote index, no aggregation, and chunking
         datafeedConfig.setChunkingConfig(ChunkingConfig.newAuto());
-        listener = ActionListener.wrap(
-            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class)),
-            e -> fail()
+        listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
         );
         DataExtractorFactory.create(
             client,
@@ -464,9 +456,9 @@ public class DataExtractorFactoryTests extends ESTestCase {
                         .field("time")
                 )
         );
-        ActionListener<DataExtractorFactory> listener = ActionListener.wrap(dataExtractorFactory -> {
-            assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class));
-        }, e -> fail());
+        ActionListener<DataExtractorFactory> listener = ActionTestUtils.assertNoFailureListener(
+            dataExtractorFactory -> assertThat(dataExtractorFactory, instanceOf(ChunkedDataExtractorFactory.class))
+        );
         DataExtractorFactory.create(
             client,
             datafeedConfig.build(),

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/dataframe/DestinationIndexTests.java
@@ -24,6 +24,7 @@ import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesAction;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
@@ -339,7 +340,7 @@ public class DestinationIndexTests extends ESTestCase {
             return null;
         }
 
-        DestinationIndex.createDestinationIndex(client, clock, config, ActionListener.wrap(response -> {}, e -> fail(e.getMessage())));
+        DestinationIndex.createDestinationIndex(client, clock, config, ActionTestUtils.assertNoFailureListener(response -> {}));
 
         GetSettingsRequest capturedGetSettingsRequest = getSettingsRequestCaptor.getValue();
         assertThat(capturedGetSettingsRequest.indices(), equalTo(SOURCE_INDEX));
@@ -622,7 +623,7 @@ public class DestinationIndexTests extends ESTestCase {
             client,
             config,
             getIndexResponse,
-            ActionListener.wrap(response -> assertThat(response.isAcknowledged(), is(true)), e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(response -> assertThat(response.isAcknowledged(), is(true)))
         );
 
         verify(client, atLeastOnce()).threadPool();

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/JobManagerTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.ResourceNotFoundException;
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
@@ -149,7 +150,7 @@ public class JobManagerTests extends ESTestCase {
             filter,
             Collections.emptySet(),
             Collections.emptySet(),
-            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
         Mockito.verifyNoMoreInteractions(auditor, updateJobProcessNotifier);
@@ -207,7 +208,7 @@ public class JobManagerTests extends ESTestCase {
             filter,
             new TreeSet<>(Arrays.asList("item 1", "item 2")),
             new TreeSet<>(Collections.singletonList("item 3")),
-            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
@@ -265,7 +266,7 @@ public class JobManagerTests extends ESTestCase {
             filter,
             new TreeSet<>(Arrays.asList("a", "b")),
             Collections.emptySet(),
-            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
         verify(auditor).info(jobReferencingFilter.getId(), "Filter [foo_filter] has been modified; added items: ['a', 'b']");
@@ -302,7 +303,7 @@ public class JobManagerTests extends ESTestCase {
             filter,
             Collections.emptySet(),
             new TreeSet<>(Arrays.asList("a", "b")),
-            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
         verify(auditor).info(jobReferencingFilter.getId(), "Filter [foo_filter] has been modified; removed items: ['a', 'b']");
@@ -329,7 +330,7 @@ public class JobManagerTests extends ESTestCase {
 
         jobManager.updateProcessOnCalendarChanged(
             Arrays.asList("job-1", "job-3", "job-4"),
-            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
@@ -374,10 +375,7 @@ public class JobManagerTests extends ESTestCase {
         mockClientBuilder.prepareSearchFields(MlConfigIndex.indexName(), fieldHits);
         JobManager jobManager = createJobManager(mockClientBuilder.build());
 
-        jobManager.updateProcessOnCalendarChanged(
-            Collections.singletonList("group-1"),
-            ActionListener.wrap(r -> {}, e -> fail(e.getMessage()))
-        );
+        jobManager.updateProcessOnCalendarChanged(Collections.singletonList("group-1"), ActionTestUtils.assertNoFailureListener(r -> {}));
 
         ArgumentCaptor<UpdateParams> updateParamsCaptor = ArgumentCaptor.forClass(UpdateParams.class);
         verify(updateJobProcessNotifier, times(2)).submitJobUpdate(updateParamsCaptor.capture(), any());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobDataDeleterTests.java
@@ -6,7 +6,7 @@
  */
 package org.elasticsearch.xpack.ml.job.persistence;
 
-import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.settings.Settings;
@@ -63,7 +63,7 @@ public class JobDataDeleterTests extends ESTestCase {
     public void testDeleteAllAnnotations() {
         Arrays.asList(false, true).forEach(deleteUserAnnotations -> {
             JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID, deleteUserAnnotations);
-            jobDataDeleter.deleteAllAnnotations(ActionListener.wrap(deleteResponse -> {}, e -> fail(e.toString())));
+            jobDataDeleter.deleteAllAnnotations(ActionTestUtils.assertNoFailureListener(deleteResponse -> {}));
 
             if (deleteUserAnnotations) {
                 verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
@@ -92,12 +92,7 @@ public class JobDataDeleterTests extends ESTestCase {
                 tuple(1_000_000_000L, null),
                 tuple(null, 2_000_000_000L)
             );
-            jobDataDeleter.deleteAnnotations(
-                range.v1(),
-                range.v2(),
-                null,
-                ActionListener.wrap(deleteResponse -> {}, e -> fail(e.toString()))
-            );
+            jobDataDeleter.deleteAnnotations(range.v1(), range.v2(), null, ActionTestUtils.assertNoFailureListener(deleteResponse -> {}));
 
             if (deleteUserAnnotations) {
                 verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());
@@ -125,7 +120,7 @@ public class JobDataDeleterTests extends ESTestCase {
                 null,
                 null,
                 Set.of("dummy_event"),
-                ActionListener.wrap(deleteResponse -> {}, e -> fail(e.toString()))
+                ActionTestUtils.assertNoFailureListener(deleteResponse -> {})
             );
 
             if (deleteUserAnnotations) {
@@ -150,7 +145,7 @@ public class JobDataDeleterTests extends ESTestCase {
     public void testDeleteDatafeedTimingStats() {
         Arrays.asList(false, true).forEach(deleteUserAnnotations -> {
             JobDataDeleter jobDataDeleter = new JobDataDeleter(client, JOB_ID, deleteUserAnnotations);
-            jobDataDeleter.deleteDatafeedTimingStats(ActionListener.wrap(deleteResponse -> {}, e -> fail(e.toString())));
+            jobDataDeleter.deleteDatafeedTimingStats(ActionTestUtils.assertNoFailureListener(deleteResponse -> {}));
 
             if (deleteUserAnnotations) {
                 verify(client, times(2)).execute(eq(DeleteByQueryAction.INSTANCE), deleteRequestCaptor.capture(), any());

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsPersisterTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.OriginSettingClient;
@@ -292,7 +293,7 @@ public class JobResultsPersisterTests extends ESTestCase {
         persister.persistDatafeedTimingStats(
             timingStats,
             WriteRequest.RefreshPolicy.IMMEDIATE,
-            ActionListener.wrap(r -> {}, e -> fail("unexpected exception " + e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(r -> {})
         );
 
         InOrder inOrder = inOrder(client);

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProviderTests.java
@@ -19,6 +19,7 @@ import org.elasticsearch.action.search.SearchAction;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
@@ -693,9 +694,11 @@ public class JobResultsProviderTests extends ESTestCase {
         Client client = getBasicMockedClient();
 
         JobResultsProvider provider = createProvider(client);
-        provider.datafeedTimingStats(List.of(), null, ActionListener.wrap(statsByJobId -> assertThat(statsByJobId, anEmptyMap()), e -> {
-            throw new AssertionError("Failure getting datafeed timing stats", e);
-        }));
+        provider.datafeedTimingStats(
+            List.of(),
+            null,
+            ActionTestUtils.assertNoFailureListener(statsByJobId -> assertThat(statsByJobId, anEmptyMap()))
+        );
 
         verifyNoMoreInteractions(client);
     }
@@ -785,7 +788,7 @@ public class JobResultsProviderTests extends ESTestCase {
         provider.datafeedTimingStats(
             List.of("foo", "bar"),
             null,
-            ActionListener.wrap(
+            ActionTestUtils.assertNoFailureListener(
                 statsByJobId -> assertThat(
                     statsByJobId,
                     equalTo(
@@ -796,8 +799,7 @@ public class JobResultsProviderTests extends ESTestCase {
                             new DatafeedTimingStats("bar", 7, 77, 777.0, contextBar)
                         )
                     )
-                ),
-                e -> fail(e.getMessage())
+                )
             )
         );
 

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/job/process/autodetect/AutodetectProcessManagerTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -575,7 +576,7 @@ public class AutodetectProcessManagerTests extends ESTestCase {
         );
 
         FlushJobParams params = FlushJobParams.builder().build();
-        manager.flushJob(jobTask, params, ActionListener.wrap(flushAcknowledgement -> {}, e -> fail(e.getMessage())));
+        manager.flushJob(jobTask, params, ActionTestUtils.assertNoFailureListener(flushAcknowledgement -> {}));
 
         verify(autodetectCommunicator).flushJob(same(params), any());
     }

--- a/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
+++ b/x-pack/plugin/ml/src/test/java/org/elasticsearch/xpack/ml/process/MlMemoryTrackerTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.ml.process;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.ClusterSettings;
@@ -136,7 +137,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
         }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(), any());
 
         if (isMaster) {
-            memoryTracker.refresh(persistentTasks, ActionListener.wrap(aVoid -> {}, ESTestCase::assertNull));
+            memoryTracker.refresh(persistentTasks, ActionTestUtils.assertNoFailureListener(aVoid -> {}));
         } else {
             AtomicReference<Exception> exception = new AtomicReference<>();
             memoryTracker.refresh(persistentTasks, ActionListener.wrap(e -> fail("Expected failure response"), exception::set));
@@ -209,7 +210,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
         }).when(jobResultsProvider).getEstablishedMemoryUsage(anyString(), any(), any(), any(), any());
 
         if (isMaster) {
-            memoryTracker.refresh(persistentTasks, toSkip, ActionListener.wrap(aVoid -> {}, ESTestCase::assertNull));
+            memoryTracker.refresh(persistentTasks, toSkip, ActionTestUtils.assertNoFailureListener(aVoid -> {}));
         } else {
             AtomicReference<Exception> exception = new AtomicReference<>();
             memoryTracker.refresh(persistentTasks, toSkip, ActionListener.wrap(e -> fail("Expected failure response"), exception::set));
@@ -335,10 +336,7 @@ public class MlMemoryTrackerTests extends ESTestCase {
 
         if (isMaster) {
             AtomicReference<Long> refreshedMemoryRequirement = new AtomicReference<>();
-            memoryTracker.refreshAnomalyDetectorJobMemory(
-                jobId,
-                ActionListener.wrap(refreshedMemoryRequirement::set, ESTestCase::assertNull)
-            );
+            memoryTracker.refreshAnomalyDetectorJobMemory(jobId, ActionTestUtils.assertNoFailureListener(refreshedMemoryRequirement::set));
             if (haveEstablishedModelMemory) {
                 assertEquals(
                     Long.valueOf(modelBytes + Job.PROCESS_MEMORY_OVERHEAD.getBytes()),

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/MonitoringServiceTests.java
@@ -182,14 +182,14 @@ public class MonitoringServiceTests extends ESTestCase {
 
         @Override
         public void export(Collection<MonitoringDoc> docs, ActionListener<Void> listener) {
-            super.export(docs, ActionListener.wrap(r -> {
+            super.export(docs, listener.delegateFailureAndWrap((l, r) -> {
                 try {
                     latch.await();
-                    listener.onResponse(null);
+                    l.onResponse(null);
                 } catch (InterruptedException e) {
-                    listener.onFailure(new ExportException("BlockingExporter failed", e));
+                    l.onFailure(new ExportException("BlockingExporter failed", e));
                 }
-            }, listener::onFailure));
+            }));
 
         }
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/ExportersTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.monitoring.exporter;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.block.ClusterBlocks;
@@ -322,7 +323,7 @@ public class ExportersTests extends ESTestCase {
         exporters = new Exporters(settings.build(), factories, clusterService, licenseState, threadContext, sslService);
 
         // synchronously checks the cluster state
-        exporters.wrapExportBulk(ActionListener.wrap(bulk -> assertThat(bulk, is(nullValue())), e -> fail(e.getMessage())));
+        exporters.wrapExportBulk(ActionTestUtils.assertNoFailureListener(bulk -> assertThat(bulk, is(nullValue()))));
 
         verify(state).blocks();
     }

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/HttpExporterTests.java
@@ -11,6 +11,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.Request;
 import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
@@ -606,10 +607,10 @@ public class HttpExporterTests extends ESTestCase {
             verify(listener).setResource(resource);
 
             final CountDownLatch awaitResponseAndClose = new CountDownLatch(1);
-            final ActionListener<ExportBulk> bulkListener = ActionListener.wrap(bulk -> {
+            final ActionListener<ExportBulk> bulkListener = ActionTestUtils.assertNoFailureListener(bulk -> {
                 assertNull("should have been invoked with null value to denote migration in progress", bulk);
                 awaitResponseAndClose.countDown();
-            }, e -> fail("[onResponse] should have been invoked with null value to denote migration in progress"));
+            });
 
             exporter.openBulk(bulkListener);
 
@@ -680,11 +681,10 @@ public class HttpExporterTests extends ESTestCase {
             verify(listener).setResource(resource);
 
             final CountDownLatch awaitResponseAndClose = new CountDownLatch(1);
-            final ActionListener<ExportBulk> bulkListener = ActionListener.wrap(bulk -> {
+            final ActionListener<ExportBulk> bulkListener = ActionTestUtils.assertNoFailureListener(bulk -> {
                 assertThat(bulk, nullValue());
-
                 awaitResponseAndClose.countDown();
-            }, e -> fail(e.getMessage()));
+            });
 
             exporter.openBulk(bulkListener);
 
@@ -718,11 +718,10 @@ public class HttpExporterTests extends ESTestCase {
             verify(listener).setResource(resource);
 
             final CountDownLatch awaitResponseAndClose = new CountDownLatch(1);
-            final ActionListener<ExportBulk> bulkListener = ActionListener.wrap(bulk -> {
+            final ActionListener<ExportBulk> bulkListener = ActionTestUtils.assertNoFailureListener(bulk -> {
                 assertThat(bulk.getName(), equalTo(exporterName()));
-
                 awaitResponseAndClose.countDown();
-            }, e -> fail(e.getMessage()));
+            });
 
             exporter.openBulk(bulkListener);
 

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/exporter/http/TemplateHttpResourceTests.java
@@ -9,7 +9,7 @@ package org.elasticsearch.xpack.monitoring.exporter.http;
 import org.apache.http.HttpEntity;
 import org.apache.lucene.util.SetOnce;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.xpack.core.monitoring.exporter.MonitoringTemplateUtils;
 
@@ -112,7 +112,7 @@ public class TemplateHttpResourceTests extends AbstractPublishableHttpResourceTe
     public void testDoPublishFalseWithNonPublishedResource() {
         RestClient mockClient = mock(RestClient.class);
         SetOnce<HttpResource.ResourcePublishResult> result = new SetOnce<>();
-        resource.doPublish(mockClient, ActionListener.wrap(result::set, e -> { throw new RuntimeException("Unexpected exception", e); }));
+        resource.doPublish(mockClient, ActionTestUtils.assertNoFailureListener(result::set));
         verifyNoMoreInteractions(mockClient); // Should not have used the client at all.
         HttpResource.ResourcePublishResult resourcePublishResult = result.get();
         assertThat(resourcePublishResult, notNullValue());

--- a/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementServiceTests.java
+++ b/x-pack/plugin/ql/src/test/java/org/elasticsearch/xpack/ql/async/AsyncTaskManagementServiceTests.java
@@ -10,6 +10,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionRequestValidationException;
 import org.elasticsearch.action.ActionResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -258,12 +259,12 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
             TimeValue.timeValueMillis(1),
             TimeValue.timeValueMinutes(10),
             keepOnCompletion,
-            ActionListener.wrap(r -> {
+            ActionTestUtils.assertNoFailureListener(r -> {
                 assertThat(r.string, nullValue());
                 assertThat(r.id, notNullValue());
                 assertThat(responseHolder.getAndSet(r), nullValue());
                 latch.countDown();
-            }, e -> fail("Shouldn't be here"))
+            })
         );
         assertThat(latch.await(20, TimeUnit.SECONDS), equalTo(true));
 
@@ -284,7 +285,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
             CountDownLatch getResponseCountDown = getResponse(
                 responseHolder.get().id,
                 TimeValue.timeValueSeconds(5),
-                ActionListener.wrap(responseRef::set, e -> fail("Shouldn't be here"))
+                ActionTestUtils.assertNoFailureListener(responseRef::set)
             );
 
             executionLatch.countDown();
@@ -328,7 +329,7 @@ public class AsyncTaskManagementServiceTests extends ESSingleNodeTestCase {
     private StoredAsyncResponse<TestResponse> getResponse(String id, TimeValue timeout) throws InterruptedException {
         AtomicReference<StoredAsyncResponse<TestResponse>> response = new AtomicReference<>();
         assertThat(
-            getResponse(id, timeout, ActionListener.wrap(response::set, e -> fail("Shouldn't be here"))).await(10, TimeUnit.SECONDS),
+            getResponse(id, timeout, ActionTestUtils.assertNoFailureListener(response::set)).await(10, TimeUnit.SECONDS),
             equalTo(true)
         );
         return response.get();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/CancellableLdapRunnableTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/ldap/CancellableLdapRunnableTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.security.authc.ldap;
 
 import org.elasticsearch.ElasticsearchTimeoutException;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.security.user.User;
 import org.elasticsearch.xpack.security.authc.ldap.LdapRealm.CancellableLdapRunnable;
@@ -73,9 +74,7 @@ public class CancellableLdapRunnableTests extends ESTestCase {
         final CountDownLatch listenerCalledLatch = new CountDownLatch(1);
         final CountDownLatch timeoutCalledLatch = new CountDownLatch(1);
         final CountDownLatch runningLatch = new CountDownLatch(1);
-        final ActionListener<User> listener = ActionListener.wrap(user -> { listenerCalledLatch.countDown(); }, e -> {
-            throw new AssertionError("onFailure should not be executed");
-        });
+        final ActionListener<User> listener = ActionTestUtils.assertNoFailureListener(user -> listenerCalledLatch.countDown());
         final CancellableLdapRunnable<User> runnable = new CancellableLdapRunnable<>(listener, e -> null, () -> {
             runningLatch.countDown();
             try {
@@ -97,9 +96,7 @@ public class CancellableLdapRunnableTests extends ESTestCase {
 
     public void testExceptionInRunnable() {
         AtomicReference<String> resultRef = new AtomicReference<>();
-        final ActionListener<String> listener = ActionListener.wrap(resultRef::set, e -> {
-            throw new AssertionError("onFailure should not be executed");
-        });
+        final ActionListener<String> listener = ActionTestUtils.assertNoFailureListener(resultRef::set);
         String defaultValue = randomAlphaOfLengthBetween(2, 10);
         final CancellableLdapRunnable<String> runnable = new CancellableLdapRunnable<>(listener, e -> defaultValue, () -> {
             throw new RuntimeException("runnable intentionally failed");

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/support/CachingUsernamePasswordRealmTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.security.authc.support;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.settings.Settings;
@@ -478,13 +479,10 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
                     for (int i1 = 0; i1 < numberOfIterations; i1++) {
                         UsernamePasswordToken token = new UsernamePasswordToken(username, password);
 
-                        realm.authenticate(token, ActionListener.wrap((result) -> {
+                        realm.authenticate(token, ActionTestUtils.assertNoFailureListener((result) -> {
                             if (result.isAuthenticated() == false) {
                                 throw new IllegalStateException("proper password led to an unauthenticated result: " + result);
                             }
-                        }, (e) -> {
-                            logger.error("caught exception", e);
-                            fail("unexpected exception - " + e);
                         }));
                     }
 
@@ -639,16 +637,13 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
                     for (int i1 = 0; i1 < numberOfIterations; i1++) {
                         UsernamePasswordToken token = new UsernamePasswordToken(username, invalidPassword ? randomPassword : password);
 
-                        realm.authenticate(token, ActionListener.wrap((result) -> {
+                        realm.authenticate(token, ActionTestUtils.assertNoFailureListener((result) -> {
                             assertThat(threadPool.getThreadContext().getTransient("key"), is(threadNum));
                             if (invalidPassword && result.isAuthenticated()) {
                                 throw new RuntimeException("invalid password led to an authenticated user: " + result);
                             } else if (invalidPassword == false && result.isAuthenticated() == false) {
                                 throw new RuntimeException("proper password led to an unauthenticated result: " + result);
                             }
-                        }, (e) -> {
-                            logger.error("caught exception", e);
-                            fail("unexpected exception - " + e);
                         }));
                     }
 
@@ -705,14 +700,11 @@ public class CachingUsernamePasswordRealmTests extends ESTestCase {
                     latch.countDown();
                     latch.await();
                     for (int i1 = 0; i1 < numberOfIterations; i1++) {
-                        realm.lookupUser(username, ActionListener.wrap((user) -> {
+                        realm.lookupUser(username, ActionTestUtils.assertNoFailureListener((user) -> {
                             assertThat(threadPool.getThreadContext().getTransient("key"), is(threadNum));
                             if (user == null) {
                                 throw new RuntimeException("failed to lookup user");
                             }
-                        }, (e) -> {
-                            logger.error("caught exception", e);
-                            fail("unexpected exception");
                         }));
                     }
 

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationServiceTests.java
@@ -71,6 +71,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchScrollAction;
 import org.elasticsearch.action.search.SearchScrollRequest;
 import org.elasticsearch.action.search.SearchTransportService;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.IndicesOptions;
 import org.elasticsearch.action.support.PlainActionFuture;
 import org.elasticsearch.action.support.WriteRequest;
@@ -1117,7 +1118,7 @@ public class AuthorizationServiceTests extends ESTestCase {
             SearchRequest searchRequest = new SearchRequest("does_not_exist").indicesOptions(
                 IndicesOptions.fromOptions(true, true, true, false)
             );
-            final ActionListener<Void> listener = ActionListener.wrap(ignore -> {
+            final ActionListener<Void> listener = ActionTestUtils.assertNoFailureListener(ignore -> {
                 final IndicesAccessControl indicesAccessControl = threadContext.getTransient(
                     AuthorizationServiceField.INDICES_PERMISSIONS_KEY
                 );
@@ -1127,7 +1128,7 @@ public class AuthorizationServiceTests extends ESTestCase {
                 );
                 assertFalse(indexAccessControl.getFieldPermissions().hasFieldLevelSecurity());
                 assertFalse(indexAccessControl.getDocumentPermissions().hasDocumentLevelPermissions());
-            }, e -> { fail(e.getMessage()); });
+            });
             final CountDownLatch latch = new CountDownLatch(1);
             authorizationService.authorize(authentication, SearchAction.NAME, searchRequest, new LatchedActionListener<>(listener, latch));
             latch.await();

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationUtilsTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authz/AuthorizationUtilsTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.security.authz;
 
 import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.metadata.DataLifecycle;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
@@ -151,14 +152,14 @@ public class AuthorizationUtilsTests extends ESTestCase {
         final String headerValue = randomAlphaOfLengthBetween(4, 16);
         final CountDownLatch latch = new CountDownLatch(2);
 
-        final ActionListener<Void> listener = ActionListener.wrap(v -> {
+        final ActionListener<Void> listener = ActionTestUtils.assertNoFailureListener(v -> {
             assertNull(threadContext.getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME));
             assertNull(threadContext.getHeader(headerName));
             final Authentication authentication = securityContext.getAuthentication();
             assertEquals(user, authentication.getEffectiveSubject().getUser());
             assertEquals(version, authentication.getEffectiveSubject().getTransportVersion());
             latch.countDown();
-        }, e -> fail(e.getMessage()));
+        });
 
         final Consumer<ThreadContext.StoredContext> consumer = original -> {
             assertNull(threadContext.getTransient(ThreadContext.ACTION_ORIGIN_TRANSIENT_NAME));

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowFunctionsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/ShowFunctionsTests.java
@@ -7,6 +7,7 @@
 
 package org.elasticsearch.xpack.sql.plan.logical.command;
 
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.tree.Source;
 import org.elasticsearch.xpack.sql.SqlTestUtils;
@@ -14,20 +15,18 @@ import org.elasticsearch.xpack.sql.expression.function.SqlFunctionRegistry;
 import org.elasticsearch.xpack.sql.session.SchemaRowSet;
 import org.elasticsearch.xpack.sql.session.SqlSession;
 
-import static org.elasticsearch.action.ActionListener.wrap;
-
 public class ShowFunctionsTests extends ESTestCase {
 
     public void testShowFunctions() throws Exception {
         ShowFunctions showFunctions = new ShowFunctions(Source.EMPTY, null);
         SqlSession session = new SqlSession(SqlTestUtils.TEST_CFG, null, new SqlFunctionRegistry(), null, null, null, null, null, null);
 
-        showFunctions.execute(session, wrap(p -> {
+        showFunctions.execute(session, ActionTestUtils.assertNoFailureListener(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertTrue(150 <= r.size());
             assertEquals(2, r.columnCount());
             assertEquals("AVG", r.column(0));
             assertEquals("AGGREGATE", r.column(1));
-        }, ex -> fail(ex.getMessage())));
+        }));
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysColumnsTests.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
 import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.index.EsIndex;
@@ -40,7 +41,6 @@ import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.TestUtils.UTC;
 import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.INTRODUCING_VERSION_FIELD_TYPE;
@@ -370,7 +370,7 @@ public class SysColumnsTests extends ESTestCase {
         );
         Tuple<Command, SqlSession> tuple = sql(sql, params, config, mapping);
 
-        tuple.v1().execute(tuple.v2(), wrap(p -> consumer.accept((SchemaRowSet) p.rowSet()), ex -> fail(ex.getMessage())));
+        tuple.v1().execute(tuple.v2(), ActionTestUtils.assertNoFailureListener(p -> consumer.accept((SchemaRowSet) p.rowSet())));
     }
 
     private void executeCommand(

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTablesTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
 import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.index.EsIndex;
@@ -38,7 +39,6 @@ import java.util.function.Consumer;
 
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.index.IndexResolver.SQL_TABLE;
 import static org.elasticsearch.xpack.ql.index.IndexResolver.SQL_VIEW;
 import static org.elasticsearch.xpack.sql.analysis.analyzer.AnalyzerTestUtils.analyzer;
@@ -406,6 +406,6 @@ public class SysTablesTests extends ESTestCase {
             return Void.TYPE;
         }).when(resolver).resolveNames(any(), any(), any(), any(), any());
 
-        tuple.v1().execute(tuple.v2(), wrap(p -> consumer.accept((SchemaRowSet) p.rowSet()), ex -> fail(ex.getMessage())));
+        tuple.v1().execute(tuple.v2(), ActionTestUtils.assertNoFailureListener(p -> consumer.accept((SchemaRowSet) p.rowSet())));
     }
 }

--- a/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
+++ b/x-pack/plugin/sql/src/test/java/org/elasticsearch/xpack/sql/plan/logical/command/sys/SysTypesTests.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.sql.plan.logical.command.sys;
 
 import org.elasticsearch.Version;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.core.Tuple;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.ql.index.EsIndex;
@@ -33,7 +34,6 @@ import java.util.List;
 import java.util.Set;
 
 import static java.util.Arrays.asList;
-import static org.elasticsearch.action.ActionListener.wrap;
 import static org.elasticsearch.xpack.ql.index.VersionCompatibilityChecks.isTypeSupportedInVersion;
 import static org.elasticsearch.xpack.ql.type.DataTypes.UNSIGNED_LONG;
 import static org.elasticsearch.xpack.ql.type.DataTypes.VERSION;
@@ -123,7 +123,7 @@ public class SysTypesTests extends ESTestCase {
             "OBJECT"
         );
 
-        cmd.v1().execute(cmd.v2(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(19, r.columnCount());
             assertEquals(SqlDataTypes.types().size(), r.size());
@@ -139,8 +139,7 @@ public class SysTypesTests extends ESTestCase {
                 assertEquals(names.get(i), r.column(0));
                 r.advanceRow();
             }
-
-        }, ex -> fail(ex.getMessage())));
+        }));
     }
 
     public void testUnsignedLongFiltering() {
@@ -150,7 +149,7 @@ public class SysTypesTests extends ESTestCase {
             for (Mode mode : Mode.values()) {
                 Tuple<Command, SqlSession> cmd = sql("SYS TYPES", mode, version);
 
-                cmd.v1().execute(cmd.v2(), wrap(p -> {
+                cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
                     SchemaRowSet r = (SchemaRowSet) p.rowSet();
                     List<String> types = new ArrayList<>();
                     r.forEachRow(rv -> types.add((String) rv.column(0)));
@@ -158,7 +157,7 @@ public class SysTypesTests extends ESTestCase {
                         isTypeSupportedInVersion(UNSIGNED_LONG, Version.fromId(cmd.v2().configuration().version().id)),
                         types.contains(UNSIGNED_LONG.toString())
                     );
-                }, ex -> fail(ex.getMessage())));
+                }));
             }
         }
     }
@@ -170,7 +169,7 @@ public class SysTypesTests extends ESTestCase {
             for (Mode mode : Mode.values()) {
                 Tuple<Command, SqlSession> cmd = sql("SYS TYPES", mode, version);
 
-                cmd.v1().execute(cmd.v2(), wrap(p -> {
+                cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
                     SchemaRowSet r = (SchemaRowSet) p.rowSet();
                     List<String> types = new ArrayList<>();
                     r.forEachRow(rv -> types.add((String) rv.column(0)));
@@ -178,7 +177,7 @@ public class SysTypesTests extends ESTestCase {
                         isTypeSupportedInVersion(VERSION, Version.fromId(cmd.v2().configuration().version().id)),
                         types.contains(VERSION.toString())
                     );
-                }, ex -> fail(ex.getMessage())));
+                }));
             }
         }
     }
@@ -186,37 +185,37 @@ public class SysTypesTests extends ESTestCase {
     public void testSysTypesDefaultFiltering() {
         Tuple<Command, SqlSession> cmd = sql("SYS TYPES 0");
 
-        cmd.v1().execute(cmd.v2(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(SqlDataTypes.types().size(), r.size());
-        }, ex -> fail(ex.getMessage())));
+        }));
     }
 
     public void testSysTypesPositiveFiltering() {
         // boolean = 16
         Tuple<Command, SqlSession> cmd = sql("SYS TYPES " + JDBCType.BOOLEAN.getVendorTypeNumber());
 
-        cmd.v1().execute(cmd.v2(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(1, r.size());
             assertEquals("BOOLEAN", r.column(0));
-        }, ex -> fail(ex.getMessage())));
+        }));
     }
 
     public void testSysTypesNegativeFiltering() {
         Tuple<Command, SqlSession> cmd = sql("SYS TYPES " + JDBCType.TINYINT.getVendorTypeNumber());
 
-        cmd.v1().execute(cmd.v2(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(1, r.size());
             assertEquals("BYTE", r.column(0));
-        }, ex -> fail(ex.getMessage())));
+        }));
     }
 
     public void testSysTypesMultipleMatches() {
         Tuple<Command, SqlSession> cmd = sql("SYS TYPES " + JDBCType.VARCHAR.getVendorTypeNumber());
 
-        cmd.v1().execute(cmd.v2(), wrap(p -> {
+        cmd.v1().execute(cmd.v2(), ActionTestUtils.assertNoFailureListener(p -> {
             SchemaRowSet r = (SchemaRowSet) p.rowSet();
             assertEquals(4, r.size());
             assertEquals("IP", r.column(0));
@@ -226,6 +225,6 @@ public class SysTypesTests extends ESTestCase {
             assertEquals("TEXT", r.column(0));
             assertTrue(r.advanceRow());
             assertEquals("VERSION", r.column(0));
-        }, ex -> fail(ex.getMessage())));
+        }));
     }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformCheckpointServiceNodeTests.java
@@ -401,9 +401,9 @@ public class TransformCheckpointServiceNodeTests extends TransformSingleNodeTest
         TransformProgress nextCheckpointProgress,
         ActionListener<TransformCheckpointingInfo> listener
     ) {
-        ActionListener<TransformCheckpointingInfoBuilder> checkPointInfoListener = ActionListener.wrap(infoBuilder -> {
-            listener.onResponse(infoBuilder.build());
-        }, listener::onFailure);
+        ActionListener<TransformCheckpointingInfoBuilder> checkPointInfoListener = listener.delegateFailureAndWrap(
+            (l, infoBuilder) -> l.onResponse(infoBuilder.build())
+        );
         transformCheckpointService.getCheckpointingInfo(
             mockClientForCheckpointing,
             transformId,

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointTests.java
@@ -278,10 +278,13 @@ public class TransformGetCheckpointTests extends ESSingleNodeTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
-        LatchedActionListener<GetCheckpointAction.Response> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
-            assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
-            furtherTests.accept(r);
-        }, e -> { fail("got unexpected exception: " + e); }), latch);
+        LatchedActionListener<GetCheckpointAction.Response> listener = new LatchedActionListener<>(
+            ActionTestUtils.assertNoFailureListener(r -> {
+                assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
+                furtherTests.accept(r);
+            }),
+            latch
+        );
 
         ActionTestUtils.execute(getCheckpointAction, transformTask, request, listener);
         assertTrue("timed out after 20s", latch.await(20, TimeUnit.SECONDS));

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/AuthorizationStatePersistenceUtilsTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/AuthorizationStatePersistenceUtilsTests.java
@@ -10,6 +10,7 @@ package org.elasticsearch.xpack.transform.persistence;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.indices.TestIndexNameExpressionResolver;
@@ -104,7 +105,7 @@ public class AuthorizationStatePersistenceUtilsTests extends TransformSingleNode
     private <T> void assertAsync(Consumer<ActionListener<T>> function, T expected) throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(1);
         LatchedActionListener<T> listener = new LatchedActionListener<>(
-            ActionListener.wrap(r -> assertThat(r, is(equalTo(expected))), e -> fail("got unexpected exception: " + e.getMessage())),
+            ActionTestUtils.assertNoFailureListener(r -> assertThat(r, is(equalTo(expected)))),
             latch
         );
         function.accept(listener);

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformPrivilegeCheckerTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.metadata.IndexMetadata;
@@ -120,7 +121,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             config,
             false,
-            ActionListener.wrap(aVoid -> {
+            ActionTestUtils.assertNoFailureListener(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
@@ -130,7 +131,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(sourceIndicesPrivileges.getIndices(), is(arrayContaining(SOURCE_INDEX_NAME)));
                 assertThat(sourceIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "view_index_metadata")));
                 assertThat(sourceIndicesPrivileges.allowRestrictedIndices(), is(true));
-            }, e -> fail(e.getMessage()))
+            })
         );
     }
 
@@ -146,10 +147,8 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             config,
             false,
-            ActionListener.wrap(aVoid -> {
-                // _has_privileges API is not called for the remote index
-                assertThat(client.lastHasPrivilegesRequest, is(nullValue()));
-            }, e -> fail(e.getMessage()))
+            // _has_privileges API is not called for the remote index
+            ActionTestUtils.assertNoFailureListener(aVoid -> assertThat(client.lastHasPrivilegesRequest, is(nullValue())))
         );
     }
 
@@ -163,7 +162,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             TRANSFORM_CONFIG,
             true,
-            ActionListener.wrap(aVoid -> {
+            ActionTestUtils.assertNoFailureListener(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
@@ -177,7 +176,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index", "create_index")));
                 assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
-            }, e -> fail(e.getMessage()))
+            })
         );
     }
 
@@ -197,7 +196,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             TRANSFORM_CONFIG,
             true,
-            ActionListener.wrap(aVoid -> {
+            ActionTestUtils.assertNoFailureListener(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
@@ -211,7 +210,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index")));
                 assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
-            }, e -> fail(e.getMessage()))
+            })
         );
     }
 
@@ -233,7 +232,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             config,
             true,
-            ActionListener.wrap(aVoid -> {
+            ActionTestUtils.assertNoFailureListener(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
@@ -243,7 +242,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index")));
                 assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
-            }, e -> fail(e.getMessage()))
+            })
         );
     }
 
@@ -266,7 +265,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             config,
             true,
-            ActionListener.wrap(aVoid -> {
+            ActionTestUtils.assertNoFailureListener(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
@@ -280,7 +279,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(destIndicesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destIndicesPrivileges.getPrivileges(), is(arrayContaining("read", "index", "delete")));
                 assertThat(destIndicesPrivileges.allowRestrictedIndices(), is(true));
-            }, e -> fail(e.getMessage()))
+            })
         );
     }
 
@@ -303,7 +302,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
             client,
             config,
             true,
-            ActionListener.wrap(aVoid -> {
+            ActionTestUtils.assertNoFailureListener(aVoid -> {
                 HasPrivilegesRequest request = client.lastHasPrivilegesRequest;
                 assertThat(request.username(), is(equalTo(USER_NAME)));
                 assertThat(request.applicationPrivileges(), is(emptyArray()));
@@ -324,7 +323,7 @@ public class TransformPrivilegeCheckerTests extends ESTestCase {
                 assertThat(destAliasesPrivileges.getIndices(), is(arrayContaining(DEST_INDEX_NAME)));
                 assertThat(destAliasesPrivileges.getPrivileges(), is(arrayContaining("read", "index", "manage")));
                 assertThat(destAliasesPrivileges.allowRestrictedIndices(), is(true));
-            }, e -> fail(e.getMessage()))
+            })
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/action/TransformUpdaterTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.ActionRequest;
 import org.elasticsearch.action.ActionResponse;
 import org.elasticsearch.action.ActionType;
 import org.elasticsearch.action.LatchedActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.action.support.master.AcknowledgedRequest;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
@@ -488,10 +489,10 @@ public class TransformUpdaterTests extends ESTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
-        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
+        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(r -> {
             assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             furtherTests.accept(r);
-        }, e -> { fail("got unexpected exception: " + e); }), latch);
+        }), latch);
 
         function.accept(listener);
         assertTrue("timed out after 20s", latch.await(20, TimeUnit.SECONDS));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformIndexTests.java
@@ -14,6 +14,7 @@ import org.elasticsearch.action.admin.indices.create.CreateIndexAction;
 import org.elasticsearch.action.admin.indices.create.CreateIndexRequest;
 import org.elasticsearch.action.admin.indices.get.GetIndexAction;
 import org.elasticsearch.action.admin.indices.get.GetIndexResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.metadata.MappingMetadata;
 import org.elasticsearch.common.settings.Settings;
@@ -85,7 +86,7 @@ public class TransformIndexTests extends ESTestCase {
         TransformIndex.isDestinationIndexCreatedByTransform(
             client,
             DEST_INDEX,
-            new LatchedActionListener<>(ActionListener.wrap(Assert::assertFalse, e -> fail(e.getMessage())), latch)
+            new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(Assert::assertFalse), latch)
         );
         assertTrue(latch.await(10, TimeUnit.SECONDS));
     }
@@ -99,7 +100,7 @@ public class TransformIndexTests extends ESTestCase {
             client,
             DEST_INDEX,
             new LatchedActionListener<>(
-                ActionListener.wrap(value -> assertThat(value, is(equalTo(expectedValue))), e -> fail(e.getMessage())),
+                ActionTestUtils.assertNoFailureListener(value -> assertThat(value, is(equalTo(expectedValue)))),
                 latch
             )
         );
@@ -146,7 +147,7 @@ public class TransformIndexTests extends ESTestCase {
             client,
             TransformConfigTests.randomTransformConfig(TRANSFORM_ID),
             TransformIndex.createTransformDestIndexSettings(new HashMap<>(), TRANSFORM_ID, clock),
-            ActionListener.wrap(Assert::assertTrue, e -> fail(e.getMessage()))
+            ActionTestUtils.assertNoFailureListener(Assert::assertTrue)
         );
 
         ArgumentCaptor<CreateIndexRequest> createIndexRequestCaptor = ArgumentCaptor.forClass(CreateIndexRequest.class);
@@ -172,7 +173,7 @@ public class TransformIndexTests extends ESTestCase {
             .setDest(new DestConfig("my-dest", null, null))
             .build();
 
-        TransformIndex.setUpDestinationAliases(client, config, ActionListener.wrap(Assert::assertTrue, e -> fail(e.getMessage())));
+        TransformIndex.setUpDestinationAliases(client, config, ActionTestUtils.assertNoFailureListener(Assert::assertTrue));
 
         verifyNoMoreInteractions(client);
     }
@@ -185,7 +186,7 @@ public class TransformIndexTests extends ESTestCase {
             .setDest(new DestConfig("my-dest", List.of(), null))
             .build();
 
-        TransformIndex.setUpDestinationAliases(client, config, ActionListener.wrap(Assert::assertTrue, e -> fail(e.getMessage())));
+        TransformIndex.setUpDestinationAliases(client, config, ActionTestUtils.assertNoFailureListener(Assert::assertTrue));
 
         verifyNoMoreInteractions(client);
     }
@@ -199,7 +200,7 @@ public class TransformIndexTests extends ESTestCase {
             .setDest(new DestConfig(destIndex, List.of(new DestAlias(".all", false), new DestAlias(".latest", true)), null))
             .build();
 
-        TransformIndex.setUpDestinationAliases(client, config, ActionListener.wrap(Assert::assertTrue, e -> fail(e.getMessage())));
+        TransformIndex.setUpDestinationAliases(client, config, ActionTestUtils.assertNoFailureListener(Assert::assertTrue));
 
         ArgumentCaptor<IndicesAliasesRequest> indicesAliasesRequestCaptor = ArgumentCaptor.forClass(IndicesAliasesRequest.class);
         verify(client).execute(eq(IndicesAliasesAction.INSTANCE), indicesAliasesRequestCaptor.capture(), any());

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/persistence/TransformInternalIndexTests.java
@@ -12,6 +12,7 @@ import org.elasticsearch.Version;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
 import org.elasticsearch.action.admin.indices.create.CreateIndexResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.AdminClient;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ClusterAdminClient;
@@ -119,7 +120,7 @@ public class TransformInternalIndexTests extends ESTestCase {
         Client client = mock(Client.class);
 
         AtomicBoolean gotResponse = new AtomicBoolean(false);
-        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+        ActionListener<Void> testListener = ActionTestUtils.assertNoFailureListener(aVoid -> gotResponse.set(true));
 
         TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
 
@@ -150,7 +151,7 @@ public class TransformInternalIndexTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
 
         AtomicBoolean gotResponse = new AtomicBoolean(false);
-        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+        ActionListener<Void> testListener = ActionTestUtils.assertNoFailureListener(aVoid -> gotResponse.set(true));
 
         TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
 
@@ -187,7 +188,7 @@ public class TransformInternalIndexTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
 
         AtomicBoolean gotResponse = new AtomicBoolean(false);
-        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+        ActionListener<Void> testListener = ActionTestUtils.assertNoFailureListener(aVoid -> gotResponse.set(true));
 
         TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
 
@@ -225,7 +226,7 @@ public class TransformInternalIndexTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
 
         AtomicBoolean gotResponse = new AtomicBoolean(false);
-        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+        ActionListener<Void> testListener = ActionTestUtils.assertNoFailureListener(aVoid -> gotResponse.set(true));
 
         TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
 
@@ -272,7 +273,7 @@ public class TransformInternalIndexTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
 
         AtomicBoolean gotResponse = new AtomicBoolean(false);
-        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+        ActionListener<Void> testListener = ActionTestUtils.assertNoFailureListener(aVoid -> gotResponse.set(true));
 
         TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
 
@@ -311,7 +312,7 @@ public class TransformInternalIndexTests extends ESTestCase {
         when(client.threadPool()).thenReturn(threadPool);
 
         AtomicBoolean gotResponse = new AtomicBoolean(false);
-        ActionListener<Void> testListener = ActionListener.wrap(aVoid -> gotResponse.set(true), e -> fail(e.getMessage()));
+        ActionListener<Void> testListener = ActionTestUtils.assertNoFailureListener(aVoid -> gotResponse.set(true));
 
         TransformInternalIndex.createLatestVersionedIndexIfRequired(clusterService, client, testListener);
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/ClientTransformIndexerTests.java
@@ -20,6 +20,7 @@ import org.elasticsearch.action.search.OpenPointInTimeResponse;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Tuple;
@@ -113,11 +114,8 @@ public class ClientTransformIndexerTests extends ESTestCase {
         Tuple<String, SearchRequest> namedSearchRequest = new Tuple<>("test", searchRequest);
         indexer.doSearch(
             namedSearchRequest,
-            ActionListener.wrap(
-                // A search of zero indices should return null rather than attempt to search all indices
-                ESTestCase::assertNull,
-                e -> fail(e.getMessage())
-            )
+            // A search of zero indices should return null rather than attempt to search all indices
+            ActionTestUtils.assertNoFailureListener(ESTestCase::assertNull)
         );
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerStateTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -783,9 +784,10 @@ public class TransformIndexerStateTests extends ESTestCase {
     }
 
     private void countResponse(Consumer<ActionListener<Void>> function, CountDownLatch latch) throws InterruptedException {
-        LatchedActionListener<Void> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
-            assertEquals("listener called more than once", 1, latch.getCount());
-        }, e -> { fail("got unexpected exception: " + e.getMessage()); }), latch);
+        LatchedActionListener<Void> listener = new LatchedActionListener<>(
+            ActionTestUtils.assertNoFailureListener(r -> assertEquals("listener called more than once", 1, latch.getCount())),
+            latch
+        );
         function.accept(listener);
     }
 

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformIndexerTests.java
@@ -18,6 +18,7 @@ import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.TimeValue;
@@ -493,10 +494,10 @@ public class TransformIndexerTests extends ESTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
-        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
+        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(r -> {
             assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             furtherTests.accept(r);
-        }, e -> { fail("got unexpected exception: " + e); }), latch);
+        }), latch);
 
         function.accept(listener);
         assertTrue("timed out after 5s", latch.await(5, TimeUnit.SECONDS));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/TransformTaskTests.java
@@ -10,7 +10,7 @@ package org.elasticsearch.xpack.transform.transforms;
 import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.Version;
-import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.client.internal.ParentTaskAssigningClient;
 import org.elasticsearch.cluster.ClusterName;
@@ -221,9 +221,7 @@ public class TransformTaskTests extends ESTestCase {
 
         transformTask.init(mock(PersistentTasksService.class), taskManager, "task-id", 42);
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
-        transformTask.fail("because", ActionListener.wrap(r -> { listenerCalled.compareAndSet(false, true); }, e -> {
-            fail("setting transform task to failed failed with: " + e);
-        }));
+        transformTask.fail("because", ActionTestUtils.assertNoFailureListener(r -> { listenerCalled.compareAndSet(false, true); }));
 
         TransformState state = transformTask.getState();
         assertEquals(TransformTaskState.FAILED, state.getTaskState());

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/latest/LatestTests.java
@@ -7,7 +7,7 @@
 
 package org.elasticsearch.xpack.transform.transforms.latest;
 
-import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.test.ESTestCase;
 import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfig;
 import org.elasticsearch.xpack.core.transform.transforms.latest.LatestConfigTests;
@@ -23,7 +23,7 @@ public class LatestTests extends ESTestCase {
     public void testValidateConfig() {
         LatestConfig latestConfig = LatestConfigTests.randomLatestConfig();
         Function latest = new Latest(latestConfig);
-        latest.validateConfig(ActionListener.wrap(isValid -> assertThat(isValid, is(true)), e -> fail(e.getMessage())));
+        latest.validateConfig(ActionTestUtils.assertNoFailureListener(isValid -> assertThat(isValid, is(true))));
     }
 
     public void testGetPerformanceCriticalFields() {

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/AggregationSchemaAndResultTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.index.query.TermQueryBuilder;
@@ -289,10 +290,10 @@ public class AggregationSchemaAndResultTests extends ESTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
-        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
+        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(r -> {
             assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             furtherTests.accept(r);
-        }, e -> { fail("got unexpected exception: " + e); }), latch);
+        }), latch);
 
         function.accept(listener);
         assertTrue("timed out after 20s", latch.await(20, TimeUnit.SECONDS));

--- a/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
+++ b/x-pack/plugin/transform/src/test/java/org/elasticsearch/xpack/transform/transforms/pivot/SchemaUtilTests.java
@@ -15,6 +15,7 @@ import org.elasticsearch.action.LatchedActionListener;
 import org.elasticsearch.action.fieldcaps.FieldCapabilities;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesRequest;
 import org.elasticsearch.action.fieldcaps.FieldCapabilitiesResponse;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.test.ESTestCase;
@@ -258,10 +259,10 @@ public class SchemaUtilTests extends ESTestCase {
         CountDownLatch latch = new CountDownLatch(1);
         AtomicBoolean listenerCalled = new AtomicBoolean(false);
 
-        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionListener.wrap(r -> {
+        LatchedActionListener<T> listener = new LatchedActionListener<>(ActionTestUtils.assertNoFailureListener(r -> {
             assertTrue("listener called more than once", listenerCalled.compareAndSet(false, true));
             furtherTests.accept(r);
-        }, e -> { fail("got unexpected exception: " + e); }), latch);
+        }), latch);
 
         function.accept(listener);
         assertTrue("timed out after 20s", latch.await(20, TimeUnit.SECONDS));

--- a/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
+++ b/x-pack/plugin/watcher/src/test/java/org/elasticsearch/xpack/watcher/transport/actions/TransportPutWatchActionTests.java
@@ -11,6 +11,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.index.IndexResponse;
 import org.elasticsearch.action.support.ActionFilters;
+import org.elasticsearch.action.support.ActionTestUtils;
 import org.elasticsearch.client.internal.Client;
 import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.service.ClusterService;
@@ -42,8 +43,6 @@ import java.util.Set;
 
 import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyLong;
@@ -116,7 +115,7 @@ public class TransportPutWatchActionTests extends ESTestCase {
 
         PutWatchRequest putWatchRequest = new PutWatchRequest();
         putWatchRequest.setId("_id");
-        action.doExecute(putWatchRequest, ActionListener.wrap(r -> {}, e -> assertThat(e, is(nullValue()))));
+        action.doExecute(putWatchRequest, ActionTestUtils.assertNoFailureListener(r -> {}));
 
         ArgumentCaptor<Map> captor = ArgumentCaptor.forClass(Map.class);
         verify(watch.status()).setHeaders(captor.capture());


### PR DESCRIPTION
There were a couple duplicate approaches to this in the codebase and I dried them up. Mostly motivated by the fact that many of these approaches didn't cleanly bubble up the stack-trace so failures had to be found in logs or stack-traces were swallowed completely.
