### PR TITLE
Interpret microseconds cpu stats properly as nanos from cgroups2

### DIFF
--- a/docs/changelog/96924.yaml
+++ b/docs/changelog/96924.yaml
@@ -1,0 +1,6 @@
+pr: 96924
+summary: Interpret microseconds cpu stats properly as nanos from cgroups2
+area: Infra/Core
+type: bug
+issues:
+ - 96089

--- a/docs/changelog/96924.yaml
+++ b/docs/changelog/96924.yaml
@@ -1,5 +1,5 @@
 pr: 96924
-summary: Interpret microseconds cpu stats properly as nanos from cgroups2
+summary: Interpret microseconds cpu stats from cgroups2 properly as nanos
 area: Infra/Core
 type: bug
 issues:

--- a/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
+++ b/server/src/main/java/org/elasticsearch/monitor/os/OsProbe.java
@@ -692,7 +692,7 @@ public class OsProbe {
                 // `cpuacct` was merged with `cpu` in v2
                 final Map<String, Long> cpuStatsMap = getCgroupV2CpuStats(cpuControlGroup);
 
-                cgroupCpuAcctUsageNanos = cpuStatsMap.get("usage_usec");
+                cgroupCpuAcctUsageNanos = cpuStatsMap.get("usage_usec") * 1000; // convert from micros to nanos
 
                 long[] cpuLimits = getCgroupV2CpuLimit(cpuControlGroup);
                 cgroupCpuAcctCpuCfsQuotaMicros = cpuLimits[0];
@@ -701,7 +701,7 @@ public class OsProbe {
                 cpuStat = new OsStats.Cgroup.CpuStat(
                     cpuStatsMap.get("nr_periods"),
                     cpuStatsMap.get("nr_throttled"),
-                    cpuStatsMap.get("throttled_usec")
+                    cpuStatsMap.get("throttled_usec") * 1000
                 );
 
                 cgroupMemoryLimitInBytes = getCgroupV2MemoryLimitInBytes(memoryControlGroup);

--- a/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
+++ b/server/src/test/java/org/elasticsearch/monitor/os/OsProbeTests.java
@@ -185,20 +185,34 @@ public class OsProbeTests extends ESTestCase {
 
         final OsStats.Cgroup cgroup = probe.osStats().getCgroup();
 
-        if (availableCgroupsVersion > 0) {
-            assertNotNull(cgroup);
-            assertThat(cgroup.getCpuAcctControlGroup(), equalTo("/" + hierarchy));
-            assertThat(cgroup.getCpuAcctUsageNanos(), equalTo(364869866063112L));
-            assertThat(cgroup.getCpuControlGroup(), equalTo("/" + hierarchy));
-            assertThat(cgroup.getCpuCfsPeriodMicros(), equalTo(100000L));
-            assertThat(cgroup.getCpuCfsQuotaMicros(), equalTo(50000L));
-            assertThat(cgroup.getCpuStat().getNumberOfElapsedPeriods(), equalTo(17992L));
-            assertThat(cgroup.getCpuStat().getNumberOfTimesThrottled(), equalTo(1311L));
-            assertThat(cgroup.getCpuStat().getTimeThrottledNanos(), equalTo(139298645489L));
-            assertThat(cgroup.getMemoryLimitInBytes(), equalTo("18446744073709551615"));
-            assertThat(cgroup.getMemoryUsageInBytes(), equalTo("4796416"));
-        } else {
-            assertNull(cgroup);
+        switch (availableCgroupsVersion) {
+            case 0 -> assertNull(cgroup);
+            case 1 -> {
+                assertNotNull(cgroup);
+                assertThat(cgroup.getCpuAcctControlGroup(), equalTo("/" + hierarchy));
+                assertThat(cgroup.getCpuAcctUsageNanos(), equalTo(364869866063112L));
+                assertThat(cgroup.getCpuControlGroup(), equalTo("/" + hierarchy));
+                assertThat(cgroup.getCpuCfsPeriodMicros(), equalTo(100000L));
+                assertThat(cgroup.getCpuCfsQuotaMicros(), equalTo(50000L));
+                assertThat(cgroup.getCpuStat().getNumberOfElapsedPeriods(), equalTo(17992L));
+                assertThat(cgroup.getCpuStat().getNumberOfTimesThrottled(), equalTo(1311L));
+                assertThat(cgroup.getCpuStat().getTimeThrottledNanos(), equalTo(139298645489L));
+                assertThat(cgroup.getMemoryLimitInBytes(), equalTo("18446744073709551615"));
+                assertThat(cgroup.getMemoryUsageInBytes(), equalTo("4796416"));
+            }
+            case 2 -> {
+                assertNotNull(cgroup);
+                assertThat(cgroup.getCpuAcctControlGroup(), equalTo("/" + hierarchy));
+                assertThat(cgroup.getCpuAcctUsageNanos(), equalTo(364869866063000L));
+                assertThat(cgroup.getCpuControlGroup(), equalTo("/" + hierarchy));
+                assertThat(cgroup.getCpuCfsPeriodMicros(), equalTo(100000L));
+                assertThat(cgroup.getCpuCfsQuotaMicros(), equalTo(50000L));
+                assertThat(cgroup.getCpuStat().getNumberOfElapsedPeriods(), equalTo(17992L));
+                assertThat(cgroup.getCpuStat().getNumberOfTimesThrottled(), equalTo(1311L));
+                assertThat(cgroup.getCpuStat().getTimeThrottledNanos(), equalTo(139298645000L));
+                assertThat(cgroup.getMemoryLimitInBytes(), equalTo("18446744073709551615"));
+                assertThat(cgroup.getMemoryUsageInBytes(), equalTo("4796416"));
+            }
         }
     }
 
@@ -447,12 +461,12 @@ public class OsProbeTests extends ESTestCase {
             List<String> readCgroupV2CpuStats(String controlGroup) {
                 assertThat(controlGroup, equalTo("/" + hierarchy));
                 return List.of(
-                    "usage_usec 364869866063112",
+                    "usage_usec 364869866063",
                     "user_usec 34636",
                     "system_usec 9896",
                     "nr_periods 17992",
                     "nr_throttled 1311",
-                    "throttled_usec 139298645489"
+                    "throttled_usec 139298645"
                 );
             }
 


### PR DESCRIPTION
This fixes #96089

The OsProbe class is reading cgroup CPU stats as microseconds, thinking they're nanos. They need to be re-interpreted as nanos here