### PR TITLE
Remove invalid asserts in MergingDigest.

### DIFF
--- a/docs/changelog/96928.yaml
+++ b/docs/changelog/96928.yaml
@@ -1,5 +1,0 @@
-pr: 96928
-summary: Remove invalid asserts in `MergingDigest`
-area: Aggregations
-type: bug
-issues: []

--- a/docs/changelog/96928.yaml
+++ b/docs/changelog/96928.yaml
@@ -1,0 +1,5 @@
+pr: 96928
+summary: Remove invalid asserts in `MergingDigest`
+area: Aggregations
+type: bug
+issues: []

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/MergingDigest.java
@@ -313,8 +313,6 @@ public class MergingDigest extends AbstractTDigest {
     ) {
         // when our incoming buffer fills up, we combine our existing centroids with the incoming data,
         // and then reduce the centroids by merging if possible
-        assert lastUsedCell <= 0 || weight[0] == 1;
-        assert lastUsedCell <= 0 || weight[lastUsedCell - 1] == 1;
         System.arraycopy(mean, 0, incomingMean, incomingCount, lastUsedCell);
         System.arraycopy(weight, 0, incomingWeight, incomingCount, lastUsedCell);
         incomingCount += lastUsedCell;


### PR DESCRIPTION
The asserts were misfiring in this test:

```
REPRODUCE WITH: ./gradlew ':server:test' --tests "org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviationTests.testReduceRandom" -Dtests.seed=AA1D81AD056870F0 -Dtests.locale=en-CA -Dtests.timezone=US/Eastern -Druntime.java=20

org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviationTests > testReduceRandom FAILED
    java.lang.AssertionError
        at __randomizedtesting.SeedInfo.seed([AA1D81AD056870F0:6A202DBC2335E9A6]:0)
        at org.elasticsearch.tdigest.MergingDigest.merge(MergingDigest.java:316)
        at org.elasticsearch.tdigest.MergingDigest.mergeNewValues(MergingDigest.java:298)
        at org.elasticsearch.tdigest.MergingDigest.mergeNewValues(MergingDigest.java:288)
        at org.elasticsearch.tdigest.MergingDigest.quantile(MergingDigest.java:485)
        at org.elasticsearch.tdigest.HybridDigest.quantile(HybridDigest.java:141)
        at org.elasticsearch.search.aggregations.metrics.TDigestState.quantile(TDigestState.java:247)
        at org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviation.computeMedianAbsoluteDeviation(InternalMedianAbsoluteDeviation.java:38)
        at org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviation.<init>(InternalMedianAbsoluteDeviation.java:48)
        at org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviationTests.createTestInstance(InternalMedianAbsoluteDeviationTests.java:33)
        at org.elasticsearch.search.aggregations.metrics.InternalMedianAbsoluteDeviationTests.createTestInstance(InternalMedianAbsoluteDeviationTests.java:23)
```

They should have been removed earlier, it's possible for the first and the last centroid to have weight > 1.

Related to #95903