### PR TITLE
Add openjdk21 ea to java ci test matrix

### DIFF
--- a/.ci/matrix-runtime-javas.yml
+++ b/.ci/matrix-runtime-javas.yml
@@ -11,3 +11,4 @@ ES_RUNTIME_JAVA:
   - openjdk18
   - openjdk19
   - openjdk20
+  - openjdk21


### PR DESCRIPTION
We want to test openjdk 21 ea early in our ci infrastructure