### PR TITLE
Specialize TerminateAfterCollector to not rely on MultiCollector

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/query/QueryPhase.java
@@ -208,11 +208,11 @@ public class QueryPhase {
             if (searchContext.terminateAfter() != SearchContext.DEFAULT_TERMINATE_AFTER) {
                 // add terminate_after before the filter collectors
                 // it will only be applied on documents accepted by these filter collectors
-                TerminateAfterCollector terminateAfterCollector = new TerminateAfterCollector(searchContext.terminateAfter());
                 final Collector collector = collectorManager.newCollector();
+                TerminateAfterCollector terminateAfterCollector = new TerminateAfterCollector(collector, searchContext.terminateAfter());
                 collectorManager = wrapWithProfilerCollectorManagerIfNeeded(
                     searchContext.getProfilers(),
-                    new SingleThreadCollectorManager(MultiCollector.wrap(terminateAfterCollector, collector)),
+                    new SingleThreadCollectorManager(terminateAfterCollector),
                     REASON_SEARCH_TERMINATE_AFTER_COUNT,
                     collector
                 );


### PR DESCRIPTION
`TerminateAfterCollector` requires using `MultiCollector` so far, to guarantee that early termination does not prevent the execution from being terminated when the threshold is reached.

`MultiCollector` achieves that, but is very generic in that it can wrap an arbitrary number of collectors, and has sub-optimal logic to detect the score mode from the wrapped collectors. We can instead have a specialized collector that handles `CollectionTerminatedException` and overrides `setMinCompetitiveScore` so that total hits tracking and terminate_after
play well together. Behavior remains the same as using `MultiCollector` but the logic is all included in `TerminateAfterCollector`, easier to follow and specialized for its purpose.