### PR TITLE
Use indices admin client shortcut in most integration tests

### DIFF
--- a/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
+++ b/modules/aggregations/src/internalClusterTest/java/org/elasticsearch/aggregations/bucket/TimeSeriesAggregationsIT.java
@@ -524,7 +524,7 @@ public class TimeSeriesAggregationsIT extends AggregationIntegTestCase {
         response = client().prepareSearch("test").setQuery(queryBuilder).setSize(10).addAggregation(timeSeries("by_ts")).get();
         assertSearchResponse(response);
 
-        assertAcked(client().admin().indices().delete(new DeleteIndexRequest("test")).actionGet());
+        assertAcked(indicesAdmin().delete(new DeleteIndexRequest("test")).actionGet());
     }
 
     public static TimeSeriesAggregationBuilder timeSeries(String name) {

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/QueryStringWithAnalyzersIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/QueryStringWithAnalyzersIT.java
@@ -32,9 +32,7 @@ public class QueryStringWithAnalyzersIT extends ESIntegTestCase {
      */
     public void testCustomWordDelimiterQueryString() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(
                     Settings.builder()
                         .put("analysis.analyzer.my_analyzer.type", "custom")

--- a/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
+++ b/modules/analysis-common/src/internalClusterTest/java/org/elasticsearch/analysis/common/ReloadSynonymAnalyzerIT.java
@@ -62,9 +62,7 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
             out.println("foo, baz");
         }
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(
                     indexSettings(cluster().numDataNodes() * 2, 1).put("analysis.analyzer.my_synonym_analyzer.tokenizer", "standard")
                         .put("analysis.analyzer.my_synonym_analyzer.filter", "my_synonym_filter")
@@ -76,13 +74,13 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
         );
 
         client().prepareIndex("test").setId("1").setSource("field", "foo").get();
-        assertNoFailures(client().admin().indices().prepareRefresh("test").execute().actionGet());
+        assertNoFailures(indicesAdmin().prepareRefresh("test").execute().actionGet());
 
         SearchResponse response = client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "baz")).get();
         assertHitCount(response, 1L);
         response = client().prepareSearch("test").setQuery(QueryBuilders.matchQuery("field", "buzz")).get();
         assertHitCount(response, 0L);
-        Response analyzeResponse = client().admin().indices().prepareAnalyze("test", "foo").setAnalyzer("my_synonym_analyzer").get();
+        Response analyzeResponse = indicesAdmin().prepareAnalyze("test", "foo").setAnalyzer("my_synonym_analyzer").get();
         assertEquals(2, analyzeResponse.getTokens().size());
         assertEquals("foo", analyzeResponse.getTokens().get(0).getTerm());
         assertEquals("baz", analyzeResponse.getTokens().get(1).getTerm());
@@ -108,7 +106,7 @@ public class ReloadSynonymAnalyzerIT extends ESIntegTestCase {
                 reloadResponse.getReloadDetails().get("test").getReloadedAnalyzers()
             );
 
-            analyzeResponse = client().admin().indices().prepareAnalyze("test", "foo").setAnalyzer("my_synonym_analyzer").get();
+            analyzeResponse = indicesAdmin().prepareAnalyze("test", "foo").setAnalyzer("my_synonym_analyzer").get();
             assertEquals(3, analyzeResponse.getTokens().size());
             Set<String> tokens = new HashSet<>();
             analyzeResponse.getTokens().stream().map(AnalyzeToken::getTerm).forEach(t -> tokens.add(t));

--- a/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MassiveWordListTests.java
+++ b/modules/analysis-common/src/test/java/org/elasticsearch/analysis/common/MassiveWordListTests.java
@@ -27,9 +27,7 @@ public class MassiveWordListTests extends ESSingleNodeTestCase {
         for (int i = 0; i < wordList.length; i++) {
             wordList[i] = "hello world";
         }
-        client().admin()
-            .indices()
-            .prepareCreate("test")
+        indicesAdmin().prepareCreate("test")
             .setSettings(
                 Settings.builder()
                     .put("index.number_of_shards", 1)

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamIT.java
@@ -176,7 +176,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
         String backingIndex = barDataStream.getIndices().get(0).getName();
         backingIndices.add(backingIndex);
-        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
+        GetIndexResponse getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         Map<?, ?> mappings = getIndexResponse.getMappings().get(backingIndex).getSourceAsMap();
@@ -184,7 +184,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
         backingIndex = fooDataStream.getIndices().get(0).getName();
         backingIndices.add(backingIndex);
-        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
+        getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         mappings = getIndexResponse.getMappings().get(backingIndex).getSourceAsMap();
@@ -198,17 +198,17 @@ public class DataStreamIT extends ESIntegTestCase {
         verifyDocs("metrics-bar", numDocsBar, 1, 1);
         verifyDocs("metrics-foo", numDocsFoo, 1, 1);
 
-        RolloverResponse fooRolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("metrics-foo", null)).get();
+        RolloverResponse fooRolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("metrics-foo", null)).get();
         assertThat(fooRolloverResponse.getNewIndex(), backingIndexEqualTo("metrics-foo", 2));
         assertTrue(fooRolloverResponse.isRolledOver());
 
-        RolloverResponse barRolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("metrics-bar", null)).get();
+        RolloverResponse barRolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("metrics-bar", null)).get();
         assertThat(barRolloverResponse.getNewIndex(), backingIndexEqualTo("metrics-bar", 2));
         assertTrue(barRolloverResponse.isRolledOver());
 
         backingIndex = fooRolloverResponse.getNewIndex();
         backingIndices.add(backingIndex);
-        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
+        getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         mappings = getIndexResponse.getMappings().get(backingIndex).getSourceAsMap();
@@ -216,7 +216,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
         backingIndex = barRolloverResponse.getNewIndex();
         backingIndices.add(backingIndex);
-        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
+        getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         mappings = getIndexResponse.getMappings().get(backingIndex).getSourceAsMap();
@@ -239,7 +239,7 @@ public class DataStreamIT extends ESIntegTestCase {
             expectThrows(
                 IndexNotFoundException.class,
                 "Backing index '" + index + "' should have been deleted.",
-                () -> client().admin().indices().getIndex(new GetIndexRequest().indices(index)).actionGet()
+                () -> indicesAdmin().getIndex(new GetIndexRequest().indices(index)).actionGet()
             );
         }
     }
@@ -467,7 +467,7 @@ public class DataStreamIT extends ESIntegTestCase {
         String backingIndex = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().get(0).getName();
         assertThat(backingIndex, backingIndexEqualTo(dataStreamName, 1));
 
-        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(dataStreamName)).actionGet();
+        GetIndexResponse getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(dataStreamName)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         assertThat(
@@ -475,12 +475,12 @@ public class DataStreamIT extends ESIntegTestCase {
             equalTo("keyword")
         );
 
-        RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).get();
+        RolloverResponse rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).get();
         backingIndex = rolloverResponse.getNewIndex();
         assertThat(backingIndex, backingIndexEqualTo(dataStreamName, 2));
         assertTrue(rolloverResponse.isRolledOver());
 
-        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
+        getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         assertThat(
@@ -506,7 +506,7 @@ public class DataStreamIT extends ESIntegTestCase {
             expectThrows(
                 IndexNotFoundException.class,
                 "Backing index '" + index.getName() + "' should have been deleted.",
-                () -> client().admin().indices().getIndex(new GetIndexRequest().indices(index.getName())).actionGet()
+                () -> indicesAdmin().getIndex(new GetIndexRequest().indices(index.getName())).actionGet()
             );
         }
     }
@@ -553,7 +553,7 @@ public class DataStreamIT extends ESIntegTestCase {
         IndicesAliasesRequest aliasesRequest = new IndicesAliasesRequest();
         String aliasToDataStream = "logs";
         aliasesRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).alias(aliasToDataStream).index("logs-foobar"));
-        assertAcked(client().admin().indices().aliases(aliasesRequest).actionGet());
+        assertAcked(indicesAdmin().aliases(aliasesRequest).actionGet());
 
         verifyResolvability(
             dataStreamName,
@@ -562,43 +562,40 @@ public class DataStreamIT extends ESIntegTestCase {
                 .setOpType(DocWriteRequest.OpType.CREATE),
             false
         );
-        verifyResolvability(dataStreamName, client().admin().indices().prepareRefresh(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareRefresh(dataStreamName), false);
         verifyResolvability(dataStreamName, client().prepareSearch(dataStreamName), false, 1);
         verifyResolvability(
             dataStreamName,
             client().prepareMultiSearch().add(client().prepareSearch(dataStreamName).setQuery(matchAllQuery())),
             false
         );
-        verifyResolvability(dataStreamName, client().admin().indices().prepareClearCache(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareFlush(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareSegments(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareStats(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareForceMerge(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareValidateQuery(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareRecoveries(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetAliases("dummy").addIndices(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetFieldMappings(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().preparePutMapping(dataStreamName).setSource("""
+        verifyResolvability(dataStreamName, indicesAdmin().prepareClearCache(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareFlush(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareSegments(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareStats(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareForceMerge(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareValidateQuery(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareRecoveries(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareGetAliases("dummy").addIndices(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareGetFieldMappings(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().preparePutMapping(dataStreamName).setSource("""
             {"_doc":{"properties": {"my_field":{"type":"keyword"}}}}""", XContentType.JSON), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetMappings(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareGetMappings(dataStreamName), false);
         verifyResolvability(
             dataStreamName,
-            client().admin()
-                .indices()
-                .prepareUpdateSettings(dataStreamName)
-                .setSettings(Settings.builder().put("index.number_of_replicas", 0)),
+            indicesAdmin().prepareUpdateSettings(dataStreamName).setSettings(Settings.builder().put("index.number_of_replicas", 0)),
             false
         );
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetSettings(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareGetSettings(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().cluster().prepareHealth(dataStreamName), false);
         verifyResolvability(dataStreamName, client().admin().cluster().prepareState().setIndices(dataStreamName), false);
         verifyResolvability(dataStreamName, client().prepareFieldCaps(dataStreamName).setFields("*"), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareGetIndex().addIndices(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareOpen(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareClose(dataStreamName), true);
-        verifyResolvability(aliasToDataStream, client().admin().indices().prepareClose(aliasToDataStream), true);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareGetIndex().addIndices(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareOpen(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareClose(dataStreamName), true);
+        verifyResolvability(aliasToDataStream, indicesAdmin().prepareClose(aliasToDataStream), true);
         verifyResolvability(dataStreamName, client().admin().cluster().prepareSearchShards(dataStreamName), false);
-        verifyResolvability(dataStreamName, client().admin().indices().prepareShardStores(dataStreamName), false);
+        verifyResolvability(dataStreamName, indicesAdmin().prepareShardStores(dataStreamName), false);
 
         request = new CreateDataStreamAction.Request("logs-barbaz");
         client().execute(CreateDataStreamAction.INSTANCE, request).actionGet();
@@ -611,42 +608,39 @@ public class DataStreamIT extends ESIntegTestCase {
         );
 
         String wildcardExpression = "logs*";
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareRefresh(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareRefresh(wildcardExpression), false);
         verifyResolvability(wildcardExpression, client().prepareSearch(wildcardExpression), false, 2);
         verifyResolvability(
             wildcardExpression,
             client().prepareMultiSearch().add(client().prepareSearch(wildcardExpression).setQuery(matchAllQuery())),
             false
         );
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareClearCache(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareFlush(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareSegments(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareStats(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareForceMerge(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareValidateQuery(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareRecoveries(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareGetAliases(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareGetFieldMappings(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().preparePutMapping(wildcardExpression).setSource("""
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareClearCache(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareFlush(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareSegments(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareStats(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareForceMerge(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareValidateQuery(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareRecoveries(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareGetAliases(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareGetFieldMappings(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().preparePutMapping(wildcardExpression).setSource("""
             {"_doc":{"properties": {"my_field":{"type":"keyword"}}}}""", XContentType.JSON), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareGetMappings(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareGetSettings(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareGetMappings(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareGetSettings(wildcardExpression), false);
         verifyResolvability(
             wildcardExpression,
-            client().admin()
-                .indices()
-                .prepareUpdateSettings(wildcardExpression)
-                .setSettings(Settings.builder().put("index.number_of_replicas", 0)),
+            indicesAdmin().prepareUpdateSettings(wildcardExpression).setSettings(Settings.builder().put("index.number_of_replicas", 0)),
             false
         );
         verifyResolvability(wildcardExpression, client().admin().cluster().prepareHealth(wildcardExpression), false);
         verifyResolvability(wildcardExpression, client().admin().cluster().prepareState().setIndices(wildcardExpression), false);
         verifyResolvability(wildcardExpression, client().prepareFieldCaps(wildcardExpression).setFields("*"), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareGetIndex().addIndices(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareOpen(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareClose(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareGetIndex().addIndices(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareOpen(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareClose(wildcardExpression), false);
         verifyResolvability(wildcardExpression, client().admin().cluster().prepareSearchShards(wildcardExpression), false);
-        verifyResolvability(wildcardExpression, client().admin().indices().prepareShardStores(wildcardExpression), false);
+        verifyResolvability(wildcardExpression, indicesAdmin().prepareShardStores(wildcardExpression), false);
     }
 
     public void testCannotDeleteComposableTemplateUsedByDataStream() throws Exception {
@@ -715,8 +709,8 @@ public class DataStreamIT extends ESIntegTestCase {
         AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index(dataStreamName).aliases("foo");
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(
             response.getDataStreamAliases(),
             equalTo(Map.of("metrics-foo", List.of(new DataStreamAlias("foo", List.of("metrics-foo"), null, null))))
@@ -743,8 +737,8 @@ public class DataStreamIT extends ESIntegTestCase {
             .filter(Map.of("term", Map.of("type", Map.of("value", "y"))));
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(
             response.getDataStreamAliases(),
             equalTo(
@@ -775,8 +769,8 @@ public class DataStreamIT extends ESIntegTestCase {
             .filter(Map.of("term", Map.of("type", Map.of("value", "x"))));
         aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+        response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(
             response.getDataStreamAliases(),
             equalTo(
@@ -825,8 +819,8 @@ public class DataStreamIT extends ESIntegTestCase {
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addFilteredAliasAction);
         aliasesAddRequest.addAliasAction(addUnfilteredAliasAction);
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(response.getDataStreamAliases(), hasKey("logs-foobar"));
         assertThat(
             response.getDataStreamAliases().get("logs-foobar"),
@@ -863,12 +857,12 @@ public class DataStreamIT extends ESIntegTestCase {
         }
         Map<String, Object> indexFilters = Map.of("term", Map.of("type", Map.of("value", "y")));
         AliasActions addAction = new AliasActions(AliasActions.Type.ADD).aliases(alias).indices(dataStreams).filter(indexFilters);
-        assertAcked(client().admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(addAction)).actionGet());
+        assertAcked(indicesAdmin().aliases(new IndicesAliasesRequest().addAliasAction(addAction)).actionGet());
 
         addAction = new AliasActions(AliasActions.Type.ADD).aliases(alias).indices(dataStreams[0]).filter(indexFilters).writeIndex(true);
-        assertAcked(client().admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(addAction)).actionGet());
+        assertAcked(indicesAdmin().aliases(new IndicesAliasesRequest().addAliasAction(addAction)).actionGet());
 
-        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(response.getDataStreamAliases().size(), equalTo(dataStreams.length));
         List<DataStreamAlias> result = response.getDataStreamAliases()
             .values()
@@ -910,10 +904,10 @@ public class DataStreamIT extends ESIntegTestCase {
         }
         Exception e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin().indices().aliases(new IndicesAliasesRequest().addAliasAction(addAction)).actionGet()
+            () -> indicesAdmin().aliases(new IndicesAliasesRequest().addAliasAction(addAction)).actionGet()
         );
         assertThat(e.getMessage(), equalTo("failed to parse filter for alias [" + alias + "]"));
-        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(response.getDataStreamAliases(), anEmptyMap());
     }
 
@@ -927,7 +921,7 @@ public class DataStreamIT extends ESIntegTestCase {
         AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index(backingIndex).aliases("first_gen");
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        Exception e = expectThrows(IllegalArgumentException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
         assertThat(
             e.getMessage(),
             equalTo(
@@ -951,7 +945,7 @@ public class DataStreamIT extends ESIntegTestCase {
         AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index("metrics-*").aliases("my-alias");
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(addAction);
-        Exception e = expectThrows(IllegalArgumentException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        Exception e = expectThrows(IllegalArgumentException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
         assertThat(e.getMessage(), equalTo("expressions [metrics-*] that match with both data streams and regular indices are disallowed"));
     }
 
@@ -965,8 +959,8 @@ public class DataStreamIT extends ESIntegTestCase {
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("metrics-foo").aliases("my-alias1"));
         aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("metrics-myindex").aliases("my-alias2"));
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+        GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(
             response.getDataStreamAliases(),
             equalTo(Map.of("metrics-foo", List.of(new DataStreamAlias("my-alias1", List.of("metrics-foo"), null, null))))
@@ -980,8 +974,8 @@ public class DataStreamIT extends ESIntegTestCase {
         } else {
             aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.REMOVE).index("_all").aliases("my-*"));
         }
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-        response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+        response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
         assertThat(response.getDataStreamAliases(), anEmptyMap());
         assertThat(response.getAliases().get("metrics-myindex").size(), equalTo(0));
         assertThat(response.getAliases().size(), equalTo(1));
@@ -997,8 +991,8 @@ public class DataStreamIT extends ESIntegTestCase {
             aliasesAddRequest.addAliasAction(
                 new AliasActions(AliasActions.Type.ADD).index("metrics-foo").aliases("my-alias1", "my-alias2")
             );
-            assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-            GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+            assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+            GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
             assertThat(response.getDataStreamAliases().keySet(), containsInAnyOrder("metrics-foo"));
             assertThat(
                 response.getDataStreamAliases().get("metrics-foo"),
@@ -1013,7 +1007,7 @@ public class DataStreamIT extends ESIntegTestCase {
         {
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("metrics-foo").aliases("my-alias*"));
-            expectThrows(InvalidAliasNameException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
+            expectThrows(InvalidAliasNameException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
         }
         // REMOVE does resolve wildcards:
         {
@@ -1023,8 +1017,8 @@ public class DataStreamIT extends ESIntegTestCase {
             } else {
                 aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.REMOVE).index("_all").aliases("_all"));
             }
-            assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
-            GetAliasesResponse response = client().admin().indices().getAliases(new GetAliasesRequest()).actionGet();
+            assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
+            GetAliasesResponse response = indicesAdmin().getAliases(new GetAliasesRequest()).actionGet();
             assertThat(response.getDataStreamAliases(), anEmptyMap());
             assertThat(response.getAliases().size(), equalTo(0));
         }
@@ -1039,10 +1033,7 @@ public class DataStreamIT extends ESIntegTestCase {
             AliasActions addAction = new AliasActions(AliasActions.Type.ADD).index("metrics-*").aliases("my-alias").routing("[routing]");
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(addAction);
-            Exception e = expectThrows(
-                IllegalArgumentException.class,
-                () -> client().admin().indices().aliases(aliasesAddRequest).actionGet()
-            );
+            Exception e = expectThrows(IllegalArgumentException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
             assertThat(e.getMessage(), equalTo("aliases that point to data streams don't support routing"));
         }
         {
@@ -1051,10 +1042,7 @@ public class DataStreamIT extends ESIntegTestCase {
                 .indexRouting("[index_routing]");
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(addAction);
-            Exception e = expectThrows(
-                IllegalArgumentException.class,
-                () -> client().admin().indices().aliases(aliasesAddRequest).actionGet()
-            );
+            Exception e = expectThrows(IllegalArgumentException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
             assertThat(e.getMessage(), equalTo("aliases that point to data streams don't support index_routing"));
         }
         {
@@ -1063,10 +1051,7 @@ public class DataStreamIT extends ESIntegTestCase {
                 .searchRouting("[search_routing]");
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(addAction);
-            Exception e = expectThrows(
-                IllegalArgumentException.class,
-                () -> client().admin().indices().aliases(aliasesAddRequest).actionGet()
-            );
+            Exception e = expectThrows(IllegalArgumentException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
             assertThat(e.getMessage(), equalTo("aliases that point to data streams don't support search_routing"));
         }
         {
@@ -1075,10 +1060,7 @@ public class DataStreamIT extends ESIntegTestCase {
                 .isHidden(randomBoolean());
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(addAction);
-            Exception e = expectThrows(
-                IllegalArgumentException.class,
-                () -> client().admin().indices().aliases(aliasesAddRequest).actionGet()
-            );
+            Exception e = expectThrows(IllegalArgumentException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
             assertThat(e.getMessage(), equalTo("aliases that point to data streams don't support is_hidden"));
         }
     }
@@ -1127,7 +1109,7 @@ public class DataStreamIT extends ESIntegTestCase {
         String backingIndex1 = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().get(0).getName();
         assertThat(backingIndex1, backingIndexEqualTo("logs-foobar", 1));
 
-        RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("logs-foobar", null)).get();
+        RolloverResponse rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("logs-foobar", null)).get();
         String backingIndex2 = rolloverResponse.getNewIndex();
         assertThat(backingIndex2, backingIndexEqualTo("logs-foobar", 2));
         assertTrue(rolloverResponse.isRolledOver());
@@ -1138,7 +1120,7 @@ public class DataStreamIT extends ESIntegTestCase {
             DataStreamTimestampFieldMapper.NAME,
             Map.of("enabled", true)
         );
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("logs-foobar").get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("logs-foobar").get();
         assertThat(getMappingsResponse.getMappings().size(), equalTo(2));
         assertThat(getMappingsResponse.getMappings().get(backingIndex1).getSourceAsMap(), equalTo(expectedMapping));
         assertThat(getMappingsResponse.getMappings().get(backingIndex2).getSourceAsMap(), equalTo(expectedMapping));
@@ -1149,13 +1131,11 @@ public class DataStreamIT extends ESIntegTestCase {
             DataStreamTimestampFieldMapper.NAME,
             Map.of("enabled", true)
         );
-        client().admin()
-            .indices()
-            .preparePutMapping("logs-foobar")
+        indicesAdmin().preparePutMapping("logs-foobar")
             .setSource("{\"properties\":{\"my_field\":{\"type\":\"keyword\"}}}", XContentType.JSON)
             .get();
         // The mappings of all backing indices should be updated:
-        getMappingsResponse = client().admin().indices().prepareGetMappings("logs-foobar").get();
+        getMappingsResponse = indicesAdmin().prepareGetMappings("logs-foobar").get();
         assertThat(getMappingsResponse.getMappings().size(), equalTo(2));
         assertThat(getMappingsResponse.getMappings().get(backingIndex1).getSourceAsMap(), equalTo(expectedMapping));
         assertThat(getMappingsResponse.getMappings().get(backingIndex2).getSourceAsMap(), equalTo(expectedMapping));
@@ -1175,19 +1155,19 @@ public class DataStreamIT extends ESIntegTestCase {
         String backingIndex1 = getDataStreamResponse.getDataStreams().get(0).getDataStream().getIndices().get(0).getName();
         assertThat(backingIndex1, backingIndexEqualTo("logs-foobar", 1));
 
-        RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("logs-foobar", null)).get();
+        RolloverResponse rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("logs-foobar", null)).get();
         String backingIndex2 = rolloverResponse.getNewIndex();
         assertThat(backingIndex2, backingIndexEqualTo("logs-foobar", 2));
         assertTrue(rolloverResponse.isRolledOver());
 
         // The index settings of all backing indices should be updated:
-        GetSettingsResponse getSettingsResponse = client().admin().indices().prepareGetSettings("logs-foobar").get();
+        GetSettingsResponse getSettingsResponse = indicesAdmin().prepareGetSettings("logs-foobar").get();
         assertThat(getSettingsResponse.getIndexToSettings().size(), equalTo(2));
         assertThat(getSettingsResponse.getSetting(backingIndex1, "index.number_of_replicas"), equalTo("1"));
         assertThat(getSettingsResponse.getSetting(backingIndex2, "index.number_of_replicas"), equalTo("1"));
 
         setReplicaCount(0, "logs-foobar");
-        getSettingsResponse = client().admin().indices().prepareGetSettings("logs-foobar").get();
+        getSettingsResponse = indicesAdmin().prepareGetSettings("logs-foobar").get();
         assertThat(getSettingsResponse.getIndexToSettings().size(), equalTo(2));
         assertThat(getSettingsResponse.getSetting(backingIndex1, "index.number_of_replicas"), equalTo("0"));
         assertThat(getSettingsResponse.getSetting(backingIndex2, "index.number_of_replicas"), equalTo("0"));
@@ -1319,7 +1299,7 @@ public class DataStreamIT extends ESIntegTestCase {
         int numDocsFoo = randomIntBetween(2, 16);
         indexDocs("metrics-foo", numDocsFoo);
 
-        RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("metrics-foo", null)).get();
+        RolloverResponse rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("metrics-foo", null)).get();
         assertThat(rolloverResponse.getNewIndex(), backingIndexEqualTo("metrics-foo", 2));
 
         // ingest some more data in the rolled data stream
@@ -1352,7 +1332,7 @@ public class DataStreamIT extends ESIntegTestCase {
     }
 
     private static void assertBackingIndex(String backingIndex, String timestampFieldPathInMapping, Map<?, ?> expectedMapping) {
-        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
+        GetIndexResponse getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndex)).actionGet();
         assertThat(getIndexResponse.getSettings().get(backingIndex), notNullValue());
         assertThat(getIndexResponse.getSettings().get(backingIndex).getAsBoolean("index.hidden", null), is(true));
         Map<?, ?> mappings = getIndexResponse.getMappings().get(backingIndex).getSourceAsMap();
@@ -1434,7 +1414,7 @@ public class DataStreamIT extends ESIntegTestCase {
         assertThat(getDataStreamsResponse.getDataStreams().get(2).getDataStream().getName(), equalTo("logs-foobaz2"));
         assertThat(getDataStreamsResponse.getDataStreams().get(3).getDataStream().getName(), equalTo("logs-foobaz3"));
 
-        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices("logs-bar*")).actionGet();
+        GetIndexResponse getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices("logs-bar*")).actionGet();
         assertThat(getIndexResponse.getIndices(), arrayWithSize(4));
         assertThat(getIndexResponse.getIndices(), hasItemInArray("logs-barbaz"));
         assertThat(getIndexResponse.getIndices(), hasItemInArray("logs-barfoo"));
@@ -1454,7 +1434,7 @@ public class DataStreamIT extends ESIntegTestCase {
         v1Request.patterns(List.of("logs-foo*"));
         v1Request.settings(settings);
         v1Request.order(Integer.MAX_VALUE); // in order to avoid number_of_replicas being overwritten by random_template
-        client().admin().indices().putTemplate(v1Request).actionGet();
+        indicesAdmin().putTemplate(v1Request).actionGet();
 
         BulkRequest bulkRequest = new BulkRequest();
         bulkRequest.add(new IndexRequest("logs-foobar").opType(CREATE).source("{}", XContentType.JSON));
@@ -1466,7 +1446,7 @@ public class DataStreamIT extends ESIntegTestCase {
             .actionGet();
         assertThat(getDataStreamsResponse.getDataStreams(), hasSize(0));
 
-        GetIndexResponse getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices("logs-foobar")).actionGet();
+        GetIndexResponse getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices("logs-foobar")).actionGet();
         assertThat(getIndexResponse.getIndices(), arrayWithSize(1));
         assertThat(getIndexResponse.getIndices(), hasItemInArray("logs-foobar"));
         assertThat(getIndexResponse.getSettings().get("logs-foobar").get(IndexMetadata.SETTING_NUMBER_OF_REPLICAS), equalTo("0"));
@@ -1554,9 +1534,7 @@ public class DataStreamIT extends ESIntegTestCase {
                 logger.info("--> [{}] waiting for all the other threads before starting", i);
                 barrier.await();
                 while (running.get()) {
-                    RolloverResponse resp = client().admin()
-                        .indices()
-                        .prepareRolloverIndex(dsName)
+                    RolloverResponse resp = indicesAdmin().prepareRolloverIndex(dsName)
                         .setConditions(RolloverConditions.newBuilder().addMaxIndexDocsCondition(2L))
                         .get();
                     if (resp.isRolledOver()) {
@@ -1587,7 +1565,7 @@ public class DataStreamIT extends ESIntegTestCase {
                     .actionGet();
                 String newBackingIndexName = getDataStreamResponse.getDataStreams().get(0).getDataStream().getWriteIndex().getName();
                 assertThat(newBackingIndexName, backingIndexEqualTo("potato-biscuit", 2));
-                client().admin().indices().prepareGetIndex().addIndices(newBackingIndexName).get();
+                indicesAdmin().prepareGetIndex().addIndices(newBackingIndexName).get();
             } catch (Exception e) {
                 logger.info("--> expecting second index to be created but it has not yet been created");
                 fail("expecting second index to exist");
@@ -1650,7 +1628,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
     public void testCreateDataStreamWithSameNameAsIndexAlias() throws Exception {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest("my-index").alias(new Alias("my-alias"));
-        assertAcked(client().admin().indices().create(createIndexRequest).actionGet());
+        assertAcked(indicesAdmin().create(createIndexRequest).actionGet());
 
         // Important detail: create template with data stream template after the index has been created
         DataStreamIT.putComposableIndexTemplate("my-template", List.of("my-*"));
@@ -1663,7 +1641,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
     public void testCreateDataStreamWithSameNameAsIndex() throws Exception {
         CreateIndexRequest createIndexRequest = new CreateIndexRequest("my-index").alias(new Alias("my-alias"));
-        assertAcked(client().admin().indices().create(createIndexRequest).actionGet());
+        assertAcked(indicesAdmin().create(createIndexRequest).actionGet());
 
         // Important detail: create template with data stream template after the index has been created
         DataStreamIT.putComposableIndexTemplate("my-template", List.of("my-*"));
@@ -1680,7 +1658,7 @@ public class DataStreamIT extends ESIntegTestCase {
             assertAcked(client().execute(CreateDataStreamAction.INSTANCE, request).actionGet());
             var aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("my-ds").aliases("my-alias"));
-            assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+            assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
 
             var request2 = new CreateDataStreamAction.Request("my-alias");
             var e = expectThrows(
@@ -1716,13 +1694,13 @@ public class DataStreamIT extends ESIntegTestCase {
         {
             DataStreamIT.putComposableIndexTemplate("my-template", List.of("logs-*"));
             CreateIndexRequest createIndexRequest = new CreateIndexRequest("es-logs").alias(new Alias("logs"));
-            assertAcked(client().admin().indices().create(createIndexRequest).actionGet());
+            assertAcked(indicesAdmin().create(createIndexRequest).actionGet());
 
             var request = new CreateDataStreamAction.Request("logs-es");
             assertAcked(client().execute(CreateDataStreamAction.INSTANCE, request).actionGet());
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("logs-es").aliases("logs"));
-            var e = expectThrows(IllegalStateException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
+            var e = expectThrows(IllegalStateException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
             assertThat(e.getMessage(), containsString("data stream alias and indices alias have the same name (logs)"));
         }
         {
@@ -1747,14 +1725,14 @@ public class DataStreamIT extends ESIntegTestCase {
         DataStreamIT.putComposableIndexTemplate("my-template", List.of("logs-*"));
 
         CreateIndexRequest createIndexRequest = new CreateIndexRequest("logs");
-        assertAcked(client().admin().indices().create(createIndexRequest).actionGet());
+        assertAcked(indicesAdmin().create(createIndexRequest).actionGet());
 
         {
             var request = new CreateDataStreamAction.Request("logs-es");
             assertAcked(client().execute(CreateDataStreamAction.INSTANCE, request).actionGet());
             IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
             aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("logs-es").aliases("logs"));
-            var e = expectThrows(InvalidAliasNameException.class, () -> client().admin().indices().aliases(aliasesAddRequest).actionGet());
+            var e = expectThrows(InvalidAliasNameException.class, () -> indicesAdmin().aliases(aliasesAddRequest).actionGet());
             assertThat(
                 e.getMessage(),
                 equalTo("Invalid alias name [logs]: an index or data stream exists with the same name as the alias")
@@ -1788,10 +1766,10 @@ public class DataStreamIT extends ESIntegTestCase {
         assertAcked(client().execute(CreateDataStreamAction.INSTANCE, request).actionGet());
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("logs-es").aliases("logs"));
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
 
         CreateIndexRequest createIndexRequest = new CreateIndexRequest("logs");
-        var e = expectThrows(InvalidIndexNameException.class, () -> client().admin().indices().create(createIndexRequest).actionGet());
+        var e = expectThrows(InvalidIndexNameException.class, () -> indicesAdmin().create(createIndexRequest).actionGet());
         assertThat(e.getMessage(), equalTo("Invalid index name [logs], already exists as alias"));
     }
 
@@ -1802,19 +1780,19 @@ public class DataStreamIT extends ESIntegTestCase {
         assertAcked(client().execute(CreateDataStreamAction.INSTANCE, request).actionGet());
         IndicesAliasesRequest aliasesAddRequest = new IndicesAliasesRequest();
         aliasesAddRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("logs-es").aliases("logs"));
-        assertAcked(client().admin().indices().aliases(aliasesAddRequest).actionGet());
+        assertAcked(indicesAdmin().aliases(aliasesAddRequest).actionGet());
 
         {
             CreateIndexRequest createIndexRequest = new CreateIndexRequest("my-index").alias(new Alias("logs"));
-            var e = expectThrows(IllegalStateException.class, () -> client().admin().indices().create(createIndexRequest).actionGet());
+            var e = expectThrows(IllegalStateException.class, () -> indicesAdmin().create(createIndexRequest).actionGet());
             assertThat(e.getMessage(), containsString("data stream alias and indices alias have the same name (logs)"));
         }
         {
             CreateIndexRequest createIndexRequest = new CreateIndexRequest("my-index");
-            assertAcked(client().admin().indices().create(createIndexRequest).actionGet());
+            assertAcked(indicesAdmin().create(createIndexRequest).actionGet());
             IndicesAliasesRequest addAliasRequest = new IndicesAliasesRequest();
             addAliasRequest.addAliasAction(new AliasActions(AliasActions.Type.ADD).index("my-index").aliases("logs"));
-            var e = expectThrows(IllegalStateException.class, () -> client().admin().indices().aliases(addAliasRequest).actionGet());
+            var e = expectThrows(IllegalStateException.class, () -> indicesAdmin().aliases(addAliasRequest).actionGet());
             assertThat(e.getMessage(), containsString("data stream alias and indices alias have the same name (logs)"));
         }
     }
@@ -1824,8 +1802,8 @@ public class DataStreamIT extends ESIntegTestCase {
         DataStreamIT.putComposableIndexTemplate("my-template", List.of("logs-*"));
         var request = new CreateDataStreamAction.Request(dataStreamName);
         assertAcked(client().execute(CreateDataStreamAction.INSTANCE, request).actionGet());
-        assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
-        var indicesStatsResponse = client().admin().indices().stats(new IndicesStatsRequest()).actionGet();
+        assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
+        var indicesStatsResponse = indicesAdmin().stats(new IndicesStatsRequest()).actionGet();
         assertThat(indicesStatsResponse.getIndices().size(), equalTo(2));
         ClusterState before = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
         assertThat(before.getMetadata().dataStreams().get(dataStreamName).getIndices(), hasSize(2));
@@ -1870,7 +1848,7 @@ public class DataStreamIT extends ESIntegTestCase {
         var ghostReference = brokenDataStreamHolder.get().getIndices().get(0);
 
         // Many APIs fail with NPE, because of broken data stream:
-        expectThrows(NullPointerException.class, () -> client().admin().indices().stats(new IndicesStatsRequest()).actionGet());
+        expectThrows(NullPointerException.class, () -> indicesAdmin().stats(new IndicesStatsRequest()).actionGet());
         expectThrows(NullPointerException.class, () -> client().search(new SearchRequest()).actionGet());
 
         assertAcked(
@@ -1884,7 +1862,7 @@ public class DataStreamIT extends ESIntegTestCase {
         // Data stream resolves now to one backing index.
         // Note, that old backing index still exists and has been unhidden.
         // The modify data stream api only fixed the data stream by removing a broken reference to a backing index.
-        indicesStatsResponse = client().admin().indices().stats(new IndicesStatsRequest()).actionGet();
+        indicesStatsResponse = indicesAdmin().stats(new IndicesStatsRequest()).actionGet();
         assertThat(indicesStatsResponse.getIndices().size(), equalTo(2));
     }
 
@@ -1942,7 +1920,7 @@ public class DataStreamIT extends ESIntegTestCase {
             assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
             assertThat(itemResponse.getIndex(), startsWith(backingIndexPrefix));
         }
-        client().admin().indices().refresh(new RefreshRequest(dataStream)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
     }
 
     static void verifyDocs(String dataStream, long expectedNumHits, List<String> expectedIndices) {
@@ -2099,7 +2077,7 @@ public class DataStreamIT extends ESIntegTestCase {
 
         indexDocsAndEnsureThereIsCapturedWriteLoad(dataStreamName);
 
-        assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
+        assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
         final ClusterState clusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
         final DataStream dataStream = clusterState.getMetadata().dataStreams().get(dataStreamName);
 
@@ -2176,7 +2154,7 @@ public class DataStreamIT extends ESIntegTestCase {
             currentDataStreamWriteIndexRoutingTable.shard(1).replicaShards().get(0)
         );
 
-        assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
+        assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
         final ClusterState clusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
         final DataStream dataStream = clusterState.getMetadata().dataStreams().get(dataStreamName);
 
@@ -2238,7 +2216,7 @@ public class DataStreamIT extends ESIntegTestCase {
             (handler, request, channel, task) -> channel.sendResponse(new RuntimeException("Unable to get stats"))
         );
 
-        assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
+        assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
 
         final ClusterState clusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
         final DataStream dataStream = clusterState.getMetadata().dataStreams().get(dataStreamName);
@@ -2264,11 +2242,11 @@ public class DataStreamIT extends ESIntegTestCase {
 
             // Ensure that we get a stable size to compare against the expected size
             assertThat(
-                client().admin().indices().prepareForceMerge().setFlush(true).setMaxNumSegments(1).get().getSuccessfulShards(),
+                indicesAdmin().prepareForceMerge().setFlush(true).setMaxNumSegments(1).get().getSuccessfulShards(),
                 is(greaterThanOrEqualTo(numberOfShards))
             );
 
-            assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
+            assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
         }
 
         final ClusterState clusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
@@ -2280,11 +2258,9 @@ public class DataStreamIT extends ESIntegTestCase {
             .map(Index::getName)
             .toList();
 
-        final IndicesStatsResponse indicesStatsResponse = client().admin()
-            .indices()
-            .prepareStats(dataStreamReadIndices.toArray(new String[dataStreamReadIndices.size()]))
-            .setStore(true)
-            .get();
+        final IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats(
+            dataStreamReadIndices.toArray(new String[dataStreamReadIndices.size()])
+        ).setStore(true).get();
         long expectedTotalSizeInBytes = 0;
         int shardCount = 0;
         for (ShardStats shard : indicesStatsResponse.getShards()) {
@@ -2310,7 +2286,7 @@ public class DataStreamIT extends ESIntegTestCase {
             final ClusterState clusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
             final DataStream dataStream = clusterState.getMetadata().dataStreams().get(dataStreamName);
             final String writeIndex = dataStream.getWriteIndex().getName();
-            final IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(writeIndex).get();
+            final IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats(writeIndex).get();
             for (IndexShardStats indexShardStats : indicesStatsResponse.getIndex(writeIndex).getIndexShards().values()) {
                 for (ShardStats shard : indexShardStats.getShards()) {
                     final IndexingStats.Stats shardIndexingStats = shard.getStats().getIndexing().getTotal();

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamMigrationIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamMigrationIT.java
@@ -47,8 +47,8 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
     public void testBasicMigration() throws Exception {
         putComposableIndexTemplate("id1", List.of("migrate*"));
 
-        admin().indices().create(new CreateIndexRequest("index1")).get();
-        admin().indices().create(new CreateIndexRequest("index2")).get();
+        indicesAdmin().create(new CreateIndexRequest("index1")).get();
+        indicesAdmin().create(new CreateIndexRequest("index2")).get();
 
         int numDocs1 = randomIntBetween(2, 16);
         indexDocs("index1", numDocs1);
@@ -59,13 +59,13 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index1").alias(alias).writeIndex(true));
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index2").alias(alias).writeIndex(false));
-        assertAcked(admin().indices().aliases(request).get());
+        assertAcked(indicesAdmin().aliases(request).get());
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
             IndicesOptions.fromOptions(true, true, true, true, true)
         );
-        ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
+        ResolveIndexAction.Response resolveResponse = indicesAdmin().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
         assertThat(resolveResponse.getAliases().get(0).getName(), equalTo(alias));
         assertThat(resolveResponse.getDataStreams().size(), equalTo(0));
@@ -73,7 +73,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
 
         client().execute(MigrateToDataStreamAction.INSTANCE, new MigrateToDataStreamAction.Request(alias)).get();
 
-        resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
+        resolveResponse = indicesAdmin().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(0));
         assertThat(resolveResponse.getDataStreams().size(), equalTo(1));
         assertThat(resolveResponse.getDataStreams().get(0).getName(), equalTo(alias));
@@ -86,8 +86,8 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
     }
 
     public void testMigrationWithoutTemplate() throws Exception {
-        admin().indices().create(new CreateIndexRequest("index1")).get();
-        admin().indices().create(new CreateIndexRequest("index2")).get();
+        indicesAdmin().create(new CreateIndexRequest("index1")).get();
+        indicesAdmin().create(new CreateIndexRequest("index2")).get();
 
         int numDocs1 = randomIntBetween(2, 16);
         indexDocs("index1", numDocs1);
@@ -98,13 +98,13 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index1").alias(alias).writeIndex(true));
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index2").alias(alias).writeIndex(false));
-        assertAcked(admin().indices().aliases(request).get());
+        assertAcked(indicesAdmin().aliases(request).get());
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
             IndicesOptions.fromOptions(true, true, true, true, true)
         );
-        ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
+        ResolveIndexAction.Response resolveResponse = indicesAdmin().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
         assertThat(resolveResponse.getAliases().get(0).getName(), equalTo(alias));
         assertThat(resolveResponse.getDataStreams().size(), equalTo(0));
@@ -123,20 +123,20 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
     public void testMigrationWithoutIndexMappings() throws Exception {
         putComposableIndexTemplate("id1", List.of("migrate*"));
 
-        admin().indices().create(new CreateIndexRequest("index1")).get();
-        admin().indices().create(new CreateIndexRequest("index2")).get();
+        indicesAdmin().create(new CreateIndexRequest("index1")).get();
+        indicesAdmin().create(new CreateIndexRequest("index2")).get();
 
         String alias = "migrate-to-data-stream";
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index1").alias(alias).writeIndex(true));
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index2").alias(alias).writeIndex(false));
-        assertAcked(admin().indices().aliases(request).get());
+        assertAcked(indicesAdmin().aliases(request).get());
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
             IndicesOptions.fromOptions(true, true, true, true, true)
         );
-        ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
+        ResolveIndexAction.Response resolveResponse = indicesAdmin().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
         assertThat(resolveResponse.getAliases().get(0).getName(), equalTo(alias));
         assertThat(resolveResponse.getDataStreams().size(), equalTo(0));
@@ -153,8 +153,8 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
     public void testMigrationWithoutTimestampMapping() throws Exception {
         putComposableIndexTemplate("id1", List.of("migrate*"));
 
-        admin().indices().create(new CreateIndexRequest("index1")).get();
-        admin().indices().create(new CreateIndexRequest("index2")).get();
+        indicesAdmin().create(new CreateIndexRequest("index1")).get();
+        indicesAdmin().create(new CreateIndexRequest("index2")).get();
 
         int numDocs1 = randomIntBetween(2, 16);
         indexDocs("index1", numDocs1, "foo");
@@ -165,13 +165,13 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index1").alias(alias).writeIndex(true));
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index2").alias(alias).writeIndex(false));
-        assertAcked(admin().indices().aliases(request).get());
+        assertAcked(indicesAdmin().aliases(request).get());
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
             IndicesOptions.fromOptions(true, true, true, true, true)
         );
-        ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
+        ResolveIndexAction.Response resolveResponse = indicesAdmin().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
         assertThat(resolveResponse.getAliases().get(0).getName(), equalTo(alias));
         assertThat(resolveResponse.getDataStreams().size(), equalTo(0));
@@ -188,8 +188,8 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
     public void testMigrationWithoutWriteIndex() throws Exception {
         putComposableIndexTemplate("id1", List.of("migrate*"));
 
-        admin().indices().create(new CreateIndexRequest("index1")).get();
-        admin().indices().create(new CreateIndexRequest("index2")).get();
+        indicesAdmin().create(new CreateIndexRequest("index1")).get();
+        indicesAdmin().create(new CreateIndexRequest("index2")).get();
 
         int numDocs1 = randomIntBetween(2, 16);
         indexDocs("index1", numDocs1);
@@ -200,13 +200,13 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
         IndicesAliasesRequest request = new IndicesAliasesRequest();
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index1").alias(alias).writeIndex(false));
         request.addAliasAction(IndicesAliasesRequest.AliasActions.add().index("index2").alias(alias).writeIndex(false));
-        assertAcked(admin().indices().aliases(request).get());
+        assertAcked(indicesAdmin().aliases(request).get());
 
         ResolveIndexAction.Request resolveRequest = new ResolveIndexAction.Request(
             new String[] { "*" },
             IndicesOptions.fromOptions(true, true, true, true, true)
         );
-        ResolveIndexAction.Response resolveResponse = admin().indices().resolveIndex(resolveRequest).get();
+        ResolveIndexAction.Response resolveResponse = indicesAdmin().resolveIndex(resolveRequest).get();
         assertThat(resolveResponse.getAliases().size(), equalTo(1));
         assertThat(resolveResponse.getAliases().get(0).getName(), equalTo(alias));
         assertThat(resolveResponse.getDataStreams().size(), equalTo(0));
@@ -249,7 +249,7 @@ public class DataStreamMigrationIT extends ESIntegTestCase {
             assertThat(itemResponse.getFailureMessage(), nullValue());
             assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
         }
-        client().admin().indices().refresh(new RefreshRequest(index)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(index)).actionGet();
     }
 
 }

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataStreamsSnapshotsIT.java
@@ -953,7 +953,7 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
             .execute();
         waitForBlockOnAnyDataNode(repoName);
         awaitNumberOfSnapshotsInProgress(1);
-        final ActionFuture<RolloverResponse> rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("ds", null));
+        final ActionFuture<RolloverResponse> rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("ds", null));
 
         if (partial) {
             assertTrue(rolloverResponse.get().isRolledOver());
@@ -995,11 +995,11 @@ public class DataStreamsSnapshotsIT extends AbstractSnapshotIntegTestCase {
             .execute();
         waitForBlockOnAnyDataNode(repoName);
         awaitNumberOfSnapshotsInProgress(1);
-        final RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest("ds", null)).get();
+        final RolloverResponse rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest("ds", null)).get();
         assertTrue(rolloverResponse.isRolledOver());
 
         logger.info("--> deleting former write index");
-        assertAcked(client().admin().indices().prepareDelete(rolloverResponse.getOldIndex()));
+        assertAcked(indicesAdmin().prepareDelete(rolloverResponse.getOldIndex()));
 
         unblockAllDataNodes(repoName);
         final SnapshotInfo snapshotInfo = assertSuccessful(snapshotFuture);

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataTierDataStreamIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/DataTierDataStreamIT.java
@@ -55,19 +55,19 @@ public class DataTierDataStreamIT extends ESIntegTestCase {
             .setWaitForActiveShards(0)
             .get()
             .getIndex();
-        var idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(dsIndexName);
+        var idxSettings = indicesAdmin().prepareGetIndex().addIndices(index).get().getSettings().get(dsIndexName);
         assertThat(DataTier.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
 
         logger.info("--> waiting for {} to be yellow", index);
         ensureYellow(index);
 
         // Roll over index and ensure the second index also went to the "hot" tier
-        var rolledOverIndexName = client().admin().indices().prepareRolloverIndex(index).get().getNewIndex();
+        var rolledOverIndexName = indicesAdmin().prepareRolloverIndex(index).get().getNewIndex();
 
         // new index name should have the rolled over name
         assertNotEquals(dsIndexName, rolledOverIndexName);
 
-        idxSettings = client().admin().indices().prepareGetIndex().addIndices(index).get().getSettings().get(rolledOverIndexName);
+        idxSettings = indicesAdmin().prepareGetIndex().addIndices(index).get().getSettings().get(rolledOverIndexName);
         assertThat(DataTier.TIER_PREFERENCE_SETTING.get(idxSettings), equalTo(DataTier.DATA_HOT));
     }
 

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamSnapshotIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/SystemDataStreamSnapshotIT.java
@@ -96,7 +96,7 @@ public class SystemDataStreamSnapshotIT extends AbstractSnapshotIntegTestCase {
         }
 
         {
-            GetIndexResponse indicesRemaining = client().admin().indices().prepareGetIndex().addIndices("_all").get();
+            GetIndexResponse indicesRemaining = indicesAdmin().prepareGetIndex().addIndices("_all").get();
             assertThat(indicesRemaining.indices(), arrayWithSize(0));
             assertSystemDataStreamDoesNotExist();
         }
@@ -216,10 +216,10 @@ public class SystemDataStreamSnapshotIT extends AbstractSnapshotIntegTestCase {
             assertTrue(response.isAcknowledged());
         }
 
-        assertAcked(client().admin().indices().prepareDelete("my-index"));
+        assertAcked(indicesAdmin().prepareDelete("my-index"));
 
         {
-            GetIndexResponse indicesRemaining = client().admin().indices().prepareGetIndex().addIndices("_all").get();
+            GetIndexResponse indicesRemaining = indicesAdmin().prepareGetIndex().addIndices("_all").get();
             assertThat(indicesRemaining.indices(), arrayWithSize(0));
         }
 

--- a/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
+++ b/modules/data-streams/src/internalClusterTest/java/org/elasticsearch/datastreams/TSDBIndexingIT.java
@@ -142,7 +142,7 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
         }
 
         // fetch end time
-        var getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(backingIndexName)).actionGet();
+        var getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(backingIndexName)).actionGet();
         Instant endTime = IndexSettings.TIME_SERIES_END_TIME.get(getIndexResponse.getSettings().get(backingIndexName));
 
         // index another doc and verify index
@@ -177,11 +177,11 @@ public class TSDBIndexingIT extends ESSingleNodeTestCase {
 
         // rollover
         var rolloverRequest = new RolloverRequest("k8s", null);
-        var rolloverResponse = client().admin().indices().rolloverIndex(rolloverRequest).actionGet();
+        var rolloverResponse = indicesAdmin().rolloverIndex(rolloverRequest).actionGet();
         var newBackingIndexName = rolloverResponse.getNewIndex();
 
         // index and check target index is new
-        getIndexResponse = client().admin().indices().getIndex(new GetIndexRequest().indices(newBackingIndexName)).actionGet();
+        getIndexResponse = indicesAdmin().getIndex(new GetIndexRequest().indices(newBackingIndexName)).actionGet();
         Instant newStartTime = IndexSettings.TIME_SERIES_START_TIME.get(getIndexResponse.getSettings().get(newBackingIndexName));
         Instant newEndTime = IndexSettings.TIME_SERIES_END_TIME.get(getIndexResponse.getSettings().get(newBackingIndexName));
 

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamsStatsTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/DataStreamsStatsTests.java
@@ -127,10 +127,8 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
     public void testStatsClosedBackingIndexDataStream() throws Exception {
         String dataStreamName = createDataStream();
         createDocument(dataStreamName);
-        assertTrue(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).get().isAcknowledged());
-        assertTrue(
-            client().admin().indices().close(new CloseIndexRequest(".ds-" + dataStreamName + "-*-000001")).actionGet().isAcknowledged()
-        );
+        assertTrue(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).get().isAcknowledged());
+        assertTrue(indicesAdmin().close(new CloseIndexRequest(".ds-" + dataStreamName + "-*-000001")).actionGet().isAcknowledged());
 
         assertBusy(() -> {
             assertNotEquals(ClusterHealthStatus.RED, client().admin().cluster().health(new ClusterHealthRequest()).actionGet().getStatus());
@@ -169,7 +167,7 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
     public void testStatsRolledDataStream() throws Exception {
         String dataStreamName = createDataStream();
         long timestamp = createDocument(dataStreamName);
-        assertTrue(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).get().isAcknowledged());
+        assertTrue(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).get().isAcknowledged());
         timestamp = max(timestamp, createDocument(dataStreamName));
 
         DataStreamsStatsAction.Response stats = getDataStreamsStats();
@@ -264,9 +262,7 @@ public class DataStreamsStatsTests extends ESSingleNodeTestCase {
                         .endObject()
                 )
         ).get();
-        client().admin()
-            .indices()
-            .refresh(new RefreshRequest(".ds-" + dataStreamName + "*").indicesOptions(IndicesOptions.lenientExpandOpenHidden()))
+        indicesAdmin().refresh(new RefreshRequest(".ds-" + dataStreamName + "*").indicesOptions(IndicesOptions.lenientExpandOpenHidden()))
             .get();
         return timestamp;
     }

--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/LookAHeadTimeTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/LookAHeadTimeTests.java
@@ -116,7 +116,7 @@ public class LookAHeadTimeTests extends ESSingleNodeTestCase {
         } catch (ResourceAlreadyExistsException e) {
             // ignore
         }
-        client().admin().indices().updateSettings(new UpdateSettingsRequest(settings)).actionGet();
+        indicesAdmin().updateSettings(new UpdateSettingsRequest(settings)).actionGet();
     }
 
 }

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/DataLifecycleServiceIT.java
@@ -305,7 +305,7 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
             for (int i = 0; i < randomIntBetween(10, 50); i++) {
                 indexDocs(dataStreamName, randomIntBetween(1, 300));
                 // Make sure the segments get written:
-                FlushResponse flushResponse = client().admin().indices().flush(new FlushRequest(toBeRolledOverIndex)).actionGet();
+                FlushResponse flushResponse = indicesAdmin().flush(new FlushRequest(toBeRolledOverIndex)).actionGet();
                 assertThat(flushResponse.getStatus(), equalTo(RestStatus.OK));
             }
 
@@ -562,7 +562,7 @@ public class DataLifecycleServiceIT extends ESIntegTestCase {
             assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
             assertThat(itemResponse.getIndex(), startsWith(backingIndexPrefix));
         }
-        client().admin().indices().refresh(new RefreshRequest(dataStream)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
     }
 
     static void putComposableIndexTemplate(

--- a/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/ExplainDataLifecycleIT.java
+++ b/modules/dlm/src/internalClusterTest/java/org/elasticsearch/dlm/ExplainDataLifecycleIT.java
@@ -290,7 +290,7 @@ public class ExplainDataLifecycleIT extends ESIntegTestCase {
             assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
             assertThat(itemResponse.getIndex(), startsWith(backingIndexPrefix));
         }
-        client().admin().indices().refresh(new RefreshRequest(dataStream)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
     }
 
     static void putComposableIndexTemplate(

--- a/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
+++ b/modules/ingest-geoip/src/internalClusterTest/java/org/elasticsearch/ingest/geoip/GeoIpDownloaderIT.java
@@ -305,21 +305,21 @@ public class GeoIpDownloaderIT extends AbstractGeoIpIT {
 
         // Creating an index which does not reference the pipeline should not trigger the database download.
         String indexIdentifier = randomIdentifier();
-        assertAcked(client().admin().indices().prepareCreate(indexIdentifier).get());
+        assertAcked(indicesAdmin().prepareCreate(indexIdentifier).get());
         assertNull(getTask().getState());
 
         // Set the pipeline as default_pipeline or final_pipeline for the index.
         // This should trigger the database download.
         Setting<String> pipelineSetting = randomFrom(IndexSettings.FINAL_PIPELINE, IndexSettings.DEFAULT_PIPELINE);
         Settings indexSettings = Settings.builder().put(pipelineSetting.getKey(), pipelineId).build();
-        assertAcked(client().admin().indices().prepareUpdateSettings(indexIdentifier).setSettings(indexSettings).get());
+        assertAcked(indicesAdmin().prepareUpdateSettings(indexIdentifier).setSettings(indexSettings).get());
         assertBusy(() -> {
             GeoIpTaskState state = getGeoIpTaskState();
             assertEquals(Set.of("GeoLite2-ASN.mmdb", "GeoLite2-City.mmdb", "GeoLite2-Country.mmdb"), state.getDatabases().keySet());
         }, 2, TimeUnit.MINUTES);
 
         // Remove the created index.
-        assertAcked(client().admin().indices().prepareDelete(indexIdentifier).get());
+        assertAcked(indicesAdmin().prepareDelete(indexIdentifier).get());
     }
 
     @TestLogging(value = "org.elasticsearch.ingest.geoip:TRACE", reason = "https://github.com/elastic/elasticsearch/issues/69972")

--- a/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
+++ b/modules/lang-expression/src/internalClusterTest/java/org/elasticsearch/script/expression/MoreExpressionIT.java
@@ -504,7 +504,7 @@ public class MoreExpressionIT extends ESIntegTestCase {
 
     public void testStringSpecialValueVariable() throws Exception {
         // i.e. expression script for term aggregations, which is not allowed
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("text", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("text", "type=keyword").get());
         ensureGreen("test");
         indexRandom(
             true,

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/SearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/SearchTemplateIT.java
@@ -57,7 +57,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         createIndex("test");
         client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("text", "value1").endObject()).get();
         client().prepareIndex("test").setId("2").setSource(jsonBuilder().startObject().field("text", "value2").endObject()).get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
     }
 
     // Relates to #6318
@@ -172,7 +172,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         bulkRequestBuilder.add(client().prepareIndex("test").setId("4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
         bulkRequestBuilder.add(client().prepareIndex("test").setId("5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
         bulkRequestBuilder.get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("fieldParam", "foo");
@@ -218,7 +218,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         bulkRequestBuilder.add(client().prepareIndex("test").setId("4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
         bulkRequestBuilder.add(client().prepareIndex("test").setId("5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
         bulkRequestBuilder.get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         Map<String, Object> templateParams = new HashMap<>();
         templateParams.put("fieldParam", "foo");
@@ -254,7 +254,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         ensureGreen("testindex");
 
         client().prepareIndex("testindex").setId("1").setSource(jsonBuilder().startObject().field("searchtext", "dev1").endObject()).get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         int iterations = randomIntBetween(2, 11);
         String query = """
@@ -343,7 +343,7 @@ public class SearchTemplateIT extends ESSingleNodeTestCase {
         bulkRequestBuilder.add(client().prepareIndex("test").setId("4").setSource("{\"theField\":\"foo 4\"}", XContentType.JSON));
         bulkRequestBuilder.add(client().prepareIndex("test").setId("5").setSource("{\"theField\":\"bar\"}", XContentType.JSON));
         bulkRequestBuilder.get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         Map<String, Object> arrayTemplateParams = new HashMap<>();
         String[] fieldParams = { "foo", "bar" };

--- a/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
+++ b/modules/legacy-geo/src/test/java/org/elasticsearch/legacygeo/search/LegacyGeoShapeQueryTests.java
@@ -57,7 +57,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
             .endObject()
             .endObject()
             .endObject();
-        client().admin().indices().prepareCreate(indexName).setMapping(xcb).setSettings(settings).get();
+        indicesAdmin().prepareCreate(indexName).setMapping(xcb).setSettings(settings).get();
     }
 
     @Override
@@ -81,7 +81,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
                 .endObject()
         );
 
-        client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("geo_points_only").setMapping(mapping).get();
         ensureGreen();
 
         // MULTIPOINT
@@ -122,7 +122,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
                 .endObject()
         );
 
-        client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("geo_points_only").setMapping(mapping).get();
         ensureGreen();
 
         Geometry geometry = GeometryTestUtils.randomGeometry(false);
@@ -162,7 +162,7 @@ public class LegacyGeoShapeQueryTests extends GeoShapeQueryTestCase {
                 .endObject()
         );
 
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         MultiPoint multiPoint = GeometryTestUtils.randomMultiPoint(false);

--- a/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/BWCTemplateTests.java
+++ b/modules/mapper-extras/src/test/java/org/elasticsearch/index/mapper/extras/BWCTemplateTests.java
@@ -30,9 +30,9 @@ public class BWCTemplateTests extends ESSingleNodeTestCase {
         byte[] metricBeat = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/extras/metricbeat-6.0.template.json");
         byte[] packetBeat = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/extras/packetbeat-6.0.template.json");
         byte[] fileBeat = copyToBytesFromClasspath("/org/elasticsearch/index/mapper/extras/filebeat-6.0.template.json");
-        client().admin().indices().preparePutTemplate("metricbeat").setSource(metricBeat, XContentType.JSON).get();
-        client().admin().indices().preparePutTemplate("packetbeat").setSource(packetBeat, XContentType.JSON).get();
-        client().admin().indices().preparePutTemplate("filebeat").setSource(fileBeat, XContentType.JSON).get();
+        indicesAdmin().preparePutTemplate("metricbeat").setSource(metricBeat, XContentType.JSON).get();
+        indicesAdmin().preparePutTemplate("packetbeat").setSource(packetBeat, XContentType.JSON).get();
+        indicesAdmin().preparePutTemplate("filebeat").setSource(fileBeat, XContentType.JSON).get();
 
         client().prepareIndex("metricbeat-foo").setId("1").setSource("message", "foo").get();
         client().prepareIndex("packetbeat-foo").setId("1").setSource("message", "foo").get();

--- a/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
+++ b/modules/parent-join/src/internalClusterTest/java/org/elasticsearch/join/query/ChildQuerySearchIT.java
@@ -312,17 +312,17 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
         // index simple data with flushes, so we have many segments
         createIndexRequest("test", "parent", "p1", null, "p_field", "p_value1").get();
-        client().admin().indices().prepareFlush().get();
+        indicesAdmin().prepareFlush().get();
         createIndexRequest("test", "child", "c1", "p1", "c_field", "red").get();
-        client().admin().indices().prepareFlush().get();
+        indicesAdmin().prepareFlush().get();
         createIndexRequest("test", "child", "c2", "p1", "c_field", "yellow").get();
-        client().admin().indices().prepareFlush().get();
+        indicesAdmin().prepareFlush().get();
         createIndexRequest("test", "parent", "p2", null, "p_field", "p_value2").get();
-        client().admin().indices().prepareFlush().get();
+        indicesAdmin().prepareFlush().get();
         createIndexRequest("test", "child", "c3", "p2", "c_field", "blue").get();
-        client().admin().indices().prepareFlush().get();
+        indicesAdmin().prepareFlush().get();
         createIndexRequest("test", "child", "c4", "p2", "c_field", "red").get();
-        client().admin().indices().prepareFlush().get();
+        indicesAdmin().prepareFlush().get();
         refresh();
 
         // HAS CHILD QUERY
@@ -446,7 +446,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         // update p1 and see what that we get updated values...
 
         createIndexRequest("test", "parent", "p1", null, "p_field", "p_value1_updated").get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         searchResponse = client().prepareSearch("test")
             .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "yellow"), ScoreMode.None)))
@@ -748,7 +748,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
         createIndexRequest("test", "parent", "1", null, "p_field", 1).get();
         createIndexRequest("test", "child", "2", "1", "c_field", 1).get();
-        client().admin().indices().prepareFlush("test").get();
+        indicesAdmin().prepareFlush("test").get();
 
         client().prepareIndex("test").setId("3").setSource("p_field", 2).get();
 
@@ -800,7 +800,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
 
         // query filter in case for p/c shouldn't execute per segment, but rather
         createIndexRequest("test", "parent", "1", null, "p_field", 1).get();
-        client().admin().indices().prepareFlush("test").setForce(true).get();
+        indicesAdmin().prepareFlush("test").setForce(true).get();
         createIndexRequest("test", "child", "2", "1", "c_field", 1).get();
         refresh();
 
@@ -924,7 +924,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
             createIndexRequest("test", "child", "d" + i, "p1", "c_field", "red").get();
             createIndexRequest("test", "parent", "p2", null, "p_field", "p_value2").get();
             createIndexRequest("test", "child", "c3", "p2", "c_field", "x").get();
-            client().admin().indices().prepareRefresh("test").get();
+            indicesAdmin().prepareRefresh("test").get();
         }
 
         searchResponse = client().prepareSearch("test")
@@ -1038,8 +1038,8 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("test", "parent", "p9", null, "p_field", "p_value9").get();
         createIndexRequest("test", "parent", "p10", null, "p_field", "p_value10").get();
         createIndexRequest("test", "child", "c1", "p1", "c_field", "blue").get();
-        client().admin().indices().prepareFlush("test").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareFlush("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch("test")
             .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "blue"), ScoreMode.None)))
@@ -1048,7 +1048,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
 
         createIndexRequest("test", "child", "c2", "p2", "c_field", "blue").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         searchResponse = client().prepareSearch("test")
             .setQuery(constantScoreQuery(hasChildQuery("child", termQuery("c_field", "blue"), ScoreMode.None)))
@@ -1312,14 +1312,14 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         createIndexRequest("test", "child", "c1", "p1", "c_field", "blue").get();
         createIndexRequest("test", "child", "c2", "p1", "c_field", "red").get();
         createIndexRequest("test", "child", "c3", "p2", "c_field", "red").get();
-        client().admin().indices().prepareForceMerge("test").setMaxNumSegments(1).setFlush(true).get();
+        indicesAdmin().prepareForceMerge("test").setMaxNumSegments(1).setFlush(true).get();
         createIndexRequest("test", "parent", "p3", null, "p_field", "p_value3").get();
         createIndexRequest("test", "parent", "p4", null, "p_field", "p_value4").get();
         createIndexRequest("test", "child", "c4", "p3", "c_field", "green").get();
         createIndexRequest("test", "child", "c5", "p3", "c_field", "blue").get();
         createIndexRequest("test", "child", "c6", "p4", "c_field", "blue").get();
-        client().admin().indices().prepareFlush("test").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareFlush("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         for (int i = 0; i < 2; i++) {
             SearchResponse searchResponse = client().prepareSearch()
@@ -1334,7 +1334,7 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         }
 
         createIndexRequest("test", "child", "c3", "p2", "c_field", "blue").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(
@@ -1781,9 +1781,9 @@ public class ChildQuerySearchIT extends ParentChildTestCase {
         refresh();
 
         assertAcked(
-            admin().indices().prepareAliases().addAlias("my-index", "filter1", hasChildQuery("child", matchAllQuery(), ScoreMode.None))
+            indicesAdmin().prepareAliases().addAlias("my-index", "filter1", hasChildQuery("child", matchAllQuery(), ScoreMode.None))
         );
-        assertAcked(admin().indices().prepareAliases().addAlias("my-index", "filter2", hasParentQuery("parent", matchAllQuery(), false)));
+        assertAcked(indicesAdmin().prepareAliases().addAlias("my-index", "filter2", hasParentQuery("parent", matchAllQuery(), false)));
 
         SearchResponse response = client().prepareSearch("filter1").get();
         assertHitCount(response, 1);

--- a/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
+++ b/modules/percolator/src/internalClusterTest/java/org/elasticsearch/percolator/PercolatorQuerySearchIT.java
@@ -68,9 +68,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testPercolatorQuery() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
         );
 
@@ -91,7 +89,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         BytesReference source = BytesReference.bytes(jsonBuilder().startObject().endObject());
         logger.info("percolating empty doc");
@@ -150,9 +148,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testPercolatorRangeQueries() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(
                     "field1",
                     "type=long",
@@ -183,7 +179,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
         client().prepareIndex("test")
             .setId("4")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field2").from(10).to(12)).endObject())
@@ -200,7 +196,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
         client().prepareIndex("test")
             .setId("7")
             .setSource(jsonBuilder().startObject().field("query", rangeQuery("field3").from("192.168.1.0").to("192.168.1.5")).endObject())
@@ -233,7 +229,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         // Test long range:
         BytesReference source = BytesReference.bytes(jsonBuilder().startObject().field("field1", 12).endObject());
@@ -281,10 +277,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testPercolatorGeoQueries() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setMapping("id", "type=keyword", "field1", "type=geo_point", "query", "type=percolator")
+            indicesAdmin().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=geo_point", "query", "type=percolator")
         );
 
         client().prepareIndex("test")
@@ -339,9 +332,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testPercolatorQueryExistingDocument() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("id", "type=keyword", "field1", "type=keyword", "field2", "type=keyword", "query", "type=percolator")
         );
 
@@ -366,7 +357,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("4").setSource("{\"id\": \"4\"}", XContentType.JSON).get();
         client().prepareIndex("test").setId("5").setSource(XContentType.JSON, "id", "5", "field1", "value").get();
         client().prepareIndex("test").setId("6").setSource(XContentType.JSON, "id", "6", "field1", "value", "field2", "value").get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         logger.info("percolating empty doc");
         SearchResponse response = client().prepareSearch()
@@ -397,16 +388,14 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testPercolatorQueryExistingDocumentSourceDisabled() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("_source", "enabled=false", "field1", "type=keyword", "query", "type=percolator")
         );
 
         client().prepareIndex("test").setId("1").setSource(jsonBuilder().startObject().field("query", matchAllQuery()).endObject()).get();
 
         client().prepareIndex("test").setId("2").setSource("{}", XContentType.JSON).get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         logger.info("percolating empty doc with source disabled");
         IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> {
@@ -417,9 +406,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testPercolatorSpecificQueries() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text", "query", "type=percolator")
         );
 
@@ -446,7 +433,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         client().prepareIndex("test")
             .setId("3")
@@ -488,7 +475,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         BytesReference source = BytesReference.bytes(
             jsonBuilder().startObject()
@@ -517,9 +504,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             fieldMapping.append(",index_options=offsets");
         }
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("id", "type=keyword", "field1", fieldMapping.toString(), "query", "type=percolator")
         );
         client().prepareIndex("test")
@@ -547,7 +532,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             .setSource(jsonBuilder().startObject().field("id", "5").field("query", termQuery("field1", "fox")).endObject())
             .execute()
             .actionGet();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         BytesReference document = BytesReference.bytes(
             jsonBuilder().startObject().field("field1", "The quick brown fox jumps over the lazy dog").endObject()
@@ -762,10 +747,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testTakePositionOffsetGapIntoAccount() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setMapping("field", "type=text,position_increment_gap=5", "query", "type=percolator")
+            indicesAdmin().prepareCreate("test").setMapping("field", "type=text,position_increment_gap=5", "query", "type=percolator")
         );
         client().prepareIndex("test")
             .setId("1")
@@ -775,7 +757,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             .setId("2")
             .setSource(jsonBuilder().startObject().field("query", new MatchPhraseQueryBuilder("field", "brown fox").slop(5)).endObject())
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch()
             .setQuery(new PercolateQueryBuilder("query", new BytesArray("{\"field\" : [\"brown\", \"fox\"]}"), XContentType.JSON))
@@ -786,19 +768,13 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testManyPercolatorFields() throws Exception {
         String queryFieldName = randomAlphaOfLength(8);
+        assertAcked(indicesAdmin().prepareCreate("test1").setMapping(queryFieldName, "type=percolator", "field", "type=keyword"));
         assertAcked(
-            client().admin().indices().prepareCreate("test1").setMapping(queryFieldName, "type=percolator", "field", "type=keyword")
-        );
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test2")
+            indicesAdmin().prepareCreate("test2")
                 .setMapping(queryFieldName, "type=percolator", "second_query_field", "type=percolator", "field", "type=keyword")
         );
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test3")
+            indicesAdmin().prepareCreate("test3")
                 .setMapping(
                     jsonBuilder().startObject()
                         .startObject("_doc")
@@ -823,13 +799,9 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testWithMultiplePercolatorFields() throws Exception {
         String queryFieldName = randomAlphaOfLength(8);
+        assertAcked(indicesAdmin().prepareCreate("test1").setMapping(queryFieldName, "type=percolator", "field", "type=keyword"));
         assertAcked(
-            client().admin().indices().prepareCreate("test1").setMapping(queryFieldName, "type=percolator", "field", "type=keyword")
-        );
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test2")
+            indicesAdmin().prepareCreate("test2")
                 .setMapping(
                     jsonBuilder().startObject()
                         .startObject("_doc")
@@ -866,7 +838,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         BytesReference source = BytesReference.bytes(jsonBuilder().startObject().field("field", "value").endObject());
         SearchResponse response = client().prepareSearch()
@@ -930,7 +902,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping(mapping));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(mapping));
         client().prepareIndex("test")
             .setId("q1")
             .setSource(
@@ -957,13 +929,13 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         client().prepareIndex("test")
             .setId("q3")
             .setSource(jsonBuilder().startObject().field("id", "q3").field("query", QueryBuilders.matchAllQuery()).endObject())
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch()
             .setQuery(
@@ -1089,7 +1061,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
     }
 
     public void testPercolatorQueryViaMultiSearch() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "query", "type=percolator"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "query", "type=percolator"));
 
         client().prepareIndex("test")
             .setId("1")
@@ -1120,7 +1092,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             .setSource(jsonBuilder().startObject().field("field1", "c").endObject())
             .execute()
             .actionGet();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         MultiSearchResponse response = client().prepareMultiSearch()
             .add(
@@ -1204,10 +1176,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
     public void testDisallowExpensiveQueries() throws IOException {
         try {
             assertAcked(
-                client().admin()
-                    .indices()
-                    .prepareCreate("test")
-                    .setMapping("id", "type=keyword", "field1", "type=keyword", "query", "type=percolator")
+                indicesAdmin().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=keyword", "query", "type=percolator")
             );
 
             client().prepareIndex("test")
@@ -1251,7 +1220,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
 
     public void testWrappedWithConstantScore() throws Exception {
 
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("d", "type=date", "q", "type=percolator"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("d", "type=date", "q", "type=percolator"));
 
         client().prepareIndex("test")
             .setId("1")
@@ -1265,7 +1234,7 @@ public class PercolatorQuerySearchIT extends ESIntegTestCase {
             .execute()
             .actionGet();
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch("test")
             .setQuery(

--- a/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
+++ b/modules/percolator/src/test/java/org/elasticsearch/percolator/PercolatorQuerySearchTests.java
@@ -73,7 +73,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
     }
 
     public void testPercolateScriptQuery() throws IOException {
-        client().admin().indices().prepareCreate("index").setMapping("query", "type=percolator").get();
+        indicesAdmin().prepareCreate("index").setMapping("query", "type=percolator").get();
         client().prepareIndex("index")
             .setId("1")
             .setSource(
@@ -122,9 +122,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
             .endObject();
         createIndex(
             "test",
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 // to avoid normal document from being cached by BitsetFilterCache
                 .setSettings(Settings.builder().put(BitsetFilterCache.INDEX_LOAD_RANDOM_ACCESS_FILTERS_EAGERLY_SETTING.getKey(), false))
                 .setMapping(mapping)
@@ -144,7 +142,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         for (int i = 0; i < 32; i++) {
             SearchResponse response = client().prepareSearch()
@@ -215,7 +213,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
             mapping.endObject();
         }
         mapping.endObject();
-        createIndex("test", client().admin().indices().prepareCreate("test").setMapping(mapping));
+        createIndex("test", indicesAdmin().prepareCreate("test").setMapping(mapping));
         Script script = new Script(ScriptType.INLINE, MockScriptPlugin.NAME, "use_fielddata_please", Collections.emptyMap());
         client().prepareIndex("test")
             .setId("q1")
@@ -225,7 +223,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
         XContentBuilder doc = jsonBuilder();
         doc.startObject();
         {
@@ -263,7 +261,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
             .setId("1")
             .setSource(jsonBuilder().startObject().field("query", matchQuery("field1", "value")).endObject())
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch("test")
             .setQuery(
@@ -316,7 +314,7 @@ public class PercolatorQuerySearchTests extends ESSingleNodeTestCase {
                     .endObject()
             )
             .get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         try (Engine.Searcher searcher = indexService.getShard(0).acquireSearcher("test")) {
             long[] currentTime = new long[] { System.currentTimeMillis() };

--- a/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
+++ b/modules/rank-eval/src/internalClusterTest/java/org/elasticsearch/index/rankeval/RankEvalRequestIT.java
@@ -64,7 +64,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         refresh();
 
         // set up an alias that can also be used in tests
-        assertAcked(client().admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(TEST_INDEX).alias(INDEX_ALIAS)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(TEST_INDEX).alias(INDEX_ALIAS)));
     }
 
     /**
@@ -274,7 +274,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         assertEquals(6, details.getRelevantRetrieved());
 
         // test that ignore_unavailable=true works but returns one result less
-        assertTrue(client().admin().indices().prepareClose("test2").get().isAcknowledged());
+        assertTrue(indicesAdmin().prepareClose("test2").get().isAcknowledged());
 
         request.indicesOptions(IndicesOptions.fromParameters(null, "true", null, "false", SearchRequest.DEFAULT_INDICES_OPTIONS));
         response = client().execute(RankEvalAction.INSTANCE, request).actionGet();
@@ -283,7 +283,7 @@ public class RankEvalRequestIT extends ESIntegTestCase {
         assertEquals(5, details.getRelevantRetrieved());
 
         // test that ignore_unavailable=false or default settings throw an IndexClosedException
-        assertTrue(client().admin().indices().prepareClose("test2").get().isAcknowledged());
+        assertTrue(indicesAdmin().prepareClose("test2").get().isAcknowledged());
         request.indicesOptions(IndicesOptions.fromParameters(null, "false", null, "false", SearchRequest.DEFAULT_INDICES_OPTIONS));
         response = client().execute(RankEvalAction.INSTANCE, request).actionGet();
         assertEquals(1, response.getFailures().size());

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/client/documentation/ReindexDocumentationIT.java
@@ -69,7 +69,7 @@ public class ReindexDocumentationIT extends ESIntegTestCase {
 
     @Before
     public void setup() {
-        client().admin().indices().prepareCreate(INDEX_NAME).get();
+        indicesAdmin().prepareCreate(INDEX_NAME).get();
     }
 
     @SuppressWarnings("unused")

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/AbstractFeatureMigrationIntegTest.java
@@ -190,7 +190,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
             docs.add(ESIntegTestCase.client().prepareIndex(indexName).setId(Integer.toString(i)).setSource("some_field", "words words"));
         }
         indexRandom(true, docs);
-        IndicesStatsResponse indexStats = ESIntegTestCase.client().admin().indices().prepareStats(indexName).setDocs(true).get();
+        IndicesStatsResponse indexStats = ESIntegTestCase.indicesAdmin().prepareStats(indexName).setDocs(true).get();
         Assert.assertThat(indexStats.getIndex(indexName).getTotal().getDocs().getCount(), is((long) INDEX_DOC_COUNT));
     }
 
@@ -246,7 +246,7 @@ public abstract class AbstractFeatureMigrationIntegTest extends ESIntegTestCase 
         Set<String> actualAliasNames = imd.getAliases().keySet();
         assertThat(actualAliasNames, containsInAnyOrder(aliasNames.toArray()));
 
-        IndicesStatsResponse indexStats = client().admin().indices().prepareStats(imd.getIndex().getName()).setDocs(true).get();
+        IndicesStatsResponse indexStats = indicesAdmin().prepareStats(imd.getIndex().getName()).setDocs(true).get();
         assertNotNull(indexStats);
         final IndexStats thisIndexStats = indexStats.getIndex(imd.getIndex().getName());
         assertNotNull(thisIndexStats);

--- a/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
+++ b/modules/reindex/src/internalClusterTest/java/org/elasticsearch/migration/FeatureMigrationIT.java
@@ -330,9 +330,7 @@ public class FeatureMigrationIT extends AbstractFeatureMigrationIntegTest {
             createSystemIndexForDescriptor(descriptor);
         }
 
-        client().admin()
-            .indices()
-            .preparePutTemplate("bad_template")
+        indicesAdmin().preparePutTemplate("bad_template")
             .setPatterns(Collections.singletonList(templatePrefix + "*"))
             .addAlias(new Alias(templatePrefix + "-legacy-alias"))
             .get();

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFailureTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexFailureTests.java
@@ -88,7 +88,7 @@ public class ReindexFailureTests extends ReindexTestCase {
             ReindexRequestBuilder copy = reindex().source("source").destination("dest");
             copy.source().setSize(10);
             Future<BulkByScrollResponse> response = copy.execute();
-            client().admin().indices().prepareDelete("source").get();
+            indicesAdmin().prepareDelete("source").get();
 
             try {
                 response.get();

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSingleNodeTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/ReindexSingleNodeTests.java
@@ -33,7 +33,7 @@ public class ReindexSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("source").setId(Integer.toString(i)).setSource("foo", i).get();
         }
 
-        client().admin().indices().prepareRefresh("source").get();
+        indicesAdmin().prepareRefresh("source").get();
         assertHitCount(client().prepareSearch("source").setSize(0).get(), max);
 
         // Copy a subset of the docs sorted

--- a/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
+++ b/modules/reindex/src/test/java/org/elasticsearch/reindex/RetryTests.java
@@ -175,9 +175,9 @@ public class RetryTests extends ESIntegTestCase {
         final Settings indexSettings = indexSettings(1, 0).put("index.routing.allocation.include.color", "blue").build();
 
         // Create the source index on the node with small thread pools so we can block them.
-        client().admin().indices().prepareCreate("source").setSettings(indexSettings).execute().actionGet();
+        indicesAdmin().prepareCreate("source").setSettings(indexSettings).execute().actionGet();
         // Not all test cases use the dest index but those that do require that it be on the node will small thread pools
-        client().admin().indices().prepareCreate("dest").setSettings(indexSettings).execute().actionGet();
+        indicesAdmin().prepareCreate("dest").setSettings(indexSettings).execute().actionGet();
         // Build the test data. Don't use indexRandom because that won't work consistently with such small thread pools.
         BulkRequestBuilder bulk = client().prepareBulk();
         for (int i = 0; i < DOC_COUNT; i++) {
@@ -187,7 +187,7 @@ public class RetryTests extends ESIntegTestCase {
         Retry retry = new Retry(BackoffPolicy.exponentialBackoff(), client().threadPool());
         BulkResponse initialBulkResponse = retry.withBackoff(client()::bulk, bulk.request()).actionGet();
         assertFalse(initialBulkResponse.buildFailureMessage(), initialBulkResponse.hasFailures());
-        client().admin().indices().prepareRefresh("source").get();
+        indicesAdmin().prepareRefresh("source").get();
 
         AbstractBulkByScrollRequestBuilder<?, ?> builder = request.apply(internalCluster().masterClient());
         // Make sure we use more than one batch so we have to scroll

--- a/plugins/analysis-icu/src/internalClusterTest/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
+++ b/plugins/analysis-icu/src/internalClusterTest/java/org/elasticsearch/index/mapper/ICUCollationKeywordFieldMapperIT.java
@@ -64,7 +64,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         // both values should collate to same value
         indexRandom(
@@ -105,7 +105,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         // everything should be indexed fine, no exceptions
         indexRandom(
@@ -169,7 +169,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -214,7 +214,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -259,7 +259,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -304,7 +304,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -345,7 +345,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(true, client().prepareIndex(index).setId("1").setSource("""
             {"collate":"foobar-10"}""", XContentType.JSON), client().prepareIndex(index).setId("2").setSource("""
@@ -382,7 +382,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(true, client().prepareIndex(index).setId("1").setSource("""
             {"id":"1","collate":"résumé"}""", XContentType.JSON), client().prepareIndex(index).setId("2").setSource("""
@@ -418,7 +418,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,
@@ -466,7 +466,7 @@ public class ICUCollationKeywordFieldMapperIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         indexRandom(
             true,

--- a/plugins/mapper-size/src/internalClusterTest/java/org/elasticsearch/index/mapper/size/SizeMappingIT.java
+++ b/plugins/mapper-size/src/internalClusterTest/java/org/elasticsearch/index/mapper/size/SizeMappingIT.java
@@ -41,7 +41,7 @@ public class SizeMappingIT extends ESIntegTestCase {
         String index = "foo";
 
         XContentBuilder builder = jsonBuilder().startObject().startObject("_size").field("enabled", true).endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         // check mapping again
         assertSizeMappingEnabled(index, true);
@@ -54,7 +54,7 @@ public class SizeMappingIT extends ESIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        AcknowledgedResponse putMappingResponse = client().admin().indices().preparePutMapping(index).setSource(updateMappingBuilder).get();
+        AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping(index).setSource(updateMappingBuilder).get();
         assertAcked(putMappingResponse);
 
         // make sure size field is still in mapping
@@ -65,7 +65,7 @@ public class SizeMappingIT extends ESIntegTestCase {
         String index = "foo";
 
         XContentBuilder builder = jsonBuilder().startObject().startObject("_size").field("enabled", true).endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping(builder));
 
         // check mapping again
         assertSizeMappingEnabled(index, true);
@@ -76,7 +76,7 @@ public class SizeMappingIT extends ESIntegTestCase {
             .field("enabled", false)
             .endObject()
             .endObject();
-        AcknowledgedResponse putMappingResponse = client().admin().indices().preparePutMapping(index).setSource(updateMappingBuilder).get();
+        AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping(index).setSource(updateMappingBuilder).get();
         assertAcked(putMappingResponse);
 
         // make sure size field is still in mapping
@@ -89,7 +89,7 @@ public class SizeMappingIT extends ESIntegTestCase {
             "Expected size field mapping to be " + (enabled ? "enabled" : "disabled") + " for %s",
             index
         );
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings(index).get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings(index).get();
         Map<String, Object> mappingSource = getMappingsResponse.getMappings().get(index).getSourceAsMap();
         assertThat(errMsg, mappingSource, hasKey("_size"));
         String sizeAsString = mappingSource.get("_size").toString();

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/cluster/allocation/ClusterAllocationExplainIT.java
@@ -1061,7 +1061,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             indexData();
         } else {
             logger.info("--> close the index, now the replica is stale");
-            assertAcked(admin().indices().prepareClose("idx"));
+            assertAcked(indicesAdmin().prepareClose("idx"));
 
             final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth("idx")
                 .setTimeout(TimeValue.timeValueSeconds(30))
@@ -1203,8 +1203,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
 
         logger.info("--> creating a {} index with {} primary, {} replicas", state, numPrimaries, numReplicas);
         assertAcked(
-            admin().indices()
-                .prepareCreate("idx")
+            indicesAdmin().prepareCreate("idx")
                 .setSettings(indexSettings(numPrimaries, numReplicas).put(settings))
                 .setWaitForActiveShards(activeShardCount)
                 .get()
@@ -1214,7 +1213,7 @@ public final class ClusterAllocationExplainIT extends ESIntegTestCase {
             indexData();
         }
         if (state == IndexMetadata.State.CLOSE) {
-            assertAcked(admin().indices().prepareClose("idx"));
+            assertAcked(indicesAdmin().prepareClose("idx"));
 
             final ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth("idx")
                 .setTimeout(TimeValue.timeValueSeconds(30))

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/forcemerge/ForceMergeIT.java
@@ -51,13 +51,13 @@ public class ForceMergeIT extends ESIntegTestCase {
         assertThat(getForceMergeUUID(primary), nullValue());
         assertThat(getForceMergeUUID(replica), nullValue());
 
-        final ForceMergeResponse forceMergeResponse = client().admin().indices().prepareForceMerge(index).setMaxNumSegments(1).get();
+        final ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge(index).setMaxNumSegments(1).get();
 
         assertThat(forceMergeResponse.getFailedShards(), is(0));
         assertThat(forceMergeResponse.getSuccessfulShards(), is(2));
 
         // Force flush to force a new commit that contains the force flush UUID
-        final FlushResponse flushResponse = client().admin().indices().prepareFlush(index).setForce(true).get();
+        final FlushResponse flushResponse = indicesAdmin().prepareFlush(index).setForce(true).get();
         assertThat(flushResponse.getFailedShards(), is(0));
         assertThat(flushResponse.getSuccessfulShards(), is(2));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/mapping/put/ValidateMappingRequestPluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/mapping/put/ValidateMappingRequestPluginIT.java
@@ -57,38 +57,38 @@ public class ValidateMappingRequestPluginIT extends ESSingleNodeTestCase {
         {
             String origin = randomFrom("", "3", "4", "5");
             PutMappingRequest request = new PutMappingRequest().indices("index_1").source("t1", "type=keyword").origin(origin);
-            Exception e = expectThrows(IllegalStateException.class, () -> client().admin().indices().putMapping(request).actionGet());
+            Exception e = expectThrows(IllegalStateException.class, () -> indicesAdmin().putMapping(request).actionGet());
             assertThat(e.getMessage(), equalTo("not allowed: index[index_1] origin[" + origin + "]"));
         }
         {
             PutMappingRequest request = new PutMappingRequest().indices("index_1")
                 .origin(randomFrom("1", "2"))
                 .source("t1", "type=keyword");
-            assertAcked(client().admin().indices().putMapping(request).actionGet());
+            assertAcked(indicesAdmin().putMapping(request).actionGet());
         }
 
         {
             String origin = randomFrom("", "1", "4", "5");
             PutMappingRequest request = new PutMappingRequest().indices("index_2").source("t2", "type=keyword").origin(origin);
-            Exception e = expectThrows(IllegalStateException.class, () -> client().admin().indices().putMapping(request).actionGet());
+            Exception e = expectThrows(IllegalStateException.class, () -> indicesAdmin().putMapping(request).actionGet());
             assertThat(e.getMessage(), equalTo("not allowed: index[index_2] origin[" + origin + "]"));
         }
         {
             PutMappingRequest request = new PutMappingRequest().indices("index_2")
                 .origin(randomFrom("2", "3"))
                 .source("t1", "type=keyword");
-            assertAcked(client().admin().indices().putMapping(request).actionGet());
+            assertAcked(indicesAdmin().putMapping(request).actionGet());
         }
 
         {
             String origin = randomFrom("", "1", "3", "4");
             PutMappingRequest request = new PutMappingRequest().indices("*").source("t3", "type=keyword").origin(origin);
-            Exception e = expectThrows(IllegalStateException.class, () -> client().admin().indices().putMapping(request).actionGet());
+            Exception e = expectThrows(IllegalStateException.class, () -> indicesAdmin().putMapping(request).actionGet());
             assertThat(e.getMessage(), containsString("not allowed:"));
         }
         {
             PutMappingRequest request = new PutMappingRequest().indices("index_2").origin("2").source("t3", "type=keyword");
-            assertAcked(client().admin().indices().putMapping(request).actionGet());
+            assertAcked(indicesAdmin().putMapping(request).actionGet());
         }
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/refresh/RefreshBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/refresh/RefreshBlocksIT.java
@@ -39,7 +39,7 @@ public class RefreshBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("test", blockSetting);
-                RefreshResponse response = client().admin().indices().prepareRefresh("test").execute().actionGet();
+                RefreshResponse response = indicesAdmin().prepareRefresh("test").execute().actionGet();
                 assertNoFailures(response);
                 assertThat(response.getSuccessfulShards(), equalTo(numShards.totalNumShards));
             } finally {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsBlocksIT.java
@@ -36,7 +36,7 @@ public class IndicesStatsBlocksIT extends ESIntegTestCase {
         )) {
             try {
                 enableIndexBlock("ro", blockSetting);
-                IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats("ro").execute().actionGet();
+                IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats("ro").execute().actionGet();
                 assertNotNull(indicesStatsResponse.getIndex("ro"));
             } finally {
                 disableIndexBlock("ro", blockSetting);
@@ -46,7 +46,7 @@ public class IndicesStatsBlocksIT extends ESIntegTestCase {
         // Request is blocked
         try {
             enableIndexBlock("ro", IndexMetadata.SETTING_BLOCKS_METADATA);
-            client().admin().indices().prepareStats("ro").execute().actionGet();
+            indicesAdmin().prepareStats("ro").execute().actionGet();
             fail("Exists should fail when " + IndexMetadata.SETTING_BLOCKS_METADATA + " is true");
         } catch (ClusterBlockException e) {
             // Ok, a ClusterBlockException is expected

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkIntegrationIT.java
@@ -60,7 +60,7 @@ public class BulkIntegrationIT extends ESIntegTestCase {
         bulkBuilder.add(bulkAction.getBytes(StandardCharsets.UTF_8), 0, bulkAction.length(), null, XContentType.JSON);
         bulkBuilder.get();
         assertBusy(() -> {
-            GetMappingsResponse mappingsResponse = client().admin().indices().prepareGetMappings().get();
+            GetMappingsResponse mappingsResponse = indicesAdmin().prepareGetMappings().get();
             assertTrue(mappingsResponse.getMappings().containsKey("logstash-2014.03.30"));
         });
     }
@@ -179,7 +179,7 @@ public class BulkIntegrationIT extends ESIntegTestCase {
         }
         ensureGreen(index);
         assertBusy(() -> assertThat(docID.get(), greaterThanOrEqualTo(1)));
-        assertAcked(client().admin().indices().prepareDelete(index));
+        assertAcked(indicesAdmin().prepareDelete(index));
         stopped.set(true);
         for (Thread thread : threads) {
             thread.join(ReplicationRequest.DEFAULT_TIMEOUT.millis() / 2);

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2RetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessor2RetryIT.java
@@ -134,7 +134,7 @@ public class BulkProcessor2RetryIT extends ESIntegTestCase {
             }
         }
 
-        client().admin().indices().refresh(new RefreshRequest()).get();
+        indicesAdmin().refresh(new RefreshRequest()).get();
 
         SearchResponse results = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).setSize(0).get();
         assertThat(bulkProcessor.getTotalBytesInFlight(), equalTo(0L));

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorRetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkProcessorRetryIT.java
@@ -129,7 +129,7 @@ public class BulkProcessorRetryIT extends ESIntegTestCase {
             }
         }
 
-        client().admin().indices().refresh(new RefreshRequest()).get();
+        indicesAdmin().refresh(new RefreshRequest()).get();
 
         SearchResponse results = client().prepareSearch(INDEX_NAME).setQuery(QueryBuilders.matchAllQuery()).setSize(0).get();
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/bulk/BulkWithUpdatesIT.java
@@ -640,7 +640,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         SearchResponse searchResponse = client().prepareSearch("bulkindex*").get();
         assertHitCount(searchResponse, 3);
 
-        assertBusy(() -> assertAcked(client().admin().indices().prepareClose("bulkindex2")));
+        assertBusy(() -> assertAcked(indicesAdmin().prepareClose("bulkindex2")));
 
         BulkRequest bulkRequest2 = new BulkRequest();
         bulkRequest2.add(new IndexRequest("bulkindex1").id("1").source(Requests.INDEX_CONTENT_TYPE, "text", "hallo1"))
@@ -660,7 +660,7 @@ public class BulkWithUpdatesIT extends ESIntegTestCase {
         createIndex("bulkindex1");
 
         client().prepareIndex("bulkindex1").setId("1").setSource("text", "test").get();
-        assertBusy(() -> assertAcked(client().admin().indices().prepareClose("bulkindex1")));
+        assertBusy(() -> assertAcked(indicesAdmin().prepareClose("bulkindex1")));
 
         BulkRequest bulkRequest = new BulkRequest().setRefreshPolicy(RefreshPolicy.IMMEDIATE);
         bulkRequest.add(new IndexRequest("bulkindex1").id("1").source(Requests.INDEX_CONTENT_TYPE, "text", "hallo1"))

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/LookupRuntimeFieldIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/LookupRuntimeFieldIT.java
@@ -42,7 +42,7 @@ public class LookupRuntimeFieldIT extends ESIntegTestCase {
         for (Map<String, String> author : authors) {
             client().prepareIndex("authors").setSource(author).setRefreshPolicy(randomFrom(WriteRequest.RefreshPolicy.values())).get();
         }
-        client().admin().indices().prepareRefresh("authors").get();
+        indicesAdmin().prepareRefresh("authors").get();
 
         indicesAdmin().prepareCreate("publishers")
             .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)))

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/PointInTimeIT.java
@@ -209,7 +209,7 @@ public class PointInTimeIT extends ESIntegTestCase {
         assertHitCount(resp1, index1);
         if (rarely()) {
             assertBusy(() -> {
-                final CommonStats stats = client().admin().indices().prepareStats().setSearch(true).get().getTotal();
+                final CommonStats stats = indicesAdmin().prepareStats().setSearch(true).get().getTotal();
                 assertThat(stats.search.getOpenContexts(), equalTo(0L));
             }, 60, TimeUnit.SECONDS);
         } else {
@@ -245,7 +245,7 @@ public class PointInTimeIT extends ESIntegTestCase {
             SearchResponse resp = client().prepareSearch().setPreference(null).setPointInTime(new PointInTimeBuilder(pit)).get();
             assertNoFailures(resp);
             assertHitCount(resp, index1 + index2);
-            client().admin().indices().prepareDelete("index-1").get();
+            indicesAdmin().prepareDelete("index-1").get();
             if (randomBoolean()) {
                 resp = client().prepareSearch("index-*").get();
                 assertNoFailures(resp);
@@ -381,7 +381,7 @@ public class PointInTimeIT extends ESIntegTestCase {
     }
 
     public void testPITTiebreak() throws Exception {
-        assertAcked(client().admin().indices().prepareDelete("index-*").get());
+        assertAcked(indicesAdmin().prepareDelete("index-*").get());
         int numIndex = randomIntBetween(2, 10);
         int expectedNumDocs = 0;
         for (int i = 0; i < numIndex; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/SearchShardsIT.java
@@ -43,19 +43,19 @@ public class SearchShardsIT extends ESIntegTestCase {
         for (int i = 0; i < indicesWithData; i++) {
             String index = "index-with-data-" + i;
             ElasticsearchAssertions.assertAcked(
-                admin().indices().prepareCreate(index).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
+                indicesAdmin().prepareCreate(index).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
             );
             int numDocs = randomIntBetween(1, 10);
             for (int j = 0; j < numDocs; j++) {
                 client().prepareIndex(index).setSource("value", i).setId(Integer.toString(i)).get();
             }
-            client().admin().indices().prepareRefresh(index).get();
+            indicesAdmin().prepareRefresh(index).get();
         }
         int indicesWithoutData = between(1, 10);
         for (int i = 0; i < indicesWithoutData; i++) {
             String index = "index-without-data-" + i;
             ElasticsearchAssertions.assertAcked(
-                admin().indices().prepareCreate(index).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
+                indicesAdmin().prepareCreate(index).setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1))
             );
         }
         // Range query
@@ -110,15 +110,14 @@ public class SearchShardsIT extends ESIntegTestCase {
         for (int i = 0; i < numIndices; i++) {
             String index = "index-" + i;
             ElasticsearchAssertions.assertAcked(
-                admin().indices()
-                    .prepareCreate(index)
+                indicesAdmin().prepareCreate(index)
                     .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)))
             );
             int numDocs = randomIntBetween(10, 1000);
             for (int j = 0; j < numDocs; j++) {
                 client().prepareIndex(index).setSource("value", i).setId(Integer.toString(i)).get();
             }
-            client().admin().indices().prepareRefresh(index).get();
+            indicesAdmin().prepareRefresh(index).get();
         }
         int iterations = iterations(2, 10);
         for (int i = 0; i < iterations; i++) {
@@ -164,8 +163,7 @@ public class SearchShardsIT extends ESIntegTestCase {
                 String index = "index-" + i;
                 int numShards = between(1, 5);
                 ElasticsearchAssertions.assertAcked(
-                    admin().indices()
-                        .prepareCreate(index)
+                    indicesAdmin().prepareCreate(index)
                         .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numShards))
                 );
                 totalShards += numShards;
@@ -173,7 +171,7 @@ public class SearchShardsIT extends ESIntegTestCase {
                 for (int j = 0; j < numDocs; j++) {
                     client().prepareIndex(index).setSource("value", i).setId(Integer.toString(i)).get();
                 }
-                client().admin().indices().prepareRefresh(index).get();
+                indicesAdmin().prepareRefresh(index).get();
             }
             SearchShardsRequest request = new SearchShardsRequest(
                 new String[] { "index-*" },

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/search/TransportSearchIT.java
@@ -259,7 +259,7 @@ public class TransportSearchIT extends ESIntegTestCase {
             IndexResponse indexResponse = client().index(indexRequest).actionGet();
             assertEquals(RestStatus.CREATED, indexResponse.status());
         }
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         SearchRequest originalRequest = new SearchRequest();
         SearchSourceBuilder source = new SearchSourceBuilder();
@@ -302,8 +302,8 @@ public class TransportSearchIT extends ESIntegTestCase {
         assertAcked(prepareCreate("test1").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)));
         assertAcked(prepareCreate("test2").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)));
         assertAcked(prepareCreate("test3").setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards)));
-        client().admin().indices().prepareAliases().addAlias("test1", "testAlias").get();
-        client().admin().indices().prepareAliases().addAlias(new String[] { "test2", "test3" }, "testFailedAlias").get();
+        indicesAdmin().prepareAliases().addAlias("test1", "testAlias").get();
+        indicesAdmin().prepareAliases().addAlias(new String[] { "test2", "test3" }, "testFailedAlias").get();
 
         long[] validCheckpoints = new long[numberOfShards];
         Arrays.fill(validCheckpoints, SequenceNumbers.UNASSIGNED_SEQ_NO);
@@ -554,7 +554,7 @@ public class TransportSearchIT extends ESIntegTestCase {
             IndexResponse indexResponse = client().prepareIndex(indexName).setSource("number", randomInt()).get();
             assertEquals(RestStatus.CREATED, indexResponse.status());
         }
-        client().admin().indices().prepareRefresh(indexName).get();
+        indicesAdmin().prepareRefresh(indexName).get();
     }
 
     private long requestBreakerUsed() {

--- a/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/action/support/ActiveShardsObserverIT.java
@@ -110,7 +110,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
         );
         waitForIndexCreationToComplete(indexName);
         if (indexExists(indexName)) {
-            client().admin().indices().prepareDelete(indexName).get();
+            indicesAdmin().prepareDelete(indexName).get();
         }
 
         // enough data nodes, all shards are active
@@ -139,7 +139,7 @@ public class ActiveShardsObserverIT extends ESIntegTestCase {
         assertBusy(() -> assertTrue(clusterAdmin().prepareState().get().getState().metadata().hasIndex(indexName)));
 
         logger.info("--> delete the index");
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         logger.info("--> ensure the create index request completes");
         assertAcked(responseListener.get());

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/IndexAliasesIT.java
@@ -84,7 +84,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases("test", () -> {
             logger.info("--> aliasing index [test] with [alias1]");
-            assertAcked(admin().indices().prepareAliases().addAlias("test", "alias1", false));
+            assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1", false));
         });
 
         logger.info("--> indexing against [alias1], should fail now");
@@ -103,7 +103,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases("test", () -> {
             logger.info("--> aliasing index [test] with [alias1]");
-            assertAcked(admin().indices().prepareAliases().addAlias("test", "alias1"));
+            assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1"));
         });
 
         logger.info("--> indexing against [alias1], should work now");
@@ -118,7 +118,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases("test_x", () -> {
             logger.info("--> add index [test_x] with [alias1]");
-            assertAcked(admin().indices().prepareAliases().addAlias("test_x", "alias1"));
+            assertAcked(indicesAdmin().prepareAliases().addAlias("test_x", "alias1"));
         });
 
         logger.info("--> indexing against [alias1], should fail now");
@@ -148,7 +148,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases("test_x", () -> {
             logger.info("--> remove aliasing index [test_x] with [alias1]");
-            assertAcked(admin().indices().prepareAliases().removeAlias("test_x", "alias1"));
+            assertAcked(indicesAdmin().prepareAliases().removeAlias("test_x", "alias1"));
         });
 
         logger.info("--> indexing against [alias1], should work now");
@@ -157,7 +157,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases("test_x", () -> {
             logger.info("--> add index [test_x] with [alias1] as write-index");
-            assertAcked(admin().indices().prepareAliases().addAlias("test_x", "alias1", true));
+            assertAcked(indicesAdmin().prepareAliases().addAlias("test_x", "alias1", true));
         });
 
         logger.info("--> indexing against [alias1], should work now");
@@ -170,7 +170,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases("test_x", () -> {
             logger.info("--> remove [alias1], Aliasing index [test_x] with [alias1]");
-            assertAcked(admin().indices().prepareAliases().removeAlias("test", "alias1").addAlias("test_x", "alias1"));
+            assertAcked(indicesAdmin().prepareAliases().removeAlias("test", "alias1").addAlias("test_x", "alias1"));
         });
 
         logger.info("--> indexing against [alias1], should work against [test_x]");
@@ -185,14 +185,14 @@ public class IndexAliasesIT extends ESIntegTestCase {
         // invalid filter, invalid json
         Exception e = expectThrows(
             IllegalArgumentException.class,
-            () -> admin().indices().prepareAliases().addAlias("test", "alias1", "abcde").get()
+            () -> indicesAdmin().prepareAliases().addAlias("test", "alias1", "abcde").get()
         );
         assertThat(e.getMessage(), equalTo("failed to parse filter for alias [alias1]"));
 
         // valid json , invalid filter
         e = expectThrows(
             IllegalArgumentException.class,
-            () -> admin().indices().prepareAliases().addAlias("test", "alias1", "{ \"test\": {} }").get()
+            () -> indicesAdmin().prepareAliases().addAlias("test", "alias1", "{ \"test\": {} }").get()
         );
         assertThat(e.getMessage(), equalTo("failed to parse filter for alias [alias1]"));
     }
@@ -205,7 +205,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         logger.info("--> aliasing index [test] with [alias1] and filter [user:kimchy]");
         QueryBuilder filter = termQuery("user", "kimchy");
-        assertAliasesVersionIncreases("test", () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "alias1", filter)));
+        assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1", filter)));
 
         // For now just making sure that filter was stored with the alias
         logger.info("--> making sure that filter was stored with alias [alias1] and filter [user:kimchy]");
@@ -224,7 +224,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         logger.info("--> aliasing index [test] with [alias1] and empty filter");
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> admin().indices().prepareAliases().addAlias("test", "alias1", "{}").get()
+            () -> indicesAdmin().prepareAliases().addAlias("test", "alias1", "{}").get()
         );
         assertEquals("failed to parse filter for alias [alias1]", iae.getMessage());
     }
@@ -237,19 +237,19 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         logger.info("--> adding filtering aliases to index [test]");
 
-        assertAliasesVersionIncreases("test", () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "alias1")));
-        assertAliasesVersionIncreases("test", () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "alias2")));
+        assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1")));
+        assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias2")));
         assertAliasesVersionIncreases(
             "test",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "foos", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "foos", termQuery("name", "foo")))
         );
         assertAliasesVersionIncreases(
             "test",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "bars", termQuery("name", "bar")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "bars", termQuery("name", "bar")))
         );
         assertAliasesVersionIncreases(
             "test",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "tests", termQuery("name", "test")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "tests", termQuery("name", "test")))
         );
 
         logger.info("--> indexing against [test]");
@@ -342,23 +342,23 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> adding filtering aliases to index [test1]");
-        assertAliasesVersionIncreases("test1", () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "aliasToTest1")));
-        assertAliasesVersionIncreases("test1", () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "aliasToTests")));
+        assertAliasesVersionIncreases("test1", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "aliasToTest1")));
+        assertAliasesVersionIncreases("test1", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "aliasToTests")));
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "foos", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "foos", termQuery("name", "foo")))
         );
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "bars", termQuery("name", "bar")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "bars", termQuery("name", "bar")))
         );
 
         logger.info("--> adding filtering aliases to index [test2]");
-        assertAliasesVersionIncreases("test2", () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "aliasToTest2")));
-        assertAliasesVersionIncreases("test2", () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "aliasToTests")));
+        assertAliasesVersionIncreases("test2", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "aliasToTest2")));
+        assertAliasesVersionIncreases("test2", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "aliasToTests")));
         assertAliasesVersionIncreases(
             "test2",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "foos", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "foos", termQuery("name", "foo")))
         );
 
         logger.info("--> indexing against [test1]");
@@ -448,31 +448,31 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> adding aliases to indices");
-        assertAliasesVersionIncreases("test1", () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "alias12")));
-        assertAliasesVersionIncreases("test2", () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "alias12")));
+        assertAliasesVersionIncreases("test1", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "alias12")));
+        assertAliasesVersionIncreases("test2", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "alias12")));
 
         logger.info("--> adding filtering aliases to indices");
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "filter1", termQuery("name", "test1")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "filter1", termQuery("name", "test1")))
         );
 
         assertAliasesVersionIncreases(
             "test2",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "filter23", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "filter23", termQuery("name", "foo")))
         );
         assertAliasesVersionIncreases(
             "test3",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test3", "filter23", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test3", "filter23", termQuery("name", "foo")))
         );
 
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "filter13", termQuery("name", "baz")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "filter13", termQuery("name", "baz")))
         );
         assertAliasesVersionIncreases(
             "test3",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test3", "filter13", termQuery("name", "baz")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test3", "filter13", termQuery("name", "baz")))
         );
 
         logger.info("--> indexing against [test1]");
@@ -571,31 +571,31 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> adding filtering aliases to index [test1]");
-        assertAliasesVersionIncreases("test1", () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "aliasToTest1")));
-        assertAliasesVersionIncreases("test1", () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "aliasToTests")));
+        assertAliasesVersionIncreases("test1", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "aliasToTest1")));
+        assertAliasesVersionIncreases("test1", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "aliasToTests")));
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "foos", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "foos", termQuery("name", "foo")))
         );
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "bars", termQuery("name", "bar")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "bars", termQuery("name", "bar")))
         );
         assertAliasesVersionIncreases(
             "test1",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test1", "tests", termQuery("name", "test")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test1", "tests", termQuery("name", "test")))
         );
 
         logger.info("--> adding filtering aliases to index [test2]");
-        assertAliasesVersionIncreases("test2", () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "aliasToTest2")));
-        assertAliasesVersionIncreases("test2", () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "aliasToTests")));
+        assertAliasesVersionIncreases("test2", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "aliasToTest2")));
+        assertAliasesVersionIncreases("test2", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "aliasToTests")));
         assertAliasesVersionIncreases(
             "test2",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "foos", termQuery("name", "foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "foos", termQuery("name", "foo")))
         );
         assertAliasesVersionIncreases(
             "test2",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test2", "tests", termQuery("name", "test")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test2", "tests", termQuery("name", "test")))
         );
 
         logger.info("--> indexing against [test1]");
@@ -629,8 +629,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertAliasesVersionIncreases(
             "test1",
             () -> assertAcked(
-                admin().indices()
-                    .prepareAliases()
+                indicesAdmin().prepareAliases()
                     .addAlias("test1", "aliasToTest1")
                     .addAlias("test1", "aliasToTests")
                     .addAlias("test1", "foos", termQuery("name", "foo"))
@@ -643,8 +642,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertAliasesVersionIncreases(
             "test2",
             () -> assertAcked(
-                admin().indices()
-                    .prepareAliases()
+                indicesAdmin().prepareAliases()
                     .addAlias("test2", "aliasToTest2")
                     .addAlias("test2", "aliasToTests")
                     .addAlias("test2", "foos", termQuery("name", "foo"))
@@ -655,10 +653,10 @@ public class IndexAliasesIT extends ESIntegTestCase {
         String[] indices = { "test1", "test2" };
         String[] aliases = { "aliasToTest1", "foos", "bars", "tests", "aliasToTest2", "aliasToTests" };
 
-        assertAliasesVersionIncreases(indices, () -> admin().indices().prepareAliases().removeAlias(indices, aliases).get());
+        assertAliasesVersionIncreases(indices, () -> indicesAdmin().prepareAliases().removeAlias(indices, aliases).get());
 
         for (String alias : aliases) {
-            assertTrue(admin().indices().prepareGetAliases(alias).get().getAliases().isEmpty());
+            assertTrue(indicesAdmin().prepareGetAliases(alias).get().getAliases().isEmpty());
         }
 
         logger.info("--> creating index [foo_foo] and [bar_bar]");
@@ -667,20 +665,20 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> adding [foo] alias to [foo_foo] and [bar_bar]");
-        assertAliasesVersionIncreases("foo_foo", () -> assertAcked(admin().indices().prepareAliases().addAlias("foo_foo", "foo")));
-        assertAliasesVersionIncreases("bar_bar", () -> assertAcked(admin().indices().prepareAliases().addAlias("bar_bar", "foo")));
+        assertAliasesVersionIncreases("foo_foo", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("foo_foo", "foo")));
+        assertAliasesVersionIncreases("bar_bar", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("bar_bar", "foo")));
 
         assertAliasesVersionIncreases(
             "foo_foo",
-            () -> assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.remove().index("foo*").alias("foo")))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index("foo*").alias("foo")))
         );
 
-        assertFalse(admin().indices().prepareGetAliases("foo").get().getAliases().isEmpty());
-        assertTrue(admin().indices().prepareGetAliases("foo").setIndices("foo_foo").get().getAliases().isEmpty());
-        assertFalse(admin().indices().prepareGetAliases("foo").setIndices("bar_bar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("foo").get().getAliases().isEmpty());
+        assertTrue(indicesAdmin().prepareGetAliases("foo").setIndices("foo_foo").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("foo").setIndices("bar_bar").get().getAliases().isEmpty());
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> admin().indices().prepareAliases().addAliasAction(AliasActions.remove().index("foo").alias("foo")).execute().actionGet()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index("foo").alias("foo")).execute().actionGet()
         );
         assertEquals(
             "The provided expression [foo] matches an alias, specify the corresponding concrete indices instead.",
@@ -696,20 +694,20 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         for (int i = 0; i < 10; i++) {
             final String aliasName = "alias" + i;
-            assertAliasesVersionIncreases("test", () -> assertAcked(admin().indices().prepareAliases().addAlias("test", aliasName)));
+            assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", aliasName)));
             client().index(new IndexRequest(aliasName).id("1").source(source("1", "test"), XContentType.JSON)).get();
         }
     }
 
     public void testWaitForAliasCreationSingleShard() throws Exception {
         logger.info("--> creating index [test]");
-        assertAcked(admin().indices().create(new CreateIndexRequest("test").settings(indexSettings(1, 0))).get());
+        assertAcked(indicesAdmin().create(new CreateIndexRequest("test").settings(indexSettings(1, 0))).get());
 
         ensureGreen();
 
         for (int i = 0; i < 10; i++) {
             final String aliasName = "alias" + i;
-            assertAliasesVersionIncreases("test", () -> assertAcked(admin().indices().prepareAliases().addAlias("test", aliasName)));
+            assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", aliasName)));
             client().index(new IndexRequest(aliasName).id("1").source(source("1", "test"), XContentType.JSON)).get();
         }
     }
@@ -728,10 +726,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
             executor.submit(new Runnable() {
                 @Override
                 public void run() {
-                    assertAliasesVersionIncreases(
-                        "test",
-                        () -> assertAcked(admin().indices().prepareAliases().addAlias("test", aliasName))
-                    );
+                    assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", aliasName)));
                     client().index(new IndexRequest(aliasName).id("1").source(source("1", "test"), XContentType.JSON)).actionGet();
                 }
             });
@@ -750,14 +745,14 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> creating alias1 ");
-        assertAliasesVersionIncreases("test", () -> assertAcked((admin().indices().prepareAliases().addAlias("test", "alias1"))));
+        assertAliasesVersionIncreases("test", () -> assertAcked((indicesAdmin().prepareAliases().addAlias("test", "alias1"))));
         TimeValue timeout = TimeValue.timeValueSeconds(2);
         logger.info("--> recreating alias1 ");
         StopWatch stopWatch = new StopWatch();
         stopWatch.start();
         assertAliasesVersionUnchanged(
             "test",
-            () -> assertAcked((admin().indices().prepareAliases().addAlias("test", "alias1").setTimeout(timeout)))
+            () -> assertAcked((indicesAdmin().prepareAliases().addAlias("test", "alias1").setTimeout(timeout)))
         );
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
 
@@ -766,7 +761,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         final TermQueryBuilder fooFilter = termQuery("name", "foo");
         assertAliasesVersionIncreases(
             "test",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "alias1", fooFilter).setTimeout(timeout))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1", fooFilter).setTimeout(timeout))
         );
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
 
@@ -774,7 +769,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         stopWatch.start();
         assertAliasesVersionUnchanged(
             "test",
-            () -> assertAcked((admin().indices().prepareAliases().addAlias("test", "alias1", fooFilter).setTimeout(timeout)))
+            () -> assertAcked((indicesAdmin().prepareAliases().addAlias("test", "alias1", fooFilter).setTimeout(timeout)))
         );
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
 
@@ -783,7 +778,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         final TermQueryBuilder barFilter = termQuery("name", "bar");
         assertAliasesVersionIncreases(
             "test",
-            () -> assertAcked((admin().indices().prepareAliases().addAlias("test", "alias1", barFilter).setTimeout(timeout)))
+            () -> assertAcked((indicesAdmin().prepareAliases().addAlias("test", "alias1", barFilter).setTimeout(timeout)))
         );
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
 
@@ -798,7 +793,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         stopWatch.start();
         assertAliasesVersionIncreases(
             "test",
-            () -> assertAcked((admin().indices().prepareAliases().removeAlias("test", "alias1").setTimeout(timeout)))
+            () -> assertAcked((indicesAdmin().prepareAliases().removeAlias("test", "alias1").setTimeout(timeout)))
         );
         assertThat(stopWatch.stop().lastTaskTime().millis(), lessThan(timeout.millis()));
     }
@@ -809,7 +804,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
         logger.info("--> deleting alias1 which does not exist");
         try {
-            admin().indices().prepareAliases().removeAlias("test", "alias1").get();
+            indicesAdmin().prepareAliases().removeAlias("test", "alias1").get();
             fail("Expected AliasesNotFoundException");
         } catch (AliasesNotFoundException e) {
             assertThat(e.getMessage(), containsString("[alias1] missing"));
@@ -830,11 +825,11 @@ public class IndexAliasesIT extends ESIntegTestCase {
         logger.info("--> creating aliases [alias1, alias2]");
         assertAliasesVersionIncreases(
             "foobar",
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("foobar", "alias1").addAlias("foobar", "alias2"))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("foobar", "alias1").addAlias("foobar", "alias2"))
         );
 
         logger.info("--> getting alias1");
-        GetAliasesResponse getResponse = admin().indices().prepareGetAliases("alias1").get();
+        GetAliasesResponse getResponse = indicesAdmin().prepareGetAliases("alias1").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(1));
@@ -843,10 +838,10 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("alias1").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("alias1").get().getAliases().isEmpty());
 
         logger.info("--> getting all aliases that start with alias*");
-        getResponse = admin().indices().prepareGetAliases("alias*").get();
+        getResponse = indicesAdmin().prepareGetAliases("alias*").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(2));
@@ -860,14 +855,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(1).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(1).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(1).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("alias*").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("alias*").get().getAliases().isEmpty());
 
         logger.info("--> creating aliases [bar, baz, foo]");
         assertAliasesVersionIncreases(
             new String[] { "bazbar", "foobar" },
             () -> assertAcked(
-                admin().indices()
-                    .prepareAliases()
+                indicesAdmin().prepareAliases()
                     .addAlias("bazbar", "bar")
                     .addAlias("bazbar", "bac", termQuery("field", "value"))
                     .addAlias("foobar", "foo")
@@ -877,12 +871,12 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertAliasesVersionIncreases(
             "foobar",
             () -> assertAcked(
-                admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("foobar").alias("bac").routing("bla"))
+                indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("foobar").alias("bac").routing("bla"))
             )
         );
 
         logger.info("--> getting bar and baz for index bazbar");
-        getResponse = admin().indices().prepareGetAliases("bar", "bac").addIndices("bazbar").get();
+        getResponse = indicesAdmin().prepareGetAliases("bar", "bac").addIndices("bazbar").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("bazbar").size(), equalTo(2));
@@ -898,13 +892,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("bazbar").get(1).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("bazbar").get(1).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("bazbar").get(1).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("bar").get().getAliases().isEmpty());
-        assertFalse(admin().indices().prepareGetAliases("bac").get().getAliases().isEmpty());
-        assertFalse(admin().indices().prepareGetAliases("bar").addIndices("bazbar").get().getAliases().isEmpty());
-        assertFalse(admin().indices().prepareGetAliases("bac").addIndices("bazbar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("bar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("bac").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("bar").addIndices("bazbar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("bac").addIndices("bazbar").get().getAliases().isEmpty());
 
         logger.info("--> getting *b* for index baz*");
-        getResponse = admin().indices().prepareGetAliases("*b*").addIndices("baz*").get();
+        getResponse = indicesAdmin().prepareGetAliases("*b*").addIndices("baz*").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("bazbar").size(), equalTo(2));
@@ -920,10 +914,10 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("bazbar").get(1).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("bazbar").get(1).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("bazbar").get(1).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("*b*").addIndices("baz*").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("*b*").addIndices("baz*").get().getAliases().isEmpty());
 
         logger.info("--> getting *b* for index *bar");
-        getResponse = admin().indices().prepareGetAliases("b*").addIndices("*bar").get();
+        getResponse = indicesAdmin().prepareGetAliases("b*").addIndices("*bar").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(2));
         assertThat(getResponse.getAliases().get("bazbar").size(), equalTo(2));
@@ -944,10 +938,10 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), equalTo("bla"));
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), equalTo("bla"));
-        assertFalse(admin().indices().prepareGetAliases("b*").addIndices("*bar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("b*").addIndices("*bar").get().getAliases().isEmpty());
 
         logger.info("--> getting f* for index *bar");
-        getResponse = admin().indices().prepareGetAliases("f*").addIndices("*bar").get();
+        getResponse = indicesAdmin().prepareGetAliases("f*").addIndices("*bar").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").get(0), notNullValue());
@@ -955,11 +949,11 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("f*").addIndices("*bar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("f*").addIndices("*bar").get().getAliases().isEmpty());
 
         // alias at work
         logger.info("--> getting f* for index *bac");
-        getResponse = admin().indices().prepareGetAliases("foo").addIndices("*bac").get();
+        getResponse = indicesAdmin().prepareGetAliases("foo").addIndices("*bac").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(1));
@@ -968,10 +962,10 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("foo").addIndices("*bac").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("foo").addIndices("*bac").get().getAliases().isEmpty());
 
         logger.info("--> getting foo for index foobar");
-        getResponse = admin().indices().prepareGetAliases("foo").addIndices("foobar").get();
+        getResponse = indicesAdmin().prepareGetAliases("foo").addIndices("foobar").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(1));
         assertThat(getResponse.getAliases().get("foobar").get(0), notNullValue());
@@ -979,13 +973,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(getResponse.getAliases().get("foobar").get(0).getFilter(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getIndexRouting(), nullValue());
         assertThat(getResponse.getAliases().get("foobar").get(0).getSearchRouting(), nullValue());
-        assertFalse(admin().indices().prepareGetAliases("foo").addIndices("foobar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("foo").addIndices("foobar").get().getAliases().isEmpty());
 
         for (String aliasName : new String[] { null, "_all", "*" }) {
             logger.info("--> getting {} alias for index foobar", aliasName);
             getResponse = aliasName != null
-                ? admin().indices().prepareGetAliases(aliasName).addIndices("foobar").get()
-                : admin().indices().prepareGetAliases().addIndices("foobar").get();
+                ? indicesAdmin().prepareGetAliases(aliasName).addIndices("foobar").get()
+                : indicesAdmin().prepareGetAliases().addIndices("foobar").get();
             assertThat(getResponse, notNullValue());
             assertThat(getResponse.getAliases().size(), equalTo(1));
             assertThat(getResponse.getAliases().get("foobar").size(), equalTo(4));
@@ -997,20 +991,20 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         // alias at work again
         logger.info("--> getting * for index *bac");
-        getResponse = admin().indices().prepareGetAliases("*").addIndices("*bac").get();
+        getResponse = indicesAdmin().prepareGetAliases("*").addIndices("*bac").get();
         assertThat(getResponse, notNullValue());
         assertThat(getResponse.getAliases().size(), equalTo(2));
         assertThat(getResponse.getAliases().get("foobar").size(), equalTo(4));
         assertThat(getResponse.getAliases().get("bazbar").size(), equalTo(2));
-        assertFalse(admin().indices().prepareGetAliases("*").addIndices("*bac").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("*").addIndices("*bac").get().getAliases().isEmpty());
 
-        assertAcked(admin().indices().prepareAliases().removeAlias("foobar", "foo"));
+        assertAcked(indicesAdmin().prepareAliases().removeAlias("foobar", "foo"));
 
-        getResponse = admin().indices().prepareGetAliases("foo").addIndices("foobar").get();
+        getResponse = indicesAdmin().prepareGetAliases("foo").addIndices("foobar").get();
         for (final Map.Entry<String, List<AliasMetadata>> entry : getResponse.getAliases().entrySet()) {
             assertTrue(entry.getValue().isEmpty());
         }
-        assertTrue(admin().indices().prepareGetAliases("foo").addIndices("foobar").get().getAliases().isEmpty());
+        assertTrue(indicesAdmin().prepareGetAliases("foo").addIndices("foobar").get().getAliases().isEmpty());
     }
 
     public void testGetAllAliasesWorks() {
@@ -1019,10 +1013,10 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAliasesVersionIncreases(
             new String[] { "index1", "index2" },
-            () -> assertAcked(admin().indices().prepareAliases().addAlias("index1", "alias1").addAlias("index2", "alias2"))
+            () -> assertAcked(indicesAdmin().prepareAliases().addAlias("index1", "alias1").addAlias("index2", "alias2"))
         );
 
-        GetAliasesResponse response = admin().indices().prepareGetAliases().get();
+        GetAliasesResponse response = indicesAdmin().prepareGetAliases().get();
         assertThat(response.getAliases(), hasKey("index1"));
         assertThat(response.getAliases(), hasKey("index1"));
     }
@@ -1093,17 +1087,17 @@ public class IndexAliasesIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("--> adding [week_20] alias to [2017-05-20]");
-        assertAcked(admin().indices().prepareAliases().addAlias("2017-05-20", "week_20"));
+        assertAcked(indicesAdmin().prepareAliases().addAlias("2017-05-20", "week_20"));
 
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("week_20").alias("tmp")).execute().actionGet()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("week_20").alias("tmp")).execute().actionGet()
         );
         assertEquals(
             "The provided expression [week_20] matches an alias, specify the corresponding concrete indices instead.",
             iae.getMessage()
         );
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("2017-05-20").alias("tmp")).execute().get());
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("2017-05-20").alias("tmp")).execute().get());
     }
 
     // Before 2.0 alias filters were parsed at alias creation time, in order
@@ -1132,17 +1126,13 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertAliasesVersionIncreases(
             "my-index",
             () -> assertAcked(
-                admin().indices()
-                    .prepareAliases()
-                    .addAlias("my-index", "filter1", rangeQuery("timestamp").from("2016-12-01").to("2016-12-31"))
+                indicesAdmin().prepareAliases().addAlias("my-index", "filter1", rangeQuery("timestamp").from("2016-12-01").to("2016-12-31"))
             )
         );
         assertAliasesVersionIncreases(
             "my-index",
             () -> assertAcked(
-                admin().indices()
-                    .prepareAliases()
-                    .addAlias("my-index", "filter2", rangeQuery("timestamp").from("2016-01-01").to("2016-12-31"))
+                indicesAdmin().prepareAliases().addAlias("my-index", "filter2", rangeQuery("timestamp").from("2016-01-01").to("2016-12-31"))
             )
         );
 
@@ -1170,11 +1160,11 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
                 assertAliasesVersionIncreases(
                     "test",
-                    () -> assertAcked(admin().indices().prepareAliases().addAlias("test", "alias1").addAlias("test", "alias2"))
+                    () -> assertAcked(indicesAdmin().prepareAliases().addAlias("test", "alias1").addAlias("test", "alias2"))
                 );
-                assertAliasesVersionIncreases("test", () -> assertAcked(admin().indices().prepareAliases().removeAlias("test", "alias1")));
-                assertThat(admin().indices().prepareGetAliases("alias2").execute().actionGet().getAliases().get("test").size(), equalTo(1));
-                assertFalse(admin().indices().prepareGetAliases("alias2").get().getAliases().isEmpty());
+                assertAliasesVersionIncreases("test", () -> assertAcked(indicesAdmin().prepareAliases().removeAlias("test", "alias1")));
+                assertThat(indicesAdmin().prepareGetAliases("alias2").execute().actionGet().getAliases().get("test").size(), equalTo(1));
+                assertFalse(indicesAdmin().prepareGetAliases("alias2").get().getAliases().isEmpty());
             } finally {
                 disableIndexBlock("test", block);
             }
@@ -1185,14 +1175,14 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
             assertAliasesVersionUnchanged(
                 "test",
-                () -> assertBlocked(admin().indices().prepareAliases().addAlias("test", "alias3"), INDEX_READ_ONLY_BLOCK)
+                () -> assertBlocked(indicesAdmin().prepareAliases().addAlias("test", "alias3"), INDEX_READ_ONLY_BLOCK)
             );
             assertAliasesVersionUnchanged(
                 "test",
-                () -> assertBlocked(admin().indices().prepareAliases().removeAlias("test", "alias2"), INDEX_READ_ONLY_BLOCK)
+                () -> assertBlocked(indicesAdmin().prepareAliases().removeAlias("test", "alias2"), INDEX_READ_ONLY_BLOCK)
             );
-            assertThat(admin().indices().prepareGetAliases("alias2").execute().actionGet().getAliases().get("test").size(), equalTo(1));
-            assertFalse(admin().indices().prepareGetAliases("alias2").get().getAliases().isEmpty());
+            assertThat(indicesAdmin().prepareGetAliases("alias2").execute().actionGet().getAliases().get("test").size(), equalTo(1));
+            assertFalse(indicesAdmin().prepareGetAliases("alias2").get().getAliases().isEmpty());
 
         } finally {
             disableIndexBlock("test", SETTING_READ_ONLY);
@@ -1203,14 +1193,14 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
             assertAliasesVersionUnchanged(
                 "test",
-                () -> assertBlocked(admin().indices().prepareAliases().addAlias("test", "alias3"), INDEX_METADATA_BLOCK)
+                () -> assertBlocked(indicesAdmin().prepareAliases().addAlias("test", "alias3"), INDEX_METADATA_BLOCK)
             );
             assertAliasesVersionUnchanged(
                 "test",
-                () -> assertBlocked(admin().indices().prepareAliases().removeAlias("test", "alias2"), INDEX_METADATA_BLOCK)
+                () -> assertBlocked(indicesAdmin().prepareAliases().removeAlias("test", "alias2"), INDEX_METADATA_BLOCK)
             );
-            assertBlocked(admin().indices().prepareGetAliases("alias2"), INDEX_METADATA_BLOCK);
-            assertBlocked(admin().indices().prepareGetAliases("alias2"), INDEX_METADATA_BLOCK);
+            assertBlocked(indicesAdmin().prepareGetAliases("alias2"), INDEX_METADATA_BLOCK);
+            assertBlocked(indicesAdmin().prepareGetAliases("alias2"), INDEX_METADATA_BLOCK);
 
         } finally {
             disableIndexBlock("test", SETTING_BLOCKS_METADATA);
@@ -1221,8 +1211,8 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertAcked(prepareCreate("foo_foo"));
         assertAcked(prepareCreate("bar_bar"));
         assertAliasesVersionIncreases(new String[] { "foo_foo", "bar_bar" }, () -> {
-            assertAcked(admin().indices().prepareAliases().addAlias("foo_foo", "foo"));
-            assertAcked(admin().indices().prepareAliases().addAlias("bar_bar", "foo"));
+            assertAcked(indicesAdmin().prepareAliases().addAlias("foo_foo", "foo"));
+            assertAcked(indicesAdmin().prepareAliases().addAlias("bar_bar", "foo"));
         });
 
         IllegalArgumentException iae = expectThrows(
@@ -1236,12 +1226,12 @@ public class IndexAliasesIT extends ESIntegTestCase {
 
         assertAcked(indicesAdmin().prepareAliases().removeIndex("foo*"));
         assertFalse(indexExists("foo_foo"));
-        assertFalse(admin().indices().prepareGetAliases("foo").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("foo").get().getAliases().isEmpty());
         assertTrue(indexExists("bar_bar"));
-        assertFalse(admin().indices().prepareGetAliases("foo").setIndices("bar_bar").get().getAliases().isEmpty());
+        assertFalse(indicesAdmin().prepareGetAliases("foo").setIndices("bar_bar").get().getAliases().isEmpty());
 
         assertAcked(indicesAdmin().prepareAliases().removeIndex("bar_bar"));
-        assertTrue(admin().indices().prepareGetAliases("foo").get().getAliases().isEmpty());
+        assertTrue(indicesAdmin().prepareGetAliases("foo").get().getAliases().isEmpty());
         assertFalse(indexExists("bar_bar"));
     }
 
@@ -1261,61 +1251,57 @@ public class IndexAliasesIT extends ESIntegTestCase {
         final String alias = randomAlphaOfLength(7).toLowerCase(Locale.ROOT);
         createIndex(index1, index2);
 
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias)));
 
         IllegalStateException ex = expectThrows(IllegalStateException.class, () -> {
-            AcknowledgedResponse res = admin().indices()
-                .prepareAliases()
+            AcknowledgedResponse res = indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(true))
                 .get();
         });
         logger.error("exception: {}", ex.getMessage());
         assertThat(ex.getMessage(), containsString("has is_hidden set to true on indices"));
 
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.remove().index(index1).alias(alias)));
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(false)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index(index1).alias(alias)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(false)));
         expectThrows(
             IllegalStateException.class,
-            () -> admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(true)).get()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(true)).get()
         );
 
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.remove().index(index1).alias(alias)));
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(true)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index(index1).alias(alias)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(true)));
         expectThrows(
             IllegalStateException.class,
-            () -> admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(false)).get()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(false)).get()
         );
         expectThrows(
             IllegalStateException.class,
-            () -> admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias)).get()
+            () -> indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias)).get()
         );
 
         // Both visible
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.remove().index(index1).alias(alias)));
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(false)));
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(false)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.remove().index(index1).alias(alias)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(false)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(false)));
 
         // Both hidden
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.remove().index(index1).alias(alias))
                 .addAliasAction(AliasActions.remove().index(index2).alias(alias))
         );
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(true)));
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(true)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(true)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(true)));
 
         // Visible on one, then update it to hidden & add to a second as hidden simultaneously
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.remove().index(index1).alias(alias))
                 .addAliasAction(AliasActions.remove().index(index2).alias(alias))
         );
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(false)));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(false)));
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.add().index(index1).alias(alias).isHidden(true))
                 .addAliasAction(AliasActions.add().index(index2).alias(alias).isHidden(true))
         );
@@ -1328,8 +1314,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         createIndex(writeIndex, nonWriteIndex);
 
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.add().index(writeIndex).alias(alias).isHidden(true).writeIndex(true))
                 .addAliasAction(AliasActions.add().index(nonWriteIndex).alias(alias).isHidden(true))
         );
@@ -1384,7 +1369,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
     }
 
     private void checkAliases() {
-        GetAliasesResponse getAliasesResponse = admin().indices().prepareGetAliases("alias1").get();
+        GetAliasesResponse getAliasesResponse = indicesAdmin().prepareGetAliases("alias1").get();
         assertThat(getAliasesResponse.getAliases().get("test").size(), equalTo(1));
         AliasMetadata aliasMetadata = getAliasesResponse.getAliases().get("test").get(0);
         assertThat(aliasMetadata.alias(), equalTo("alias1"));
@@ -1393,7 +1378,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(aliasMetadata.searchRouting(), nullValue());
         assertThat(aliasMetadata.isHidden(), nullValue());
 
-        getAliasesResponse = admin().indices().prepareGetAliases("alias2").get();
+        getAliasesResponse = indicesAdmin().prepareGetAliases("alias2").get();
         assertThat(getAliasesResponse.getAliases().get("test").size(), equalTo(1));
         aliasMetadata = getAliasesResponse.getAliases().get("test").get(0);
         assertThat(aliasMetadata.alias(), equalTo("alias2"));
@@ -1402,7 +1387,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(aliasMetadata.searchRouting(), nullValue());
         assertThat(aliasMetadata.isHidden(), nullValue());
 
-        getAliasesResponse = admin().indices().prepareGetAliases("alias3").get();
+        getAliasesResponse = indicesAdmin().prepareGetAliases("alias3").get();
         assertThat(getAliasesResponse.getAliases().get("test").size(), equalTo(1));
         aliasMetadata = getAliasesResponse.getAliases().get("test").get(0);
         assertThat(aliasMetadata.alias(), equalTo("alias3"));
@@ -1411,7 +1396,7 @@ public class IndexAliasesIT extends ESIntegTestCase {
         assertThat(aliasMetadata.searchRouting(), equalTo("search"));
         assertThat(aliasMetadata.isHidden(), nullValue());
 
-        getAliasesResponse = admin().indices().prepareGetAliases("alias4").get();
+        getAliasesResponse = indicesAdmin().prepareGetAliases("alias4").get();
         assertThat(getAliasesResponse.getAliases().get("test").size(), equalTo(1));
         aliasMetadata = getAliasesResponse.getAliases().get("test").get(0);
         assertThat(aliasMetadata.alias(), equalTo("alias4"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/NetNewSystemIndexAliasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/NetNewSystemIndexAliasIT.java
@@ -49,7 +49,7 @@ public class NetNewSystemIndexAliasIT extends ESIntegTestCase {
         ensureGreen();
 
         GetAliasesRequest getAliasesRequest = new GetAliasesRequest();
-        GetAliasesResponse aliasResponse = client().admin().indices().getAliases(getAliasesRequest).get();
+        GetAliasesResponse aliasResponse = indicesAdmin().getAliases(getAliasesRequest).get();
         assertThat(aliasResponse.getAliases().size(), is(0));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/aliases/SystemIndexAliasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/aliases/SystemIndexAliasIT.java
@@ -37,7 +37,7 @@ public class SystemIndexAliasIT extends ESIntegTestCase {
     public void testCreateAliasForSystemIndex() throws Exception {
         createIndex(PRIMARY_INDEX_NAME);
         ensureGreen();
-        assertAcked(admin().indices().prepareAliases().addAlias(PRIMARY_INDEX_NAME, INDEX_NAME + "-system-alias"));
+        assertAcked(indicesAdmin().prepareAliases().addAlias(PRIMARY_INDEX_NAME, INDEX_NAME + "-system-alias"));
 
         final GetAliasesResponse getAliasesResponse = indicesAdmin().getAliases(
             new GetAliasesRequest().indicesOptions(IndicesOptions.strictExpandHidden())
@@ -51,6 +51,6 @@ public class SystemIndexAliasIT extends ESIntegTestCase {
         );
         getAliasesResponse.getAliases().get(PRIMARY_INDEX_NAME).forEach(alias -> assertThat(alias.isHidden(), is(true)));
 
-        assertAcked(client().admin().indices().prepareDeleteTemplate("*").get());
+        assertAcked(indicesAdmin().prepareDeleteTemplate("*").get());
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterHealthIT.java
@@ -98,7 +98,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         }
 
         createIndex("index-2");
-        assertAcked(client().admin().indices().prepareClose("index-2"));
+        assertAcked(indicesAdmin().prepareClose("index-2"));
 
         {
             ClusterHealthResponse response = clusterAdmin().prepareHealth().setWaitForGreenStatus().get();
@@ -152,7 +152,7 @@ public class ClusterHealthIT extends ESIntegTestCase {
         }
 
         createIndex("index-3", Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 50).build());
-        assertAcked(client().admin().indices().prepareClose("index-3"));
+        assertAcked(indicesAdmin().prepareClose("index-3"));
 
         {
             ClusterHealthResponse response = clusterAdmin().prepareHealth()

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/ClusterInfoServiceIT.java
@@ -143,7 +143,7 @@ public class ClusterInfoServiceIT extends ESIntegTestCase {
             )
         );
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareClose(indexName));
+            assertAcked(indicesAdmin().prepareClose(indexName));
         }
         ensureGreen(indexName);
         InternalTestCluster internalTestCluster = internalCluster();

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/DesiredNodesSnapshotsIT.java
@@ -36,7 +36,7 @@ public class DesiredNodesSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final var snapshotName = "snapshot";
         createFullSnapshot(repositoryName, snapshotName);
 
-        client().admin().indices().prepareDelete(indexName).get();
+        indicesAdmin().prepareDelete(indexName).get();
 
         final var updateDesiredNodesWithNewHistoryRequest = randomUpdateDesiredNodesRequest();
         final var updateDesiredNodesResponse = updateDesiredNodes(updateDesiredNodesWithNewHistoryRequest);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/MinimumMasterNodesIT.java
@@ -262,7 +262,7 @@ public class MinimumMasterNodesIT extends ESIntegTestCase {
             equalTo(false)
         );
         // flush for simpler debugging
-        client().admin().indices().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().execute().actionGet();
 
         refresh();
         logger.info("--> verify we get the data back");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleClusterStateIT.java
@@ -183,7 +183,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         ClusterStateResponse clusterStateResponseUnfiltered = client().admin().cluster().prepareState().get();
         assertThat(clusterStateResponseUnfiltered.getState().metadata().templates().size(), is(greaterThanOrEqualTo(2)));
 
-        GetIndexTemplatesResponse getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates("foo_template").get();
+        GetIndexTemplatesResponse getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates("foo_template").get();
         assertIndexTemplateExists(getIndexTemplatesResponse, "foo_template");
     }
 
@@ -258,7 +258,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
                 .get()
         );
         ensureGreen(); // wait for green state, so its both green, and there are no more pending events
-        MappingMetadata masterMappingMetadata = client().admin().indices().prepareGetMappings("test").get().getMappings().get("test");
+        MappingMetadata masterMappingMetadata = indicesAdmin().prepareGetMappings("test").get().getMappings().get("test");
         for (Client client : clients()) {
             MappingMetadata mappingMetadata = client.admin()
                 .indices()
@@ -278,7 +278,7 @@ public class SimpleClusterStateIT extends ESIntegTestCase {
         ensureGreen("fuu");
 
         // close one index
-        assertAcked(client().admin().indices().close(new CloseIndexRequest("fuu")).get());
+        assertAcked(indicesAdmin().close(new CloseIndexRequest("fuu")).get());
         clusterStateResponse = client().admin().cluster().prepareState().clear().setMetadata(true).setIndices("f*").get();
         assertThat(clusterStateResponse.getState().metadata().indices().size(), is(1));
         assertThat(clusterStateResponse.getState().metadata().index("foo").getState(), equalTo(IndexMetadata.State.OPEN));

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/SimpleDataNodesIT.java
@@ -36,7 +36,7 @@ public class SimpleDataNodesIT extends ESIntegTestCase {
 
     public void testIndexingBeforeAndAfterDataNodesStart() {
         internalCluster().startNode(nonDataNode());
-        client().admin().indices().create(new CreateIndexRequest("test").waitForActiveShards(ActiveShardCount.NONE)).actionGet();
+        indicesAdmin().create(new CreateIndexRequest("test").waitForActiveShards(ActiveShardCount.NONE)).actionGet();
         try {
             client().index(new IndexRequest("test").id("1").source(SOURCE, XContentType.JSON).timeout(timeValueSeconds(1))).actionGet();
             fail("no allocation should happen");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RareClusterStateIT.java
@@ -75,7 +75,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         ensureGreen(index);
 
         // close to have some unassigned started shards shards..
-        client().admin().indices().prepareClose(index).get();
+        indicesAdmin().prepareClose(index).get();
 
         final String masterName = internalCluster().getMasterName();
         final ClusterService clusterService = internalCluster().clusterService(masterName);
@@ -192,7 +192,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         refresh();
         disruption.startDisrupting();
         logger.info("--> delete index");
-        executeAndCancelCommittedPublication(client().admin().indices().prepareDelete("test").setTimeout("0s")).get(10, TimeUnit.SECONDS);
+        executeAndCancelCommittedPublication(indicesAdmin().prepareDelete("test").setTimeout("0s")).get(10, TimeUnit.SECONDS);
         logger.info("--> and recreate it");
         executeAndCancelCommittedPublication(
             prepareCreate("test").setSettings(
@@ -262,12 +262,12 @@ public class RareClusterStateIT extends ESIntegTestCase {
 
         // Add a new mapping...
         ActionFuture<AcknowledgedResponse> putMappingResponse = executeAndCancelCommittedPublication(
-            client().admin().indices().preparePutMapping("index").setSource("field", "type=long")
+            indicesAdmin().preparePutMapping("index").setSource("field", "type=long")
         );
 
         // ...and wait for mappings to be available on master
         assertBusy(() -> {
-            MappingMetadata typeMappings = client().admin().indices().prepareGetMappings("index").get().getMappings().get("index");
+            MappingMetadata typeMappings = indicesAdmin().prepareGetMappings("index").get().getMappings().get("index");
             assertNotNull(typeMappings);
             Object properties;
             try {
@@ -344,7 +344,7 @@ public class RareClusterStateIT extends ESIntegTestCase {
         internalCluster().setDisruptionScheme(disruption);
         disruption.startDisrupting();
         final ActionFuture<AcknowledgedResponse> putMappingResponse = executeAndCancelCommittedPublication(
-            client().admin().indices().preparePutMapping("index").setSource("field", "type=long")
+            indicesAdmin().preparePutMapping("index").setSource("field", "type=long")
         );
 
         final Index index = resolveIndex("index");

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveCustomsCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/RemoveCustomsCommandIT.java
@@ -45,7 +45,7 @@ public class RemoveCustomsCommandIT extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
         String node = internalCluster().startNode();
         createIndex("test");
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
         assertEquals(1, client().admin().cluster().prepareState().get().getState().metadata().indexGraveyard().getTombstones().size());
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
         ensureStableCluster(1);
@@ -71,7 +71,7 @@ public class RemoveCustomsCommandIT extends ESIntegTestCase {
         internalCluster().setBootstrapMasterNodeIndex(0);
         String node = internalCluster().startNode();
         createIndex("test");
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
         assertEquals(1, client().admin().cluster().prepareState().get().getState().metadata().indexGraveyard().getTombstones().size());
         Settings dataPathSettings = internalCluster().dataPathSettings(node);
         ensureStableCluster(1);

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/coordination/ZenDiscoveryIT.java
@@ -44,7 +44,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
 
         createIndex("test");
         ensureSearchable("test");
-        RecoveryResponse r = client().admin().indices().prepareRecoveries("test").get();
+        RecoveryResponse r = indicesAdmin().prepareRecoveries("test").get();
         int numRecoveriesBeforeNewMaster = r.shardRecoveryStates().get("test").size();
 
         final String oldMaster = internalCluster().getMasterName();
@@ -56,7 +56,7 @@ public class ZenDiscoveryIT extends ESIntegTestCase {
         });
         ensureSearchable("test");
 
-        r = client().admin().indices().prepareRecoveries("test").get();
+        r = indicesAdmin().prepareRecoveries("test").get();
         int numRecoveriesAfterNewMaster = r.shardRecoveryStates().get("test").size();
         assertThat(numRecoveriesAfterNewMaster, equalTo(numRecoveriesBeforeNewMaster));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/TemplateUpgradeServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/metadata/TemplateUpgradeServiceIT.java
@@ -139,7 +139,7 @@ public class TemplateUpgradeServiceIT extends ESIntegTestCase {
             // the updates only happen on cluster state updates, so we need to make sure that the cluster state updates are happening
             // so we need to simulate updates to make sure the template upgrade kicks in
             updateClusterSettings(Settings.builder().put(TestPlugin.UPDATE_TEMPLATE_DUMMY_SETTING.getKey(), updateCount.incrementAndGet()));
-            List<IndexTemplateMetadata> templates = client().admin().indices().prepareGetTemplates("test_*").get().getIndexTemplates();
+            List<IndexTemplateMetadata> templates = indicesAdmin().prepareGetTemplates("test_*").get().getIndexTemplates();
             assertThat(templates, hasSize(3));
             boolean addedFound = false;
             boolean changedFound = false;

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/DiskThresholdMonitorIT.java
@@ -55,7 +55,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
                 .build()
         );
         // ensure we have a system index on the data node too.
-        assertAcked(client().admin().indices().prepareCreate(TaskResultsService.TASK_INDEX));
+        assertAcked(indicesAdmin().prepareCreate(TaskResultsService.TASK_INDEX));
 
         getTestFileStore(dataNodeName).setTotalSpace(1L);
         refreshClusterInfo();
@@ -110,7 +110,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
                 .build()
         );
         // ensure we have a system index on the data node too.
-        assertAcked(client().admin().indices().prepareCreate(TaskResultsService.TASK_INDEX));
+        assertAcked(indicesAdmin().prepareCreate(TaskResultsService.TASK_INDEX));
 
         getTestFileStore(dataNodeName).setTotalSpace(1L);
         refreshClusterInfo();
@@ -143,7 +143,7 @@ public class DiskThresholdMonitorIT extends DiskUsageIntegTestCase {
 
     // Retrieves the value of the given block on an index.
     private static String getIndexBlock(String indexName, String blockName) {
-        return client().admin().indices().prepareGetSettings(indexName).setNames(blockName).get().getSetting(indexName, blockName);
+        return indicesAdmin().prepareGetSettings(indexName).setNames(blockName).get().getSetting(indexName, blockName);
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/routing/allocation/decider/MockDiskUsagesIT.java
@@ -443,7 +443,7 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
             assertThat("node2 has 2 shards", shardCountByNodeId.get(nodeIds.get(2)), equalTo(2));
         }
 
-        final long shardsOnGoodPath = Arrays.stream(client().admin().indices().prepareStats("test").get().getShards())
+        final long shardsOnGoodPath = Arrays.stream(indicesAdmin().prepareStats("test").get().getShards())
             .filter(
                 shardStats -> shardStats.getShardRouting().currentNodeId().equals(nodeWithTwoPaths)
                     && shardStats.getDataPath().startsWith(pathOverWatermark.toString()) == false
@@ -468,20 +468,20 @@ public class MockDiskUsagesIT extends ESIntegTestCase {
         logger.info("--> waiting for shards to relocate off path [{}]", pathOverWatermark);
 
         assertBusy(() -> {
-            for (final ShardStats shardStats : client().admin().indices().prepareStats("test").get().getShards()) {
+            for (final ShardStats shardStats : indicesAdmin().prepareStats("test").get().getShards()) {
                 assertThat(shardStats.getDataPath(), not(startsWith(pathOverWatermark.toString())));
             }
         });
 
         ensureGreen("test");
 
-        for (final ShardStats shardStats : client().admin().indices().prepareStats("test").get().getShards()) {
+        for (final ShardStats shardStats : indicesAdmin().prepareStats("test").get().getShards()) {
             assertThat(shardStats.getDataPath(), not(startsWith(pathOverWatermark.toString())));
         }
 
         assertThat(
             "should not have moved any shards off of the path that wasn't too full",
-            Arrays.stream(client().admin().indices().prepareStats("test").get().getShards())
+            Arrays.stream(indicesAdmin().prepareStats("test").get().getShards())
                 .filter(
                     shardStats -> shardStats.getShardRouting().currentNodeId().equals(nodeWithTwoPaths)
                         && shardStats.getDataPath().startsWith(pathOverWatermark.toString()) == false

--- a/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/cluster/shards/ClusterShardLimitIT.java
@@ -126,7 +126,7 @@ public class ClusterShardLimitIT extends ESIntegTestCase {
 
         final IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin().indices().prepareCreate("should-fail").get()
+            () -> indicesAdmin().prepareCreate("should-fail").get()
         );
         verifyException(dataNodes, counts, e);
         ClusterState clusterState = clusterAdmin().prepareState().get().getState();

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiskDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/DiskDisruptionIT.java
@@ -111,7 +111,7 @@ public class DiskDisruptionIT extends AbstractDisruptionTestCase {
         final Thread globalCheckpointSampler = new Thread(() -> {
             while (stopGlobalCheckpointFetcher.get() == false) {
                 try {
-                    for (ShardStats shardStats : client().admin().indices().prepareStats("test").clear().get().getShards()) {
+                    for (ShardStats shardStats : indicesAdmin().prepareStats("test").clear().get().getShards()) {
                         final int shardId = shardStats.getShardRouting().id();
                         final long globalCheckpoint = shardStats.getSeqNoStats().getGlobalCheckpoint();
                         shardToGcp.compute(shardId, (i, v) -> Math.max(v, globalCheckpoint));
@@ -166,7 +166,7 @@ public class DiskDisruptionIT extends AbstractDisruptionTestCase {
         logger.info("waiting for green");
         ensureGreen("test");
 
-        for (ShardStats shardStats : client().admin().indices().prepareStats("test").clear().get().getShards()) {
+        for (ShardStats shardStats : indicesAdmin().prepareStats("test").clear().get().getShards()) {
             final int shardId = shardStats.getShardRouting().id();
             final long maxSeqNo = shardStats.getSeqNoStats().getMaxSeqNo();
             if (shardStats.getShardRouting().active()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/MasterDisruptionIT.java
@@ -249,7 +249,7 @@ public class MasterDisruptionIT extends AbstractDisruptionTestCase {
         disruption.stopDisrupting();
 
         assertBusy(() -> {
-            IndicesStatsResponse stats = client().admin().indices().prepareStats("test").clear().get();
+            IndicesStatsResponse stats = indicesAdmin().prepareStats("test").clear().get();
             for (ShardStats shardStats : stats.getShards()) {
                 assertThat(
                     shardStats.getShardRouting().toString(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/discovery/SnapshotDisruptionIT.java
@@ -186,7 +186,7 @@ public class SnapshotDisruptionIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> done");
 
         logger.info("--> recreate the index with potentially different shard counts");
-        client().admin().indices().prepareDelete(idxName).get();
+        indicesAdmin().prepareDelete(idxName).get();
         createIndex(idxName);
         index(idxName, JsonXContent.contentBuilder().startObject().field("foo", "bar").endObject());
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/AliasedIndexDocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/AliasedIndexDocumentActionsIT.java
@@ -17,7 +17,7 @@ public class AliasedIndexDocumentActionsIT extends DocumentActionsIT {
     protected void createIndex() {
         logger.info("Creating index [test1] with alias [test]");
         try {
-            client().admin().indices().prepareDelete("test1").execute().actionGet();
+            indicesAdmin().prepareDelete("test1").execute().actionGet();
         } catch (Exception e) {
             // ignore
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/DocumentActionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/DocumentActionsIT.java
@@ -118,7 +118,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
         assertThat(deleteResponse.getIndex(), equalTo(getConcreteIndexName()));
         assertThat(deleteResponse.getId(), equalTo("1"));
         logger.info("Refreshing");
-        client().admin().indices().refresh(new RefreshRequest("test")).actionGet();
+        indicesAdmin().refresh(new RefreshRequest("test")).actionGet();
 
         logger.info("Get [type1/1] (should be empty)");
         for (int i = 0; i < 5; i++) {
@@ -132,11 +132,11 @@ public class DocumentActionsIT extends ESIntegTestCase {
         client().index(new IndexRequest("test").id("2").source(source("2", "test2"))).actionGet();
 
         logger.info("Flushing");
-        FlushResponse flushResult = client().admin().indices().prepareFlush("test").execute().actionGet();
+        FlushResponse flushResult = indicesAdmin().prepareFlush("test").execute().actionGet();
         assertThat(flushResult.getSuccessfulShards(), equalTo(numShards.totalNumShards));
         assertThat(flushResult.getFailedShards(), equalTo(0));
         logger.info("Refreshing");
-        client().admin().indices().refresh(new RefreshRequest("test")).actionGet();
+        indicesAdmin().refresh(new RefreshRequest("test")).actionGet();
 
         logger.info("Get [type1/1] and [type1/2]");
         for (int i = 0; i < 5; i++) {
@@ -222,7 +222,7 @@ public class DocumentActionsIT extends ESIntegTestCase {
         assertThat(bulkResponse.getItems()[5].getIndex(), equalTo(getConcreteIndexName()));
 
         waitForRelocation(ClusterHealthStatus.GREEN);
-        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh("test").execute().actionGet();
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh("test").execute().actionGet();
         assertNoFailures(refreshResponse);
         assertThat(refreshResponse.getSuccessfulShards(), equalTo(numShards.totalNumShards));
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/document/ShardInfoIT.java
@@ -122,7 +122,7 @@ public class ShardInfoIT extends ESIntegTestCase {
             ClusterHealthResponse healthResponse = clusterAdmin().prepareHealth("idx").setWaitForNoRelocatingShards(true).get();
             assertThat(healthResponse.isTimedOut(), equalTo(false));
 
-            RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("idx").setActiveOnly(true).get();
+            RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries("idx").setActiveOnly(true).get();
             assertThat(recoveryResponse.shardRecoveryStates().get("idx").size(), equalTo(0));
         });
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/MetadataNodesIT.java
@@ -77,7 +77,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
         assertIndexInMetaState(masterNode, index);
         assertIndexDirectoryDeleted(masterNode, resolveIndex);
 
-        client().admin().indices().prepareDelete(index).get();
+        indicesAdmin().prepareDelete(index).get();
         assertIndexDirectoryDeleted(node1, resolveIndex);
         assertIndexDirectoryDeleted(node2, resolveIndex);
     }
@@ -96,7 +96,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
         assertIndexInMetaState(masterNode, index);
 
         logger.info("--> close index");
-        client().admin().indices().prepareClose(index).get();
+        indicesAdmin().prepareClose(index).get();
         // close the index
         ClusterStateResponse clusterStateResponse = clusterAdmin().prepareState().get();
         assertThat(clusterStateResponse.getState().getMetadata().index(index).getState().name(), equalTo(IndexMetadata.State.CLOSE.name()));
@@ -114,7 +114,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
             )
             .get();
 
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings(index).get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings(index).get();
         assertNotNull(
             ((Map<String, ?>) (getMappingsResponse.getMappings().get(index).getSourceAsMap().get("properties"))).get("integer_field")
         );
@@ -145,7 +145,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
             )
             .get();
 
-        getMappingsResponse = client().admin().indices().prepareGetMappings(index).get();
+        getMappingsResponse = indicesAdmin().prepareGetMappings(index).get();
         assertNotNull(
             ((Map<String, ?>) (getMappingsResponse.getMappings().get(index).getSourceAsMap().get("properties"))).get("float_field")
         );
@@ -156,7 +156,7 @@ public class MetadataNodesIT extends ESIntegTestCase {
         assertThat(indicesMetadata.get(index).getState(), equalTo(IndexMetadata.State.CLOSE));
 
         // finally check that meta data is also written of index opened again
-        assertAcked(client().admin().indices().prepareOpen(index).get());
+        assertAcked(indicesAdmin().prepareOpen(index).get());
         // make sure index is fully initialized and nothing is changed anymore
         ensureGreen();
         indicesMetadata = getIndicesMetadataOnNode(dataNode);

--- a/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/gateway/ReplicaShardAllocatorSyncIdIT.java
@@ -174,14 +174,14 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
             IntStream.range(0, between(100, 500)).mapToObj(n -> client().prepareIndex(indexName).setSource("f", "v")).toList()
         );
         if (randomBoolean()) {
-            client().admin().indices().prepareFlush(indexName).get();
+            indicesAdmin().prepareFlush(indexName).get();
         }
         ensureGlobalCheckpointAdvancedAndSynced(indexName);
         syncFlush(indexName);
         internalCluster().stopNode(nodeWithReplica);
         // Wait until the peer recovery retention leases of the offline node are expired
         assertBusy(() -> {
-            for (ShardStats shardStats : client().admin().indices().prepareStats(indexName).get().getShards()) {
+            for (ShardStats shardStats : indicesAdmin().prepareStats(indexName).get().getShards()) {
                 assertThat(shardStats.getRetentionLeaseStats().retentionLeases().leases(), hasSize(1));
             }
         });
@@ -207,7 +207,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
         recoveryStarted.await();
         nodeWithReplica = internalCluster().startDataOnlyNode(nodeWithReplicaSettings);
         // AllocationService only calls GatewayAllocator if there are unassigned shards
-        assertAcked(client().admin().indices().prepareCreate("dummy-index").setWaitForActiveShards(0));
+        assertAcked(indicesAdmin().prepareCreate("dummy-index").setWaitForActiveShards(0));
         ensureGreen(indexName);
         assertThat(internalCluster().nodesInclude(indexName), containsInAnyOrder(nodeWithPrimary, nodeWithReplica));
         assertNoOpRecoveries(indexName);
@@ -239,7 +239,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
             IntStream.range(0, between(200, 500)).mapToObj(n -> client().prepareIndex(indexName).setSource("f", "v")).toList()
         );
         if (randomBoolean()) {
-            client().admin().indices().prepareFlush(indexName).get();
+            indicesAdmin().prepareFlush(indexName).get();
         }
         ensureGlobalCheckpointAdvancedAndSynced(indexName);
         syncFlush(indexName);
@@ -248,7 +248,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
         ensureYellow(indexName);
         // Wait until the peer recovery retention leases of the offline node are expired
         assertBusy(() -> {
-            for (ShardStats shardStats : client().admin().indices().prepareStats(indexName).get().getShards()) {
+            for (ShardStats shardStats : indicesAdmin().prepareStats(indexName).get().getShards()) {
                 assertThat(shardStats.getRetentionLeaseStats().retentionLeases().leases(), hasSize(1));
             }
         });
@@ -278,7 +278,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
             );
         }
         if (randomBoolean()) {
-            client().admin().indices().prepareFlush(indexName).get();
+            indicesAdmin().prepareFlush(indexName).get();
         }
         if (randomBoolean()) {
             syncFlush(indexName);
@@ -311,7 +311,7 @@ public class ReplicaShardAllocatorSyncIdIT extends ESIntegTestCase {
     }
 
     private void assertNoOpRecoveries(String indexName) {
-        for (RecoveryState recovery : client().admin().indices().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
+        for (RecoveryState recovery : indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
             if (recovery.getPrimary() == false) {
                 assertThat(recovery.getIndex().fileDetails(), empty());
                 assertThat(recovery.getTranslog().totalLocal(), equalTo(recovery.getTranslog().totalOperations()));

--- a/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/get/GetActionIT.java
@@ -195,13 +195,13 @@ public class GetActionIT extends ESIntegTestCase {
     }
 
     public void testGetWithAliasPointingToMultipleIndices() {
-        client().admin().indices().prepareCreate("index1").addAlias(new Alias("alias1").indexRouting("0")).get();
+        indicesAdmin().prepareCreate("index1").addAlias(new Alias("alias1").indexRouting("0")).get();
         if (randomBoolean()) {
             indicesAdmin().prepareCreate("index2")
                 .addAlias(new Alias("alias1").indexRouting("0").writeIndex(randomFrom(false, null)))
                 .get();
         } else {
-            client().admin().indices().prepareCreate("index3").addAlias(new Alias("alias1").indexRouting("1").writeIndex(true)).get();
+            indicesAdmin().prepareCreate("index3").addAlias(new Alias("alias1").indexRouting("1").writeIndex(true)).get();
         }
         IndexResponse indexResponse = client().prepareIndex("index1").setId("id").setSource(Collections.singletonMap("foo", "bar")).get();
         assertThat(indexResponse.status().getStatus(), equalTo(RestStatus.CREATED.getStatus()));
@@ -646,7 +646,7 @@ public class GetActionIT extends ESIntegTestCase {
         ensureGreen();
 
         logger.info("flushing");
-        FlushResponse flushResponse = client().admin().indices().prepareFlush("my-index").setForce(true).get();
+        FlushResponse flushResponse = indicesAdmin().prepareFlush("my-index").setForce(true).get();
         if (flushResponse.getSuccessfulShards() == 0) {
             StringBuilder sb = new StringBuilder("failed to flush at least one shard. total shards [").append(
                 flushResponse.getTotalShards()

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/FinalPipelineIT.java
@@ -335,15 +335,13 @@ public class FinalPipelineIT extends ESIntegTestCase {
         final Settings defaultPipelineSettings = Settings.builder()
             .put(IndexSettings.DEFAULT_PIPELINE.getKey(), "default_pipeline")
             .build();
-        admin().indices()
-            .preparePutTemplate("default")
+        indicesAdmin().preparePutTemplate("default")
             .setPatterns(List.of("index*"))
             .setOrder(defaultPipelineOrder)
             .setSettings(defaultPipelineSettings)
             .get();
         final Settings finalPipelineSettings = Settings.builder().put(IndexSettings.FINAL_PIPELINE.getKey(), "final_pipeline").build();
-        admin().indices()
-            .preparePutTemplate("final")
+        indicesAdmin().preparePutTemplate("final")
             .setPatterns(List.of("index*"))
             .setOrder(finalPipelineOrder)
             .setSettings(finalPipelineSettings)
@@ -369,8 +367,7 @@ public class FinalPipelineIT extends ESIntegTestCase {
         final Settings lowOrderFinalPipelineSettings = Settings.builder()
             .put(IndexSettings.FINAL_PIPELINE.getKey(), "low_order_final_pipeline")
             .build();
-        admin().indices()
-            .preparePutTemplate("low_order")
+        indicesAdmin().preparePutTemplate("low_order")
             .setPatterns(List.of("index*"))
             .setOrder(lowOrder)
             .setSettings(lowOrderFinalPipelineSettings)
@@ -378,8 +375,7 @@ public class FinalPipelineIT extends ESIntegTestCase {
         final Settings highOrderFinalPipelineSettings = Settings.builder()
             .put(IndexSettings.FINAL_PIPELINE.getKey(), "high_order_final_pipeline")
             .build();
-        admin().indices()
-            .preparePutTemplate("high_order")
+        indicesAdmin().preparePutTemplate("high_order")
             .setPatterns(List.of("index*"))
             .setOrder(highOrder)
             .setSettings(highOrderFinalPipelineSettings)

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/HiddenIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/HiddenIndexIT.java
@@ -146,9 +146,7 @@ public class HiddenIndexIT extends ESIntegTestCase {
         assertAcked(indicesAdmin().prepareCreate(hiddenIndex).setSettings(Settings.builder().put("index.hidden", true).build()).get());
 
         assertAcked(
-            admin().indices()
-                .prepareAliases()
-                .addAliasAction(IndicesAliasesRequest.AliasActions.add().index(hiddenIndex).alias(visibleAlias))
+            indicesAdmin().prepareAliases().addAliasAction(IndicesAliasesRequest.AliasActions.add().index(hiddenIndex).alias(visibleAlias))
         );
 
         // The index should be returned here when queried by name or by wildcard because the alias is visible
@@ -165,8 +163,7 @@ public class HiddenIndexIT extends ESIntegTestCase {
 
         // Now try with a hidden alias
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(IndicesAliasesRequest.AliasActions.remove().index(hiddenIndex).alias(visibleAlias))
                 .addAliasAction(IndicesAliasesRequest.AliasActions.add().index(hiddenIndex).alias(hiddenAlias).isHidden(true))
         );
@@ -189,8 +186,7 @@ public class HiddenIndexIT extends ESIntegTestCase {
 
         // Now try with a hidden alias that starts with a dot
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(IndicesAliasesRequest.AliasActions.remove().index(hiddenIndex).alias(hiddenAlias))
                 .addAliasAction(IndicesAliasesRequest.AliasActions.add().index(hiddenIndex).alias(dotHiddenAlias).isHidden(true))
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/IndexSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/IndexSettingsIT.java
@@ -43,7 +43,7 @@ public class IndexSettingsIT extends ESIntegTestCase {
         try {
             internalCluster().fullRestart();
 
-            final var indicesClient = client().admin().indices();
+            final var indicesClient = indicesAdmin();
             assertThat(indicesClient.prepareGetSettings("test").get().getSetting("test", "archived.index.test_setting"), equalTo("true"));
             updateIndexSettings(Settings.builder().putNull("archived.*"), "test");
             assertNull(indicesClient.prepareGetSettings("test").get().getSetting("test", "archived.index.test_setting"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/WaitUntilRefreshIT.java
@@ -150,7 +150,7 @@ public class WaitUntilRefreshIT extends ESIntegTestCase {
             .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
             .execute();
         while (false == index.isDone()) {
-            client().admin().indices().prepareRefresh("test").get();
+            indicesAdmin().prepareRefresh("test").get();
         }
         assertEquals(RestStatus.CREATED, index.get().status());
         assertFalse("request shouldn't have forced a refresh", index.get().forcedRefresh());

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/engine/InternalEngineMergeIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/engine/InternalEngineMergeIT.java
@@ -44,7 +44,7 @@ public class InternalEngineMergeIT extends ESIntegTestCase {
             BulkResponse response = request.execute().actionGet();
             refresh();
             assertNoFailures(response);
-            IndicesStatsResponse stats = client().admin().indices().prepareStats("test").setSegments(true).setMerge(true).get();
+            IndicesStatsResponse stats = indicesAdmin().prepareStats("test").setSegments(true).setMerge(true).get();
             logger.info(
                 "index round [{}] - segments {}, total merges {}, current merge {}",
                 i,
@@ -56,7 +56,7 @@ public class InternalEngineMergeIT extends ESIntegTestCase {
         final long upperNumberSegments = 2 * numOfShards * 10;
 
         assertBusy(() -> {
-            IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
+            IndicesStatsResponse stats = indicesAdmin().prepareStats().setSegments(true).setMerge(true).get();
             logger.info(
                 "numshards {}, segments {}, total merges {}, current merge {}",
                 numOfShards,
@@ -70,7 +70,7 @@ public class InternalEngineMergeIT extends ESIntegTestCase {
             assertThat(current, equalTo(0L));
         });
 
-        IndicesStatsResponse stats = client().admin().indices().prepareStats().setSegments(true).setMerge(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats().setSegments(true).setMerge(true).get();
         logger.info(
             "numshards {}, segments {}, total merges {}, current merge {}",
             numOfShards,

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/fielddata/FieldDataLoadingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/fielddata/FieldDataLoadingIT.java
@@ -36,7 +36,7 @@ public class FieldDataLoadingIT extends ESIntegTestCase {
         ensureGreen();
 
         client().prepareIndex("test").setId("1").setSource("name", "name").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         ClusterStatsResponse response = clusterAdmin().prepareClusterStats().get();
         assertThat(response.getIndicesStats().getFieldData().getMemorySizeInBytes(), greaterThan(0L));

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/CopyToMapperIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/CopyToMapperIntegrationIT.java
@@ -26,14 +26,14 @@ import static org.hamcrest.Matchers.equalTo;
 
 public class CopyToMapperIntegrationIT extends ESIntegTestCase {
     public void testDynamicTemplateCopyTo() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test-idx").setMapping(createDynamicTemplateMapping()));
+        assertAcked(indicesAdmin().prepareCreate("test-idx").setMapping(createDynamicTemplateMapping()));
 
         int recordCount = between(1, 200);
 
         for (int i = 0; i < recordCount * 2; i++) {
             client().prepareIndex("test-idx").setId(Integer.toString(i)).setSource("test_field", "test " + i, "even", i % 2 == 0).get();
         }
-        client().admin().indices().prepareRefresh("test-idx").execute().actionGet();
+        indicesAdmin().prepareRefresh("test-idx").execute().actionGet();
 
         SubAggCollectionMode aggCollectionMode = randomFrom(SubAggCollectionMode.values());
 
@@ -64,9 +64,9 @@ public class CopyToMapperIntegrationIT extends ESIntegTestCase {
                 .endObject()
                 .endObject()
         );
-        assertAcked(client().admin().indices().prepareCreate("test-idx").setMapping(mapping));
+        assertAcked(indicesAdmin().prepareCreate("test-idx").setMapping(mapping));
         client().prepareIndex("test-idx").setId("1").setSource("foo", "bar").get();
-        client().admin().indices().prepareRefresh("test-idx").execute().actionGet();
+        indicesAdmin().prepareRefresh("test-idx").execute().actionGet();
         SearchResponse response = client().prepareSearch("test-idx").setQuery(QueryBuilders.termQuery("root.top.child", "bar")).get();
         assertThat(response.getHits().getTotalHits().value, equalTo(1L));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/MultiFieldsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/mapper/MultiFieldsIntegrationIT.java
@@ -34,9 +34,9 @@ import static org.hamcrest.Matchers.nullValue;
 public class MultiFieldsIntegrationIT extends ESIntegTestCase {
     @SuppressWarnings("unchecked")
     public void testMultiFields() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createTypeSource()));
+        assertAcked(indicesAdmin().prepareCreate("my-index").setMapping(createTypeSource()));
 
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
         assertThat(mappingMetadata, not(nullValue()));
         Map<String, Object> mappingSource = mappingMetadata.sourceAsMap();
@@ -52,9 +52,9 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
         searchResponse = client().prepareSearch("my-index").setQuery(matchQuery("title.not_analyzed", "Multi fields")).get();
         assertThat(searchResponse.getHits().getTotalHits().value, equalTo(1L));
 
-        assertAcked(client().admin().indices().preparePutMapping("my-index").setSource(createPutMappingSource()));
+        assertAcked(indicesAdmin().preparePutMapping("my-index").setSource(createPutMappingSource()));
 
-        getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
+        getMappingsResponse = indicesAdmin().prepareGetMappings("my-index").get();
         mappingMetadata = getMappingsResponse.mappings().get("my-index");
         assertThat(mappingMetadata, not(nullValue()));
         mappingSource = mappingMetadata.sourceAsMap();
@@ -74,9 +74,9 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testGeoPointMultiField() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("geo_point")));
+        assertAcked(indicesAdmin().prepareCreate("my-index").setMapping(createMappingSource("geo_point")));
 
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
         assertThat(mappingMetadata, not(nullValue()));
         Map<String, Object> mappingSource = mappingMetadata.sourceAsMap();
@@ -103,9 +103,9 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testCompletionMultiField() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("completion")));
+        assertAcked(indicesAdmin().prepareCreate("my-index").setMapping(createMappingSource("completion")));
 
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
         assertThat(mappingMetadata, not(nullValue()));
         Map<String, Object> mappingSource = mappingMetadata.sourceAsMap();
@@ -125,9 +125,9 @@ public class MultiFieldsIntegrationIT extends ESIntegTestCase {
 
     @SuppressWarnings("unchecked")
     public void testIpMultiField() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("ip")));
+        assertAcked(indicesAdmin().prepareCreate("my-index").setMapping(createMappingSource("ip")));
 
-        GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings("my-index").get();
+        GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings("my-index").get();
         MappingMetadata mappingMetadata = getMappingsResponse.mappings().get("my-index");
         assertThat(mappingMetadata, not(nullValue()));
         Map<String, Object> mappingSource = mappingMetadata.sourceAsMap();

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/GlobalCheckpointSyncIT.java
@@ -62,7 +62,7 @@ public class GlobalCheckpointSyncIT extends ESIntegTestCase {
         }
 
         assertBusy(() -> {
-            SeqNoStats seqNoStats = client().admin().indices().prepareStats("test").get().getIndex("test").getShards()[0].getSeqNoStats();
+            SeqNoStats seqNoStats = indicesAdmin().prepareStats("test").get().getIndex("test").getShards()[0].getSeqNoStats();
             assertThat(seqNoStats.getGlobalCheckpoint(), equalTo(seqNoStats.getMaxSeqNo()));
         });
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseCreationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/seqno/PeerRecoveryRetentionLeaseCreationIT.java
@@ -83,7 +83,7 @@ public class PeerRecoveryRetentionLeaseCreationIT extends ESIntegTestCase {
     }
 
     public RetentionLeases getRetentionLeases() {
-        return client().admin().indices().prepareStats(INDEX_NAME).get().getShards()[0].getRetentionLeaseStats().retentionLeases();
+        return indicesAdmin().prepareStats(INDEX_NAME).get().getShards()[0].getRetentionLeaseStats().retentionLeases();
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/RemoveCorruptedShardDataCommandIT.java
@@ -433,7 +433,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
             SearchRequestBuilder q = client().prepareSearch(indexName).setPreference("_only_nodes:" + node).setQuery(matchAllQuery());
             assertHitCount(q.get(), numDocsToKeep);
         }
-        final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).setActiveOnly(false).get();
+        final RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).setActiveOnly(false).get();
         final RecoveryState replicaRecoveryState = recoveryResponse.shardRecoveryStates()
             .get(indexName)
             .stream()
@@ -540,7 +540,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
             );
         }
 
-        final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).setActiveOnly(false).get();
+        final RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).setActiveOnly(false).get();
         final RecoveryState replicaRecoveryState = recoveryResponse.shardRecoveryStates()
             .get(indexName)
             .stream()
@@ -651,7 +651,7 @@ public class RemoveCorruptedShardDataCommandIT extends ESIntegTestCase {
     }
 
     private SeqNoStats getSeqNoStats(String index, int shardId) {
-        final ShardStats[] shardStats = client().admin().indices().prepareStats(index).get().getIndices().get(index).getShards();
+        final ShardStats[] shardStats = indicesAdmin().prepareStats(index).get().getIndices().get(index).getShards();
         return shardStats[shardId].getSeqNoStats();
     }
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/shard/SearchIdleIT.java
@@ -143,7 +143,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         }
         indexingDone.await();
         t.join();
-        final IndicesStatsResponse statsResponse = client().admin().indices().stats(new IndicesStatsRequest()).actionGet();
+        final IndicesStatsResponse statsResponse = indicesAdmin().stats(new IndicesStatsRequest()).actionGet();
         for (ShardStats shardStats : statsResponse.getShards()) {
             if (randomTimeValue != null && shardStats.isSearchIdle()) {
                 assertTrue(shardStats.getSearchIdleTime() >= randomTimeValue.millis());
@@ -163,7 +163,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         assertTrue(shard.isSearchIdle());
         CountDownLatch refreshLatch = new CountDownLatch(1);
         // async on purpose to make sure it happens concurrently
-        client().admin().indices().prepareRefresh().execute(ActionListener.running(refreshLatch::countDown));
+        indicesAdmin().prepareRefresh().execute(ActionListener.running(refreshLatch::countDown));
         assertHitCount(client().prepareSearch().get(), 1);
         client().prepareIndex("test").setId("1").setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
         scheduleRefresh(shard, false);
@@ -171,9 +171,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
 
         // now disable background refresh and make sure the refresh happens
         CountDownLatch updateSettingsLatch = new CountDownLatch(1);
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1).build())
             .execute(ActionListener.running(updateSettingsLatch::countDown));
         assertHitCount(client().prepareSearch().get(), 2);
@@ -189,7 +187,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         assertFalse(shard.hasRefreshPending());
         assertTrue(shard.isSearchIdle());
         assertHitCount(client().prepareSearch().get(), 3);
-        final IndicesStatsResponse statsResponse = client().admin().indices().stats(new IndicesStatsRequest()).actionGet();
+        final IndicesStatsResponse statsResponse = indicesAdmin().stats(new IndicesStatsRequest()).actionGet();
         for (ShardStats shardStats : statsResponse.getShards()) {
             if (shardStats.isSearchIdle()) {
                 assertTrue(shardStats.getSearchIdleTime() >= TimeValue.ZERO.millis());
@@ -219,9 +217,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
     public void testSearchIdleStats() throws InterruptedException {
         int searchIdleAfter = randomIntBetween(2, 5);
         final String indexName = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(
                 Settings.builder()
                     .put(IndexSettings.INDEX_SEARCH_IDLE_AFTER.getKey(), searchIdleAfter + "s")
@@ -229,12 +225,12 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
             )
             .get();
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(indexName).get().getShards()).allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(indexName).get().getShards()).allMatch(ShardStats::isSearchIdle),
             searchIdleAfter,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse statsResponse = client().admin().indices().prepareStats(indexName).get();
+        final IndicesStatsResponse statsResponse = indicesAdmin().prepareStats(indexName).get();
         assertTrue(Arrays.stream(statsResponse.getShards()).allMatch(ShardStats::isSearchIdle));
         assertTrue(Arrays.stream(statsResponse.getShards()).allMatch(x -> x.getSearchIdleTime() >= searchIdleAfter));
     }
@@ -298,19 +294,18 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
                 .get()
                 .status()
         );
-        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(idleIndex, activeIndex).get().getStatus());
+        assertEquals(RestStatus.OK, indicesAdmin().prepareRefresh(idleIndex, activeIndex).get().getStatus());
 
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(idleIndex, activeIndex).get().getShards())
-                .allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(idleIndex, activeIndex).get().getShards()).allMatch(ShardStats::isSearchIdle),
             2,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse idleIndexStatsBefore = client().admin().indices().prepareStats("test1").get();
+        final IndicesStatsResponse idleIndexStatsBefore = indicesAdmin().prepareStats("test1").get();
         assertIdleShard(idleIndexStatsBefore);
 
-        final IndicesStatsResponse activeIndexStatsBefore = client().admin().indices().prepareStats("test2").get();
+        final IndicesStatsResponse activeIndexStatsBefore = indicesAdmin().prepareStats("test2").get();
         assertIdleShard(activeIndexStatsBefore);
 
         // WHEN
@@ -326,7 +321,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> assertEquals("test2", searchHit.getIndex()));
         // NOTE: we need an empty result from at least one shard
         assertEquals(1, searchResponse.getHits().getHits().length);
-        final IndicesStatsResponse idleIndexStatsAfter = client().admin().indices().prepareStats(idleIndex).get();
+        final IndicesStatsResponse idleIndexStatsAfter = indicesAdmin().prepareStats(idleIndex).get();
         assertIdleShardsRefreshStats(idleIndexStatsBefore, idleIndexStatsAfter);
     }
 
@@ -364,19 +359,18 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
             RestStatus.CREATED,
             client().prepareIndex(activeIndex).setSource("keyword", "active", "unmapped", "bbb").get().status()
         );
-        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(idleIndex, activeIndex).get().getStatus());
+        assertEquals(RestStatus.OK, indicesAdmin().prepareRefresh(idleIndex, activeIndex).get().getStatus());
 
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(idleIndex, activeIndex).get().getShards())
-                .allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(idleIndex, activeIndex).get().getShards()).allMatch(ShardStats::isSearchIdle),
             2,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse idleIndexStatsBefore = client().admin().indices().prepareStats("test1").get();
+        final IndicesStatsResponse idleIndexStatsBefore = indicesAdmin().prepareStats("test1").get();
         assertIdleShard(idleIndexStatsBefore);
 
-        final IndicesStatsResponse activeIndexStatsBefore = client().admin().indices().prepareStats("test2").get();
+        final IndicesStatsResponse activeIndexStatsBefore = indicesAdmin().prepareStats("test2").get();
         assertIdleShard(activeIndexStatsBefore);
 
         // WHEN
@@ -392,7 +386,7 @@ public class SearchIdleIT extends ESSingleNodeTestCase {
         Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> assertEquals("test2", searchHit.getIndex()));
         // NOTE: we need an empty result from at least one shard
         assertEquals(1, searchResponse.getHits().getHits().length);
-        final IndicesStatsResponse idleIndexStatsAfter = client().admin().indices().prepareStats(idleIndex).get();
+        final IndicesStatsResponse idleIndexStatsAfter = indicesAdmin().prepareStats(idleIndex).get();
         assertIdleShardsRefreshStats(idleIndexStatsBefore, idleIndexStatsAfter);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/CorruptedFileIT.java
@@ -163,8 +163,8 @@ public class CorruptedFileIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureGreen();
         // double flush to create safe commit in case of async durability
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).get());
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).get());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
 
@@ -235,7 +235,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
             eventListener.setNewDelegate(listener);
         }
         try {
-            client().admin().indices().prepareDelete("test").get();
+            indicesAdmin().prepareDelete("test").get();
             latch.await();
             assertThat(exception, empty());
         } finally {
@@ -274,8 +274,8 @@ public class CorruptedFileIT extends ESIntegTestCase {
         indexRandom(true, builders);
         ensureGreen();
         // double flush to create safe commit in case of async durability
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).get());
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).get());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).get());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
 
@@ -409,7 +409,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         indexRandom(true, builders);
         ensureGreen();
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).execute().actionGet());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
 
@@ -548,7 +548,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         indexRandom(true, builders);
         ensureGreen();
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).execute().actionGet());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
 
@@ -615,7 +615,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
         }
         indexRandom(true, builders);
         ensureGreen();
-        assertAllSuccessful(client().admin().indices().prepareFlush().setForce(true).execute().actionGet());
+        assertAllSuccessful(indicesAdmin().prepareFlush().setForce(true).execute().actionGet());
         // we have to flush at least once here since we don't corrupt the translog
         assertHitCount(client().prepareSearch().setSize(0).get(), numDocs);
 
@@ -631,7 +631,7 @@ public class CorruptedFileIT extends ESIntegTestCase {
 
         final Index index = resolveIndex("test");
 
-        final IndicesShardStoresResponse stores = client().admin().indices().prepareShardStores(index.getName()).get();
+        final IndicesShardStoresResponse stores = indicesAdmin().prepareShardStores(index.getName()).get();
 
         for (Map.Entry<Integer, List<IndicesShardStoresResponse.StoreStatus>> shards : stores.getStoreStatuses()
             .get(index.getName())

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/store/ExceptionRetryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/store/ExceptionRetryIT.java
@@ -69,7 +69,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
         Client client = internalCluster().coordOnlyNodeClient();
         NodesStatsResponse nodeStats = client().admin().cluster().prepareNodesStats().get();
         NodeStats unluckyNode = randomFrom(nodeStats.getNodes().stream().filter((s) -> s.getNode().canContainData()).toList());
-        assertAcked(client().admin().indices().prepareCreate("index").setSettings(indexSettings(5, 1)));
+        assertAcked(indicesAdmin().prepareCreate("index").setSettings(indexSettings(5, 1)));
         ensureGreen("index");
         logger.info("unlucky node: {}", unluckyNode.getNode());
         // create a transport service that throws a ConnectTransportException for one bulk request and therefore triggers a retry.
@@ -133,7 +133,7 @@ public class ExceptionRetryIT extends ESIntegTestCase {
         assertSearchResponse(searchResponse);
         assertThat(dupCounter, equalTo(0L));
         assertHitCount(searchResponse, numDocs);
-        IndicesStatsResponse index = client().admin().indices().prepareStats("index").clear().setSegments(true).get();
+        IndicesStatsResponse index = indicesAdmin().prepareStats("index").clear().setSegments(true).get();
         IndexStats indexStats = index.getIndex("index");
         long maxUnsafeAutoIdTimestamp = Long.MIN_VALUE;
         for (IndexShardStats indexShardStats : indexStats) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/index/suggest/stats/SuggestStatsIT.java
@@ -42,7 +42,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
 
     public void testSimpleStats() throws Exception {
         // clear all stats first
-        client().admin().indices().prepareStats().clear().execute().actionGet();
+        indicesAdmin().prepareStats().clear().execute().actionGet();
         final int numNodes = cluster().numDataNodes();
         assertThat(numNodes, greaterThanOrEqualTo(2));
         final int shardsIdx1 = randomIntBetween(1, 10); // we make sure each node gets at least a single shard...
@@ -79,7 +79,7 @@ public class SuggestStatsIT extends ESIntegTestCase {
         }
         long endTime = System.currentTimeMillis();
 
-        IndicesStatsResponse indicesStats = client().admin().indices().prepareStats().execute().actionGet();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats().execute().actionGet();
         final SearchStats.Stats suggest = indicesStats.getTotal().getSearch().getTotal();
 
         // check current

--- a/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indexlifecycle/IndexLifecycleActionIT.java
@@ -203,7 +203,7 @@ public class IndexLifecycleActionIT extends ESIntegTestCase {
 
         logger.info("Deleting index [test]");
         // last, lets delete the index
-        AcknowledgedResponse deleteIndexResponse = client().admin().indices().prepareDelete("test").execute().actionGet();
+        AcknowledgedResponse deleteIndexResponse = indicesAdmin().prepareDelete("test").execute().actionGet();
         assertThat(deleteIndexResponse.isAcknowledged(), equalTo(true));
 
         clusterState = client().admin().cluster().prepareState().get().getState();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/DateMathIndexExpressionsIntegrationIT.java
@@ -74,7 +74,7 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         String index3 = ".marvel-" + DateTimeFormatter.ofPattern("yyyy.MM.dd", Locale.ROOT).format(now.minusDays(2));
         createIndex(index1, index2, index3);
 
-        GetSettingsResponse getSettingsResponse = dateSensitiveGet(client().admin().indices().prepareGetSettings(index1, index2, index3));
+        GetSettingsResponse getSettingsResponse = dateSensitiveGet(indicesAdmin().prepareGetSettings(index1, index2, index3));
         assertEquals(index1, getSettingsResponse.getSetting(index1, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));
         assertEquals(index2, getSettingsResponse.getSetting(index2, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));
         assertEquals(index3, getSettingsResponse.getSetting(index3, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));
@@ -113,9 +113,7 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         assertThat(mgetResponse.getResponses()[2].getResponse().isExists(), is(true));
         assertThat(mgetResponse.getResponses()[2].getResponse().getId(), equalTo("3"));
 
-        IndicesStatsResponse indicesStatsResponse = dateSensitiveGet(
-            client().admin().indices().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3)
-        );
+        IndicesStatsResponse indicesStatsResponse = dateSensitiveGet(indicesAdmin().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3));
         assertThat(indicesStatsResponse.getIndex(index1), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index2), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
@@ -150,9 +148,7 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 3);
         assertSearchHits(searchResponse, "1", "2", "3");
 
-        IndicesStatsResponse indicesStatsResponse = dateSensitiveGet(
-            client().admin().indices().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3)
-        );
+        IndicesStatsResponse indicesStatsResponse = dateSensitiveGet(indicesAdmin().prepareStats(dateMathExp1, dateMathExp2, dateMathExp3));
         assertThat(indicesStatsResponse.getIndex(index1), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index2), notNullValue());
         assertThat(indicesStatsResponse.getIndex(index3), notNullValue());
@@ -168,7 +164,7 @@ public class DateMathIndexExpressionsIntegrationIT extends ESIntegTestCase {
         String dateMathExp3 = "<.marvel-{now/d-2d}>";
         createIndex(dateMathExp1, dateMathExp2, dateMathExp3);
 
-        GetSettingsResponse getSettingsResponse = dateSensitiveGet(client().admin().indices().prepareGetSettings(index1, index2, index3));
+        GetSettingsResponse getSettingsResponse = dateSensitiveGet(indicesAdmin().prepareGetSettings(index1, index2, index3));
         assertEquals(dateMathExp1, getSettingsResponse.getSetting(index1, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));
         assertEquals(dateMathExp2, getSettingsResponse.getSetting(index2, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));
         assertEquals(dateMathExp3, getSettingsResponse.getSetting(index3, IndexMetadata.SETTING_INDEX_PROVIDED_NAME));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesLifecycleListenerIT.java
@@ -95,7 +95,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
         assertThat("beforeIndexCreated called on each data node", allCreatedCount.get(), greaterThanOrEqualTo(3));
 
         try {
-            client().admin().indices().prepareCreate("failed").setSettings(Settings.builder().put("index.fail", true)).get();
+            indicesAdmin().prepareCreate("failed").setSettings(Settings.builder().put("index.fail", true)).get();
             fail("should have thrown an exception during creation");
         } catch (Exception e) {
             assertTrue(e.getMessage().contains("failing on purpose"));
@@ -200,7 +200,7 @@ public class IndicesLifecycleListenerIT extends ESIntegTestCase {
         assertShardStatesMatch(stateChangeListenerNode2, 3, CREATED, RECOVERING, POST_RECOVERY, STARTED);
 
         // close the index
-        assertAcked(client().admin().indices().prepareClose("test"));
+        assertAcked(indicesAdmin().prepareClose("test"));
 
         assertThat(stateChangeListenerNode1.afterCloseSettings.getAsInt(SETTING_NUMBER_OF_SHARDS, -1), equalTo(6));
         assertThat(stateChangeListenerNode1.afterCloseSettings.getAsInt(SETTING_NUMBER_OF_REPLICAS, -1), equalTo(1));

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/IndicesRequestCacheIT.java
@@ -45,9 +45,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testCacheAggs() throws Exception {
         Client client = client();
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("f", "type=date")
                 .setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .get()
@@ -73,7 +71,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
 
         // The cached is actually used
         assertThat(
-            client.admin().indices().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(),
+            indicesAdmin().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMemorySizeInBytes(),
             greaterThan(0L)
         );
 
@@ -106,9 +104,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testQueryRewrite() throws Exception {
         Client client = client();
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("s", "type=date")
                 .setSettings(
                     indexSettings(5, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
@@ -132,7 +128,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertCacheState(client, "index", 0, 0);
 
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
-        ForceMergeResponse forceMergeResponse = client.admin().indices().prepareForceMerge("index").setFlush(true).get();
+        ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge("index").setFlush(true).get();
         ElasticsearchAssertions.assertAllSuccessful(forceMergeResponse);
         refresh();
         ensureSearchable("index");
@@ -174,9 +170,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testQueryRewriteMissingValues() throws Exception {
         Client client = client();
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("s", "type=date")
                 .setSettings(indexSettings(1, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .get()
@@ -197,7 +191,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertCacheState(client, "index", 0, 0);
 
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
-        ForceMergeResponse forceMergeResponse = client.admin().indices().prepareForceMerge("index").setFlush(true).get();
+        ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge("index").setFlush(true).get();
         ElasticsearchAssertions.assertAllSuccessful(forceMergeResponse);
         refresh();
         ensureSearchable("index");
@@ -235,9 +229,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testQueryRewriteDates() throws Exception {
         Client client = client();
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("d", "type=date")
                 .setSettings(indexSettings(1, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .get()
@@ -258,7 +250,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertCacheState(client, "index", 0, 0);
 
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
-        ForceMergeResponse forceMergeResponse = client.admin().indices().prepareForceMerge("index").setFlush(true).get();
+        ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge("index").setFlush(true).get();
         ElasticsearchAssertions.assertAllSuccessful(forceMergeResponse);
         refresh();
         ensureSearchable("index");
@@ -300,9 +292,9 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testQueryRewriteDatesWithNow() throws Exception {
         Client client = client();
         Settings settings = indexSettings(1, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true).build();
-        assertAcked(client.admin().indices().prepareCreate("index-1").setMapping("d", "type=date").setSettings(settings).get());
-        assertAcked(client.admin().indices().prepareCreate("index-2").setMapping("d", "type=date").setSettings(settings).get());
-        assertAcked(client.admin().indices().prepareCreate("index-3").setMapping("d", "type=date").setSettings(settings).get());
+        assertAcked(indicesAdmin().prepareCreate("index-1").setMapping("d", "type=date").setSettings(settings).get());
+        assertAcked(indicesAdmin().prepareCreate("index-2").setMapping("d", "type=date").setSettings(settings).get());
+        assertAcked(indicesAdmin().prepareCreate("index-3").setMapping("d", "type=date").setSettings(settings).get());
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         DateFormatter formatter = DateFormatter.forPattern("strict_date_optional_time");
         indexRandom(
@@ -378,7 +370,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         Settings settings = indexSettings(2, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true)
             .put("index.number_of_routing_shards", 2)
             .build();
-        assertAcked(client.admin().indices().prepareCreate("index").setMapping("s", "type=date").setSettings(settings).get());
+        assertAcked(indicesAdmin().prepareCreate("index").setMapping("s", "type=date").setSettings(settings).get());
         indexRandom(
             true,
             client.prepareIndex("index").setId("1").setRouting("1").setSource("s", "2016-03-19"),
@@ -395,7 +387,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         assertCacheState(client, "index", 0, 0);
 
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
-        ForceMergeResponse forceMergeResponse = client.admin().indices().prepareForceMerge("index").setFlush(true).get();
+        ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge("index").setFlush(true).get();
         ElasticsearchAssertions.assertAllSuccessful(forceMergeResponse);
         refresh();
         ensureSearchable("index");
@@ -474,9 +466,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         Client client = client();
         Settings settings = indexSettings(1, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true).build();
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("created_at", "type=date")
                 .setSettings(settings)
                 .addAlias(new Alias("last_week").filter(QueryBuilders.rangeQuery("created_at").gte("now-7d/d")))
@@ -485,7 +475,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
         ZonedDateTime now = ZonedDateTime.now(ZoneOffset.UTC);
         client.prepareIndex("index").setId("1").setRouting("1").setSource("created_at", DateTimeFormatter.ISO_LOCAL_DATE.format(now)).get();
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
-        ForceMergeResponse forceMergeResponse = client.admin().indices().prepareForceMerge("index").setFlush(true).get();
+        ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge("index").setFlush(true).get();
         ElasticsearchAssertions.assertAllSuccessful(forceMergeResponse);
         refresh();
 
@@ -523,9 +513,7 @@ public class IndicesRequestCacheIT extends ESIntegTestCase {
     public void testProfileDisableCache() throws Exception {
         Client client = client();
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("k", "type=keyword")
                 .setSettings(indexSettings(1, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/SystemIndexMappingUpdateServiceIT.java
@@ -117,7 +117,7 @@ public class SystemIndexMappingUpdateServiceIT extends ESIntegTestCase {
      */
     private void triggerClusterStateUpdates() {
         final String name = randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
-        client().admin().indices().putTemplate(new PutIndexTemplateRequest(name).patterns(List.of(name))).actionGet();
+        indicesAdmin().putTemplate(new PutIndexTemplateRequest(name).patterns(List.of(name))).actionGet();
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/analysis/PreBuiltAnalyzerIntegrationIT.java
@@ -63,7 +63,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
                 .endObject()
                 .endObject();
 
-            client().admin().indices().prepareCreate(indexName).setMapping(mapping).setSettings(settings(randomVersion)).get();
+            indicesAdmin().prepareCreate(indexName).setMapping(mapping).setSettings(settings(randomVersion)).get();
         }
 
         ensureGreen();
@@ -86,7 +86,7 @@ public class PreBuiltAnalyzerIntegrationIT extends ESIntegTestCase {
         int amountOfIndicesToClose = randomInt(numIndices - 1);
         for (int i = 0; i < amountOfIndicesToClose; i++) {
             String indexName = indexNames.get(i);
-            client().admin().indices().prepareClose(indexName).execute().actionGet();
+            indicesAdmin().prepareClose(indexName).execute().actionGet();
         }
 
         ensureGreen();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/flush/FlushIT.java
@@ -55,7 +55,7 @@ public class FlushIT extends ESIntegTestCase {
             final CountDownLatch latch = new CountDownLatch(10);
             final CopyOnWriteArrayList<Throwable> errors = new CopyOnWriteArrayList<>();
             for (int j = 0; j < 10; j++) {
-                client().admin().indices().prepareFlush("test").execute(new ActionListener<FlushResponse>() {
+                indicesAdmin().prepareFlush("test").execute(new ActionListener<FlushResponse>() {
                     @Override
                     public void onResponse(FlushResponse flushResponse) {
                         try {
@@ -93,16 +93,13 @@ public class FlushIT extends ESIntegTestCase {
         assertThat(
             expectThrows(
                 ValidationException.class,
-                () -> client().admin().indices().flush(new FlushRequest().force(true).waitIfOngoing(false)).actionGet()
+                () -> indicesAdmin().flush(new FlushRequest().force(true).waitIfOngoing(false)).actionGet()
             ).getMessage(),
             containsString("wait_if_ongoing must be true for a force flush")
         );
+        assertThat(indicesAdmin().flush(new FlushRequest().force(true).waitIfOngoing(true)).actionGet().getShardFailures(), emptyArray());
         assertThat(
-            client().admin().indices().flush(new FlushRequest().force(true).waitIfOngoing(true)).actionGet().getShardFailures(),
-            emptyArray()
-        );
-        assertThat(
-            client().admin().indices().flush(new FlushRequest().force(false).waitIfOngoing(randomBoolean())).actionGet().getShardFailures(),
+            indicesAdmin().flush(new FlushRequest().force(false).waitIfOngoing(randomBoolean())).actionGet().getShardFailures(),
             emptyArray()
         );
     }
@@ -135,7 +132,7 @@ public class FlushIT extends ESIntegTestCase {
             ensureGreen(indexName);
         }
         assertBusy(() -> {
-            for (ShardStats shardStats : client().admin().indices().prepareStats(indexName).get().getShards()) {
+            for (ShardStats shardStats : indicesAdmin().prepareStats(indexName).get().getShards()) {
                 assertThat(shardStats.getStats().getTranslog().getUncommittedOperations(), equalTo(0));
             }
         }, 30, TimeUnit.SECONDS);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/MalformedDynamicTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/mapping/MalformedDynamicTemplateIT.java
@@ -58,7 +58,7 @@ public class MalformedDynamicTemplateIT extends ESIntegTestCase {
             ).setMapping(mapping).get()
         );
         client().prepareIndex(indexName).setSource("{\"foo\" : \"bar\"}", XContentType.JSON).get();
-        assertNoFailures((client().admin().indices().prepareRefresh(indexName)).get());
+        assertNoFailures((indicesAdmin().prepareRefresh(indexName)).get());
         assertHitCount(client().prepareSearch(indexName).get(), 1);
 
         MapperParsingException ex = expectThrows(

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/CircuitBreakerServiceIT.java
@@ -66,7 +66,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
     private void reset() {
         logger.info("--> resetting breaker settings");
         // clear all caches, we could be very close (or even above) the limit and then we will not be able to reset the breaker settings
-        client().admin().indices().prepareClearCache().setFieldDataCache(true).setQueryCache(true).setRequestCache(true).get();
+        indicesAdmin().prepareClearCache().setFieldDataCache(true).setQueryCache(true).setRequestCache(true).get();
 
         Settings.Builder resetSettings = Settings.builder();
         Stream.of(
@@ -293,7 +293,7 @@ public class CircuitBreakerServiceIT extends ESIntegTestCase {
 
     /** Issues a cache clear and waits 30 seconds for the field data breaker to be cleared */
     public void clearFieldData() throws Exception {
-        client().admin().indices().prepareClearCache().setFieldDataCache(true).execute().actionGet();
+        indicesAdmin().prepareClearCache().setFieldDataCache(true).execute().actionGet();
         assertBusy(() -> {
             NodesStatsResponse resp = clusterAdmin().prepareNodesStats().clear().setBreaker(true).get(new TimeValue(15, TimeUnit.SECONDS));
             for (NodeStats nStats : resp.getNodes()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/memory/breaker/RandomExceptionCircuitBreakerIT.java
@@ -135,7 +135,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
         }
         logger.info("Start Refresh");
         // don't assert on failures here
-        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh("test").execute().get();
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh("test").execute().get();
         final boolean refreshFailed = refreshResponse.getShardFailures().length != 0 || refreshResponse.getFailedShards() != 0;
         logger.info(
             "Refresh failed: [{}] numShardsFailed: [{}], shardFailuresLength: [{}], successfulShards: [{}], totalShards: [{}] ",
@@ -172,7 +172,7 @@ public class RandomExceptionCircuitBreakerIT extends ESIntegTestCase {
                 // breaker adjustment code, it should show up here by the breaker
                 // estimate being either positive or negative.
                 ensureGreen("test");  // make sure all shards are there - there could be shards that are still starting up.
-                assertAllSuccessful(client().admin().indices().prepareClearCache("test").setFieldDataCache(true).execute().actionGet());
+                assertAllSuccessful(indicesAdmin().prepareClearCache("test").setFieldDataCache(true).execute().actionGet());
 
                 // Since .cleanUp() is no longer called on cache clear, we need to call it on each node manually
                 for (String node : internalCluster().getNodeNames()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/DanglingIndicesIT.java
@@ -190,7 +190,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
         // not cause the deleted dangling index to be considered "live" again, just because its
         // tombstone has been pushed out of the graveyard.
         createIndex("additional");
-        assertAcked(client().admin().indices().prepareDelete("additional"));
+        assertAcked(indicesAdmin().prepareDelete("additional"));
         assertThat(listDanglingIndices(), is(empty()));
     }
 
@@ -215,8 +215,8 @@ public class DanglingIndicesIT extends ESIntegTestCase {
                     @Override
                     public Settings onNodeStopped(String nodeName) throws Exception {
                         internalCluster().validateClusterFormed();
-                        assertAcked(client().admin().indices().prepareDelete(INDEX_NAME));
-                        assertAcked(client().admin().indices().prepareDelete(OTHER_INDEX_NAME));
+                        assertAcked(indicesAdmin().prepareDelete(INDEX_NAME));
+                        assertAcked(indicesAdmin().prepareDelete(OTHER_INDEX_NAME));
                         return super.onNodeStopped(nodeName);
                     }
                 });
@@ -244,7 +244,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
         // not cause the deleted dangling index to be considered "live" again, just because its
         // tombstone has been pushed out of the graveyard.
         createIndex("additional");
-        assertAcked(client().admin().indices().prepareDelete("additional"));
+        assertAcked(indicesAdmin().prepareDelete("additional"));
         assertBusy(() -> assertThat(listDanglingIndices(), empty()));
     }
 
@@ -305,7 +305,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
         final long endTimeMillis = System.currentTimeMillis() + timeout.millis();
         while (isImporting.get() && System.currentTimeMillis() < endTimeMillis) {
             try {
-                client().admin().indices().prepareDelete(INDEX_NAME).get(timeout);
+                indicesAdmin().prepareDelete(INDEX_NAME).get(timeout);
                 isImporting.set(false);
             } catch (Exception e) {
                 // failures are expected
@@ -316,7 +316,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
             if (isImporting.get()) {
                 isImporting.set(false);
                 try {
-                    client().admin().indices().prepareDelete(INDEX_NAME).get(timeout);
+                    indicesAdmin().prepareDelete(INDEX_NAME).get(timeout);
                 } catch (Exception e) {
                     throw new AssertionError("delete index never succeeded", e);
                 }
@@ -391,7 +391,7 @@ public class DanglingIndicesIT extends ESIntegTestCase {
                 internalCluster().validateClusterFormed();
                 stoppedNodeName.set(nodeName);
                 for (String index : indices) {
-                    assertAcked(client().admin().indices().prepareDelete(index));
+                    assertAcked(indicesAdmin().prepareDelete(index));
                 }
                 return super.onNodeStopped(nodeName);
             }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/IndexPrimaryRelocationIT.java
@@ -33,7 +33,7 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
 
     public void testPrimaryRelocationWhileIndexing() throws Exception {
         internalCluster().ensureAtLeastNumDataNodes(randomIntBetween(2, 3));
-        client().admin().indices().prepareCreate("test").setSettings(indexSettings(1, 0)).setMapping("field", "type=text").get();
+        indicesAdmin().prepareCreate("test").setSettings(indexSettings(1, 0)).setMapping("field", "type=text").get();
         ensureGreen("test");
         AtomicInteger numAutoGenDocs = new AtomicInteger();
         final AtomicBoolean finished = new AtomicBoolean(false);
@@ -106,7 +106,7 @@ public class IndexPrimaryRelocationIT extends ESIntegTestCase {
             }
             if (i > 0 && i % 5 == 0) {
                 logger.info("--> [iteration {}] flushing index", i);
-                client().admin().indices().prepareFlush("test").get();
+                indicesAdmin().prepareFlush("test").get();
             }
         }
         finished.set(true);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/recovery/ReplicaToPrimaryPromotionIT.java
@@ -49,7 +49,7 @@ public class ReplicaToPrimaryPromotionIT extends ESIntegTestCase {
         // sometimes test with a closed index
         final IndexMetadata.State indexState = randomFrom(IndexMetadata.State.OPEN, IndexMetadata.State.CLOSE);
         if (indexState == IndexMetadata.State.CLOSE) {
-            CloseIndexResponse closeIndexResponse = client().admin().indices().prepareClose(indexName).get();
+            CloseIndexResponse closeIndexResponse = indicesAdmin().prepareClose(indexName).get();
             assertThat("close index not acked - " + closeIndexResponse, closeIndexResponse.isAcknowledged(), equalTo(true));
             ensureGreen(indexName);
         }
@@ -73,7 +73,7 @@ public class ReplicaToPrimaryPromotionIT extends ESIntegTestCase {
         }
 
         if (indexState == IndexMetadata.State.CLOSE) {
-            assertAcked(client().admin().indices().prepareOpen(indexName));
+            assertAcked(indicesAdmin().prepareOpen(indexName));
             ensureYellowAndNoInitializingShards(indexName);
         }
         assertHitCount(client().prepareSearch(indexName).setSize(0).get(), numOfDocs);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/GetSettingsBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/GetSettingsBlocksIT.java
@@ -39,7 +39,7 @@ public class GetSettingsBlocksIT extends ESIntegTestCase {
         for (String block : Arrays.asList(SETTING_BLOCKS_READ, SETTING_BLOCKS_WRITE, SETTING_READ_ONLY, SETTING_READ_ONLY_ALLOW_DELETE)) {
             try {
                 enableIndexBlock("test", block);
-                GetSettingsResponse response = client().admin().indices().prepareGetSettings("test").get();
+                GetSettingsResponse response = indicesAdmin().prepareGetSettings("test").get();
                 assertThat(response.getIndexToSettings().size(), greaterThanOrEqualTo(1));
                 assertThat(response.getSetting("test", "index.refresh_interval"), equalTo("-1"));
                 assertThat(response.getSetting("test", "index.merge.policy.expunge_deletes_allowed"), equalTo("30"));
@@ -51,7 +51,7 @@ public class GetSettingsBlocksIT extends ESIntegTestCase {
 
         try {
             enableIndexBlock("test", SETTING_BLOCKS_METADATA);
-            assertBlocked(client().admin().indices().prepareGetSettings("test"));
+            assertBlocked(indicesAdmin().prepareGetSettings("test"));
         } finally {
             disableIndexBlock("test", SETTING_BLOCKS_METADATA);
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/InternalSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/InternalSettingsIT.java
@@ -30,14 +30,14 @@ public class InternalSettingsIT extends ESIntegTestCase {
     public void testSetInternalIndexSettingOnCreate() {
         final Settings settings = Settings.builder().put("index.internal", "internal").build();
         createIndex("index", settings);
-        final GetSettingsResponse response = client().admin().indices().prepareGetSettings("index").get();
+        final GetSettingsResponse response = indicesAdmin().prepareGetSettings("index").get();
         assertThat(response.getSetting("index", "index.internal"), equalTo("internal"));
     }
 
     public void testUpdateInternalIndexSettingViaSettingsAPI() {
         final Settings settings = Settings.builder().put("index.internal", "internal").build();
         createIndex("test", settings);
-        final GetSettingsResponse response = client().admin().indices().prepareGetSettings("test").get();
+        final GetSettingsResponse response = indicesAdmin().prepareGetSettings("test").get();
         assertThat(response.getSetting("test", "index.internal"), equalTo("internal"));
         // we can not update the setting via the update settings API
         final IllegalArgumentException e = expectThrows(
@@ -48,20 +48,20 @@ public class InternalSettingsIT extends ESIntegTestCase {
         );
         final String message = "can not update internal setting [index.internal]; this setting is managed via a dedicated API";
         assertThat(e, hasToString(containsString(message)));
-        final GetSettingsResponse responseAfterAttemptedUpdate = client().admin().indices().prepareGetSettings("test").get();
+        final GetSettingsResponse responseAfterAttemptedUpdate = indicesAdmin().prepareGetSettings("test").get();
         assertThat(responseAfterAttemptedUpdate.getSetting("test", "index.internal"), equalTo("internal"));
     }
 
     public void testUpdateInternalIndexSettingViaDedicatedAPI() {
         final Settings settings = Settings.builder().put("index.internal", "internal").build();
         createIndex("test", settings);
-        final GetSettingsResponse response = client().admin().indices().prepareGetSettings("test").get();
+        final GetSettingsResponse response = indicesAdmin().prepareGetSettings("test").get();
         assertThat(response.getSetting("test", "index.internal"), equalTo("internal"));
         client().execute(
             InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.INSTANCE,
             new InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.Request("test", "index.internal", "internal-update")
         ).actionGet();
-        final GetSettingsResponse responseAfterUpdate = client().admin().indices().prepareGetSettings("test").get();
+        final GetSettingsResponse responseAfterUpdate = indicesAdmin().prepareGetSettings("test").get();
         assertThat(responseAfterUpdate.getSetting("test", "index.internal"), equalTo("internal-update"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/PrivateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/PrivateSettingsIT.java
@@ -46,7 +46,7 @@ public class PrivateSettingsIT extends ESIntegTestCase {
         );
         final String message = "can not update private setting [index.private]; this setting is managed by Elasticsearch";
         assertThat(e, hasToString(containsString(message)));
-        final GetSettingsResponse responseAfterAttemptedUpdate = client().admin().indices().prepareGetSettings("test").get();
+        final GetSettingsResponse responseAfterAttemptedUpdate = indicesAdmin().prepareGetSettings("test").get();
         assertNull(responseAfterAttemptedUpdate.getSetting("test", "index.private"));
     }
 
@@ -56,7 +56,7 @@ public class PrivateSettingsIT extends ESIntegTestCase {
             InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.INSTANCE,
             new InternalOrPrivateSettingsPlugin.UpdateInternalOrPrivateAction.Request("test", "index.private", "private-update")
         ).actionGet();
-        final GetSettingsResponse responseAfterUpdate = client().admin().indices().prepareGetSettings("test").get();
+        final GetSettingsResponse responseAfterUpdate = indicesAdmin().prepareGetSettings("test").get();
         assertThat(responseAfterUpdate.getSetting("test", "index.private"), equalTo("private-update"));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateNumberOfReplicasIT.java
@@ -178,7 +178,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
+            assertAcked(indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
 
             clusterHealth = client().admin()
                 .cluster()
@@ -301,7 +301,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
         assertThat(clusterHealth.getIndices().get("test").getActiveShards(), equalTo(numShards.numPrimaries * 2));
 
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
+            assertAcked(indicesAdmin().prepareClose("test").setWaitForActiveShards(ActiveShardCount.ALL));
 
             clusterHealth = client().admin()
                 .cluster()
@@ -476,7 +476,7 @@ public class UpdateNumberOfReplicasIT extends ESIntegTestCase {
                 .get()
         );
         final int numberOfReplicas = Integer.parseInt(
-            client().admin().indices().prepareGetSettings("test-index").get().getSetting("test-index", "index.number_of_replicas")
+            indicesAdmin().prepareGetSettings("test-index").get().getSetting("test-index", "index.number_of_replicas")
         );
         assertThat(numberOfReplicas, equalTo(0));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/settings/UpdateSettingsIT.java
@@ -686,8 +686,7 @@ public class UpdateSettingsIT extends ESIntegTestCase {
         // Create a list of not interned strings to make sure interning setting values works
         final List<String> queryFieldsSetting = List.of(new String("foo"), new String("bar"), new String("bla"));
         assertAcked(
-            admin().indices()
-                .prepareUpdateSettings(index1, index2)
+            indicesAdmin().prepareUpdateSettings(index1, index2)
                 .setSettings(Settings.builder().putList("query.default_field", queryFieldsSetting))
         );
         final Settings updatedIndex1SettingsMaster = clusterServiceMaster.state().metadata().index(index1).getSettings();

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexDisableCloseAllIT.java
@@ -28,7 +28,7 @@ public class CloseIndexDisableCloseAllIT extends ESIntegTestCase {
     public void testCloseAllRequiresName() {
         createIndex("test1", "test2", "test3");
 
-        assertAcked(client().admin().indices().prepareClose("test3", "test2"));
+        assertAcked(indicesAdmin().prepareClose("test3", "test2"));
         assertIndexIsClosed("test2", "test3");
 
         // disable closing
@@ -37,7 +37,7 @@ public class CloseIndexDisableCloseAllIT extends ESIntegTestCase {
 
         IllegalStateException illegalStateException = expectThrows(
             IllegalStateException.class,
-            () -> client().admin().indices().prepareClose("test_no_close").get()
+            () -> indicesAdmin().prepareClose("test_no_close").get()
         );
         assertEquals(
             illegalStateException.getMessage(),

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseIndexIT.java
@@ -463,7 +463,7 @@ public class CloseIndexIT extends ESIntegTestCase {
                 for (int i = 0; i < moreDocs; i++) {
                     client.prepareIndex(indexName).setSource("num", i).get();
                 }
-                assertAcked(client.admin().indices().prepareClose(indexName));
+                assertAcked(indicesAdmin().prepareClose(indexName));
                 return super.onNodeStopped(nodeName);
             }
         });

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/CloseWhileRelocatingShardsIT.java
@@ -205,7 +205,7 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
                     // Closing is not always acknowledged when shards are relocating: this is the case when the target shard is initializing
                     // or is catching up operations. In these cases the TransportVerifyShardBeforeCloseAction will detect that the global
                     // and max sequence number don't match and will not ack the close.
-                    AcknowledgedResponse closeResponse = client().admin().indices().prepareClose(indexToClose).get();
+                    AcknowledgedResponse closeResponse = indicesAdmin().prepareClose(indexToClose).get();
                     if (closeResponse.isAcknowledged()) {
                         assertTrue("Index closing should not be acknowledged twice", acknowledgedCloses.add(indexToClose));
                     }
@@ -244,7 +244,7 @@ public class CloseWhileRelocatingShardsIT extends ESIntegTestCase {
             interruptedRecoveries.forEach(CloseIndexIT::assertIndexIsClosed);
 
             assertThat("Consider that the test failed if no indices were successfully closed", acknowledgedCloses.size(), greaterThan(0));
-            assertAcked(client().admin().indices().prepareOpen("index-*"));
+            assertAcked(indicesAdmin().prepareOpen("index-*"));
             ensureGreen(indices);
 
             for (String index : acknowledgedCloses) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/state/ReopenWhileClosingIT.java
@@ -66,12 +66,12 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
         final CountDownLatch block = new CountDownLatch(1);
         final Releasable releaseBlock = interceptVerifyShardBeforeCloseActions(indexName, block::countDown);
 
-        ActionFuture<CloseIndexResponse> closeIndexResponse = client().admin().indices().prepareClose(indexName).execute();
+        ActionFuture<CloseIndexResponse> closeIndexResponse = indicesAdmin().prepareClose(indexName).execute();
         assertTrue("Waiting for index to have a closing blocked", block.await(60, TimeUnit.SECONDS));
         assertIndexIsBlocked(indexName);
         assertFalse(closeIndexResponse.isDone());
 
-        assertAcked(client().admin().indices().prepareOpen(indexName));
+        assertAcked(indicesAdmin().prepareOpen(indexName));
 
         releaseBlock.close();
         assertFalse(closeIndexResponse.get().isAcknowledged());
@@ -91,13 +91,13 @@ public class ReopenWhileClosingIT extends ESIntegTestCase {
         final CountDownLatch block = new CountDownLatch(1);
         final Releasable releaseBlock = interceptVerifyShardBeforeCloseActions(randomFrom(indices), block::countDown);
 
-        ActionFuture<CloseIndexResponse> closeIndexResponse = client().admin().indices().prepareClose("index-*").execute();
+        ActionFuture<CloseIndexResponse> closeIndexResponse = indicesAdmin().prepareClose("index-*").execute();
         assertTrue("Waiting for index to have a closing blocked", block.await(60, TimeUnit.SECONDS));
         assertFalse(closeIndexResponse.isDone());
         indices.forEach(ReopenWhileClosingIT::assertIndexIsBlocked);
 
         final List<String> reopenedIndices = randomSubsetOf(randomIntBetween(1, indices.size()), indices);
-        assertAcked(client().admin().indices().prepareOpen(reopenedIndices.toArray(Strings.EMPTY_ARRAY)));
+        assertAcked(indicesAdmin().prepareOpen(reopenedIndices.toArray(Strings.EMPTY_ARRAY)));
 
         releaseBlock.close();
         assertFalse(closeIndexResponse.get().isAcknowledged());

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/store/IndicesStoreIntegrationIT.java
@@ -233,7 +233,7 @@ public class IndicesStoreIntegrationIT extends ESIntegTestCase {
         logClusterState();
         // delete the index. node_1 that still waits for the next cluster state update will then get the delete index next.
         // it must still delete the shard, even if it cannot find it anymore in indicesservice
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
 
         assertShardDeleted(node_1, index, 0);
         assertIndexDeleted(node_1, index);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/IndexTemplateBlocksIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/IndexTemplateBlocksIT.java
@@ -50,7 +50,7 @@ public class IndexTemplateBlocksIT extends ESIntegTestCase {
         try {
             setClusterReadOnly(true);
 
-            GetIndexTemplatesResponse response = client().admin().indices().prepareGetTemplates("template_blocks").execute().actionGet();
+            GetIndexTemplatesResponse response = indicesAdmin().prepareGetTemplates("template_blocks").execute().actionGet();
             assertThat(response.getIndexTemplates(), hasSize(1));
 
             assertBlocked(
@@ -60,7 +60,7 @@ public class IndexTemplateBlocksIT extends ESIntegTestCase {
                     .addAlias(new Alias("alias_1"))
             );
 
-            assertBlocked(client().admin().indices().prepareDeleteTemplate("template_blocks"));
+            assertBlocked(indicesAdmin().prepareDeleteTemplate("template_blocks"));
 
         } finally {
             setClusterReadOnly(false);

--- a/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/indices/template/SimpleIndexTemplateIT.java
@@ -228,7 +228,7 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
             .actionGet();
 
         logger.info("--> explicitly delete template_1");
-        admin().indices().prepareDeleteTemplate("template_1").execute().actionGet();
+        indicesAdmin().prepareDeleteTemplate("template_1").execute().actionGet();
 
         ClusterState state = admin().cluster().prepareState().execute().actionGet().getState();
 
@@ -261,14 +261,14 @@ public class SimpleIndexTemplateIT extends ESIntegTestCase {
             .actionGet();
 
         logger.info("--> delete template*");
-        admin().indices().prepareDeleteTemplate("template*").execute().actionGet();
+        indicesAdmin().prepareDeleteTemplate("template*").execute().actionGet();
         assertThat(
             admin().cluster().prepareState().execute().actionGet().getState().metadata().templates().size(),
             equalTo(existingTemplates)
         );
 
         logger.info("--> delete * with no templates, make sure we don't get a failure");
-        admin().indices().prepareDeleteTemplate("*").execute().actionGet();
+        indicesAdmin().prepareDeleteTemplate("*").execute().actionGet();
         assertThat(admin().cluster().prepareState().execute().actionGet().getState().metadata().templates().size(), equalTo(0));
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/operateAllIndices/DestructiveOperationsIT.java
@@ -33,12 +33,12 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         createIndex("index1", "1index");
 
         // Should succeed, since no wildcards
-        assertAcked(client().admin().indices().prepareDelete("1index").get());
+        assertAcked(indicesAdmin().prepareDelete("1index").get());
         // Special "match none" pattern succeeds, since non-destructive
-        assertAcked(client().admin().indices().prepareDelete("*", "-*").get());
+        assertAcked(indicesAdmin().prepareDelete("*", "-*").get());
 
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareDelete("i*").get());
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareDelete("_all").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareDelete("i*").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareDelete("_all").get());
     }
 
     public void testDeleteIndexDefaultBehaviour() throws Exception {
@@ -49,9 +49,9 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         createIndex("index1", "1index");
 
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareDelete("_all").get());
+            assertAcked(indicesAdmin().prepareDelete("_all").get());
         } else {
-            assertAcked(client().admin().indices().prepareDelete("*").get());
+            assertAcked(indicesAdmin().prepareDelete("*").get());
         }
 
         assertThat(indexExists("_all"), equalTo(false));
@@ -63,12 +63,12 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         createIndex("index1", "1index");
 
         // Should succeed, since no wildcards
-        assertAcked(client().admin().indices().prepareClose("1index").get());
+        assertAcked(indicesAdmin().prepareClose("1index").get());
         // Special "match none" pattern succeeds, since non-destructive
-        assertAcked(client().admin().indices().prepareClose("*", "-*").get());
+        assertAcked(indicesAdmin().prepareClose("*", "-*").get());
 
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareClose("i*").get());
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareClose("_all").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareClose("i*").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareClose("_all").get());
     }
 
     public void testCloseIndexDefaultBehaviour() throws Exception {
@@ -79,9 +79,9 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         createIndex("index1", "1index");
 
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareClose("_all").get());
+            assertAcked(indicesAdmin().prepareClose("_all").get());
         } else {
-            assertAcked(client().admin().indices().prepareClose("*").get());
+            assertAcked(indicesAdmin().prepareClose("*").get());
         }
 
         ClusterState state = clusterAdmin().prepareState().get().getState();
@@ -94,13 +94,13 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         updateClusterSettings(Settings.builder().put(DestructiveOperations.REQUIRES_NAME_SETTING.getKey(), true));
 
         createIndex("index1", "1index");
-        assertAcked(client().admin().indices().prepareClose("1index", "index1").get());
+        assertAcked(indicesAdmin().prepareClose("1index", "index1").get());
 
         // Special "match none" pattern succeeds, since non-destructive
-        assertAcked(client().admin().indices().prepareOpen("*", "-*").get());
+        assertAcked(indicesAdmin().prepareOpen("*", "-*").get());
 
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareOpen("i*").get());
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareOpen("_all").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareOpen("i*").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareOpen("_all").get());
     }
 
     public void testOpenIndexDefaultBehaviour() throws Exception {
@@ -109,12 +109,12 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         }
 
         createIndex("index1", "1index");
-        assertAcked(client().admin().indices().prepareClose("1index", "index1").get());
+        assertAcked(indicesAdmin().prepareClose("1index", "index1").get());
 
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareOpen("_all").get());
+            assertAcked(indicesAdmin().prepareOpen("_all").get());
         } else {
-            assertAcked(client().admin().indices().prepareOpen("*").get());
+            assertAcked(indicesAdmin().prepareOpen("*").get());
         }
 
         ClusterState state = clusterAdmin().prepareState().get().getState();
@@ -129,12 +129,12 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         createIndex("index1", "1index");
 
         // Should succeed, since no wildcards
-        assertAcked(client().admin().indices().prepareAddBlock(WRITE, "1index").get());
+        assertAcked(indicesAdmin().prepareAddBlock(WRITE, "1index").get());
         // Special "match none" pattern succeeds, since non-destructive
-        assertAcked(client().admin().indices().prepareAddBlock(WRITE, "*", "-*").get());
+        assertAcked(indicesAdmin().prepareAddBlock(WRITE, "*", "-*").get());
 
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareAddBlock(WRITE, "i*").get());
-        expectThrows(IllegalArgumentException.class, () -> client().admin().indices().prepareAddBlock(WRITE, "_all").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareAddBlock(WRITE, "i*").get());
+        expectThrows(IllegalArgumentException.class, () -> indicesAdmin().prepareAddBlock(WRITE, "_all").get());
     }
 
     public void testAddIndexBlockDefaultBehaviour() throws Exception {
@@ -145,9 +145,9 @@ public class DestructiveOperationsIT extends ESIntegTestCase {
         createIndex("index1", "1index");
 
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareAddBlock(WRITE, "_all").get());
+            assertAcked(indicesAdmin().prepareAddBlock(WRITE, "_all").get());
         } else {
-            assertAcked(client().admin().indices().prepareAddBlock(WRITE, "*").get());
+            assertAcked(indicesAdmin().prepareAddBlock(WRITE, "*").get());
         }
 
         ClusterState state = clusterAdmin().prepareState().get().getState();

--- a/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/plugins/IndexFoldersDeletionListenerIT.java
@@ -94,7 +94,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
             assertNoDeletions(shardsByNode.getKey());
         }
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
         assertPendingDeletesProcessed();
 
         assertBusy(() -> {
@@ -236,7 +236,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
         internalCluster().stopNode(stoppedNode);
         ensureStableCluster(3 + 1, masterNode);
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final String restartedNode = internalCluster().startNode(stoppedNodeDataPathSettings);
         ensureStableCluster(4 + 1, masterNode);
@@ -276,7 +276,7 @@ public class IndexFoldersDeletionListenerIT extends ESIntegTestCase {
         ensureStableCluster(1, masterNode);
 
         logger.debug("--> deleting leftover indices");
-        assertAcked(client().admin().indices().prepareDelete("index-*"));
+        assertAcked(indicesAdmin().prepareDelete("index-*"));
 
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/FullRollingRestartIT.java
@@ -181,7 +181,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         }
         ensureGreen();
         ClusterState state = clusterAdmin().prepareState().get().getState();
-        RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
+        RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
             assertNotEquals(
                 "relocated "
@@ -200,7 +200,7 @@ public class FullRollingRestartIT extends ESIntegTestCase {
         ensureGreen();
         clusterAdmin().prepareState().get();
 
-        recoveryResponse = client().admin().indices().prepareRecoveries("test").get();
+        recoveryResponse = indicesAdmin().prepareRecoveries("test").get();
         for (RecoveryState recoveryState : recoveryResponse.shardRecoveryStates().get("test")) {
             assertNotEquals(
                 "relocated "

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RecoveryWhileUnderLoadIT.java
@@ -88,7 +88,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             indexer.continueIndexing(extraDocs);
             logger.info("--> flushing the index ....");
             // now flush, just to make sure we have some data in the index, not just translog
-            client().admin().indices().prepareFlush().execute().actionGet();
+            indicesAdmin().prepareFlush().execute().actionGet();
 
             logger.info("--> waiting for {} docs to be indexed ...", waitFor);
             waitForDocs(waitFor, indexer);
@@ -147,7 +147,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             indexer.continueIndexing(extraDocs);
             logger.info("--> flushing the index ....");
             // now flush, just to make sure we have some data in the index, not just translog
-            client().admin().indices().prepareFlush().execute().actionGet();
+            indicesAdmin().prepareFlush().execute().actionGet();
 
             logger.info("--> waiting for {} docs to be indexed ...", waitFor);
             waitForDocs(waitFor, indexer);
@@ -203,7 +203,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
             indexer.continueIndexing(extraDocs);
             logger.info("--> flushing the index ....");
             // now flush, just to make sure we have some data in the index, not just translog
-            client().admin().indices().prepareFlush().execute().actionGet();
+            indicesAdmin().prepareFlush().execute().actionGet();
 
             logger.info("--> waiting for {} docs to be indexed ...", waitFor);
             waitForDocs(waitFor, indexer);
@@ -334,7 +334,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
         if (error) {
             // Printing out shards and their doc count
-            IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats().get();
+            IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats().get();
             for (ShardStats shardStats : indicesStatsResponse.getShards()) {
                 DocsStats docsStats = shardStats.getStats().docs;
                 logger.info(
@@ -411,7 +411,7 @@ public class RecoveryWhileUnderLoadIT extends ESIntegTestCase {
 
     private void refreshAndAssert() throws Exception {
         assertBusy(() -> {
-            RefreshResponse actionGet = client().admin().indices().prepareRefresh().get();
+            RefreshResponse actionGet = indicesAdmin().prepareRefresh().get();
             assertAllSuccessful(actionGet);
         }, 5, TimeUnit.MINUTES);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/RelocationIT.java
@@ -124,14 +124,14 @@ public class RelocationIT extends ESIntegTestCase {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         logger.info("--> flush so we have an actual index");
-        client().admin().indices().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().execute().actionGet();
         logger.info("--> index more docs so we have something in the translog");
         for (int i = 10; i < 20; i++) {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
 
         logger.info("--> verifying count");
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().execute().actionGet();
         assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
 
         logger.info("--> start another node");
@@ -155,7 +155,7 @@ public class RelocationIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> verifying count again...");
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().execute().actionGet();
         assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
     }
 
@@ -212,7 +212,7 @@ public class RelocationIT extends ESIntegTestCase {
                 clusterAdmin().prepareReroute().add(new MoveAllocationCommand("test", 0, nodes[fromNode], nodes[toNode])).get();
                 if (rarely()) {
                     logger.debug("--> flushing");
-                    client().admin().indices().prepareFlush().get();
+                    indicesAdmin().prepareFlush().get();
                 }
                 ClusterHealthResponse clusterHealthResponse = clusterAdmin().prepareHealth()
                     .setWaitForEvents(Priority.LANGUID)
@@ -230,7 +230,7 @@ public class RelocationIT extends ESIntegTestCase {
             logger.info("--> indexing threads stopped");
 
             logger.info("--> refreshing the index");
-            client().admin().indices().prepareRefresh("test").execute().actionGet();
+            indicesAdmin().prepareRefresh("test").execute().actionGet();
             logger.info("--> searching the index");
             boolean ranOnce = false;
             for (int i = 0; i < 10; i++) {
@@ -550,7 +550,7 @@ public class RelocationIT extends ESIntegTestCase {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         logger.info("--> flush so we have an actual index");
-        client().admin().indices().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().execute().actionGet();
         logger.info("--> index more docs so we have something in the translog");
         for (int i = 10; i < 20; i++) {
             client().prepareIndex("test")
@@ -581,7 +581,7 @@ public class RelocationIT extends ESIntegTestCase {
         assertThat(clusterHealthResponse.isTimedOut(), equalTo(false));
 
         logger.info("--> verifying count");
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().execute().actionGet();
         assertThat(client().prepareSearch("test").setSize(0).execute().actionGet().getHits().getTotalHits().value, equalTo(20L));
     }
 
@@ -601,7 +601,7 @@ public class RelocationIT extends ESIntegTestCase {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value" + i).execute().actionGet();
         }
         logger.info("--> flush so we have an actual index");
-        client().admin().indices().prepareFlush().execute().actionGet();
+        indicesAdmin().prepareFlush().execute().actionGet();
         logger.info("--> index more docs so we have something in the translog");
         final List<ActionFuture<IndexResponse>> pendingIndexResponses = new ArrayList<>();
         for (int i = 10; i < 20; i++) {
@@ -648,7 +648,7 @@ public class RelocationIT extends ESIntegTestCase {
 
         logger.info("--> verifying count");
         assertBusy(() -> {
-            client().admin().indices().prepareRefresh().execute().actionGet();
+            indicesAdmin().prepareRefresh().execute().actionGet();
             assertTrue(pendingIndexResponses.stream().allMatch(ActionFuture::isDone));
         }, 1, TimeUnit.MINUTES);
 
@@ -687,7 +687,7 @@ public class RelocationIT extends ESIntegTestCase {
     private void assertActiveCopiesEstablishedPeerRecoveryRetentionLeases() throws Exception {
         assertBusy(() -> {
             for (String index : clusterAdmin().prepareState().get().getState().metadata().indices().keySet()) {
-                Map<ShardId, List<ShardStats>> byShardId = Stream.of(client().admin().indices().prepareStats(index).get().getShards())
+                Map<ShardId, List<ShardStats>> byShardId = Stream.of(indicesAdmin().prepareStats(index).get().getShards())
                     .collect(Collectors.groupingBy(l -> l.getShardRouting().shardId()));
                 for (List<ShardStats> shardStats : byShardId.values()) {
                     Set<String> expectedLeaseIds = shardStats.stream()

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/SimpleRecoveryIT.java
@@ -43,12 +43,12 @@ public class SimpleRecoveryIT extends ESIntegTestCase {
         NumShards numShards = getNumShards("test");
 
         client().index(new IndexRequest("test").id("1").source(source("1", "test"), XContentType.JSON)).actionGet();
-        FlushResponse flushResponse = client().admin().indices().flush(new FlushRequest("test")).actionGet();
+        FlushResponse flushResponse = indicesAdmin().flush(new FlushRequest("test")).actionGet();
         assertThat(flushResponse.getTotalShards(), equalTo(numShards.totalNumShards));
         assertThat(flushResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
         assertThat(flushResponse.getFailedShards(), equalTo(0));
         client().index(new IndexRequest("test").id("2").source(source("2", "test"), XContentType.JSON)).actionGet();
-        RefreshResponse refreshResponse = client().admin().indices().refresh(new RefreshRequest("test")).actionGet();
+        RefreshResponse refreshResponse = indicesAdmin().refresh(new RefreshRequest("test")).actionGet();
         assertThat(refreshResponse.getTotalShards(), equalTo(numShards.totalNumShards));
         assertThat(refreshResponse.getSuccessfulShards(), equalTo(numShards.numPrimaries));
         assertThat(refreshResponse.getFailedShards(), equalTo(0));

--- a/server/src/internalClusterTest/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/recovery/TruncatedRecoveryIT.java
@@ -97,9 +97,9 @@ public class TruncatedRecoveryIT extends ESIntegTestCase {
         }
         ensureGreen();
         // ensure we have flushed segments and make them a big one via optimize
-        client().admin().indices().prepareFlush().setForce(true).get();
-        client().admin().indices().prepareFlush().setForce(true).get(); // double flush to create safe commit in case of async durability
-        client().admin().indices().prepareForceMerge().setMaxNumSegments(1).setFlush(true).get();
+        indicesAdmin().prepareFlush().setForce(true).get();
+        indicesAdmin().prepareFlush().setForce(true).get(); // double flush to create safe commit in case of async durability
+        indicesAdmin().prepareForceMerge().setMaxNumSegments(1).setFlush(true).get();
 
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicBoolean truncate = new AtomicBoolean(true);

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasResolveRoutingIT.java
@@ -33,8 +33,8 @@ public class AliasResolveRoutingIT extends ESIntegTestCase {
         createIndex("test-0");
         createIndex("test-1");
         ensureGreen();
-        client().admin().indices().prepareAliases().addAlias("test-0", "alias-0").addAlias("test-1", "alias-1").get();
-        client().admin().indices().prepareClose("test-1").get();
+        indicesAdmin().prepareAliases().addAlias("test-0", "alias-0").addAlias("test-1", "alias-1").get();
+        indicesAdmin().prepareClose("test-1").get();
         indexRandom(
             true,
             client().prepareIndex("test-0").setId("1").setSource("field1", "the quick brown fox jumps"),

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/AliasRoutingIT.java
@@ -35,7 +35,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
     public void testAliasCrudRouting() throws Exception {
         createIndex("test");
         ensureGreen();
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias0").routing("0")));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias0").routing("0")));
 
         logger.info("--> indexing with id [1], and routing [0] using alias");
         client().prepareIndex("alias0").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
@@ -100,8 +100,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.add().index("test").alias("alias"))
                 .addAliasAction(AliasActions.add().index("test").alias("alias0").routing("0"))
                 .addAliasAction(AliasActions.add().index("test").alias("alias1").routing("1"))
@@ -455,8 +454,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
         createIndex("test-b");
         ensureGreen();
         assertAcked(
-            admin().indices()
-                .prepareAliases()
+            indicesAdmin().prepareAliases()
                 .addAliasAction(AliasActions.add().index("test-a").alias("alias-a0").routing("0"))
                 .addAliasAction(AliasActions.add().index("test-a").alias("alias-a1").routing("1"))
                 .addAliasAction(AliasActions.add().index("test-b").alias("alias-b0").routing("0"))
@@ -566,7 +564,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
     public void testAliasSearchRoutingWithConcreteAndAliasedIndices_issue2682() throws Exception {
         createIndex("index", "index_2");
         ensureGreen();
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("index").alias("index_1").routing("1")));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("index").alias("index_1").routing("1")));
 
         logger.info("--> indexing on index_1 which is an alias for index with routing [1]");
         client().prepareIndex("index_1").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
@@ -597,7 +595,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
     public void testAliasSearchRoutingWithConcreteAndAliasedIndices_issue3268() throws Exception {
         createIndex("index", "index_2");
         ensureGreen();
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("index").alias("index_1").routing("1")));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("index").alias("index_1").routing("1")));
 
         logger.info("--> indexing on index_1 which is an alias for index with routing [1]");
         client().prepareIndex("index_1").setId("1").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
@@ -622,7 +620,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
         logger.info("--> creating alias with routing [3]");
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias").routing("3")));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias").routing("3")));
 
         logger.info("--> indexing with id [0], and routing [3]");
         client().prepareIndex("alias").setId("0").setSource("field", "value1").setRefreshPolicy(RefreshPolicy.IMMEDIATE).get();
@@ -653,7 +651,7 @@ public class AliasRoutingIT extends ESIntegTestCase {
         }
 
         logger.info("--> creating alias with routing [4]");
-        assertAcked(admin().indices().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias").routing("4")));
+        assertAcked(indicesAdmin().prepareAliases().addAliasAction(AliasActions.add().index("test").alias("alias").routing("4")));
 
         logger.info("--> verifying search with wrong routing should not find");
         for (int i = 0; i < 5; i++) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/PartitionedRoutingIT.java
@@ -227,7 +227,7 @@ public class PartitionedRoutingIT extends ESIntegTestCase {
             }
         }
 
-        client().admin().indices().prepareRefresh(index).get();
+        indicesAdmin().prepareRefresh(index).get();
 
         return routingToDocumentIds;
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/routing/SimpleRoutingIT.java
@@ -388,7 +388,7 @@ public class SimpleRoutingIT extends ESIntegTestCase {
         }
 
         client().prepareUpdate(indexOrAlias(), "1").setRouting(routingValue).setDoc(Requests.INDEX_CONTENT_TYPE, "field", "value2").get();
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().execute().actionGet();
 
         for (int i = 0; i < 5; i++) {
             try {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchCancellationIT.java
@@ -62,7 +62,7 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         awaitForBlock(plugins);
         cancelSearch(SearchAction.NAME);
         disableBlocks(plugins);
-        logger.info("Segments {}", Strings.toString(client().admin().indices().prepareSegments("test").get()));
+        logger.info("Segments {}", Strings.toString(indicesAdmin().prepareSegments("test").get()));
         ensureSearchWasCancelled(searchResponse);
     }
 
@@ -79,7 +79,7 @@ public class SearchCancellationIT extends AbstractSearchCancellationTestCase {
         awaitForBlock(plugins);
         cancelSearch(SearchAction.NAME);
         disableBlocks(plugins);
-        logger.info("Segments {}", Strings.toString(client().admin().indices().prepareSegments("test").get()));
+        logger.info("Segments {}", Strings.toString(indicesAdmin().prepareSegments("test").get()));
         ensureSearchWasCancelled(searchResponse);
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/SearchWithRejectionsIT.java
@@ -38,7 +38,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
         for (int i = 0; i < docs; i++) {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", "value").get();
         }
-        IndicesStatsResponse indicesStats = client().admin().indices().prepareStats().get();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats().get();
         assertThat(indicesStats.getTotal().getSearch().getOpenContexts(), equalTo(0L));
         refresh();
 
@@ -56,7 +56,7 @@ public class SearchWithRejectionsIT extends ESIntegTestCase {
             } catch (Exception t) {}
         }
         assertBusy(
-            () -> assertThat(client().admin().indices().prepareStats().get().getTotal().getSearch().getOpenContexts(), equalTo(0L)),
+            () -> assertThat(indicesAdmin().prepareStats().get().getTotal().getSearch().getOpenContexts(), equalTo(0L)),
             1,
             TimeUnit.SECONDS
         );

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/EquivalenceIT.java
@@ -128,7 +128,7 @@ public class EquivalenceIT extends ESIntegTestCase {
             source = source.endArray().endObject();
             client().prepareIndex("idx").setSource(source).get();
         }
-        assertNoFailures(client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).get());
+        assertNoFailures(indicesAdmin().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).get());
 
         final int numRanges = randomIntBetween(1, 20);
         final double[][] ranges = new double[numRanges][];
@@ -253,9 +253,7 @@ public class EquivalenceIT extends ESIntegTestCase {
         }
         indexRandom(true, indexingRequests);
 
-        assertNoFailures(
-            client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get()
-        );
+        assertNoFailures(indicesAdmin().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
 
         SearchResponse resp = client().prepareSearch("idx")
             .addAggregation(
@@ -354,9 +352,7 @@ public class EquivalenceIT extends ESIntegTestCase {
             source = source.endArray().endObject();
             client().prepareIndex("idx").setSource(source).get();
         }
-        assertNoFailures(
-            client().admin().indices().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get()
-        );
+        assertNoFailures(indicesAdmin().prepareRefresh("idx").setIndicesOptions(IndicesOptions.lenientExpandOpen()).execute().get());
 
         Map<String, Object> params = new HashMap<>();
         params.put("interval", interval);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/MetadataIT.java
@@ -27,7 +27,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertSear
 public class MetadataIT extends ESIntegTestCase {
 
     public void testMetadataSetOnAggregationResult() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("name", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("idx").setMapping("name", "type=keyword").get());
         IndexRequestBuilder[] builders = new IndexRequestBuilder[randomInt(30)];
         for (int i = 0; i < builders.length; i++) {
             String name = "name_" + randomIntBetween(1, 10);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DateHistogramIT.java
@@ -161,7 +161,7 @@ public class DateHistogramIT extends ESIntegTestCase {
         addExpectedBucket(date(1, 6), 1, 5, 1);
         addExpectedBucket(date(1, 7), 1, 5, 1);
 
-        assertAcked(client().admin().indices().prepareCreate("sort_idx").setMapping("date", "type=date").get());
+        assertAcked(indicesAdmin().prepareCreate("sort_idx").setMapping("date", "type=date").get());
         for (int i = 1; i <= 3; i++) {
             builders.add(
                 client().prepareIndex("sort_idx")
@@ -1355,7 +1355,7 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     public void testDSTBoundaryIssue9491() throws InterruptedException, ExecutionException {
-        assertAcked(client().admin().indices().prepareCreate("test9491").setMapping("d", "type=date").get());
+        assertAcked(indicesAdmin().prepareCreate("test9491").setMapping("d", "type=date").get());
         indexRandom(
             true,
             client().prepareIndex("test9491").setSource("d", "2014-10-08T13:00:00Z"),
@@ -1378,7 +1378,7 @@ public class DateHistogramIT extends ESIntegTestCase {
     }
 
     public void testIssue8209() throws InterruptedException, ExecutionException {
-        assertAcked(client().admin().indices().prepareCreate("test8209").setMapping("d", "type=date").get());
+        assertAcked(indicesAdmin().prepareCreate("test8209").setMapping("d", "type=date").get());
         indexRandom(
             true,
             client().prepareIndex("test8209").setSource("d", "2014-01-01T00:00:00Z"),
@@ -1447,7 +1447,7 @@ public class DateHistogramIT extends ESIntegTestCase {
      */
     public void testRewriteTimeZone_EpochMillisFormat() throws InterruptedException, ExecutionException {
         String index = "test31392";
-        assertAcked(client().admin().indices().prepareCreate(index).setMapping("d", "type=date,format=epoch_millis").get());
+        assertAcked(indicesAdmin().prepareCreate(index).setMapping("d", "type=date,format=epoch_millis").get());
         indexRandom(true, client().prepareIndex(index).setSource("d", "1477954800000"));
         ensureSearchable(index);
         SearchResponse response = client().prepareSearch(index)

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/DiversifiedSamplerIT.java
@@ -86,7 +86,7 @@ public class DiversifiedSamplerIT extends ESIntegTestCase {
                 .setSource("name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
         }
-        client().admin().indices().refresh(new RefreshRequest("test")).get();
+        indicesAdmin().refresh(new RefreshRequest("test")).get();
     }
 
     public void testIssue10719() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/HistogramIT.java
@@ -188,7 +188,7 @@ public class HistogramIT extends ESIntegTestCase {
         addExpectedBucket(6, 1, 5, 1);
         addExpectedBucket(7, 1, 5, 1);
 
-        assertAcked(client().admin().indices().prepareCreate("sort_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=double").get());
+        assertAcked(indicesAdmin().prepareCreate("sort_idx").setMapping(SINGLE_VALUED_FIELD_NAME, "type=double").get());
         for (int i = 1; i <= 3; i++) {
             builders.add(
                 client().prepareIndex("sort_idx")

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/MinDocCountIT.java
@@ -92,7 +92,7 @@ public class MinDocCountIT extends AbstractTermsTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("s", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("idx").setMapping("s", "type=keyword").get());
 
         cardinality = randomIntBetween(8, 30);
         final List<IndexRequestBuilder> indexRequests = new ArrayList<>();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/NaNSortingIT.java
@@ -103,7 +103,7 @@ public class NaNSortingIT extends ESIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("string_value", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("idx").setMapping("string_value", "type=keyword").get());
         final int numDocs = randomIntBetween(2, 10);
         for (int i = 0; i < numDocs; ++i) {
             final long value = randomInt(5);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/SamplerIT.java
@@ -84,7 +84,7 @@ public class SamplerIT extends ESIntegTestCase {
                 .setSource("name", parts[2], "genre", parts[8], "price", Float.parseFloat(parts[3]))
                 .get();
         }
-        client().admin().indices().refresh(new RefreshRequest("test")).get();
+        indicesAdmin().refresh(new RefreshRequest("test")).get();
     }
 
     public void testIssue10719() throws Exception {

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/bucket/TermsDocCountErrorIT.java
@@ -51,7 +51,7 @@ public class TermsDocCountErrorIT extends ESIntegTestCase {
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").setMapping(STRING_FIELD_NAME, "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("idx").setMapping(STRING_FIELD_NAME, "type=keyword").get());
         List<IndexRequestBuilder> builders = new ArrayList<>();
         int numDocs = between(10, 200);
         int numUniqueTerms = between(2, numDocs / 2);

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/metrics/TopHitsIT.java
@@ -1226,7 +1226,7 @@ public class TopHitsIT extends ESIntegTestCase {
                 equalTo(3L)
             );
         } finally {
-            assertAcked(client().admin().indices().prepareDelete("cache_test_idx")); // delete this - if we use tests.iters it would fail
+            assertAcked(indicesAdmin().prepareDelete("cache_test_idx")); // delete this - if we use tests.iters it would fail
         }
     }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/aggregations/pipeline/BucketMetricsPipeLineAggregationTestCase.java
@@ -77,7 +77,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
 
     @Override
     public void setupSuiteScopeCluster() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("idx").setMapping("tag", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("idx").setMapping("tag", "type=keyword").get());
         createIndex("idx_unmapped");
 
         numDocs = randomIntBetween(6, 20);
@@ -465,7 +465,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
             .endObject()
           .endObject();
         // end::noformat
-        assertAcked(client().admin().indices().prepareCreate("foo_2").setMapping(builder).get());
+        assertAcked(indicesAdmin().prepareCreate("foo_2").setMapping(builder).get());
         // tag::noformat
         XContentBuilder docBuilder = jsonBuilder().startObject()
             .startObject("license")
@@ -477,7 +477,7 @@ abstract class BucketMetricsPipeLineAggregationTestCase<T extends NumericMetrics
         // end::noformat
         client().prepareIndex("foo_2").setSource(docBuilder).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
-        client().admin().indices().prepareRefresh();
+        indicesAdmin().prepareRefresh();
 
         TermsAggregationBuilder groupByLicenseAgg = terms("group_by_license_partnumber").field("license.partnumber.keyword");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/SearchWithRandomExceptionsIT.java
@@ -113,7 +113,7 @@ public class SearchWithRandomExceptionsIT extends ESIntegTestCase {
         }
         logger.info("Start Refresh");
         // don't assert on failures here
-        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh("test").execute().get();
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh("test").execute().get();
         final boolean refreshFailed = refreshResponse.getShardFailures().length != 0 || refreshResponse.getFailedShards() != 0;
         logger.info(
             "Refresh failed [{}] numShardsFailed: [{}], shardFailuresLength: [{}], successfulShards: [{}], totalShards: [{}] ",

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportSearchFailuresIT.java
@@ -49,7 +49,7 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
         for (int i = 0; i < 100; i++) {
             index(client(), Integer.toString(i), "test", i);
         }
-        RefreshResponse refreshResponse = client().admin().indices().refresh(new RefreshRequest("test")).actionGet();
+        RefreshResponse refreshResponse = indicesAdmin().refresh(new RefreshRequest("test")).actionGet();
         assertThat(refreshResponse.getTotalShards(), equalTo(test.totalNumShards));
         assertThat(refreshResponse.getSuccessfulShards(), equalTo(test.numPrimaries));
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
@@ -86,7 +86,7 @@ public class TransportSearchFailuresIT extends ESIntegTestCase {
         assertThat(clusterHealth.getStatus(), anyOf(equalTo(ClusterHealthStatus.YELLOW), equalTo(ClusterHealthStatus.GREEN)));
         assertThat(clusterHealth.getActiveShards(), equalTo(test.totalNumShards));
 
-        refreshResponse = client().admin().indices().refresh(new RefreshRequest("test")).actionGet();
+        refreshResponse = indicesAdmin().refresh(new RefreshRequest("test")).actionGet();
         assertThat(refreshResponse.getTotalShards(), equalTo(test.totalNumShards));
         assertThat(refreshResponse.getSuccessfulShards(), equalTo(test.totalNumShards));
         assertThat(refreshResponse.getFailedShards(), equalTo(0));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/basic/TransportTwoNodesSearchIT.java
@@ -101,7 +101,7 @@ public class TransportTwoNodesSearchIT extends ESIntegTestCase {
 
     public void testDfsQueryThenFetch() throws Exception {
         Settings.Builder settingsBuilder = Settings.builder().put(indexSettings());
-        client().admin().indices().create(new CreateIndexRequest("test").settings(settingsBuilder)).actionGet();
+        indicesAdmin().create(new CreateIndexRequest("test").settings(settingsBuilder)).actionGet();
         ensureGreen();
 
         // we need to have age (ie number of repeats of "test" term) high enough

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/FetchSubPhasePluginIT.java
@@ -70,7 +70,7 @@ public class FetchSubPhasePluginIT extends ESIntegTestCase {
         client().index(new IndexRequest("test").id("1").source(jsonBuilder().startObject().field("test", "I am sam i am").endObject()))
             .actionGet();
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse response = client().prepareSearch()
             .setSource(new SearchSourceBuilder().ext(Collections.singletonList(new TermVectorsFetchBuilder("test"))))

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fetch/subphase/highlight/HighlighterSearchIT.java
@@ -2975,7 +2975,7 @@ public class HighlighterSearchIT extends ESIntegTestCase {
             .endObject()
             .endObject();
         assertAcked(prepareCreate("test").setMapping(mapping));
-        assertAcked(client().admin().indices().prepareAliases().addAlias("test", "filtered_alias", matchQuery("foo", "japanese")));
+        assertAcked(indicesAdmin().prepareAliases().addAlias("test", "filtered_alias", matchQuery("foo", "japanese")));
         ensureGreen();
 
         indexRandom(true, client().prepareIndex("test").setSource("foo", "test japanese"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/fieldcaps/FieldCapabilitiesIT.java
@@ -181,7 +181,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             .endObject()
             .endObject();
         assertAcked(prepareCreate("new_index").setMapping(newIndexMapping));
-        assertAcked(client().admin().indices().prepareAliases().addAlias("new_index", "current"));
+        assertAcked(indicesAdmin().prepareAliases().addAlias("new_index", "current"));
     }
 
     @Override
@@ -461,7 +461,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         reqs.add(client().prepareIndex("log-index-2").setSource("timestamp", "2020-10-10"));
         indexRandom(true, reqs);
         ensureGreen("log-index-1", "log-index-2");
-        client().admin().indices().prepareRefresh("log-index-1", "log-index-2").get();
+        indicesAdmin().prepareRefresh("log-index-1", "log-index-2").get();
     }
 
     public void testTargetNodeFails() throws Exception {
@@ -614,7 +614,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
             """;
         String[] indices = IntStream.range(0, between(1, 9)).mapToObj(n -> "test_many_index_" + n).toArray(String[]::new);
         for (String index : indices) {
-            assertAcked(client().admin().indices().prepareCreate(index).setMapping(mapping).get());
+            assertAcked(indicesAdmin().prepareCreate(index).setMapping(mapping).get());
         }
         FieldCapabilitiesRequest request = new FieldCapabilitiesRequest();
         request.indices("test_many_index_*");
@@ -650,7 +650,7 @@ public class FieldCapabilitiesIT extends ESIntegTestCase {
         // add an extra field for some indices
         String[] indicesWithExtraField = randomSubsetOf(between(1, indices.length), indices).stream().sorted().toArray(String[]::new);
         ensureGreen(indices);
-        assertAcked(client().admin().indices().preparePutMapping(indicesWithExtraField).setSource("extra_field", "type=integer").get());
+        assertAcked(indicesAdmin().preparePutMapping(indicesWithExtraField).setSource("extra_field", "type=integer").get());
         for (String index : indicesWithExtraField) {
             client().prepareIndex(index).setSource("extra_field", randomIntBetween(1, 1000)).get();
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/functionscore/QueryRescorerIT.java
@@ -174,26 +174,24 @@ public class QueryRescorerIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1))
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1)));
 
         client().prepareIndex("test").setId("1").setSource("field1", "massachusetts avenue boston massachusetts").get();
         client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts").get();
         client().prepareIndex("test").setId("3").setSource("field1", "boston avenue lexington massachusetts").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         client().prepareIndex("test").setId("4").setSource("field1", "boston road lexington massachusetts").get();
         client().prepareIndex("test").setId("5").setSource("field1", "lexington street lexington massachusetts").get();
         client().prepareIndex("test").setId("6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
         client().prepareIndex("test").setId("7").setSource("field1", "bosten street san franciso california").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         client().prepareIndex("test").setId("8").setSource("field1", "hollywood boulevard los angeles california").get();
         client().prepareIndex("test").setId("9").setSource("field1", "1st street boston massachussetts").get();
         client().prepareIndex("test").setId("10").setSource("field1", "1st street boston massachusetts").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         client().prepareIndex("test").setId("11").setSource("field1", "2st street boston massachusetts").get();
         client().prepareIndex("test").setId("12").setSource("field1", "3st street boston massachusetts").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(QueryBuilders.matchQuery("field1", "lexington avenue massachusetts").operator(Operator.OR))
             .setFrom(0)
@@ -265,16 +263,14 @@ public class QueryRescorerIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1))
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1)));
 
         client().prepareIndex("test").setId("3").setSource("field1", "massachusetts").get();
         client().prepareIndex("test").setId("6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         client().prepareIndex("test").setId("1").setSource("field1", "lexington massachusetts avenue").get();
         client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts road").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(QueryBuilders.matchQuery("field1", "massachusetts"))
@@ -347,16 +343,14 @@ public class QueryRescorerIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1))
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(mapping).setSettings(builder.put("index.number_of_shards", 1)));
 
         client().prepareIndex("test").setId("3").setSource("field1", "massachusetts").get();
         client().prepareIndex("test").setId("6").setSource("field1", "massachusetts avenue lexington massachusetts").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         client().prepareIndex("test").setId("1").setSource("field1", "lexington massachusetts avenue").get();
         client().prepareIndex("test").setId("2").setSource("field1", "lexington avenue boston massachusetts road").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(QueryBuilders.matchQuery("field1", "massachusetts").operator(Operator.OR))

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/morelikethis/MoreLikeThisIT.java
@@ -80,7 +80,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .actionGet();
         client().index(new IndexRequest("test").id("2").source(jsonBuilder().startObject().field("text", "lucene release").endObject()))
             .actionGet();
-        client().admin().indices().refresh(new RefreshRequest()).actionGet();
+        indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis");
         SearchResponse response = client().prepareSearch()
@@ -113,7 +113,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .actionGet();
         client().index(new IndexRequest("test").id("2").source(jsonBuilder().startObject().field("text", "lucene release").endObject()))
             .actionGet();
-        client().admin().indices().refresh(new RefreshRequest()).actionGet();
+        indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis");
         SearchResponse response = client().prepareSearch()
@@ -150,7 +150,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             new IndexRequest("test").id("2").source(jsonBuilder().startObject().field("myField", "and_foo").field("empty", "").endObject())
         ).actionGet();
 
-        client().admin().indices().refresh(new RefreshRequest()).actionGet();
+        indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(
@@ -175,7 +175,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         client().index(new IndexRequest("test").id("3").source(jsonBuilder().startObject().field("some_long", -666).endObject()))
             .actionGet();
 
-        client().admin().indices().refresh(new RefreshRequest()).actionGet();
+        indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis");
         SearchResponse response = client().prepareSearch()
@@ -218,7 +218,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         client().index(
             new IndexRequest("test").id("4").source(jsonBuilder().startObject().field("text", "elasticsearch release").endObject())
         ).actionGet();
-        client().admin().indices().refresh(new RefreshRequest()).actionGet();
+        indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running moreLikeThis on index");
         SearchResponse response = client().prepareSearch()
@@ -254,8 +254,8 @@ public class MoreLikeThisIT extends ESIntegTestCase {
         String indexName = "foo";
         String aliasName = "foo_name";
 
-        client().admin().indices().prepareCreate(indexName).get();
-        client().admin().indices().prepareAliases().addAlias(indexName, aliasName).get();
+        indicesAdmin().prepareCreate(indexName).get();
+        indicesAdmin().prepareAliases().addAlias(indexName, aliasName).get();
 
         assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));
 
@@ -277,12 +277,12 @@ public class MoreLikeThisIT extends ESIntegTestCase {
     }
 
     public void testMoreLikeThisIssue2197() throws Exception {
-        client().admin().indices().prepareCreate("foo").get();
+        indicesAdmin().prepareCreate("foo").get();
         client().prepareIndex("foo")
             .setId("1")
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
             .get();
-        client().admin().indices().prepareRefresh("foo").get();
+        indicesAdmin().prepareRefresh("foo").get();
         assertThat(ensureGreen(), equalTo(ClusterHealthStatus.GREEN));
 
         SearchResponse response = client().prepareSearch()
@@ -297,7 +297,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
 
     // Issue #2489
     public void testMoreLikeWithCustomRouting() throws Exception {
-        client().admin().indices().prepareCreate("foo").get();
+        indicesAdmin().prepareCreate("foo").get();
         ensureGreen();
 
         client().prepareIndex("foo")
@@ -305,7 +305,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
             .setRouting("2")
             .get();
-        client().admin().indices().prepareRefresh("foo").get();
+        indicesAdmin().prepareRefresh("foo").get();
 
         SearchResponse response = client().prepareSearch()
             .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("foo", "1").routing("2") }))
@@ -324,7 +324,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             .setSource(jsonBuilder().startObject().startObject("foo").field("bar", "boz").endObject().endObject())
             .setRouting("4000")
             .get();
-        client().admin().indices().prepareRefresh("foo").get();
+        indicesAdmin().prepareRefresh("foo").get();
         SearchResponse response = client().prepareSearch()
             .setQuery(new MoreLikeThisQueryBuilder(null, new Item[] { new Item("foo", "1").routing("4000") }))
             .get();
@@ -510,7 +510,7 @@ public class MoreLikeThisIT extends ESIntegTestCase {
             new IndexRequest("test").id("2")
                 .source(jsonBuilder().startObject().field("text", "Lucene has been ported to other programming languages").endObject())
         ).actionGet();
-        client().admin().indices().refresh(new RefreshRequest()).actionGet();
+        indicesAdmin().refresh(new RefreshRequest()).actionGet();
 
         logger.info("Running More Like This with include true");
         SearchResponse response = client().prepareSearch()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/nested/SimpleNestedIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/nested/SimpleNestedIT.java
@@ -361,7 +361,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
                 )
         );
 
-        client().admin().indices().prepareAliases().addAlias("test", "alias1", QueryBuilders.termQuery("field1", "value1")).get();
+        indicesAdmin().prepareAliases().addAlias("test", "alias1", QueryBuilders.termQuery("field1", "value1")).get();
 
         ensureGreen();
 
@@ -1564,7 +1564,7 @@ public class SimpleNestedIT extends ESIntegTestCase {
         assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
 
         // Now add nested mapping
-        assertAcked(client().admin().indices().preparePutMapping("test").setSource("array1", "type=nested"));
+        assertAcked(indicesAdmin().preparePutMapping("test").setSource("array1", "type=nested"));
 
         XContentBuilder builder = jsonBuilder().startObject()
             .startArray("array1")
@@ -1596,16 +1596,15 @@ public class SimpleNestedIT extends ESIntegTestCase {
         clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
         assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), greaterThan(0L));
 
-        assertAcked(client().admin().indices().prepareDelete("test"));
+        assertAcked(indicesAdmin().prepareDelete("test"));
         clusterStatsResponse = client().admin().cluster().prepareClusterStats().get();
         assertThat(clusterStatsResponse.getIndicesStats().getSegments().getBitsetMemoryInBytes(), equalTo(0L));
     }
 
     private void assertDocumentCount(String index, long numdocs) {
-        IndicesStatsResponse stats = admin().indices().prepareStats(index).clear().setDocs(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(index).clear().setDocs(true).get();
         assertNoFailures(stats);
         assertThat(stats.getIndex(index).getPrimaries().docs.getCount(), is(numdocs));
-
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/ExistsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/ExistsIT.java
@@ -74,7 +74,7 @@ public class ExistsIT extends ESIntegTestCase {
             .endObject()
             .endObject();
 
-        assertAcked(client().admin().indices().prepareCreate("idx").setMapping(mapping));
+        assertAcked(indicesAdmin().prepareCreate("idx").setMapping(mapping));
         Map<String, Object> barObject = new HashMap<>();
         barObject.put("foo", "bar");
         barObject.put("bar", singletonMap("bar", "foo"));

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SearchQueryIT.java
@@ -427,7 +427,7 @@ public class SearchQueryIT extends ESIntegTestCase {
     }
 
     public void testIdsQueryTestsIdIndexed() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test"));
+        assertAcked(indicesAdmin().prepareCreate("test"));
 
         indexRandom(
             true,
@@ -456,7 +456,7 @@ public class SearchQueryIT extends ESIntegTestCase {
     public void testTermIndexQuery() throws Exception {
         String[] indexNames = { "test1", "test2" };
         for (String indexName : indexNames) {
-            assertAcked(client().admin().indices().prepareCreate(indexName));
+            assertAcked(indicesAdmin().prepareCreate(indexName));
 
             indexRandom(true, client().prepareIndex(indexName).setId(indexName + "1").setSource("field1", "value1"));
 
@@ -678,7 +678,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "1", "2");
 
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         builder = multiMatchQuery("value1", "field1", "field2").operator(Operator.AND); // Operator only applies on terms inside a field!
                                                                                         // Fields are always OR-ed together.
         searchResponse = client().prepareSearch().setQuery(builder).get();
@@ -693,7 +693,7 @@ public class SearchQueryIT extends ESIntegTestCase {
         assertHitCount(searchResponse, 2L);
         assertSearchHits(searchResponse, "3", "1");
 
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         builder = multiMatchQuery("value1").field("field1").field("field3", 1.5f).operator(Operator.AND); // Operator only applies on terms
                                                                                                           // inside a field! Fields are
                                                                                                           // always OR-ed together.
@@ -1661,7 +1661,7 @@ public class SearchQueryIT extends ESIntegTestCase {
 
     public void testDateProvidedAsNumber() throws InterruptedException {
         createIndex("test");
-        assertAcked(client().admin().indices().preparePutMapping("test").setSource("field", "type=date,format=epoch_millis").get());
+        assertAcked(indicesAdmin().preparePutMapping("test").setSource("field", "type=date,format=epoch_millis").get());
         indexRandom(
             true,
             client().prepareIndex("test").setId("1").setSource("field", 1000000000001L),

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/query/SimpleQueryStringIT.java
@@ -339,7 +339,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
                 .endObject()
         );
 
-        CreateIndexRequestBuilder mappingRequest = client().admin().indices().prepareCreate("test1").setMapping(mapping);
+        CreateIndexRequestBuilder mappingRequest = indicesAdmin().prepareCreate("test1").setMapping(mapping);
         mappingRequest.get();
         indexRandom(true, client().prepareIndex("test1").setId("1").setSource("location", "Köln"));
         refresh();
@@ -386,7 +386,7 @@ public class SimpleQueryStringIT extends ESIntegTestCase {
                 .endObject()
         );
 
-        CreateIndexRequestBuilder mappingRequest = client().admin().indices().prepareCreate("test1").setMapping(mapping);
+        CreateIndexRequestBuilder mappingRequest = indicesAdmin().prepareCreate("test1").setMapping(mapping);
         mappingRequest.get();
         indexRandom(true, client().prepareIndex("test1").setId("1").setSource("body", "Some Text"));
         refresh();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchPreferenceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/routing/SearchPreferenceIT.java
@@ -106,7 +106,7 @@ public class SearchPreferenceIT extends ESIntegTestCase {
     }
 
     public void testSimplePreference() {
-        client().admin().indices().prepareCreate("test").setSettings("{\"number_of_replicas\": 1}", XContentType.JSON).get();
+        indicesAdmin().prepareCreate("test").setSettings("{\"number_of_replicas\": 1}", XContentType.JSON).get();
         ensureGreen();
 
         client().prepareIndex("test").setSource("field1", "value1").get();
@@ -254,7 +254,7 @@ public class SearchPreferenceIT extends ESIntegTestCase {
 
         assertSearchesSpecificNode("test", customPreference, nodeId);
 
-        assertAcked(client().admin().indices().prepareDelete("test2"));
+        assertAcked(indicesAdmin().prepareDelete("test2"));
 
         assertSearchesSpecificNode("test", customPreference, nodeId);
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scriptfilter/ScriptQuerySearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scriptfilter/ScriptQuerySearchIT.java
@@ -101,9 +101,7 @@ public class ScriptQuerySearchIT extends ESIntegTestCase {
         final byte[] randomBytesDoc1 = getRandomBytes(15);
         final byte[] randomBytesDoc2 = getRandomBytes(16);
 
-        assertAcked(
-            client().admin().indices().prepareCreate("my-index").setMapping(createMappingSource("binary")).setSettings(indexSettings())
-        );
+        assertAcked(indicesAdmin().prepareCreate("my-index").setMapping(createMappingSource("binary")).setSettings(indexSettings()));
         client().prepareIndex("my-index")
             .setId("1")
             .setSource(jsonBuilder().startObject().field("binaryData", Base64.getEncoder().encodeToString(randomBytesDoc1)).endObject())

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/scroll/SearchScrollIT.java
@@ -68,7 +68,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     }
 
     public void testSimpleScrollQueryThenFetch() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
+        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
@@ -80,7 +80,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .get();
         }
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse searchResponse = client().prepareSearch()
             .setQuery(matchAllQuery())
@@ -118,7 +118,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     }
 
     public void testSimpleScrollQueryThenFetchSmallSizeUnevenDistribution() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
+        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
@@ -133,7 +133,7 @@ public class SearchScrollIT extends ESIntegTestCase {
             client().prepareIndex("test").setId(Integer.toString(i)).setSource("field", i).setRouting(routing).get();
         }
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse searchResponse = client().prepareSearch()
             .setSearchType(SearchType.QUERY_THEN_FETCH)
@@ -185,7 +185,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     }
 
     public void testScrollAndUpdateIndex() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 5)).get();
+        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 5)).get();
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         for (int i = 0; i < 500; i++) {
@@ -201,7 +201,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .get();
         }
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         assertThat(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get().getHits().getTotalHits().value, equalTo(500L));
         assertThat(
@@ -237,7 +237,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                 searchResponse = client().prepareSearchScroll(searchResponse.getScrollId()).setScroll(TimeValue.timeValueMinutes(2)).get();
             } while (searchResponse.getHits().getHits().length > 0);
 
-            client().admin().indices().prepareRefresh().get();
+            indicesAdmin().prepareRefresh().get();
             assertThat(client().prepareSearch().setSize(0).setQuery(matchAllQuery()).get().getHits().getTotalHits().value, equalTo(500L));
             assertThat(
                 client().prepareSearch().setSize(0).setQuery(termQuery("message", "test")).get().getHits().getTotalHits().value,
@@ -261,7 +261,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     }
 
     public void testSimpleScrollQueryThenFetch_clearScrollIds() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
+        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
@@ -273,7 +273,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .get();
         }
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse searchResponse1 = client().prepareSearch()
             .setQuery(matchAllQuery())
@@ -381,7 +381,7 @@ public class SearchScrollIT extends ESIntegTestCase {
     }
 
     public void testSimpleScrollQueryThenFetchClearAllScrollIds() throws Exception {
-        client().admin().indices().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
+        indicesAdmin().prepareCreate("test").setSettings(Settings.builder().put("index.number_of_shards", 3)).get();
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
 
         clusterAdmin().prepareHealth().setWaitForEvents(Priority.LANGUID).setWaitForGreenStatus().get();
@@ -393,7 +393,7 @@ public class SearchScrollIT extends ESIntegTestCase {
                 .get();
         }
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         SearchResponse searchResponse1 = client().prepareSearch()
             .setQuery(matchAllQuery())
@@ -553,11 +553,11 @@ public class SearchScrollIT extends ESIntegTestCase {
             assertThat(((Number) hit.getSortValues()[0]).longValue(), equalTo(counter++));
         }
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareClose("test"));
-            assertAcked(client().admin().indices().prepareOpen("test"));
+            assertAcked(indicesAdmin().prepareClose("test"));
+            assertAcked(indicesAdmin().prepareOpen("test"));
             ensureGreen("test");
         } else {
-            assertAcked(client().admin().indices().prepareDelete("test"));
+            assertAcked(indicesAdmin().prepareDelete("test"));
         }
     }
 
@@ -647,7 +647,7 @@ public class SearchScrollIT extends ESIntegTestCase {
         client().prepareIndex("test").setId("1").setSource("created_date", "2020-01-01").get();
         client().prepareIndex("test").setId("2").setSource("created_date", "2020-01-02").get();
         client().prepareIndex("test").setId("3").setSource("created_date", "2020-01-03").get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         SearchResponse resp = null;
         try {
             int totalHits = 0;
@@ -680,7 +680,7 @@ public class SearchScrollIT extends ESIntegTestCase {
             index("demo", "demo-" + i, Map.of());
             index("prod", "prod-" + i, Map.of());
         }
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
         SearchResponse respFromDemoIndex = client().prepareSearch("demo")
             .setSize(randomIntBetween(1, 10))
             .setQuery(new MatchAllQueryBuilder())

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/searchafter/SearchAfterIT.java
@@ -61,7 +61,7 @@ public class SearchAfterIT extends ESIntegTestCase {
     private static final int NUM_DOCS = 100;
 
     public void testsShouldFail() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=long", "field2", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=long", "field2", "type=keyword").get());
         ensureGreen();
         indexRandom(true, client().prepareIndex("test").setId("0").setSource("field1", 0, "field2", "toto"));
         {
@@ -155,7 +155,7 @@ public class SearchAfterIT extends ESIntegTestCase {
     }
 
     public void testWithNullStrings() throws InterruptedException {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field2", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field2", "type=keyword").get());
         ensureGreen();
         indexRandom(
             true,
@@ -352,7 +352,7 @@ public class SearchAfterIT extends ESIntegTestCase {
     }
 
     private void createIndexMappingsFromObjectType(String indexName, List<Object> types) {
-        CreateIndexRequestBuilder indexRequestBuilder = client().admin().indices().prepareCreate(indexName);
+        CreateIndexRequestBuilder indexRequestBuilder = indicesAdmin().prepareCreate(indexName);
         List<String> mappings = new ArrayList<>();
         int numFields = types.size();
         for (int i = 0; i < numFields; i++) {
@@ -429,7 +429,7 @@ public class SearchAfterIT extends ESIntegTestCase {
         if (randomBoolean()) {
             indexSettings.put("sort.field", "timestamp").put("sort.order", randomFrom("desc", "asc"));
         }
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(indexSettings).setMapping("""
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(indexSettings).setMapping("""
             {"properties":{"timestamp":{"type": "date", "format": "epoch_millis"}}}"""));
         Randomness.shuffle(timestamps);
         final BulkRequestBuilder bulk = client().prepareBulk();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/simple/SimpleSearchIT.java
@@ -261,7 +261,7 @@ public class SimpleSearchIT extends ESIntegTestCase {
     public void testRangeQueryKeyword() throws Exception {
         createIndex("test");
 
-        client().admin().indices().preparePutMapping("test").setSource("field", "type=keyword").get();
+        indicesAdmin().preparePutMapping("test").setSource("field", "type=keyword").get();
 
         client().prepareIndex("test").setId("0").setSource("field", "").get();
         client().prepareIndex("test").setId("1").setSource("field", "A").get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/FieldSortIT.java
@@ -210,7 +210,7 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     public void testTrackScores() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("svalue", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("svalue", "type=keyword").get());
         ensureGreen();
         index(
             "test",
@@ -321,7 +321,7 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     public void test3078() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field", "type=keyword").get());
         ensureGreen();
 
         for (int i = 1; i < 101; i++) {
@@ -459,7 +459,7 @@ public class FieldSortIT extends ESIntegTestCase {
     }
 
     public void testIssue2986() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=keyword").get());
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=keyword").get());
 
         client().prepareIndex("test").setId("1").setSource("{\"field1\":\"value1\"}", XContentType.JSON).get();
         client().prepareIndex("test").setId("2").setSource("{\"field1\":\"value2\"}", XContentType.JSON).get();
@@ -479,11 +479,11 @@ public class FieldSortIT extends ESIntegTestCase {
     public void testIssue2991() {
         for (int i = 1; i < 4; i++) {
             try {
-                client().admin().indices().prepareDelete("test").get();
+                indicesAdmin().prepareDelete("test").get();
             } catch (Exception e) {
                 // ignore
             }
-            assertAcked(client().admin().indices().prepareCreate("test").setMapping("tag", "type=keyword").get());
+            assertAcked(indicesAdmin().prepareCreate("test").setMapping("tag", "type=keyword").get());
             ensureGreen();
             client().prepareIndex("test").setId("1").setSource("tag", "alpha").get();
             refresh();
@@ -582,7 +582,7 @@ public class FieldSortIT extends ESIntegTestCase {
                 if (random.nextInt(5) != 0) {
                     refresh();
                 } else {
-                    client().admin().indices().prepareFlush().get();
+                    indicesAdmin().prepareFlush().get();
                 }
             }
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/GeoDistanceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/GeoDistanceIT.java
@@ -145,7 +145,7 @@ public class GeoDistanceIT extends ESIntegTestCase {
             )
             .get();
 
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         // Order: Asc
         SearchResponse searchResponse = client().prepareSearch("test")

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/sort/SimpleSortIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/sort/SimpleSortIT.java
@@ -170,7 +170,7 @@ public class SimpleSortIT extends ESIntegTestCase {
                 if (random.nextInt(5) != 0) {
                     refresh();
                 } else {
-                    client().admin().indices().prepareFlush().get();
+                    indicesAdmin().prepareFlush().get();
                 }
             }
         }
@@ -258,7 +258,7 @@ public class SimpleSortIT extends ESIntegTestCase {
         for (int i = 10; i < 20; i++) { // add some docs that don't have values in those fields
             client().prepareIndex("test").setId("" + i).setSource(jsonBuilder().startObject().field("ord", i).endObject()).get();
         }
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         // test the long values
         SearchResponse searchResponse = client().prepareSearch()

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/stats/FieldUsageStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/stats/FieldUsageStatsIT.java
@@ -49,7 +49,7 @@ public class FieldUsageStatsIT extends ESIntegTestCase {
     public void testFieldUsageStats() throws ExecutionException, InterruptedException {
         internalCluster().ensureAtLeastNumDataNodes(2);
         int numShards = randomIntBetween(1, 2);
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(indexSettings(numShards, 1)));
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(indexSettings(numShards, 1)));
 
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy/MM/dd", Locale.ROOT);
         LocalDate date = LocalDate.of(2015, 9, 1);
@@ -60,7 +60,7 @@ public class FieldUsageStatsIT extends ESIntegTestCase {
                 .setSource("field", "value", "field2", "value2", "date_field", formatter.format(date.plusDays(i)))
                 .get();
         }
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         ensureGreen("test");
 

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/CompletionSuggestSearchIT.java
@@ -932,7 +932,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
 
     public void testThatStatsAreWorking() throws Exception {
         String otherField = "testOtherField";
-        client().admin().indices().prepareCreate(INDEX).setSettings(indexSettings(2, 0)).get();
+        indicesAdmin().prepareCreate(INDEX).setSettings(indexSettings(2, 0)).get();
         ensureGreen();
         AcknowledgedResponse putMappingResponse = indicesAdmin().preparePutMapping(INDEX)
             .setSource(
@@ -1299,18 +1299,18 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             .get();
         // we have 2 docs in a segment...
         client().prepareIndex(INDEX).setId("2").setSource(jsonBuilder().startObject().field("somefield", "somevalue").endObject()).get();
-        ForceMergeResponse actionGet = client().admin().indices().prepareForceMerge().setFlush(true).setMaxNumSegments(1).get();
+        ForceMergeResponse actionGet = indicesAdmin().prepareForceMerge().setFlush(true).setMaxNumSegments(1).get();
         assertAllSuccessful(actionGet);
         refresh();
         // update the first one and then merge.. the target segment will have no value in FIELD
         client().prepareIndex(INDEX).setId("1").setSource(jsonBuilder().startObject().field("somefield", "somevalue").endObject()).get();
-        actionGet = client().admin().indices().prepareForceMerge().setFlush(true).setMaxNumSegments(1).get();
+        actionGet = indicesAdmin().prepareForceMerge().setFlush(true).setMaxNumSegments(1).get();
         assertAllSuccessful(actionGet);
         refresh();
 
         assertSuggestions("b");
         assertThat(2L, equalTo(client().prepareSearch(INDEX).setSize(0).get().getHits().getTotalHits().value));
-        for (IndexShardSegments seg : client().admin().indices().prepareSegments().get().getIndices().get(INDEX)) {
+        for (IndexShardSegments seg : indicesAdmin().prepareSegments().get().getIndices().get(INDEX)) {
             ShardSegments[] shards = seg.shards();
             for (ShardSegments shardSegments : shards) {
                 assertThat(shardSegments.getSegments().size(), equalTo(1));
@@ -1525,7 +1525,7 @@ public class CompletionSuggestSearchIT extends ESIntegTestCase {
             builder.field("collapse_field", "collapse me").endObject();  // all docs the same value for collapsing
             client().prepareIndex(index).setId("" + i).setSource(builder).get();
         }
-        client().admin().indices().prepareRefresh(index).get();
+        indicesAdmin().prepareRefresh(index).get();
         CompletionSuggestionBuilder prefix = SuggestBuilders.completionSuggestion(suggestField).prefix("sug").size(1);
 
         SearchResponse searchResponse = client().prepareSearch("test")

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/suggest/ContextCompletionSuggestSearchIT.java
@@ -180,7 +180,7 @@ public class ContextCompletionSuggestSearchIT extends ESIntegTestCase {
             )
             .get();
         assertThat(indexResponse.status(), equalTo(RestStatus.CREATED));
-        assertNoFailures(client().admin().indices().prepareRefresh(INDEX).get());
+        assertNoFailures(indicesAdmin().prepareRefresh(INDEX).get());
         CompletionSuggestionBuilder contextSuggestQuery = SuggestBuilders.completionSuggestion(FIELD)
             .prefix("sugg")
             .contexts(

--- a/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/similarity/SimilarityIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.not;
 public class SimilarityIT extends ESIntegTestCase {
     public void testCustomBM25Similarity() throws Exception {
         try {
-            client().admin().indices().prepareDelete("test").execute().actionGet();
+            indicesAdmin().prepareDelete("test").execute().actionGet();
         } catch (Exception e) {
             // ignore
         }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedRestoreIT.java
@@ -46,7 +46,7 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
 
         final String snapshotName = "snapshot";
         createFullSnapshot(repositoryName, snapshotName);
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         logger.info("--> blocking all data nodes for repository [{}]", repositoryName);
         blockAllDataNodes(repositoryName);
@@ -82,7 +82,7 @@ public class AbortedRestoreIT extends AbstractSnapshotIntegTestCase {
         waitForMaxActiveSnapshotThreads(dataNode, equalTo(snapshotThreadPoolInfo.getMax()));
 
         logger.info("--> aborting restore by deleting the index");
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         logger.info("--> unblocking repository [{}]", repositoryName);
         unblockAllDataNodes(repositoryName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/AbortedSnapshotIT.java
@@ -97,7 +97,7 @@ public class AbortedSnapshotIT extends AbstractSnapshotIntegTestCase {
         }
 
         assertTrue(store.hasReferences());
-        assertAcked(client().admin().indices().prepareDelete(indexName).get());
+        assertAcked(indicesAdmin().prepareDelete(indexName).get());
 
         // this is the key assertion: we must release the store without needing any SNAPSHOT threads to make further progress
         assertBusy(() -> assertFalse(store.hasReferences()));

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/BlobStoreIncrementalityIT.java
@@ -148,7 +148,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
             client().bulk(bulkRequest).get();
             flushAndRefresh(indexName);
         }
-        final IndexStats indexStats = client().admin().indices().prepareStats(indexName).get().getIndex(indexName);
+        final IndexStats indexStats = indicesAdmin().prepareStats(indexName).get().getIndex(indexName);
         assertThat(indexStats.getIndexShards().get(0).getPrimary().getSegments().getCount(), greaterThan(1L));
 
         final String snapshot1 = "snap-1";
@@ -203,19 +203,19 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         final long beforeSegmentCount = beforeIndexDetails.getMaxSegmentsPerShard();
 
         // reactivate merges
-        assertAcked(admin().indices().prepareClose(indexName).get());
+        assertAcked(indicesAdmin().prepareClose(indexName).get());
         updateIndexSettings(
             Settings.builder()
                 .put(MergePolicyConfig.INDEX_MERGE_POLICY_SEGMENTS_PER_TIER_SETTING.getKey(), "2")
                 .put(MergePolicyConfig.INDEX_MERGE_ENABLED, "true"),
             indexName
         );
-        assertAcked(admin().indices().prepareOpen(indexName).get());
-        assertEquals(0, admin().indices().prepareForceMerge(indexName).setFlush(true).get().getFailedShards());
+        assertAcked(indicesAdmin().prepareOpen(indexName).get());
+        assertEquals(0, indicesAdmin().prepareForceMerge(indexName).setFlush(true).get().getFailedShards());
 
         // wait for merges to reduce segment count
         assertBusy(() -> {
-            IndicesStatsResponse stats = client().admin().indices().prepareStats(indexName).setSegments(true).get();
+            IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).setSegments(true).get();
             assertThat(stats.getIndex(indexName).getPrimaries().getSegments().getCount(), lessThan(beforeSegmentCount));
         }, 30L, TimeUnit.SECONDS);
 
@@ -238,7 +238,7 @@ public class BlobStoreIncrementalityIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> asserting that index [{}] contains [{}] documents", index, expectedCount);
         assertDocCount(index, expectedCount);
         logger.info("--> deleting index [{}]", index);
-        assertThat(client().admin().indices().prepareDelete(index).get().isAcknowledged(), is(true));
+        assertThat(indicesAdmin().prepareDelete(index).get().isAcknowledged(), is(true));
     }
 
     private void assertTwoIdenticalShardSnapshots(String repo, String indexName, String snapshot1, String snapshot2) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CloneSnapshotIT.java
@@ -128,7 +128,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         indexRandomDocs(indexName, randomIntBetween(20, 100));
         if (randomBoolean()) {
-            assertAcked(admin().indices().prepareDelete(indexName));
+            assertAcked(indicesAdmin().prepareDelete(indexName));
         }
         final String targetSnapshot = "target-snapshot";
         assertAcked(startClone(repoName, sourceSnapshot, targetSnapshot, indexName).get());
@@ -306,7 +306,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String sourceSnapshot = "source-snapshot";
         createFullSnapshot(repoName, sourceSnapshot);
 
-        assertAcked(admin().indices().prepareDelete(indexBlocked).get());
+        assertAcked(indicesAdmin().prepareDelete(indexBlocked).get());
 
         final String targetSnapshot1 = "target-snapshot";
         blockMasterOnShardClone(repoName);
@@ -707,7 +707,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
 
         final String sourceSnapshot = "source-snapshot";
         createFullSnapshot(repoName, sourceSnapshot);
-        assertAcked(admin().indices().prepareDelete(testIndex).get());
+        assertAcked(indicesAdmin().prepareDelete(testIndex).get());
 
         final MockRepository repo = getRepositoryOnMaster(repoName);
         repo.setBlockOnceOnReadSnapshotInfoIfAlreadyBlocked();
@@ -780,8 +780,7 @@ public class CloneSnapshotIT extends AbstractSnapshotIntegTestCase {
         final ActionFuture<CreateSnapshotResponse> fullSnapshotFuture1 = startFullSnapshot(repoName, "full-snapshot-1");
         waitForBlock(dataNode, repoName);
         // make sure we don't have so many files in the shard that will get blocked to fully clog up the snapshot pool on the data node
-        final var files = admin().indices()
-            .prepareStats("test-index-3")
+        final var files = indicesAdmin().prepareStats("test-index-3")
             .setSegments(true)
             .setIncludeSegmentFileSizes(true)
             .get()

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/ConcurrentSnapshotsIT.java
@@ -916,7 +916,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         final ActionFuture<CreateSnapshotResponse> snapshotFour = startFullSnapshot(repoName, "snapshot-four", true);
         awaitNumberOfSnapshotsInProgress(2);
 
-        assertAcked(client().admin().indices().prepareDelete("index-two"));
+        assertAcked(indicesAdmin().prepareDelete("index-two"));
         unblockNode(repoName, masterNode);
 
         assertThat(snapshotThree.get().getSnapshotInfo().state(), is(SnapshotState.SUCCESS));
@@ -1760,7 +1760,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         assertSuccessful(snapshot2);
         awaitNumberOfSnapshotsInProgress(2);
         assertFalse(snapshot3.isDone());
-        assertAcked(admin().indices().prepareDelete(index1).get());
+        assertAcked(indicesAdmin().prepareDelete(index1).get());
         assertSuccessful(snapshot3);
         unblockNode(repository, master);
 
@@ -1819,7 +1819,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
             cloneTarget2
         ).setIndices(index1, index2).execute();
 
-        assertAcked(admin().indices().prepareDelete(index1).get());
+        assertAcked(indicesAdmin().prepareDelete(index1).get());
         assertSuccessful(snapshot3);
         unblockNode(repository, master);
 
@@ -2046,7 +2046,7 @@ public class ConcurrentSnapshotsIT extends AbstractSnapshotIntegTestCase {
         waitForBlockOnAnyDataNode(repoName);
         // recreate index and start full snapshot to test that shard state updates from the first partial snapshot are correctly are
         // correctly applied to the second snapshot that will contain a different index by the same name
-        assertAcked(client().admin().indices().prepareDelete(index1).get());
+        assertAcked(indicesAdmin().prepareDelete(index1).get());
         createIndexWithContent(index1, highShardCountSettings);
         final ActionFuture<CreateSnapshotResponse> nonPartialFuture = startFullSnapshot(repoName, "full-snapshot");
         unblockAllDataNodes(repoName);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/CorruptedBlobStoreRepositoryIT.java
@@ -518,7 +518,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
         assertThat(snapshotInfos.get(0).snapshotId().getName(), equalTo(snapshot1));
 
         logger.info("-->  deleting index [{}]", indexName);
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         logger.info("-->  restoring snapshot [{}]", snapshot1);
         clusterAdmin().prepareRestoreSnapshot("test-repo", snapshot1)
@@ -796,7 +796,7 @@ public class CorruptedBlobStoreRepositoryIT extends AbstractSnapshotIntegTestCas
             "--> restoring the first snapshot, the repository should not have lost any shard data despite deleting index-N, "
                 + "because it uses snap-*.data files and not the index-N to determine what files to restore"
         );
-        client().admin().indices().prepareDelete("test-idx-1", "test-idx-2").get();
+        indicesAdmin().prepareDelete("test-idx-1", "test-idx-2").get();
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("test-repo", "test-snap-1")
             .setWaitForCompletion(true)
             .get();

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/FeatureStateResetApiIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/FeatureStateResetApiIT.java
@@ -83,28 +83,19 @@ public class FeatureStateResetApiIT extends ESIntegTestCase {
         );
 
         // verify that both indices are gone
-        Exception e1 = expectThrows(
-            IndexNotFoundException.class,
-            () -> client().admin().indices().prepareGetIndex().addIndices(systemIndex1).get()
-        );
+        Exception e1 = expectThrows(IndexNotFoundException.class, () -> indicesAdmin().prepareGetIndex().addIndices(systemIndex1).get());
 
         assertThat(e1.getMessage(), containsString("no such index"));
 
-        Exception e2 = expectThrows(
-            IndexNotFoundException.class,
-            () -> client().admin().indices().prepareGetIndex().addIndices(associatedIndex).get()
-        );
+        Exception e2 = expectThrows(IndexNotFoundException.class, () -> indicesAdmin().prepareGetIndex().addIndices(associatedIndex).get());
 
         assertThat(e2.getMessage(), containsString("no such index"));
 
-        Exception e3 = expectThrows(
-            IndexNotFoundException.class,
-            () -> client().admin().indices().prepareGetIndex().addIndices(systemIndex2).get()
-        );
+        Exception e3 = expectThrows(IndexNotFoundException.class, () -> indicesAdmin().prepareGetIndex().addIndices(systemIndex2).get());
 
         assertThat(e3.getMessage(), containsString("no such index"));
 
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().addIndices("my_index").get();
+        GetIndexResponse response = indicesAdmin().prepareGetIndex().addIndices("my_index").get();
 
         assertThat(response.getIndices(), arrayContaining("my_index"));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/MetadataLoadingDuringSnapshotRestoreIT.java
@@ -91,7 +91,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertIndexMetadataLoads("snap", "docs", 1);
         assertIndexMetadataLoads("snap", "others", 1);
 
-        assertAcked(client().admin().indices().prepareDelete("docs", "others"));
+        assertAcked(indicesAdmin().prepareDelete("docs", "others"));
 
         // Restoring a snapshot loads indices metadata but not the global state
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repository", "snap")
@@ -102,7 +102,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertIndexMetadataLoads("snap", "docs", 2);
         assertIndexMetadataLoads("snap", "others", 2);
 
-        assertAcked(client().admin().indices().prepareDelete("docs"));
+        assertAcked(indicesAdmin().prepareDelete("docs"));
 
         // Restoring a snapshot with selective indices loads only required index metadata
         restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repository", "snap")
@@ -114,7 +114,7 @@ public class MetadataLoadingDuringSnapshotRestoreIT extends AbstractSnapshotInte
         assertIndexMetadataLoads("snap", "docs", 3);
         assertIndexMetadataLoads("snap", "others", 2);
 
-        assertAcked(client().admin().indices().prepareDelete("docs", "others"));
+        assertAcked(indicesAdmin().prepareDelete("docs", "others"));
 
         // Restoring a snapshot including the global state loads it with the index metadata
         restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot("repository", "snap")

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoryThrottlingStatsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RepositoryThrottlingStatsIT.java
@@ -33,7 +33,7 @@ public class RepositoryThrottlingStatsIT extends AbstractSnapshotIntegTestCase {
         logger.info("--> create index");
         createIndexWithRandomDocs("test-idx", 100);
 
-        IndicesStatsResponse indicesStats = client().admin().indices().prepareStats("test-idx").get();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats("test-idx").get();
         IndexStats indexStats = indicesStats.getIndex("test-idx");
         long totalSizeInBytes = 0;
         for (ShardStats shard : indexStats.getShards()) {

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/RestoreSnapshotIT.java
@@ -931,7 +931,7 @@ public class RestoreSnapshotIT extends AbstractSnapshotIntegTestCase {
         final String snapshotName = "test-snapshot";
         createSnapshot(repoName, snapshotName, List.of(indexName));
         index(indexName, "some_id", Map.of("foo", "bar"));
-        assertAcked(admin().indices().prepareClose(indexName).get());
+        assertAcked(indicesAdmin().prepareClose(indexName).get());
         final MockLogAppender mockAppender = new MockLogAppender();
         mockAppender.addExpectation(
             new MockLogAppender.UnseenEventExpectation("no warnings", FileRestoreContext.class.getCanonicalName(), Level.WARN, "*")

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotCustomPluginStateIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotCustomPluginStateIT.java
@@ -139,7 +139,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
         if (testTemplate) {
             logger.info("-->  delete test template");
             cluster().wipeTemplates("test-template");
-            GetIndexTemplatesResponse getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+            GetIndexTemplatesResponse getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates().get();
             assertIndexTemplateMissing(getIndexTemplatesResponse, "test-template");
         }
 
@@ -162,7 +162,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
         assertThat(restoreSnapshotResponse.getRestoreInfo().totalShards(), equalTo(0));
 
         logger.info("--> check that template wasn't restored");
-        GetIndexTemplatesResponse getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+        GetIndexTemplatesResponse getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates().get();
         assertIndexTemplateMissing(getIndexTemplatesResponse, "test-template");
 
         logger.info("--> restore cluster state");
@@ -175,7 +175,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
 
         if (testTemplate) {
             logger.info("--> check that template is restored");
-            getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+            getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates().get();
             assertIndexTemplateExists(getIndexTemplatesResponse, "test-template");
         }
 
@@ -219,7 +219,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
             assertAcked(clusterAdmin().prepareDeleteStoredScript("foobar").get());
         }
 
-        getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+        getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates().get();
         assertIndexTemplateMissing(getIndexTemplatesResponse, "test-template");
 
         logger.info("--> try restoring index and cluster state from snapshot without global state");
@@ -232,7 +232,7 @@ public class SnapshotCustomPluginStateIT extends AbstractSnapshotIntegTestCase {
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
 
         logger.info("--> check that global state wasn't restored but index was");
-        getIndexTemplatesResponse = client().admin().indices().prepareGetTemplates().get();
+        getIndexTemplatesResponse = indicesAdmin().prepareGetTemplates().get();
         assertIndexTemplateMissing(getIndexTemplatesResponse, "test-template");
         assertFalse(clusterAdmin().prepareGetPipeline("barbaz").get().isFound());
         assertNull(clusterAdmin().prepareGetStoredScript("foobar").get().getSource());

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SnapshotStressTestsIT.java
@@ -506,7 +506,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         snapshotInfo.repository(),
                         snapshotInfo.snapshotId().getName()
                     );
-                    client().admin().indices().prepareClose(indicesToClose).execute(mustSucceed(closeIndexResponse -> {
+                    indicesAdmin().prepareClose(indicesToClose).execute(mustSucceed(closeIndexResponse -> {
                         logger.info(
                             "--> finished closing indices {} in preparation for restoring from [{}:{}]",
                             indicesToRestoreList,
@@ -528,7 +528,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
                         snapshotInfo.repository(),
                         snapshotInfo.snapshotId().getName()
                     );
-                    client().admin().indices().prepareDelete(indicesToDelete).execute(mustSucceed(deleteIndicesResponse -> {
+                    indicesAdmin().prepareDelete(indicesToDelete).execute(mustSucceed(deleteIndicesResponse -> {
                         logger.info(
                             "--> finished deleting indices {} in preparation for restoring from [{}:{}]",
                             indicesToRestoreList,
@@ -1387,7 +1387,7 @@ public class SnapshotStressTestsIT extends AbstractSnapshotIntegTestCase {
 
                             logger.info("--> deleting index [{}]", indexName);
 
-                            client().admin().indices().prepareDelete(indexName).execute(mustSucceed(acknowledgedResponse -> {
+                            indicesAdmin().prepareDelete(indexName).execute(mustSucceed(acknowledgedResponse -> {
                                 logger.info("--> deleting index [{}] finished", indexName);
                                 assertTrue(acknowledgedResponse.isAcknowledged());
                                 createIndexAndContinue(releaseAll);

--- a/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/snapshots/SystemIndicesSnapshotIT.java
@@ -279,7 +279,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         assertThat(getDocCount(AssociatedIndicesTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
 
         // And delete the associated index so we can restore it
-        assertAcked(client().admin().indices().prepareDelete(AssociatedIndicesTestPlugin.ASSOCIATED_INDEX_NAME).get());
+        assertAcked(indicesAdmin().prepareDelete(AssociatedIndicesTestPlugin.ASSOCIATED_INDEX_NAME).get());
 
         // restore the feature state and its associated index
         RestoreSnapshotResponse restoreSnapshotResponse = clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
@@ -407,7 +407,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
             .get();
         assertSnapshotSuccess(createSnapshotResponse);
 
-        assertAcked(client().admin().indices().prepareDelete(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, nonSystemIndex).get());
+        assertAcked(indicesAdmin().prepareDelete(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, nonSystemIndex).get());
 
         // Restore using a rename pattern that matches both the regular and the system index
         clusterAdmin().prepareRestoreSnapshot(REPO_NAME, "test-snap")
@@ -481,7 +481,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
         indexDoc(SystemIndexTestPlugin.SYSTEM_INDEX_NAME, "2", "purpose", "post-snapshot doc");
         refresh(SystemIndexTestPlugin.SYSTEM_INDEX_NAME);
 
-        assertAcked(client().admin().indices().prepareDelete(regularIndex).get());
+        assertAcked(indicesAdmin().prepareDelete(regularIndex).get());
         assertThat(getDocCount(SystemIndexTestPlugin.SYSTEM_INDEX_NAME), equalTo(2L));
 
         // restore with global state and all indices but explicitly no feature states.
@@ -806,7 +806,7 @@ public class SystemIndicesSnapshotIT extends AbstractSnapshotIntegTestCase {
     }
 
     private long getDocCount(String indexName) {
-        return client().admin().indices().prepareStats(indexName).get().getPrimaries().getDocs().getCount();
+        return indicesAdmin().prepareStats(indexName).get().getPrimaries().getDocs().getCount();
     }
 
     public static class SystemIndexTestPlugin extends Plugin implements SystemIndexPlugin {

--- a/server/src/internalClusterTest/java/org/elasticsearch/timeseries/support/TimeSeriesDimensionsLimitIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/timeseries/support/TimeSeriesDimensionsLimitIT.java
@@ -194,7 +194,7 @@ public class TimeSeriesDimensionsLimitIT extends ESIntegTestCase {
             settings.put(MapperService.INDEX_MAPPING_DIMENSION_FIELDS_LIMIT_SETTING.getKey(), dimensionsFieldLimit);
         }
 
-        client().admin().indices().prepareCreate("test").setSettings(settings.build()).setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setSettings(settings.build()).setMapping(mapping).get();
     }
 
 }

--- a/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/validate/SimpleValidateQueryIT.java
@@ -225,7 +225,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
 
     public void testValidateEmptyCluster() {
         try {
-            client().admin().indices().prepareValidateQuery().get();
+            indicesAdmin().prepareValidateQuery().get();
             fail("Expected IndexNotFoundException");
         } catch (IndexNotFoundException e) {
             assertThat(e.getMessage(), is("no such index [_all] and no indices exist"));
@@ -236,7 +236,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
         createIndex("test");
         ensureGreen();
 
-        ValidateQueryResponse validateQueryResponse = client().admin().indices().prepareValidateQuery().setExplain(true).get();
+        ValidateQueryResponse validateQueryResponse = indicesAdmin().prepareValidateQuery().setExplain(true).get();
         assertThat(validateQueryResponse.isValid(), equalTo(true));
         assertThat(validateQueryResponse.getQueryExplanation().size(), equalTo(1));
         assertThat(validateQueryResponse.getQueryExplanation().get(0).getIndex(), equalTo("test"));
@@ -337,7 +337,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
         ensureGreen();
         refresh();
 
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.wrapperQuery(new BytesArray("""
+        assertThat(indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.wrapperQuery(new BytesArray("""
             {"foo": "bar", "query": {"term" : { "user" : "kimchy" }}}
             """))).get().isValid(), equalTo(false));
     }
@@ -347,7 +347,7 @@ public class SimpleValidateQueryIT extends ESIntegTestCase {
         ensureGreen();
         refresh();
 
-        assertThat(client().admin().indices().prepareValidateQuery("test").setQuery(QueryBuilders.wrapperQuery(new BytesArray("""
+        assertThat(indicesAdmin().prepareValidateQuery("test").setQuery(QueryBuilders.wrapperQuery(new BytesArray("""
             {"query": {"term" : { "user" : "kimchy" }}, "foo": "bar"}
             """))).get().isValid(), equalTo(false));
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentDocumentOperationIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/versioning/ConcurrentDocumentOperationIT.java
@@ -50,7 +50,7 @@ public class ConcurrentDocumentOperationIT extends ESIntegTestCase {
 
         assertThat(failure.get(), nullValue());
 
-        client().admin().indices().prepareRefresh().execute().actionGet();
+        indicesAdmin().prepareRefresh().execute().actionGet();
 
         logger.info("done indexing, check all have the same field value");
         Map<String, Object> masterSource = client().prepareGet("test", "1").execute().actionGet().getSourceAsMap();

--- a/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
+++ b/server/src/test/java/org/elasticsearch/action/admin/indices/stats/IndicesStatsTests.java
@@ -40,7 +40,7 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
 
     public void testSegmentStatsEmptyIndex() {
         createIndex("test");
-        IndicesStatsResponse rsp = client().admin().indices().prepareStats("test").get();
+        IndicesStatsResponse rsp = indicesAdmin().prepareStats("test").get();
         SegmentsStats stats = rsp.getTotal().getSegments();
         assertEquals(0, stats.getCount());
     }
@@ -67,25 +67,23 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject();
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(mapping)
                 .setSettings(Settings.builder().put("index.store.type", storeType.getSettingsKey()))
         );
         ensureGreen("test");
         client().prepareIndex("test").setId("1").setSource("foo", "bar", "bar", "baz", "baz", 42).get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
-        IndicesStatsResponse rsp = client().admin().indices().prepareStats("test").get();
+        IndicesStatsResponse rsp = indicesAdmin().prepareStats("test").get();
         SegmentsStats stats = rsp.getIndex("test").getTotal().getSegments();
         assertThat(stats.getCount(), greaterThan(0L));
 
         // now check multiple segments stats are merged together
         client().prepareIndex("test").setId("2").setSource("foo", "bar", "bar", "baz", "baz", 43).get();
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
-        rsp = client().admin().indices().prepareStats("test").get();
+        rsp = indicesAdmin().prepareStats("test").get();
         SegmentsStats stats2 = rsp.getIndex("test").getTotal().getSegments();
         assertThat(stats2.getCount(), greaterThan(stats.getCount()));
     }
@@ -94,7 +92,7 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
         createIndex("test");
         ensureGreen("test");
 
-        IndicesStatsResponse rsp = client().admin().indices().prepareStats("test").get();
+        IndicesStatsResponse rsp = indicesAdmin().prepareStats("test").get();
         for (ShardStats shardStats : rsp.getIndex("test").getShards()) {
             final CommitStats commitStats = shardStats.getCommitStats();
             assertNotNull(commitStats);
@@ -119,7 +117,7 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
         logger.info("starting to wait");
         long end = System.nanoTime() + TimeUnit.MINUTES.toNanos(1);
         while (true) {
-            IndicesStatsResponse stats = client().admin().indices().prepareStats("test").clear().setRefresh(true).setDocs(true).get();
+            IndicesStatsResponse stats = indicesAdmin().prepareStats("test").clear().setRefresh(true).setDocs(true).get();
             CommonStats common = stats.getIndices().get("test").getTotal();
             // There shouldn't be a doc. If there is then we did *something* weird.
             assertEquals(0, common.docs.getCount());
@@ -133,11 +131,11 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
         }
 
         // Refresh the index and wait for the request to come back
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         index.get();
 
         // The document should appear in the statistics and the refresh listener should be gone
-        IndicesStatsResponse stats = client().admin().indices().prepareStats("test").clear().setRefresh(true).setDocs(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats("test").clear().setRefresh(true).setDocs(true).get();
         CommonStats common = stats.getIndices().get("test").getTotal();
         assertEquals(1, common.docs.getCount());
         assertEquals(0, common.refresh.getListeners());
@@ -145,7 +143,7 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
 
     public void testUuidOnRootStatsIndices() {
         String uuid = createIndex("test").indexUUID();
-        IndicesStatsResponse rsp = client().admin().indices().prepareStats().get();
+        IndicesStatsResponse rsp = indicesAdmin().prepareStats().get();
         assertEquals(uuid, rsp.getIndex("test").getUuid());
     }
 
@@ -155,7 +153,7 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
         String yellowIndex = "yellow-index";
         createIndex(yellowIndex, Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1).build());
 
-        IndicesStatsResponse rsp = client().admin().indices().prepareStats().all().get();
+        IndicesStatsResponse rsp = indicesAdmin().prepareStats().all().get();
 
         IndexStats greenIndexStats = rsp.getIndex(greenIndex);
         assertEquals(ClusterHealthStatus.GREEN, greenIndexStats.getHealth());
@@ -170,13 +168,9 @@ public class IndicesStatsTests extends ESSingleNodeTestCase {
         String closeIndex = "close-index";
         createIndex(closeIndex);
 
-        client().admin().indices().close(new CloseIndexRequest(closeIndex)).get();
+        indicesAdmin().close(new CloseIndexRequest(closeIndex)).get();
 
-        IndicesStatsResponse rsp = client().admin()
-            .indices()
-            .prepareStats()
-            .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_CLOSED)
-            .get();
+        IndicesStatsResponse rsp = indicesAdmin().prepareStats().setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_CLOSED).get();
         IndexStats openIndexStats = rsp.getIndex(openIndex);
         assertEquals(IndexMetadata.State.OPEN, openIndexStats.getState());
 

--- a/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
+++ b/server/src/test/java/org/elasticsearch/action/search/KnnSearchSingleNodeTests.java
@@ -57,7 +57,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("index").setSource("text", "goodnight world").get();
         }
 
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
         client().prepareUpdate("index", "0").setDoc("vector", (Object) null).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE).get();
 
         float[] queryVector = randomVector();
@@ -100,7 +100,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("index").setSource("text", "goodnight world").get();
         }
 
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector();
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 5, 50, null).boost(5.0f);
@@ -144,7 +144,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("index").setId(String.valueOf(doc)).setSource("vector", randomVector(), "field", value).get();
         }
 
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector();
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 5, 50, null).addFilterQuery(
@@ -187,7 +187,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
         }
         client().prepareIndex("index").setId("lookup-doc").setSource("other-field", "value").get();
 
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector();
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 5, 50, null).addFilterQuery(
@@ -234,7 +234,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("index").setSource("vector_2", randomVector(20f, 21f), "text", "hello world", "number", 2).get();
             client().prepareIndex("index").setSource("text", "goodnight world", "number", 3).get();
         }
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector(20f, 21f);
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 5, 50, null).boost(5.0f);
@@ -292,7 +292,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             float[] vector = randomVector();
             client().prepareIndex("index").setSource("vector", vector, "vector_2", vector, "number", doc).get();
         }
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector();
         // Having the same query vector and same docs should mean our KNN scores are linearly combined if the same doc is matched
@@ -351,7 +351,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject();
         createIndex("index", indexSettings, builder);
-        client().admin().indices().prepareAliases().addAlias("index", "test-alias", QueryBuilders.termQuery("field", "hit")).get();
+        indicesAdmin().prepareAliases().addAlias("index", "test-alias", QueryBuilders.termQuery("field", "hit")).get();
 
         int expectedHits = 0;
         for (int doc = 0; doc < 10; doc++) {
@@ -362,7 +362,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
                 client().prepareIndex("index").setId(String.valueOf(doc)).setSource("vector", randomVector(), "field", "not hit").get();
             }
         }
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector();
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 10, 50, null);
@@ -393,8 +393,8 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("index2").setId(String.valueOf(doc)).setSource("vector", randomVector()).get();
         }
 
-        client().admin().indices().prepareForceMerge("index1", "index2").setMaxNumSegments(1).get();
-        client().admin().indices().prepareRefresh("index1", "index2").get();
+        indicesAdmin().prepareForceMerge("index1", "index2").setMaxNumSegments(1).get();
+        indicesAdmin().prepareRefresh("index1", "index2").get();
 
         // Since there's no kNN search action at the transport layer, we just emulate
         // how the action works (it builds a kNN query under the hood)
@@ -430,7 +430,7 @@ public class KnnSearchSingleNodeTests extends ESSingleNodeTestCase {
             client().prepareIndex("index").setSource("vector", randomVector(2048)).get();
         }
 
-        client().admin().indices().prepareRefresh("index").get();
+        indicesAdmin().prepareRefresh("index").get();
 
         float[] queryVector = randomVector(2048);
         KnnSearchBuilder knnSearch = new KnnSearchBuilder("vector", queryVector, 3, 50, null).boost(5.0f);

--- a/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceBatchingTests.java
+++ b/server/src/test/java/org/elasticsearch/cluster/metadata/MetadataIndexStateServiceBatchingTests.java
@@ -53,11 +53,11 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         final var masterService = clusterService.getMasterService();
 
         // create some indices, and randomly close some of them
-        createIndex("test-1", client().admin().indices().prepareCreate("test-1"));
-        createIndex("test-2", client().admin().indices().prepareCreate("test-2"));
-        createIndex("test-3", client().admin().indices().prepareCreate("test-3"));
+        createIndex("test-1", indicesAdmin().prepareCreate("test-1"));
+        createIndex("test-2", indicesAdmin().prepareCreate("test-2"));
+        createIndex("test-3", indicesAdmin().prepareCreate("test-3"));
         String[] closedIndices = randomSubsetOf(between(1, 3), "test-1", "test-2", "test-3").toArray(Strings.EMPTY_ARRAY);
-        assertAcked(client().admin().indices().prepareClose(closedIndices));
+        assertAcked(indicesAdmin().prepareClose(closedIndices));
         ensureGreen("test-1", "test-2", "test-3");
 
         final var assertingListener = closedIndexCountListener(closedIndices.length);
@@ -67,8 +67,8 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         block1.run(); // wait for block
 
         // fire off some opens
-        final var future1 = client().admin().indices().prepareOpen("test-1").execute();
-        final var future2 = client().admin().indices().prepareOpen("test-2", "test-3").execute();
+        final var future1 = indicesAdmin().prepareOpen("test-1").execute();
+        final var future2 = indicesAdmin().prepareOpen("test-2", "test-3").execute();
 
         // check the queue for the open-indices tasks
         assertThat(findPendingTasks(masterService, "open-indices"), hasSize(2));
@@ -93,9 +93,9 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         final var masterService = clusterService.getMasterService();
 
         // create some indices
-        createIndex("test-1", client().admin().indices().prepareCreate("test-1"));
-        createIndex("test-2", client().admin().indices().prepareCreate("test-2"));
-        createIndex("test-3", client().admin().indices().prepareCreate("test-3"));
+        createIndex("test-1", indicesAdmin().prepareCreate("test-1"));
+        createIndex("test-2", indicesAdmin().prepareCreate("test-2"));
+        createIndex("test-3", indicesAdmin().prepareCreate("test-3"));
         ensureGreen("test-1", "test-2", "test-3");
 
         final var assertingListener = closedIndexCountListener(3);
@@ -105,8 +105,8 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         block1.run(); // wait for block
 
         // fire off some closes
-        final var future1 = client().admin().indices().prepareClose("test-1").execute();
-        final var future2 = client().admin().indices().prepareClose("test-2", "test-3").execute();
+        final var future1 = indicesAdmin().prepareClose("test-1").execute();
+        final var future2 = indicesAdmin().prepareClose("test-2", "test-3").execute();
 
         // check the queue for the first close tasks (the add-block-index-to-close tasks)
         assertThat(findPendingTasks(masterService, "add-block-index-to-close"), hasSize(2));
@@ -147,9 +147,9 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         final var masterService = clusterService.getMasterService();
 
         // create some indices
-        createIndex("test-1", client().admin().indices().prepareCreate("test-1"));
-        createIndex("test-2", client().admin().indices().prepareCreate("test-2"));
-        createIndex("test-3", client().admin().indices().prepareCreate("test-3"));
+        createIndex("test-1", indicesAdmin().prepareCreate("test-1"));
+        createIndex("test-2", indicesAdmin().prepareCreate("test-2"));
+        createIndex("test-3", indicesAdmin().prepareCreate("test-3"));
         ensureGreen("test-1", "test-2", "test-3");
 
         final var assertingListener = blockedIndexCountListener();
@@ -159,8 +159,8 @@ public class MetadataIndexStateServiceBatchingTests extends ESSingleNodeTestCase
         block1.run(); // wait for block
 
         // fire off some closes
-        final var future1 = client().admin().indices().prepareAddBlock(APIBlock.WRITE, "test-1").execute();
-        final var future2 = client().admin().indices().prepareAddBlock(APIBlock.WRITE, "test-2", "test-3").execute();
+        final var future1 = indicesAdmin().prepareAddBlock(APIBlock.WRITE, "test-1").execute();
+        final var future2 = indicesAdmin().prepareAddBlock(APIBlock.WRITE, "test-2", "test-3").execute();
 
         // check the queue for the first add-block tasks (the add-index-block tasks)
         assertThat(findPendingTasks(masterService, "add-index-block-[write]"), hasSize(2));

--- a/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/index/IndexServiceTests.java
@@ -62,7 +62,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         ensureGreen("test");
 
         final Index index = indexService.index();
-        assertAcked(client().admin().indices().prepareClose(index.getName()));
+        assertAcked(indicesAdmin().prepareClose(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
 
         final IndexService closedIndexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
@@ -125,7 +125,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
 
         // now close the index
         final Index index = indexService.index();
-        assertAcked(client().admin().indices().prepareClose(index.getName()));
+        assertAcked(indicesAdmin().prepareClose(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
 
         final IndexService closedIndexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
@@ -135,7 +135,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertEquals(1000000, task.getInterval().millis());
 
         // now reopen the index
-        assertAcked(client().admin().indices().prepareOpen(index.getName()));
+        assertAcked(indicesAdmin().prepareOpen(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
         indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
         assertNotSame(closedIndexService, indexService);
@@ -164,9 +164,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertTrue(indexService.getRefreshTask().mustReschedule());
 
         // now disable
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1))
             .get();
         assertNotSame(refreshTask, indexService.getRefreshTask());
@@ -174,9 +172,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertFalse(refreshTask.isScheduled());
 
         // set it to 100ms
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "100ms"))
             .get();
         assertNotSame(refreshTask, indexService.getRefreshTask());
@@ -188,9 +184,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertEquals(100, refreshTask.getInterval().millis());
 
         // set it to 200ms
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "200ms"))
             .get();
         assertNotSame(refreshTask, indexService.getRefreshTask());
@@ -202,9 +196,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertEquals(200, refreshTask.getInterval().millis());
 
         // set it to 200ms again
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "200ms"))
             .get();
         assertSame(refreshTask, indexService.getRefreshTask());
@@ -215,7 +207,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
 
         // now close the index
         final Index index = indexService.index();
-        assertAcked(client().admin().indices().prepareClose(index.getName()));
+        assertAcked(indicesAdmin().prepareClose(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
 
         final IndexService closedIndexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
@@ -226,7 +218,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertEquals(200, closedIndexService.getRefreshTask().getInterval().millis());
 
         // now reopen the index
-        assertAcked(client().admin().indices().prepareOpen(index.getName()));
+        assertAcked(indicesAdmin().prepareOpen(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
         indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
         assertNotSame(closedIndexService, indexService);
@@ -253,7 +245,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
 
         // now close the index
         final Index index = indexService.index();
-        assertAcked(client().admin().indices().prepareClose(index.getName()));
+        assertAcked(indicesAdmin().prepareClose(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
 
         final IndexService closedIndexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
@@ -264,7 +256,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertEquals(5000, closedIndexService.getFsyncTask().getInterval().millis());
 
         // now reopen the index
-        assertAcked(client().admin().indices().prepareOpen(index.getName()));
+        assertAcked(indicesAdmin().prepareOpen(index.getName()));
         assertBusy(() -> assertTrue("Index not found: " + index.getName(), getInstanceFromNode(IndicesService.class).hasIndex(index)));
         indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(index);
         assertNotSame(closedIndexService, indexService);
@@ -290,9 +282,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         IndexShard shard = indexService.getShard(0);
         client().prepareIndex("test").setId("0").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
         // now disable the refresh
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), -1))
             .get();
         // when we update we reschedule the existing task AND fire off an async refresh to make sure we make everything visible
@@ -310,9 +300,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         assertFalse(refreshTask.isClosed());
         // refresh every millisecond
         client().prepareIndex("test").setId("1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), "1ms"))
             .get();
         assertTrue(refreshTask.isClosed());
@@ -355,9 +343,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         ensureGreen("test");
         assertNull(indexService.getFsyncTask());
 
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.ASYNC))
             .get();
 
@@ -368,16 +354,12 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         final IndexShard shard = indexService.getShard(0);
         assertBusy(() -> assertFalse(shard.isSyncNeeded()));
 
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();
         assertNull(indexService.getFsyncTask());
 
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.ASYNC))
             .get();
         assertNotNull(indexService.getFsyncTask());
@@ -391,7 +373,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         ensureGreen("test");
         assertTrue(indexService.getTrimTranslogTask().mustReschedule());
         client().prepareIndex("test").setId("1").setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
-        client().admin().indices().prepareFlush("test").get();
+        indicesAdmin().prepareFlush("test").get();
         IndexShard shard = indexService.getShard(0);
         assertBusy(() -> assertThat(IndexShardTestCase.getTranslog(shard).totalOperations(), equalTo(0)));
     }
@@ -410,7 +392,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
             client().prepareIndex().setIndex(indexName).setId(String.valueOf(i)).setSource("{\"foo\": \"bar\"}", XContentType.JSON).get();
             translogOps++;
             if (randomBoolean()) {
-                client().admin().indices().prepareFlush(indexName).get();
+                indicesAdmin().prepareFlush(indexName).get();
                 if (indexService.getIndexSettings().isSoftDeleteEnabled()) {
                     translogOps = 0;
                 }
@@ -418,7 +400,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         }
         assertThat(translog.totalOperations(), equalTo(translogOps));
         assertThat(translog.stats().estimatedNumberOfOperations(), equalTo(translogOps));
-        assertAcked(client().admin().indices().prepareClose("test"));
+        assertAcked(indicesAdmin().prepareClose("test"));
 
         indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(indexService.index());
         assertTrue(indexService.getTrimTranslogTask().mustReschedule());
@@ -431,7 +413,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
             )
         );
 
-        assertAcked(client().admin().indices().prepareOpen("test"));
+        assertAcked(indicesAdmin().prepareOpen("test"));
 
         indexService = getInstanceFromNode(IndicesService.class).indexServiceSafe(indexService.index());
         translog = IndexShardTestCase.getTranslog(indexService.getShard(0));
@@ -467,7 +449,7 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
             .put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), "5s")
             .put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.ASYNC.name());
 
-        client().admin().indices().prepareUpdateSettings("test").setSettings(builder).get();
+        indicesAdmin().prepareUpdateSettings("test").setSettings(builder).get();
 
         assertNotNull(indexService.getFsyncTask());
         assertTrue(indexService.getFsyncTask().mustReschedule());
@@ -475,10 +457,8 @@ public class IndexServiceTests extends ESSingleNodeTestCase {
         IndexMetadata indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");
         assertEquals("5s", indexMetadata.getSettings().get(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey()));
 
-        client().admin().indices().prepareClose("test").get();
-        client().admin()
-            .indices()
-            .prepareUpdateSettings("test")
+        indicesAdmin().prepareClose("test").get();
+        indicesAdmin().prepareUpdateSettings("test")
             .setSettings(Settings.builder().put(IndexSettings.INDEX_TRANSLOG_SYNC_INTERVAL_SETTING.getKey(), "20s"))
             .get();
         indexMetadata = client().admin().cluster().prepareState().execute().actionGet().getState().metadata().index("test");

--- a/server/src/test/java/org/elasticsearch/index/engine/InternalEngineSettingsTests.java
+++ b/server/src/test/java/org/elasticsearch/index/engine/InternalEngineSettingsTests.java
@@ -36,7 +36,7 @@ public class InternalEngineSettingsTests extends ESSingleNodeTestCase {
                 .build();
             assertEquals(gcDeletes, build.getAsTime(IndexSettings.INDEX_GC_DELETES_SETTING.getKey(), null).millis());
 
-            client().admin().indices().prepareUpdateSettings("foo").setSettings(build).get();
+            indicesAdmin().prepareUpdateSettings("foo").setSettings(build).get();
             LiveIndexWriterConfig currentIndexWriterConfig = engine.getCurrentIndexWriterConfig();
             assertEquals(currentIndexWriterConfig.getUseCompoundFile(), true);
 
@@ -46,18 +46,18 @@ public class InternalEngineSettingsTests extends ESSingleNodeTestCase {
         }
 
         Settings settings = Settings.builder().put(IndexSettings.INDEX_GC_DELETES_SETTING.getKey(), 1000, TimeUnit.MILLISECONDS).build();
-        client().admin().indices().prepareUpdateSettings("foo").setSettings(settings).get();
+        indicesAdmin().prepareUpdateSettings("foo").setSettings(settings).get();
         assertEquals(engine.getGcDeletesInMillis(), 1000);
         assertTrue(engine.config().isEnableGcDeletes());
 
         settings = Settings.builder().put(IndexSettings.INDEX_GC_DELETES_SETTING.getKey(), "0ms").build();
 
-        client().admin().indices().prepareUpdateSettings("foo").setSettings(settings).get();
+        indicesAdmin().prepareUpdateSettings("foo").setSettings(settings).get();
         assertEquals(engine.getGcDeletesInMillis(), 0);
         assertTrue(engine.config().isEnableGcDeletes());
 
         settings = Settings.builder().put(IndexSettings.INDEX_GC_DELETES_SETTING.getKey(), 1000, TimeUnit.MILLISECONDS).build();
-        client().admin().indices().prepareUpdateSettings("foo").setSettings(settings).get();
+        indicesAdmin().prepareUpdateSettings("foo").setSettings(settings).get();
         assertEquals(engine.getGcDeletesInMillis(), 1000);
         assertTrue(engine.config().isEnableGcDeletes());
     }

--- a/server/src/test/java/org/elasticsearch/index/fieldstats/FieldStatsProviderRefreshTests.java
+++ b/server/src/test/java/org/elasticsearch/index/fieldstats/FieldStatsProviderRefreshTests.java
@@ -26,9 +26,7 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
 
     public void testQueryRewriteOnRefresh() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("index")
+            indicesAdmin().prepareCreate("index")
                 .setMapping("s", "type=text")
                 .setSettings(indexSettings(1, 0).put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .get()
@@ -82,17 +80,17 @@ public class FieldStatsProviderRefreshTests extends ESSingleNodeTestCase {
 
     private void assertRequestCacheStats(long expectedHits, long expectedMisses) {
         assertThat(
-            client().admin().indices().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
+            indicesAdmin().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getHitCount(),
             equalTo(expectedHits)
         );
         assertThat(
-            client().admin().indices().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMissCount(),
+            indicesAdmin().prepareStats("index").setRequestCache(true).get().getTotal().getRequestCache().getMissCount(),
             equalTo(expectedMisses)
         );
     }
 
     private void refreshIndex() {
-        RefreshResponse refreshResponse = client().admin().indices().prepareRefresh("index").get();
+        RefreshResponse refreshResponse = indicesAdmin().prepareRefresh("index").get();
         assertThat(refreshResponse.getSuccessfulShards(), equalTo(refreshResponse.getSuccessfulShards()));
     }
 

--- a/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
+++ b/server/src/test/java/org/elasticsearch/repositories/blobstore/BlobStoreRepositoryTests.java
@@ -126,7 +126,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
             String id = Integer.toString(i);
             client().prepareIndex(indexName).setId(id).setSource("text", "sometext").get();
         }
-        client().admin().indices().prepareFlush(indexName).get();
+        indicesAdmin().prepareFlush(indexName).get();
 
         logger.info("--> create first snapshot");
         CreateSnapshotResponse createSnapshotResponse = client.admin()
@@ -282,9 +282,7 @@ public class BlobStoreRepositoryTests extends ESSingleNodeTestCase {
         ensureGreen("green-index");
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("red-index")
+            indicesAdmin().prepareCreate("red-index")
                 .setSettings(
                     Settings.builder()
                         .put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getConcreteSettingForNamespace("_name").getKey(), "*")

--- a/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
+++ b/server/src/test/java/org/elasticsearch/search/SearchServiceTests.java
@@ -252,7 +252,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         SearchService service = getInstanceFromNode(SearchService.class);
 
         assertEquals(1, service.getActiveContexts());
-        assertAcked(client().admin().indices().prepareDelete("index"));
+        assertAcked(indicesAdmin().prepareDelete("index"));
         assertEquals(0, service.getActiveContexts());
     }
 
@@ -404,7 +404,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         MockSearchService service = (MockSearchService) getInstanceFromNode(SearchService.class);
         service.setOnPutContext(context -> {
             if (context.indexShard() == indexShard) {
-                assertAcked(client().admin().indices().prepareDelete("index"));
+                assertAcked(indicesAdmin().prepareDelete("index"));
             }
         });
 
@@ -438,7 +438,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             // ok
         }
 
-        expectThrows(IndexNotFoundException.class, () -> client().admin().indices().prepareGetIndex().setIndices("index").get());
+        expectThrows(IndexNotFoundException.class, () -> indicesAdmin().prepareGetIndex().setIndices("index").get());
 
         assertEquals(0, service.getActiveContexts());
 
@@ -1117,9 +1117,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
 
         IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .indices()
-                .prepareUpdateSettings("throttled_threadpool_index")
+            () -> indicesAdmin().prepareUpdateSettings("throttled_threadpool_index")
                 .setSettings(Settings.builder().put(IndexSettings.INDEX_SEARCH_THROTTLED.getKey(), false))
                 .get()
         );
@@ -1431,7 +1429,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         for (int i = 0; i < numDocs; i++) {
             client().prepareIndex("test").setSource("f", "v").get();
         }
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         AtomicBoolean stopped = new AtomicBoolean(false);
         Thread[] searchers = new Thread[randomIntBetween(1, 4)];
         CountDownLatch latch = new CountDownLatch(searchers.length);
@@ -1449,7 +1447,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
             searchers[i].start();
         }
         latch.await();
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
         stopped.set(true);
         for (Thread searcher : searchers) {
             searcher.join();
@@ -1834,7 +1832,7 @@ public class SearchServiceTests extends ESSingleNodeTestCase {
         for (int i = 0; i < numDocs; i++) {
             client().prepareIndex("test").setSource("id", Integer.toString(i)).get();
         }
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         String pitId = client().execute(
             OpenPointInTimeAction.INSTANCE,

--- a/test/external-modules/seek-tracking-directory/src/internalClusterTest/java/org/elasticsearch/test/seektracker/SeekTrackerPluginIT.java
+++ b/test/external-modules/seek-tracking-directory/src/internalClusterTest/java/org/elasticsearch/test/seektracker/SeekTrackerPluginIT.java
@@ -38,7 +38,7 @@ public class SeekTrackerPluginIT extends ESIntegTestCase {
 
     public void testSeekTrackerPlugin() throws InterruptedException {
 
-        assertAcked(client().admin().indices().prepareCreate("index"));
+        assertAcked(indicesAdmin().prepareCreate("index"));
         List<IndexRequestBuilder> docs = new ArrayList<>();
         for (int i = 0; i < 100; i++) {
             docs.add(client().prepareIndex("index").setSource("field", "term" + i % 5));

--- a/test/framework/src/integTest/java/org/elasticsearch/test/test/InternalClusterForbiddenSettingIT.java
+++ b/test/framework/src/integTest/java/org/elasticsearch/test/test/InternalClusterForbiddenSettingIT.java
@@ -28,23 +28,23 @@ public class InternalClusterForbiddenSettingIT extends ESIntegTestCase {
         final Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT);
         // create / delete an index with forbidden setting
         prepareCreate("test").setSettings(settings(version).build()).get();
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
         // full restart
         internalCluster().fullRestart();
         // create / delete an index with forbidden setting
         prepareCreate("test").setSettings(settings(version).build()).get();
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
     }
 
     public void testRollingRestart() throws Exception {
         final Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.CURRENT);
         // create / delete an index with forbidden setting
         prepareCreate("test").setSettings(settings(version).build()).get();
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
         // rolling restart
         internalCluster().rollingRestart(new InternalTestCluster.RestartCallback());
         // create / delete an index with forbidden setting
         prepareCreate("test").setSettings(settings(version).build()).get();
-        client().admin().indices().prepareDelete("test").get();
+        indicesAdmin().prepareDelete("test").get();
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/indices/recovery/AbstractIndexRecoveryIntegTestCase.java
@@ -108,9 +108,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForNodes(">=3").get();
         assertThat(response.isTimedOut(), is(false));
 
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(
                 Settings.builder()
                     .put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "blue")
@@ -224,9 +222,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         ClusterHealthResponse response = client().admin().cluster().prepareHealth().setWaitForNodes(">=3").get();
         assertThat(response.isTimedOut(), is(false));
 
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(
                 Settings.builder()
                     .put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "blue")
@@ -335,9 +331,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
         );
         final String redNodeName = internalCluster().startNode(Settings.builder().put("node.attr.color", "red").put(nodeSettings).build());
 
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(
                 Settings.builder()
                     .put(IndexMetadata.INDEX_ROUTING_INCLUDE_GROUP_SETTING.getKey() + "color", "blue")
@@ -477,9 +471,7 @@ public abstract class AbstractIndexRecoveryIntegTestCase extends ESIntegTestCase
     private void createSnapshotThatCanBeUsedDuringRecovery(String indexName) throws Exception {
         // Ensure that the safe commit == latest commit
         assertBusy(() -> {
-            ShardStats stats = client().admin()
-                .indices()
-                .prepareStats(indexName)
+            ShardStats stats = indicesAdmin().prepareStats(indexName)
                 .clear()
                 .get()
                 .asMap()

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/BaseShapeIntegTestCase.java
@@ -230,14 +230,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         mapping.endObject().endObject().endObject();
 
         // create index
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setSettings(settings(randomSupportedVersion()).build())
-                .setMapping(mapping)
-                .get()
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(settings(randomSupportedVersion()).build()).setMapping(mapping).get());
         ensureGreen();
 
         String source = """
@@ -286,9 +279,7 @@ public abstract class BaseShapeIntegTestCase<T extends AbstractGeometryQueryBuil
         mapping.endObject().endObject().endObject();
 
         final Version version = randomSupportedVersion();
-        CreateIndexRequestBuilder mappingRequest = client().admin()
-            .indices()
-            .prepareCreate("shapes")
+        CreateIndexRequestBuilder mappingRequest = indicesAdmin().prepareCreate("shapes")
             .setMapping(mapping)
             .setSettings(settings(version).build());
         mappingRequest.get();

--- a/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/geo/GeoShapeIntegTestCase.java
@@ -49,14 +49,7 @@ public abstract class GeoShapeIntegTestCase extends BaseShapeIntegTestCase<GeoSh
         mapping.endObject().endObject().endObject();
 
         // create index
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setSettings(settings(randomSupportedVersion()).build())
-                .setMapping(mapping)
-                .get()
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(settings(randomSupportedVersion()).build()).setMapping(mapping).get());
         ensureGreen();
 
         String source = """

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/AsyncSearchActionIT.java
@@ -439,7 +439,7 @@ public class AsyncSearchActionIT extends AsyncSearchIntegTestCase {
         assertThat(response.getExpirationTime(), greaterThan(now));
 
         // remove the async search index
-        client().admin().indices().prepareDelete(XPackPlugin.ASYNC_RESULTS_INDEX).get();
+        indicesAdmin().prepareDelete(XPackPlugin.ASYNC_RESULTS_INDEX).get();
 
         Exception exc = expectThrows(Exception.class, () -> getAsyncSearch(response.getId()));
         Throwable cause = exc instanceof ExecutionException

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/existence/FrozenExistenceDeciderIT.java
@@ -101,7 +101,7 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
             .put(SETTING_NUMBER_OF_REPLICAS, 1)
             .put(LifecycleSettings.LIFECYCLE_NAME, "policy")
             .build();
-        CreateIndexResponse res = client().admin().indices().prepareCreate(INDEX_NAME).setSettings(settings).get();
+        CreateIndexResponse res = indicesAdmin().prepareCreate(INDEX_NAME).setSettings(settings).get();
         assertTrue(res.isAcknowledged());
         logger.info("created index");
 
@@ -138,7 +138,7 @@ public class FrozenExistenceDeciderIT extends AbstractFrozenAutoscalingIntegTest
     }
 
     private String[] indices() {
-        return client().admin().indices().prepareGetIndex().addIndices("index").get().indices();
+        return indicesAdmin().prepareGetIndex().addIndices("index").get().indices();
     }
 
     private void assertMinimumCapacity(AutoscalingCapacity.AutoscalingResources resources) {

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/FrozenStorageDeciderIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/FrozenStorageDeciderIT.java
@@ -24,10 +24,7 @@ public class FrozenStorageDeciderIT extends AbstractFrozenAutoscalingIntegTestCa
         setupRepoAndPolicy();
         createAndMountIndex();
 
-        IndicesStatsResponse statsResponse = client().admin()
-            .indices()
-            .stats(new IndicesStatsRequest().indices(restoredIndexName))
-            .actionGet();
+        IndicesStatsResponse statsResponse = indicesAdmin().stats(new IndicesStatsRequest().indices(restoredIndexName)).actionGet();
         final ClusterInfoService clusterInfoService = internalCluster().getCurrentMasterNodeInstance(ClusterInfoService.class);
         ClusterInfoServiceUtils.refresh(((InternalClusterInfoService) clusterInfoService));
         assertThat(

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ProactiveStorageIT.java
@@ -59,7 +59,7 @@ public class ProactiveStorageIT extends AutoscalingStorageIntegTestCase {
                     )
                     .toArray(IndexRequestBuilder[]::new)
             );
-            assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dsName, null)).actionGet());
+            assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dsName, null)).actionGet());
         }
         forceMerge();
         refresh();
@@ -67,7 +67,7 @@ public class ProactiveStorageIT extends AutoscalingStorageIntegTestCase {
         // just check it does not throw when not refreshed.
         capacity();
 
-        IndicesStatsResponse stats = client().admin().indices().prepareStats(dsName).clear().setStore(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(dsName).clear().setStore(true).get();
         long used = stats.getTotal().getStore().getSizeInBytes();
         long maxShardSize = Arrays.stream(stats.getShards()).mapToLong(s -> s.getStats().getStore().sizeInBytes()).max().orElseThrow();
         // As long as usage is above low watermark, we will trigger a proactive scale up, since the simulated shards have an in-sync

--- a/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
+++ b/x-pack/plugin/autoscaling/src/internalClusterTest/java/org/elasticsearch/xpack/autoscaling/storage/ReactiveStorageIT.java
@@ -76,7 +76,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         // just check it does not throw when not refreshed.
         capacity();
 
-        IndicesStatsResponse stats = client().admin().indices().prepareStats(indexName).clear().setStore(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).clear().setStore(true).get();
         long used = stats.getTotal().getStore().getSizeInBytes();
         long minShardSize = Arrays.stream(stats.getShards()).mapToLong(s -> s.getStats().getStore().sizeInBytes()).min().orElseThrow();
         long maxShardSize = Arrays.stream(stats.getShards()).mapToLong(s -> s.getStats().getStore().sizeInBytes()).max().orElseThrow();
@@ -272,7 +272,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         forceMerge();
         refresh();
 
-        IndicesStatsResponse stats = client().admin().indices().prepareStats(indexName).clear().setStore(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).clear().setStore(true).get();
         long used = stats.getTotal().getStore().getSizeInBytes();
         long maxShardSize = Arrays.stream(stats.getShards()).mapToLong(s -> s.getStats().getStore().sizeInBytes()).max().orElseThrow();
 
@@ -342,9 +342,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
 
         String shrinkName = "shrink-" + indexName;
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareResizeIndex(indexName, shrinkName)
+            indicesAdmin().prepareResizeIndex(indexName, shrinkName)
                 .setSettings(
                     Settings.builder()
                         .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
@@ -388,7 +386,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         assertAcked(client().admin().cluster().prepareReroute());
         ensureGreen();
 
-        client().admin().indices().prepareDelete(indexName).get();
+        indicesAdmin().prepareDelete(indexName).get();
         response = capacity();
         assertThat(
             response.results().get(policyName).requiredCapacity().total().storage(),
@@ -422,7 +420,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         forceMerge();
         refresh();
 
-        IndicesStatsResponse stats = client().admin().indices().prepareStats(indexName).clear().setStore(true).get();
+        IndicesStatsResponse stats = indicesAdmin().prepareStats(indexName).clear().setStore(true).get();
         long used = stats.getTotal().getStore().getSizeInBytes();
 
         long enoughSpace = used + HIGH_WATERMARK_BYTES + 1;
@@ -454,9 +452,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         String cloneName = "clone-" + indexName;
         int resizedShardCount = resizeType == ResizeType.CLONE ? 1 : between(2, 10);
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareResizeIndex(indexName, cloneName)
+            indicesAdmin().prepareResizeIndex(indexName, cloneName)
                 .setSettings(
                     Settings.builder()
                         .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, resizedShardCount)
@@ -495,7 +491,7 @@ public class ReactiveStorageIT extends AutoscalingStorageIntegTestCase {
         assertAcked(client().admin().cluster().prepareReroute());
         ensureGreen();
 
-        client().admin().indices().prepareDelete(indexName).get();
+        indicesAdmin().prepareDelete(indexName).get();
         response = capacity();
         assertThat(
             response.results().get(policyName).requiredCapacity().total().storage().getBytes(),

--- a/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesTests.java
+++ b/x-pack/plugin/ccr/src/test/java/org/elasticsearch/xpack/ccr/action/ShardChangesTests.java
@@ -102,9 +102,7 @@ public class ShardChangesTests extends ESSingleNodeTestCase {
     }
 
     public void testMissingOperations() throws Exception {
-        client().admin()
-            .indices()
-            .prepareCreate("index")
+        indicesAdmin().prepareCreate("index")
             .setSettings(
                 indexSettings(1, 0).put("index.soft_deletes.retention.operations", 0)
                     .put(IndexService.RETENTION_LEASE_SYNC_INTERVAL_SETTING.getKey(), "200ms")
@@ -135,13 +133,10 @@ public class ShardChangesTests extends ESSingleNodeTestCase {
         forceMergeRequest.maxNumSegments(1);
         client().admin().indices().forceMerge(forceMergeRequest).actionGet();
 
-        client().admin()
-            .indices()
-            .execute(
-                RetentionLeaseActions.Add.INSTANCE,
-                new RetentionLeaseActions.AddRequest(new ShardId(resolveIndex("index"), 0), "test", RetentionLeaseActions.RETAIN_ALL, "ccr")
-            )
-            .get();
+        indicesAdmin().execute(
+            RetentionLeaseActions.Add.INSTANCE,
+            new RetentionLeaseActions.AddRequest(new ShardId(resolveIndex("index"), 0), "test", RetentionLeaseActions.RETAIN_ALL, "ccr")
+        ).get();
 
         ShardStats shardStats = client().admin().indices().prepareStats("index").get().getIndex("index").getShards()[0];
         String historyUUID = shardStats.getCommitStats().getUserData().get(Engine.HISTORY_UUID_KEY);

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/termsenum/TermsEnumTests.java
@@ -60,9 +60,7 @@ public class TermsEnumTests extends ESSingleNodeTestCase {
         int numshards = randomBoolean() ? 1 : randomIntBetween(1, 5);
         createIndex(indexName, Settings.builder().put("index.merge.enabled", false).put("number_of_shards", numshards).build());
 
-        client().admin()
-            .indices()
-            .preparePutMapping(indexName)
+        indicesAdmin().preparePutMapping(indexName)
             .setSource(
                 XContentFactory.jsonBuilder()
                     .startObject()
@@ -125,9 +123,7 @@ public class TermsEnumTests extends ESSingleNodeTestCase {
             Settings.builder().put(IndexSettings.INDEX_REFRESH_INTERVAL_SETTING.getKey(), new TimeValue(50, TimeUnit.MILLISECONDS)).build()
         );
 
-        client().admin()
-            .indices()
-            .preparePutMapping(indexName)
+        indicesAdmin().preparePutMapping(indexName)
             .setSource(
                 XContentFactory.jsonBuilder()
                     .startObject()
@@ -188,9 +184,7 @@ public class TermsEnumTests extends ESSingleNodeTestCase {
         createIndex(indexName);
         int numDocs = 500;
 
-        client().admin()
-            .indices()
-            .preparePutMapping(indexName)
+        indicesAdmin().preparePutMapping(indexName)
             .setSource(
                 XContentFactory.jsonBuilder()
                     .startObject()

--- a/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
+++ b/x-pack/plugin/enrich/src/internalClusterTest/java/org/elasticsearch/xpack/enrich/EnrichMultiNodeIT.java
@@ -276,7 +276,7 @@ public class EnrichMultiNodeIT extends ESIntegTestCase {
             );
             client().index(indexRequest).actionGet();
         }
-        client().admin().indices().refresh(new RefreshRequest(SOURCE_INDEX_NAME)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(SOURCE_INDEX_NAME)).actionGet();
         return List.copyOf(keys);
     }
 

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/EnrichPolicyRunnerTests.java
@@ -353,7 +353,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
     }
 
     private GetIndexResponse getGetIndexResponseAndCheck(String createdEnrichIndex) {
-        GetIndexResponse enrichIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
+        GetIndexResponse enrichIndex = indicesAdmin().getIndex(new GetIndexRequest().indices(".enrich-test1")).actionGet();
         assertThat(enrichIndex.getIndices().length, equalTo(1));
         assertThat(enrichIndex.getIndices()[0], equalTo(createdEnrichIndex));
         Settings settings = enrichIndex.getSettings().get(createdEnrichIndex);
@@ -370,7 +370,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .actionGet();
         assertEquals(RestStatus.CREATED, indexRequest.status());
 
-        GetIndexResponse sourceIndex = client().admin().indices().getIndex(new GetIndexRequest().indices(sourceIndexName)).actionGet();
+        GetIndexResponse sourceIndex = indicesAdmin().getIndex(new GetIndexRequest().indices(sourceIndexName)).actionGet();
         // Validate Mapping
         Map<String, Object> sourceIndexMapping = sourceIndex.getMappings().get(sourceIndexName).sourceAsMap();
         Map<?, ?> sourceIndexProperties = (Map<?, ?>) sourceIndexMapping.get("properties");
@@ -797,7 +797,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
 
     public void testRunnerNoSourceMapping() throws Exception {
         final String sourceIndex = "source-index";
-        CreateIndexResponse createResponse = client().admin().indices().create(new CreateIndexRequest(sourceIndex)).actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         List<String> enrichFields = List.of("field2", "field5");
@@ -854,10 +854,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         String policyName = "test1";
@@ -918,10 +915,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         String policyName = "test1";
@@ -985,10 +979,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(
@@ -1097,10 +1088,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(
@@ -1209,10 +1197,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(new IndexRequest().index(sourceIndex).id("id").source("""
@@ -1327,10 +1312,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(new IndexRequest().index(sourceIndex).id("id").source("""
@@ -1454,10 +1436,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(new IndexRequest().index(sourceIndex).id("id").source("""
@@ -1581,10 +1560,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(new IndexRequest().index(sourceIndex).id("id").source("""
@@ -1727,10 +1703,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
             .endObject()
             .endObject()
             .endObject();
-        CreateIndexResponse createResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder))
-            .actionGet();
+        CreateIndexResponse createResponse = indicesAdmin().create(new CreateIndexRequest(sourceIndex).mapping(mappingBuilder)).actionGet();
         assertTrue(createResponse.isAcknowledged());
 
         IndexResponse indexRequest = client().index(
@@ -2273,10 +2246,7 @@ public class EnrichPolicyRunnerTests extends ESSingleNodeTestCase {
     }
 
     private void validateSegments(String createdEnrichIndex, int expectedDocs) {
-        IndicesSegmentResponse indicesSegmentResponse = client().admin()
-            .indices()
-            .segments(new IndicesSegmentsRequest(createdEnrichIndex))
-            .actionGet();
+        IndicesSegmentResponse indicesSegmentResponse = indicesAdmin().segments(new IndicesSegmentsRequest(createdEnrichIndex)).actionGet();
         IndexSegments indexSegments = indicesSegmentResponse.getIndices().get(createdEnrichIndex);
         assertNotNull(indexSegments);
         assertThat(indexSegments.getShards().size(), is(equalTo(1)));

--- a/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
+++ b/x-pack/plugin/enrich/src/test/java/org/elasticsearch/xpack/enrich/action/TransportDeleteEnrichPolicyActionTests.java
@@ -132,11 +132,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
         createIndex(EnrichPolicy.getIndexName(name, 1001));
         createIndex(EnrichPolicy.getIndexName(name, 1002));
 
-        client().admin()
-            .indices()
-            .prepareGetIndex()
-            .setIndices(EnrichPolicy.getIndexName(name, 1001), EnrichPolicy.getIndexName(name, 1002))
-            .get();
+        indicesAdmin().prepareGetIndex().setIndices(EnrichPolicy.getIndexName(name, 1001), EnrichPolicy.getIndexName(name, 1002)).get();
 
         final CountDownLatch latch = new CountDownLatch(1);
         final AtomicReference<AcknowledgedResponse> reference = new AtomicReference<>();
@@ -158,9 +154,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
 
         expectThrows(
             IndexNotFoundException.class,
-            () -> client().admin()
-                .indices()
-                .prepareGetIndex()
+            () -> indicesAdmin().prepareGetIndex()
                 .setIndices(EnrichPolicy.getIndexName(name, 1001), EnrichPolicy.getIndexName(name, 1001))
                 .get()
         );
@@ -285,7 +279,7 @@ public class TransportDeleteEnrichPolicyActionTests extends AbstractEnrichTestCa
             assertNotNull(EnrichStore.getPolicy(otherName, clusterService.state()));
 
             // and the index associated with the other index should be unaffected
-            client().admin().indices().prepareGetIndex().setIndices(EnrichPolicy.getIndexName(otherName, 1001)).get();
+            indicesAdmin().prepareGetIndex().setIndices(EnrichPolicy.getIndexName(otherName, 1001)).get();
         }
     }
 }

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/AsyncEqlSearchActionIT.java
@@ -83,9 +83,7 @@ public class AsyncEqlSearchActionIT extends AbstractEqlBlockingIntegTestCase {
 
     private void prepareIndex() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date", "i", "type=integer")
                 .get()
         );

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/EqlCancellationIT.java
@@ -40,9 +40,7 @@ public class EqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
 
     public void testCancellation() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date")
                 .get()
         );

--- a/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
+++ b/x-pack/plugin/eql/src/internalClusterTest/java/org/elasticsearch/xpack/eql/action/RestEqlCancellationIT.java
@@ -60,9 +60,7 @@ public class RestEqlCancellationIT extends AbstractEqlBlockingIntegTestCase {
 
     public void testRestCancellation() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date")
                 .get()
         );

--- a/x-pack/plugin/fleet/src/internalClusterTest/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsActionIT.java
+++ b/x-pack/plugin/fleet/src/internalClusterTest/java/org/elasticsearch/xpack/fleet/action/GetGlobalCheckpointsActionIT.java
@@ -51,9 +51,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
     public void testGetGlobalCheckpoints() throws Exception {
         int shards = between(1, 5);
         String indexName = "test_index";
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(
                 indexSettings(shards, 1)
                     // ESIntegTestCase randomizes durability settings. The global checkpoint only advances after a fsync, hence we
@@ -90,9 +88,9 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
 
         assertEquals(totalDocuments, Arrays.stream(response2.globalCheckpoints()).map(s -> s + 1).sum());
 
-        client().admin().indices().prepareRefresh(indexName).get();
+        indicesAdmin().prepareRefresh(indexName).get();
 
-        final IndicesStatsResponse statsResponse = client().admin().indices().prepareStats(indexName).get();
+        final IndicesStatsResponse statsResponse = indicesAdmin().prepareStats(indexName).get();
         long[] fromStats = Arrays.stream(statsResponse.getShards())
             .filter(i -> i.getShardRouting().primary())
             .sorted(Comparator.comparingInt(value -> value.getShardRouting().id()))
@@ -103,9 +101,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
 
     public void testPollGlobalCheckpointAdvancement() throws Exception {
         String indexName = "test_index";
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(indexSettings(1, 1).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();
 
@@ -145,9 +141,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
 
     public void testPollGlobalCheckpointAdvancementTimeout() {
         String indexName = "test_index";
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();
 
@@ -173,9 +167,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
 
     public void testMustProvideCorrectNumberOfShards() {
         String indexName = "test_index";
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();
 
@@ -200,9 +192,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
 
     public void testWaitForAdvanceOnlySupportsOneShard() {
         String indexName = "test_index";
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(indexSettings(3, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();
 
@@ -265,9 +255,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
         long start = System.nanoTime();
         ActionFuture<GetGlobalCheckpointsAction.Response> future = client().execute(GetGlobalCheckpointsAction.INSTANCE, request);
         Thread.sleep(randomIntBetween(10, 100));
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setSettings(indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();
         client().prepareIndex(indexName).setId(Integer.toString(0)).setSource("{}", XContentType.JSON).get();
@@ -287,9 +275,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
             EMPTY_ARRAY,
             TEN_SECONDS
         );
-        client().admin()
-            .indices()
-            .prepareCreate("not-assigned")
+        indicesAdmin().prepareCreate("not-assigned")
             .setWaitForActiveShards(ActiveShardCount.NONE)
             .setSettings(
                 indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST)
@@ -313,9 +299,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
             EMPTY_ARRAY,
             timeout
         );
-        client().admin()
-            .indices()
-            .prepareCreate("not-assigned")
+        indicesAdmin().prepareCreate("not-assigned")
             .setWaitForActiveShards(ActiveShardCount.NONE)
             .setSettings(
                 indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST)
@@ -339,9 +323,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
             EMPTY_ARRAY,
             TEN_SECONDS
         );
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setWaitForActiveShards(ActiveShardCount.NONE)
             .setSettings(
                 indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST)
@@ -366,9 +348,7 @@ public class GetGlobalCheckpointsActionIT extends ESIntegTestCase {
         updateClusterSettings(Settings.builder().put(CLUSTER_ROUTING_ALLOCATION_NODE_INITIAL_PRIMARIES_RECOVERIES_SETTING.getKey(), 0));
 
         String indexName = "throttled";
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setWaitForActiveShards(ActiveShardCount.NONE)
             .setSettings(indexSettings(1, 0).put(IndexSettings.INDEX_TRANSLOG_DURABILITY_SETTING.getKey(), Translog.Durability.REQUEST))
             .get();

--- a/x-pack/plugin/fleet/src/internalClusterTest/java/org/elasticsearch/xpack/fleet/action/SearchUsageStatsIT.java
+++ b/x-pack/plugin/fleet/src/internalClusterTest/java/org/elasticsearch/xpack/fleet/action/SearchUsageStatsIT.java
@@ -46,7 +46,7 @@ public class SearchUsageStatsIT extends ESIntegTestCase {
             assertEquals(0, stats.getSectionsUsage().size());
         }
 
-        client().admin().indices().prepareCreate("index").get();
+        indicesAdmin().prepareCreate("index").get();
         ensureGreen("index");
 
         // doesn't get counted because it doesn't specify a request body

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexIT.java
@@ -79,8 +79,8 @@ public class FrozenIndexIT extends ESIntegTestCase {
 
         ensureGreen("index");
 
-        assertThat(client().admin().indices().prepareFlush("index").get().getSuccessfulShards(), equalTo(2));
-        assertThat(client().admin().indices().prepareRefresh("index").get().getSuccessfulShards(), equalTo(2));
+        assertThat(indicesAdmin().prepareFlush("index").get().getSuccessfulShards(), equalTo(2));
+        assertThat(indicesAdmin().prepareRefresh("index").get().getSuccessfulShards(), equalTo(2));
 
         final String excludeSetting = INDEX_ROUTING_EXCLUDE_GROUP_SETTING.getConcreteSettingForNamespace("_name").getKey();
         updateIndexSettings(Settings.builder().put(excludeSetting, nodeNames.get(0)), "index");
@@ -220,9 +220,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
         final String assignedNode = randomFrom(dataNodes);
         final String indexName = "test";
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate(indexName)
+            indicesAdmin().prepareCreate(indexName)
                 .setSettings(
                     Settings.builder()
                         .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5))
@@ -293,7 +291,7 @@ public class FrozenIndexIT extends ESIntegTestCase {
 
         final String pitId = client().execute(OpenPointInTimeAction.INSTANCE, openPointInTimeRequest).actionGet().getPointInTimeId();
         try {
-            client().admin().indices().prepareDelete("index-1").get();
+            indicesAdmin().prepareDelete("index-1").get();
             // Return partial results if allow partial search result is allowed
             SearchResponse resp = client().prepareSearch()
                 .setPreference(null)

--- a/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexRecoveryTests.java
+++ b/x-pack/plugin/frozen-indices/src/internalClusterTest/java/org/elasticsearch/index/engine/frozen/FrozenIndexRecoveryTests.java
@@ -66,7 +66,7 @@ public class FrozenIndexRecoveryTests extends ESIntegTestCase {
                 .collect(toList())
         );
         ensureGreen(indexName);
-        client().admin().indices().prepareFlush(indexName).get();
+        indicesAdmin().prepareFlush(indexName).get();
         // index more documents while one shard copy is offline
         internalCluster().restartNode(dataNodes.get(1), new InternalTestCluster.RestartCallback() {
             @Override
@@ -82,7 +82,7 @@ public class FrozenIndexRecoveryTests extends ESIntegTestCase {
         });
         ensureGreen(indexName);
         internalCluster().assertSameDocIdsOnShards();
-        for (RecoveryState recovery : client().admin().indices().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
+        for (RecoveryState recovery : indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
             if (recovery.getPrimary() == false) {
                 assertThat(recovery.getIndex().fileDetails(), not(empty()));
             }
@@ -90,7 +90,7 @@ public class FrozenIndexRecoveryTests extends ESIntegTestCase {
         internalCluster().fullRestart();
         ensureGreen(indexName);
         internalCluster().assertSameDocIdsOnShards();
-        for (RecoveryState recovery : client().admin().indices().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
+        for (RecoveryState recovery : indicesAdmin().prepareRecoveries(indexName).get().shardRecoveryStates().get(indexName)) {
             if (recovery.getPrimary() == false) {
                 assertThat(recovery.getIndex().fileDetails(), empty());
             }

--- a/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
+++ b/x-pack/plugin/graph/src/internalClusterTest/java/org/elasticsearch/xpack/graph/test/GraphTests.java
@@ -77,9 +77,7 @@ public class GraphTests extends ESSingleNodeTestCase {
     public void setUp() throws Exception {
         super.setUp();
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(indexSettings(2, 0))
                 .setMapping("decade", "type=keyword", "people", "type=keyword", "description", "type=text,fielddata=true")
         );
@@ -98,19 +96,13 @@ public class GraphTests extends ESSingleNodeTestCase {
                 numDocs++;
             }
         }
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
         // Ensure single segment with no deletes. Hopefully solves test instability in
         // issue https://github.com/elastic/x-pack-elasticsearch/issues/918
-        ForceMergeResponse actionGet = client().admin()
-            .indices()
-            .prepareForceMerge("test")
-            .setFlush(true)
-            .setMaxNumSegments(1)
-            .execute()
-            .actionGet();
-        client().admin().indices().prepareRefresh("test").get();
+        ForceMergeResponse actionGet = indicesAdmin().prepareForceMerge("test").setFlush(true).setMaxNumSegments(1).execute().actionGet();
+        indicesAdmin().prepareRefresh("test").get();
         assertAllSuccessful(actionGet);
-        for (IndexShardSegments seg : client().admin().indices().prepareSegments().get().getIndices().get("test")) {
+        for (IndexShardSegments seg : indicesAdmin().prepareSegments().get().getIndices().get("test")) {
             ShardSegments[] shards = seg.shards();
             for (ShardSegments shardSegments : shards) {
                 assertEquals(1, shardSegments.getSegments().size());

--- a/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
+++ b/x-pack/plugin/identity-provider/src/internalClusterTest/java/org/elasticsearch/xpack/idp/saml/sp/SamlServiceProviderIndexTests.java
@@ -73,8 +73,8 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
     @After
     public void deleteTemplateAndIndex() {
-        client().admin().indices().delete(new DeleteIndexRequest(SamlServiceProviderIndex.INDEX_NAME + "*")).actionGet();
-        client().admin().indices().prepareDeleteTemplate(SamlServiceProviderIndex.TEMPLATE_NAME).get();
+        indicesAdmin().delete(new DeleteIndexRequest(SamlServiceProviderIndex.INDEX_NAME + "*")).actionGet();
+        indicesAdmin().prepareDeleteTemplate(SamlServiceProviderIndex.TEMPLATE_NAME).get();
         serviceProviderIndex.close();
     }
 
@@ -132,7 +132,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
 
         // Create an index that will trigger the template, but isn't the standard index name
         final String customIndexName = SamlServiceProviderIndex.INDEX_NAME + "-test";
-        client().admin().indices().create(new CreateIndexRequest(customIndexName)).actionGet();
+        indicesAdmin().create(new CreateIndexRequest(customIndexName)).actionGet();
 
         final IndexMetadata indexMetadata = clusterService.state().metadata().index(customIndexName);
         assertThat(indexMetadata, notNullValue());
@@ -158,7 +158,7 @@ public class SamlServiceProviderIndexTests extends ESSingleNodeTestCase {
     public void testInstallTemplateAutomaticallyOnClusterChange() throws Exception {
         // Create an index that will trigger a cluster state change
         final String indexName = randomAlphaOfLength(7).toLowerCase(Locale.ROOT);
-        client().admin().indices().create(new CreateIndexRequest(indexName)).actionGet();
+        indicesAdmin().create(new CreateIndexRequest(indexName)).actionGet();
 
         ensureGreen(indexName);
 

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/ClusterStateWaitThresholdBreachTests.java
@@ -109,7 +109,7 @@ public class ClusterStateWaitThresholdBreachTests extends ESIntegTestCase {
             // configuring the threshold to the minimum value
             .put(LifecycleSettings.LIFECYCLE_STEP_WAIT_TIME_THRESHOLD, "1h")
             .build();
-        CreateIndexResponse res = client().admin().indices().prepareCreate(managedIndex).setSettings(settings).get();
+        CreateIndexResponse res = indicesAdmin().prepareCreate(managedIndex).setSettings(settings).get();
         assertTrue(res.isAcknowledged());
 
         String[] firstAttemptShrinkIndexName = new String[1];

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataAndIndexLifecycleMixingTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataAndIndexLifecycleMixingTests.java
@@ -750,7 +750,7 @@ public class DataAndIndexLifecycleMixingTests extends ESIntegTestCase {
             assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
             assertThat(itemResponse.getIndex(), startsWith(backingIndexPrefix));
         }
-        client().admin().indices().refresh(new RefreshRequest(dataStream)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
     }
 
     static void putComposableIndexTemplate(

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/DataTiersMigrationsTests.java
@@ -119,7 +119,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
             .put(SETTING_NUMBER_OF_REPLICAS, 1)
             .put(LifecycleSettings.LIFECYCLE_NAME, policy)
             .build();
-        CreateIndexResponse res = client().admin().indices().prepareCreate(managedIndex).setSettings(settings).get();
+        CreateIndexResponse res = indicesAdmin().prepareCreate(managedIndex).setSettings(settings).get();
         assertTrue(res.isAcknowledged());
 
         assertBusy(() -> {
@@ -180,7 +180,7 @@ public class DataTiersMigrationsTests extends ESIntegTestCase {
             .put(SETTING_NUMBER_OF_REPLICAS, 1)
             .put(LifecycleSettings.LIFECYCLE_NAME, policy)
             .build();
-        CreateIndexResponse res = client().admin().indices().prepareCreate(managedIndex).setSettings(settings).get();
+        CreateIndexResponse res = indicesAdmin().prepareCreate(managedIndex).setSettings(settings).get();
         assertTrue(res.isAcknowledged());
 
         assertBusy(() -> {

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/IndexLifecycleInitialisationTests.java
@@ -178,10 +178,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         );
 
         logger.info("Creating index [test]");
-        CreateIndexResponse createIndexResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest("test").settings(settings))
-            .actionGet();
+        CreateIndexResponse createIndexResponse = indicesAdmin().create(new CreateIndexRequest("test").settings(settings)).actionGet();
         assertAcked(createIndexResponse);
         ClusterState clusterState = client().admin().cluster().prepareState().get().getState();
         RoutingNode routingNodeEntry1 = clusterState.getRoutingNodes().node(node1);
@@ -264,10 +261,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         long actualModifiedDate = Instant.from(ISO_ZONED_DATE_TIME.parse(responseItem.getModifiedDate())).toEpochMilli();
 
         logger.info("Creating index [test]");
-        CreateIndexResponse createIndexResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest("test").settings(settings))
-            .actionGet();
+        CreateIndexResponse createIndexResponse = indicesAdmin().create(new CreateIndexRequest("test").settings(settings)).actionGet();
         assertAcked(createIndexResponse);
 
         // using AtomicLong only to extract a value from a lambda rather than the more traditional atomic update use-case
@@ -340,14 +334,11 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
 
         String indexName = "test-2019.09.14";
         logger.info("Creating index [{}]", indexName);
-        CreateIndexResponse createIndexResponse = client().admin()
-            .indices()
-            .create(
-                new CreateIndexRequest(indexName).settings(
-                    Settings.builder().put(settings).put(IndexSettings.LIFECYCLE_PARSE_ORIGINATION_DATE, true)
-                )
+        CreateIndexResponse createIndexResponse = indicesAdmin().create(
+            new CreateIndexRequest(indexName).settings(
+                Settings.builder().put(settings).put(IndexSettings.LIFECYCLE_PARSE_ORIGINATION_DATE, true)
             )
-            .actionGet();
+        ).actionGet();
         assertAcked(createIndexResponse);
 
         DateFormatter dateFormatter = DateFormatter.forPattern("yyyy.MM.dd");
@@ -422,10 +413,7 @@ public class IndexLifecycleInitialisationTests extends ESIntegTestCase {
         PutLifecycleAction.Request putLifecycleRequest = new PutLifecycleAction.Request(lifecyclePolicy);
         assertAcked(client().execute(PutLifecycleAction.INSTANCE, putLifecycleRequest).get());
         logger.info("Creating index [test]");
-        CreateIndexResponse createIndexResponse = client().admin()
-            .indices()
-            .create(new CreateIndexRequest("test").settings(settings))
-            .actionGet();
+        CreateIndexResponse createIndexResponse = indicesAdmin().create(new CreateIndexRequest("test").settings(settings)).actionGet();
         assertAcked(createIndexResponse);
 
         ClusterState clusterState = client().admin().cluster().prepareState().get().getState();

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/ilm/UpdateSettingsStepTests.java
@@ -129,7 +129,7 @@ public class UpdateSettingsStepTests extends ESSingleNodeTestCase {
     }
 
     public void testUpdateSettingsStepRetriesOnError() throws InterruptedException {
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(Settings.builder().build()).get());
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(Settings.builder().build()).get());
 
         ClusterService clusterService = getInstanceFromNode(ClusterService.class);
         ClusterState state = clusterService.state();

--- a/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
+++ b/x-pack/plugin/ilm/src/internalClusterTest/java/org/elasticsearch/xpack/slm/SLMSnapshotBlockingIntegTests.java
@@ -401,7 +401,7 @@ public class SLMSnapshotBlockingIntegTests extends AbstractSnapshotIntegTestCase
         AtomicReference<String> successfulSnapshotName = new AtomicReference<>();
         {
             logger.info("--> deleting old index [{}], as it is now missing shards", indexName);
-            assertAcked(client().admin().indices().prepareDelete(indexName).get());
+            assertAcked(indicesAdmin().prepareDelete(indexName).get());
             createAndPopulateIndex(indexName);
 
             logger.info("--> unblocking snapshots");

--- a/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/SearchIdleTests.java
+++ b/x-pack/plugin/mapper-constant-keyword/src/test/java/org/elasticsearch/xpack/constantkeyword/mapper/SearchIdleTests.java
@@ -114,16 +114,15 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
 
         assertEquals(RestStatus.CREATED, client().prepareIndex(idleIndex).setSource("keyword", randomAlphaOfLength(10)).get().status());
         assertEquals(RestStatus.CREATED, client().prepareIndex(activeIndex).setSource("keyword", randomAlphaOfLength(10)).get().status());
-        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(idleIndex, activeIndex).get().getStatus());
+        assertEquals(RestStatus.OK, indicesAdmin().prepareRefresh(idleIndex, activeIndex).get().getStatus());
 
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(idleIndex, activeIndex).get().getShards())
-                .allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(idleIndex, activeIndex).get().getShards()).allMatch(ShardStats::isSearchIdle),
             2,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse beforeStatsResponse = client().admin().indices().prepareStats("test*").get();
+        final IndicesStatsResponse beforeStatsResponse = indicesAdmin().prepareStats("test*").get();
         assertIdleShard(beforeStatsResponse);
 
         // WHEN
@@ -135,7 +134,7 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
         assertEquals(0, searchResponse.getHits().getHits().length);
 
         // THEN
-        final IndicesStatsResponse afterStatsResponse = client().admin().indices().prepareStats("test*").get();
+        final IndicesStatsResponse afterStatsResponse = indicesAdmin().prepareStats("test*").get();
 
         assertIdleShardsRefreshStats(beforeStatsResponse, afterStatsResponse);
     }
@@ -177,19 +176,18 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
 
         assertEquals(RestStatus.CREATED, client().prepareIndex(idleIndex).setSource("keyword", randomAlphaOfLength(10)).get().status());
         assertEquals(RestStatus.CREATED, client().prepareIndex(activeIndex).setSource("keyword", randomAlphaOfLength(10)).get().status());
-        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(idleIndex, activeIndex).get().getStatus());
+        assertEquals(RestStatus.OK, indicesAdmin().prepareRefresh(idleIndex, activeIndex).get().getStatus());
 
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(idleIndex, activeIndex).get().getShards())
-                .allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(idleIndex, activeIndex).get().getShards()).allMatch(ShardStats::isSearchIdle),
             2,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse idleIndexStatsBefore = client().admin().indices().prepareStats("test1").get();
+        final IndicesStatsResponse idleIndexStatsBefore = indicesAdmin().prepareStats("test1").get();
         assertIdleShard(idleIndexStatsBefore);
 
-        final IndicesStatsResponse activeIndexStatsBefore = client().admin().indices().prepareStats("test2").get();
+        final IndicesStatsResponse activeIndexStatsBefore = indicesAdmin().prepareStats("test2").get();
         assertIdleShard(activeIndexStatsBefore);
 
         // WHEN
@@ -200,7 +198,7 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
         Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> assertEquals("test2", searchHit.getIndex()));
 
         // THEN
-        final IndicesStatsResponse idleIndexStatsAfter = client().admin().indices().prepareStats(idleIndex).get();
+        final IndicesStatsResponse idleIndexStatsAfter = indicesAdmin().prepareStats(idleIndex).get();
         assertIdleShardsRefreshStats(idleIndexStatsBefore, idleIndexStatsAfter);
     }
 
@@ -241,16 +239,15 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
 
         assertEquals(RestStatus.CREATED, client().prepareIndex(idleIndex).setSource("keyword", randomAlphaOfLength(10)).get().status());
         assertEquals(RestStatus.CREATED, client().prepareIndex(activeIndex).setSource("keyword", randomAlphaOfLength(10)).get().status());
-        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(idleIndex, activeIndex).get().getStatus());
+        assertEquals(RestStatus.OK, indicesAdmin().prepareRefresh(idleIndex, activeIndex).get().getStatus());
 
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(idleIndex, activeIndex).get().getShards())
-                .allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(idleIndex, activeIndex).get().getShards()).allMatch(ShardStats::isSearchIdle),
             2,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse beforeStatsResponse = client().admin().indices().prepareStats("test*").get();
+        final IndicesStatsResponse beforeStatsResponse = indicesAdmin().prepareStats("test*").get();
         assertIdleShard(beforeStatsResponse);
 
         // WHEN
@@ -264,7 +261,7 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
             new String[] { "test1", "test2" },
             Arrays.stream(searchResponse.getHits().getHits()).map(SearchHit::getIndex).sorted().toArray()
         );
-        final IndicesStatsResponse afterStatsResponse = client().admin().indices().prepareStats("test*").get();
+        final IndicesStatsResponse afterStatsResponse = indicesAdmin().prepareStats("test*").get();
         assertIdleShardsRefreshStats(beforeStatsResponse, afterStatsResponse);
     }
 
@@ -301,19 +298,18 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
 
         assertEquals(RestStatus.CREATED, client().prepareIndex(idleIndex).setSource("keyword", "value").get().status());
         assertEquals(RestStatus.CREATED, client().prepareIndex(activeIndex).setSource("keyword", "value").get().status());
-        assertEquals(RestStatus.OK, client().admin().indices().prepareRefresh(idleIndex, activeIndex).get().getStatus());
+        assertEquals(RestStatus.OK, indicesAdmin().prepareRefresh(idleIndex, activeIndex).get().getStatus());
 
         waitUntil(
-            () -> Arrays.stream(client().admin().indices().prepareStats(idleIndex, activeIndex).get().getShards())
-                .allMatch(ShardStats::isSearchIdle),
+            () -> Arrays.stream(indicesAdmin().prepareStats(idleIndex, activeIndex).get().getShards()).allMatch(ShardStats::isSearchIdle),
             2,
             TimeUnit.SECONDS
         );
 
-        final IndicesStatsResponse idleIndexStatsBefore = client().admin().indices().prepareStats("test1").get();
+        final IndicesStatsResponse idleIndexStatsBefore = indicesAdmin().prepareStats("test1").get();
         assertIdleShard(idleIndexStatsBefore);
 
-        final IndicesStatsResponse activeIndexStatsBefore = client().admin().indices().prepareStats("test2").get();
+        final IndicesStatsResponse activeIndexStatsBefore = indicesAdmin().prepareStats("test2").get();
         assertIdleShard(activeIndexStatsBefore);
 
         // WHEN
@@ -327,7 +323,7 @@ public class SearchIdleTests extends ESSingleNodeTestCase {
         assertEquals(idleIndexShardsCount, searchResponse.getSkippedShards());
         assertEquals(0, searchResponse.getFailedShards());
         Arrays.stream(searchResponse.getHits().getHits()).forEach(searchHit -> assertEquals("test2", searchHit.getIndex()));
-        final IndicesStatsResponse idleIndexStatsAfter = client().admin().indices().prepareStats(idleIndex).get();
+        final IndicesStatsResponse idleIndexStatsAfter = indicesAdmin().prepareStats(idleIndex).get();
         assertIdleShardsRefreshStats(idleIndexStatsBefore, idleIndexStatsAfter);
     }
 

--- a/x-pack/plugin/mapper-version/src/internalClusterTest/java/org/elasticsearch/xpack/versionfield/VersionFieldIT.java
+++ b/x-pack/plugin/mapper-version/src/internalClusterTest/java/org/elasticsearch/xpack/versionfield/VersionFieldIT.java
@@ -43,9 +43,7 @@ public class VersionFieldIT extends ESSingleNodeTestCase {
         String indexName = "test";
         createIndex(indexName);
 
-        client().admin()
-            .indices()
-            .preparePutMapping(indexName)
+        indicesAdmin().preparePutMapping(indexName)
             .setSource(
                 XContentFactory.jsonBuilder()
                     .startObject()
@@ -69,7 +67,7 @@ public class VersionFieldIT extends ESSingleNodeTestCase {
             .get();
         client().prepareIndex(indexName).setId("4").setSource(jsonBuilder().startObject().field("version", "2.1.0").endObject()).get();
         client().prepareIndex(indexName).setId("5").setSource(jsonBuilder().startObject().field("version", "3.11.5").endObject()).get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         // terms aggs
         SearchResponse response = client().prepareSearch(indexName)
@@ -90,9 +88,7 @@ public class VersionFieldIT extends ESSingleNodeTestCase {
         String indexName = "test";
         createIndex(indexName);
 
-        client().admin()
-            .indices()
-            .preparePutMapping(indexName)
+        indicesAdmin().preparePutMapping(indexName)
             .setSource(
                 XContentFactory.jsonBuilder()
                     .startObject()
@@ -116,7 +112,7 @@ public class VersionFieldIT extends ESSingleNodeTestCase {
             .get();
         client().prepareIndex(indexName).setId("4").setSource(jsonBuilder().startObject().field("version", "2.1.0").endObject()).get();
         client().prepareIndex(indexName).setId("5").setSource(jsonBuilder().startObject().field("version", "3.11.5").endObject()).get();
-        client().admin().indices().prepareRefresh().get();
+        indicesAdmin().prepareRefresh().get();
 
         {
             TermsEnumResponse response = client().execute(TermsEnumAction.INSTANCE, new TermsEnumRequest(indexName).field("version")).get();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationEvaluationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ClassificationEvaluationIT.java
@@ -690,9 +690,7 @@ public class ClassificationEvaluationIT extends MlNativeDataFrameAnalyticsIntegT
     }
 
     static void createAnimalsIndex(String indexName) {
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
+        indicesAdmin().prepareCreate(indexName)
             .setMapping(
                 ANIMAL_NAME_KEYWORD_FIELD,
                 "type=keyword",

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ExplainDataFrameAnalyticsIT.java
@@ -57,9 +57,7 @@ public class ExplainDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsInteg
 
         String sourceIndex = "test-source-query-is-applied";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping(
                 "numeric_1",
                 "type=double",

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlInitializationServiceIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlInitializationServiceIT.java
@@ -199,9 +199,7 @@ public class MlInitializationServiceIT extends MlNativeAutodetectIntegTestCase {
     }
 
     private static Map<String, Settings> getIndexToSettingsMap(List<String> indexNames) {
-        GetSettingsResponse getSettingsResponse = client().admin()
-            .indices()
-            .prepareGetSettings()
+        GetSettingsResponse getSettingsResponse = indicesAdmin().prepareGetSettings()
             .setIndices(indexNames.toArray(String[]::new))
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
             .get();
@@ -210,9 +208,7 @@ public class MlInitializationServiceIT extends MlNativeAutodetectIntegTestCase {
     }
 
     private static Map<String, List<AliasMetadata>> getIndexToAliasesMap(List<String> indexNames) {
-        GetAliasesResponse getAliasesResponse = client().admin()
-            .indices()
-            .prepareGetAliases()
+        GetAliasesResponse getAliasesResponse = indicesAdmin().prepareGetAliases()
             .setIndices(indexNames.toArray(String[]::new))
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
             .get();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/MlNativeAutodetectIntegTestCase.java
@@ -267,9 +267,7 @@ abstract class MlNativeAutodetectIntegTestCase extends MlNativeIntegTestCase {
 
     protected void assertThatNumberOfAnnotationsIsEqualTo(int expectedNumberOfAnnotations) throws IOException {
         // Refresh the annotations index so that recently indexed annotation docs are visible.
-        client().admin()
-            .indices()
-            .prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
+        indicesAdmin().prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
             .execute()
             .actionGet();

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/ModelPlotsIT.java
@@ -40,11 +40,7 @@ public class ModelPlotsIT extends MlNativeAutodetectIntegTestCase {
 
     @Before
     public void setUpData() {
-        client().admin()
-            .indices()
-            .prepareCreate(DATA_INDEX)
-            .setMapping("time", "type=date,format=epoch_millis", "user", "type=keyword")
-            .get();
+        indicesAdmin().prepareCreate(DATA_INDEX).setMapping("time", "type=date,format=epoch_millis", "user", "type=keyword").get();
 
         List<String> users = Arrays.asList("user_1", "user_2", "user_3");
 

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionEvaluationIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RegressionEvaluationIT.java
@@ -138,11 +138,7 @@ public class RegressionEvaluationIT extends MlNativeDataFrameAnalyticsIntegTestC
     }
 
     private static void createHousesIndex(String indexName) {
-        client().admin()
-            .indices()
-            .prepareCreate(indexName)
-            .setMapping(PRICE_FIELD, "type=double", PRICE_PREDICTION_FIELD, "type=double")
-            .get();
+        indicesAdmin().prepareCreate(indexName).setMapping(PRICE_FIELD, "type=double", PRICE_PREDICTION_FIELD, "type=double").get();
     }
 
     private static void indexHousesData(String indexName) {

--- a/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
+++ b/x-pack/plugin/ml/qa/native-multi-node-tests/src/javaRestTest/java/org/elasticsearch/xpack/ml/integration/RunDataFrameAnalyticsIT.java
@@ -60,9 +60,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testOutlierDetectionWithFewDocuments() throws Exception {
         String sourceIndex = "test-outlier-detection-with-few-docs";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=unsigned_long", "categorical_1", "type=keyword")
             .get();
 
@@ -157,9 +155,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testPreview() throws Exception {
         String sourceIndex = "test-outlier-detection-preview";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=unsigned_long", "categorical_1", "type=keyword")
             .get();
 
@@ -199,9 +195,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testOutlierDetectionWithEnoughDocumentsToScroll() throws Exception {
         String sourceIndex = "test-outlier-detection-with-enough-docs-to-scroll";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
@@ -359,9 +353,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testStopOutlierDetectionWithEnoughDocumentsToScroll() throws Exception {
         String sourceIndex = "test-stop-outlier-detection-with-enough-docs-to-scroll";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
@@ -429,15 +421,11 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         String destIndex = "test-outlier-detection-with-multiple-source-indices-results";
         String[] sourceIndex = new String[] { sourceIndex1, sourceIndex2 };
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex1)
+        indicesAdmin().prepareCreate(sourceIndex1)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex2)
+        indicesAdmin().prepareCreate(sourceIndex2)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
@@ -503,15 +491,11 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
         String sourceIndex = "test-outlier-detection-with-pre-existing-dest-index";
         String destIndex = "test-outlier-detection-with-pre-existing-dest-index-results";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
-        client().admin()
-            .indices()
-            .prepareCreate(destIndex)
+        indicesAdmin().prepareCreate(destIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
@@ -570,11 +554,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testModelMemoryLimitLowerThanEstimatedMemoryUsage() throws Exception {
         String sourceIndex = "test-model-memory-limit";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
-            .setMapping("col_1", "type=double", "col_2", "type=float", "col_3", "type=keyword")
-            .get();
+        indicesAdmin().prepareCreate(sourceIndex).setMapping("col_1", "type=double", "col_2", "type=float", "col_3", "type=keyword").get();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         for (int i = 0; i < 10000; i++) {  // This number of rows should make memory usage estimate greater than 1MB
@@ -607,11 +587,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testLazyAssignmentWithModelMemoryLimitTooHighForAssignment() throws Exception {
         String sourceIndex = "test-lazy-assign-model-memory-limit-too-high";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
-            .setMapping("col_1", "type=double", "col_2", "type=float", "col_3", "type=keyword")
-            .get();
+        indicesAdmin().prepareCreate(sourceIndex).setMapping("col_1", "type=double", "col_2", "type=float", "col_3", "type=keyword").get();
 
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk().setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE);
         IndexRequest indexRequest = new IndexRequest(sourceIndex).id("doc_1").source("col_1", 1.0, "col_2", 1.0, "col_3", "str");
@@ -662,9 +638,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testOutlierDetectionStopAndRestart() throws Exception {
         String sourceIndex = "test-outlier-detection-stop-and-restart";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 
@@ -733,9 +707,7 @@ public class RunDataFrameAnalyticsIT extends MlNativeDataFrameAnalyticsIntegTest
     public void testOutlierDetectionWithCustomParams() throws Exception {
         String sourceIndex = "test-outlier-detection-with-custom-params";
 
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setMapping("numeric_1", "type=double", "numeric_2", "type=float", "categorical_1", "type=keyword")
             .get();
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AnnotationIndexIT.java
@@ -95,9 +95,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         String reindexedIndexName = ".reindexed-v7-ml-annotations-6";
         createReindexedIndex(reindexedIndexName);
 
-        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = client().admin()
-            .indices()
-            .prepareAliases()
+        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = indicesAdmin().prepareAliases()
             .addAliasAction(
                 IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.READ_ALIAS_NAME).isHidden(true)
             )
@@ -109,7 +107,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
                 IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.LATEST_INDEX_NAME).isHidden(true)
             );
 
-        client().admin().indices().aliases(indicesAliasesRequestBuilder.request()).actionGet();
+        indicesAdmin().aliases(indicesAliasesRequestBuilder.request()).actionGet();
 
         client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
 
@@ -137,9 +135,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         String reindexedIndexName = ".reindexed-v7-ml-annotations-6";
         createReindexedIndex(reindexedIndexName);
 
-        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = client().admin()
-            .indices()
-            .prepareAliases()
+        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = indicesAdmin().prepareAliases()
             .addAliasAction(
                 IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.READ_ALIAS_NAME).isHidden(true)
             )
@@ -151,7 +147,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
                 IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.LATEST_INDEX_NAME).isHidden(true)
             );
 
-        client().admin().indices().aliases(indicesAliasesRequestBuilder.request()).actionGet();
+        indicesAdmin().aliases(indicesAliasesRequestBuilder.request()).actionGet();
 
         client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
 
@@ -179,9 +175,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         String reindexedIndexName = ".reindexed-v7-ml-annotations-6";
         createReindexedIndex(reindexedIndexName);
 
-        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = client().admin()
-            .indices()
-            .prepareAliases()
+        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = indicesAdmin().prepareAliases()
             // The difference compared to the standard reindexing test is that the read and write aliases are not correctly set up.
             // The annotations index maintenance code should add them back.
             .addAliasAction(IndicesAliasesRequest.AliasActions.removeIndex().index(AnnotationIndex.LATEST_INDEX_NAME))
@@ -189,7 +183,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
                 IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.LATEST_INDEX_NAME).isHidden(true)
             );
 
-        client().admin().indices().aliases(indicesAliasesRequestBuilder.request()).actionGet();
+        indicesAdmin().aliases(indicesAliasesRequestBuilder.request()).actionGet();
 
         client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
 
@@ -216,9 +210,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         String reindexedIndexName = ".reindexed-v7-ml-annotations-6";
         createReindexedIndex(reindexedIndexName);
 
-        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = client().admin()
-            .indices()
-            .prepareAliases()
+        IndicesAliasesRequestBuilder indicesAliasesRequestBuilder = indicesAdmin().prepareAliases()
             // The difference compared to the standard reindexing test is that the read and write aliases are not correctly set up.
             // The annotations index maintenance code should add them back.
             .addAliasAction(IndicesAliasesRequest.AliasActions.removeIndex().index(AnnotationIndex.LATEST_INDEX_NAME))
@@ -226,7 +218,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
                 IndicesAliasesRequest.AliasActions.add().index(reindexedIndexName).alias(AnnotationIndex.LATEST_INDEX_NAME).isHidden(true)
             );
 
-        client().admin().indices().aliases(indicesAliasesRequestBuilder.request()).actionGet();
+        indicesAdmin().aliases(indicesAliasesRequestBuilder.request()).actionGet();
 
         client().execute(SetUpgradeModeAction.INSTANCE, new SetUpgradeModeAction.Request(false)).actionGet();
 
@@ -258,12 +250,10 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
         // switched to only point at the new index.
         assertBusy(() -> {
             assertTrue(annotationsIndexExists(AnnotationIndex.LATEST_INDEX_NAME));
-            Map<String, List<AliasMetadata>> aliases = client().admin()
-                .indices()
-                .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME)
-                .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
-                .get()
-                .getAliases();
+            Map<String, List<AliasMetadata>> aliases = indicesAdmin().prepareGetAliases(
+                AnnotationIndex.READ_ALIAS_NAME,
+                AnnotationIndex.WRITE_ALIAS_NAME
+            ).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN).get().getAliases();
             assertNotNull(aliases);
             List<String> indicesWithReadAlias = new ArrayList<>();
             for (var entry : aliases.entrySet()) {
@@ -337,9 +327,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
     }
 
     private boolean annotationsIndexExists(String expectedName) {
-        GetIndexResponse getIndexResponse = client().admin()
-            .indices()
-            .prepareGetIndex()
+        GetIndexResponse getIndexResponse = indicesAdmin().prepareGetIndex()
             .setIndices(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN)
             .execute()
@@ -349,12 +337,11 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
 
     private int numberOfAnnotationsAliases() {
         int count = 0;
-        Map<String, List<AliasMetadata>> aliases = client().admin()
-            .indices()
-            .prepareGetAliases(AnnotationIndex.READ_ALIAS_NAME, AnnotationIndex.WRITE_ALIAS_NAME, AnnotationIndex.LATEST_INDEX_NAME)
-            .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
-            .get()
-            .getAliases();
+        Map<String, List<AliasMetadata>> aliases = indicesAdmin().prepareGetAliases(
+            AnnotationIndex.READ_ALIAS_NAME,
+            AnnotationIndex.WRITE_ALIAS_NAME,
+            AnnotationIndex.LATEST_INDEX_NAME
+        ).setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN).get().getAliases();
         if (aliases != null) {
             for (var aliasList : aliases.values()) {
                 for (AliasMetadata aliasMetadata : aliasList) {
@@ -375,7 +362,7 @@ public class AnnotationIndexIT extends MlSingleNodeTestCase {
                     .put(IndexMetadata.SETTING_INDEX_HIDDEN, true)
             );
 
-        client().admin().indices().create(createIndexRequest).actionGet();
+        indicesAdmin().create(createIndexRequest).actionGet();
 
         // At this point the upgrade assistant would reindex the old index into the new index but there's
         // no point in this test as there's nothing in the old index.

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/AutodetectResultProcessorIT.java
@@ -773,9 +773,7 @@ public class AutodetectResultProcessorIT extends MlSingleNodeTestCase {
 
     private List<Annotation> getAnnotations() throws Exception {
         // Refresh the annotations index so that recently indexed annotation docs are visible.
-        client().admin()
-            .indices()
-            .prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
+        indicesAdmin().prepareRefresh(AnnotationIndex.LATEST_INDEX_NAME)
             .setIndicesOptions(IndicesOptions.STRICT_EXPAND_OPEN_HIDDEN_FORBID_CLOSED)
             .execute()
             .actionGet();

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/BasicDistributedJobsIT.java
@@ -362,9 +362,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
 
         // Create the indices (using installed templates) and set the routing to specific nodes
         // State and results go on the state-and-results node, config goes on the config node
-        client().admin()
-            .indices()
-            .prepareCreate(".ml-anomalies-shared")
+        indicesAdmin().prepareCreate(".ml-anomalies-shared")
             .setSettings(
                 Settings.builder()
                     .put("index.routing.allocation.include.ml-indices", "state-and-results")
@@ -372,9 +370,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
                     .build()
             )
             .get();
-        client().admin()
-            .indices()
-            .prepareCreate(".ml-state")
+        indicesAdmin().prepareCreate(".ml-state")
             .setSettings(
                 Settings.builder()
                     .put("index.routing.allocation.include.ml-indices", "state-and-results")
@@ -382,9 +378,7 @@ public class BasicDistributedJobsIT extends BaseMlIntegTestCase {
                     .build()
             )
             .get();
-        client().admin()
-            .indices()
-            .prepareCreate(".ml-config")
+        indicesAdmin().prepareCreate(".ml-config")
             .setSettings(
                 Settings.builder()
                     .put("index.routing.allocation.exclude.ml-indices", "state-and-results")

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelRestorerIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/ChunkedTrainedModelRestorerIT.java
@@ -123,9 +123,7 @@ public class ChunkedTrainedModelRestorerIT extends MlSingleNodeTestCase {
         String index2 = "foo-2";
 
         for (String index : new String[] { index1, index2 }) {
-            client().admin()
-                .indices()
-                .prepareCreate(index)
+            indicesAdmin().prepareCreate(index)
                 .setMapping(
                     TrainedModelDefinitionDoc.DEFINITION.getPreferredName(),
                     "type=binary",

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobResultsProviderIT.java
@@ -796,9 +796,7 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
                 {"job_id":"other_job","snapshot_id":"11", "snapshot_doc_count":1,"retain":false}""", XContentType.JSON)
             .get();
 
-        client().admin()
-            .indices()
-            .prepareRefresh(AnomalyDetectorsIndex.jobStateIndexPattern(), AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*")
+        indicesAdmin().prepareRefresh(AnomalyDetectorsIndex.jobStateIndexPattern(), AnomalyDetectorsIndex.jobResultsIndexPrefix() + "*")
             .get();
 
         PlainActionFuture<QueryPage<ModelSnapshot>> future = new PlainActionFuture<>();
@@ -890,14 +888,11 @@ public class JobResultsProviderIT extends MlSingleNodeTestCase {
         Quantiles quantiles = new Quantiles(jobId, new Date(), "quantile-state");
         indexQuantiles(quantiles);
 
-        client().admin()
-            .indices()
-            .prepareRefresh(
-                MlMetaIndex.indexName(),
-                AnomalyDetectorsIndex.jobStateIndexPattern(),
-                AnomalyDetectorsIndex.jobResultsAliasedName(jobId)
-            )
-            .get();
+        indicesAdmin().prepareRefresh(
+            MlMetaIndex.indexName(),
+            AnomalyDetectorsIndex.jobStateIndexPattern(),
+            AnomalyDetectorsIndex.jobResultsAliasedName(jobId)
+        ).get();
 
         AutodetectParams params = getAutodetectParams(job.build(new Date()));
 

--- a/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
+++ b/x-pack/plugin/ml/src/internalClusterTest/java/org/elasticsearch/xpack/ml/integration/JobStorageDeletionTaskIT.java
@@ -193,9 +193,7 @@ public class JobStorageDeletionTaskIT extends BaseMlIntegTestCase {
 
         // Make sure dedicated index is gone
         assertThat(
-            client().admin()
-                .indices()
-                .prepareGetIndex()
+            indicesAdmin().prepareGetIndex()
                 .setIndices(dedicatedIndex)
                 .setIndicesOptions(IndicesOptions.LENIENT_EXPAND_OPEN_CLOSED_HIDDEN)
                 .get()

--- a/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/local/LocalIndicesCleanerTests.java
+++ b/x-pack/plugin/monitoring/src/test/java/org/elasticsearch/xpack/monitoring/cleaner/local/LocalIndicesCleanerTests.java
@@ -53,9 +53,7 @@ public class LocalIndicesCleanerTests extends AbstractIndicesCleanerTestCase {
             // in some cases. When the plugin security is enabled, it expands wildcards to the existing index, which then gets deleted,
             // so when es core gets the request with the explicit index name, it throws an index not found exception as that index
             // doesn't exist anymore. If we ignore unavailable instead no error will be thrown.
-            GetSettingsResponse getSettingsResponse = client().admin()
-                .indices()
-                .prepareGetSettings()
+            GetSettingsResponse getSettingsResponse = indicesAdmin().prepareGetSettings()
                 .addIndices(".monitoring-*")
                 .setIndicesOptions(IndicesOptions.fromOptions(true, true, true, true, true))
                 .get();

--- a/x-pack/plugin/old-lucene-versions/src/internalClusterTest/java/org/elasticsearch/xpack/lucene/bwc/ArchiveSettingValidationIntegTests.java
+++ b/x-pack/plugin/old-lucene-versions/src/internalClusterTest/java/org/elasticsearch/xpack/lucene/bwc/ArchiveSettingValidationIntegTests.java
@@ -27,9 +27,7 @@ public class ArchiveSettingValidationIntegTests extends AbstractArchiveTestCase 
 
         final IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .indices()
-                .prepareUpdateSettings(indexName)
+            () -> indicesAdmin().prepareUpdateSettings(indexName)
                 .setSettings(Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), false))
                 .get()
         );

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankMultiShardIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankMultiShardIT.java
@@ -86,7 +86,7 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
         client().prepareIndex("tiny_index").setSource("vector", new float[] { 1.0f }, "text", "other").get();
         client().prepareIndex("tiny_index").setSource("vector", new float[] { 2.0f }, "text", "term").get();
 
-        client().admin().indices().prepareRefresh("tiny_index").get();
+        indicesAdmin().prepareRefresh("tiny_index").get();
 
         // Set up an index with non-random data, so we can
         // do direct tests against expected results.
@@ -138,7 +138,7 @@ public class RRFRankMultiShardIT extends ESIntegTestCase {
                 .get();
         }
 
-        client().admin().indices().prepareRefresh("nrd_index").get();
+        indicesAdmin().prepareRefresh("nrd_index").get();
     }
 
     public void testTotalDocsSmallerThanSize() {

--- a/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankShardCanMatchIT.java
+++ b/x-pack/plugin/rank-rrf/src/internalClusterTest/java/org/elasticsearch/xpack/rank/rrf/RRFRankShardCanMatchIT.java
@@ -146,7 +146,7 @@ public class RRFRankShardCanMatchIT extends ESIntegTestCase {
             shardB = b;
         }
 
-        client().admin().indices().prepareRefresh("value_index").get();
+        indicesAdmin().prepareRefresh("value_index").get();
 
         // match 2 separate shard with no overlap in queries
         SearchResponse response = client().prepareSearch("value_index")

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleActionSingleNodeTests.java
@@ -227,7 +227,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
             .endObject();
 
         mapping.endObject().endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate(sourceIndex).setSettings(settings.build()).setMapping(mapping).get());
+        assertAcked(indicesAdmin().prepareCreate(sourceIndex).setSettings(settings.build()).setMapping(mapping).get());
     }
 
     public void testRollupIndex() throws IOException {
@@ -359,7 +359,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         logger.info("Updating index [{}] with settings [{}]", sourceIndex, settings);
 
         var updateSettingsReq = new UpdateSettingsRequest(settings, sourceIndex);
-        assertAcked(client().admin().indices().updateSettings(updateSettingsReq).actionGet());
+        assertAcked(indicesAdmin().updateSettings(updateSettingsReq).actionGet());
 
         DownsampleConfig config = new DownsampleConfig(randomInterval());
         SourceSupplier sourceSupplier = () -> {
@@ -375,7 +375,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         prepareSourceIndex(sourceIndex);
         rollup(sourceIndex, rollupIndex, config);
 
-        GetIndexResponse indexSettingsResp = client().admin().indices().prepareGetIndex().addIndices(sourceIndex, rollupIndex).get();
+        GetIndexResponse indexSettingsResp = indicesAdmin().prepareGetIndex().addIndices(sourceIndex, rollupIndex).get();
         assertRollupIndexSettings(sourceIndex, rollupIndex, indexSettingsResp);
         for (String key : settings.keySet()) {
             assertEquals(settings.get(key), indexSettingsResp.getSetting(rollupIndex, key));
@@ -434,7 +434,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         prepareSourceIndex(sourceIndex);
 
         // Create an empty index with the same name as the rollup index
-        assertAcked(client().admin().indices().prepareCreate(rollupIndex).setSettings(indexSettings(1, 0)).get());
+        assertAcked(indicesAdmin().prepareCreate(rollupIndex).setSettings(indexSettings(1, 0)).get());
         ResourceAlreadyExistsException exception = expectThrows(
             ResourceAlreadyExistsException.class,
             () -> rollup(sourceIndex, rollupIndex, config)
@@ -453,9 +453,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
     public void testRollupIndexWithNoMetrics() throws IOException {
         // Create a source index that contains no metric fields in its mapping
         String sourceIndex = "no-metrics-idx-" + randomAlphaOfLength(5).toLowerCase(Locale.ROOT);
-        client().admin()
-            .indices()
-            .prepareCreate(sourceIndex)
+        indicesAdmin().prepareCreate(sourceIndex)
             .setSettings(
                 indexSettings(numOfShards, numOfReplicas).put(IndexSettings.MODE.getKey(), IndexMode.TIME_SERIES)
                     .putList(IndexMetadata.INDEX_ROUTING_PATH.getKey(), List.of(FIELD_DIMENSION_1))
@@ -522,7 +520,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
         client().execute(DownsampleAction.INSTANCE, new DownsampleAction.Request(sourceIndex, rollupIndex, config), rollupListener);
         assertBusy(() -> {
             try {
-                assertEquals(client().admin().indices().prepareGetIndex().addIndices(rollupIndex).get().getIndices().length, 1);
+                assertEquals(indicesAdmin().prepareGetIndex().addIndices(rollupIndex).get().getIndices().length, 1);
             } catch (IndexNotFoundException e) {
                 fail("rollup index has not been created");
             }
@@ -627,9 +625,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
 
         // block rollup index
         assertAcked(
-            client().admin()
-                .indices()
-                .preparePutTemplate(rollupIndex)
+            indicesAdmin().preparePutTemplate(rollupIndex)
                 .setPatterns(List.of(rollupIndex))
                 .setSettings(Settings.builder().put("index.blocks.write", "true").build())
                 .get()
@@ -735,9 +731,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
     private void prepareSourceIndex(String sourceIndex) {
         // Set the source index to read-only state
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareUpdateSettings(sourceIndex)
+            indicesAdmin().prepareUpdateSettings(sourceIndex)
                 .setSettings(Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), true).build())
                 .get()
         );
@@ -750,7 +744,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
     }
 
     private RolloverResponse rollover(String dataStreamName) throws ExecutionException, InterruptedException {
-        RolloverResponse response = client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).get();
+        RolloverResponse response = indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).get();
         assertAcked(response);
         return response;
     }
@@ -762,7 +756,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
     @SuppressWarnings("unchecked")
     private void assertRollupIndex(String sourceIndex, String rollupIndex, DownsampleConfig config) throws IOException {
         // Retrieve field information for the metric fields
-        final GetMappingsResponse getMappingsResponse = client().admin().indices().prepareGetMappings(sourceIndex).get();
+        final GetMappingsResponse getMappingsResponse = indicesAdmin().prepareGetMappings(sourceIndex).get();
         final Map<String, Object> sourceIndexMappings = getMappingsResponse.mappings()
             .entrySet()
             .stream()
@@ -790,7 +784,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
 
         assertRollupIndexAggregations(sourceIndex, rollupIndex, config, metricFields, labelFields);
 
-        GetIndexResponse indexSettingsResp = client().admin().indices().prepareGetIndex().addIndices(sourceIndex, rollupIndex).get();
+        GetIndexResponse indexSettingsResp = indicesAdmin().prepareGetIndex().addIndices(sourceIndex, rollupIndex).get();
         assertRollupIndexSettings(sourceIndex, rollupIndex, indexSettingsResp);
 
         Map<String, Map<String, Object>> mappings = (Map<String, Map<String, Object>>) indexSettingsResp.getMappings()
@@ -800,9 +794,7 @@ public class DownsampleActionSingleNodeTests extends ESSingleNodeTestCase {
 
         assertFieldMappings(config, metricFields, mappings);
 
-        GetMappingsResponse indexMappings = client().admin()
-            .indices()
-            .getMappings(new GetMappingsRequest().indices(rollupIndex, sourceIndex))
+        GetMappingsResponse indexMappings = indicesAdmin().getMappings(new GetMappingsRequest().indices(rollupIndex, sourceIndex))
             .actionGet();
         Map<String, String> rollupIndexProperties = (Map<String, String>) indexMappings.mappings()
             .get(rollupIndex)

--- a/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleDataStreamTests.java
+++ b/x-pack/plugin/rollup/src/test/java/org/elasticsearch/xpack/downsample/DownsampleDataStreamTests.java
@@ -76,23 +76,18 @@ public class DownsampleDataStreamTests extends ESSingleNodeTestCase {
         putComposableIndexTemplate("1", List.of(dataStreamName));
         client().execute(CreateDataStreamAction.INSTANCE, new CreateDataStreamAction.Request(dataStreamName)).actionGet();
         indexDocs(dataStreamName, 10, Instant.now().toEpochMilli());
-        final RolloverResponse rolloverResponse = client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).get();
+        final RolloverResponse rolloverResponse = indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).get();
         // NOTE: here we calculate a delay to index documents because the next data stream write index is created with a start time of
         // (about) two hours in the future. As a result, we need to have documents whose @timestamp is in the future to avoid documents
         // being indexed in the old data stream backing index.
-        final String newIndexStartTime = client().admin()
-            .indices()
-            .prepareGetSettings(rolloverResponse.getNewIndex())
+        final String newIndexStartTime = indicesAdmin().prepareGetSettings(rolloverResponse.getNewIndex())
             .get()
             .getSetting(rolloverResponse.getNewIndex(), IndexSettings.TIME_SERIES_START_TIME.getKey());
         indexDocs(dataStreamName, 10, Instant.parse(newIndexStartTime).toEpochMilli());
-        client().admin()
-            .indices()
-            .updateSettings(
-                new UpdateSettingsRequest().indices(rolloverResponse.getOldIndex())
-                    .settings(Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build())
-            )
-            .actionGet();
+        indicesAdmin().updateSettings(
+            new UpdateSettingsRequest().indices(rolloverResponse.getOldIndex())
+                .settings(Settings.builder().put(IndexMetadata.SETTING_BLOCKS_WRITE, true).build())
+        ).actionGet();
 
         // WHEN (simulate downsampling as done by an ILM action)
         final String downsampleTargetIndex = DataStream.BACKING_INDEX_PREFIX + dataStreamName + "-downsample-1h";
@@ -101,23 +96,17 @@ public class DownsampleDataStreamTests extends ESSingleNodeTestCase {
             downsampleTargetIndex,
             new DownsampleConfig(DateHistogramInterval.HOUR)
         );
-        final AcknowledgedResponse downsampleResponse = client().admin()
-            .indices()
-            .execute(DownsampleAction.INSTANCE, downsampleRequest)
-            .actionGet();
+        final AcknowledgedResponse downsampleResponse = indicesAdmin().execute(DownsampleAction.INSTANCE, downsampleRequest).actionGet();
 
         /*
          * Force an index update to avoid failing with "Index updates are expected as index settings version has changed",
          * due to a possible bug while checking settings versions and actual settings/metadata changes.
          * See {@link IndexSettings#updateIndexMetadata}.
          */
-        client().admin()
-            .indices()
-            .updateSettings(
-                new UpdateSettingsRequest().indices(downsampleTargetIndex)
-                    .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build())
-            )
-            .actionGet();
+        indicesAdmin().updateSettings(
+            new UpdateSettingsRequest().indices(downsampleTargetIndex)
+                .settings(Settings.builder().put(IndexMetadata.SETTING_INDEX_HIDDEN, false).build())
+        ).actionGet();
 
         final ModifyDataStreamsAction.Request modifyDataStreamRequest = new ModifyDataStreamsAction.Request(
             List.of(
@@ -129,10 +118,10 @@ public class DownsampleDataStreamTests extends ESSingleNodeTestCase {
 
         // THEN
         assertThat(downsampleResponse.isAcknowledged(), equalTo(true));
-        final GetDataStreamAction.Response getDataStreamActionResponse = client().admin()
-            .indices()
-            .execute(GetDataStreamAction.INSTANCE, new GetDataStreamAction.Request(new String[] { dataStreamName }))
-            .actionGet();
+        final GetDataStreamAction.Response getDataStreamActionResponse = indicesAdmin().execute(
+            GetDataStreamAction.INSTANCE,
+            new GetDataStreamAction.Request(new String[] { dataStreamName })
+        ).actionGet();
         assertThat(getDataStreamActionResponse.getDataStreams().get(0).getDataStream().getIndices().size(), equalTo(2));
         final List<String> backingIndices = getDataStreamActionResponse.getDataStreams()
             .get(0)
@@ -239,7 +228,7 @@ public class DownsampleDataStreamTests extends ESSingleNodeTestCase {
         final BulkItemResponse[] items = bulkResponse.getItems();
         assertThat(items.length, equalTo(numDocs));
         assertThat(bulkResponse.hasFailures(), equalTo(false));
-        final RefreshResponse refreshResponse = client().admin().indices().refresh(new RefreshRequest(dataStream)).actionGet();
+        final RefreshResponse refreshResponse = indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
         assertThat(refreshResponse.getStatus().getStatus(), equalTo(RestStatus.OK.getStatus()));
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/BaseSearchableSnapshotsIntegTestCase.java
@@ -209,7 +209,7 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
         refresh(indexName);
         if (randomBoolean()) {
             assertThat(
-                client().admin().indices().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
+                indicesAdmin().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
                 equalTo(0)
             );
         }
@@ -321,7 +321,7 @@ public abstract class BaseSearchableSnapshotsIntegTestCase extends AbstractSnaps
     protected void assertRecoveryStats(String indexName, boolean preWarmEnabled) throws Exception {
         int shardCount = getNumShards(indexName).totalNumShards;
         assertBusy(() -> {
-            final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).get();
+            final RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).get();
             assertThat(recoveryResponse.toString(), recoveryResponse.shardRecoveryStates().get(indexName).size(), equalTo(shardCount));
 
             for (List<RecoveryState> recoveryStates : recoveryResponse.shardRecoveryStates().values()) {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/ClusterStateApplierOrderingTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/ClusterStateApplierOrderingTests.java
@@ -58,7 +58,7 @@ public class ClusterStateApplierOrderingTests extends BaseSearchableSnapshotsInt
         assertThat(snapshotInfo.successfulShards(), greaterThan(0));
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         Settings.Builder indexSettingsBuilder = Settings.builder()
             .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), false)

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/PrevalidateNodeRemovalWithSearchableSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/PrevalidateNodeRemovalWithSearchableSnapshotIntegTests.java
@@ -40,7 +40,7 @@ public class PrevalidateNodeRemovalWithSearchableSnapshotIntegTests extends Base
         createIndexWithContent(indexName, indexSettingsNoReplicas(1).put(INDEX_SOFT_DELETES_SETTING.getKey(), true).build());
         createRepository(repoName, "fs");
         createSnapshot(repoName, snapshotName, List.of(indexName));
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
         // Pin the searchable snapshot index to one node
         final String restoredIndexName = mountSnapshot(
             repoName,

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/RetrySearchIntegTests.java
@@ -41,9 +41,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         final int numberOfShards = between(1, 5);
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate(indexName)
+            indicesAdmin().prepareCreate(indexName)
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, numberOfShards).build())
                 .setMapping("""
                     {"properties":{"created_date":{"type": "date", "format": "yyyy-MM-dd"}}}""")
@@ -55,7 +53,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         }
         indexRandom(true, false, indexRequestBuilders);
         assertThat(
-            client().admin().indices().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
+            indicesAdmin().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
             equalTo(0)
         );
         refresh(indexName);
@@ -65,7 +63,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         createRepository(repositoryName, "fs");
 
         final SnapshotId snapshotOne = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final int numberOfReplicas = between(0, 2);
         final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();
@@ -110,9 +108,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
     public void testRetryPointInTime() throws Exception {
         final String indexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate(indexName)
+            indicesAdmin().prepareCreate(indexName)
                 .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)).build())
                 .setMapping("""
                     {"properties":{"created_date":{"type": "date", "format": "yyyy-MM-dd"}}}""")
@@ -124,7 +120,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         }
         indexRandom(true, false, indexRequestBuilders);
         assertThat(
-            client().admin().indices().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
+            indicesAdmin().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
             equalTo(0)
         );
         refresh(indexName);
@@ -134,7 +130,7 @@ public class RetrySearchIntegTests extends BaseSearchableSnapshotsIntegTestCase 
         createRepository(repositoryName, "fs");
 
         final SnapshotId snapshotOne = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final int numberOfReplicas = between(0, 2);
         final Settings indexSettings = Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, numberOfReplicas).build();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsCanMatchOnCoordinatorIntegTests.java
@@ -122,7 +122,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         createRepository(repositoryName, "mock");
 
         final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-1", List.of(indexOutsideSearchRange)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexOutsideSearchRange));
+        assertAcked(indicesAdmin().prepareDelete(indexOutsideSearchRange));
 
         final String searchableSnapshotIndexOutsideSearchRange = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
 
@@ -368,7 +368,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         createRepository(repositoryName, "mock");
 
         final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-1", List.of(indexWithinSearchRange)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexWithinSearchRange));
+        assertAcked(indicesAdmin().prepareDelete(indexWithinSearchRange));
 
         final String searchableSnapshotIndexWithinSearchRange = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
 
@@ -440,9 +440,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
 
     private void createIndexWithTimestamp(String indexName, int numShards, Settings extraSettings) throws IOException {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate(indexName)
+            indicesAdmin().prepareCreate(indexName)
                 .setMapping(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -480,7 +478,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
         indexRandom(true, false, indexRequestBuilders);
 
         assertThat(
-            client().admin().indices().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
+            indicesAdmin().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
             equalTo(0)
         );
         refresh(indexName);
@@ -502,7 +500,7 @@ public class SearchableSnapshotsCanMatchOnCoordinatorIntegTests extends BaseFroz
 
     private void waitUntilRecoveryIsDone(String index) throws Exception {
         assertBusy(() -> {
-            RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(index).get();
+            RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(index).get();
             assertThat(recoveryResponse.hasRecoveries(), equalTo(true));
             for (List<RecoveryState> value : recoveryResponse.shardRecoveryStates().values()) {
                 for (RecoveryState recoveryState : value) {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsIntegTests.java
@@ -115,7 +115,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             originalIndexSettings.put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), randomFrom("false", "true", "checksum"));
         }
         assertAcked(prepareCreate(indexName, originalIndexSettings));
-        assertAcked(client().admin().indices().prepareAliases().addAlias(indexName, aliasName));
+        assertAcked(indicesAdmin().prepareAliases().addAlias(indexName, aliasName));
 
         populateIndex(indexName, 10_000);
 
@@ -162,9 +162,9 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         final boolean deletedBeforeMount = randomBoolean();
         if (deletedBeforeMount) {
-            assertAcked(client().admin().indices().prepareDelete(indexName));
+            assertAcked(indicesAdmin().prepareDelete(indexName));
         } else {
-            assertAcked(client().admin().indices().prepareClose(indexName));
+            assertAcked(indicesAdmin().prepareClose(indexName));
         }
 
         final boolean cacheEnabled = randomBoolean();
@@ -233,12 +233,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         assertThat(repositoryMetadata.name(), equalTo(fsRepoName));
         assertThat(repositoryMetadata.uuid(), not(equalTo(RepositoryData.MISSING_UUID)));
 
-        final Settings settings = client().admin()
-            .indices()
-            .prepareGetSettings(restoredIndexName)
-            .get()
-            .getIndexToSettings()
-            .get(restoredIndexName);
+        final Settings settings = indicesAdmin().prepareGetSettings(restoredIndexName).get().getIndexToSettings().get(restoredIndexName);
         assertThat(SearchableSnapshots.SNAPSHOT_REPOSITORY_UUID_SETTING.get(settings), equalTo(repositoryMetadata.uuid()));
         assertThat(SearchableSnapshots.SNAPSHOT_REPOSITORY_NAME_SETTING.get(settings), equalTo(fsRepoName));
         assertThat(SearchableSnapshots.SNAPSHOT_SNAPSHOT_NAME_SETTING.get(settings), equalTo(snapshotName));
@@ -276,19 +271,17 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         );
 
         if (deletedBeforeMount) {
-            assertThat(client().admin().indices().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(0));
-            assertAcked(client().admin().indices().prepareAliases().addAlias(restoredIndexName, aliasName));
+            assertThat(indicesAdmin().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(0));
+            assertAcked(indicesAdmin().prepareAliases().addAlias(restoredIndexName, aliasName));
         } else if (indexName.equals(restoredIndexName) == false) {
-            assertThat(client().admin().indices().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(1));
+            assertThat(indicesAdmin().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(1));
             assertAcked(
-                client().admin()
-                    .indices()
-                    .prepareAliases()
+                indicesAdmin().prepareAliases()
                     .addAliasAction(IndicesAliasesRequest.AliasActions.remove().index(indexName).alias(aliasName).mustExist(true))
                     .addAlias(restoredIndexName, aliasName)
             );
         }
-        assertThat(client().admin().indices().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(1));
+        assertThat(indicesAdmin().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(1));
         assertTotalHits(aliasName, originalAllHits, originalBarHits);
 
         internalCluster().fullRestart();
@@ -339,9 +332,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         final String clonedIndexName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareResizeIndex(restoredIndexName, clonedIndexName)
+            indicesAdmin().prepareResizeIndex(restoredIndexName, clonedIndexName)
                 .setResizeType(ResizeType.CLONE)
                 .setSettings(
                     Settings.builder()
@@ -353,9 +344,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         ensureGreen(clonedIndexName);
         assertTotalHits(clonedIndexName, originalAllHits, originalBarHits);
 
-        final Settings clonedIndexSettings = client().admin()
-            .indices()
-            .prepareGetSettings(clonedIndexName)
+        final Settings clonedIndexSettings = indicesAdmin().prepareGetSettings(clonedIndexName)
             .get()
             .getIndexToSettings()
             .get(clonedIndexName);
@@ -366,9 +355,9 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         assertFalse(clonedIndexSettings.hasValue(SearchableSnapshots.SNAPSHOT_INDEX_ID_SETTING.getKey()));
         assertFalse(clonedIndexSettings.hasValue(IndexModule.INDEX_RECOVERY_TYPE_SETTING.getKey()));
 
-        assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
-        assertThat(client().admin().indices().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(0));
-        assertAcked(client().admin().indices().prepareAliases().addAlias(clonedIndexName, aliasName));
+        assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
+        assertThat(indicesAdmin().prepareGetAliases(aliasName).get().getAliases().size(), equalTo(0));
+        assertAcked(indicesAdmin().prepareAliases().addAlias(clonedIndexName, aliasName));
         assertTotalHits(aliasName, originalAllHits, originalBarHits);
     }
 
@@ -401,7 +390,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             }
             refresh(indexName);
             assertThat(
-                client().admin().indices().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
+                indicesAdmin().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
                 equalTo(0)
             );
         });
@@ -420,7 +409,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         indexingThead.join();
         snapshotThread.join();
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         logger.info("--> restoring index [{}]", restoredIndexName);
 
@@ -440,7 +429,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
         ensureGreen(restoredIndexName);
 
-        assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+        assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
     }
 
     public void testMaxRestoreBytesPerSecIsUsed() throws Exception {
@@ -490,7 +479,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         assertThat(snapshotInfo.successfulShards(), greaterThan(0));
         assertThat(snapshotInfo.successfulShards(), equalTo(snapshotInfo.totalShards()));
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         logger.info("--> restoring index [{}] using rate limits [{}]", restoredIndexName, useRateLimits);
         final MountSearchableSnapshotRequest mount = new MountSearchableSnapshotRequest(
@@ -526,11 +515,11 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             updateClusterSettings(Settings.builder().putNull(INDICES_RECOVERY_MAX_BYTES_PER_SEC_SETTING.getKey()));
         }
 
-        assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+        assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
     }
 
     private Map<String, Long> getMaxShardSizeByNodeInBytes(String indexName) {
-        IndicesStatsResponse indicesStats = client().admin().indices().prepareStats(indexName).get();
+        IndicesStatsResponse indicesStats = indicesAdmin().prepareStats(indexName).get();
         IndexStats indexStats = indicesStats.getIndex(indexName);
         Map<String, Long> maxShardSizeByNode = new HashMap<>();
         for (ShardStats shard : indexStats.getShards()) {
@@ -571,7 +560,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         createFullSnapshot(fsRepoName, snapshotName);
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         {
             logger.info("--> restoring index [{}] with default replica counts", restoredIndexName);
@@ -592,16 +581,14 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
             ensureGreen(restoredIndexName);
 
-            final Settings settings = client().admin()
-                .indices()
-                .prepareGetSettings(restoredIndexName)
+            final Settings settings = indicesAdmin().prepareGetSettings(restoredIndexName)
                 .get()
                 .getIndexToSettings()
                 .get(restoredIndexName);
             assertThat(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings), equalTo(0));
             assertThat(IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.get(settings).toString(), equalTo("false"));
 
-            assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+            assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
         }
 
         {
@@ -626,16 +613,14 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
             ensureGreen(restoredIndexName);
 
-            final Settings settings = client().admin()
-                .indices()
-                .prepareGetSettings(restoredIndexName)
+            final Settings settings = indicesAdmin().prepareGetSettings(restoredIndexName)
                 .get()
                 .getIndexToSettings()
                 .get(restoredIndexName);
             assertThat(IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(settings), equalTo(replicaCount));
             assertThat(IndexMetadata.INDEX_AUTO_EXPAND_REPLICAS_SETTING.get(settings).toString(), equalTo("false"));
 
-            assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+            assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
         }
 
         {
@@ -666,7 +651,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 equalTo(Math.min(replicaLimit + 1, dataNodesCount))
             );
 
-            assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+            assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
         }
     }
 
@@ -681,7 +666,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         createRepository(repositoryName, "fs");
 
         final SnapshotId snapshotOne = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final SnapshotStatus snapshotOneStatus = client().admin()
             .cluster()
@@ -716,9 +701,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         boolean indexed = randomBoolean();
         final String dateType = randomFrom("date", "date_nanos");
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate(indexName)
+            indicesAdmin().prepareCreate(indexName)
                 .setMapping(
                     XContentFactory.jsonBuilder()
                         .startObject()
@@ -755,7 +738,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         }
         indexRandom(true, false, indexRequestBuilders);
         assertThat(
-            client().admin().indices().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
+            indicesAdmin().prepareForceMerge(indexName).setOnlyExpungeDeletes(true).setFlush(true).get().getFailedShards(),
             equalTo(0)
         );
         refresh(indexName);
@@ -765,7 +748,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         createRepository(repositoryName, "fs");
 
         final SnapshotId snapshotOne = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         mountSnapshot(repositoryName, snapshotOne.getName(), indexName, indexName, Settings.EMPTY);
         ensureGreen(indexName);
@@ -870,7 +853,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 assertThat(stats.getTotalFileCount(), greaterThan(1));
             }
         }
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         assertThat(
             client().admin().cluster().prepareGetRepositories(repositoryName).get().repositories().get(0).uuid(),
@@ -883,7 +866,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         if (randomBoolean()) {
             logger.info("--> closing index before snapshot");
-            assertAcked(client().admin().indices().prepareClose(restoredIndexName));
+            assertAcked(indicesAdmin().prepareClose(restoredIndexName));
         }
 
         // The repository that contains the cluster snapshot (may be different from the one containing the data)
@@ -913,7 +896,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 assertThat(stats.getTotalFileCount(), equalTo(0));
             }
         }
-        assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+        assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
 
         // The repository that contains the cluster snapshot -- may be different from backupRepositoryName if we're only using one repo and
         // we rename it.
@@ -1017,7 +1000,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
         createRepository(dataRepoName, "fs");
 
         final SnapshotId dataSnapshot = createSnapshot(dataRepoName, "data-snapshot", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final String restoredIndexName = randomValueOtherThan(indexName, () -> randomAlphaOfLength(10).toLowerCase(Locale.ROOT));
         mountSnapshot(dataRepoName, dataSnapshot.getName(), indexName, restoredIndexName, Settings.EMPTY);
@@ -1025,7 +1008,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         if (randomBoolean()) {
             logger.info("--> closing index before snapshot");
-            assertAcked(client().admin().indices().prepareClose(restoredIndexName));
+            assertAcked(indicesAdmin().prepareClose(restoredIndexName));
         }
 
         // Back up the cluster to a different repo
@@ -1040,7 +1023,7 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
             .get()
             .repositories()
             .get(0);
-        assertAcked(client().admin().indices().prepareDelete(restoredIndexName));
+        assertAcked(indicesAdmin().prepareDelete(restoredIndexName));
         assertAcked(client().admin().cluster().prepareDeleteRepository(dataRepoName));
 
         // Restore the backup snapshot
@@ -1125,21 +1108,19 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
 
         final String snapshot = "snapshot_" + suffix;
         createFullSnapshot(repository, snapshot);
-        assertAcked(client().admin().indices().prepareDelete(index));
+        assertAcked(indicesAdmin().prepareDelete(index));
 
         {
             final String mountedIndex = mountSnapshot(repository, snapshot, index, Settings.EMPTY);
             assertThat(
-                client().admin()
-                    .indices()
-                    .prepareGetSettings(mountedIndex)
+                indicesAdmin().prepareGetSettings(mountedIndex)
                     .get()
                     .getIndexToSettings()
                     .get(mountedIndex)
                     .get(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey()),
                 equalTo("false")
             );
-            assertAcked(client().admin().indices().prepareDelete(mountedIndex));
+            assertAcked(indicesAdmin().prepareDelete(mountedIndex));
         }
         {
             final String overridingCheckOnStartup = randomValueOtherThan(checkOnStartup, () -> randomFrom("false", "true", "checksum"));
@@ -1150,16 +1131,14 @@ public class SearchableSnapshotsIntegTests extends BaseSearchableSnapshotsIntegT
                 Settings.builder().put(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey(), overridingCheckOnStartup).build()
             );
             assertThat(
-                client().admin()
-                    .indices()
-                    .prepareGetSettings(mountedIndex)
+                indicesAdmin().prepareGetSettings(mountedIndex)
                     .get()
                     .getIndexToSettings()
                     .get(mountedIndex)
                     .get(IndexSettings.INDEX_CHECK_ON_STARTUP.getKey()),
                 equalTo(overridingCheckOnStartup)
             );
-            assertAcked(client().admin().indices().prepareDelete(mountedIndex));
+            assertAcked(indicesAdmin().prepareDelete(mountedIndex));
         }
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsLicenseIntegTests.java
@@ -61,7 +61,7 @@ public class SearchableSnapshotsLicenseIntegTests extends BaseFrozenSearchableSn
         createIndex(indexName);
         createFullSnapshot(repoName, snapshotName);
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final MountSearchableSnapshotRequest req = new MountSearchableSnapshotRequest(
             indexName,

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsRecoverFromSnapshotIntegTests.java
@@ -52,7 +52,7 @@ public class SearchableSnapshotsRecoverFromSnapshotIntegTests extends BaseSearch
 
         final var snapshotName = randomAlphaOfLength(10).toLowerCase(Locale.ROOT);
         createSnapshot(repositoryName, snapshotName, List.of(indexName));
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final var restoredIndexName = "restored-" + indexName;
         mountSnapshot(

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsResizeIntegTests.java
@@ -46,7 +46,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
         );
         indexRandomDocs("index", scaledRandomIntBetween(0, 1_000));
         createSnapshot("repository", "snapshot", List.of("index"));
-        assertAcked(client().admin().indices().prepareDelete("index"));
+        assertAcked(indicesAdmin().prepareDelete("index"));
         mountSnapshot("repository", "snapshot", "index", "mounted-index", Settings.EMPTY, randomFrom(Storage.values()));
         ensureGreen("mounted-index");
     }
@@ -54,7 +54,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
     @After
     @Override
     public void tearDown() throws Exception {
-        assertAcked(client().admin().indices().prepareDelete("mounted-*"));
+        assertAcked(indicesAdmin().prepareDelete("mounted-*"));
         assertAcked(client().admin().cluster().prepareDeleteSnapshot("repository", "snapshot").get());
         assertAcked(client().admin().cluster().prepareDeleteRepository("repository"));
         super.tearDown();
@@ -63,9 +63,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
     public void testShrinkSearchableSnapshotIndex() {
         final IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .indices()
-                .prepareResizeIndex("mounted-index", "shrunk-index")
+            () -> indicesAdmin().prepareResizeIndex("mounted-index", "shrunk-index")
                 .setResizeType(ResizeType.SHRINK)
                 .setSettings(indexSettingsNoReplicas(1).build())
                 .get()
@@ -76,9 +74,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
     public void testSplitSearchableSnapshotIndex() {
         final IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .indices()
-                .prepareResizeIndex("mounted-index", "split-index")
+            () -> indicesAdmin().prepareResizeIndex("mounted-index", "split-index")
                 .setResizeType(ResizeType.SPLIT)
                 .setSettings(indexSettingsNoReplicas(4).build())
                 .get()
@@ -89,7 +85,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
     public void testCloneSearchableSnapshotIndex() {
         IllegalArgumentException exception = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin().indices().prepareResizeIndex("mounted-index", "cloned-index").setResizeType(ResizeType.CLONE).get()
+            () -> indicesAdmin().prepareResizeIndex("mounted-index", "cloned-index").setResizeType(ResizeType.CLONE).get()
         );
         assertThat(
             exception.getMessage(),
@@ -98,9 +94,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
 
         exception = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .indices()
-                .prepareResizeIndex("mounted-index", "cloned-index")
+            () -> indicesAdmin().prepareResizeIndex("mounted-index", "cloned-index")
                 .setResizeType(ResizeType.CLONE)
                 .setSettings(Settings.builder().putNull(IndexModule.INDEX_STORE_TYPE_SETTING.getKey()).build())
                 .get()
@@ -111,9 +105,7 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
         );
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareResizeIndex("mounted-index", "cloned-index")
+            indicesAdmin().prepareResizeIndex("mounted-index", "cloned-index")
                 .setResizeType(ResizeType.CLONE)
                 .setSettings(
                     Settings.builder()
@@ -125,6 +117,6 @@ public class SearchableSnapshotsResizeIntegTests extends BaseFrozenSearchableSna
                 )
         );
         ensureGreen("cloned-index");
-        assertAcked(client().admin().indices().prepareDelete("cloned-index"));
+        assertAcked(indicesAdmin().prepareDelete("cloned-index"));
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsSettingValidationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsSettingValidationIntegTests.java
@@ -33,7 +33,7 @@ public class SearchableSnapshotsSettingValidationIntegTests extends BaseFrozenSe
         createIndex(indexName);
         createFullSnapshot(repoName, snapshotName);
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final MountSearchableSnapshotRequest req = new MountSearchableSnapshotRequest(
             indexName,
@@ -54,9 +54,7 @@ public class SearchableSnapshotsSettingValidationIntegTests extends BaseFrozenSe
     public void testCannotRemoveWriteBlock() {
         final IllegalArgumentException iae = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin()
-                .indices()
-                .prepareUpdateSettings(indexName)
+            () -> indicesAdmin().prepareUpdateSettings(indexName)
                 .setSettings(Settings.builder().put(IndexMetadata.INDEX_BLOCKS_WRITE_SETTING.getKey(), false))
                 .get()
         );

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUuidValidationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/SearchableSnapshotsUuidValidationIntegTests.java
@@ -123,7 +123,7 @@ public class SearchableSnapshotsUuidValidationIntegTests extends BaseFrozenSearc
             containsString("snapshot UUID mismatch")
         );
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
     }
 
     private static RestoreBlockingActionFilter getBlockingActionFilter() {

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/AllocationFilteringIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/AllocationFilteringIntegTests.java
@@ -55,7 +55,7 @@ public class AllocationFilteringIntegTests extends BaseSearchableSnapshotsIntegT
         populateIndex(indexName, 10);
         ensureGreen(indexName);
         createFullSnapshot(fsRepoName, snapshotName);
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final Settings.Builder indexSettingsBuilder = Settings.builder()
             .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true)
@@ -141,9 +141,7 @@ public class AllocationFilteringIntegTests extends BaseSearchableSnapshotsIntegT
         assertThat(restoreSnapshotResponse.getRestoreInfo().failedShards(), equalTo(0));
         ensureGreen(mountRequest.mountedIndexName());
 
-        final Settings mountedIndexSettings = client().admin()
-            .indices()
-            .prepareGetSettings(mountRequest.mountedIndexName())
+        final Settings mountedIndexSettings = indicesAdmin().prepareGetSettings(mountRequest.mountedIndexName())
             .get()
             .getIndexToSettings()
             .get(mountRequest.mountedIndexName());

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotAllocationIntegTests.java
@@ -35,7 +35,7 @@ public class SearchableSnapshotAllocationIntegTests extends BaseSearchableSnapsh
         createRepository(repoName, "fs");
         final String snapshotName = "test-snapshot";
         createSnapshot(repoName, snapshotName, List.of(index));
-        assertAcked(client().admin().indices().prepareDelete(index));
+        assertAcked(indicesAdmin().prepareDelete(index));
         final String restoredIndex = mountSnapshot(repoName, snapshotName, index, Settings.EMPTY);
         ensureGreen(restoredIndex);
         internalCluster().startDataOnlyNodes(randomIntBetween(1, 4));
@@ -67,7 +67,7 @@ public class SearchableSnapshotAllocationIntegTests extends BaseSearchableSnapsh
         createRepository(repoName, "fs");
         final String snapshotName = "test-snapshot";
         createSnapshot(repoName, snapshotName, List.of(index));
-        assertAcked(client().admin().indices().prepareDelete(index));
+        assertAcked(indicesAdmin().prepareDelete(index));
         final String restoredIndex = mountSnapshot(
             repoName,
             snapshotName,

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDataTierIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDataTierIntegTests.java
@@ -69,9 +69,7 @@ public class SearchableSnapshotDataTierIntegTests extends BaseFrozenSearchableSn
     }
 
     private void updatePreference(String tier) {
-        client().admin()
-            .indices()
-            .updateSettings(new UpdateSettingsRequest(mountedIndexName).settings(Map.of(DataTier.TIER_PREFERENCE, tier)))
+        indicesAdmin().updateSettings(new UpdateSettingsRequest(mountedIndexName).settings(Map.of(DataTier.TIER_PREFERENCE, tier)))
             .actionGet();
     }
 }

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDiskThresholdIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotDiskThresholdIntegTests.java
@@ -123,7 +123,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
                             waitForDocs(nbDocs, indexer);
                             indexer.assertNoFailures();
                             assertNoFailures(
-                                client().admin().indices().prepareForceMerge().setFlush(true).setIndices(index).setMaxNumSegments(1).get()
+                                indicesAdmin().prepareForceMerge().setFlush(true).setIndices(index).setMaxNumSegments(1).get()
                             );
                             Map<String, Long> storeSize = sizeOfShardsStores(index);
                             if (storeSize.get(index) > WATERMARK_BYTES) {
@@ -207,7 +207,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
         createSnapshot(repositoryName, snapshot, nbIndices);
 
         final Map<String, Long> indicesStoresSizes = sizeOfShardsStores("index-*");
-        assertAcked(client().admin().indices().prepareDelete("index-*"));
+        assertAcked(indicesAdmin().prepareDelete("index-*"));
 
         // The test completes reliably successfully only when we do a full copy, we can overcommit on SHARED_CACHE
         final Storage storage = FULL_COPY;
@@ -290,7 +290,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
         createSnapshot(repositoryName, snapshotName, nbIndices);
 
         Map<String, Long> indicesStoresSizes = sizeOfShardsStores("index-*");
-        assertAcked(client().admin().indices().prepareDelete("index-*"));
+        assertAcked(indicesAdmin().prepareDelete("index-*"));
 
         String coldNodeName = internalCluster().startNode(
             Settings.builder().put(NodeRoleSettings.NODE_ROLES_SETTING.getKey(), DiscoveryNodeRole.DATA_COLD_NODE_ROLE.roleName()).build()
@@ -364,7 +364,7 @@ public class SearchableSnapshotDiskThresholdIntegTests extends DiskUsageIntegTes
     }
 
     private static Map<String, Long> sizeOfShardsStores(String indexPattern) {
-        return Arrays.stream(client().admin().indices().prepareStats(indexPattern).clear().setStore(true).get().getShards())
+        return Arrays.stream(indicesAdmin().prepareStats(indexPattern).clear().setStore(true).get().getShards())
             .collect(
                 Collectors.toUnmodifiableMap(s -> s.getShardRouting().getIndexName(), s -> s.getStats().getStore().sizeInBytes(), Long::sum)
             );

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotEnableAllocationDeciderIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotEnableAllocationDeciderIntegTests.java
@@ -68,7 +68,7 @@ public class SearchableSnapshotEnableAllocationDeciderIntegTests extends BaseSea
         createRepository(repositoryName, "mock");
 
         final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-1", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
         return mountSnapshot(repositoryName, snapshotId.getName(), indexName, Settings.EMPTY);
     }
 

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotShutdownIntegTests.java
@@ -111,7 +111,7 @@ public class SearchableSnapshotShutdownIntegTests extends BaseSearchableSnapshot
             createAndPopulateIndex(indexName, Settings.builder());
 
             final SnapshotId snapshotId = createSnapshot(repositoryName, "snapshot-" + i, List.of(indexName)).snapshotId();
-            assertAcked(client().admin().indices().prepareDelete(indexName));
+            assertAcked(indicesAdmin().prepareDelete(indexName));
             restoredIndices.add(mountSnapshot(repositoryName, snapshotId.getName(), indexName, Settings.EMPTY));
         }
         return restoredIndices;

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotsRelocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/allocation/SearchableSnapshotsRelocationIntegTests.java
@@ -41,7 +41,7 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
         createRepository(repoName, "mock");
         final String snapshotName = "test-snapshot";
         createSnapshot(repoName, snapshotName, List.of(index));
-        assertAcked(client().admin().indices().prepareDelete(index));
+        assertAcked(indicesAdmin().prepareDelete(index));
         final String restoredIndex = mountSnapshot(repoName, snapshotName, index, Settings.EMPTY);
         ensureGreen(restoredIndex);
         final String secondDataNode = internalCluster().startDataOnlyNode();
@@ -115,9 +115,7 @@ public class SearchableSnapshotsRelocationIntegTests extends BaseSearchableSnaps
     }
 
     private static Stream<RecoveryState> getRelocationsStream(String restoredIndex) {
-        return client().admin()
-            .indices()
-            .prepareRecoveries(restoredIndex)
+        return indicesAdmin().prepareRecoveries(restoredIndex)
             .setDetailed(true)
             .setActiveOnly(true)
             .get()

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheIntegTests.java
@@ -138,11 +138,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
 
         if (randomBoolean()) {
             logger.info("--> force-merging index before snapshotting");
-            final ForceMergeResponse forceMergeResponse = client().admin()
-                .indices()
-                .prepareForceMerge(indexName)
-                .setMaxNumSegments(1)
-                .get();
+            final ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge(indexName).setMaxNumSegments(1).get();
             assertThat(forceMergeResponse.getSuccessfulShards(), equalTo(numberOfShards.totalNumShards));
             assertThat(forceMergeResponse.getFailedShards(), equalTo(0));
         }
@@ -152,7 +148,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
         createRepository(repositoryName, "fs", repositoryLocation);
 
         final SnapshotId snapshot = createSnapshot(repositoryName, "test-snapshot", List.of(indexName)).snapshotId();
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         expectThrows(
             IndexNotFoundException.class,
@@ -329,7 +325,7 @@ public class SearchableSnapshotsBlobStoreCacheIntegTests extends BaseFrozenSearc
         assertHitCount(client().prepareSearch(restoredAgainIndex).setSize(0).setTrackTotalHits(true).get(), numberOfDocs);
 
         logger.info("--> deleting indices, maintenance service should clean up [{}] docs in system index", numberOfCachedBlobs);
-        assertAcked(client().admin().indices().prepareDelete("restored-*"));
+        assertAcked(indicesAdmin().prepareDelete("restored-*"));
 
         assertBusy(() -> {
             refreshSystemIndex();

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/blob/SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests.java
@@ -90,7 +90,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
         assertThat(numberOfEntriesInCache, equalTo(mountedIndices.values().stream().mapToLong(Tuple::v2).sum()));
 
         final List<String> indicesToDelete = randomSubsetOf(randomIntBetween(1, mountedIndices.size()), mountedIndices.keySet());
-        assertAcked(client().admin().indices().prepareDelete(indicesToDelete.toArray(String[]::new)));
+        assertAcked(indicesAdmin().prepareDelete(indicesToDelete.toArray(String[]::new)));
 
         final long expectedDeletedEntriesInCache = mountedIndices.entrySet()
             .stream()
@@ -159,7 +159,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
                 snapshotIndexName,
                 remainingMountedIndex
             );
-            assertAcked(client().admin().indices().prepareDelete(moreIndicesToDelete.toArray(String[]::new)));
+            assertAcked(indicesAdmin().prepareDelete(moreIndicesToDelete.toArray(String[]::new)));
 
             assertBusy(() -> {
                 refreshSystemIndex(true);
@@ -194,7 +194,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
         }
 
         logger.info("--> deleting indices, maintenance service should clean up snapshot blob cache index");
-        assertAcked(client().admin().indices().prepareDelete("mounted-*"));
+        assertAcked(indicesAdmin().prepareDelete("mounted-*"));
         assertBusy(() -> {
             refreshSystemIndex(true);
             assertHitCount(systemClient().prepareSearch(SNAPSHOT_BLOB_CACHE_INDEX).setSize(0).get(), 0L);
@@ -239,7 +239,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
         indicesToDelete.add(randomFrom(otherMountedIndices.keySet()));
 
         assertAcked(systemClient().admin().indices().prepareDelete(SNAPSHOT_BLOB_CACHE_INDEX));
-        assertAcked(client().admin().indices().prepareDelete(indicesToDelete.toArray(String[]::new)));
+        assertAcked(indicesAdmin().prepareDelete(indicesToDelete.toArray(String[]::new)));
         assertAcked(client().admin().cluster().prepareDeleteRepository("repo"));
         ensureClusterStateConsistency();
 
@@ -343,7 +343,7 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
     }
 
     private Settings getIndexSettings(String indexName) {
-        return client().admin().indices().prepareGetSettings(indexName).get().getIndexToSettings().get(indexName);
+        return indicesAdmin().prepareGetSettings(indexName).get().getIndexToSettings().get(indexName);
     }
 
     private Map<String, Tuple<Settings, Long>> mountRandomIndicesWithCache(String repositoryName, int min, int max) throws Exception {
@@ -396,10 +396,10 @@ public class SearchableSnapshotsBlobStoreCacheMaintenanceIntegTests extends Base
                 } else {
                     logger.info("--> mounted index [{}] did not generate any entry in cache", mountedIndex);
                     assertAcked(client().admin().cluster().prepareDeleteSnapshot(repositoryName, snapshot).get());
-                    assertAcked(client().admin().indices().prepareDelete(mountedIndex));
+                    assertAcked(indicesAdmin().prepareDelete(mountedIndex));
                 }
             }
-            assertAcked(client().admin().indices().prepareDelete(indexName));
+            assertAcked(indicesAdmin().prepareDelete(indexName));
             i += 1;
         }
         return Collections.unmodifiableMap(mountedIndices);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/NodesCachesStatsIntegTests.java
@@ -61,7 +61,7 @@ public class NodesCachesStatsIntegTests extends BaseFrozenSearchableSnapshotsInt
         final String snapshot = "snapshot";
         createFullSnapshot(repository, snapshot);
 
-        assertAcked(client().admin().indices().prepareDelete(index));
+        assertAcked(indicesAdmin().prepareDelete(index));
 
         final String mountedIndex = "mounted-index";
         mountSnapshot(repository, snapshot, index, mountedIndex, Settings.EMPTY, Storage.SHARED_CACHE);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/cache/shared/PartiallyCachedShardAllocationIntegTests.java
@@ -86,7 +86,7 @@ public class PartiallyCachedShardAllocationIntegTests extends BaseFrozenSearchab
         populateIndex(indexName, 10);
         ensureGreen(indexName);
         createFullSnapshot(fsRepoName, snapshotName);
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         final Settings.Builder indexSettingsBuilder = Settings.builder()
             .put(SearchableSnapshots.SNAPSHOT_CACHE_ENABLED_SETTING.getKey(), true);

--- a/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
+++ b/x-pack/plugin/searchable-snapshots/src/internalClusterTest/java/org/elasticsearch/xpack/searchablesnapshots/recovery/SearchableSnapshotRecoveryStateIntegrationTests.java
@@ -78,7 +78,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
 
         final SnapshotInfo snapshotInfo = createFullSnapshot(fsRepoName, snapshotName);
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         mountSnapshot(fsRepoName, snapshotName, indexName, restoredIndexName, Settings.EMPTY);
         ensureGreen(restoredIndexName);
@@ -134,7 +134,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
 
         final SnapshotInfo snapshotInfo = createFullSnapshot(fsRepoName, snapshotName);
 
-        assertAcked(client().admin().indices().prepareDelete(indexName));
+        assertAcked(indicesAdmin().prepareDelete(indexName));
 
         mountSnapshot(fsRepoName, snapshotName, indexName, restoredIndexName, Settings.EMPTY);
         ensureGreen(restoredIndexName);
@@ -209,7 +209,7 @@ public class SearchableSnapshotRecoveryStateIntegrationTests extends BaseSearcha
     }
 
     private RecoveryState getRecoveryState(String indexName) {
-        final RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).get();
+        final RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).get();
         Map<String, List<RecoveryState>> shardRecoveries = recoveryResponse.shardRecoveryStates();
         assertThat(shardRecoveries.containsKey(indexName), equalTo(true));
         List<RecoveryState> recoveryStates = shardRecoveries.get(indexName);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataLifecycleServiceRuntimeSecurityIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DataLifecycleServiceRuntimeSecurityIT.java
@@ -236,7 +236,7 @@ public class DataLifecycleServiceRuntimeSecurityIT extends SecurityIntegTestCase
             assertThat(itemResponse.status(), equalTo(RestStatus.CREATED));
             assertThat(itemResponse.getIndex(), startsWith(backingIndexPrefix));
         }
-        client().admin().indices().refresh(new RefreshRequest(dataStream)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(dataStream)).actionGet();
     }
 
     public static class SystemDataStreamTestPlugin extends Plugin implements SystemIndexPlugin {

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DlsFlsRequestCacheTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DlsFlsRequestCacheTests.java
@@ -396,29 +396,21 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
                 .get()
         );
 
-        assertAcked(client.admin().indices().prepareCreate(DLS_INDEX).addAlias(new Alias("dls-alias")).get());
+        assertAcked(indicesAdmin().prepareCreate(DLS_INDEX).addAlias(new Alias("dls-alias")).get());
         client.prepareIndex(DLS_INDEX).setId("101").setSource("number", 101, "letter", "A").get();
         client.prepareIndex(DLS_INDEX).setId("102").setSource("number", 102, "letter", "B").get();
 
-        assertAcked(client.admin().indices().prepareCreate(FLS_INDEX).addAlias(new Alias("fls-alias")).get());
+        assertAcked(indicesAdmin().prepareCreate(FLS_INDEX).addAlias(new Alias("fls-alias")).get());
         client.prepareIndex(FLS_INDEX).setId("201").setSource("public", "X", "private", "x").get();
         client.prepareIndex(FLS_INDEX).setId("202").setSource("public", "Y", "private", "y").get();
 
         assertAcked(
-            client.admin()
-                .indices()
-                .prepareCreate(INDEX)
-                .addAlias(new Alias(ALIAS1))
-                .addAlias(new Alias(ALIAS2))
-                .addAlias(new Alias(ALL_ALIAS))
-                .get()
+            indicesAdmin().prepareCreate(INDEX).addAlias(new Alias(ALIAS1)).addAlias(new Alias(ALIAS2)).addAlias(new Alias(ALL_ALIAS)).get()
         );
         client.prepareIndex(INDEX).setId("1").setSource("number", 1, "letter", "a", "private", "sesame_1", "public", "door_1").get();
         client.prepareIndex(INDEX).setId("2").setSource("number", 2, "letter", "b", "private", "sesame_2", "public", "door_2").get();
 
-        assertAcked(
-            client.admin().indices().prepareCreate(DLS_TEMPLATE_ROLE_QUERY_INDEX).addAlias(new Alias(DLS_TEMPLATE_ROLE_QUERY_ALIAS)).get()
-        );
+        assertAcked(indicesAdmin().prepareCreate(DLS_TEMPLATE_ROLE_QUERY_INDEX).addAlias(new Alias(DLS_TEMPLATE_ROLE_QUERY_ALIAS)).get());
         client.prepareIndex(DLS_TEMPLATE_ROLE_QUERY_INDEX).setId("1").setSource("username", DLS_TEMPLATE_ROLE_QUERY_USER_1).get();
         client.prepareIndex(DLS_TEMPLATE_ROLE_QUERY_INDEX).setId("2").setSource("username", DLS_TEMPLATE_ROLE_QUERY_USER_2).get();
 
@@ -429,15 +421,14 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
         assertCacheState(DLS_TEMPLATE_ROLE_QUERY_INDEX, 0, 0);
 
         // Force merge the index to ensure there can be no background merges during the subsequent searches that would invalidate the cache
-        final ForceMergeResponse forceMergeResponse = client.admin()
-            .indices()
-            .prepareForceMerge(DLS_INDEX, FLS_INDEX, INDEX, DLS_TEMPLATE_ROLE_QUERY_INDEX)
-            .setFlush(true)
-            .get();
+        final ForceMergeResponse forceMergeResponse = indicesAdmin().prepareForceMerge(
+            DLS_INDEX,
+            FLS_INDEX,
+            INDEX,
+            DLS_TEMPLATE_ROLE_QUERY_INDEX
+        ).setFlush(true).get();
         ElasticsearchAssertions.assertAllSuccessful(forceMergeResponse);
-        final RefreshResponse refreshResponse = client.admin()
-            .indices()
-            .prepareRefresh(DLS_INDEX, FLS_INDEX, INDEX, DLS_TEMPLATE_ROLE_QUERY_INDEX)
+        final RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(DLS_INDEX, FLS_INDEX, INDEX, DLS_TEMPLATE_ROLE_QUERY_INDEX)
             .get();
         assertThat(refreshResponse.getFailedShards(), equalTo(0));
         ensureGreen(DLS_INDEX, FLS_INDEX, INDEX, DLS_TEMPLATE_ROLE_QUERY_INDEX);
@@ -488,13 +479,7 @@ public class DlsFlsRequestCacheTests extends SecuritySingleNodeTestCase {
     }
 
     private void assertCacheState(String index, long expectedHits, long expectedMisses) {
-        RequestCacheStats requestCacheStats = client().admin()
-            .indices()
-            .prepareStats(index)
-            .setRequestCache(true)
-            .get()
-            .getTotal()
-            .getRequestCache();
+        RequestCacheStats requestCacheStats = indicesAdmin().prepareStats(index).setRequestCache(true).get().getTotal().getRequestCache();
         // Check the hit count and miss count together so if they are not
         // correct we can see both values
         assertEquals(

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentAndFieldLevelSecurityTests.java
@@ -109,9 +109,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testSimpleQuery() {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("id", "1", "field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("id", "2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
@@ -146,9 +144,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     public void testUpdatesAreRejected() {
         for (String indexName : List.of("<test-{2015.05.05||+1d}>", "test")) {
             assertAcked(
-                client().admin()
-                    .indices()
-                    .prepareCreate(indexName)
+                indicesAdmin().prepareCreate(indexName)
                     .setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text")
                     .setSettings(indexSettings(1, 0))
             );
@@ -181,7 +177,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testDLSIsAppliedBeforeFLS() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field1", "value2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
@@ -202,9 +198,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testQueryCache() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
                 .setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text")
         );
@@ -260,7 +254,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testGetMappingsIsFiltered() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
@@ -294,7 +288,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testGetIndexMappingsIsFiltered() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
@@ -325,7 +319,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testGetFieldMappingsIsFiltered() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
@@ -368,7 +362,7 @@ public class DocumentAndFieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testFieldCapabilitiesIsFiltered() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityFeatureUsageTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityFeatureUsageTests.java
@@ -84,9 +84,7 @@ public class DocumentLevelSecurityFeatureUsageTests extends AbstractDocumentAndF
     }
 
     public void testDlsFeatureUsageTracking() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("3").setSource("field3", "value3").setRefreshPolicy(IMMEDIATE).get();
@@ -106,9 +104,7 @@ public class DocumentLevelSecurityFeatureUsageTests extends AbstractDocumentAndF
     }
 
     public void testDlsFlsFeatureUsageNotTracked() {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("id", "1", "field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("id", "2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityRandomTests.java
@@ -92,10 +92,10 @@ public class DocumentLevelSecurityRandomTests extends SecurityIntegTestCase {
     }
 
     public void testDuelWithAliasFilters() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
 
         List<IndexRequestBuilder> requests = new ArrayList<>(numberOfRoles);
-        IndicesAliasesRequestBuilder builder = client().admin().indices().prepareAliases();
+        IndicesAliasesRequestBuilder builder = indicesAdmin().prepareAliases();
         for (int i = 1; i <= numberOfRoles; i++) {
             String value = "value" + i;
             requests.add(client().prepareIndex("test").setId(value).setSource("field1", value));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/DocumentLevelSecurityTests.java
@@ -201,9 +201,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testSimpleQuery() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("3").setSource("field3", "value3").setRefreshPolicy(IMMEDIATE).get();
@@ -237,9 +235,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testGetApi() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
 
         client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").get();
@@ -300,9 +296,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testRealtimeGetApi() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
                 .setSettings(Settings.builder().put("refresh_interval", "-1").build())
         );
@@ -374,9 +368,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testMGetApi() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
 
         client().prepareIndex("test").setId("1").setSource("field1", "value1").get();
         client().prepareIndex("test").setId("2").setSource("field2", "value2").get();
@@ -444,15 +436,11 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testMSearch() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test1")
+            indicesAdmin().prepareCreate("test1")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text", "id", "type=integer")
         );
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test2")
+            indicesAdmin().prepareCreate("test2")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text", "id", "type=integer")
         );
 
@@ -462,7 +450,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         client().prepareIndex("test2").setId("1").setSource("field1", "value1", "id", 1).get();
         client().prepareIndex("test2").setId("2").setSource("field2", "value2", "id", 2).get();
         client().prepareIndex("test2").setId("3").setSource("field3", "value3", "id", 3).get();
-        client().admin().indices().prepareRefresh("test1", "test2").get();
+        indicesAdmin().prepareRefresh("test1", "test2").get();
 
         MultiSearchResponse response = client().filterWithHeader(
             Collections.singletonMap(BASIC_AUTH_HEADER, basicAuthHeaderValue("user1", USERS_PASSWD))
@@ -534,12 +522,10 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testPercolateQueryWithIndexedDocWithDLS() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("query_index")
+            indicesAdmin().prepareCreate("query_index")
                 .setMapping("message", "type=text", "query", "type=percolator", "field1", "type=text", "field2", "type=text")
         );
-        assertAcked(client().admin().indices().prepareCreate("doc_index").setMapping("message", "type=text", "field1", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("doc_index").setMapping("message", "type=text", "field1", "type=text"));
         client().prepareIndex("query_index")
             .setId("1")
             .setSource("""
@@ -577,15 +563,11 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testGeoQueryWithIndexedShapeWithDLS() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("search_index")
+            indicesAdmin().prepareCreate("search_index")
                 .setMapping("search_field", "type=shape", "field1", "type=text", "field2", "type=text")
         );
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("shape_index")
+            indicesAdmin().prepareCreate("shape_index")
                 .setMapping("shape_field", "type=shape", "field1", "type=text", "field2", "type=text")
         );
         client().prepareIndex("search_index")
@@ -647,15 +629,11 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testTermsLookupOnIndexWithDLS() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("search_index")
+            indicesAdmin().prepareCreate("search_index")
                 .setMapping("search_field", "type=keyword", "field1", "type=text", "field2", "type=text")
         );
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("lookup_index")
+            indicesAdmin().prepareCreate("lookup_index")
                 .setMapping("lookup_field", "type=keyword", "field1", "type=text", "field2", "type=text")
         );
         client().prepareIndex("search_index")
@@ -738,9 +716,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testTVApi() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(
                     "field1",
                     "type=text,term_vector=with_positions_offsets_payloads",
@@ -803,9 +779,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testMTVApi() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(
                     "field1",
                     "type=text,term_vector=with_positions_offsets_payloads",
@@ -881,14 +855,14 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(client().admin().indices().prepareCreate("test").setSettings(indexSettings).setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(indexSettings).setMapping(builder));
 
         for (int i = 0; i < 5; i++) {
             client().prepareIndex("test").setSource("field1", "value1", "other", "valueA", "vector", new float[] { i, i, i }).get();
             client().prepareIndex("test").setSource("field2", "value2", "other", "valueB", "vector", new float[] { i, i, i }).get();
         }
 
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         // Since there's no kNN search action at the transport layer, we just emulate
         // how the action works (it builds a kNN query under the hood)
@@ -934,9 +908,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testGlobalAggregation() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text,fielddata=true", "field3", "type=text")
         );
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
@@ -1100,9 +1072,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testScroll() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1153,9 +1123,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testReaderId() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1197,9 +1165,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testRequestCache() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1236,7 +1202,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testUpdateApiIsBlocked() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1").setRefreshPolicy(IMMEDIATE).get();
 
         // With document level security enabled the update is not allowed:
@@ -1278,7 +1244,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testNestedInnerHits() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "nested_field", "type=nested"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "nested_field", "type=nested"));
         client().prepareIndex("test")
             .setId("1")
             .setSource(
@@ -1336,9 +1302,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testSuggesters() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(indexSettings(1, 0))
                 .setMapping("field1", "type=text", "suggest_field1", "type=text", "suggest_field2", "type=completion")
         );
@@ -1363,9 +1327,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         refresh("test");
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("fls-index")
+            indicesAdmin().prepareCreate("fls-index")
                 .setSettings(indexSettings(1, 0))
                 .setMapping(
                     "field1",
@@ -1451,9 +1413,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testProfile() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(indexSettings(1, 0))
                 .setMapping("field1", "type=text", "other_field", "type=text")
         );
@@ -1470,9 +1430,7 @@ public class DocumentLevelSecurityTests extends SecurityIntegTestCase {
         refresh("test");
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("fls-index")
+            indicesAdmin().prepareCreate("fls-index")
                 .setSettings(indexSettings(1, 0))
                 .setMapping("field1", "type=text", "other_field", "type=text", "yet_another", "type=text")
         );

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityFeatureUsageTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityFeatureUsageTests.java
@@ -73,7 +73,7 @@ public class FieldLevelSecurityFeatureUsageTests extends AbstractDocumentAndFiel
     }
 
     public void testFlsFeatureUsageTracking() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("test").setId("2").setSource("field1", "value2", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityRandomTests.java
@@ -156,7 +156,7 @@ public class FieldLevelSecurityRandomTests extends SecurityIntegTestCase {
             fieldMappers[j++] = "type=text";
             doc.put(field, "value");
         }
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping(fieldMappers));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(fieldMappers));
         client().prepareIndex("test").setId("1").setSource(doc).setRefreshPolicy(IMMEDIATE).get();
 
         for (String allowedField : allowedFields) {
@@ -177,9 +177,7 @@ public class FieldLevelSecurityRandomTests extends SecurityIntegTestCase {
 
     public void testDuel() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("id", "type=keyword", "field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/FieldLevelSecurityTests.java
@@ -225,9 +225,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testQuery() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text", "alias", "type=alias,path=field1")
         );
         client().prepareIndex("test")
@@ -390,7 +388,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping(builder));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(builder));
 
         client().prepareIndex("test")
             .setSource("field1", "value1", "field2", "value2", "vector", new float[] { 0.0f, 0.0f, 0.0f })
@@ -447,8 +445,8 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testPercolateQueryWithIndexedDocWithFLS() {
-        assertAcked(client().admin().indices().prepareCreate("query_index").setMapping("query", "type=percolator", "field2", "type=text"));
-        assertAcked(client().admin().indices().prepareCreate("doc_index").setMapping("field2", "type=text", "field1", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("query_index").setMapping("query", "type=percolator", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("doc_index").setMapping("field2", "type=text", "field1", "type=text"));
         client().prepareIndex("query_index").setId("1").setSource("""
             {"query": {"match": {"field2": "bonsai tree"}}}""", XContentType.JSON).setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("doc_index").setId("1").setSource("""
@@ -489,8 +487,8 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testGeoQueryWithIndexedShapeWithFLS() {
-        assertAcked(client().admin().indices().prepareCreate("search_index").setMapping("field", "type=shape", "other", "type=shape"));
-        assertAcked(client().admin().indices().prepareCreate("shape_index").setMapping("field", "type=shape", "other", "type=shape"));
+        assertAcked(indicesAdmin().prepareCreate("search_index").setMapping("field", "type=shape", "other", "type=shape"));
+        assertAcked(indicesAdmin().prepareCreate("shape_index").setMapping("field", "type=shape", "other", "type=shape"));
         client().prepareIndex("search_index").setId("1").setSource("""
             {
               "field": {
@@ -589,8 +587,8 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testTermsLookupOnIndexWithFLS() {
-        assertAcked(client().admin().indices().prepareCreate("search_index").setMapping("field", "type=keyword", "other", "type=text"));
-        assertAcked(client().admin().indices().prepareCreate("lookup_index").setMapping("field", "type=keyword", "other", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("search_index").setMapping("field", "type=keyword", "other", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("lookup_index").setMapping("field", "type=keyword", "other", "type=text"));
         client().prepareIndex("search_index").setId("1").setSource("field", List.of("value1", "value2")).setRefreshPolicy(IMMEDIATE).get();
         client().prepareIndex("search_index")
             .setId("2")
@@ -635,9 +633,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testGetApi() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
 
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2", "field3", "value3").get();
 
@@ -730,9 +726,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testRealtimeGetApi() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
                 .setSettings(Settings.builder().put("refresh_interval", "-1").build())
         );
@@ -793,9 +787,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testMGetApi() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2", "field3", "value3").get();
 
         boolean realtime = randomBoolean();
@@ -901,22 +893,12 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testMSearchApi() throws Exception {
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test1")
-                .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test2")
-                .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test1").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test2").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
 
         client().prepareIndex("test1").setId("1").setSource("field1", "value1", "field2", "value2", "field3", "value3").get();
         client().prepareIndex("test2").setId("1").setSource("field1", "value1", "field2", "value2", "field3", "value3").get();
-        client().admin().indices().prepareRefresh("test1", "test2").get();
+        indicesAdmin().prepareRefresh("test1", "test2").get();
 
         // user1 is granted access to field1 only
         MultiSearchResponse response = client().filterWithHeader(
@@ -1049,9 +1031,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testScroll() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1110,9 +1090,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testPointInTimeId() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1152,9 +1130,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testQueryCache() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1191,9 +1167,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testScrollWithQueryCache() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndexModule.INDEX_QUERY_CACHE_EVERYTHING_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text")
         );
@@ -1297,9 +1271,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testRequestCache() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(Settings.builder().put(IndicesRequestCache.INDEX_CACHE_REQUEST_ENABLED_SETTING.getKey(), true))
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
         );
@@ -1332,9 +1304,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testFields() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(
                     "field1",
                     "type=text,store=true",
@@ -1453,9 +1423,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testSource() throws Exception {
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text")
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text"));
         client().prepareIndex("test")
             .setId("1")
             .setSource("field1", "value1", "field2", "value2", "field3", "value3")
@@ -1528,10 +1496,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testSort() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setMapping("field1", "type=long", "field2", "type=long", "alias", "type=alias,path=field1")
+            indicesAdmin().prepareCreate("test").setMapping("field1", "type=long", "field2", "type=long", "alias", "type=alias,path=field1")
         );
         client().prepareIndex("test").setId("1").setSource("field1", 1d, "field2", 2d).setRefreshPolicy(IMMEDIATE).get();
 
@@ -1579,9 +1544,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testHighlighting() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text", "alias", "type=alias,path=field1")
         );
         client().prepareIndex("test")
@@ -1631,9 +1594,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testAggs() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text,fielddata=true", "field2", "type=text,fielddata=true", "alias", "type=alias,path=field1")
         );
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
@@ -1682,9 +1643,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testTVApi() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(
                     "field1",
                     "type=text,term_vector=with_positions_offsets_payloads",
@@ -1774,9 +1733,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testMTVApi() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping(
                     "field1",
                     "type=text,term_vector=with_positions_offsets_payloads",
@@ -1942,7 +1899,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testUpdateApiIsBlocked() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value1").setRefreshPolicy(IMMEDIATE).get();
 
         // With field level security enabled the update is not allowed:
@@ -1984,7 +1941,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
     }
 
     public void testQuery_withRoleWithFieldWildcards() {
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping("field1", "type=text", "field2", "type=text"));
         client().prepareIndex("test").setId("1").setSource("field1", "value1", "field2", "value2").setRefreshPolicy(IMMEDIATE).get();
 
         // user6 has access to all fields, so the query should match with the document:
@@ -2008,9 +1965,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testExistQuery() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text", "field3", "type=text", "alias", "type=alias,path=field1")
         );
 
@@ -2084,10 +2039,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
 
     public void testLookupRuntimeFields() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("hosts")
-                .setMapping("field1", "type=keyword", "field2", "type=text", "field3", "type=text")
+            indicesAdmin().prepareCreate("hosts").setMapping("field1", "type=keyword", "field2", "type=text", "field3", "type=text")
         );
         client().prepareIndex("hosts")
             .setId("1")
@@ -2101,9 +2053,7 @@ public class FieldLevelSecurityTests extends SecurityIntegTestCase {
             .get();
 
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("logs")
+            indicesAdmin().prepareCreate("logs")
                 .setMapping("field1", "type=keyword", "field2", "type=text", "field3", "type=date,format=yyyy-MM-dd")
         );
 

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndicesPermissionsWithAliasesWildcardsAndRegexsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/IndicesPermissionsWithAliasesWildcardsAndRegexsTests.java
@@ -93,9 +93,7 @@ public class IndicesPermissionsWithAliasesWildcardsAndRegexsTests extends Securi
 
     public void testGetResolveWildcardsRegexs() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text")
                 .addAlias(new Alias("my_alias"))
                 .addAlias(new Alias("an_alias"))
@@ -127,9 +125,7 @@ public class IndicesPermissionsWithAliasesWildcardsAndRegexsTests extends Securi
 
     public void testSearchResolveWildcardsRegexs() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("field1", "type=text", "field2", "type=text")
                 .addAlias(new Alias("my_alias"))
                 .addAlias(new Alias("an_alias"))
@@ -198,7 +194,7 @@ public class IndicesPermissionsWithAliasesWildcardsAndRegexsTests extends Securi
             new IndicesAliasesRequest.AliasActions(IndicesAliasesRequest.AliasActions.Type.ADD).aliases("my_alias", "an_alias")
                 .index("test")
         );
-        assertAcked(client().admin().indices().aliases(aliasesRequest).actionGet());
+        assertAcked(indicesAdmin().aliases(aliasesRequest).actionGet());
 
         String value = DateFieldMapper.DEFAULT_DATE_TIME_FORMATTER.formatMillis(System.currentTimeMillis());
         client().prepareIndex("test")

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/KibanaUserRoleIntegTests.java
@@ -65,9 +65,7 @@ public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
         final String field = "foo";
         indexRandom(true, client().prepareIndex().setIndex(index).setSource(field, "bar"));
 
-        GetFieldMappingsResponse response = client().admin()
-            .indices()
-            .prepareGetFieldMappings()
+        GetFieldMappingsResponse response = indicesAdmin().prepareGetFieldMappings()
             .addIndices("logstash-*")
             .setFields("*")
             .includeDefaults(true)
@@ -89,11 +87,7 @@ public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
         final String field = "foo";
         indexRandom(true, client().prepareIndex().setIndex(index).setSource(field, "bar"));
 
-        ValidateQueryResponse response = client().admin()
-            .indices()
-            .prepareValidateQuery(index)
-            .setQuery(QueryBuilders.termQuery(field, "bar"))
-            .get();
+        ValidateQueryResponse response = indicesAdmin().prepareValidateQuery(index).setQuery(QueryBuilders.termQuery(field, "bar")).get();
         assertThat(response.isValid(), is(true));
 
         response = client().filterWithHeader(
@@ -133,7 +127,7 @@ public class KibanaUserRoleIntegTests extends NativeRealmIntegTestCase {
         final String field = "foo";
         indexRandom(true, client().prepareIndex().setIndex(index).setSource(field, "bar"));
 
-        GetIndexResponse response = client().admin().indices().prepareGetIndex().setIndices(index).get();
+        GetIndexResponse response = indicesAdmin().prepareGetIndex().setIndices(index).get();
         assertThat(response.getIndices(), arrayContaining(index));
 
         response = client().filterWithHeader(

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/MultipleIndicesPermissionsTests.java
@@ -299,9 +299,7 @@ public class MultipleIndicesPermissionsTests extends SecurityIntegTestCase {
 
     public void testMultiNamesWorkCorrectly() {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("index1")
+            indicesAdmin().prepareCreate("index1")
                 .setMapping("field1", "type=text")
                 .addAlias(new Alias("alias1").filter(QueryBuilders.termQuery("field1", "public")))
         );

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/RoleMappingFileSettingsIT.java
@@ -391,10 +391,7 @@ public class RoleMappingFileSettingsIT extends NativeRealmIntegTestCase {
 
         var savedClusterState = setupClusterStateListenerForSecurityWriteError(internalCluster().getMasterName());
 
-        final CloseIndexResponse closeIndexResponse = client().admin()
-            .indices()
-            .close(new CloseIndexRequest(INTERNAL_SECURITY_MAIN_INDEX_7))
-            .get();
+        final CloseIndexResponse closeIndexResponse = indicesAdmin().close(new CloseIndexRequest(INTERNAL_SECURITY_MAIN_INDEX_7)).get();
         assertTrue(closeIndexResponse.isAcknowledged());
 
         writeJSONFile(internalCluster().getMasterName(), testJSON);

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ShrinkIndexWithSecurityTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/integration/ShrinkIndexWithSecurityTests.java
@@ -51,7 +51,7 @@ public class ShrinkIndexWithSecurityTests extends SecurityIntegTestCase {
 
         // wait for green and then shrink
         ensureGreen();
-        assertAcked(client().admin().indices().prepareResizeIndex("bigindex", "shrunk_bigindex").setSettings(indexSettings(1, 0).build()));
+        assertAcked(indicesAdmin().prepareResizeIndex("bigindex", "shrunk_bigindex").setSettings(indexSettings(1, 0).build()));
 
         // verify all docs
         ensureGreen();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/TemplateUpgraderTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/TemplateUpgraderTests.java
@@ -53,9 +53,7 @@ public class TemplateUpgraderTests extends SecurityIntegTestCase {
             return map;
         };
 
-        AcknowledgedResponse putIndexTemplateResponse = client().admin()
-            .indices()
-            .preparePutTemplate("removed-template")
+        AcknowledgedResponse putIndexTemplateResponse = indicesAdmin().preparePutTemplate("removed-template")
             .setOrder(1)
             .setPatterns(Collections.singletonList(randomAlphaOfLength(10)))
             .get();

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/action/filter/DestructiveOperationsTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/action/filter/DestructiveOperationsTests.java
@@ -26,37 +26,37 @@ public class DestructiveOperationsTests extends SecurityIntegTestCase {
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareDelete("*").get()
+                () -> indicesAdmin().prepareDelete("*").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
-            String[] indices = client().admin().indices().prepareGetIndex().setIndices("index1").get().getIndices();
+            String[] indices = indicesAdmin().prepareGetIndex().setIndices("index1").get().getIndices();
             assertEquals(1, indices.length);
             assertEquals("index1", indices[0]);
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareDelete("*", "-index1").get()
+                () -> indicesAdmin().prepareDelete("*", "-index1").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
-            String[] indices = client().admin().indices().prepareGetIndex().setIndices("index1").get().getIndices();
+            String[] indices = indicesAdmin().prepareGetIndex().setIndices("index1").get().getIndices();
             assertEquals(1, indices.length);
             assertEquals("index1", indices[0]);
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareDelete("_all").get()
+                () -> indicesAdmin().prepareDelete("_all").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
-            String[] indices = client().admin().indices().prepareGetIndex().setIndices("index1").get().getIndices();
+            String[] indices = indicesAdmin().prepareGetIndex().setIndices("index1").get().getIndices();
             assertEquals(1, indices.length);
             assertEquals("index1", indices[0]);
         }
 
         // the "*,-*" pattern is specially handled because it makes a destructive action non-destructive
-        assertAcked(client().admin().indices().prepareDelete("*", "-*"));
-        assertAcked(client().admin().indices().prepareDelete("index1"));
+        assertAcked(indicesAdmin().prepareDelete("*", "-*"));
+        assertAcked(indicesAdmin().prepareDelete("index1"));
     }
 
     public void testDestructiveOperationsDefaultBehaviour() {
@@ -67,19 +67,19 @@ public class DestructiveOperationsTests extends SecurityIntegTestCase {
 
         switch (randomIntBetween(0, 2)) {
             case 0 -> {
-                assertAcked(client().admin().indices().prepareClose("*"));
-                assertAcked(client().admin().indices().prepareOpen("*"));
-                assertAcked(client().admin().indices().prepareDelete("*"));
+                assertAcked(indicesAdmin().prepareClose("*"));
+                assertAcked(indicesAdmin().prepareOpen("*"));
+                assertAcked(indicesAdmin().prepareDelete("*"));
             }
             case 1 -> {
-                assertAcked(client().admin().indices().prepareClose("_all"));
-                assertAcked(client().admin().indices().prepareOpen("_all"));
-                assertAcked(client().admin().indices().prepareDelete("_all"));
+                assertAcked(indicesAdmin().prepareClose("_all"));
+                assertAcked(indicesAdmin().prepareOpen("_all"));
+                assertAcked(indicesAdmin().prepareDelete("_all"));
             }
             case 2 -> {
-                assertAcked(client().admin().indices().prepareClose("*", "-index1"));
-                assertAcked(client().admin().indices().prepareOpen("*", "-index1"));
-                assertAcked(client().admin().indices().prepareDelete("*", "-index1"));
+                assertAcked(indicesAdmin().prepareClose("*", "-index1"));
+                assertAcked(indicesAdmin().prepareOpen("*", "-index1"));
+                assertAcked(indicesAdmin().prepareDelete("*", "-index1"));
             }
             default -> throw new UnsupportedOperationException();
         }
@@ -90,52 +90,52 @@ public class DestructiveOperationsTests extends SecurityIntegTestCase {
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareClose("*").get()
+                () -> indicesAdmin().prepareClose("*").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareClose("*", "-index1").get()
+                () -> indicesAdmin().prepareClose("*", "-index1").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareClose("_all").get()
+                () -> indicesAdmin().prepareClose("_all").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareOpen("*").get()
+                () -> indicesAdmin().prepareOpen("*").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareOpen("*", "-index1").get()
+                () -> indicesAdmin().prepareOpen("*", "-index1").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
         }
         {
             IllegalArgumentException illegalArgumentException = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().prepareOpen("_all").get()
+                () -> indicesAdmin().prepareOpen("_all").get()
             );
             assertEquals("Wildcard expressions or all indices are not allowed", illegalArgumentException.getMessage());
         }
 
         // the "*,-*" pattern is specially handled because it makes a destructive action non-destructive
-        assertAcked(client().admin().indices().prepareClose("*", "-*"));
-        assertAcked(client().admin().indices().prepareOpen("*", "-*"));
+        assertAcked(indicesAdmin().prepareClose("*", "-*"));
+        assertAcked(indicesAdmin().prepareOpen("*", "-*"));
 
         createIndex("index1");
-        assertAcked(client().admin().indices().prepareClose("index1"));
-        assertAcked(client().admin().indices().prepareOpen("index1"));
+        assertAcked(indicesAdmin().prepareClose("index1"));
+        assertAcked(indicesAdmin().prepareOpen("index1"));
     }
 }

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authc/ApiKeyIntegTests.java
@@ -761,7 +761,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
 
     private void refreshSecurityIndex() throws Exception {
         assertBusy(() -> {
-            final RefreshResponse refreshResponse = client().admin().indices().prepareRefresh(SECURITY_MAIN_ALIAS).get();
+            final RefreshResponse refreshResponse = indicesAdmin().prepareRefresh(SECURITY_MAIN_ALIAS).get();
             assertThat(refreshResponse.getFailedShards(), is(0));
         });
     }
@@ -1887,10 +1887,7 @@ public class ApiKeyIntegTests extends SecurityIntegTestCase {
         assertEquals(2, apiKeyService.getRoleDescriptorsBytesCache().count());
 
         // Close security index to trigger invalidation
-        final CloseIndexResponse closeIndexResponse = client().admin()
-            .indices()
-            .close(new CloseIndexRequest(INTERNAL_SECURITY_MAIN_INDEX_7))
-            .get();
+        final CloseIndexResponse closeIndexResponse = indicesAdmin().close(new CloseIndexRequest(INTERNAL_SECURITY_MAIN_INDEX_7)).get();
         assertTrue(closeIndexResponse.isAcknowledged());
         assertBusy(() -> {
             expectThrows(NullPointerException.class, () -> apiKeyService.getFromCache(docId));

--- a/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
+++ b/x-pack/plugin/security/src/internalClusterTest/java/org/elasticsearch/xpack/security/authz/IndexAliasesTests.java
@@ -118,11 +118,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
     public void createBogusIndex() {
         // randomly create an index with two aliases from user admin, to make sure it doesn't affect any of the test results
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("bogus_index_1")
-                .addAlias(new Alias("bogus_alias_1"))
-                .addAlias(new Alias("bogus_alias_2"))
+            indicesAdmin().prepareCreate("bogus_index_1").addAlias(new Alias("bogus_alias_1")).addAlias(new Alias("bogus_alias_2"))
         );
     }
 
@@ -384,9 +380,9 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
 
         // add unauthorized aliases
         if (randomBoolean()) {
-            assertAcked(client().admin().indices().prepareAliases().addAlias("test_1", "alias_1").get());
+            assertAcked(indicesAdmin().prepareAliases().addAlias("test_1", "alias_1").get());
         }
-        assertAcked(client().admin().indices().prepareAliases().addAlias("test_1", "alias_2").get());
+        assertAcked(indicesAdmin().prepareAliases().addAlias("test_1", "alias_2").get());
 
         // fails: user doesn't have manage_aliases on alias_1
         assertThrowsAuthorizationException(
@@ -807,7 +803,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         assertAcked(client.admin().indices().prepareAliases().removeIndex("*").get());
         GetAliasesResponse getAliasesResponse = client.admin().indices().prepareGetAliases().setAliases("*").get();
         assertThat(getAliasesResponse.getAliases().size(), equalTo(0));
-        assertAliases(client().admin().indices().prepareGetAliases().setAliases("*"), "bogus_index_1", "bogus_alias_1", "bogus_alias_2");
+        assertAliases(indicesAdmin().prepareGetAliases().setAliases("*"), "bogus_index_1", "bogus_alias_1", "bogus_alias_2");
     }
 
     public void testAliasesForHiddenIndices() {
@@ -849,7 +845,7 @@ public class IndexAliasesTests extends SecurityIntegTestCase {
         assertThat(response.getAliases().get(hiddenIndex).get(0).alias(), Matchers.equalTo(visibleAlias));
         assertThat(response.getAliases().get(hiddenIndex).get(0).isHidden(), nullValue());
 
-        response = client().admin().indices().prepareGetAliases("alias*").get();
+        response = indicesAdmin().prepareGetAliases("alias*").get();
         assertThat(response.getAliases().get(hiddenIndex), hasSize(1));
         assertThat(response.getAliases().get(hiddenIndex).get(0).alias(), Matchers.equalTo(visibleAlias));
         assertThat(response.getAliases().get(hiddenIndex).get(0).isHidden(), nullValue());

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/test/SecurityIntegTestCase.java
@@ -341,7 +341,7 @@ public abstract class SecurityIntegTestCase extends ESIntegTestCase {
 
         if (frequently()) {
             boolean aliasAdded = false;
-            IndicesAliasesRequestBuilder builder = client().admin().indices().prepareAliases();
+            IndicesAliasesRequestBuilder builder = indicesAdmin().prepareAliases();
             for (String index : indices) {
                 if (frequently()) {
                     // one alias per index with prefix "alias-"

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/DesiredBalanceShutdownIT.java
@@ -51,9 +51,7 @@ public class DesiredBalanceShutdownIT extends ESIntegTestCase {
                 logger.info("--> excluding index from [{}] and concurrently starting replacement with [{}]", oldNodeName, newNodeName);
 
                 final PlainActionFuture<AcknowledgedResponse> excludeFuture = new PlainActionFuture<>();
-                client().admin()
-                    .indices()
-                    .prepareUpdateSettings(INDEX)
+                indicesAdmin().prepareUpdateSettings(INDEX)
                     .setSettings(
                         Settings.builder()
                             .put(IndexMetadata.INDEX_ROUTING_EXCLUDE_GROUP_PREFIX + "._name", oldNodeName)

--- a/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
+++ b/x-pack/plugin/shutdown/src/internalClusterTest/java/org/elasticsearch/xpack/shutdown/NodeShutdownShardsIT.java
@@ -516,7 +516,7 @@ public class NodeShutdownShardsIT extends ESIntegTestCase {
     }
 
     private void assertIndexSetting(String index, String setting, String expectedValue) {
-        var response = client().admin().indices().prepareGetSettings(index).get();
+        var response = indicesAdmin().prepareGetSettings(index).get();
         assertThat(response.getSetting(index, setting), equalTo(expectedValue));
     }
 }

--- a/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
+++ b/x-pack/plugin/snapshot-based-recoveries/src/internalClusterTest/java/org/elasticsearch/xpack/snapshotbasedrecoveries/recovery/SnapshotBasedIndexRecoveryIT.java
@@ -650,7 +650,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
                     )
                 );
 
-                assertAcked(client().admin().indices().prepareDelete(indexName).get());
+                assertAcked(indicesAdmin().prepareDelete(indexName).get());
 
                 assertBusy(mockLogAppender::assertAllExpectationsMatched);
             } finally {
@@ -771,7 +771,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
             updateIndexSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 1), indexName);
             safeAwait(readFromBlobCalledLatch);
 
-            assertAcked(client().admin().indices().prepareDelete(indexName).get());
+            assertAcked(indicesAdmin().prepareDelete(indexName).get());
             // cancellation flag is set when applying the cluster state that deletes the index, so no further waiting is necessary
             isCancelled.set(true);
             readFromBlobRespondLatch.countDown();
@@ -802,7 +802,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
         createRepo(repoName, TestRepositoryPlugin.INSTRUMENTED_TYPE);
         createSnapshot(repoName, "snap", Collections.singletonList(indexName));
 
-        assertAcked(client().admin().indices().prepareDelete(indexName).get());
+        assertAcked(indicesAdmin().prepareDelete(indexName).get());
 
         List<String> restoredIndexDataNodes = internalCluster().startDataOnlyNodes(2);
         RestoreSnapshotResponse restoreSnapshotResponse = client().admin()
@@ -1139,7 +1139,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
                 boolean cancelRecovery = randomBoolean();
                 if (cancelRecovery) {
-                    assertAcked(client().admin().indices().prepareDelete(indexRecoveredFromSnapshot1).get());
+                    assertAcked(indicesAdmin().prepareDelete(indexRecoveredFromSnapshot1).get());
 
                     respondToRecoverSnapshotFile.run();
 
@@ -1604,9 +1604,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
 
         // Ensure that the safe commit == latest commit
         assertBusy(() -> {
-            ShardStats stats = client().admin()
-                .indices()
-                .prepareStats(indexName)
+            ShardStats stats = indicesAdmin().prepareStats(indexName)
                 .clear()
                 .get()
                 .asMap()
@@ -1690,7 +1688,7 @@ public class SnapshotBasedIndexRecoveryIT extends AbstractSnapshotIntegTestCase 
     }
 
     private RecoveryState getLatestPeerRecoveryStateForShard(String indexName, int shardId) {
-        RecoveryResponse recoveryResponse = client().admin().indices().prepareRecoveries(indexName).get();
+        RecoveryResponse recoveryResponse = indicesAdmin().prepareRecoveries(indexName).get();
         assertThat(recoveryResponse.hasRecoveries(), equalTo(true));
         List<RecoveryState> indexRecoveries = recoveryResponse.shardRecoveryStates().get(indexName);
         assertThat(indexRecoveries, notNullValue());

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/SpatialDiskUsageIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/SpatialDiskUsageIT.java
@@ -72,9 +72,7 @@ public class SpatialDiskUsageIT extends ESIntegTestCase {
         mapping.endObject();
 
         final String index = "test-index";
-        client().admin()
-            .indices()
-            .prepareCreate(index)
+        indicesAdmin().prepareCreate(index)
             .setMapping(mapping)
             .setSettings(Settings.builder().put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, between(1, 5)))
             .get();

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/CartesianShapeIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/CartesianShapeIT.java
@@ -47,9 +47,7 @@ public class CartesianShapeIT extends CartesianShapeIntegTestCase {
     public void testMappingUpdate() {
         // create index
         Version version = randomSupportedVersion();
-        assertAcked(
-            client().admin().indices().prepareCreate("test").setSettings(settings(version).build()).setMapping("shape", "type=shape").get()
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(settings(version).build()).setMapping("shape", "type=shape").get());
         ensureGreen();
 
         String update = """
@@ -64,7 +62,7 @@ public class CartesianShapeIT extends CartesianShapeIntegTestCase {
 
         MapperParsingException e = expectThrows(
             MapperParsingException.class,
-            () -> client().admin().indices().preparePutMapping("test").setSource(update, XContentType.JSON).get()
+            () -> indicesAdmin().preparePutMapping("test").setSource(update, XContentType.JSON).get()
         );
         assertThat(e.getMessage(), containsString("unknown parameter [strategy] on mapper [shape] of type [shape]"));
     }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoGridAggAndQueryConsistencyIT.java
@@ -101,7 +101,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
+        indicesAdmin().prepareCreate("test").setMapping(xcb).get();
 
         BulkRequestBuilder builder = client().prepareBulk();
         builder.add(
@@ -112,7 +112,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
         );
 
         assertFalse(builder.get().hasFailures());
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         GeoBoundingBox boundingBox = new GeoBoundingBox(new GeoPoint(-11.29550, 179.999992), new GeoPoint(-11.29552, -179.999992));
 
@@ -146,7 +146,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
+        indicesAdmin().prepareCreate("test").setMapping(xcb).get();
 
         BulkRequestBuilder builder = client().prepareBulk();
         builder.add(
@@ -159,7 +159,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
         builder.add(new IndexRequest("test").source("{\"geometry\" : \"" + mp + "\"}", XContentType.JSON));
 
         assertFalse(builder.get().hasFailures());
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         // BBOX (172.21916569181505, -173.17785081207947, 86.17678739494652, 83.01600086049713)
         GeoBoundingBox boundingBox = new GeoBoundingBox(
@@ -247,7 +247,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
             .endObject()
             .endObject()
             .endObject();
-        client().admin().indices().prepareCreate("test").setMapping(xcb).get();
+        indicesAdmin().prepareCreate("test").setMapping(xcb).get();
 
         Point queryPoint = GeometryTestUtils.randomPoint();
         String[] tiles = new String[maxPrecision + 1];
@@ -270,7 +270,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
 
         }
         assertFalse(builder.get().hasFailures());
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         for (int i = minPrecision; i <= maxPrecision; i++) {
             GeoGridAggregationBuilder builderPoint = aggBuilder.apply("geometry").field("geometry").precision(i);
@@ -287,7 +287,7 @@ public class GeoGridAggAndQueryConsistencyIT extends ESIntegTestCase {
             builder.add(new IndexRequest("test").source(doc, XContentType.JSON));
         }
         assertFalse(builder.get().hasFailures());
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         int zoom = randomIntBetween(minPrecision, maxPrecision);
         Rectangle rectangle = toBoundingBox.apply(tiles[zoom]);

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeScriptDocValuesIT.java
@@ -158,7 +158,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             .startObject("location")
             .field("type", "geo_shape");
         xContentBuilder.endObject().endObject().endObject().endObject();
-        assertAcked(client().admin().indices().prepareCreate("test").setMapping(xContentBuilder));
+        assertAcked(indicesAdmin().prepareCreate("test").setMapping(xContentBuilder));
         ensureGreen();
     }
 
@@ -255,7 +255,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             )
             .get();
 
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         GeoShapeValues.GeoShapeValue value = GeoTestUtils.geoShapeValue(geometry);
 
@@ -314,7 +314,7 @@ public class GeoShapeScriptDocValuesIT extends ESSingleNodeTestCase {
             .setSource(jsonBuilder().startObject().field("name", "TestPosition").nullField("location").endObject())
             .get();
 
-        client().admin().indices().prepareRefresh("test").get();
+        indicesAdmin().prepareRefresh("test").get();
 
         SearchResponse searchResponse = client().prepareSearch()
             .addStoredField("_source")

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeWithDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/GeoShapeWithDocValuesIT.java
@@ -71,12 +71,7 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
         // create index
         Version version = randomSupportedVersion();
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setSettings(settings(version).build())
-                .setMapping("shape", "type=geo_shape")
-                .get()
+            indicesAdmin().prepareCreate("test").setSettings(settings(version).build()).setMapping("shape", "type=geo_shape").get()
         );
         ensureGreen();
 
@@ -93,7 +88,7 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
         if (version.before(Version.V_8_0_0)) {
             IllegalArgumentException e = expectThrows(
                 IllegalArgumentException.class,
-                () -> client().admin().indices().preparePutMapping("test").setSource(update, XContentType.JSON).get()
+                () -> indicesAdmin().preparePutMapping("test").setSource(update, XContentType.JSON).get()
             );
             assertThat(
                 e.getMessage(),
@@ -102,7 +97,7 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
         } else {
             MapperParsingException e = expectThrows(
                 MapperParsingException.class,
-                () -> client().admin().indices().preparePutMapping("test").setSource(update, XContentType.JSON).get()
+                () -> indicesAdmin().preparePutMapping("test").setSource(update, XContentType.JSON).get()
             );
             assertThat(
                 e.getMessage(),
@@ -113,10 +108,7 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
 
     public void testPercolatorGeoQueries() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setMapping("id", "type=keyword", "field1", "type=geo_shape", "query", "type=percolator")
+            indicesAdmin().prepareCreate("test").setMapping("id", "type=keyword", "field1", "type=geo_shape", "query", "type=percolator")
         );
 
         client().prepareIndex("test")
@@ -175,14 +167,7 @@ public class GeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
         mapping.endObject().endObject().endObject();
 
         // create index
-        assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
-                .setSettings(settings(randomSupportedVersion()).build())
-                .setMapping(mapping)
-                .get()
-        );
+        assertAcked(indicesAdmin().prepareCreate("test").setSettings(settings(randomSupportedVersion()).build()).setMapping(mapping).get());
         ensureGreen();
 
         String source = """

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/LegacyGeoShapeWithDocValuesIT.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/LegacyGeoShapeWithDocValuesIT.java
@@ -54,9 +54,7 @@ public class LegacyGeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
     public void testMappingUpdate() {
         // create index
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setSettings(settings(randomSupportedVersion()).build())
                 .setMapping("shape", "type=geo_shape,strategy=recursive")
                 .get()
@@ -74,7 +72,7 @@ public class LegacyGeoShapeWithDocValuesIT extends GeoShapeIntegTestCase {
 
         IllegalArgumentException e = expectThrows(
             IllegalArgumentException.class,
-            () -> client().admin().indices().preparePutMapping("test").setSource(update, XContentType.JSON).get()
+            () -> indicesAdmin().preparePutMapping("test").setSource(update, XContentType.JSON).get()
         );
         assertThat(e.getMessage(), containsString("mapper [shape] of type [geo_shape] cannot change strategy from [recursive] to [BKD]"));
     }

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverPointTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverPointTests.java
@@ -42,7 +42,7 @@ public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
 
     public void testProcessRelationSupport() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         Rectangle rectangle = new Rectangle(-35, -25, -25, -35);
@@ -65,7 +65,7 @@ public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
 
     public void testQueryLine() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         Line line = new Line(new double[] { -25, -25 }, new double[] { -35, -35 });
@@ -79,7 +79,7 @@ public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
 
     public void testQueryLinearRing() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         LinearRing linearRing = new LinearRing(new double[] { -25, -35, -25 }, new double[] { -25, -35, -25 });
@@ -101,7 +101,7 @@ public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
 
     public void testQueryMultiLine() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         Line lsb1 = new Line(new double[] { -35, -25 }, new double[] { -35, -25 });
@@ -120,7 +120,7 @@ public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
 
     public void testQueryMultiPoint() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         MultiPoint multiPoint = new MultiPoint(List.of(new Point(-35, -25), new Point(-15, -5)));
@@ -134,7 +134,7 @@ public class ShapeQueryOverPointTests extends ShapeQueryTestCase {
 
     public void testQueryPoint() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate("test").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("test").setMapping(mapping).get();
         ensureGreen();
 
         Point point = new Point(-35, -2);

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryOverShapeTests.java
@@ -69,14 +69,10 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         super.setUp();
 
         // create test index
-        assertAcked(
-            client().admin().indices().prepareCreate(INDEX).setMapping(FIELD, "type=shape", "alias", "type=alias,path=" + FIELD).get()
-        );
+        assertAcked(indicesAdmin().prepareCreate(INDEX).setMapping(FIELD, "type=shape", "alias", "type=alias,path=" + FIELD).get());
         // create index that ignores malformed geometry
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate(IGNORE_MALFORMED_INDEX)
+            indicesAdmin().prepareCreate(IGNORE_MALFORMED_INDEX)
                 .setMapping(FIELD, "type=shape,ignore_malformed=true", "_source", "enabled=false")
                 .get()
         );
@@ -132,7 +128,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
         String indexName = "shapes_index";
         String searchIndex = "search_index";
         createIndex(indexName);
-        client().admin().indices().prepareCreate(searchIndex).setMapping("location", "type=shape").get();
+        indicesAdmin().prepareCreate(searchIndex).setMapping("location", "type=shape").get();
 
         String location = """
             "location" : {"type":"polygon", "coordinates":[[[-10,-10],[10,-10],[10,10],[-10,10],[-10,-10]]]}""";
@@ -241,7 +237,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
             }""", args);
 
         client().prepareIndex(INDEX).setId("0").setSource(source, XContentType.JSON).setRouting("ABC").get();
-        client().admin().indices().prepareRefresh(INDEX).get();
+        indicesAdmin().prepareRefresh(INDEX).get();
 
         SearchResponse searchResponse = client().prepareSearch(INDEX)
             .setQuery(new ShapeQueryBuilder(FIELD, "0").indexedShapeIndex(INDEX).indexedShapeRouting("ABC"))
@@ -282,7 +278,7 @@ public class ShapeQueryOverShapeTests extends ShapeQueryTestCase {
 
     public void testContainsShapeQuery() {
 
-        client().admin().indices().prepareCreate("test_contains").setMapping("location", "type=shape").execute().actionGet();
+        indicesAdmin().prepareCreate("test_contains").setMapping("location", "type=shape").execute().actionGet();
 
         String doc = """
             {"location" : {"type":"envelope", "coordinates":[ [-100.0, 100.0], [100.0, -100.0]]}}""";

--- a/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
+++ b/x-pack/plugin/spatial/src/internalClusterTest/java/org/elasticsearch/xpack/spatial/search/ShapeQueryTestCase.java
@@ -52,7 +52,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testNullShape() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -66,7 +66,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testIndexPointsFilterRectangle() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -103,7 +103,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testIndexPointsCircle() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -132,7 +132,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testIndexPointsPolygon() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -161,7 +161,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testIndexPointsMultiPolygon() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -204,7 +204,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testIndexPointsRectangle() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -233,7 +233,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
 
     public void testIndexPointsIndexedRectangle() throws Exception {
         String mapping = Strings.toString(createDefaultMapping());
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get();
         ensureGreen();
 
         client().prepareIndex(defaultIndexName)
@@ -260,7 +260,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
                 .endObject()
                 .endObject()
         );
-        client().admin().indices().prepareCreate(indexedShapeIndex).setMapping(queryShapesMapping).get();
+        indicesAdmin().prepareCreate(indexedShapeIndex).setMapping(queryShapesMapping).get();
         ensureGreen();
 
         client().prepareIndex(indexedShapeIndex)
@@ -300,7 +300,7 @@ public abstract class ShapeQueryTestCase extends ESSingleNodeTestCase {
     }
 
     public void testDistanceQuery() throws Exception {
-        client().admin().indices().prepareCreate("test_distance").setMapping("location", "type=shape").execute().actionGet();
+        indicesAdmin().prepareCreate("test_distance").setMapping("location", "type=shape").execute().actionGet();
         ensureGreen();
 
         Circle circle = new Circle(1, 0, 10);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/index/query/LegacyGeoShapeWithDocValuesQueryTests.java
@@ -64,7 +64,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
         final Settings finalSetting;
         MapperParsingException ex = expectThrows(
             MapperParsingException.class,
-            () -> client().admin().indices().prepareCreate(indexName).setMapping(xcb).setSettings(settings).get()
+            () -> indicesAdmin().prepareCreate(indexName).setMapping(xcb).setSettings(settings).get()
         );
         assertThat(
             ex.getMessage(),
@@ -72,7 +72,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
         );
         Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
         finalSetting = settings(version).put(settings).build();
-        client().admin().indices().prepareCreate(indexName).setMapping(xcb).setSettings(finalSetting).get();
+        indicesAdmin().prepareCreate(indexName).setMapping(xcb).setSettings(finalSetting).get();
     }
 
     @Override
@@ -98,7 +98,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
 
         MapperParsingException ex = expectThrows(
             MapperParsingException.class,
-            () -> client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).get()
+            () -> indicesAdmin().prepareCreate("geo_points_only").setMapping(mapping).get()
         );
         assertThat(
             ex.getMessage(),
@@ -110,7 +110,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
 
         Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
         Settings settings = settings(version).build();
-        client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).setSettings(settings).get();
+        indicesAdmin().prepareCreate("geo_points_only").setMapping(mapping).setSettings(settings).get();
         ensureGreen();
 
         // MULTIPOINT
@@ -153,7 +153,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
 
         MapperParsingException ex = expectThrows(
             MapperParsingException.class,
-            () -> client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).get()
+            () -> indicesAdmin().prepareCreate("geo_points_only").setMapping(mapping).get()
         );
         assertThat(
             ex.getMessage(),
@@ -165,7 +165,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
 
         Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
         Settings settings = settings(version).build();
-        client().admin().indices().prepareCreate("geo_points_only").setMapping(mapping).setSettings(settings).get();
+        indicesAdmin().prepareCreate("geo_points_only").setMapping(mapping).setSettings(settings).get();
         ensureGreen();
 
         Geometry geometry = GeometryTestUtils.randomGeometry(false);
@@ -207,7 +207,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
 
         MapperParsingException ex = expectThrows(
             MapperParsingException.class,
-            () -> client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).get()
+            () -> indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).get()
         );
         assertThat(
             ex.getMessage(),
@@ -216,7 +216,7 @@ public class LegacyGeoShapeWithDocValuesQueryTests extends GeoShapeQueryTestCase
 
         Version version = VersionUtils.randomPreviousCompatibleVersion(random(), Version.V_8_0_0);
         Settings settings = settings(version).build();
-        client().admin().indices().prepareCreate(defaultIndexName).setMapping(mapping).setSettings(settings).get();
+        indicesAdmin().prepareCreate(defaultIndexName).setMapping(mapping).setSettings(settings).get();
         ensureGreen();
 
         MultiPoint multiPoint = GeometryTestUtils.randomMultiPoint(false);

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AsyncSqlSearchActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/AsyncSqlSearchActionIT.java
@@ -79,9 +79,7 @@ public class AsyncSqlSearchActionIT extends AbstractSqlBlockingIntegTestCase {
 
     private void prepareIndex() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date", "i", "type=integer")
                 .get()
         );

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/RestSqlCancellationIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/RestSqlCancellationIT.java
@@ -73,9 +73,7 @@ public class RestSqlCancellationIT extends AbstractSqlBlockingIntegTestCase {
     @TestLogging(value = "org.elasticsearch.xpack.sql:TRACE", reason = "debug")
     public void testRestCancellation() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date")
                 .get()
         );

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlActionIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.hasSize;
 public class SqlActionIT extends AbstractSqlIntegTestCase {
 
     public void testSqlAction() {
-        assertAcked(client().admin().indices().prepareCreate("test").get());
+        assertAcked(indicesAdmin().prepareCreate("test").get());
         client().prepareBulk()
             .add(new IndexRequest("test").id("1").source("data", "bar", "count", 42))
             .add(new IndexRequest("test").id("2").source("data", "baz", "count", 43))

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlCancellationIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlCancellationIT.java
@@ -39,9 +39,7 @@ public class SqlCancellationIT extends AbstractSqlBlockingIntegTestCase {
 
     public void testCancellation() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("test")
+            indicesAdmin().prepareCreate("test")
                 .setMapping("val", "type=integer", "event_type", "type=keyword", "@timestamp", "type=date")
                 .get()
         );

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlClearCursorActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlClearCursorActionIT.java
@@ -20,7 +20,7 @@ import static org.hamcrest.Matchers.notNullValue;
 public class SqlClearCursorActionIT extends AbstractSqlIntegTestCase {
 
     public void testSqlClearCursorAction() {
-        assertAcked(client().admin().indices().prepareCreate("test").get());
+        assertAcked(indicesAdmin().prepareCreate("test").get());
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
         int indexSize = randomIntBetween(100, 300);
         logger.info("Indexing {} records", indexSize);
@@ -52,7 +52,7 @@ public class SqlClearCursorActionIT extends AbstractSqlIntegTestCase {
     }
 
     public void testAutoCursorCleanup() {
-        assertAcked(client().admin().indices().prepareCreate("test").get());
+        assertAcked(indicesAdmin().prepareCreate("test").get());
         BulkRequestBuilder bulkRequestBuilder = client().prepareBulk();
         int indexSize = randomIntBetween(100, 300);
         logger.info("Indexing {} records", indexSize);
@@ -91,15 +91,6 @@ public class SqlClearCursorActionIT extends AbstractSqlIntegTestCase {
     }
 
     private long getNumberOfSearchContexts() {
-        return client().admin()
-            .indices()
-            .prepareStats("test")
-            .clear()
-            .setSearch(true)
-            .get()
-            .getIndex("test")
-            .getTotal()
-            .getSearch()
-            .getOpenContexts();
+        return indicesAdmin().prepareStats("test").clear().setSearch(true).get().getIndex("test").getTotal().getSearch().getOpenContexts();
     }
 }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLicenseIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlLicenseIT.java
@@ -163,7 +163,7 @@ public class SqlLicenseIT extends AbstractLicensesIntegrationTestCase {
     // TODO test SqlGetIndicesAction. Skipping for now because of lack of serialization support.
 
     private void setupTestIndex() {
-        ElasticsearchAssertions.assertAcked(client().admin().indices().prepareCreate("test").get());
+        ElasticsearchAssertions.assertAcked(indicesAdmin().prepareCreate("test").get());
         client().prepareBulk()
             .add(new IndexRequest("test").id("1").source("data", "bar", "count", 42))
             .add(new IndexRequest("test").id("2").source("data", "baz", "count", 43))

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlSearchPageTimeoutIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlSearchPageTimeoutIT.java
@@ -61,7 +61,7 @@ public class SqlSearchPageTimeoutIT extends AbstractSqlIntegTestCase {
     }
 
     private void setupTestIndex() {
-        assertAcked(client().admin().indices().prepareCreate("test").get());
+        assertAcked(indicesAdmin().prepareCreate("test").get());
         client().prepareBulk()
             .add(new IndexRequest("test").id("1").source("field", "bar"))
             .add(new IndexRequest("test").id("2").source("field", "baz"))
@@ -71,15 +71,6 @@ public class SqlSearchPageTimeoutIT extends AbstractSqlIntegTestCase {
     }
 
     private long getNumberOfSearchContexts() {
-        return client().admin()
-            .indices()
-            .prepareStats("test")
-            .clear()
-            .setSearch(true)
-            .get()
-            .getIndex("test")
-            .getTotal()
-            .getSearch()
-            .getOpenContexts();
+        return indicesAdmin().prepareStats("test").clear().setSearch(true).get().getIndex("test").getTotal().getSearch().getOpenContexts();
     }
 }

--- a/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlTranslateActionIT.java
+++ b/x-pack/plugin/sql/src/internalClusterTest/java/org/elasticsearch/xpack/sql/action/SqlTranslateActionIT.java
@@ -21,7 +21,7 @@ import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcke
 public class SqlTranslateActionIT extends AbstractSqlIntegTestCase {
 
     public void testSqlTranslateAction() {
-        assertAcked(client().admin().indices().prepareCreate("test").get());
+        assertAcked(indicesAdmin().prepareCreate("test").get());
         client().prepareBulk()
             .add(new IndexRequest("test").id("1").source("data", "bar", "count", 42, "date", "1984-01-04"))
             .add(new IndexRequest("test").id("2").source("data", "baz", "count", 43, "date", "1989-12-19"))

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/checkpoint/TransformGetCheckpointIT.java
@@ -30,7 +30,7 @@ public class TransformGetCheckpointIT extends TransformSingleNodeTestCase {
         final int indices = randomIntBetween(1, 5);
 
         for (int i = 0; i < indices; ++i) {
-            client().admin().indices().prepareCreate(indexNamePrefix + i).setSettings(indexSettings(shards, 1)).get();
+            indicesAdmin().prepareCreate(indexNamePrefix + i).setSettings(indexSettings(shards, 1)).get();
         }
 
         final GetCheckpointAction.Request request = new GetCheckpointAction.Request(
@@ -55,7 +55,7 @@ public class TransformGetCheckpointIT extends TransformSingleNodeTestCase {
             }
         }
 
-        client().admin().indices().refresh(new RefreshRequest(indexNamePrefix + "*"));
+        indicesAdmin().refresh(new RefreshRequest(indexNamePrefix + "*"));
 
         final GetCheckpointAction.Response response2 = client().execute(GetCheckpointAction.INSTANCE, request).get();
         assertEquals(indices, response2.getCheckpoints().size());
@@ -75,7 +75,7 @@ public class TransformGetCheckpointIT extends TransformSingleNodeTestCase {
             checkpointSum
         );
 
-        final IndicesStatsResponse statsResponse = client().admin().indices().prepareStats(indexNamePrefix + "*").get();
+        final IndicesStatsResponse statsResponse = indicesAdmin().prepareStats(indexNamePrefix + "*").get();
 
         assertEquals(
             "Checkpoint API and indices stats don't match",

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformInternalIndexIT.java
@@ -58,10 +58,7 @@ public class TransformInternalIndexIT extends TransformSingleNodeTestCase {
             TransformInternalIndex.addTransformsConfigMappings(builder);
             builder.endObject();
             builder.endObject();
-            client().admin()
-                .indices()
-                .create(new CreateIndexRequest(OLD_INDEX).mapping(builder).origin(ClientHelper.TRANSFORM_ORIGIN))
-                .actionGet();
+            indicesAdmin().create(new CreateIndexRequest(OLD_INDEX).mapping(builder).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
         }
         String transformIndex = "transform-index-deletes-old";
         createSourceIndex(transformIndex);
@@ -136,6 +133,6 @@ public class TransformInternalIndexIT extends TransformSingleNodeTestCase {
     }
 
     private void createSourceIndex(String index) {
-        client().admin().indices().create(new CreateIndexRequest(index)).actionGet();
+        indicesAdmin().create(new CreateIndexRequest(index)).actionGet();
     }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformOldTransformsIT.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/integration/TransformOldTransformsIT.java
@@ -65,10 +65,7 @@ public class TransformOldTransformsIT extends TransformSingleNodeTestCase {
             TransformInternalIndex.addTransformsConfigMappings(builder);
             builder.endObject();
             builder.endObject();
-            client().admin()
-                .indices()
-                .create(new CreateIndexRequest(OLD_INDEX).mapping(builder).origin(ClientHelper.TRANSFORM_ORIGIN))
-                .actionGet();
+            indicesAdmin().create(new CreateIndexRequest(OLD_INDEX).mapping(builder).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
         }
         String transformIndex = "transform-index";
         createSourceIndex(transformIndex);
@@ -160,6 +157,6 @@ public class TransformOldTransformsIT extends TransformSingleNodeTestCase {
     }
 
     private void createSourceIndex(String index) {
-        client().admin().indices().create(new CreateIndexRequest(index)).actionGet();
+        indicesAdmin().create(new CreateIndexRequest(index)).actionGet();
     }
 }

--- a/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
+++ b/x-pack/plugin/transform/src/internalClusterTest/java/org/elasticsearch/xpack/transform/persistence/TransformConfigManagerTests.java
@@ -338,10 +338,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         String oldIndex = TransformInternalIndexConstants.INDEX_PATTERN + "001";
         String docId = TransformConfig.documentId(transformConfig2.getId());
         TransformConfig transformConfig = TransformConfigTests.randomTransformConfig(transformConfig2.getId());
-        client().admin()
-            .indices()
-            .create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN))
-            .actionGet();
+        indicesAdmin().create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
@@ -406,10 +403,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         String transformId = "transform_42";
         String docId = TransformConfig.documentId(transformId);
         TransformConfig transformConfig = TransformConfigTests.randomTransformConfig(transformId);
-        client().admin()
-            .indices()
-            .create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN))
-            .actionGet();
+        indicesAdmin().create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
@@ -534,10 +528,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         String transformId = "transform_test_delete_old_configurations";
         String docId = TransformConfig.documentId(transformId);
         TransformConfig transformConfig = TransformConfigTests.randomTransformConfig("transform_test_delete_old_configurations");
-        client().admin()
-            .indices()
-            .create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN))
-            .actionGet();
+        indicesAdmin().create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformConfig.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
@@ -557,7 +548,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         assertAsync(listener -> transformConfigManager.deleteOldTransformConfigurations(transformId, listener), true, null, null);
 
-        client().admin().indices().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(false));
         assertThat(
             client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
@@ -570,10 +561,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         String transformId = "transform_test_delete_old_stored_documents";
         String docId = TransformStoredDoc.documentId(transformId);
         TransformStoredDoc transformStoredDoc = TransformStoredDocTests.randomTransformStoredDoc(transformId);
-        client().admin()
-            .indices()
-            .create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN))
-            .actionGet();
+        indicesAdmin().create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformStoredDoc.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));
@@ -593,7 +581,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
             null
         );
 
-        client().admin().indices().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
 
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(true));
         assertThat(
@@ -603,7 +591,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
 
         assertAsync(listener -> transformConfigManager.deleteOldTransformStoredDocuments(transformId, listener), 1L, null, null);
 
-        client().admin().indices().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
+        indicesAdmin().refresh(new RefreshRequest(TransformInternalIndexConstants.INDEX_NAME_PATTERN)).actionGet();
         assertThat(client().get(new GetRequest(oldIndex).id(docId)).actionGet().isExists(), is(false));
         assertThat(
             client().get(new GetRequest(TransformInternalIndexConstants.LATEST_INDEX_NAME).id(docId)).actionGet().isExists(),
@@ -710,10 +698,7 @@ public class TransformConfigManagerTests extends TransformSingleNodeTestCase {
         TransformConfig transformConfigNew = TransformConfigTests.randomTransformConfig(transformId);
 
         // create config in old index
-        client().admin()
-            .indices()
-            .create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN))
-            .actionGet();
+        indicesAdmin().create(new CreateIndexRequest(oldIndex).mapping(mappings()).origin(ClientHelper.TRANSFORM_ORIGIN)).actionGet();
 
         try (XContentBuilder builder = XContentFactory.jsonBuilder()) {
             XContentBuilder source = transformConfigOld.toXContent(builder, new ToXContent.MapParams(TO_XCONTENT_PARAMS));

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/throttler/ActionThrottleTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/throttler/ActionThrottleTests.java
@@ -327,7 +327,7 @@ public class ActionThrottleTests extends AbstractWatcherIntegrationTestCase {
                 .endObject()
         );
 
-        client().admin().indices().prepareCreate("foo").setMapping(mapping).get();
+        indicesAdmin().prepareCreate("foo").setMapping(mapping).get();
 
         TimeValue throttlePeriod = new TimeValue(60, TimeUnit.MINUTES);
 

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/actions/webhook/WebhookIntegrationTests.java
@@ -143,7 +143,7 @@ public class WebhookIntegrationTests extends AbstractWatcherIntegrationTestCase 
     }
 
     public void testWebhookWithTimebasedIndex() throws Exception {
-        assertAcked(client().admin().indices().prepareCreate("<logstash-{now/d}>").get());
+        assertAcked(indicesAdmin().prepareCreate("<logstash-{now/d}>").get());
 
         HttpServerTransport serverTransport = internalCluster().getDataNodeInstance(HttpServerTransport.class);
         TransportAddress publishAddress = serverTransport.boundAddress().publishAddress();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionSearchTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/condition/ArrayCompareConditionSearchTests.java
@@ -31,7 +31,7 @@ public class ArrayCompareConditionSearchTests extends AbstractWatcherIntegration
 
     public void testExecuteWithAggs() throws Exception {
         String index = "test-index";
-        client().admin().indices().prepareCreate(index).get();
+        indicesAdmin().prepareCreate(index).get();
 
         ArrayCompareCondition.Op op = randomFrom(ArrayCompareCondition.Op.values());
         ArrayCompareCondition.Quantifier quantifier = randomFrom(ArrayCompareCondition.Quantifier.values());

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateHttpMappingsTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateHttpMappingsTests.java
@@ -126,7 +126,7 @@ public class HistoryTemplateHttpMappingsTests extends AbstractWatcherIntegration
 
     public void testExceptionMapping() throws Exception {
         // delete all history indices to ensure that we only need to check a single index
-        assertAcked(client().admin().indices().prepareDelete(HistoryStoreField.INDEX_PREFIX + "*"));
+        assertAcked(indicesAdmin().prepareDelete(HistoryStoreField.INDEX_PREFIX + "*"));
 
         String id = randomAlphaOfLength(10);
         // switch between delaying the input or the action http request
@@ -174,7 +174,7 @@ public class HistoryTemplateHttpMappingsTests extends AbstractWatcherIntegration
 
         // ensure that enabled is set to false
         List<Boolean> indexed = new ArrayList<>();
-        GetMappingsResponse mappingsResponse = client().admin().indices().prepareGetMappings(HistoryStoreField.INDEX_PREFIX + "*").get();
+        GetMappingsResponse mappingsResponse = indicesAdmin().prepareGetMappings(HistoryStoreField.INDEX_PREFIX + "*").get();
         for (MappingMetadata mapping : mappingsResponse.getMappings().values()) {
             Map<String, Object> docMapping = mapping.getSourceAsMap();
             if (abortAtInput) {

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateTimeMappingsTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateTimeMappingsTests.java
@@ -46,9 +46,7 @@ public class HistoryTemplateTimeMappingsTests extends AbstractWatcherIntegration
 
         assertWatchWithMinimumActionsCount("_id", ExecutionState.EXECUTED, 1);
         assertBusy(() -> {
-            GetMappingsResponse mappingsResponse = client().admin()
-                .indices()
-                .prepareGetMappings()
+            GetMappingsResponse mappingsResponse = indicesAdmin().prepareGetMappings()
                 .setIndicesOptions(IndicesOptions.strictExpandHidden())
                 .get();
             assertThat(mappingsResponse, notNullValue());

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateTransformMappingsTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/history/HistoryTemplateTransformMappingsTests.java
@@ -31,9 +31,7 @@ public class HistoryTemplateTransformMappingsTests extends AbstractWatcherIntegr
 
     public void testTransformFields() throws Exception {
         assertAcked(
-            client().admin()
-                .indices()
-                .prepareCreate("idx")
+            indicesAdmin().prepareCreate("idx")
                 .setMapping(
                     jsonBuilder().startObject()
                         .startObject("properties")
@@ -92,9 +90,7 @@ public class HistoryTemplateTransformMappingsTests extends AbstractWatcherIntegr
         new ExecuteWatchRequestBuilder(client(), "_second").setRecordExecution(true).get();
 
         assertBusy(() -> {
-            GetFieldMappingsResponse response = client().admin()
-                .indices()
-                .prepareGetFieldMappings(".watcher-history*")
+            GetFieldMappingsResponse response = indicesAdmin().prepareGetFieldMappings(".watcher-history*")
                 .setFields("result.actions.transform.payload")
                 .includeDefaults(true)
                 .get();

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BasicWatcherTests.java
@@ -479,7 +479,7 @@ public class BasicWatcherTests extends AbstractWatcherIntegrationTestCase {
         // Even if there is no .watches index this api should work and return 0 watches.
         DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest("*");
         deleteIndexRequest.indicesOptions(IndicesOptions.lenientExpandOpenHidden());
-        client().admin().indices().delete(deleteIndexRequest).actionGet();
+        indicesAdmin().delete(deleteIndexRequest).actionGet();
         request = new QueryWatchesAction.Request(null, null, null, null, null);
         response = client().execute(QueryWatchesAction.INSTANCE, request).actionGet();
         assertThat(response.getWatchTotalCount(), equalTo(0L));

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/BootStrapTests.java
@@ -356,7 +356,7 @@ public class BootStrapTests extends AbstractWatcherIntegrationTestCase {
         // A watch record without a watch is the easiest to simulate, so that is what this test does.
         if (indexExists(Watch.INDEX) == false) {
             // we rarely create an .watches alias in the base class
-            assertAcked(client().admin().indices().prepareCreate(Watch.INDEX));
+            assertAcked(indicesAdmin().prepareCreate(Watch.INDEX));
         }
         LocalDateTime localDateTime = LocalDateTime.of(2015, 11, 5, 0, 0, 0, 0);
         ZonedDateTime triggeredTime = ZonedDateTime.of(localDateTime, ZoneOffset.UTC);

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/HistoryIntegrationTests.java
@@ -112,7 +112,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         });
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
-        GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
+        GetMappingsResponse response = indicesAdmin().prepareGetMappings(".watcher-history*").get();
         XContentSource source = new XContentSource(
             response.getMappings().values().iterator().next().source().uncompressed(),
             XContentType.JSON
@@ -158,7 +158,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
         });
 
         // as fields with dots are allowed in 5.0 again, the mapping must be checked in addition
-        GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
+        GetMappingsResponse response = indicesAdmin().prepareGetMappings(".watcher-history*").get();
         XContentSource source = new XContentSource(
             response.getMappings().values().iterator().next().source().uncompressed(),
             XContentType.JSON
@@ -221,7 +221,7 @@ public class HistoryIntegrationTests extends AbstractWatcherIntegrationTestCase 
 
         assertBusy(() -> {
             // also ensure that the status field is disabled in the watch history
-            GetMappingsResponse response = client().admin().indices().prepareGetMappings(".watcher-history*").get();
+            GetMappingsResponse response = indicesAdmin().prepareGetMappings(".watcher-history*").get();
             XContentSource mappingSource = new XContentSource(
                 response.getMappings().values().iterator().next().source().uncompressed(),
                 XContentType.JSON

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/test/integration/SingleNodeTests.java
@@ -45,7 +45,7 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
         ClusterStateResponse clusterStateResponse = client().admin().cluster().prepareState().get();
         IndexMetadata metadata = WatchStoreUtils.getConcreteIndex(Watch.INDEX, clusterStateResponse.getState().metadata());
         String watchIndexName = metadata.getIndex().getName();
-        assertAcked(client().admin().indices().prepareDelete(watchIndexName));
+        assertAcked(indicesAdmin().prepareDelete(watchIndexName));
         startWatcher();
 
         String watchId = randomAlphaOfLength(20);
@@ -60,7 +60,7 @@ public class SingleNodeTests extends AbstractWatcherIntegrationTestCase {
         assertThat(putWatchResponse.isCreated(), is(true));
 
         assertBusy(() -> {
-            client().admin().indices().prepareRefresh(".watcher-history*").get();
+            indicesAdmin().prepareRefresh(".watcher-history*").get();
             SearchResponse searchResponse = client().prepareSearch(".watcher-history*").setSize(0).get();
             assertThat(searchResponse.getHits().getTotalHits().value, is(greaterThanOrEqualTo(1L)));
         }, 30, TimeUnit.SECONDS);

--- a/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/transport/action/get/GetWatchTests.java
+++ b/x-pack/plugin/watcher/src/internalClusterTest/java/org/elasticsearch/xpack/watcher/transport/action/get/GetWatchTests.java
@@ -62,12 +62,12 @@ public class GetWatchTests extends AbstractWatcherIntegrationTestCase {
         // if the watches index is an alias, remove the alias randomly, otherwise the index
         if (randomBoolean()) {
             try {
-                GetIndexResponse indexResponse = client().admin().indices().prepareGetIndex().setIndices(Watch.INDEX).get();
+                GetIndexResponse indexResponse = indicesAdmin().prepareGetIndex().setIndices(Watch.INDEX).get();
                 boolean isWatchIndexAlias = Watch.INDEX.equals(indexResponse.indices()[0]) == false;
                 if (isWatchIndexAlias) {
-                    assertAcked(client().admin().indices().prepareAliases().removeAlias(indexResponse.indices()[0], Watch.INDEX));
+                    assertAcked(indicesAdmin().prepareAliases().removeAlias(indexResponse.indices()[0], Watch.INDEX));
                 } else {
-                    assertAcked(client().admin().indices().prepareDelete(Watch.INDEX));
+                    assertAcked(indicesAdmin().prepareDelete(Watch.INDEX));
                 }
             } catch (IndexNotFoundException e) {}
         }

--- a/x-pack/plugin/write-load-forecaster/src/internalClusterTest/java/org/elasticsearch/xpack/writeloadforecaster/WriteLoadForecasterIT.java
+++ b/x-pack/plugin/write-load-forecaster/src/internalClusterTest/java/org/elasticsearch/xpack/writeloadforecaster/WriteLoadForecasterIT.java
@@ -179,7 +179,7 @@ public class WriteLoadForecasterIT extends ESIntegTestCase {
                 final ClusterState clusterState = internalCluster().getCurrentMasterNodeInstance(ClusterService.class).state();
                 final DataStream dataStream = clusterState.getMetadata().dataStreams().get(dataStreamName);
                 final String writeIndex = dataStream.getWriteIndex().getName();
-                final IndicesStatsResponse indicesStatsResponse = client().admin().indices().prepareStats(writeIndex).get();
+                final IndicesStatsResponse indicesStatsResponse = indicesAdmin().prepareStats(writeIndex).get();
                 for (IndexShardStats indexShardStats : indicesStatsResponse.getIndex(writeIndex).getIndexShards().values()) {
                     for (ShardStats shard : indexShardStats.getShards()) {
                         final IndexingStats.Stats shardIndexingStats = shard.getStats().getIndexing().getTotal();
@@ -190,7 +190,7 @@ public class WriteLoadForecasterIT extends ESIntegTestCase {
                 }
             });
 
-            assertAcked(client().admin().indices().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
+            assertAcked(indicesAdmin().rolloverIndex(new RolloverRequest(dataStreamName, null)).actionGet());
         }
     }
 


### PR DESCRIPTION
Replacing the remaining usages that I could automatically replace and a couple that I did by hand in this PR.
Also, added the same shortcut to the single node tests to save some duplication there.
