### PR TITLE
Fix time-series geo_line to include reduce phase in MergedGeoLines

### DIFF
--- a/docs/changelog/96953.yaml
+++ b/docs/changelog/96953.yaml
@@ -1,0 +1,5 @@
+pr: 96953
+summary: Support time-series (simplify) version of `MergedGeoLines`
+area: Geo
+type: enhancement
+issues: []

--- a/docs/changelog/96953.yaml
+++ b/docs/changelog/96953.yaml
@@ -1,5 +1,6 @@
 pr: 96953
-summary: Support time-series (simplify) version of `MergedGeoLines`
+summary: Fix time-series geo_line to include reduce phase in MergedGeoLines
 area: Geo
-type: enhancement
-issues: []
+type: bug
+issues:
+  - 96983

--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -146,8 +146,10 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     // 8.10.0
     public static final TransportVersion V_8_500_019 = registerTransportVersion(8_500_019, "09bae57f-cab8-423c-aab3-c9778509ffe3");
 
+    public static final TransportVersion V_8_500_020 = registerTransportVersion(8_500_020, "ECB42C26-B258-42E5-A835-E31AF84A76DE");
+
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_019);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_020);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregator.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregator.java
@@ -61,7 +61,7 @@ abstract class GeoLineAggregator extends MetricsAggregator {
 
     @Override
     public InternalAggregation buildEmptyAggregation() {
-        return new InternalGeoLine(name, new long[0], new double[0], metadata(), true, includeSorts, sortOrder, size);
+        return new InternalGeoLine(name, new long[0], new double[0], metadata(), true, includeSorts, sortOrder, size, true, false);
     }
 
     static class Empty extends GeoLineAggregator {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineBucketedSort.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineBucketedSort.java
@@ -68,7 +68,7 @@ class GeoLineBucketedSort extends BucketedSort.ForDoubles {
         double[] sortVals = getSortValues(bucket);
         long[] bucketLine = getPoints(bucket);
         PathArraySorter.forOrder(sortOrder).apply(bucketLine, sortVals).sort();
-        return new InternalGeoLine(name, bucketLine, sortVals, metadata, complete, includeSorts, sortOrder, size);
+        return new InternalGeoLine(name, bucketLine, sortVals, metadata, complete, includeSorts, sortOrder, size, false, false);
     }
 
     long sizeOf(long bucket) {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLine.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLine.java
@@ -7,6 +7,7 @@
 package org.elasticsearch.xpack.spatial.search.aggregations;
 
 import org.apache.lucene.geo.GeoEncodingUtils;
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
@@ -30,12 +31,14 @@ import java.util.Objects;
 public class InternalGeoLine extends InternalAggregation implements GeoShapeMetricAggregation {
     private static final double SCALE = Math.pow(10, 6);
 
-    private long[] line;
-    private double[] sortVals;
-    private boolean complete;
-    private boolean includeSorts;
-    private SortOrder sortOrder;
-    private int size;
+    private final long[] line;
+    private final double[] sortVals;
+    private final boolean complete;
+    private final boolean includeSorts;
+    private final SortOrder sortOrder;
+    private final int size;
+    private final boolean nonOverlapping;
+    private final boolean simplified;
 
     /**
      * A geo_line representing the bucket for a {@link GeoLineAggregationBuilder}. The values of <code>line</code> and <code>sortVals</code>
@@ -49,6 +52,8 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
      * @param includeSorts    true iff the sort-values should be rendered in xContent as properties of the line-string. False otherwise.
      * @param sortOrder       the {@link SortOrder} for the line. Whether the points are to be plotted in asc or desc order
      * @param size            the max length of the line-string.
+     * @param nonOverlapping  true iff the geo_line will not overlap with other geo_lines at reduce phase, allowing a simpler reduce.
+     * @param simplified      true iff the geo_line was created by line simplification (not truncation) so we should do so in reduce also.
      */
     InternalGeoLine(
         String name,
@@ -58,7 +63,9 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
         boolean complete,
         boolean includeSorts,
         SortOrder sortOrder,
-        int size
+        int size,
+        boolean nonOverlapping,
+        boolean simplified
     ) {
         super(name, metadata);
         this.line = line;
@@ -67,6 +74,8 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
         this.includeSorts = includeSorts;
         this.sortOrder = sortOrder;
         this.size = size;
+        this.nonOverlapping = nonOverlapping;
+        this.simplified = simplified;
     }
 
     /**
@@ -80,6 +89,13 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
         this.includeSorts = in.readBoolean();
         this.sortOrder = SortOrder.readFromStream(in);
         this.size = in.readVInt();
+        if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_020)) {
+            nonOverlapping = in.readBoolean();
+            simplified = in.readBoolean();
+        } else {
+            nonOverlapping = false;
+            simplified = false;
+        }
     }
 
     @Override
@@ -90,6 +106,10 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
         out.writeBoolean(includeSorts);
         sortOrder.writeTo(out);
         out.writeVInt(size);
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_020)) {
+            out.writeBoolean(nonOverlapping);
+            out.writeBoolean(simplified);
+        }
     }
 
     @Override
@@ -108,7 +128,9 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
         reducedComplete &= mergedSize <= size;
         int finalSize = Math.min(mergedSize, size);
 
-        MergedGeoLines mergedGeoLines = new MergedGeoLines(internalGeoLines, finalSize, sortOrder);
+        MergedGeoLines mergedGeoLines = nonOverlapping
+            ? new MergedGeoLines.NonOverlapping(internalGeoLines, finalSize, sortOrder, simplified)
+            : new MergedGeoLines.Overlapping(internalGeoLines, finalSize, sortOrder, simplified);
         mergedGeoLines.merge();
         return new InternalGeoLine(
             name,
@@ -118,7 +140,9 @@ public class InternalGeoLine extends InternalAggregation implements GeoShapeMetr
             reducedComplete,
             reducedIncludeSorts,
             sortOrder,
-            size
+            size,
+            nonOverlapping,
+            simplified
         );
     }
 

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/MergedGeoLines.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/MergedGeoLines.java
@@ -6,32 +6,31 @@
  */
 package org.elasticsearch.xpack.spatial.search.aggregations;
 
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.search.sort.SortOrder;
 
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
 
 /**
  * Class to merge an arbitrary list of {@link InternalGeoLine} lines into a new line
  * with the appropriate max length. The final point and sort values can be found in
  * finalPoints and finalSortValues after merge is called.
  */
-final class MergedGeoLines {
+abstract class MergedGeoLines {
 
-    private final List<InternalGeoLine> geoLines;
-    private final int capacity;
-    private final SortOrder sortOrder;
-    private final int[] lineIndices; // index of which geoLine item represents
-    private final int[] idxsWithinLine; // index within the geoLine for the item
-    private int size;
-    private final long[] finalPoints;       // the final sorted list of points, sorted by their respective sort-values. valid after merge
-    private final double[] finalSortValues; // the final sorted list of sort-values. valid after merge.
+    protected final List<InternalGeoLine> geoLines;
+    protected final SortOrder sortOrder;
+    protected final boolean simplify;
+    protected int size;
+    protected final long[] finalPoints;       // the final sorted list of points, sorted by their respective sort-values. valid after merge
+    protected final double[] finalSortValues; // the final sorted list of sort-values. valid after merge.
 
-    MergedGeoLines(List<InternalGeoLine> geoLines, int finalLength, SortOrder sortOrder) {
+    private MergedGeoLines(List<InternalGeoLine> geoLines, int finalLength, SortOrder sortOrder, boolean simplify) {
         this.geoLines = geoLines;
-        this.capacity = geoLines.size();
         this.sortOrder = sortOrder;
-        this.lineIndices = new int[capacity];
-        this.idxsWithinLine = new int[capacity];
+        this.simplify = simplify;
         this.size = 0;
         this.finalPoints = new long[finalLength];
         this.finalSortValues = new double[finalLength];
@@ -45,131 +44,220 @@ final class MergedGeoLines {
         return finalSortValues;
     }
 
+    public abstract void merge();
+
     /**
-     * merges <code>geoLines</code> into one sorted list of values representing the combined line.
+     * This version does not assume all InternalGeoLines passed into the class are not overlapping
+     * and as such we need to perform a merge-sort. It does not support the simplification flag and will throw
+     * and error in that case.
      */
-    public void merge() {
-        // 1. add first element of each sub line to heap
-        for (int i = 0; i < geoLines.size(); i++) {
-            if (geoLines.get(i).length() > 0) {
-                add(i, 0);
+    static final class Overlapping extends MergedGeoLines {
+        private final int capacity;
+        private final int[] lineIndices; // index of which geoLine item represents
+        private final int[] idxsWithinLine; // index within the geoLine for the item
+
+        Overlapping(List<InternalGeoLine> geoLines, int finalLength, SortOrder sortOrder, boolean simplify) {
+            super(geoLines, finalLength, sortOrder, simplify);
+            if (simplify) {
+                throw new IllegalArgumentException("Unsupported option - simplification of overlapping geo_lines during reduce phase");
+            }
+            this.capacity = geoLines.size();
+            this.lineIndices = new int[capacity];
+            this.idxsWithinLine = new int[capacity];
+        }
+
+        /**
+         * merges <code>geoLines</code> into one sorted list of values representing the combined line.
+         */
+        @Override
+        public void merge() {
+            // 1. add first element of each sub line to heap
+            for (int i = 0; i < geoLines.size(); i++) {
+                if (geoLines.get(i).length() > 0) {
+                    add(i, 0);
+                }
+            }
+
+            // 2. take lowest/greatest value from heap and re-insert the next value from the same sub-line that specific value was chosen
+            // from.
+
+            int i = 0;
+            while (i < finalPoints.length && size > 0) {
+                // take top from heap and place in finalLists
+                int lineIdx = lineIndices[0];
+                int idxInLine = idxsWithinLine[0];
+                finalPoints[i] = getTopPoint();
+                finalSortValues[i] = getTopSortValue();
+                removeTop();
+                InternalGeoLine lineChosen = geoLines.get(lineIdx);
+                if (idxInLine + 1 < lineChosen.length()) {
+                    add(lineIdx, idxInLine + 1);
+                }
+                i++;
             }
         }
 
-        // 2. take lowest/greatest value from heap and re-insert the next value from the same sub-line that specific value was chosen from.
+        private long getTopPoint() {
+            InternalGeoLine line = geoLines.get(lineIndices[0]);
+            return line.line()[idxsWithinLine[0]];
+        }
 
-        int i = 0;
-        while (i < finalPoints.length && size > 0) {
-            // take top from heap and place in finalLists
-            int lineIdx = lineIndices[0];
-            int idxInLine = idxsWithinLine[0];
-            finalPoints[i] = getTopPoint();
-            finalSortValues[i] = getTopSortValue();
-            removeTop();
-            InternalGeoLine lineChosen = geoLines.get(lineIdx);
-            if (idxInLine + 1 < lineChosen.length()) {
-                add(lineIdx, idxInLine + 1);
+        private double getTopSortValue() {
+            InternalGeoLine line = geoLines.get(lineIndices[0]);
+            return line.sortVals()[idxsWithinLine[0]];
+        }
+
+        private void removeTop() {
+            if (size == 0) {
+                throw new IllegalStateException();
             }
-            i++;
+            lineIndices[0] = lineIndices[size - 1];
+            idxsWithinLine[0] = idxsWithinLine[size - 1];
+            size--;
+            heapifyDown();
         }
-    }
 
-    private long getTopPoint() {
-        InternalGeoLine line = geoLines.get(lineIndices[0]);
-        return line.line()[idxsWithinLine[0]];
-    }
-
-    private double getTopSortValue() {
-        InternalGeoLine line = geoLines.get(lineIndices[0]);
-        return line.sortVals()[idxsWithinLine[0]];
-    }
-
-    private void removeTop() {
-        if (size == 0) {
-            throw new IllegalStateException();
-        }
-        lineIndices[0] = lineIndices[size - 1];
-        idxsWithinLine[0] = idxsWithinLine[size - 1];
-        size--;
-        heapifyDown();
-    }
-
-    private void add(int lineIndex, int idxWithinLine) {
-        if (size >= capacity) {
-            throw new IllegalStateException();
-        }
-        lineIndices[size] = lineIndex;
-        idxsWithinLine[size] = idxWithinLine;
-        size++;
-        heapifyUp();
-    }
-
-    private boolean correctOrdering(int i, int j) {
-        InternalGeoLine lineI = geoLines.get(lineIndices[i]);
-        InternalGeoLine lineJ = geoLines.get(lineIndices[j]);
-        double valI = lineI.sortVals()[idxsWithinLine[i]];
-        double valJ = lineJ.sortVals()[idxsWithinLine[j]];
-        if (SortOrder.ASC.equals(sortOrder)) {
-            return valI > valJ;
-        }
-        return valI < valJ;
-    }
-
-    private int getParentIndex(int i) {
-        return (i - 1) / 2;
-    }
-
-    private int getLeftChildIndex(int i) {
-        return 2 * i + 1;
-    }
-
-    private int getRightChildIndex(int i) {
-        return 2 * i + 2;
-    }
-
-    private boolean hasParent(int i) {
-        return i > 0;
-    }
-
-    private boolean hasLeftChild(int i) {
-        return getLeftChildIndex(i) < size;
-    }
-
-    private boolean hasRightChild(int i) {
-        return getRightChildIndex(i) < size;
-    }
-
-    private void heapifyUp() {
-        int i = size - 1;
-        while (hasParent(i) && correctOrdering(getParentIndex(i), i)) {
-            int parentIndex = getParentIndex(i);
-            swap(parentIndex, i);
-            i = parentIndex;
-        }
-    }
-
-    private void heapifyDown() {
-        int i = 0;
-        while (hasLeftChild(i)) {
-            int childIndex = getLeftChildIndex(i);
-            if (hasRightChild(i) && correctOrdering(getRightChildIndex(i), childIndex) == false) {
-                childIndex = getRightChildIndex(i);
+        private void add(int lineIndex, int idxWithinLine) {
+            if (size >= capacity) {
+                throw new IllegalStateException();
             }
-            if (correctOrdering(childIndex, i)) {
-                break;
+            lineIndices[size] = lineIndex;
+            idxsWithinLine[size] = idxWithinLine;
+            size++;
+            heapifyUp();
+        }
+
+        private boolean correctOrdering(int i, int j) {
+            InternalGeoLine lineI = geoLines.get(lineIndices[i]);
+            InternalGeoLine lineJ = geoLines.get(lineIndices[j]);
+            double valI = lineI.sortVals()[idxsWithinLine[i]];
+            double valJ = lineJ.sortVals()[idxsWithinLine[j]];
+            if (SortOrder.ASC.equals(sortOrder)) {
+                return valI > valJ;
+            }
+            return valI < valJ;
+        }
+
+        private int getParentIndex(int i) {
+            return (i - 1) / 2;
+        }
+
+        private int getLeftChildIndex(int i) {
+            return 2 * i + 1;
+        }
+
+        private int getRightChildIndex(int i) {
+            return 2 * i + 2;
+        }
+
+        private boolean hasParent(int i) {
+            return i > 0;
+        }
+
+        private boolean hasLeftChild(int i) {
+            return getLeftChildIndex(i) < size;
+        }
+
+        private boolean hasRightChild(int i) {
+            return getRightChildIndex(i) < size;
+        }
+
+        private void heapifyUp() {
+            int i = size - 1;
+            while (hasParent(i) && correctOrdering(getParentIndex(i), i)) {
+                int parentIndex = getParentIndex(i);
+                swap(parentIndex, i);
+                i = parentIndex;
+            }
+        }
+
+        private void heapifyDown() {
+            int i = 0;
+            while (hasLeftChild(i)) {
+                int childIndex = getLeftChildIndex(i);
+                if (hasRightChild(i) && correctOrdering(getRightChildIndex(i), childIndex) == false) {
+                    childIndex = getRightChildIndex(i);
+                }
+                if (correctOrdering(childIndex, i)) {
+                    break;
+                } else {
+                    swap(childIndex, i);
+                    i = childIndex;
+                }
+            }
+        }
+
+        private void swap(int i, int j) {
+            int tmpLineIndex = lineIndices[i];
+            int tmpIdxWithinLine = idxsWithinLine[i];
+            lineIndices[i] = lineIndices[j];
+            idxsWithinLine[i] = idxsWithinLine[j];
+            lineIndices[j] = tmpLineIndex;
+            idxsWithinLine[j] = tmpIdxWithinLine;
+        }
+    }
+
+    /**
+     * This version assumes all InternalGeoLines passed into the class are not overlapping
+     * and as such we do not need to perform a merge-sort, and instead can simply concatenate ordered lines.
+     * The final result is either truncated or simplified based on the simplify parameter.
+     */
+    static final class NonOverlapping extends MergedGeoLines {
+
+        NonOverlapping(List<InternalGeoLine> geoLines, int finalLength, SortOrder sortOrder, boolean simplify) {
+            super(geoLines, finalLength, sortOrder, simplify);
+        }
+
+        /**
+         * merges <code>geoLines</code> into one sorted list of values representing the combined line.
+         */
+        @Override
+        public void merge() {
+            TreeSet<InternalGeoLine> sorted = switch (sortOrder) {
+                case DESC -> new TreeSet<>((o1, o2) -> Double.compare(o2.sortVals()[0], o1.sortVals()[0]));
+                default -> new TreeSet<>(Comparator.comparingDouble(o -> o.sortVals()[0]));
+            };
+            sorted.addAll(geoLines);
+            if (simplify) {
+                mergeAndSimplify(sorted);
             } else {
-                swap(childIndex, i);
-                i = childIndex;
+                mergeAndTruncate(sorted);
             }
         }
-    }
 
-    private void swap(int i, int j) {
-        int tmpLineIndex = lineIndices[i];
-        int tmpIdxWithinLine = idxsWithinLine[i];
-        lineIndices[i] = lineIndices[j];
-        idxsWithinLine[i] = idxsWithinLine[j];
-        lineIndices[j] = tmpLineIndex;
-        idxsWithinLine[j] = tmpIdxWithinLine;
+        private void mergeAndSimplify(TreeSet<InternalGeoLine> sorted) {
+            TimeSeriesGeoLineBuckets.Simplifier simplifier = new TimeSeriesGeoLineBuckets.Simplifier(this.finalSortValues.length, v -> v);
+            int index = 0;
+            for (InternalGeoLine geoLine : sorted) {
+                double[] values = geoLine.sortVals();
+                long[] points = geoLine.line();
+                for (int i = 0; i < values.length; i++) {
+                    double x = GeoEncodingUtils.decodeLongitude((int) (points[i] >>> 32));
+                    double y = GeoEncodingUtils.decodeLatitude((int) (points[i] & 0xffffffffL));
+                    var point = new TimeSeriesGeoLineBuckets.SimplifiablePoint(index, x, y, values[i]);
+                    simplifier.consume(point);
+                    index++;
+                }
+            }
+            TimeSeriesGeoLineBuckets.LineStream simplified = simplifier.produce();
+            for (size = 0; size < simplified.sortValues.length; size++) {
+                finalSortValues[size] = simplified.sortValues[size];
+                finalPoints[size] = simplified.encodedPoints[size];
+            }
+        }
+
+        private void mergeAndTruncate(TreeSet<InternalGeoLine> sorted) {
+            for (InternalGeoLine geoLine : sorted) {
+                int doc = 0;
+                double[] values = geoLine.sortVals();
+                long[] points = geoLine.line();
+                while (size < finalPoints.length && doc < geoLine.length()) {
+                    finalPoints[size] = points[doc];
+                    finalSortValues[size] = values[doc];
+                    size++;
+                    doc++;
+                }
+            }
+        }
     }
 }

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/MergedGeoLines.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/MergedGeoLines.java
@@ -217,7 +217,12 @@ abstract class MergedGeoLines {
                 case DESC -> new TreeSet<>((o1, o2) -> Double.compare(o2.sortVals()[0], o1.sortVals()[0]));
                 default -> new TreeSet<>(Comparator.comparingDouble(o -> o.sortVals()[0]));
             };
-            sorted.addAll(geoLines);
+            // The Comparator above relies on each line having at least one point, so filter out empty geo_lines
+            for (InternalGeoLine line : geoLines) {
+                if (line.length() > 0) {
+                    sorted.add(line);
+                }
+            }
             if (simplify) {
                 mergeAndSimplify(sorted);
             } else {

--- a/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/TimeSeriesGeoLineBuckets.java
+++ b/x-pack/plugin/spatial/src/main/java/org/elasticsearch/xpack/spatial/search/aggregations/TimeSeriesGeoLineBuckets.java
@@ -134,7 +134,7 @@ class TimeSeriesGeoLineBuckets implements Releasable {
             ArrayUtils.reverseSubArray(sortVals, 0, sortVals.length);
             ArrayUtils.reverseSubArray(bucketLine, 0, bucketLine.length);
         }
-        return new InternalGeoLine(name, bucketLine, sortVals, metadata, complete, includeSorts, sortOrder, bucketSize);
+        return new InternalGeoLine(name, bucketLine, sortVals, metadata, complete, includeSorts, sortOrder, bucketSize, true, true);
     }
 
     /**
@@ -152,11 +152,11 @@ class TimeSeriesGeoLineBuckets implements Releasable {
      * Since that library has no knowledge of timestamps or sort-fields, we need to use these custom objects
      * to maintain the geo_point-timestamp correlation through the simplification process.
      */
-    private static class SimplifiablePoint extends StreamingGeometrySimplifier.PointError {
+    static class SimplifiablePoint extends StreamingGeometrySimplifier.PointError {
         private double sortValue;
         private long encoded;
 
-        private SimplifiablePoint(int index, double x, double y, double sortValue) {
+        SimplifiablePoint(int index, double x, double y, double sortValue) {
             super(index, x, y);
             this.sortValue = sortValue;
             setEncoded(x, y);
@@ -183,9 +183,9 @@ class TimeSeriesGeoLineBuckets implements Releasable {
      * length of the geo_line, which could be much shorter. This class allocates the two arrays used internally in
      * the InternalGeoLine aggregation object, and copies the reusable memory into these arrays.
      */
-    private static class LineStream implements Geometry {
-        private final long[] encodedPoints;
-        private final double[] sortValues;
+    static class LineStream implements Geometry {
+        final long[] encodedPoints;
+        final double[] sortValues;
 
         private LineStream(int length, StreamingGeometrySimplifier.PointError[] points) {
             this.encodedPoints = new long[length];

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/GeoLineAggregatorTests.java
@@ -243,7 +243,7 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
         double[] lineSorts = Arrays.copyOf(sortValues, lineSize);
         PathArraySorter.forOrder(SortOrder.ASC).apply(linePoints, lineSorts).sort();
 
-        lines.put(groupOrd, new InternalGeoLine("track", linePoints, lineSorts, null, complete, true, SortOrder.ASC, size));
+        lines.put(groupOrd, new InternalGeoLine("track", linePoints, lineSorts, null, complete, true, SortOrder.ASC, size, false, false));
 
         testCase(aggregationBuilder, iw -> {
             for (int i = 0; i < points.length; i++) {
@@ -518,11 +518,11 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
      * Wrapper for points and sort fields that is also usable in the GeometrySimplifier library,
      * allowing us to track which points will survive geometry simplification during geo_line aggregations.
      */
-    private static class TestSimplifiablePoint extends StreamingGeometrySimplifier.PointError {
+    static class TestSimplifiablePoint extends StreamingGeometrySimplifier.PointError {
         private final double sortField;
         private final long encoded;
 
-        private TestSimplifiablePoint(int index, double x, double y, double sortField) {
+        TestSimplifiablePoint(int index, double x, double y, double sortField) {
             super(index, quantizeX(x), quantizeY(y));
             this.sortField = sortField;
             this.encoded = encode(x(), y());
@@ -554,9 +554,9 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
     }
 
     /** Allow test to use own objects for internal use in geometry simplifier, so we can track the sort-fields together with the points */
-    private static class TestLine implements Geometry {
-        private final long[] encodedPoints;
-        private final double[] sortValues;
+    static class TestLine implements Geometry {
+        final long[] encodedPoints;
+        final double[] sortValues;
 
         private TestLine(int length, StreamingGeometrySimplifier.PointError[] points) {
             this.encodedPoints = new long[length];
@@ -596,9 +596,9 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
         }
     }
 
-    private static class TestGeometrySimplifierMonitor implements StreamingGeometrySimplifier.Monitor {
-        private int addedCount;
-        private int removedCount;
+    static class TestGeometrySimplifierMonitor implements StreamingGeometrySimplifier.Monitor {
+        int addedCount;
+        int removedCount;
 
         public void reset() {
             addedCount = 0;
@@ -631,8 +631,8 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
     }
 
     /** Wrapping the Streaming GeometrySimplifier allowing the test to extract expected points and their sort fields after simplification */
-    private static class TestGeometrySimplifier extends StreamingGeometrySimplifier<TestLine> {
-        private TestGeometrySimplifier(int maxPoints, TestGeometrySimplifierMonitor monitor) {
+    static class TestGeometrySimplifier extends StreamingGeometrySimplifier<TestLine> {
+        TestGeometrySimplifier(int maxPoints, TestGeometrySimplifierMonitor monitor) {
             super("TestGeometrySimplifier", maxPoints, SimplificationErrorCalculator.TRIANGLE_AREA, monitor);
         }
 
@@ -865,7 +865,10 @@ public class GeoLineAggregatorTests extends AggregatorTestCase {
             }
             PathArraySorter.forOrder(sortOrder).apply(linePoints, lineSorts).sort();
 
-            lines.put(String.valueOf(groupOrd), new InternalGeoLine("track", linePoints, lineSorts, null, complete, true, sortOrder, size));
+            lines.put(
+                String.valueOf(groupOrd),
+                new InternalGeoLine("track", linePoints, lineSorts, null, complete, true, sortOrder, size, false, false)
+            );
 
             for (int i = 0; i < randomIntBetween(1, numPoints); i++) {
                 int idx1 = randomIntBetween(0, numPoints - 1);

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/InternalGeoLineTests.java
@@ -53,7 +53,7 @@ public class InternalGeoLineTests extends InternalAggregationTestCase<InternalGe
             }
         }
         boolean complete = length <= size;
-        return new InternalGeoLine(name, points, sortVals, metadata, complete, randomBoolean(), sortOrder, size);
+        return new InternalGeoLine(name, points, sortVals, metadata, complete, randomBoolean(), sortOrder, size, false, false);
     }
 
     @Override
@@ -90,7 +90,7 @@ public class InternalGeoLineTests extends InternalAggregationTestCase<InternalGe
             case 7 -> size = size + 1;
             default -> throw new AssertionError("Illegal randomisation branch");
         }
-        return new InternalGeoLine(name, line, sortVals, metadata, complete, includeSorts, sortOrder, size);
+        return new InternalGeoLine(name, line, sortVals, metadata, complete, includeSorts, sortOrder, size, false, false);
     }
 
     @Override

--- a/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/MergedGeoLinesTests.java
+++ b/x-pack/plugin/spatial/src/test/java/org/elasticsearch/xpack/spatial/search/aggregations/MergedGeoLinesTests.java
@@ -6,17 +6,24 @@
  */
 package org.elasticsearch.xpack.spatial.search.aggregations;
 
+import org.apache.lucene.geo.GeoEncodingUtils;
 import org.elasticsearch.search.sort.SortOrder;
 import org.elasticsearch.test.ESTestCase;
+import org.hamcrest.CoreMatchers;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
+import java.util.TreeSet;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.lessThan;
 
 public class MergedGeoLinesTests extends ESTestCase {
 
-    public InternalGeoLine randomLine(SortOrder sortOrder, int maxLength, double magicDecimal) {
+    private InternalGeoLine randomLine(SortOrder sortOrder, int maxLength, double magicDecimal) {
         String name = randomAlphaOfLength(5);
         int length = randomBoolean() ? maxLength : randomIntBetween(1, maxLength);
         boolean complete = length <= maxLength;
@@ -26,7 +33,18 @@ public class MergedGeoLinesTests extends ESTestCase {
             points[i] = randomIntBetween(1, 100);
             sortValues[i] = i + magicDecimal;
         }
-        return new InternalGeoLine(name, points, sortValues, Collections.emptyMap(), complete, randomBoolean(), sortOrder, maxLength);
+        return new InternalGeoLine(
+            name,
+            points,
+            sortValues,
+            Collections.emptyMap(),
+            complete,
+            randomBoolean(),
+            sortOrder,
+            maxLength,
+            false,
+            false
+        );
     }
 
     public void testSimpleMerge() {
@@ -40,7 +58,7 @@ public class MergedGeoLinesTests extends ESTestCase {
             finalLength += geoLines.get(i).length();
         }
         finalLength = Math.min(maxLength, finalLength);
-        MergedGeoLines mergedGeoLines = new MergedGeoLines(geoLines, finalLength, sortOrder);
+        MergedGeoLines mergedGeoLines = new MergedGeoLines.Overlapping(geoLines, finalLength, sortOrder, false);
         mergedGeoLines.merge();
 
         // assert that the mergedGeoLines are sorted (does not necessarily validate correctness, but it is a good heuristic)
@@ -63,10 +81,12 @@ public class MergedGeoLinesTests extends ESTestCase {
             true,
             randomBoolean(),
             sortOrder,
-            maxLength
+            maxLength,
+            false,
+            false
         );
         List<InternalGeoLine> geoLines = List.of(lineWithPoints, emptyLine);
-        MergedGeoLines mergedGeoLines = new MergedGeoLines(geoLines, lineWithPoints.length(), sortOrder);
+        MergedGeoLines mergedGeoLines = new MergedGeoLines.Overlapping(geoLines, lineWithPoints.length(), sortOrder, false);
         mergedGeoLines.merge();
 
         // assert that the mergedGeoLines are sorted (does not necessarily validate correctness, but it is a good heuristic)
@@ -76,4 +96,146 @@ public class MergedGeoLinesTests extends ESTestCase {
         assertArrayEquals(sortedValues, mergedGeoLines.getFinalSortValues(), 0d);
         assertArrayEquals(sortedPoints, mergedGeoLines.getFinalPoints());
     }
+
+    public void testMergeNonOverlappingGeoLinesAppendOnly() {
+        int docsPerLine = 10;
+        int numLines = 10;
+        int finalLength = docsPerLine * numLines; // all docs included, only append, no truncation
+        for (SortOrder sortOrder : new SortOrder[] { SortOrder.ASC }) {
+            boolean simplify = randomBoolean();
+            List<InternalGeoLine> lines = makeGeoLines(docsPerLine, numLines, simplify, sortOrder);
+            MergedGeoLines mergedGeoLines = new MergedGeoLines.NonOverlapping(lines, finalLength, sortOrder, simplify);
+            mergedGeoLines.merge();
+            assertLinesTruncated(lines, docsPerLine, finalLength, mergedGeoLines);
+        }
+    }
+
+    public void testMergeNonOverlappingGeoLinesAppendAndTruncate() {
+        int docsPerLine = 10;
+        int numLines = 10;
+        int finalLength = 25;  // should get two and a half geolines appended and truncated
+        boolean simplify = false;
+        List<InternalGeoLine> lines = makeGeoLines(docsPerLine, numLines, simplify, SortOrder.ASC);
+        MergedGeoLines mergedGeoLines = new MergedGeoLines.NonOverlapping(lines, finalLength, SortOrder.ASC, simplify);
+        mergedGeoLines.merge();
+        assertLinesTruncated(lines, docsPerLine, finalLength, mergedGeoLines);
+    }
+
+    public void testMergeNonOverlappingGeoLinesAppendAndSimplify() {
+        int docsPerLine = 10;
+        int numLines = 10;
+        int finalLength = 25;  // should get entire 100 points simplified down to 25
+        boolean simplify = true;
+        List<InternalGeoLine> lines = makeGeoLines(docsPerLine, numLines, simplify, SortOrder.ASC);
+        MergedGeoLines mergedGeoLines = new MergedGeoLines.NonOverlapping(lines, finalLength, SortOrder.ASC, simplify);
+        mergedGeoLines.merge();
+        assertLinesSimplified(lines, SortOrder.ASC, finalLength, mergedGeoLines);
+    }
+
+    private void assertLinesTruncated(List<InternalGeoLine> lines, int docsPerLine, int finalLength, MergedGeoLines mergedGeoLines) {
+        double[] values = mergedGeoLines.getFinalSortValues();
+        long[] points = mergedGeoLines.getFinalPoints();
+        assertThat("Same length arrays", values.length, equalTo(points.length));
+        assertThat("Geoline is truncated", values.length, equalTo(finalLength));
+        for (int i = 0; i < values.length; i++) {
+            int doc = i % docsPerLine;
+            int line = i / docsPerLine;
+            InternalGeoLine original = lines.get(line);
+            long[] originalPoints = original.line();
+            double[] originalValues = original.sortVals();
+            assertThat("Point at " + i + " same as point at (" + line + ":" + doc + ")", originalPoints[doc], equalTo(points[i]));
+            assertThat("Value at " + i + " same as value at (" + line + ":" + doc + ")", originalValues[doc], equalTo(values[i]));
+        }
+    }
+
+    private void assertLinesSimplified(List<InternalGeoLine> lines, SortOrder sortOrder, int finalLength, MergedGeoLines mergedGeoLines) {
+        double[] values = mergedGeoLines.getFinalSortValues();
+        long[] points = mergedGeoLines.getFinalPoints();
+        assertThat("Same length arrays", values.length, equalTo(points.length));
+        assertThat("Geo-line is simplified", values.length, equalTo(finalLength));
+        GeoLineAggregatorTests.TestLine simplified = makeSimplifiedLine(lines, sortOrder, finalLength);
+        assertThat("Geo-line is simplified to correct length", values.length, equalTo(simplified.sortValues.length));
+        for (int i = 0; i < values.length; i++) {
+            assertThat("Point at " + i, simplified.encodedPoints[i], equalTo(points[i]));
+            assertThat("Value at " + i, simplified.sortValues[i], equalTo(values[i]));
+        }
+    }
+
+    private GeoLineAggregatorTests.TestLine makeSimplifiedLine(List<InternalGeoLine> geoLines, SortOrder sortOrder, int finalLength) {
+        TreeSet<InternalGeoLine> sorted = switch (sortOrder) {
+            case DESC -> new TreeSet<>((o1, o2) -> Double.compare(o2.sortVals()[0], o1.sortVals()[0]));
+            default -> new TreeSet<>(Comparator.comparingDouble(o -> o.sortVals()[0]));
+        };
+        sorted.addAll(geoLines);
+        GeoLineAggregatorTests.TestGeometrySimplifierMonitor monitor = new GeoLineAggregatorTests.TestGeometrySimplifierMonitor();
+        var simplifier = new GeoLineAggregatorTests.TestGeometrySimplifier(finalLength, monitor);
+        int index = 0;
+        for (InternalGeoLine geoLine : sorted) {
+            double[] values = geoLine.sortVals();
+            long[] points = geoLine.line();
+            for (int i = 0; i < values.length; i++) {
+                double x = GeoEncodingUtils.decodeLongitude((int) (points[i] >>> 32));
+                double y = GeoEncodingUtils.decodeLatitude((int) (points[i] & 0xffffffffL));
+                var point = new GeoLineAggregatorTests.TestSimplifiablePoint(index, x, y, values[i]);
+                simplifier.consume(point);
+                index++;
+            }
+        }
+        assertThat("Simplifier added points", monitor.addedCount, CoreMatchers.equalTo(index));
+        assertThat("Simplifier Removed points", monitor.removedCount, CoreMatchers.equalTo(index - finalLength));
+        return simplifier.produce();
+    }
+
+    private List<InternalGeoLine> makeGeoLines(int docsPerLine, int numLines, boolean simplify, SortOrder sortOrder) {
+        ArrayList<InternalGeoLine> lines = new ArrayList<>();
+        NonOverlappingConfig lineConfig = new NonOverlappingConfig(docsPerLine, -50, -50, 1, 1, 1000, 10);
+        while (lines.size() < numLines) {
+            lines.add(lineConfig.makeGeoLine("test", sortOrder, simplify));
+            lineConfig = lineConfig.nextNonOverlapping();
+        }
+        for (int line = 1; line < lines.size(); line++) {
+            InternalGeoLine previous = lines.get(line - 1);
+            InternalGeoLine current = lines.get(line);
+            double[] pv = previous.sortVals();
+            double[] cv = current.sortVals();
+            assertThat("Previous line ordered", pv[0], lessThan(pv[pv.length - 1]));
+            assertThat("Current line ordered", cv[0], lessThan(cv[cv.length - 1]));
+            assertThat("Lines non-overlapping", pv[pv.length - 1], lessThan(cv[0]));
+        }
+        return lines;
+    }
+
+    private record NonOverlappingConfig(int docs, double startX, double startY, double dX, double dY, double startValue, double dV) {
+        private NonOverlappingConfig withStartPosition(double startX, double startY, double startValue) {
+            return new NonOverlappingConfig(docs, startX, startY, dX, dY, startValue, dV);
+        }
+
+        private NonOverlappingConfig nextNonOverlapping() {
+            return withStartPosition(startX + docs * dX, startY + docs * dY, startValue + docs * dV);
+        }
+
+        private InternalGeoLine makeGeoLine(String name, SortOrder sortOrder, boolean simplified) {
+            double[] values = new double[docs];
+            long[] points = new long[docs];
+            for (int i = 0; i < points.length; i++) {
+                double x = startX + i * dX;
+                double y = startY + i * dY;
+                points[i] = (((long) GeoEncodingUtils.encodeLongitude(x)) << 32) | GeoEncodingUtils.encodeLatitude(y) & 0xffffffffL;
+                values[i] = startValue + i * dV;
+            }
+            return new InternalGeoLine(
+                name,
+                points,
+                values,
+                Collections.emptyMap(),
+                randomBoolean(),
+                randomBoolean(),
+                sortOrder,
+                docs,
+                true,
+                simplified
+            );
+        }
+    }
+
 }


### PR DESCRIPTION
Recently we added support for line-simplification in geo-lines when in time-series aggregations: https://github.com/elastic/elasticsearch/pull/94954. This work did not, however, cover the case of `MergedGeoLines`, which occurs when the same geo_line covers multiple shards on data nodes, and needs to be merged on the coordinating node. The original work would use line-simplification and time-ordering on the data node, but then revert to re-sorting (unnecessary) and truncation (incorrect) on the coordinating node.

This PR rectifies that, and adds two fields to the InternalGeoLine:
* nonOverlapping
  * re-sorting is *NOT* required because the sort value ranges do not overlap, so we only sort the set of incoming geo_lines (easy/fast) instead of every single point (complex/slow).
* simplified
  * The approach to memory limiting is by line-simplification instead of truncation.
  * If the data nodes are doing line-simplification, we want the coordinating node to do that as well

For time-series, both of the above are true, and at this point all other cases will have both false. The reason for two booleans is:
* They are not necessarily related concepts
* We consider supporting line-simplification as a user-requested option in the non-time-series geo_line in future (much nicer than truncation)

Fixes #96983
