### PR TITLE
Add file extensions for vector search for preload

### DIFF
--- a/docs/reference/how-to/knn-search.asciidoc
+++ b/docs/reference/how-to/knn-search.asciidoc
@@ -51,6 +51,9 @@ of datasets and configurations that we use for our nightly benchmarks.
 [discrete]
 include::search-speed.asciidoc[tag=warm-fs-cache]
 
+The following file extensions are used for the approximate kNN search:
+"vec" (for vector values), "vex" (for HNSW graph), "vem" (for metadata).
+
 [discrete]
 === Reduce vector dimensionality
 


### PR DESCRIPTION
In this tuning guide we mentioned preload to warm up 
the filesystem cache, but we did not provide file extensions 
used in vector search. This adds these extensions.