### PR TITLE
Error message for misconfigured TSDB index

### DIFF
--- a/docs/changelog/96956.yaml
+++ b/docs/changelog/96956.yaml
@@ -1,0 +1,6 @@
+pr: 96956
+summary: Error message for misconfigured TSDB index
+area: TSDB
+type: bug
+issues:
+ - 96445

--- a/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
+++ b/modules/aggregations/src/yamlRestTest/resources/rest-api-spec/test/aggregations/time_series.yml
@@ -236,3 +236,20 @@ setup:
                     sum:
                       sum:
                         field: val
+---
+"Configure with no synthetic source":
+  - skip:
+      version: " - 8.8.99"
+      reason: "Error message fix in 8.9"
+
+  - do:
+      catch: '/Time series indices only support synthetic source./'
+      indices.create:
+        index: tsdb_error
+        body:
+          settings:
+            mode: time_series
+            routing_path: [key]
+          mappings:
+            _source:
+              enabled: false

--- a/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
+++ b/server/src/main/java/org/elasticsearch/index/mapper/SourceFieldMapper.java
@@ -137,7 +137,11 @@ public class SourceFieldMapper extends MetadataFieldMapper {
         @Override
         public SourceFieldMapper build() {
             if (enabled.getValue().explicit() && mode.get() != null) {
-                throw new MapperParsingException("Cannot set both [mode] and [enabled] parameters");
+                if (indexMode == IndexMode.TIME_SERIES) {
+                    throw new MapperParsingException("Time series indices only support synthetic source");
+                } else {
+                    throw new MapperParsingException("Cannot set both [mode] and [enabled] parameters");
+                }
             }
             if (isDefault()) {
                 return indexMode == IndexMode.TIME_SERIES ? TSDB_DEFAULT : DEFAULT;


### PR DESCRIPTION
TSDB indices should always have synthetic source.

Closes https://github.com/elastic/elasticsearch/issues/96445
