### PR TITLE
Fix double array for `sub_searches` in toXContent

### DIFF
--- a/docs/changelog/96963.yaml
+++ b/docs/changelog/96963.yaml
@@ -1,7 +1,0 @@
-pr: 96963
-summary: Fix double array for `sub_searches` in toXContent
-area: Ranking
-type: bug
-issues:
- - 96896
- - 96910

--- a/docs/changelog/96963.yaml
+++ b/docs/changelog/96963.yaml
@@ -1,0 +1,7 @@
+pr: 96963
+summary: Fix double array for `sub_searches` in toXContent
+area: Ranking
+type: bug
+issues:
+ - 96896
+ - 96910

--- a/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/builder/SearchSourceBuilder.java
@@ -1616,7 +1616,7 @@ public final class SearchSourceBuilder implements Writeable, ToXContentObject, R
             if (subSearchSourceBuilders.size() == 1) {
                 builder.field(QUERY_FIELD.getPreferredName(), subSearchSourceBuilders.get(0).getQueryBuilder());
             } else {
-                builder.array(SUB_SEARCHES_FIELD.getPreferredName(), subSearchSourceBuilders);
+                builder.xContentList(SUB_SEARCHES_FIELD.getPreferredName(), subSearchSourceBuilders);
             }
         }
 

--- a/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/action/get/MultiGetShardRequestTests.java
@@ -99,7 +99,6 @@ public class MultiGetShardRequestTests extends AbstractWireSerializingTestCase<M
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96910")
     public void testForceSyntheticUnsupported() {
         MultiGetShardRequest request = createTestInstance(true);
         StreamOutput out = new BytesStreamOutput();

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -258,7 +258,6 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         assertThat(invoked.get(), is(true));
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96910")
     public void testForceSyntheticUnsupported() throws IOException {
         SearchRequest request = createSearchRequest();
         if (request.source() != null) {

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -40,6 +40,7 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -261,6 +262,7 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         SearchRequest request = createSearchRequest();
         if (request.source() != null) {
             request.source().rankBuilder(null);
+            request.source().subSearches(new ArrayList<>());
         }
         request.setForceSyntheticSource(true);
         ShardSearchRequest shardRequest = createShardSearchReqest(request);

--- a/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
+++ b/server/src/test/java/org/elasticsearch/search/internal/ShardSearchRequestTests.java
@@ -262,7 +262,9 @@ public class ShardSearchRequestTests extends AbstractSearchTestCase {
         SearchRequest request = createSearchRequest();
         if (request.source() != null) {
             request.source().rankBuilder(null);
-            request.source().subSearches(new ArrayList<>());
+            if (request.source().subSearches().size() >= 2) {
+                request.source().subSearches(new ArrayList<>());
+            }
         }
         request.setForceSyntheticSource(true);
         ShardSearchRequest shardRequest = createShardSearchReqest(request);


### PR DESCRIPTION
This fixes two bugs:
1. `toXContent` was writing two arrays instead of one array for `sub_searches` as part of `SearchSourceBuilder`
2. Removes `sub_searches` from `ShardSearchRequestTests.setForceSyntheticSource`

Closes https://github.com/elastic/elasticsearch/issues/96896
Closes https://github.com/elastic/elasticsearch/issues/96910