### PR TITLE
Restore executionHint serialization from version V_8_500_014

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregationBuilder.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/MedianAbsoluteDeviationAggregationBuilder.java
@@ -65,6 +65,8 @@ public class MedianAbsoluteDeviationAggregationBuilder extends SingleMetricAggre
         compression = in.readDouble();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018)) {
             executionHint = in.readOptionalWriteable(TDigestExecutionHint::readFrom);
+        } else if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014)) {
+            executionHint = TDigestExecutionHint.readFrom(in);
         } else {
             executionHint = TDigestExecutionHint.HIGH_ACCURACY;
         }
@@ -128,6 +130,8 @@ public class MedianAbsoluteDeviationAggregationBuilder extends SingleMetricAggre
         out.writeDouble(compression);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018)) {
             out.writeOptionalWriteable(executionHint);
+        } else if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014)) {
+            (executionHint == null ? TDigestExecutionHint.DEFAULT : executionHint).writeTo(out);
         }
     }
 

--- a/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
+++ b/server/src/main/java/org/elasticsearch/search/aggregations/metrics/PercentilesConfig.java
@@ -143,8 +143,8 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
         TDigest(StreamInput in) throws IOException {
             this(
                 in.readDouble(),
-                in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018)
-                    ? in.readOptionalWriteable(TDigestExecutionHint::readFrom)
+                in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018) ? in.readOptionalWriteable(TDigestExecutionHint::readFrom)
+                    : in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014) ? TDigestExecutionHint.readFrom(in)
                     : TDigestExecutionHint.HIGH_ACCURACY
             );
         }
@@ -250,6 +250,8 @@ public abstract class PercentilesConfig implements ToXContent, Writeable {
             out.writeDouble(compression);
             if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018)) {
                 out.writeOptionalWriteable(executionHint);
+            } else if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014)) {
+                (executionHint == null ? TDigestExecutionHint.DEFAULT : executionHint).writeTo(out);
             }
         }
 

--- a/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
+++ b/x-pack/plugin/analytics/src/main/java/org/elasticsearch/xpack/analytics/boxplot/BoxplotAggregationBuilder.java
@@ -84,6 +84,8 @@ public class BoxplotAggregationBuilder extends ValuesSourceAggregationBuilder.Me
         compression = in.readDouble();
         if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018)) {
             executionHint = in.readOptionalWriteable(TDigestExecutionHint::readFrom);
+        } else if (in.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014)) {
+            executionHint = TDigestExecutionHint.readFrom(in);
         } else {
             executionHint = TDigestExecutionHint.HIGH_ACCURACY;
         }
@@ -99,6 +101,8 @@ public class BoxplotAggregationBuilder extends ValuesSourceAggregationBuilder.Me
         out.writeDouble(compression);
         if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_018)) {
             out.writeOptionalWriteable(executionHint);
+        } else if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014)) {
+            (executionHint == null ? TDigestExecutionHint.DEFAULT : executionHint).writeTo(out);
         }
     }
 


### PR DESCRIPTION
This was replaced by optional serialization in version V_8_500_018 in #96943, breaking backwards compatibility for serverless.

https://gradle-enterprise.elastic.co/s/r57ljjurthlow/tests/:modules:secure-settings:internalClusterTest/co.elastic.elasticsearch.settings.secure.FileSecureSettingsServiceIT/testIncrementSettings?top-execution=1

Related to #95903
