### PR TITLE
Skip redundant sorting in SortingDigest

### DIFF
--- a/docs/changelog/96967.yaml
+++ b/docs/changelog/96967.yaml
@@ -1,0 +1,6 @@
+pr: 96967
+summary: Skip redundant sorting in `SortingDigest`
+area: Aggregations
+type: enhancement
+issues:
+ - 96961

--- a/docs/changelog/96967.yaml
+++ b/docs/changelog/96967.yaml
@@ -1,6 +1,0 @@
-pr: 96967
-summary: Skip redundant sorting in `SortingDigest`
-area: Aggregations
-type: enhancement
-issues:
- - 96961

--- a/libs/tdigest/src/main/java/org/elasticsearch/tdigest/SortingDigest.java
+++ b/libs/tdigest/src/main/java/org/elasticsearch/tdigest/SortingDigest.java
@@ -42,10 +42,10 @@ public class SortingDigest extends AbstractTDigest {
     @Override
     public void add(double x, int w) {
         checkValue(x);
+        isSorted = isSorted && (values.isEmpty() || values.get(values.size() - 1) <= x);
         for (int i = 0; i < w; i++) {
             values.add(x);
         }
-        isSorted = false;
         max = Math.max(max, x);
         min = Math.min(min, x);
     }


### PR DESCRIPTION
When a SortingDigest gets serialized, it's reconstructed by writing and reading elements in sorted order. In this case, there's no need to sort the elements again.

Fixes #96961
