### PR TITLE
[Profiling] Use descriptive name for ILM policy

### DIFF
--- a/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
+++ b/x-pack/plugin/profiler/src/main/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistry.java
@@ -75,7 +75,7 @@ public class ProfilingIndexTemplateRegistry extends IndexTemplateRegistry {
 
     private static final List<LifecyclePolicy> LIFECYCLE_POLICIES = List.of(
         new LifecyclePolicyConfig(
-            "profiling",
+            "profiling-60-days",
             "/org/elasticsearch/xpack/profiler/ilm-policy/profiling-60-days.json",
             Map.of(PROFILING_TEMPLATE_VERSION_VARIABLE, String.valueOf(INDEX_TEMPLATE_VERSION))
         ).load(LifecyclePolicyConfig.DEFAULT_X_CONTENT_REGISTRY)

--- a/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistryTests.java
+++ b/x-pack/plugin/profiler/src/test/java/org/elasticsearch/xpack/profiler/ProfilingIndexTemplateRegistryTests.java
@@ -139,7 +139,7 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
                 assertThat(action, instanceOf(PutLifecycleAction.class));
                 assertThat(request, instanceOf(PutLifecycleAction.Request.class));
                 final PutLifecycleAction.Request putRequest = (PutLifecycleAction.Request) request;
-                assertThat(putRequest.getPolicy().getName(), equalTo("profiling"));
+                assertThat(putRequest.getPolicy().getName(), equalTo("profiling-60-days"));
                 assertNotNull(listener);
                 return AcknowledgedResponse.TRUE;
             } else if (action instanceof PutComponentTemplateAction) {
@@ -273,7 +273,7 @@ public class ProfilingIndexTemplateRegistryTests extends ESTestCase {
                 assertThat(action, instanceOf(PutLifecycleAction.class));
                 assertThat(request, instanceOf(PutLifecycleAction.Request.class));
                 final PutLifecycleAction.Request putRequest = (PutLifecycleAction.Request) request;
-                assertThat(putRequest.getPolicy().getName(), equalTo("profiling"));
+                assertThat(putRequest.getPolicy().getName(), equalTo("profiling-60-days"));
                 assertNotNull(listener);
                 return AcknowledgedResponse.TRUE;
 


### PR DESCRIPTION
With this commit we rename the default ILM policy for profiling from `profiling` to `profiling-60-days` which describes the policy's intention and allows to add related policies in the future more naturally.