### PR TITLE
Ensure checking application privileges work with nested-limited roles

### DIFF
--- a/docs/changelog/96970.yaml
+++ b/docs/changelog/96970.yaml
@@ -1,0 +1,5 @@
+pr: 96970
+summary: Ensure checking application privileges work with nested-limited roles
+area: Authorization
+type: enhancement
+issues: []

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRole.java
@@ -305,26 +305,24 @@ public final class LimitedRole implements Role {
         Collection<ApplicationPrivilegeDescriptor> storedPrivileges,
         @Nullable ResourcePrivilegesMap.Builder resourcePrivilegesMapBuilder
     ) {
-        boolean baseRoleCheck = baseRole.application()
-            .checkResourcePrivileges(
-                applicationName,
-                checkForResources,
-                checkForPrivilegeNames,
-                storedPrivileges,
-                resourcePrivilegesMapBuilder
-            );
+        boolean baseRoleCheck = baseRole.checkApplicationResourcePrivileges(
+            applicationName,
+            checkForResources,
+            checkForPrivilegeNames,
+            storedPrivileges,
+            resourcePrivilegesMapBuilder
+        );
         if (false == baseRoleCheck && null == resourcePrivilegesMapBuilder) {
             // short-circuit only if not interested in the detailed individual check results
             return false;
         }
-        boolean limitedByRoleCheck = limitedByRole.application()
-            .checkResourcePrivileges(
-                applicationName,
-                checkForResources,
-                checkForPrivilegeNames,
-                storedPrivileges,
-                resourcePrivilegesMapBuilder
-            );
+        boolean limitedByRoleCheck = limitedByRole.checkApplicationResourcePrivileges(
+            applicationName,
+            checkForResources,
+            checkForPrivilegeNames,
+            storedPrivileges,
+            resourcePrivilegesMapBuilder
+        );
         return baseRoleCheck && limitedByRoleCheck;
     }
 

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRoleTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/permission/LimitedRoleTests.java
@@ -903,6 +903,15 @@ public class LimitedRoleTests extends ESTestCase {
                 .addApplicationPrivilege(app2Write, Collections.singleton("moo/bar/*"))
                 .build();
 
+            if (randomBoolean()) {
+                final Role nestedLimitedRole = Role.builder(EMPTY_RESTRICTED_INDICES, "nested-limited-role")
+                    .addApplicationPrivilege(app1Read, Set.of("*"))
+                    .addApplicationPrivilege(app2Read, Set.of("*"))
+                    .addApplicationPrivilege(app2Write, Set.of("*"))
+                    .build();
+                limitedByRole = randomBoolean() ? limitedByRole.limitedBy(nestedLimitedRole) : nestedLimitedRole.limitedBy(limitedByRole);
+            }
+
             verifyResourcesPrivileges(
                 limitedByRole,
                 "app1",


### PR DESCRIPTION
This PR makes sure checkApplicationResourcePrivileges works when any of the baseRole and limitedByRole is itself a LimitedRole.

Relates: #95170, #93306
