### PR TITLE
Update histogram-aggregation docs

### DIFF
--- a/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
@@ -350,7 +350,7 @@ PUT metrics_index
   }
 }
 
-PUT metrics_index/_doc/1
+PUT metrics_index/_doc/1?refresh
 {
   "network.name" : "net-1",
   "latency_histo" : {
@@ -359,7 +359,7 @@ PUT metrics_index/_doc/1
    }
 }
 
-PUT metrics_index/_doc/2
+PUT metrics_index/_doc/2?refresh
 {
   "network.name" : "net-2",
   "latency_histo" : {
@@ -389,30 +389,31 @@ return the following output:
 --------------------------------------------------
 {
   ...
-    "aggregations": {
+  "aggregations": {
     "latency_buckets": {
       "buckets": [
         {
-          "key": 0,
-          "doc_count": 2
+          "key": 0.0,
+          "doc_count": 18
         },
         {
-          "key": 5,
-          "doc_count": 2
+          "key": 5.0,
+          "doc_count": 48
         },
         {
-          "key": 10,
-          "doc_count": 2
+          "key": 10.0,
+          "doc_count": 25
         },
         {
-          "key": 15,
-          "doc_count": 1
+          "key": 15.0,
+          "doc_count": 6
         }
       ]
     }
-...
+  }
+}
 --------------------------------------------------
-// TESTRESPONSE[skip:test not setup]
+// TESTRESPONSE[s/\.\.\./"took": $body.took,"timed_out": false,"_shards": $body._shards,"hits": $body.hits,/]
 
 [IMPORTANT]
 ========

--- a/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
@@ -345,7 +345,6 @@ PUT metrics_index
       },
       "latency_histo": {
          "type": "histogram"
-        }
       }
     }
   }

--- a/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
@@ -332,6 +332,31 @@ with latency metrics (in milliseconds) for different networks:
 
 [source,console]
 --------------------------------------------------
+PUT metrics_index
+{
+  "mappings": {
+    "properties": {
+      "network": {
+        "properties": {
+          "name": {
+            "type": "keyword"
+          }
+        }
+      },
+      "latency_hist": {
+        "properties": {
+          "values": {
+            "type": "histogram"
+          },
+          "counts": {
+            "type": "histogram"
+          }
+        }
+      }
+    }
+  }
+}
+
 PUT metrics_index/_doc/1
 {
   "network.name" : "net-1",
@@ -355,7 +380,7 @@ POST /metrics_index/_search?size=0
   "aggs": {
     "latency_buckets": {
       "histogram": {
-        "field": "latency_histo",
+        "field": "latency_histo.values",
         "interval": 5
       }
     }
@@ -371,29 +396,28 @@ return the following output:
 --------------------------------------------------
 {
   ...
-  "aggregations": {
-    "prices": {
+    "aggregations": {
+    "latency_buckets": {
       "buckets": [
         {
-          "key": 0.0,
-          "doc_count": 18
+          "key": 0,
+          "doc_count": 2
         },
         {
-          "key": 5.0,
-          "doc_count": 48
+          "key": 5,
+          "doc_count": 2
         },
         {
-          "key": 10.0,
-          "doc_count": 25
+          "key": 10,
+          "doc_count": 2
         },
         {
-          "key": 15.0,
-          "doc_count": 6
+          "key": 15,
+          "doc_count": 1
         }
       ]
     }
-  }
-}
+...
 --------------------------------------------------
 // TESTRESPONSE[skip:test not setup]
 

--- a/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
@@ -343,7 +343,7 @@ PUT metrics_index
           }
         }
       },
-      "latency_hist": {
+      "latency_histo": {
          "type": "histogram"
         }
       }

--- a/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
+++ b/docs/reference/aggregations/bucket/histogram-aggregation.asciidoc
@@ -344,13 +344,7 @@ PUT metrics_index
         }
       },
       "latency_hist": {
-        "properties": {
-          "values": {
-            "type": "histogram"
-          },
-          "counts": {
-            "type": "histogram"
-          }
+         "type": "histogram"
         }
       }
     }
@@ -380,7 +374,7 @@ POST /metrics_index/_search?size=0
   "aggs": {
     "latency_buckets": {
       "histogram": {
-        "field": "latency_histo.values",
+        "field": "latency_histo",
         "interval": 5
       }
     }


### PR DESCRIPTION
Without specifiying the mapping explicitly it will just be stored as longs and then the histogram function doesn't really show it's cool purpose. As discovered by @herrBez 

If I just run the PUT command I get this:

```
{
  "metrics_index": {
    "aliases": {},
    "mappings": {
      "properties": {
        "latency_histo": {
          "properties": {
            "counts": {
              "type": "long"
            },
            "values": {
              "type": "long"
            }
          }
        },
        "network": {
          "properties": {
            "name": {
              "type": "text",
              "fields": {
                "keyword": {
                  "type": "keyword",
                  "ignore_above": 256
                }
              }
            }
          }
        }
      }
    }
}
```

Also the documentation mentions `latency_histo`. as a field however the example answer uses a bucket called `price`, which makes even less sense...

I modified it to work as expected