### PR TITLE
[DRAFT] read arbitry length strings from smile XContent

### DIFF
--- a/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/smile/SmileXContentImpl.java
+++ b/libs/x-content/impl/src/main/java/org/elasticsearch/xcontent/provider/smile/SmileXContentImpl.java
@@ -11,6 +11,7 @@ package org.elasticsearch.xcontent.provider.smile;
 import com.fasterxml.jackson.core.JsonEncoding;
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.StreamReadConstraints;
 import com.fasterxml.jackson.dataformat.smile.SmileConstants;
 import com.fasterxml.jackson.dataformat.smile.SmileFactory;
 import com.fasterxml.jackson.dataformat.smile.SmileGenerator;
@@ -53,6 +54,7 @@ public final class SmileXContentImpl implements XContent {
         smileFactory.configure(JsonGenerator.Feature.AUTO_CLOSE_JSON_CONTENT, false);
         smileFactory.configure(JsonParser.Feature.STRICT_DUPLICATE_DETECTION, true);
         smileFactory.configure(JsonParser.Feature.USE_FAST_DOUBLE_PARSER, true);
+        smileFactory.setStreamReadConstraints(StreamReadConstraints.builder().maxStringLength(Integer.MAX_VALUE).build());
         smileXContent = new SmileXContentImpl();
     }
 


### PR DESCRIPTION
This would fix an issue with reading cluster states that contain long strings that can be serialized but not deserialized at present.

@kingherc as discussed this would fix the issue but we probably want a cleaner fix here, just opening so you have some code that you can work with right away.

for https://github.com/elastic/elasticsearch/issues/96976