### PR TITLE
Fix serialization constant

### DIFF
--- a/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
+++ b/modules/rest-root/src/main/java/org/elasticsearch/rest/root/MainResponse.java
@@ -89,7 +89,7 @@ public class MainResponse extends ActionResponse implements ToXContentObject {
     public void writeTo(StreamOutput out) throws IOException {
         out.writeString(nodeName);
         Version.writeVersion(version, out);
-        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_014)) {
+        if (out.getTransportVersion().onOrAfter(TransportVersion.V_8_500_019)) {
             TransportVersion.writeVersion(transportVersion, out);
         }
         clusterName.writeTo(out);


### PR DESCRIPTION
In #96900 a new transport version was added for additional information in the main response. However, due to upstream conflicts, this transport version had to be bumped a few times. In the process, the the version was bumped, but the condition was never updated. This commit fixes the condition to use the version that was added.