### PR TITLE
Make ESRestTestCase client configuration more configurable in subclasses

### DIFF
--- a/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
+++ b/qa/ccs-common-rest/src/yamlRestTest/java/org/elasticsearch/test/rest/yaml/RcsCcsCommonYamlTestSuiteIT.java
@@ -142,7 +142,7 @@ public class RcsCcsCommonYamlTestSuiteIT extends ESClientYamlSuiteTestCase {
         final int portSeparator = url.lastIndexOf(':');
         final var httpHost = new HttpHost(url.substring(0, portSeparator), Integer.parseInt(url.substring(portSeparator + 1)), "http");
         RestClientBuilder builder = RestClient.builder(httpHost);
-        configureClient(builder, Settings.EMPTY);
+        doConfigureClient(builder, Settings.EMPTY);
         builder.setStrictDeprecationMode(true);
         try (RestClient fulfillingClusterClient = builder.build()) {
             final Response createApiKeyResponse = fulfillingClusterClient.performRequest(createApiKeyRequest);

--- a/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/rest/ESRestTestCase.java
@@ -1302,7 +1302,14 @@ public abstract class ESRestTestCase extends ESTestCase {
         return builder.build();
     }
 
-    protected static void configureClient(RestClientBuilder builder, Settings settings) throws IOException {
+    /**
+     * Override this to configure the client with additional settings.
+     */
+    protected void configureClient(RestClientBuilder builder, Settings settings) throws IOException {
+        doConfigureClient(builder, settings);
+    }
+
+    protected static void doConfigureClient(RestClientBuilder builder, Settings settings) throws IOException {
         String truststorePath = settings.get(TRUSTSTORE_PATH);
         String certificateAuthorities = settings.get(CERTIFICATE_AUTHORITIES);
         String clientCertificatePath = settings.get(CLIENT_CERT_PATH);

--- a/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
+++ b/x-pack/plugin/eql/qa/common/src/main/java/org/elasticsearch/test/eql/RemoteClusterAwareEqlRestTestCase.java
@@ -68,7 +68,7 @@ public abstract class RemoteClusterAwareEqlRestTestCase extends ESRestTestCase {
 
     protected static RestClient clientBuilder(Settings settings, HttpHost[] hosts) throws IOException {
         RestClientBuilder builder = RestClient.builder(hosts);
-        configureClient(builder, settings);
+        doConfigureClient(builder, settings);
 
         int timeout = Math.toIntExact(timeout().millis());
         builder.setRequestConfigCallback(

--- a/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
+++ b/x-pack/plugin/security/qa/multi-cluster/src/javaRestTest/java/org/elasticsearch/xpack/remotecluster/AbstractRemoteClusterSecurityTestCase.java
@@ -94,7 +94,7 @@ public abstract class AbstractRemoteClusterSecurityTestCase extends ESRestTestCa
         final var httpHost = new HttpHost(url.substring(0, portSeparator), Integer.parseInt(url.substring(portSeparator + 1)), "http");
         RestClientBuilder builder = RestClient.builder(httpHost);
         try {
-            configureClient(builder, Settings.EMPTY);
+            doConfigureClient(builder, Settings.EMPTY);
         } catch (IOException e) {
             throw new UncheckedIOException(e);
         }

--- a/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RemoteClusterAwareSqlRestTestCase.java
+++ b/x-pack/plugin/sql/qa/server/src/main/java/org/elasticsearch/xpack/sql/qa/rest/RemoteClusterAwareSqlRestTestCase.java
@@ -61,7 +61,7 @@ public abstract class RemoteClusterAwareSqlRestTestCase extends ESRestTestCase {
 
     protected static RestClient clientBuilder(Settings settings, HttpHost[] hosts) throws IOException {
         RestClientBuilder builder = RestClient.builder(hosts);
-        configureClient(builder, settings);
+        doConfigureClient(builder, settings);
 
         int timeout = Math.toIntExact(timeout().millis());
         builder.setRequestConfigCallback(


### PR DESCRIPTION
We want to be able to tweak client configuration in tests extending ESRestTestCase. This makes that simpler
by allowing overriding the general client configuration. 