### PR TITLE
[8.7][DOCS] Fixes transform schedule_now documentation

### DIFF
--- a/docs/reference/transform/apis/schedule-now-transform.asciidoc
+++ b/docs/reference/transform/apis/schedule-now-transform.asciidoc
@@ -21,13 +21,14 @@ Schedules now a {transform}.
 * Requires the `manage_transform` cluster privilege. This privilege is included
 in the `transform_admin` built-in role.
 
-[schedule-now-transform-desc]]
+[[schedule-now-transform-desc]]
 == {api-description-title}
 
-If you _schedule_now a {transform}, it will process the new data instantly,
-without waiting for the configured `frequency` interval.
-After _schedule_now API is called, the transform will be processed again at
-`now + frequency` unless _schedule_now API is called again in the meantime.
+When you run this API, processing for the next checkpoint is started immediately 
+without waiting for the configured `frequency` interval. The API returns 
+immediately, data processing happens in the background. Subsequently, the 
+{transform} will be processed again at `now + frequency` unless the API is 
+called again in the meantime.
 
 [[schedule-now-transform-path-parms]]
 == {api-path-parms-title}


### PR DESCRIPTION
## Overview

This PR backports the following changes to the 8.7 branch:
[DOCS] Fixes transform scheduled_now documentation #96766