### PR TITLE
Bump a new transport version to make CCS compatibility checks work again

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -145,9 +145,10 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_018 = registerTransportVersion(8_500_018, "827C32CE-33D9-4AC3-A773-8FB768F59EAF");
     // 8.10.0
     public static final TransportVersion V_8_500_019 = registerTransportVersion(8_500_019, "09bae57f-cab8-423c-aab3-c9778509ffe3");
+    public static final TransportVersion V_8_500_020 = registerTransportVersion(8_500_020, "102e0d84-0c08-402c-a696-935f3a3da873");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_019);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_020);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {


### PR DESCRIPTION
The problem here is that, when a new minor release is rolled, the transport version is not incremented. This means that `MINIMUM_CCS_VERSION` and `CURRENT` are the same, which means there's no 'space' for tests to use a transport version that is not CURRENT and after the CCS version.

The fix here is to bump a new transport version.