### PR TITLE
Add exit code to CLI failure termination message

### DIFF
--- a/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
+++ b/libs/cli/src/main/java/org/elasticsearch/cli/Command.java
@@ -114,7 +114,7 @@ public abstract class Command implements Closeable {
     protected void printUserException(Terminal terminal, UserException e) {
         if (e.getMessage() != null) {
             terminal.errorPrintln("");
-            terminal.errorPrintln(Terminal.Verbosity.SILENT, "ERROR: " + e.getMessage());
+            terminal.errorPrintln(Terminal.Verbosity.SILENT, "ERROR: " + e.getMessage() + ", with exit code " + e.exitCode);
         }
     }
 


### PR DESCRIPTION
Add exit code to CLI failure termination message, to help with loopy diagnosis.