### PR TITLE
Fix unresolved conflict in TransportVersion

### DIFF
--- a/server/src/main/java/org/elasticsearch/TransportVersion.java
+++ b/server/src/main/java/org/elasticsearch/TransportVersion.java
@@ -145,12 +145,11 @@ public record TransportVersion(int id) implements Comparable<TransportVersion> {
     public static final TransportVersion V_8_500_018 = registerTransportVersion(8_500_018, "827C32CE-33D9-4AC3-A773-8FB768F59EAF");
     // 8.10.0
     public static final TransportVersion V_8_500_019 = registerTransportVersion(8_500_019, "09bae57f-cab8-423c-aab3-c9778509ffe3");
-    public static final TransportVersion V_8_500_020 = registerTransportVersion(8_500_020, "102e0d84-0c08-402c-a696-935f3a3da873");
-
     public static final TransportVersion V_8_500_020 = registerTransportVersion(8_500_020, "ECB42C26-B258-42E5-A835-E31AF84A76DE");
+    public static final TransportVersion V_8_500_021 = registerTransportVersion(8_500_021, "102e0d84-0c08-402c-a696-935f3a3da873");
 
     private static class CurrentHolder {
-        private static final TransportVersion CURRENT = findCurrent(V_8_500_020);
+        private static final TransportVersion CURRENT = findCurrent(V_8_500_021);
 
         // finds the pluggable current version, or uses the given fallback
         private static TransportVersion findCurrent(TransportVersion fallback) {


### PR DESCRIPTION
Two conflicting PR's were merged:

* https://github.com/elastic/elasticsearch/pull/97000 (bumps TransportVersion to `020` for `main` only)
* https://github.com/elastic/elasticsearch/pull/96953 (bumps TransportVersion to `020` for both `main` and `8.9`)

In order to get the second one in, I removed the `auto-merge` from the first one. This should have caused the first one to fail to merge due to git conflict, and so it would get updated to `021` and then merge. Sadly, both PR's got merged, so we have uncompilable code.
