### PR TITLE
Fix test after 'Add exit code to CLI failure termination message'

### DIFF
--- a/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
+++ b/distribution/tools/plugin-cli/src/test/java/org/elasticsearch/plugins/cli/RemovePluginActionTests.java
@@ -234,7 +234,7 @@ public class RemovePluginActionTests extends ESTestCase {
     public void testRemoveUninstalledPluginErrors() throws Exception {
         UserException e = expectThrows(UserException.class, () -> removePlugin("fake", home, randomBoolean()));
         assertEquals(ExitCodes.CONFIG, e.exitCode);
-        assertEquals("plugin [fake] not found; run 'elasticsearch-plugin list' to get list of installed plugins", e.getMessage());
+        assertThat(e.getMessage(), containsString("plugin [fake] not found"));
 
         MockTerminal terminal = MockTerminal.create();
 
@@ -245,10 +245,7 @@ public class RemovePluginActionTests extends ESTestCase {
             BufferedReader errorReader = new BufferedReader(new StringReader(terminal.getErrorOutput()))
         ) {
             assertThat(errorReader.readLine(), equalTo(""));
-            assertThat(
-                errorReader.readLine(),
-                equalTo("ERROR: plugin [fake] not found; run 'elasticsearch-plugin list' to get list of installed plugins")
-            );
+            assertThat(errorReader.readLine(), containsString("plugin [fake] not found"));
             assertThat(reader.readLine(), nullValue());
             assertThat(errorReader.readLine(), nullValue());
         }

--- a/server/src/test/java/org/elasticsearch/cli/MultiCommandTests.java
+++ b/server/src/test/java/org/elasticsearch/cli/MultiCommandTests.java
@@ -17,8 +17,8 @@ import org.junit.Before;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.stream.Collectors;
 
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.is;
@@ -213,7 +213,7 @@ public class MultiCommandTests extends CommandTestCase {
         multiCommand.subcommands.put("throw", new ErrorThrowingSubCommand());
         executeMain("throw", "--silent");
         assertThat(terminal.getOutput(), is(emptyString()));
-        assertThat(terminal.getErrorOutput().lines().toList(), contains("ERROR: Dummy error"));
+        assertThat(terminal.getErrorOutput().lines().collect(Collectors.joining()), containsString("ERROR: Dummy error"));
     }
 
     public void testNullErrorMessageSuppressesErrorOutput() throws Exception {


### PR DESCRIPTION
The PR at https://github.com/elastic/elasticsearch/pull/97004 caused a test failure.