### PR TITLE
TemplateRegistry infrastructure to install stateless resources

### DIFF
--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-final_pipeline.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-final_pipeline.json
@@ -1,0 +1,79 @@
+{
+  "description": "Built-in ingest pipeline applied by default as final pipeline to behavioral analytics event data streams.",
+  "processors": [
+    {
+      "set": {
+        "field": "_routing",
+        "copy_from": "session.id"
+      }
+    },
+    {
+      "uri_parts": {
+        "field": "page.url",
+        "target_field": "page.url",
+        "ignore_missing": true
+      }
+    },
+    {
+      "uri_parts": {
+        "field": "page.referrer",
+        "target_field": "page.referrer",
+        "ignore_missing": true
+      }
+    },
+    {
+      "foreach": {
+        "field": "search.results.items",
+        "ignore_missing": true,
+        "processor": {
+          "uri_parts": {
+            "field": "_ingest._value.page.url",
+            "target_field": "_ingest._value.page.url",
+            "ignore_missing": true
+          }
+        }
+      }
+    },
+    {
+      "user_agent": {
+        "field": "session.user_agent",
+        "target_field": "session.user_agent",
+        "ignore_missing": true,
+        "properties": ["name", "version", "os", "device"],
+        "extract_device_type": true
+      }
+    },
+    {
+      "rename": {
+        "field": "session.user_agent.name",
+        "target_field": "session.user_agent.browser.name",
+        "ignore_missing": true
+      }
+    },
+    {
+      "rename": {
+        "field": "session.user_agent.version",
+        "target_field": "session.user_agent.browser.version",
+        "ignore_missing": true
+      }
+    },
+    {
+      "geoip": {
+        "field": "session.ip",
+        "target_field": "session.location",
+        "ignore_missing": true,
+        "download_database_on_pipeline_creation": false
+      }
+    },
+    {
+      "remove": {
+        "field": "session.ip",
+        "ignore_missing": true
+      }
+    }
+  ],
+  "_meta": {
+    "managed": true
+  },
+  "version": ${xpack.entsearch.analytics.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-mappings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-mappings.json
@@ -1,0 +1,275 @@
+{
+  "template": {
+    "mappings": {
+      "dynamic": "strict",
+      "properties": {
+        "@timestamp": {
+          "type": "date"
+        },
+        "data_stream": {
+          "properties": {
+            "namespace": {
+              "type": "keyword"
+            },
+            "dataset": {
+              "type": "keyword"
+            },
+            "type": {
+              "type": "keyword"
+            }
+          }
+        },
+        "event": {
+          "properties": {
+            "action": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "source": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "document": {
+          "properties": {
+            "index": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "session": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "location": {
+              "properties": {
+                "continent_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "city_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_iso_code": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "country_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "region_name": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "location": {
+                  "type": "geo_point"
+                }
+              }
+            },
+            "user_agent": {
+              "properties": {
+                "os": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "full": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "browser": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "version": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                },
+                "device": {
+                  "properties": {
+                    "name": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    },
+                    "type": {
+                      "ignore_above": 1024,
+                      "type": "keyword"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "user": {
+          "properties": {
+            "id": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            }
+          }
+        },
+        "page": {
+          "properties": {
+            "url": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "extension": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "fragment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "port": {
+                  "type": "long"
+                },
+                "query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "scheme": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            },
+            "title": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "referrer": {
+              "properties": {
+                "domain": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "extension": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "fragment": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "original": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "path": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "port": {
+                  "type": "long"
+                },
+                "query": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                },
+                "scheme": {
+                  "ignore_above": 1024,
+                  "type": "keyword"
+                }
+              }
+            }
+          }
+        },
+        "search": {
+          "properties": {
+            "query": {
+              "ignore_above": 1024,
+              "type": "keyword"
+            },
+            "search_application": {
+                "type": "keyword",
+                "ignore_above": 1024
+            },
+            "filters": {
+              "type": "flattened"
+            },
+            "page": {
+              "properties": {
+                "current": {
+                  "type": "integer"
+                },
+                "size": {
+                  "type": "integer"
+                }
+              }
+            },
+            "sort": {
+              "properties": {
+                "name": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                },
+                "direction": {
+                  "type": "keyword",
+                  "ignore_above": 1024
+                }
+              }
+            },
+            "results": {
+              "properties": {
+                "total_results": {
+                  "type": "integer"
+                },
+                "items": {
+                  "type": "object",
+                  "enabled": false
+                }
+              }
+            }
+          }
+        },
+        "tags": {
+          "ignore_above": 1024,
+          "type": "keyword"
+        }
+      }
+    }
+  },
+  "_meta": {
+    "description": "Built-in mapping applied by default to behavioral analytics event data streams.",
+    "managed": true
+  },
+  "version": ${xpack.entsearch.analytics.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-settings.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-settings.json
@@ -1,0 +1,26 @@
+{
+  "template": {
+    "settings": {
+      "index": {
+        "codec": "best_compression",
+        "refresh_interval": "1s",
+        "number_of_shards": 1,
+        "number_of_replicas": 0,
+        "auto_expand_replicas": "0-1",
+        "final_pipeline": "behavioral_analytics-events-final_pipeline",
+        "sort": {
+          "field": ["session.id", "@timestamp"],
+          "order": ["asc", "asc"]
+        }
+      }
+    },
+    "lifecycle": {
+      "data_retention": "180d"
+    }
+  },
+  "_meta": {
+    "description": "Built-in settings applied by default to behavioral analytics event data streams.",
+    "managed": true
+  },
+  "version": ${xpack.entsearch.analytics.template.version}
+}

--- a/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-template.json
+++ b/x-pack/plugin/core/src/main/resources/org/elasticsearch/xpack/entsearch/analytics/stateless/behavioral_analytics-events-template.json
@@ -1,0 +1,17 @@
+{
+  "index_patterns": ["${event_data_stream.index_pattern}"],
+  "data_stream": {
+    "allow_custom_routing": true
+  },
+  "priority": 100,
+  "composed_of": [
+    "behavioral_analytics-events-settings",
+    "behavioral_analytics-events-mappings"
+  ],
+  "allow_auto_create": false,
+  "_meta": {
+    "description": "Built-in template applied by default to behavioral analytics event data streams.",
+    "managed": true
+  },
+  "version": ${xpack.entsearch.analytics.template.version}
+}

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/analytics/AnalyticsConstants.java
@@ -19,6 +19,7 @@ public class AnalyticsConstants {
 
     // Resource config.
     public static final String ROOT_RESOURCE_PATH = "/org/elasticsearch/xpack/entsearch/analytics/";
+    public static final String STATELESS_ROOT_RESOURCE_PATH = "/org/elasticsearch/xpack/entsearch/analytics/stateless/";
 
     // The variable to be replaced with the template version number
     public static final String TEMPLATE_VERSION_VARIABLE = "xpack.entsearch.analytics.template.version";

--- a/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
+++ b/x-pack/plugin/ent-search/src/test/java/org/elasticsearch/xpack/application/analytics/AnalyticsTemplateRegistryTests.java
@@ -63,6 +63,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static org.elasticsearch.xpack.application.analytics.AnalyticsConstants.EVENT_DATA_STREAM_INDEX_PATTERN;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
@@ -423,6 +425,15 @@ public class AnalyticsTemplateRegistryTests extends ESTestCase {
 
         ClusterChangedEvent event = createClusterChangedEvent(Collections.emptyMap(), Collections.emptyMap(), nodes);
         registry.clusterChanged(event);
+    }
+
+    public void testOnlyStatefulResourcesConfigured() {
+        assertThat(registry.getStatelessComponentTemplateConfigs(), anEmptyMap());
+        assertThat(registry.getStatelessIndexTemplateConfigs(), anEmptyMap());
+
+        // stateful resources are configured
+        assertThat(registry.getComponentTemplateConfigs(), not(anEmptyMap()));
+        assertThat(registry.getComposableTemplateConfigs(), not(anEmptyMap()));
     }
 
     // -------------


### PR DESCRIPTION
This adds the necessary infrastructure for the IndexTemplateRegistry to be able to install different component and index templates in a stateless deployment.

This also implements the stateless support for the analytics templates.