### PR TITLE
Manage multiple timers per type in AbstractProfileBreakdown

### DIFF
--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -39,7 +39,6 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Function;
 
 /**
  * DFS phase of a search request, used to make scoring 100% accurate by collecting additional info from each shard before the query phase.
@@ -68,12 +67,6 @@ public class DfsPhase {
 
         Map<String, CollectionStatistics> fieldStatistics = new HashMap<>();
         Map<Term, TermStatistics> stats = new HashMap<>();
-        final Function<DfsTimingType, Timer> maybeStart = dtt -> {
-            if (profiler != null) {
-                return profiler.startTimer(dtt);
-            }
-            return null;
-        };
 
         IndexSearcher searcher = new IndexSearcher(context.searcher().getIndexReader()) {
             @Override
@@ -81,7 +74,7 @@ public class DfsPhase {
                 if (context.isCancelled()) {
                     throw new TaskCancelledException("cancelled");
                 }
-                Timer timer = maybeStart.apply(DfsTimingType.TERM_STATISTICS);
+                Timer timer = maybeStartTimer(profiler, DfsTimingType.TERM_STATISTICS);
                 try {
                     TermStatistics ts = super.termStatistics(term, docFreq, totalTermFreq);
                     if (ts != null) {
@@ -100,7 +93,7 @@ public class DfsPhase {
                 if (context.isCancelled()) {
                     throw new TaskCancelledException("cancelled");
                 }
-                Timer timer = maybeStart.apply(DfsTimingType.COLLECTION_STATISTICS);
+                Timer timer = maybeStartTimer(profiler, DfsTimingType.COLLECTION_STATISTICS);
                 try {
                     CollectionStatistics cs = super.collectionStatistics(field);
                     if (cs != null) {
@@ -120,7 +113,7 @@ public class DfsPhase {
         }
 
         try {
-            Timer timer = maybeStart.apply(DfsTimingType.CREATE_WEIGHT);
+            Timer timer = maybeStartTimer(profiler, DfsTimingType.CREATE_WEIGHT);
             try {
                 searcher.createWeight(context.rewrittenQuery(), ScoreMode.COMPLETE, 1);
             } finally {
@@ -131,7 +124,7 @@ public class DfsPhase {
             for (RescoreContext rescoreContext : context.rescore()) {
                 for (ParsedQuery parsedQuery : rescoreContext.getParsedQueries()) {
                     final Query rewritten;
-                    timer = maybeStart.apply(DfsTimingType.REWRITE);
+                    timer = maybeStartTimer(profiler, DfsTimingType.REWRITE);
                     try {
                         rewritten = searcher.rewrite(parsedQuery.query());
                     } finally {
@@ -139,7 +132,7 @@ public class DfsPhase {
                             timer.stop();
                         }
                     }
-                    timer = maybeStart.apply(DfsTimingType.CREATE_WEIGHT);
+                    timer = maybeStartTimer(profiler, DfsTimingType.CREATE_WEIGHT);
                     try {
                         searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
                     } finally {
@@ -166,6 +159,17 @@ public class DfsPhase {
             .fieldStatistics(fieldStatistics)
             .maxDoc(context.searcher().getIndexReader().maxDoc());
     }
+
+    /**
+     * If profiler isn't null, this returns a started {@link Timer}.
+     * Otherwise, returns null.
+     */
+    private static Timer maybeStartTimer(DfsProfiler profiler, DfsTimingType dtt) {
+        if (profiler != null) {
+            return profiler.startTimer(dtt);
+        }
+        return null;
+    };
 
     private void executeKnnVectorQuery(SearchContext context) throws IOException {
         SearchSourceBuilder source = context.request().source();

--- a/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/dfs/DfsPhase.java
@@ -21,6 +21,7 @@ import org.elasticsearch.index.query.ParsedQuery;
 import org.elasticsearch.index.query.SearchExecutionContext;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.search.profile.Timer;
 import org.elasticsearch.search.profile.dfs.DfsProfiler;
 import org.elasticsearch.search.profile.dfs.DfsTimingType;
 import org.elasticsearch.search.profile.query.CollectorResult;
@@ -38,7 +39,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
+import java.util.function.Function;
 
 /**
  * DFS phase of a search request, used to make scoring 100% accurate by collecting additional info from each shard before the query phase.
@@ -67,15 +68,11 @@ public class DfsPhase {
 
         Map<String, CollectionStatistics> fieldStatistics = new HashMap<>();
         Map<Term, TermStatistics> stats = new HashMap<>();
-        final Consumer<DfsTimingType> maybeStart = dtt -> {
+        final Function<DfsTimingType, Timer> maybeStart = dtt -> {
             if (profiler != null) {
-                profiler.startTimer(dtt);
+                return profiler.startTimer(dtt);
             }
-        };
-        final Consumer<DfsTimingType> maybeStop = dtt -> {
-            if (profiler != null) {
-                profiler.stopTimer(dtt);
-            }
+            return null;
         };
 
         IndexSearcher searcher = new IndexSearcher(context.searcher().getIndexReader()) {
@@ -84,7 +81,7 @@ public class DfsPhase {
                 if (context.isCancelled()) {
                     throw new TaskCancelledException("cancelled");
                 }
-                maybeStart.accept(DfsTimingType.TERM_STATISTICS);
+                Timer timer = maybeStart.apply(DfsTimingType.TERM_STATISTICS);
                 try {
                     TermStatistics ts = super.termStatistics(term, docFreq, totalTermFreq);
                     if (ts != null) {
@@ -92,7 +89,9 @@ public class DfsPhase {
                     }
                     return ts;
                 } finally {
-                    maybeStop.accept(DfsTimingType.TERM_STATISTICS);
+                    if (timer != null) {
+                        timer.stop();
+                    }
                 }
             }
 
@@ -101,7 +100,7 @@ public class DfsPhase {
                 if (context.isCancelled()) {
                     throw new TaskCancelledException("cancelled");
                 }
-                maybeStart.accept(DfsTimingType.COLLECTION_STATISTICS);
+                Timer timer = maybeStart.apply(DfsTimingType.COLLECTION_STATISTICS);
                 try {
                     CollectionStatistics cs = super.collectionStatistics(field);
                     if (cs != null) {
@@ -109,7 +108,9 @@ public class DfsPhase {
                     }
                     return cs;
                 } finally {
-                    maybeStop.accept(DfsTimingType.COLLECTION_STATISTICS);
+                    if (timer != null) {
+                        timer.stop();
+                    }
                 }
             }
         };
@@ -119,26 +120,32 @@ public class DfsPhase {
         }
 
         try {
+            Timer timer = maybeStart.apply(DfsTimingType.CREATE_WEIGHT);
             try {
-                maybeStart.accept(DfsTimingType.CREATE_WEIGHT);
                 searcher.createWeight(context.rewrittenQuery(), ScoreMode.COMPLETE, 1);
             } finally {
-                maybeStop.accept(DfsTimingType.CREATE_WEIGHT);
+                if (timer != null) {
+                    timer.stop();
+                }
             }
             for (RescoreContext rescoreContext : context.rescore()) {
                 for (ParsedQuery parsedQuery : rescoreContext.getParsedQueries()) {
                     final Query rewritten;
+                    timer = maybeStart.apply(DfsTimingType.REWRITE);
                     try {
-                        maybeStart.accept(DfsTimingType.REWRITE);
                         rewritten = searcher.rewrite(parsedQuery.query());
                     } finally {
-                        maybeStop.accept(DfsTimingType.REWRITE);
+                        if (timer != null) {
+                            timer.stop();
+                        }
                     }
+                    timer = maybeStart.apply(DfsTimingType.CREATE_WEIGHT);
                     try {
-                        maybeStart.accept(DfsTimingType.CREATE_WEIGHT);
                         searcher.createWeight(rewritten, ScoreMode.COMPLETE, 1);
                     } finally {
-                        maybeStop.accept(DfsTimingType.CREATE_WEIGHT);
+                        if (timer != null) {
+                            timer.stop();
+                        }
                     }
                 }
             }

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchPhase.java
@@ -29,6 +29,7 @@ import org.elasticsearch.search.lookup.Source;
 import org.elasticsearch.search.lookup.SourceProvider;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.Profilers;
+import org.elasticsearch.search.profile.Timer;
 import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.xcontent.XContentType;
 
@@ -122,7 +123,7 @@ public class FetchPhase {
 
             @Override
             protected void setNextReader(LeafReaderContext ctx, int[] docsInLeaf) throws IOException {
-                profiler.startNextReader();
+                Timer timer = profiler.startNextReader();
                 this.ctx = ctx;
                 this.leafNestedDocuments = nestedDocuments.getLeafNestedDocuments(ctx);
                 this.leafStoredFieldLoader = storedFieldLoader.getLoader(ctx, docsInLeaf);
@@ -131,7 +132,9 @@ public class FetchPhase {
                 for (FetchSubPhaseProcessor processor : processors) {
                     processor.setNextReader(ctx);
                 }
-                profiler.stopNextReader();
+                if (timer != null) {
+                    timer.stop();
+                }
             }
 
             @Override
@@ -235,11 +238,13 @@ public class FetchPhase {
             SearchHit hit = new SearchHit(docId, leafStoredFieldLoader.id());
             Source source;
             if (requiresSource) {
+                Timer timer = profiler.startLoadingSource();
                 try {
-                    profiler.startLoadingSource();
                     source = sourceLoader.source(leafStoredFieldLoader, subDocId);
                 } finally {
-                    profiler.stopLoadingSource();
+                    if (timer != null) {
+                        timer.stop();
+                    }
                 }
             } else {
                 source = Source.lazy(lazyStoredSourceLoader(profiler, subReaderContext, subDocId));
@@ -318,13 +323,9 @@ public class FetchPhase {
 
         StoredFieldLoader storedFields(StoredFieldLoader storedFieldLoader);
 
-        void startLoadingSource();
+        Timer startLoadingSource();
 
-        void stopLoadingSource();
-
-        void startNextReader();
-
-        void stopNextReader();
+        Timer startNextReader();
 
         Profiler NOOP = new Profiler() {
             @Override
@@ -343,16 +344,14 @@ public class FetchPhase {
             }
 
             @Override
-            public void startLoadingSource() {}
+            public Timer startLoadingSource() {
+                return null;
+            }
 
             @Override
-            public void stopLoadingSource() {}
-
-            @Override
-            public void startNextReader() {}
-
-            @Override
-            public void stopNextReader() {}
+            public Timer startNextReader() {
+                return null;
+            }
 
             @Override
             public String toString() {

--- a/server/src/main/java/org/elasticsearch/search/fetch/FetchProfiler.java
+++ b/server/src/main/java/org/elasticsearch/search/fetch/FetchProfiler.java
@@ -69,11 +69,12 @@ public class FetchProfiler implements FetchPhase.Profiler {
                 return new LeafStoredFieldLoader() {
                     @Override
                     public void advanceTo(int doc) throws IOException {
-                        current.getTimer(FetchPhaseTiming.LOAD_STORED_FIELDS).start();
+                        final Timer timer = current.getNewTimer(FetchPhaseTiming.LOAD_STORED_FIELDS);
+                        timer.start();
                         try {
                             in.advanceTo(doc);
                         } finally {
-                            current.getTimer(FetchPhaseTiming.LOAD_STORED_FIELDS).stop();
+                            timer.stop();
                         }
                     }
 
@@ -113,7 +114,7 @@ public class FetchProfiler implements FetchPhase.Profiler {
         return new FetchSubPhaseProcessor() {
             @Override
             public void setNextReader(LeafReaderContext readerContext) throws IOException {
-                Timer timer = breakdown.getTimer(FetchSubPhaseTiming.NEXT_READER);
+                Timer timer = breakdown.getNewTimer(FetchSubPhaseTiming.NEXT_READER);
                 timer.start();
                 try {
                     delegate.setNextReader(readerContext);
@@ -129,7 +130,7 @@ public class FetchProfiler implements FetchPhase.Profiler {
 
             @Override
             public void process(HitContext hitContext) throws IOException {
-                Timer timer = breakdown.getTimer(FetchSubPhaseTiming.PROCESS);
+                Timer timer = breakdown.getNewTimer(FetchSubPhaseTiming.PROCESS);
                 timer.start();
                 try {
                     delegate.process(hitContext);
@@ -141,23 +142,17 @@ public class FetchProfiler implements FetchPhase.Profiler {
     }
 
     @Override
-    public void startLoadingSource() {
-        current.getTimer(FetchPhaseTiming.LOAD_SOURCE).start();
+    public Timer startLoadingSource() {
+        Timer timer = current.getNewTimer(FetchPhaseTiming.LOAD_SOURCE);
+        timer.start();
+        return timer;
     }
 
     @Override
-    public void stopLoadingSource() {
-        current.getTimer(FetchPhaseTiming.LOAD_SOURCE).stop();
-    }
-
-    @Override
-    public void startNextReader() {
-        current.getTimer(FetchPhaseTiming.NEXT_READER).start();
-    }
-
-    @Override
-    public void stopNextReader() {
-        current.getTimer(FetchPhaseTiming.NEXT_READER).stop();
+    public Timer startNextReader() {
+        Timer timer = current.getNewTimer(FetchPhaseTiming.NEXT_READER);
+        timer.start();
+        return timer;
     }
 
     static class FetchProfileBreakdown extends AbstractProfileBreakdown<FetchPhaseTiming> {

--- a/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
+++ b/server/src/main/java/org/elasticsearch/search/internal/ContextIndexSearcher.java
@@ -177,7 +177,7 @@ public class ContextIndexSearcher extends IndexSearcher implements Releasable {
             // each invocation so that it can build an internal representation of the query
             // tree
             QueryProfileBreakdown profile = profiler.getQueryBreakdown(query);
-            Timer timer = profile.getTimer(QueryTimingType.CREATE_WEIGHT);
+            Timer timer = profile.getNewTimer(QueryTimingType.CREATE_WEIGHT);
             timer.start();
             final Weight weight;
             try {

--- a/server/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
@@ -36,7 +36,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
         T[] enumConstants = clazz.getEnumConstants();
         timings = new HashMap<>(enumConstants.length, 1.0f);
         for (int i = 0; i < enumConstants.length; ++i) {
-            Collection<Timer> listOfTimers = new ArrayList<>();
+            Collection<Timer> listOfTimers = Collections.synchronizedCollection(new ArrayList<>());
             listOfTimers.add(new Timer());
             timings.put(enumConstants[i], listOfTimers);
         }

--- a/server/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/AbstractProfileBreakdown.java
@@ -46,7 +46,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
      * @param timingType the timing type to create a new {@link Timer} for
      * @return a new {@link Timer} instance
      */
-    public Timer getNewTimer(T timingType) {
+    public synchronized Timer getNewTimer(T timingType) {
         Timer timer = new Timer();
         timings.get(timingType.ordinal()).add(timer);
         return timer;
@@ -57,7 +57,7 @@ public abstract class AbstractProfileBreakdown<T extends Enum<T>> {
      * If multiple timers where requested from different locations or threads from this profile breakdown,
      * the approximation will contain the sum of each timers approximate time and count.
      */
-    public final Map<String, Long> toBreakdownMap() {
+    public final synchronized Map<String, Long> toBreakdownMap() {
         Map<String, Long> map = Maps.newMapWithExpectedSize(timings.keySet().size() * 2);
         for (T timingType : this.timingTypes) {
             map.put(

--- a/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingAggregator.java
@@ -68,7 +68,7 @@ public class ProfilingAggregator extends Aggregator {
 
     @Override
     public InternalAggregation[] buildAggregations(long[] owningBucketOrds) throws IOException {
-        Timer timer = profileBreakdown.getTimer(AggregationTimingType.BUILD_AGGREGATION);
+        Timer timer = profileBreakdown.getNewTimer(AggregationTimingType.BUILD_AGGREGATION);
         InternalAggregation[] result;
         timer.start();
         try {
@@ -93,7 +93,7 @@ public class ProfilingAggregator extends Aggregator {
 
     @Override
     public LeafBucketCollector getLeafCollector(AggregationExecutionContext aggCtx) throws IOException {
-        Timer timer = profileBreakdown.getTimer(AggregationTimingType.BUILD_LEAF_COLLECTOR);
+        Timer timer = profileBreakdown.getNewTimer(AggregationTimingType.BUILD_LEAF_COLLECTOR);
         timer.start();
         try {
             return new ProfilingLeafBucketCollector(delegate.getLeafCollector(aggCtx), profileBreakdown);
@@ -105,7 +105,7 @@ public class ProfilingAggregator extends Aggregator {
     @Override
     public void preCollection() throws IOException {
         this.profileBreakdown = profiler.getQueryBreakdown(delegate);
-        Timer timer = profileBreakdown.getTimer(AggregationTimingType.INITIALIZE);
+        Timer timer = profileBreakdown.getNewTimer(AggregationTimingType.INITIALIZE);
         timer.start();
         try {
             delegate.preCollection();
@@ -117,7 +117,7 @@ public class ProfilingAggregator extends Aggregator {
 
     @Override
     public void postCollection() throws IOException {
-        Timer timer = profileBreakdown.getTimer(AggregationTimingType.POST_COLLECTION);
+        Timer timer = profileBreakdown.getNewTimer(AggregationTimingType.POST_COLLECTION);
         timer.start();
         try {
             delegate.postCollection();

--- a/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingLeafBucketCollector.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/aggregation/ProfilingLeafBucketCollector.java
@@ -22,7 +22,7 @@ public class ProfilingLeafBucketCollector extends LeafBucketCollector {
 
     public ProfilingLeafBucketCollector(LeafBucketCollector delegate, AggregationProfileBreakdown profileBreakdown) {
         this.delegate = delegate;
-        this.collectTimer = profileBreakdown.getTimer(AggregationTimingType.COLLECT);
+        this.collectTimer = profileBreakdown.getNewTimer(AggregationTimingType.COLLECT);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/profile/dfs/DfsProfiler.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/dfs/DfsProfiler.java
@@ -51,12 +51,6 @@ public class DfsProfiler extends AbstractProfileBreakdown<DfsTimingType> {
         return newTimer;
     }
 
-    public Timer stopTimer(DfsTimingType dfsTimingType) {
-        Timer newTimer = getNewTimer(dfsTimingType);
-        newTimer.stop();
-        return newTimer;
-    }
-
     public QueryProfiler addQueryProfiler(InternalProfileCollectorManager collectorManager) {
         QueryProfiler queryProfiler = new QueryProfiler();
         queryProfiler.setCollectorManager(collectorManager::getCollectorTree);

--- a/server/src/main/java/org/elasticsearch/search/profile/dfs/DfsProfiler.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/dfs/DfsProfiler.java
@@ -11,6 +11,7 @@ package org.elasticsearch.search.profile.dfs;
 import org.elasticsearch.search.profile.AbstractProfileBreakdown;
 import org.elasticsearch.search.profile.ProfileResult;
 import org.elasticsearch.search.profile.SearchProfileDfsPhaseResult;
+import org.elasticsearch.search.profile.Timer;
 import org.elasticsearch.search.profile.query.InternalProfileCollectorManager;
 import org.elasticsearch.search.profile.query.QueryProfileShardResult;
 import org.elasticsearch.search.profile.query.QueryProfiler;
@@ -44,12 +45,16 @@ public class DfsProfiler extends AbstractProfileBreakdown<DfsTimingType> {
         totalTime = System.nanoTime() - startTime;
     }
 
-    public void startTimer(DfsTimingType dfsTimingType) {
-        getTimer(dfsTimingType).start();
+    public Timer startTimer(DfsTimingType dfsTimingType) {
+        Timer newTimer = getNewTimer(dfsTimingType);
+        newTimer.start();
+        return newTimer;
     }
 
-    public void stopTimer(DfsTimingType dfsTimingType) {
-        getTimer(dfsTimingType).stop();
+    public Timer stopTimer(DfsTimingType dfsTimingType) {
+        Timer newTimer = getNewTimer(dfsTimingType);
+        newTimer.stop();
+        return newTimer;
     }
 
     public QueryProfiler addQueryProfiler(InternalProfileCollectorManager collectorManager) {

--- a/server/src/main/java/org/elasticsearch/search/profile/query/ProfileScorer.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/ProfileScorer.java
@@ -33,13 +33,13 @@ final class ProfileScorer extends Scorer {
         super(w);
         this.scorer = scorer;
         this.profileWeight = w;
-        scoreTimer = profile.getTimer(QueryTimingType.SCORE);
-        nextDocTimer = profile.getTimer(QueryTimingType.NEXT_DOC);
-        advanceTimer = profile.getTimer(QueryTimingType.ADVANCE);
-        matchTimer = profile.getTimer(QueryTimingType.MATCH);
-        shallowAdvanceTimer = profile.getTimer(QueryTimingType.SHALLOW_ADVANCE);
-        computeMaxScoreTimer = profile.getTimer(QueryTimingType.COMPUTE_MAX_SCORE);
-        setMinCompetitiveScoreTimer = profile.getTimer(QueryTimingType.SET_MIN_COMPETITIVE_SCORE);
+        scoreTimer = profile.getNewTimer(QueryTimingType.SCORE);
+        nextDocTimer = profile.getNewTimer(QueryTimingType.NEXT_DOC);
+        advanceTimer = profile.getNewTimer(QueryTimingType.ADVANCE);
+        matchTimer = profile.getNewTimer(QueryTimingType.MATCH);
+        shallowAdvanceTimer = profile.getNewTimer(QueryTimingType.SHALLOW_ADVANCE);
+        computeMaxScoreTimer = profile.getNewTimer(QueryTimingType.COMPUTE_MAX_SCORE);
+        setMinCompetitiveScoreTimer = profile.getNewTimer(QueryTimingType.SET_MIN_COMPETITIVE_SCORE);
     }
 
     @Override

--- a/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
@@ -47,7 +47,6 @@ public final class ProfileWeight extends Weight {
 
     @Override
     public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-        // TODO this is called concurrently now but we only have one timer!
         final Timer timer = profile.getNewTimer(QueryTimingType.BUILD_SCORER);
         timer.start();
         final ScorerSupplier subQueryScorerSupplier;

--- a/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
+++ b/server/src/main/java/org/elasticsearch/search/profile/query/ProfileWeight.java
@@ -47,7 +47,8 @@ public final class ProfileWeight extends Weight {
 
     @Override
     public ScorerSupplier scorerSupplier(LeafReaderContext context) throws IOException {
-        Timer timer = profile.getTimer(QueryTimingType.BUILD_SCORER);
+        // TODO this is called concurrently now but we only have one timer!
+        final Timer timer = profile.getNewTimer(QueryTimingType.BUILD_SCORER);
         timer.start();
         final ScorerSupplier subQueryScorerSupplier;
         try {
@@ -103,7 +104,7 @@ public final class ProfileWeight extends Weight {
 
     @Override
     public int count(LeafReaderContext context) throws IOException {
-        Timer timer = profile.getTimer(QueryTimingType.COUNT_WEIGHT);
+        Timer timer = profile.getNewTimer(QueryTimingType.COUNT_WEIGHT);
         timer.start();
         try {
             return subQueryWeight.count(context);

--- a/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0 and the Server Side Public License, v 1; you may not use this file except
+ * in compliance with, at your election, the Elastic License 2.0 or the Server
+ * Side Public License, v 1.
+ */
+
+package org.elasticsearch.search.profile;
+
+import org.elasticsearch.test.ESTestCase;
+
+import java.util.Map;
+
+import static org.hamcrest.Matchers.equalTo;
+
+public class AbstractProfileBreakdownTests extends ESTestCase {
+
+    enum TestTimingTypes {
+        ONE, TWO, THREE
+    }
+
+    static class TestProfileBreakdown extends AbstractProfileBreakdown<TestTimingTypes> {
+        /**
+         * Sole constructor
+         */
+        TestProfileBreakdown() {
+            super(TestTimingTypes.class);
+        }
+    }
+
+    public void testManagingDifferentTimers() {
+        TestProfileBreakdown testBreakdown = new TestProfileBreakdown();
+        Timer firstTimerOne = testBreakdown.getNewTimer(TestTimingTypes.ONE);
+        runTimer(firstTimerOne);
+        assertThat(firstTimerOne.getCount(), equalTo(1L));
+        long firstTimerOneTime = firstTimerOne.getApproximateTiming();
+
+        Timer secondTimerOne = testBreakdown.getNewTimer(TestTimingTypes.ONE);
+        runTimer(secondTimerOne);
+        // test that running second timer doesn't affect first timers count etc...
+        assertThat(firstTimerOne.getCount(), equalTo(1L));
+        assertThat(firstTimerOne.getApproximateTiming(), equalTo(firstTimerOneTime));
+    }
+
+    public void testGetBreakdownAndNodeTime() {
+        TestProfileBreakdown testBreakdown = new TestProfileBreakdown();
+
+        Timer firstTimerOne = testBreakdown.getNewTimer(TestTimingTypes.ONE);
+        int firstTimerOneCount = randomIntBetween(10,20);
+        runTimerNTimes(firstTimerOne, firstTimerOneCount);
+
+        Timer firstTimerTwo = testBreakdown.getNewTimer(TestTimingTypes.TWO);
+        int firstTimerTwoCount = randomIntBetween(10,20);
+        runTimerNTimes(firstTimerTwo, firstTimerTwoCount);
+
+        Timer secondTimerTwo = testBreakdown.getNewTimer(TestTimingTypes.TWO);
+        int secondTimerTwoCount = randomIntBetween(10,20);
+        runTimerNTimes(secondTimerTwo, secondTimerTwoCount);
+
+
+        // check behaviour if one timer type hasn't been created and used
+        Map<String, Long> breakdownMap = testBreakdown.toBreakdownMap();
+        assertThat(breakdownMap.size(), equalTo(6));
+        assertThat(breakdownMap.get(TestTimingTypes.ONE.name()), equalTo(firstTimerOne.getApproximateTiming()));
+        assertThat(breakdownMap.get(TestTimingTypes.ONE.name() + "_count"), equalTo(firstTimerOne.getCount()));
+        assertThat(
+            breakdownMap.get(TestTimingTypes.TWO.name()),
+            equalTo(firstTimerTwo.getApproximateTiming() + secondTimerTwo.getApproximateTiming())
+        );
+        assertThat(breakdownMap.get(TestTimingTypes.TWO.name() + "_count"), equalTo(firstTimerTwo.getCount() + secondTimerTwo.getCount()));
+        assertThat(breakdownMap.get(TestTimingTypes.THREE.name()), equalTo(0L));
+        assertThat(breakdownMap.get(TestTimingTypes.THREE.name() + "_count"), equalTo(0L));
+
+        Timer firstTimerThree = testBreakdown.getNewTimer(TestTimingTypes.THREE);
+        int firstTimerThreeCount = randomIntBetween(10,20);
+        runTimerNTimes(firstTimerThree, firstTimerThreeCount);
+
+        breakdownMap = testBreakdown.toBreakdownMap();
+        assertThat(breakdownMap.size(), equalTo(6));
+        assertThat(breakdownMap.get(TestTimingTypes.ONE.name()), equalTo(firstTimerOne.getApproximateTiming()));
+        assertThat(breakdownMap.get(TestTimingTypes.ONE.name() + "_count"), equalTo(firstTimerOne.getCount()));
+        assertThat(
+            breakdownMap.get(TestTimingTypes.TWO.name()),
+            equalTo(firstTimerTwo.getApproximateTiming() + secondTimerTwo.getApproximateTiming())
+        );
+        assertThat(breakdownMap.get(TestTimingTypes.TWO.name() + "_count"), equalTo(firstTimerTwo.getCount() + secondTimerTwo.getCount()));
+        assertThat(breakdownMap.get(TestTimingTypes.THREE.name()), equalTo(firstTimerThree.getApproximateTiming()));
+        assertThat(breakdownMap.get(TestTimingTypes.THREE.name() + "_count"), equalTo(firstTimerThree.getCount()));
+
+        assertThat(
+            testBreakdown.toNodeTime(),
+            equalTo(
+                firstTimerOne.getApproximateTiming() + firstTimerTwo.getApproximateTiming() + secondTimerTwo.getApproximateTiming()
+                    + firstTimerThree.getApproximateTiming()
+            )
+        );
+    }
+
+    private void runTimerNTimes(Timer t, int n) {
+        for (int i = 0; i < n; i++) {
+            runTimer(t);
+        }
+    }
+
+    private void runTimer(Timer t) {
+        t.start();
+        t.stop();
+    }
+
+}

--- a/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
@@ -11,7 +11,6 @@ package org.elasticsearch.search.profile;
 import org.elasticsearch.test.ESTestCase;
 
 import java.util.Map;
-import java.util.concurrent.BrokenBarrierException;
 import java.util.concurrent.CountDownLatch;
 
 import static org.hamcrest.Matchers.equalTo;
@@ -100,7 +99,7 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
         );
     }
 
-    public void testMultiThreaded() throws BrokenBarrierException, InterruptedException {
+    public void testMultiThreaded() throws InterruptedException {
         TestProfileBreakdown testBreakdown = new TestProfileBreakdown();
         Thread[] threads = new Thread[2000];
         final CountDownLatch latch = new CountDownLatch(1);

--- a/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
@@ -17,7 +17,9 @@ import static org.hamcrest.Matchers.equalTo;
 public class AbstractProfileBreakdownTests extends ESTestCase {
 
     enum TestTimingTypes {
-        ONE, TWO, THREE
+        ONE,
+        TWO,
+        THREE
     }
 
     static class TestProfileBreakdown extends AbstractProfileBreakdown<TestTimingTypes> {
@@ -47,17 +49,16 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
         TestProfileBreakdown testBreakdown = new TestProfileBreakdown();
 
         Timer firstTimerOne = testBreakdown.getNewTimer(TestTimingTypes.ONE);
-        int firstTimerOneCount = randomIntBetween(10,20);
+        int firstTimerOneCount = randomIntBetween(10, 20);
         runTimerNTimes(firstTimerOne, firstTimerOneCount);
 
         Timer firstTimerTwo = testBreakdown.getNewTimer(TestTimingTypes.TWO);
-        int firstTimerTwoCount = randomIntBetween(10,20);
+        int firstTimerTwoCount = randomIntBetween(10, 20);
         runTimerNTimes(firstTimerTwo, firstTimerTwoCount);
 
         Timer secondTimerTwo = testBreakdown.getNewTimer(TestTimingTypes.TWO);
-        int secondTimerTwoCount = randomIntBetween(10,20);
+        int secondTimerTwoCount = randomIntBetween(10, 20);
         runTimerNTimes(secondTimerTwo, secondTimerTwoCount);
-
 
         // check behaviour if one timer type hasn't been created and used
         Map<String, Long> breakdownMap = testBreakdown.toBreakdownMap();
@@ -73,7 +74,7 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
         assertThat(breakdownMap.get(TestTimingTypes.THREE.name() + "_count"), equalTo(0L));
 
         Timer firstTimerThree = testBreakdown.getNewTimer(TestTimingTypes.THREE);
-        int firstTimerThreeCount = randomIntBetween(10,20);
+        int firstTimerThreeCount = randomIntBetween(10, 20);
         runTimerNTimes(firstTimerThree, firstTimerThreeCount);
 
         breakdownMap = testBreakdown.toBreakdownMap();

--- a/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
@@ -126,6 +126,7 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
             });
             threads[t].start();
         }
+        // starting all threads simultaneously increases the likelihood of failure in case we don't synchronize timer access properly
         latch.countDown();
         for (Thread t : threads) {
             t.join();
@@ -134,6 +135,7 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
         long totalCounter = breakdownMap.get(TestTimingTypes.ONE + "_count") + breakdownMap.get(TestTimingTypes.TWO + "_count")
             + breakdownMap.get(TestTimingTypes.THREE + "_count");
         assertEquals(threads.length * startsPerThread, totalCounter);
+
     }
 
     private void runTimerNTimes(Timer t, int n) {

--- a/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
+++ b/server/src/test/java/org/elasticsearch/search/profile/AbstractProfileBreakdownTests.java
@@ -41,9 +41,15 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
 
         Timer secondTimerOne = testBreakdown.getNewTimer(TestTimingTypes.ONE);
         runTimer(secondTimerOne);
-        // test that running second timer doesn't affect first timers count etc...
+        // test that running second timer doesn't affect first timers count etc... and vice versa
         assertThat(firstTimerOne.getCount(), equalTo(1L));
         assertThat(firstTimerOne.getApproximateTiming(), equalTo(firstTimerOneTime));
+
+        assertThat(secondTimerOne.getCount(), equalTo(1L));
+        long approximateTimingSecondTimer = secondTimerOne.getApproximateTiming();
+        runTimer(firstTimerOne);
+        assertThat(secondTimerOne.getCount(), equalTo(1L));
+        assertThat(secondTimerOne.getApproximateTiming(), equalTo(approximateTimingSecondTimer));
     }
 
     public void testGetBreakdownAndNodeTime() {
@@ -101,7 +107,7 @@ public class AbstractProfileBreakdownTests extends ESTestCase {
 
     public void testMultiThreaded() throws InterruptedException {
         TestProfileBreakdown testBreakdown = new TestProfileBreakdown();
-        Thread[] threads = new Thread[2000];
+        Thread[] threads = new Thread[200];
         final CountDownLatch latch = new CountDownLatch(1);
         int startsPerThread = between(1, 5);
         for (int t = 0; t < threads.length; t++) {


### PR DESCRIPTION
This changes AbstractProfileBreakdown to enable its use in multi-threaded contexts.
It allows to keep a list of Timer instances per timing type. This is somewhat similar to what
collector managers do for collectors. The final timing that is returned for the profiler output
is the sum of all individual timers.

Relates to #96689