### PR TITLE
Execute downsampling after allocate and migrate actions

### DIFF
--- a/docs/changelog/97014.yaml
+++ b/docs/changelog/97014.yaml
@@ -1,0 +1,6 @@
+pr: 97014
+summary: Execute downsampling after allocate and migrate actions
+area: Downsampling
+type: enhancement
+issues:
+ - 96734

--- a/docs/changelog/97014.yaml
+++ b/docs/changelog/97014.yaml
@@ -1,6 +1,6 @@
 pr: 97014
 summary: Execute downsampling after allocate and migrate actions
 area: Downsampling
-type: enhancement
+type: bug
 issues:
  - 96734

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/ilm/TimeseriesLifecycleType.java
@@ -66,9 +66,9 @@ public class TimeseriesLifecycleType implements LifecycleType {
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
-        DownsampleAction.NAME,
         AllocateAction.NAME,
         MigrateAction.NAME,
+        DownsampleAction.NAME,
         ShrinkAction.NAME,
         ForceMergeAction.NAME
     ).filter(Objects::nonNull).toList();
@@ -76,10 +76,10 @@ public class TimeseriesLifecycleType implements LifecycleType {
         SetPriorityAction.NAME,
         UnfollowAction.NAME,
         ReadOnlyAction.NAME,
-        DownsampleAction.NAME,
         SearchableSnapshotAction.NAME,
         AllocateAction.NAME,
         MigrateAction.NAME,
+        DownsampleAction.NAME,
         FreezeAction.NAME
     ).filter(Objects::nonNull).toList();
     public static final List<String> ORDERED_VALID_FROZEN_ACTIONS = List.of(UnfollowAction.NAME, SearchableSnapshotAction.NAME);


### PR DESCRIPTION
Here we change the order of actions executed for downsampling. We make sure
the ILM Allocate and Migrate actions take place before the ILM Downsample action.
This is done to make sure that the index is migrated first to the appropriate tier
before the downsample action is executed. This is useful especially to spare some
additional work that would normally happen on the hot tier (on the warm tier) when
downsampling is performed in the hot to warm (warm to cold) phase transition.

If for example the downsample action operation is done while transitioning from
hot to warm it means the hot tier is already doing different things including serving
query/aggregation requests for recent data, including data stored in indices waiting
for downsampling to complete.

Once downsampling is complete the hot tier will serve query/aggregation requests instead
of the hot tier. Also, the warm tier will run the actual downsampling task sparing the hot
tier from doing additional work. This would result in better workload balance/allocation
between the hot and warm tier.

Similar reasoning applies when downsampling happens while transitioning from warm to
cold tier.

Resolves #96734 