### PR TITLE
[8.9] Marking Cluster `_info` API as experimental (#97020)

### DIFF
--- a/docs/reference/cluster/cluster-info.asciidoc
+++ b/docs/reference/cluster/cluster-info.asciidoc
@@ -1,5 +1,8 @@
 [[cluster-info]]
 === Cluster Info API
+
+experimental::[]
+
 ++++
 <titleabbrev>Cluster Info</titleabbrev>
 ++++


### PR DESCRIPTION
Backports the following commits to 8.9:
 - Marking Cluster `_info` API as experimental (#97020)