### PR TITLE
Improve test coverage for CCS search cancellation and fix response bugs

### DIFF
--- a/docs/changelog/97029.yaml
+++ b/docs/changelog/97029.yaml
@@ -1,0 +1,5 @@
+pr: 97029
+summary: Improve test coverage for CCS search cancellation and fix response bugs
+area: Search
+type: bug
+issues: []

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -298,14 +298,11 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
             }
         });
 
-        try {
-            queryFuture.result();
-            fail("Exception should have been thrown since the search task was cancelled before the search completed");
-        } catch (Exception e) {
-            // should have been stopped due to TaskCancelledException
-            Throwable t = ExceptionsHelper.unwrap(e, TaskCancelledException.class);
-            assertNotNull(t);
-        }
+        RuntimeException e = expectThrows(RuntimeException.class, () -> queryFuture.result());
+        assertNotNull(e);
+        assertNotNull(e.getCause());
+        Throwable t = ExceptionsHelper.unwrap(e, TaskCancelledException.class);
+        assertNotNull(t);
     }
 
     /**

--- a/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/search/ccs/CrossClusterSearchIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.search.ccs;
 
+import org.elasticsearch.ExceptionsHelper;
 import org.elasticsearch.action.ActionFuture;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
 import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
@@ -43,6 +44,7 @@ import org.elasticsearch.search.internal.ReaderContext;
 import org.elasticsearch.search.internal.SearchContext;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskCancelledException;
 import org.elasticsearch.tasks.TaskInfo;
 import org.elasticsearch.test.AbstractMultiClustersTestCase;
 import org.elasticsearch.test.InternalTestCluster;
@@ -61,11 +63,13 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertHitCount;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.not;
@@ -238,6 +242,25 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
             .filter(t -> t.parentTaskId().isSet() == false)
             .findFirst()
             .get();
+
+        AtomicReference<List<TaskInfo>> remoteClusterSearchTasks = new AtomicReference<>();
+        assertBusy(() -> {
+            List<TaskInfo> remoteSearchTasks = client("cluster_a").admin()
+                .cluster()
+                .prepareListTasks()
+                .get()
+                .getTasks()
+                .stream()
+                .filter(t -> t.action().startsWith("indices:data/read/search"))
+                .collect(Collectors.toList());
+            assertThat(remoteSearchTasks.size(), greaterThan(0));
+            remoteClusterSearchTasks.set(remoteSearchTasks);
+        });
+
+        for (TaskInfo taskInfo : remoteClusterSearchTasks.get()) {
+            assertFalse("taskInfo is cancelled: " + taskInfo, taskInfo.cancelled());
+        }
+
         final CancelTasksRequest cancelRequest = new CancelTasksRequest().setTargetTaskId(rootTask.taskId());
         cancelRequest.setWaitForCompletion(randomBoolean());
         final ActionFuture<CancelTasksResponse> cancelFuture = client().admin().cluster().cancelTasks(cancelRequest);
@@ -252,6 +275,19 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
                 }
             }
         });
+
+        List<TaskInfo> remoteSearchTasksAfterCancellation = client("cluster_a").admin()
+            .cluster()
+            .prepareListTasks()
+            .get()
+            .getTasks()
+            .stream()
+            .filter(t -> t.action().startsWith("indices:data/read/search"))
+            .collect(Collectors.toList());
+        for (TaskInfo taskInfo : remoteSearchTasksAfterCancellation) {
+            assertTrue(taskInfo.description(), taskInfo.cancelled());
+        }
+
         SearchListenerPlugin.allowQueryPhase();
         assertBusy(() -> assertTrue(queryFuture.isDone()));
         assertBusy(() -> assertTrue(cancelFuture.isDone()));
@@ -261,6 +297,15 @@ public class CrossClusterSearchIT extends AbstractMultiClustersTestCase {
                 assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
             }
         });
+
+        try {
+            queryFuture.result();
+            fail("Exception should have been thrown since the search task was cancelled before the search completed");
+        } catch (Exception e) {
+            // should have been stopped due to TaskCancelledException
+            Throwable t = ExceptionsHelper.unwrap(e, TaskCancelledException.class);
+            assertNotNull(t);
+        }
     }
 
     /**

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -177,7 +177,7 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
             // check async search status before allowing query to continue but after cancellation
             AsyncSearchResponse searchResponseAfterCancellation = getAsyncSearch(response.getId());
             assertTrue(searchResponseAfterCancellation.isPartial());
-            assertFalse(searchResponseAfterCancellation.isRunning());  // FIXME - diverges from status response - question out to Luca
+            assertTrue(searchResponseAfterCancellation.isRunning());
             assertFalse(searchResponseAfterCancellation.getSearchResponse().isTimedOut());
             assertThat(searchResponseAfterCancellation.getSearchResponse().getClusters().getTotal(), equalTo(2));
             assertThat(searchResponseAfterCancellation.getSearchResponse().getFailedShards(), equalTo(0));

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -1,0 +1,454 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.elasticsearch.ExceptionsHelper;
+import org.elasticsearch.ResourceNotFoundException;
+import org.elasticsearch.action.ActionFuture;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksRequest;
+import org.elasticsearch.action.admin.cluster.node.tasks.cancel.CancelTasksResponse;
+import org.elasticsearch.action.admin.cluster.node.tasks.list.ListTasksResponse;
+import org.elasticsearch.action.search.SearchAction;
+import org.elasticsearch.action.search.ShardSearchFailure;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
+import org.elasticsearch.client.internal.Client;
+import org.elasticsearch.cluster.metadata.IndexMetadata;
+import org.elasticsearch.cluster.node.DiscoveryNode;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.core.TimeValue;
+import org.elasticsearch.index.IndexModule;
+import org.elasticsearch.index.query.MatchAllQueryBuilder;
+import org.elasticsearch.index.shard.SearchOperationListener;
+import org.elasticsearch.plugins.Plugin;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.search.builder.SearchSourceBuilder;
+import org.elasticsearch.search.internal.LegacyReaderContext;
+import org.elasticsearch.search.internal.ReaderContext;
+import org.elasticsearch.search.internal.SearchContext;
+import org.elasticsearch.tasks.CancellableTask;
+import org.elasticsearch.tasks.TaskCancelledException;
+import org.elasticsearch.tasks.TaskInfo;
+import org.elasticsearch.test.AbstractMultiClustersTestCase;
+import org.elasticsearch.test.InternalTestCluster;
+import org.elasticsearch.transport.TransportService;
+import org.elasticsearch.xcontent.ToXContent;
+import org.elasticsearch.xcontent.XContentFactory;
+import org.elasticsearch.xpack.async.AsyncResultsIndexPlugin;
+import org.elasticsearch.xpack.core.LocalStateCompositeXPackPlugin;
+import org.elasticsearch.xpack.core.async.DeleteAsyncResultAction;
+import org.elasticsearch.xpack.core.async.DeleteAsyncResultRequest;
+import org.elasticsearch.xpack.core.async.GetAsyncResultRequest;
+import org.elasticsearch.xpack.core.async.GetAsyncStatusRequest;
+import org.elasticsearch.xpack.core.search.action.AsyncSearchResponse;
+import org.elasticsearch.xpack.core.search.action.AsyncStatusResponse;
+import org.elasticsearch.xpack.core.search.action.GetAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.GetAsyncStatusAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchAction;
+import org.elasticsearch.xpack.core.search.action.SubmitAsyncSearchRequest;
+import org.hamcrest.Matchers;
+import org.junit.Before;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.not;
+
+/**
+ * This IT test copies the setup and general approach that the {@code CrossClusterSearchIT} test
+ * used for testing synchronous CCS.
+ */
+public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
+
+    private static final String REMOTE_CLUSTER = "cluster_a";
+
+    @Override
+    protected Collection<String> remoteClusterAlias() {
+        return List.of(REMOTE_CLUSTER);
+    }
+
+    @Override
+    protected boolean reuseClusters() {
+        return false;
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins(String clusterAlias) {
+        List<Class<? extends Plugin>> plugs = Arrays.asList(
+            SearchListenerPlugin.class,
+            AsyncSearch.class,
+            AsyncResultsIndexPlugin.class,
+            LocalStateCompositeXPackPlugin.class
+        );
+        return Stream.concat(super.nodePlugins(clusterAlias).stream(), plugs.stream()).collect(Collectors.toList());
+    }
+
+    public void testCancelViaTasksAPI() throws Exception {
+        setupTwoClusters();
+
+        SearchListenerPlugin.blockQueryPhase();
+
+        SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest("demo", REMOTE_CLUSTER + ":prod");
+        request.setCcsMinimizeRoundtrips(randomBoolean());
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1));
+        request.setKeepOnCompletion(true);
+        request.getSearchRequest().allowPartialSearchResults(false);
+        request.getSearchRequest().source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).size(1000));
+
+        AsyncSearchResponse response = submitAsyncSearch(request);
+        assertNotNull(response.getSearchResponse());
+        assertTrue(response.isRunning());
+
+        SearchListenerPlugin.waitSearchStarted();
+
+        ActionFuture<CancelTasksResponse> cancelFuture;
+        try {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(1));
+            final TaskInfo rootTask = tasks.get(0);
+
+            AtomicReference<List<TaskInfo>> remoteClusterSearchTasks = new AtomicReference<>();
+            assertBusy(() -> {
+                List<TaskInfo> remoteSearchTasks = client(REMOTE_CLUSTER).admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .get()
+                    .getTasks()
+                    .stream()
+                    .filter(t -> t.action().contains(SearchAction.NAME))
+                    .collect(Collectors.toList());
+                assertThat(remoteSearchTasks.size(), greaterThan(0));
+                remoteClusterSearchTasks.set(remoteSearchTasks);
+            });
+
+            for (TaskInfo taskInfo : remoteClusterSearchTasks.get()) {
+                assertFalse("taskInfo on remote cluster should not be cancelled yet: " + taskInfo, taskInfo.cancelled());
+            }
+
+            final CancelTasksRequest cancelRequest = new CancelTasksRequest().setTargetTaskId(rootTask.taskId());
+            cancelRequest.setWaitForCompletion(randomBoolean());
+            cancelFuture = client().admin().cluster().cancelTasks(cancelRequest);
+            assertBusy(() -> {
+                final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
+                for (TransportService transportService : transportServices) {
+                    Collection<CancellableTask> cancellableTasks = transportService.getTaskManager().getCancellableTasks().values();
+                    for (CancellableTask cancellableTask : cancellableTasks) {
+                        if (cancellableTask.getAction().contains(SearchAction.INSTANCE.name())) {
+                            assertTrue(cancellableTask.getDescription(), cancellableTask.isCancelled());
+                        }
+                    }
+                }
+            });
+
+            List<TaskInfo> remoteSearchTasksAfterCancellation = client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .get()
+                .getTasks()
+                .stream()
+                .filter(t -> t.action().contains(SearchAction.INSTANCE.name()))
+                .toList();
+            for (TaskInfo taskInfo : remoteSearchTasksAfterCancellation) {
+                assertTrue(taskInfo.description(), taskInfo.cancelled());
+            }
+
+            // check async search status before allowing query to continue but after cancellation
+            AsyncSearchResponse searchResponseAfterCancellation = getAsyncSearch(response.getId());
+            assertTrue(searchResponseAfterCancellation.isPartial());
+            assertFalse(searchResponseAfterCancellation.isRunning());  // FIXME - diverges from status response - question out to Luca
+            assertFalse(searchResponseAfterCancellation.getSearchResponse().isTimedOut());
+            assertThat(searchResponseAfterCancellation.getSearchResponse().getClusters().getTotal(), equalTo(2));
+            assertThat(searchResponseAfterCancellation.getSearchResponse().getFailedShards(), equalTo(0));
+
+            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
+            assertTrue(statusResponse.isPartial());
+            assertTrue(statusResponse.isRunning());
+            assertThat(statusResponse.getClusters().getTotal(), equalTo(2));
+            assertThat(statusResponse.getFailedShards(), equalTo(0));
+            assertNull(statusResponse.getCompletionStatus());
+
+        } finally {
+            SearchListenerPlugin.allowQueryPhase();
+        }
+
+        assertBusy(() -> assertTrue(cancelFuture.isDone()));
+        assertBusy(() -> {
+            final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
+            for (TransportService transportService : transportServices) {
+                assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
+            }
+        });
+
+        // wait until search status endpoint reports it as completed
+        assertBusy(() -> {
+            AsyncStatusResponse statusResponseAfterCompletion = getAsyncStatus(response.getId());
+            assertNotNull(statusResponseAfterCompletion.getCompletionStatus());
+        });
+
+        AsyncStatusResponse statusResponseAfterCompletion = getAsyncStatus(response.getId());
+        assertTrue(statusResponseAfterCompletion.isPartial());
+        assertFalse(statusResponseAfterCompletion.isRunning());
+        assertThat(statusResponseAfterCompletion.getClusters().getTotal(), equalTo(2));
+        assertThat(statusResponseAfterCompletion.getFailedShards(), greaterThan(0));
+        assertThat(statusResponseAfterCompletion.getCompletionStatus(), equalTo(RestStatus.BAD_REQUEST));
+
+        AsyncSearchResponse searchResponseAfterCompletion = getAsyncSearch(response.getId());
+        assertTrue(searchResponseAfterCompletion.isPartial());
+        assertFalse(searchResponseAfterCompletion.isRunning());
+        assertFalse(searchResponseAfterCompletion.getSearchResponse().isTimedOut());
+        assertThat(searchResponseAfterCompletion.getSearchResponse().getClusters().getTotal(), equalTo(2));
+        assertThat(searchResponseAfterCompletion.getSearchResponse().getFailedShards(), greaterThan(0));
+        Throwable cause = ExceptionsHelper.unwrap(searchResponseAfterCompletion.getFailure(), TaskCancelledException.class);
+        assertNotNull("TaskCancelledException should be in the causal chain", cause);
+        ShardSearchFailure[] shardFailures = searchResponseAfterCompletion.getSearchResponse().getShardFailures();
+        assertThat(shardFailures.length, greaterThan(0));
+        String json = Strings.toString(searchResponseAfterCompletion.toXContent(XContentFactory.jsonBuilder(), ToXContent.EMPTY_PARAMS));
+        assertThat(json, containsString("task cancelled [by user request]"));
+    }
+
+    public void testCancelViaAsyncSearchDelete() throws Exception {
+        setupTwoClusters();
+
+        SearchListenerPlugin.blockQueryPhase();
+
+        SubmitAsyncSearchRequest request = new SubmitAsyncSearchRequest("demo", REMOTE_CLUSTER + ":prod");
+        request.setCcsMinimizeRoundtrips(randomBoolean());
+        request.setWaitForCompletionTimeout(TimeValue.timeValueMillis(1));
+        request.setKeepOnCompletion(true);
+        request.getSearchRequest().allowPartialSearchResults(false);
+        request.getSearchRequest().source(new SearchSourceBuilder().query(new MatchAllQueryBuilder()).size(1000));
+
+        AsyncSearchResponse response = submitAsyncSearch(request);
+        assertNotNull(response.getSearchResponse());
+        assertTrue(response.isRunning());
+
+        SearchListenerPlugin.waitSearchStarted();
+
+        try {
+            ListTasksResponse listTasksResponse = client(LOCAL_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .setActions(SearchAction.INSTANCE.name())
+                .get();
+            List<TaskInfo> tasks = listTasksResponse.getTasks();
+            assertThat(tasks.size(), equalTo(1));
+            final TaskInfo rootTask = tasks.get(0);
+
+            AtomicReference<List<TaskInfo>> remoteClusterSearchTasks = new AtomicReference<>();
+            assertBusy(() -> {
+                List<TaskInfo> remoteSearchTasks = client(REMOTE_CLUSTER).admin()
+                    .cluster()
+                    .prepareListTasks()
+                    .get()
+                    .getTasks()
+                    .stream()
+                    .filter(t -> t.action().contains(SearchAction.NAME))
+                    .collect(Collectors.toList());
+                assertThat(remoteSearchTasks.size(), greaterThan(0));
+                remoteClusterSearchTasks.set(remoteSearchTasks);
+            });
+
+            for (TaskInfo taskInfo : remoteClusterSearchTasks.get()) {
+                assertFalse("taskInfo on remote cluster should not be cancelled yet: " + taskInfo, taskInfo.cancelled());
+            }
+
+            AcknowledgedResponse ack = deleteAsyncSearch(response.getId());
+            assertTrue(ack.isAcknowledged());
+
+            assertBusy(() -> {
+                final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
+                for (TransportService transportService : transportServices) {
+                    Collection<CancellableTask> cancellableTasks = transportService.getTaskManager().getCancellableTasks().values();
+                    for (CancellableTask cancellableTask : cancellableTasks) {
+                        if (cancellableTask.getAction().contains(SearchAction.INSTANCE.name())) {
+                            assertTrue(cancellableTask.getDescription(), cancellableTask.isCancelled());
+                        }
+                    }
+                }
+            });
+
+            List<TaskInfo> remoteSearchTasksAfterCancellation = client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareListTasks()
+                .get()
+                .getTasks()
+                .stream()
+                .filter(t -> t.action().contains(SearchAction.INSTANCE.name()))
+                .toList();
+            for (TaskInfo taskInfo : remoteSearchTasksAfterCancellation) {
+                assertTrue(taskInfo.description(), taskInfo.cancelled());
+            }
+
+            try {
+                getAsyncSearch(response.getId());
+                fail("getAsyncSearch should throw ResourceNotFoundException after deletion");
+            } catch (Exception e) {
+                assertNotNull(
+                    "after deletion, getAsyncSearch should throw an Exception with ResourceNotFoundException in the causal chain",
+                    ExceptionsHelper.unwrap(e, ResourceNotFoundException.class)
+                );
+            }
+
+            AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
+            assertTrue(statusResponse.isPartial());
+            assertTrue(statusResponse.isRunning());
+            assertThat(statusResponse.getClusters().getTotal(), equalTo(2));
+            assertThat(statusResponse.getFailedShards(), equalTo(0));
+            assertNull(statusResponse.getCompletionStatus());
+        } finally {
+            SearchListenerPlugin.allowQueryPhase();
+        }
+
+        assertBusy(() -> expectThrows(ExecutionException.class, () -> getAsyncStatus(response.getId())));
+        assertBusy(() -> {
+            final Iterable<TransportService> transportServices = cluster(REMOTE_CLUSTER).getInstances(TransportService.class);
+            for (TransportService transportService : transportServices) {
+                assertThat(transportService.getTaskManager().getBannedTaskIds(), Matchers.empty());
+            }
+        });
+    }
+
+    protected AsyncSearchResponse submitAsyncSearch(SubmitAsyncSearchRequest request) throws ExecutionException, InterruptedException {
+        return client(LOCAL_CLUSTER).execute(SubmitAsyncSearchAction.INSTANCE, request).get();
+    }
+
+    protected AsyncSearchResponse getAsyncSearch(String id) throws ExecutionException, InterruptedException {
+        return client(LOCAL_CLUSTER).execute(GetAsyncSearchAction.INSTANCE, new GetAsyncResultRequest(id)).get();
+    }
+
+    protected AsyncStatusResponse getAsyncStatus(String id) throws ExecutionException, InterruptedException {
+        return client(LOCAL_CLUSTER).execute(GetAsyncStatusAction.INSTANCE, new GetAsyncStatusRequest(id)).get();
+    }
+
+    protected AcknowledgedResponse deleteAsyncSearch(String id) throws ExecutionException, InterruptedException {
+        return client().execute(DeleteAsyncResultAction.INSTANCE, new DeleteAsyncResultRequest(id)).get();
+    }
+
+    private void setupTwoClusters() throws Exception {
+        assertAcked(client(LOCAL_CLUSTER).admin().indices().prepareCreate("demo"));
+        indexDocs(client(LOCAL_CLUSTER), "demo");
+        final InternalTestCluster remoteCluster = cluster(REMOTE_CLUSTER);
+        remoteCluster.ensureAtLeastNumDataNodes(1);
+        final Settings.Builder allocationFilter = Settings.builder();
+        if (randomBoolean()) {
+            remoteCluster.ensureAtLeastNumDataNodes(3);
+            List<String> remoteDataNodes = remoteCluster.clusterService()
+                .state()
+                .nodes()
+                .stream()
+                .filter(DiscoveryNode::canContainData)
+                .map(DiscoveryNode::getName)
+                .toList();
+            assertThat(remoteDataNodes.size(), Matchers.greaterThanOrEqualTo(3));
+            List<String> seedNodes = randomSubsetOf(between(1, remoteDataNodes.size() - 1), remoteDataNodes);
+            disconnectFromRemoteClusters();
+            configureRemoteCluster(REMOTE_CLUSTER, seedNodes);
+            if (randomBoolean()) {
+                // Using proxy connections
+                allocationFilter.put("index.routing.allocation.exclude._name", String.join(",", seedNodes));
+            } else {
+                allocationFilter.put("index.routing.allocation.include._name", String.join(",", seedNodes));
+            }
+        }
+        assertAcked(
+            client(REMOTE_CLUSTER).admin()
+                .indices()
+                .prepareCreate("prod")
+                .setSettings(Settings.builder().put(allocationFilter.build()).put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0))
+        );
+        assertFalse(
+            client(REMOTE_CLUSTER).admin()
+                .cluster()
+                .prepareHealth("prod")
+                .setWaitForYellowStatus()
+                .setTimeout(TimeValue.timeValueSeconds(10))
+                .get()
+                .isTimedOut()
+        );
+        indexDocs(client(REMOTE_CLUSTER), "prod");
+    }
+
+    private int indexDocs(Client client, String index) {
+        int numDocs = between(1, 10);
+        for (int i = 0; i < numDocs; i++) {
+            client.prepareIndex(index).setSource("f", "v").get();
+        }
+        client.admin().indices().prepareRefresh(index).get();
+        return numDocs;
+    }
+
+    @Before
+    public void resetSearchListenerPlugin() throws Exception {
+        SearchListenerPlugin.reset();
+    }
+
+    public static class SearchListenerPlugin extends Plugin {
+        private static final AtomicReference<CountDownLatch> startedLatch = new AtomicReference<>();
+        private static final AtomicReference<CountDownLatch> queryLatch = new AtomicReference<>();
+
+        static void reset() {
+            startedLatch.set(new CountDownLatch(1));
+        }
+
+        static void blockQueryPhase() {
+            queryLatch.set(new CountDownLatch(1));
+        }
+
+        static void allowQueryPhase() {
+            final CountDownLatch latch = queryLatch.get();
+            if (latch != null) {
+                latch.countDown();
+            }
+        }
+
+        static void waitSearchStarted() throws InterruptedException {
+            assertTrue(startedLatch.get().await(60, TimeUnit.SECONDS));
+        }
+
+        @Override
+        public void onIndexModule(IndexModule indexModule) {
+            indexModule.addSearchOperationListener(new SearchOperationListener() {
+                @Override
+                public void onNewReaderContext(ReaderContext readerContext) {
+                    assertThat(readerContext, not(instanceOf(LegacyReaderContext.class)));
+                }
+
+                @Override
+                public void onPreQueryPhase(SearchContext searchContext) {
+                    startedLatch.get().countDown();
+                    final CountDownLatch latch = queryLatch.get();
+                    if (latch != null) {
+                        try {
+                            assertTrue(latch.await(60, TimeUnit.SECONDS));
+                        } catch (InterruptedException e) {
+                            throw new AssertionError(e);
+                        }
+                    }
+                }
+            });
+            super.onIndexModule(indexModule);
+        }
+    }
+}

--- a/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
+++ b/x-pack/plugin/async-search/src/internalClusterTest/java/org/elasticsearch/xpack/search/CrossClusterAsyncSearchIT.java
@@ -321,15 +321,11 @@ public class CrossClusterAsyncSearchIT extends AbstractMultiClustersTestCase {
                 assertTrue(taskInfo.description(), taskInfo.cancelled());
             }
 
-            try {
-                getAsyncSearch(response.getId());
-                fail("getAsyncSearch should throw ResourceNotFoundException after deletion");
-            } catch (Exception e) {
-                assertNotNull(
-                    "after deletion, getAsyncSearch should throw an Exception with ResourceNotFoundException in the causal chain",
-                    ExceptionsHelper.unwrap(e, ResourceNotFoundException.class)
-                );
-            }
+            ExecutionException e = expectThrows(ExecutionException.class, () -> getAsyncSearch(response.getId()));
+            assertNotNull(e);
+            assertNotNull(e.getCause());
+            Throwable t = ExceptionsHelper.unwrap(e, ResourceNotFoundException.class);
+            assertNotNull("after deletion, getAsyncSearch should throw an Exception with ResourceNotFoundException in the causal chain", t);
 
             AsyncStatusResponse statusResponse = getAsyncStatus(response.getId());
             assertTrue(statusResponse.isPartial());

--- a/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SlowRunningQueryBuilder.java
+++ b/x-pack/plugin/async-search/src/test/java/org/elasticsearch/xpack/search/SlowRunningQueryBuilder.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+package org.elasticsearch.xpack.search;
+
+import org.apache.lucene.search.IndexSearcher;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.QueryVisitor;
+import org.apache.lucene.search.ScoreMode;
+import org.apache.lucene.search.Weight;
+import org.elasticsearch.TransportVersion;
+import org.elasticsearch.common.io.stream.StreamInput;
+import org.elasticsearch.common.io.stream.StreamOutput;
+import org.elasticsearch.common.lucene.search.Queries;
+import org.elasticsearch.index.query.AbstractQueryBuilder;
+import org.elasticsearch.index.query.SearchExecutionContext;
+import org.elasticsearch.xcontent.XContentBuilder;
+
+import java.io.IOException;
+
+/**
+ * A match all QueryBuilder that sleeps for a specified amount of time at various
+ * points in the query process.
+ *
+ * This QueryBuilder is useful in tests that need a slow running query, such as when
+ * you are trying to have a query timeout.
+ */
+public class SlowRunningQueryBuilder extends AbstractQueryBuilder<SlowRunningQueryBuilder> {
+
+    public static final String NAME = "slow";
+
+    private long sleepTime;
+
+    public SlowRunningQueryBuilder(long sleepTime) {
+        this.sleepTime = sleepTime;
+    }
+
+    public SlowRunningQueryBuilder(StreamInput in) throws IOException {
+        super(in);
+        this.sleepTime = in.readLong();
+    }
+
+    @Override
+    public String getWriteableName() {
+        return NAME;
+    }
+
+    @Override
+    public TransportVersion getMinimalSupportedVersion() {
+        return TransportVersion.ZERO;
+    }
+
+    @Override
+    protected void doWriteTo(StreamOutput out) throws IOException {
+        out.writeLong(sleepTime);
+    }
+
+    @Override
+    protected void doXContent(XContentBuilder builder, Params params) throws IOException {
+        builder.startObject(NAME);
+        printBoostAndQueryName(builder);
+        builder.endObject();
+    }
+
+    private void sleep() {
+        try {
+            Thread.sleep(sleepTime);
+        } catch (InterruptedException e) {}
+    }
+
+    @Override
+    protected Query doToQuery(SearchExecutionContext context) throws IOException {
+        final Query delegate = Queries.newMatchAllQuery();
+        return new Query() {
+            @Override
+            public Weight createWeight(IndexSearcher searcher, ScoreMode scoreMode, float boost) throws IOException {
+                sleep();
+                return delegate.createWeight(searcher, scoreMode, boost);
+            }
+
+            @Override
+            public String toString(String field) {
+                return delegate.toString(field);
+            }
+
+            @Override
+            public boolean equals(Object obj) {
+                return false;
+            }
+
+            @Override
+            public int hashCode() {
+                return 0;
+            }
+
+            @Override
+            public void visit(QueryVisitor visitor) {
+                visitor.visitLeaf(this);
+            }
+        };
+    }
+
+    @Override
+    protected boolean doEquals(SlowRunningQueryBuilder other) {
+        return false;
+    }
+
+    @Override
+    protected int doHashCode() {
+        return 0;
+    }
+}

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncResultsService.java
@@ -120,13 +120,8 @@ public class AsyncResultsService<Task extends AsyncTask, Response extends AsyncR
     ) {
         try {
             final Task task = store.getTaskAndCheckAuthentication(taskManager, searchId, asyncTaskClass);
-            if (task == null) {
+            if (task == null || task.isCancelled()) {
                 getSearchResponseFromIndex(searchId, request, nowInMillis, listener);
-                return;
-            }
-
-            if (task.isCancelled()) {
-                listener.onFailure(new ResourceNotFoundException(searchId.getEncoded()));
                 return;
             }
 

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/search/action/AsyncSearchResponse.java
@@ -102,7 +102,7 @@ public class AsyncSearchResponse extends ActionResponse implements StatusToXCont
     }
 
     public AsyncSearchResponse clone(String searchId) {
-        return new AsyncSearchResponse(searchId, searchResponse, error, isPartial, false, startTimeMillis, expirationTimeMillis);
+        return new AsyncSearchResponse(searchId, searchResponse, error, isPartial, isRunning, startTimeMillis, expirationTimeMillis);
     }
 
     /**


### PR DESCRIPTION
Fixes two bugs in the Async Search Response after searches have been cancelled.

Adds additional IT tests for cross-cluster async search cancellation - both by explicit cancellation 
via the Task API and by deleting the async search while it is still running.
