### PR TITLE
[Test] Initialize ReservedRolesStore for each test method

### DIFF
--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/security/authz/store/ReservedRolesStoreTests.java
@@ -213,7 +213,6 @@ import org.elasticsearch.xpack.core.watcher.transport.actions.put.PutWatchAction
 import org.elasticsearch.xpack.core.watcher.transport.actions.service.WatcherServiceAction;
 import org.elasticsearch.xpack.core.watcher.transport.actions.stats.WatcherStatsAction;
 import org.elasticsearch.xpack.core.watcher.watch.Watch;
-import org.junit.BeforeClass;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -249,8 +248,9 @@ import static org.mockito.Mockito.when;
  */
 public class ReservedRolesStoreTests extends ESTestCase {
 
-    @BeforeClass
-    public static void setUpClass() {
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
         // Initialize the reserved roles store so that static fields are populated.
         // In production code, this is guaranteed by how components are initialized by the Security plugin
         new ReservedRolesStore();
@@ -258,7 +258,6 @@ public class ReservedRolesStoreTests extends ESTestCase {
 
     private static final String READ_CROSS_CLUSTER_NAME = "internal:transport/proxy/indices:data/read/query";
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97017")
     public void testIsReserved() {
         assertThat(ReservedRolesStore.isReserved("kibana_system"), is(true));
         assertThat(ReservedRolesStore.isReserved("superuser"), is(true));


### PR DESCRIPTION
This PR changes the initialization of ReservedRolesStore from once per test class to once per test method so that it is in the expected state for each test.

The failure was because individual test can instantiate ReservedRolesStore differently which in turn mutates the class wide shared static field of reserved-roles.

Resolves: #97017