### PR TITLE
Limit the details field length we store for each SLM invocation

### DIFF
--- a/docs/changelog/97038.yaml
+++ b/docs/changelog/97038.yaml
@@ -1,0 +1,6 @@
+pr: 97038
+summary: Limit the details field length we store for each SLM invocation
+area: ILM+SLM
+type: bug
+issues:
+ - 96918

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecord.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecord.java
@@ -8,6 +8,7 @@
 package org.elasticsearch.xpack.core.slm;
 
 import org.elasticsearch.cluster.SimpleDiffable;
+import org.elasticsearch.common.Strings;
 import org.elasticsearch.common.io.stream.StreamInput;
 import org.elasticsearch.common.io.stream.StreamOutput;
 import org.elasticsearch.common.io.stream.Writeable;
@@ -31,6 +32,7 @@ public class SnapshotInvocationRecord implements SimpleDiffable<SnapshotInvocati
     static final ParseField START_TIMESTAMP = new ParseField("start_time");
     static final ParseField TIMESTAMP = new ParseField("time");
     static final ParseField DETAILS = new ParseField("details");
+    static final int MAX_DETAILS_LENGTH = 1000;
 
     private final String snapshotName;
     private final Long snapshotStartTimestamp;
@@ -54,11 +56,16 @@ public class SnapshotInvocationRecord implements SimpleDiffable<SnapshotInvocati
         return PARSER.apply(parser, name);
     }
 
-    public SnapshotInvocationRecord(String snapshotName, Long snapshotStartTimestamp, long snapshotFinishTimestamp, String details) {
+    public SnapshotInvocationRecord(
+        String snapshotName,
+        Long snapshotStartTimestamp,
+        long snapshotFinishTimestamp,
+        @Nullable String details
+    ) {
         this.snapshotName = Objects.requireNonNull(snapshotName, "snapshot name must be provided");
         this.snapshotStartTimestamp = snapshotStartTimestamp;
         this.snapshotFinishTimestamp = snapshotFinishTimestamp;
-        this.details = details;
+        this.details = Strings.substring(details, 0, MAX_DETAILS_LENGTH);
     }
 
     public SnapshotInvocationRecord(StreamInput in) throws IOException {

--- a/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecordTests.java
+++ b/x-pack/plugin/core/src/test/java/org/elasticsearch/xpack/core/slm/SnapshotInvocationRecordTests.java
@@ -14,6 +14,9 @@ import org.elasticsearch.xcontent.XContentParser;
 
 import java.io.IOException;
 
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
 public class SnapshotInvocationRecordTests extends AbstractXContentSerializingTestCase<SnapshotInvocationRecord> {
 
     @Override
@@ -53,6 +56,42 @@ public class SnapshotInvocationRecordTests extends AbstractXContentSerializingTe
                 );
             default:
                 throw new AssertionError("failure, got illegal switch case");
+        }
+    }
+
+    public void testDetailsFieldIsTruncated() {
+        {
+            // value larger than the max allowed
+            SnapshotInvocationRecord snapshotInvocationRecord = new SnapshotInvocationRecord(
+                randomAlphaOfLengthBetween(5, 10),
+                randomNonNegativeNullableLong(),
+                randomNonNegativeLong(),
+                randomAlphaOfLengthBetween(1300, 1500)
+            );
+            assertThat(snapshotInvocationRecord.getDetails().length(), is(SnapshotInvocationRecord.MAX_DETAILS_LENGTH));
+        }
+
+        {
+            // value lower than the max allowed
+            String details = randomAlphaOfLengthBetween(5, 500);
+            SnapshotInvocationRecord snapshotInvocationRecord = new SnapshotInvocationRecord(
+                randomAlphaOfLengthBetween(5, 10),
+                randomNonNegativeNullableLong(),
+                randomNonNegativeLong(),
+                details
+            );
+            assertThat(snapshotInvocationRecord.getDetails().length(), is(details.length()));
+        }
+
+        {
+            // null value, remains null
+            SnapshotInvocationRecord snapshotInvocationRecord = new SnapshotInvocationRecord(
+                randomAlphaOfLengthBetween(5, 10),
+                randomNonNegativeNullableLong(),
+                randomNonNegativeLong(),
+                null
+            );
+            assertThat(snapshotInvocationRecord.getDetails(), is(nullValue()));
         }
     }
 


### PR DESCRIPTION
The XContent representation of a `SnapshotInvocationRecord` is used to store an SLM
invocation record in the cluster state. 

The `details` field could be very large, so large we cannot deserialise it anymore when a
node starts.

This adds a limit of maximum `1000` characters for the `details` field.

Fixes #96918