### PR TITLE
Reuse already initialized `HealthMetadata`

### DIFF
--- a/docs/changelog/96843.yaml
+++ b/docs/changelog/96843.yaml
@@ -1,6 +1,0 @@
-pr: 96843
-summary: Uses `ClusterSettings` instead of Node `Settings` in `HealthMetadataService`
-area: Health
-type: bug
-issues:
- - 96219

--- a/docs/changelog/97044.yaml
+++ b/docs/changelog/97044.yaml
@@ -1,6 +1,0 @@
-pr: 97044
-summary: Reuse already initialized `HealthMetadata`
-area: Health
-type: bug
-issues:
- - 96919

--- a/docs/changelog/97044.yaml
+++ b/docs/changelog/97044.yaml
@@ -1,0 +1,6 @@
+pr: 97044
+summary: Reuse already initialized `HealthMetadata`
+area: Health
+type: bug
+issues:
+ - 96919

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/HealthMetadataServiceIT.java
@@ -10,6 +10,7 @@ package org.elasticsearch.health;
 
 import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
 import org.elasticsearch.cluster.node.DiscoveryNodeRole;
+import org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.ByteSizeValue;
 import org.elasticsearch.health.metadata.HealthMetadata;
@@ -21,15 +22,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING;
-import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING;
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING;
-import static org.elasticsearch.common.settings.Settings.EMPTY;
 import static org.elasticsearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE;
 import static org.elasticsearch.indices.ShardLimitValidator.SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN;
 import static org.elasticsearch.test.NodeRoles.onlyRoles;
@@ -54,10 +52,11 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
             for (int i = 0; i < numberOfNodes; i++) {
                 ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
                 String customWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
+                ByteSizeValue customMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
                 var customShardLimits = new HealthMetadata.ShardLimits(randomIntBetween(1, 1000), randomIntBetween(1001, 2000));
-                String nodeName = startNode(internalCluster, customWatermark, randomBytes.toString(), customShardLimits);
+                String nodeName = startNode(internalCluster, customWatermark, customMaxHeadroom.toString(), customShardLimits);
                 watermarkByNode.put(nodeName, customWatermark);
-                maxHeadroomByNode.put(nodeName, randomBytes);
+                maxHeadroomByNode.put(nodeName, customMaxHeadroom);
                 shardLimitsPerNode.put(nodeName, customShardLimits);
             }
             ensureStableCluster(numberOfNodes);
@@ -67,16 +66,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
                 var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
                 var diskMetadata = healthMetadata.getDiskMetadata();
                 assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
-                // The value of the setting `cluster.routing.allocation.disk.watermark.high.max_headroom` depends upon the existence of
-                // `cluster.routing.allocation.disk.watermark.high`. Check {@link CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING}
-                assertThat(
-                    diskMetadata.highMaxHeadroom(),
-                    equalTo(
-                        percentageMode
-                            ? maxHeadroomByNode.get(electedMaster)
-                            : CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getDefault(EMPTY)
-                    )
-                );
+                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
 
                 var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
                 assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
@@ -90,18 +80,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
                 var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
                 var diskMetadata = healthMetadata.getDiskMetadata();
                 assertThat(diskMetadata.describeHighWatermark(), equalTo(watermarkByNode.get(electedMaster)));
-
-                // The value of the setting `cluster.routing.allocation.disk.watermark.high.max_headroom` depends upon the existence of
-                // `cluster.routing.allocation.disk.watermark.high`.
-                // Check {@link DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING}
-                assertThat(
-                    diskMetadata.highMaxHeadroom(),
-                    equalTo(
-                        percentageMode
-                            ? maxHeadroomByNode.get(electedMaster)
-                            : CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getDefault(EMPTY)
-                    )
-                );
+                assertThat(diskMetadata.highMaxHeadroom(), equalTo(maxHeadroomByNode.get(electedMaster)));
 
                 var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
                 assertEquals(shardLimitsMetadata, shardLimitsPerNode.get(electedMaster));
@@ -114,7 +93,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
             int numberOfNodes = 3;
             ByteSizeValue randomBytes = ByteSizeValue.ofBytes(randomLongBetween(6, 19));
             String initialWatermark = percentageMode ? randomIntBetween(86, 94) + "%" : randomBytes.toString();
-            ByteSizeValue initialMaxHeadroom = randomBytes;
+            ByteSizeValue initialMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
             HealthMetadata.ShardLimits initialShardLimits = new HealthMetadata.ShardLimits(
                 randomIntBetween(1, 1000),
                 randomIntBetween(1001, 2000)
@@ -128,7 +107,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
             ByteSizeValue updatedLowMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
             randomBytes = ByteSizeValue.ofBytes(randomLongBetween(50, 100));
             String updatedHighWatermark = percentageMode ? randomIntBetween(60, 90) + "%" : randomBytes.toString();
-            ByteSizeValue updatedHighMaxHeadroom = randomBytes;
+            ByteSizeValue updatedHighMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
             randomBytes = ByteSizeValue.ofBytes(randomLongBetween(5, 10));
             String updatedFloodStageWatermark = percentageMode ? randomIntBetween(91, 95) + "%" : randomBytes.toString();
             ByteSizeValue updatedFloodStageMaxHeadroom = percentageMode ? randomBytes : ByteSizeValue.MINUS_ONE;
@@ -142,16 +121,7 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
                 var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
                 var diskMetadata = healthMetadata.getDiskMetadata();
                 assertThat(diskMetadata.describeHighWatermark(), equalTo(initialWatermark));
-
-                // The value of the setting `cluster.routing.allocation.disk.watermark.high.max_headroom` depends upon the existence of
-                // `cluster.routing.allocation.disk.watermark.high`.
-                // Check {@link DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING}
-                assertThat(
-                    diskMetadata.highMaxHeadroom(),
-                    equalTo(
-                        percentageMode ? initialMaxHeadroom : CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getDefault(EMPTY)
-                    )
-                );
+                assertThat(diskMetadata.highMaxHeadroom(), equalTo(initialMaxHeadroom));
 
                 var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
                 assertEquals(shardLimitsMetadata, initialShardLimits);
@@ -177,31 +147,9 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
                 var healthMetadata = HealthMetadata.getFromClusterState(internalCluster.clusterService().state());
                 var diskMetadata = healthMetadata.getDiskMetadata();
                 assertThat(diskMetadata.describeHighWatermark(), equalTo(updatedHighWatermark));
-
-                // The value of the setting `cluster.routing.allocation.disk.watermark.high.max_headroom` depends upon the existence of
-                // `cluster.routing.allocation.disk.watermark.high`.
-                // Check {@link DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING}
-                assertThat(
-                    diskMetadata.highMaxHeadroom(),
-                    equalTo(
-                        percentageMode
-                            ? updatedHighMaxHeadroom
-                            : CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getDefault(EMPTY)
-                    )
-                );
+                assertThat(diskMetadata.highMaxHeadroom(), equalTo(updatedHighMaxHeadroom));
                 assertThat(diskMetadata.describeFloodStageWatermark(), equalTo(updatedFloodStageWatermark));
-
-                // The value of the setting `cluster.routing.allocation.disk.watermark.flood_stage.max_headroom` depends upon the existence
-                // of `cluster.routing.allocation.disk.watermark.flood_stage`.
-                // Check{@link DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING}
-                assertThat(
-                    diskMetadata.floodStageMaxHeadroom(),
-                    equalTo(
-                        percentageMode
-                            ? updatedFloodStageMaxHeadroom
-                            : CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.getDefault(EMPTY)
-                    )
-                );
+                assertThat(diskMetadata.floodStageMaxHeadroom(), equalTo(updatedFloodStageMaxHeadroom));
 
                 var shardLimitsMetadata = healthMetadata.getShardLimitsMetadata();
                 assertEquals(shardLimitsMetadata, updatedShardLimits);
@@ -227,17 +175,21 @@ public class HealthMetadataServiceIT extends ESIntegTestCase {
 
     private Settings createWatermarkSettings(String highWatermark, String highMaxHeadroom) {
         // We define both thresholds to avoid inconsistencies over the type of the thresholds
-        var settings = Settings.builder()
+        Settings.Builder settings = Settings.builder()
             .put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_WATERMARK_SETTING.getKey(), percentageMode ? "85%" : "20b")
             .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.getKey(), highWatermark)
             .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.getKey(), percentageMode ? "95%" : "1b")
-            .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.getKey(), percentageMode ? "95%" : "5b");
-
+            .put(
+                DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.getKey(),
+                percentageMode ? "95%" : "5b"
+            );
         if (percentageMode) {
-            settings.put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING.getKey(), "20b")
+            settings = settings.put(CLUSTER_ROUTING_ALLOCATION_LOW_DISK_MAX_HEADROOM_SETTING.getKey(), "20b")
                 .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.getKey(), "1b")
-                .put(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING.getKey(), "5b")
-                .put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getKey(), highMaxHeadroom);
+                .put(DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING.getKey(), "5b");
+            if (highMaxHeadroom.equals("-1") == false) {
+                settings = settings.put(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.getKey(), highMaxHeadroom);
+            }
         }
         return settings.build();
     }

--- a/server/src/internalClusterTest/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceIT.java
+++ b/server/src/internalClusterTest/java/org/elasticsearch/health/node/DiskHealthIndicatorServiceIT.java
@@ -47,7 +47,6 @@ public class DiskHealthIndicatorServiceIT extends ESIntegTestCase {
         }
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96919")
     public void testRed() throws Exception {
         try (InternalTestCluster internalCluster = internalCluster()) {
             internalCluster.startMasterOnlyNode(getVeryLowWatermarksSettings());

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -24,6 +24,7 @@ import org.elasticsearch.cluster.service.MasterServiceTaskQueue;
 import org.elasticsearch.common.Priority;
 import org.elasticsearch.common.io.stream.NamedWriteableRegistry;
 import org.elasticsearch.common.settings.ClusterSettings;
+import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 
@@ -49,6 +50,7 @@ public class HealthMetadataService {
 
     private final ClusterService clusterService;
     private final ClusterStateListener clusterStateListener;
+    private final Settings settings;
     private final MasterServiceTaskQueue<UpsertHealthMetadataTask> taskQueue;
     private volatile boolean enabled;
 
@@ -59,10 +61,11 @@ public class HealthMetadataService {
     // us from checking the cluster state before the cluster state is initialized
     private volatile boolean isMaster = false;
 
-    private HealthMetadataService(ClusterService clusterService) {
+    private HealthMetadataService(ClusterService clusterService, Settings settings) {
         this.clusterService = clusterService;
+        this.settings = settings;
         this.clusterStateListener = this::updateOnClusterStateChange;
-        this.enabled = clusterService.getClusterSettings().get(ENABLED_SETTING);
+        this.enabled = ENABLED_SETTING.get(settings);
         this.taskQueue = clusterService.createTaskQueue(
             "health metadata service",
             Priority.NORMAL,
@@ -70,8 +73,8 @@ public class HealthMetadataService {
         );
     }
 
-    public static HealthMetadataService create(ClusterService clusterService) {
-        HealthMetadataService healthMetadataService = new HealthMetadataService(clusterService);
+    public static HealthMetadataService create(ClusterService clusterService, Settings settings) {
+        HealthMetadataService healthMetadataService = new HealthMetadataService(clusterService, settings);
         healthMetadataService.registerListeners();
         return healthMetadataService;
     }
@@ -81,7 +84,7 @@ public class HealthMetadataService {
             this.clusterService.addListener(clusterStateListener);
         }
 
-        var clusterSettings = clusterService.getClusterSettings();
+        ClusterSettings clusterSettings = clusterService.getClusterSettings();
         Stream.of(
             CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING,
             CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING,
@@ -156,7 +159,7 @@ public class HealthMetadataService {
     }
 
     private void resetHealthMetadata(String source) {
-        taskQueue.submitTask(source, new InsertHealthMetadata(clusterService.getClusterSettings()), null);
+        taskQueue.submitTask(source, new InsertHealthMetadata(settings), null);
     }
 
     public static List<NamedWriteableRegistry.Entry> getNamedWriteables() {
@@ -287,9 +290,9 @@ public class HealthMetadataService {
      */
     static class InsertHealthMetadata extends UpsertHealthMetadataTask {
 
-        private final ClusterSettings settings;
+        private final Settings settings;
 
-        InsertHealthMetadata(ClusterSettings settings) {
+        InsertHealthMetadata(Settings settings) {
             this.settings = settings;
         }
 
@@ -297,16 +300,16 @@ public class HealthMetadataService {
         HealthMetadata doExecute(HealthMetadata initialHealthMetadata) {
             return new HealthMetadata(
                 new HealthMetadata.Disk(
-                    settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING),
-                    settings.get(CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING),
-                    settings.get(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING),
-                    settings.get(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING),
-                    settings.get(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING),
-                    settings.get(CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING)
+                    CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.get(settings),
+                    CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.get(settings),
+                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.get(settings),
+                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.get(settings),
+                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.get(settings),
+                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING.get(settings)
                 ),
                 new HealthMetadata.ShardLimits(
-                    settings.get(SETTING_CLUSTER_MAX_SHARDS_PER_NODE),
-                    settings.get(SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN)
+                    SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(settings),
+                    SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.get(settings)
                 )
             );
         }

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -299,20 +299,23 @@ public class HealthMetadataService {
 
         @Override
         HealthMetadata doExecute(HealthMetadata initialHealthMetadata) {
-            return Objects.requireNonNullElseGet(initialHealthMetadata, () -> new HealthMetadata(
-                new HealthMetadata.Disk(
-                    CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.get(settings),
-                    CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.get(settings),
-                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.get(settings),
-                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.get(settings),
-                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.get(settings),
-                    CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING.get(settings)
-                ),
-                new HealthMetadata.ShardLimits(
-                    SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(settings),
-                    SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.get(settings)
+            return Objects.requireNonNullElseGet(
+                initialHealthMetadata,
+                () -> new HealthMetadata(
+                    new HealthMetadata.Disk(
+                        CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.get(settings),
+                        CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.get(settings),
+                        CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_WATERMARK_SETTING.get(settings),
+                        CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_MAX_HEADROOM_SETTING.get(settings),
+                        CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_WATERMARK_SETTING.get(settings),
+                        CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING.get(settings)
+                    ),
+                    new HealthMetadata.ShardLimits(
+                        SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(settings),
+                        SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.get(settings)
+                    )
                 )
-            ));
+            );
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
+++ b/server/src/main/java/org/elasticsearch/health/metadata/HealthMetadataService.java
@@ -29,6 +29,7 @@ import org.elasticsearch.core.Nullable;
 import org.elasticsearch.core.Tuple;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Stream;
 
 import static org.elasticsearch.cluster.routing.allocation.DiskThresholdSettings.CLUSTER_ROUTING_ALLOCATION_DISK_FLOOD_STAGE_FROZEN_MAX_HEADROOM_SETTING;
@@ -298,7 +299,7 @@ public class HealthMetadataService {
 
         @Override
         HealthMetadata doExecute(HealthMetadata initialHealthMetadata) {
-            return new HealthMetadata(
+            return Objects.requireNonNullElseGet(initialHealthMetadata, () -> new HealthMetadata(
                 new HealthMetadata.Disk(
                     CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_WATERMARK_SETTING.get(settings),
                     CLUSTER_ROUTING_ALLOCATION_HIGH_DISK_MAX_HEADROOM_SETTING.get(settings),
@@ -311,7 +312,7 @@ public class HealthMetadataService {
                     SETTING_CLUSTER_MAX_SHARDS_PER_NODE.get(settings),
                     SETTING_CLUSTER_MAX_SHARDS_PER_NODE_FROZEN.get(settings)
                 )
-            );
+            ));
         }
     }
 }

--- a/server/src/main/java/org/elasticsearch/node/Node.java
+++ b/server/src/main/java/org/elasticsearch/node/Node.java
@@ -1033,7 +1033,7 @@ public class Node implements Closeable {
                 threadPool,
                 systemIndices
             );
-            HealthMetadataService healthMetadataService = HealthMetadataService.create(clusterService);
+            HealthMetadataService healthMetadataService = HealthMetadataService.create(clusterService, settings);
             LocalHealthMonitor localHealthMonitor = LocalHealthMonitor.create(settings, clusterService, nodeService, threadPool, client);
             HealthInfoCache nodeHealthOverview = HealthInfoCache.create(clusterService);
             HealthApiStats healthApiStats = new HealthApiStats();


### PR DESCRIPTION
In case there's a HealthMetadata object in the `ClusterState`, just
use that object, instead of creating a new one, that will override the
previous one using default values for the settings.

The actual fix is made by the commit b31a616114ae7980de6abb993c6ac5cdff1c3386

This PR reverts #96843 because it's not correct to read from `ClusterSettings`.

Closes #96919
