### PR TITLE
Incorrect filename (date) if now close to midnight

### DIFF
--- a/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
+++ b/modules/data-streams/src/test/java/org/elasticsearch/datastreams/action/GetDataStreamsTransportActionTests.java
@@ -199,12 +199,11 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
         );
     }
 
-    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/96672")
     public void testGetTimeSeriesMixedDataStream() {
-        Instant now = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+        Instant instant = Instant.parse("2023-06-06T14:00:00.000Z").truncatedTo(ChronoUnit.SECONDS);
         String dataStream1 = "ds-1";
-        Instant twoHoursAgo = now.minus(2, ChronoUnit.HOURS);
-        Instant twoHoursAhead = now.plus(2, ChronoUnit.HOURS);
+        Instant twoHoursAgo = instant.minus(2, ChronoUnit.HOURS);
+        Instant twoHoursAhead = instant.plus(2, ChronoUnit.HOURS);
 
         ClusterState state;
         {
@@ -213,7 +212,7 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
                 mBuilder,
                 List.of(Tuple.tuple(dataStream1, 2)),
                 List.of(),
-                now.toEpochMilli(),
+                instant.toEpochMilli(),
                 Settings.EMPTY,
                 0,
                 false
@@ -231,9 +230,9 @@ public class GetDataStreamsTransportActionTests extends ESTestCase {
             ClusterSettings.createBuiltInClusterSettings()
         );
 
-        var name1 = DataStream.getDefaultBackingIndexName("ds-1", 1, now.toEpochMilli());
-        var name2 = DataStream.getDefaultBackingIndexName("ds-1", 2, now.toEpochMilli());
-        var name3 = DataStream.getDefaultBackingIndexName("ds-1", 3, now.toEpochMilli());
+        var name1 = DataStream.getDefaultBackingIndexName("ds-1", 1, instant.toEpochMilli());
+        var name2 = DataStream.getDefaultBackingIndexName("ds-1", 2, instant.toEpochMilli());
+        var name3 = DataStream.getDefaultBackingIndexName("ds-1", 3, twoHoursAgo.toEpochMilli());
         assertThat(
             response.getDataStreams(),
             contains(


### PR DESCRIPTION
If 'now' is between midnight and 2 in the night, going back 2 hours
(twoHoursAgo) results in a date whose day is the day before. Here we
use a fixed instant so to avoid the test failing depending on the value of `now`.

We also use `twoHoursAgo` instead of `now` to generate the correct filename
even if, for the selected instant, this is not strictly necessary (using `now`
or `twoHoursAgo` results in the same day in the filename).

Resolves #96672 