### PR TITLE
Cleanup redundant ActionListener.delegateFailure uses

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/snapshots/get/TransportGetSnapshotsAction.java
@@ -465,10 +465,10 @@ public class TransportGetSnapshotsAction extends TransportMasterNodeAction<GetSn
         } else {
             snapshotInfos = Collections.synchronizedList(new ArrayList<>());
         }
-        final ActionListener<Void> allDoneListener = listener.delegateFailure((l, v) -> {
+        final ActionListener<Void> allDoneListener = listener.map(v -> {
             final ArrayList<SnapshotInfo> snapshotList = new ArrayList<>(snapshotInfos);
             snapshotList.addAll(snapshotSet);
-            listener.onResponse(sortSnapshots(snapshotList, sortBy, after, 0, GetSnapshotsRequest.NO_LIMIT, order));
+            return sortSnapshots(snapshotList, sortBy, after, 0, GetSnapshotsRequest.NO_LIMIT, order);
         });
         if (snapshotIdsToIterate.isEmpty()) {
             allDoneListener.onResponse(null);

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/refresh/TransportShardRefreshAction.java
@@ -82,19 +82,19 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
         IndexShard primary,
         ActionListener<PrimaryResult<ShardRefreshReplicaRequest, ReplicationResponse>> listener
     ) {
-        primary.externalRefresh(SOURCE_API, listener.delegateFailure((l, refreshResult) -> {
+        primary.externalRefresh(SOURCE_API, listener.map(refreshResult -> {
             ShardRefreshReplicaRequest replicaRequest = new ShardRefreshReplicaRequest(shardRequest.shardId(), refreshResult);
             replicaRequest.setParentTask(shardRequest.getParentTask());
             logger.trace("{} refresh request executed on primary", primary.shardId());
-            l.onResponse(new PrimaryResult<>(replicaRequest, new ReplicationResponse()));
+            return new PrimaryResult<>(replicaRequest, new ReplicationResponse());
         }));
     }
 
     @Override
     protected void shardOperationOnReplica(ShardRefreshReplicaRequest request, IndexShard replica, ActionListener<ReplicaResult> listener) {
-        replica.externalRefresh(SOURCE_API, listener.delegateFailure((l, refreshResult) -> {
+        replica.externalRefresh(SOURCE_API, listener.map(refreshResult -> {
             logger.trace("{} refresh request executed on replica", replica.shardId());
-            l.onResponse(new ReplicaResult());
+            return new ReplicaResult();
         }));
     }
 
@@ -130,7 +130,7 @@ public class TransportShardRefreshAction extends TransportReplicationAction<
                     TransportUnpromotableShardRefreshAction.NAME,
                     unpromotableReplicaRequest,
                     new ActionListenerResponseHandler<>(
-                        listener.delegateFailure((l, r) -> l.onResponse(null)),
+                        listener.map(r -> null),
                         (in) -> ActionResponse.Empty.INSTANCE,
                         ThreadPool.Names.REFRESH
                     )

--- a/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/indices/shrink/TransportResizeAction.java
@@ -163,12 +163,13 @@ public class TransportResizeAction extends TransportMasterNodeAction<ResizeReque
             client.execute(
                 IndicesStatsAction.INSTANCE,
                 statsRequest,
-                listener.delegateFailure(
-                    (delegatedListener, indicesStatsResponse) -> delegatedListener.onResponse(
-                        new ResizeNumberOfShardsCalculator.ShrinkShardsCalculator(indicesStatsResponse.getPrimaries().store, i -> {
+                listener.map(
+                    indicesStatsResponse -> new ResizeNumberOfShardsCalculator.ShrinkShardsCalculator(
+                        indicesStatsResponse.getPrimaries().store,
+                        i -> {
                             IndexShardStats shard = indicesStatsResponse.getIndex(sourceIndex).getIndexShards().get(i);
                             return shard == null ? null : shard.getPrimary().getDocs();
-                        })
+                        }
                     )
                 )
             );

--- a/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
+++ b/server/src/main/java/org/elasticsearch/action/support/replication/PostWriteRefresh.java
@@ -159,7 +159,7 @@ public class PostWriteRefresh {
             unpromotableReplicaRequest,
             TransportRequestOptions.timeout(postWriteRefreshTimeout),
             new ActionListenerResponseHandler<>(
-                listener.delegateFailure((l, r) -> l.onResponse(wasForced)),
+                listener.map(r -> wasForced),
                 (in) -> ActionResponse.Empty.INSTANCE,
                 ThreadPool.Names.REFRESH
             )

--- a/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
+++ b/server/src/main/java/org/elasticsearch/persistent/StartPersistentTaskAction.java
@@ -220,7 +220,7 @@ public class StartPersistentTaskAction extends ActionType<PersistentTaskResponse
                 request.taskId,
                 request.taskName,
                 request.params,
-                listener.delegateFailure((delegatedListener, task) -> delegatedListener.onResponse(new PersistentTaskResponse(task)))
+                listener.map(PersistentTaskResponse::new)
             );
         }
     }

--- a/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
+++ b/server/src/main/java/org/elasticsearch/synonyms/SynonymsManagementAPIService.java
@@ -347,9 +347,7 @@ public class SynonymsManagementAPIService {
         client.execute(
             ReloadAnalyzerAction.INSTANCE,
             reloadAnalyzersRequest,
-            listener.delegateFailure((reloadResponseListener, reloadResponse) -> {
-                reloadResponseListener.onResponse(new SynonymsReloadResult<>(synonymsOperationResult, reloadResponse));
-            })
+            listener.map(reloadResponse -> new SynonymsReloadResult<>(synonymsOperationResult, reloadResponse))
         );
     }
 

--- a/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
+++ b/test/framework/src/main/java/org/elasticsearch/test/transport/StubbableTransport.java
@@ -173,9 +173,7 @@ public class StubbableTransport implements Transport {
         TransportAddress address = node.getAddress();
         OpenConnectionBehavior behavior = connectBehaviors.getOrDefault(address, defaultConnectBehavior);
 
-        ActionListener<Connection> wrappedListener = listener.delegateFailure(
-            (delegatedListener, connection) -> delegatedListener.onResponse(new WrappedConnection(connection))
-        );
+        ActionListener<Connection> wrappedListener = listener.map(WrappedConnection::new);
 
         if (behavior == null) {
             delegate.openConnection(node, profile, wrappedListener);

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/async/AsyncTaskIndexService.java
@@ -524,11 +524,7 @@ public final class AsyncTaskIndexService<R extends AsyncResponse<R>> {
                     asyncExecutionId,
                     false,
                     false,
-                    outerListener.delegateFailure(
-                        (listener, resp) -> listener.onResponse(
-                            statusProducerFromIndex.apply(resp, resp.getExpirationTime(), asyncExecutionId.getEncoded())
-                        )
-                    )
+                    outerListener.map(resp -> statusProducerFromIndex.apply(resp, resp.getExpirationTime(), asyncExecutionId.getEncoded()))
                 );
             }
         } catch (Exception exc) {

--- a/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportQuerySearchApplicationAction.java
+++ b/x-pack/plugin/ent-search/src/main/java/org/elasticsearch/xpack/application/search/action/TransportQuerySearchApplicationAction.java
@@ -60,11 +60,7 @@ public class TransportQuerySearchApplicationAction extends HandledTransportActio
                 SearchSourceBuilder sourceBuilder = templateService.renderQuery(searchApplication, request.queryParams());
                 SearchRequest searchRequest = new SearchRequest(searchApplication.name()).source(sourceBuilder);
 
-                client.execute(
-                    SearchAction.INSTANCE,
-                    searchRequest,
-                    listener.delegateFailure((l2, searchResponse) -> l2.onResponse(searchResponse))
-                );
+                client.execute(SearchAction.INSTANCE, searchRequest, l);
             } catch (Exception e) {
                 l.onFailure(e);
             }

--- a/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
+++ b/x-pack/plugin/frozen-indices/src/main/java/org/elasticsearch/xpack/frozen/action/TransportFreezeIndexAction.java
@@ -150,12 +150,10 @@ public final class TransportFreezeIndexAction extends TransportMasterNodeAction<
                     .waitForActiveShards(request.waitForActiveShards());
                 indexStateService.openIndices(
                     updateRequest,
-                    delegate.delegateFailure(
-                        (l, openIndexClusterStateUpdateResponse) -> l.onResponse(
-                            new FreezeResponse(
-                                openIndexClusterStateUpdateResponse.isAcknowledged(),
-                                openIndexClusterStateUpdateResponse.isShardsAcknowledged()
-                            )
+                    delegate.map(
+                        openIndexClusterStateUpdateResponse -> new FreezeResponse(
+                            openIndexClusterStateUpdateResponse.isAcknowledged(),
+                            openIndexClusterStateUpdateResponse.isShardsAcknowledged()
                         )
                     )
                 );

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportCloseJobAction.java
@@ -649,6 +649,6 @@ public class TransportCloseJobAction extends TransportTasksAction<
                 }
             }
             return true;
-        }, request.getCloseTimeout(), listener.delegateFailure((l, r) -> l.onResponse(response)));
+        }, request.getCloseTimeout(), listener.map(r -> response));
     }
 }

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportDeleteJobAction.java
@@ -295,7 +295,7 @@ public class TransportDeleteJobAction extends AcknowledgedTransportMasterNodeAct
         if (jobTask == null) {
             listener.onResponse(null);
         } else {
-            persistentTasksService.sendRemoveRequest(jobTask.getId(), listener.delegateFailure((l, task) -> l.onResponse(Boolean.TRUE)));
+            persistentTasksService.sendRemoveRequest(jobTask.getId(), listener.map(task -> true));
         }
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportRevertModelSnapshotAction.java
@@ -302,12 +302,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
                 // Because the model that changed is no longer in use as it has been rolled back to a time before those changes occurred
                 Annotation.Event.MODEL_CHANGE.toString()
             );
-            dataDeleter.deleteAnnotations(
-                deleteAfter.getTime() + 1,
-                null,
-                eventsToDelete,
-                listener.delegateFailure((l, r) -> l.onResponse(response))
-            );
+            dataDeleter.deleteAnnotations(deleteAfter.getTime() + 1, null, eventsToDelete, listener.map(r -> response));
         }, listener::onFailure);
     }
 
@@ -325,7 +320,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
             logger.info("[{}] Removing intervening records after reverting model: deleting results after [{}]", jobId, deleteAfter);
 
             JobDataDeleter dataDeleter = new JobDataDeleter(client, jobId);
-            dataDeleter.deleteResultsFromTime(deleteAfter.getTime() + 1, listener.delegateFailure((l, r) -> l.onResponse(response)));
+            dataDeleter.deleteResultsFromTime(deleteAfter.getTime() + 1, listener.map(r -> response));
         }, listener::onFailure);
     }
 
@@ -336,7 +331,7 @@ public class TransportRevertModelSnapshotAction extends TransportMasterNodeActio
     ) {
         return ActionListener.wrap(response -> jobResultsProvider.dataCounts(jobId, counts -> {
             counts.setLatestRecordTimeStamp(modelSnapshot.getLatestRecordTimeStamp());
-            jobDataCountsPersister.persistDataCountsAsync(jobId, counts, listener.delegateFailure((l, r) -> l.onResponse(response)));
+            jobDataCountsPersister.persistDataCountsAsync(jobId, counts, listener.map(r -> response));
         }, listener::onFailure), listener::onFailure);
     }
 

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/action/TransportStopDatafeedAction.java
@@ -507,7 +507,7 @@ public class TransportStopDatafeedAction extends TransportTasksAction<
                 }
             }
             return true;
-        }, request.getTimeout(), listener.delegateFailure((l, result) -> l.onResponse(response)));
+        }, request.getTimeout(), listener.map(result -> response));
     }
 
     @Override

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobDataCountsPersister.java
@@ -124,13 +124,7 @@ public class JobDataCountsPersister {
                 .setRequireAlias(true)
                 .setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)
                 .source(content);
-            executeAsyncWithOrigin(
-                client,
-                ML_ORIGIN,
-                IndexAction.INSTANCE,
-                request,
-                listener.delegateFailure((l, r) -> l.onResponse(true))
-            );
+            executeAsyncWithOrigin(client, ML_ORIGIN, IndexAction.INSTANCE, request, listener.map(r -> true));
         } catch (IOException ioe) {
             String msg = "[" + jobId + "] Failed writing data_counts stats";
             logger.error(msg, ioe);

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/job/persistence/JobResultsProvider.java
@@ -458,9 +458,7 @@ public class JobResultsProvider {
                 client.threadPool().getThreadContext(),
                 ML_ORIGIN,
                 request,
-                listener.<AcknowledgedResponse>delegateFailure(
-                    (l, putMappingResponse) -> l.onResponse(putMappingResponse.isAcknowledged())
-                ),
+                listener.map(AcknowledgedResponse::isAcknowledged),
                 client.admin().indices()::putMapping
             );
         } catch (IOException e) {

--- a/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
+++ b/x-pack/plugin/ml/src/main/java/org/elasticsearch/xpack/ml/rest/cat/RestCatTrainedModelsAction.java
@@ -236,16 +236,14 @@ public class RestCatTrainedModelsAction extends AbstractCatAction {
         final List<TrainedModelConfig> configs,
         final ActionListener<Table> listener
     ) {
-        return new GroupedActionListener<>(size, listener.delegateFailure((l, responses) -> {
+        return new GroupedActionListener<>(size, listener.map(responses -> {
             GetTrainedModelsStatsAction.Response statsResponse = extractResponse(responses, GetTrainedModelsStatsAction.Response.class);
             GetDataFrameAnalyticsAction.Response analytics = extractResponse(responses, GetDataFrameAnalyticsAction.Response.class);
-            l.onResponse(
-                buildTable(
-                    request,
-                    statsResponse.getResources().results(),
-                    configs,
-                    analytics == null ? Collections.emptyList() : analytics.getResources().results()
-                )
+            return buildTable(
+                request,
+                statsResponse.getResources().results(),
+                configs,
+                analytics == null ? Collections.emptyList() : analytics.getResources().results()
             );
         }));
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportDeleteRoleAction.java
@@ -37,7 +37,7 @@ public class TransportDeleteRoleAction extends HandledTransportAction<DeleteRole
         }
 
         try {
-            rolesStore.deleteRole(request, listener.delegateFailure((l, found) -> l.onResponse(new DeleteRoleResponse(found))));
+            rolesStore.deleteRole(request, listener.map(DeleteRoleResponse::new));
         } catch (Exception e) {
             logger.error((Supplier<?>) () -> "failed to delete role [" + request.name() + "]", e);
             listener.onFailure(e);

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/role/TransportPutRoleAction.java
@@ -44,13 +44,13 @@ public class TransportPutRoleAction extends HandledTransportAction<PutRoleReques
         if (validationException != null) {
             listener.onFailure(validationException);
         } else {
-            rolesStore.putRole(request, request.roleDescriptor(), listener.delegateFailure((l, created) -> {
+            rolesStore.putRole(request, request.roleDescriptor(), listener.map(created -> {
                 if (created) {
                     logger.info("added role [{}]", request.name());
                 } else {
                     logger.info("updated role [{}]", request.name());
                 }
-                l.onResponse(new PutRoleResponse(created));
+                return new PutRoleResponse(created);
             }));
         }
     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportDeleteRoleMappingAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/rolemapping/TransportDeleteRoleMappingAction.java
@@ -40,10 +40,7 @@ public class TransportDeleteRoleMappingAction extends ReservedStateAwareHandledT
 
     @Override
     protected void doExecuteProtected(Task task, DeleteRoleMappingRequest request, ActionListener<DeleteRoleMappingResponse> listener) {
-        roleMappingStore.deleteRoleMapping(
-            request,
-            listener.delegateFailure((l, found) -> l.onResponse(new DeleteRoleMappingResponse(found)))
-        );
+        roleMappingStore.deleteRoleMapping(request, listener.map(DeleteRoleMappingResponse::new));
     }
 
     @Override

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportChangePasswordAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportChangePasswordAction.java
@@ -60,6 +60,6 @@ public class TransportChangePasswordAction extends HandledTransportAction<Change
             );
             return;
         }
-        nativeUsersStore.changePassword(request, listener.delegateFailure((l, v) -> l.onResponse(ActionResponse.Empty.INSTANCE)));
+        nativeUsersStore.changePassword(request, listener.map(v -> ActionResponse.Empty.INSTANCE));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportDeleteUserAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportDeleteUserAction.java
@@ -49,6 +49,6 @@ public class TransportDeleteUserAction extends HandledTransportAction<DeleteUser
             return;
         }
 
-        usersStore.deleteUser(request, listener.delegateFailure((l, found) -> l.onResponse(new DeleteUserResponse(found))));
+        usersStore.deleteUser(request, listener.map(DeleteUserResponse::new));
     }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportSetEnabledAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/user/TransportSetEnabledAction.java
@@ -57,12 +57,7 @@ public class TransportSetEnabledAction extends HandledTransportAction<SetEnabled
             return;
         }
 
-        usersStore.setEnabled(
-            username,
-            request.enabled(),
-            request.getRefreshPolicy(),
-            listener.delegateFailure((l, v) -> l.onResponse(ActionResponse.Empty.INSTANCE))
-        );
+        usersStore.setEnabled(username, request.enabled(), request.getRefreshPolicy(), listener.map(v -> ActionResponse.Empty.INSTANCE));
     }
 
     private boolean isSameUserRequest(SetEnabledRequest request) {

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/esnative/NativeUsersStore.java
@@ -177,7 +177,7 @@ public class NativeUsersStore {
                         .setSize(0)
                         .setTrackTotalHits(true)
                         .request(),
-                    listener.<SearchResponse>delegateFailure((l, response) -> l.onResponse(response.getHits().getTotalHits().value)),
+                    listener.<SearchResponse>map(response -> response.getHits().getTotalHits().value),
                     client::search
                 )
             );

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -288,10 +288,7 @@ public class NativeRoleMappingStore implements UserRoleMapper {
         if (names == null || names.isEmpty()) {
             getMappings(listener);
         } else {
-            getMappings(listener.delegateFailure((l, mappings) -> {
-                final List<ExpressionRoleMapping> filtered = mappings.stream().filter(m -> names.contains(m.getName())).toList();
-                l.onResponse(filtered);
-            }));
+            getMappings(listener.map(mappings -> mappings.stream().filter(m -> names.contains(m.getName())).toList()));
         }
     }
 


### PR DESCRIPTION
Using delegateFailure only to apply a mapping to a response is redundant, `.map` works much better here and avoids spots (like one fixed by this) where the listener is accidentally captured by the lambda instead of using the delegate lambda parameter.
