### PR TITLE
Add proper accessor methods for ResolveAllDependencies task

### DIFF
--- a/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
+++ b/build-tools-internal/src/main/java/org/elasticsearch/gradle/internal/ResolveAllDependencies.java
@@ -27,7 +27,7 @@ public class ResolveAllDependencies extends DefaultTask {
 
     private final ObjectFactory objectFactory;
 
-    Collection<Configuration> configs;
+    private Collection<Configuration> configs;
 
     @Inject
     public ResolveAllDependencies(ObjectFactory objectFactory) {
@@ -43,6 +43,14 @@ public class ResolveAllDependencies extends DefaultTask {
     @TaskAction
     void resolveAll() {
         // do nothing, dependencies are resolved when snapshotting task inputs
+    }
+
+    public Collection<Configuration> getConfigs() {
+        return configs;
+    }
+
+    public void setConfigs(Collection<Configuration> configs) {
+        this.configs = configs;
     }
 
     private static boolean canBeResolved(Configuration configuration) {


### PR DESCRIPTION
The `configs` property in the `ResolveAllDependencies` task is package private, meaning it can't be used easily from statically compiled plugins or build scripts. Make this field private and add proper accessor methods for get/set operations.