### PR TITLE
Improve error message for search.check_ccs_compatibility=true mode flag

### DIFF
--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -8,6 +8,7 @@
 
 package org.elasticsearch.script.mustache;
 
+import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.Strings;
@@ -17,6 +18,7 @@ import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.script.ScriptType;
 import org.elasticsearch.script.mustache.MultiSearchTemplateResponse.Item;
 import org.elasticsearch.search.DummyQueryParserPlugin;
+import org.elasticsearch.search.FailBeforeCurrentVersionQueryBuilder;
 import org.elasticsearch.search.SearchService;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.elasticsearch.xcontent.json.JsonXContent;
@@ -200,9 +202,13 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
         assertThat(ex.getMessage(), containsString("[class org.elasticsearch.action.search.SearchRequest] is not compatible with version"));
         assertThat(ex.getMessage(), containsString("'search.check_ccs_compatibility' setting is enabled."));
 
-        String expectedCause = "[fail_before_current_version] was released first in version XXXXXXX, failed compatibility check trying to"
-            + " send it to node with version XXXXXXX";
-        String actualCause = ex.getCause().getMessage().replaceAll("\\d{7,}", "XXXXXXX");
+        String expectedCause = Strings.format(
+            "[fail_before_current_version] was released first in version %s, failed compatibility "
+                + "check trying to send it to node with version %s",
+            FailBeforeCurrentVersionQueryBuilder.FUTURE_VERSION,
+            TransportVersion.MINIMUM_CCS_VERSION
+        );
+        String actualCause = ex.getCause().getMessage();
         assertEquals(expectedCause, actualCause);
     }
 }

--- a/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
+++ b/modules/lang-mustache/src/internalClusterTest/java/org/elasticsearch/script/mustache/MultiSearchTemplateIT.java
@@ -8,7 +8,6 @@
 
 package org.elasticsearch.script.mustache;
 
-import org.elasticsearch.TransportVersion;
 import org.elasticsearch.action.index.IndexRequestBuilder;
 import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.common.Strings;
@@ -200,9 +199,10 @@ public class MultiSearchTemplateIT extends ESIntegTestCase {
         Exception ex = response.getFailure();
         assertThat(ex.getMessage(), containsString("[class org.elasticsearch.action.search.SearchRequest] is not compatible with version"));
         assertThat(ex.getMessage(), containsString("'search.check_ccs_compatibility' setting is enabled."));
-        assertEquals(
-            "This query isn't serializable with transport versions before " + TransportVersion.current(),
-            ex.getCause().getMessage()
-        );
+
+        String expectedCause = "[fail_before_current_version] was released first in version XXXXXXX, failed compatibility check trying to"
+            + " send it to node with version XXXXXXX";
+        String actualCause = ex.getCause().getMessage().replaceAll("\\d{7,}", "XXXXXXX");
+        assertEquals(expectedCause, actualCause);
     }
 }

--- a/test/framework/src/main/java/org/elasticsearch/search/FailBeforeCurrentVersionQueryBuilder.java
+++ b/test/framework/src/main/java/org/elasticsearch/search/FailBeforeCurrentVersionQueryBuilder.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 public class FailBeforeCurrentVersionQueryBuilder extends DummyQueryBuilder {
 
     public static final String NAME = "fail_before_current_version";
+    public static final int FUTURE_VERSION = TransportVersion.current().id() + 11_111;
 
     public FailBeforeCurrentVersionQueryBuilder(StreamInput in) throws IOException {
         super(in);
@@ -48,6 +49,6 @@ public class FailBeforeCurrentVersionQueryBuilder extends DummyQueryBuilder {
     public TransportVersion getMinimalSupportedVersion() {
         // this is what causes the failure - it always reports a version in the future, so it is never compatible with
         // current or minimum CCS TransportVersion
-        return new TransportVersion(TransportVersion.current().id() + 11_111);
+        return new TransportVersion(FUTURE_VERSION);
     }
 }


### PR DESCRIPTION
The code to have the better error message is already present. But the current tests are not set up in a way to reveal that. This commit adjusts the testing FailBeforeCurrentQueryBuilder to demonstrate that the useful error messages are present.

To show this via manual testing, I changed the MatchAllQueryBuilder to return a TransportVersion in the future from its getMinimalSupportedVersion method.

When I start elasticsearch with `-E search.check_ccs_compatibility=true` and do a match_all query, the response is:

```
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "[class org.elasticsearch.action.search.SearchRequest] is not compatible with version 8500020 and the 'search.check_ccs_compatibility' setting is enabled."
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "[class org.elasticsearch.action.search.SearchRequest] is not compatible with version 8500020 and the 'search.check_ccs_compatibility' setting is enabled.",
    "caused_by": {
      "type": "illegal_argument_exception",
      "reason": "[match_all] was released first in version 8511132, failed compatibility check trying to send it to node with version 8500020"
    }
  },
  "status": 400
}
```

The reason in the cause_by section shows which query failed and why (which version it was introduced in) compared to the version being used by the cluster being queried.

Closes #85487