### PR TITLE
Fix Painless method lookup over unknown super interfaces

### DIFF
--- a/docs/changelog/97062.yaml
+++ b/docs/changelog/97062.yaml
@@ -1,0 +1,6 @@
+pr: 97062
+summary: Fix Painless method lookup over unknown super interfaces
+area: Infra/Scripting
+type: bug
+issues:
+ - 97022

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ systemProp.jdk.tls.client.protocols=TLSv1.2
 
 # java homes resolved by environment variables
 org.gradle.java.installations.auto-detect=false
-org.gradle.java.installations.fromEnv=JAVA_TOOLCHAIN_HOME,JAVA_HOME,RUNTIME_JAVA_HOME,JAVA20_HOME,JAVA19_HOME,JAVA18_HOME,JAVA17_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
+org.gradle.java.installations.fromEnv=JAVA_TOOLCHAIN_HOME,JAVA_HOME,RUNTIME_JAVA_HOME,JAVA21_HOME,JAVA20_HOME,JAVA19_HOME,JAVA18_HOME,JAVA17_HOME,JAVA16_HOME,JAVA15_HOME,JAVA14_HOME,JAVA13_HOME,JAVA12_HOME,JAVA11_HOME,JAVA8_HOME
 
 # log some dependency verification info to console
 org.gradle.dependency.verification.console=verbose

--- a/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
+++ b/modules/lang-painless/src/main/java/org/elasticsearch/painless/lookup/PainlessLookup.java
@@ -360,9 +360,8 @@ public final class PainlessLookup {
                         if (painlessObject != null) {
                             return painlessObject;
                         }
-
-                        targetInterfaces.addAll(Arrays.asList(targetInterface.getInterfaces()));
                     }
+                    targetInterfaces.addAll(Arrays.asList(targetInterface.getInterfaces()));
                 }
             }
 


### PR DESCRIPTION
In Java 21 List now extends SequencedCollection, instead of Collection directly. When resolving methods Painless starts at the defined type, and iterates up through super classes and interfaces. Unfortunately if a superinterface was not known, as it is for SequencedCollection since it is not in the allowed list of classes, method resolution would give up. This commit adjusts the superinterface interation to continue traversing until the method is found or no more superinterfaces are found.

fixes #97022