### PR TITLE
[DOCS] Placeholder for synonym APIs

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1881,3 +1881,33 @@ Refer to <<example-watches>> for other Watcher examples.
 === Fix watermark errors
 
 Refer to <<fix-watermark-errors>>.
+
+[role="exclude",id="get-synonym-rule"]
+=== Get synonym rule API
+
+coming::[8.10.0]
+
+[role="exclude",id="get-synonyms"]
+=== Get synonym set API
+
+coming::[8.10.0]
+
+[role="exclude",id="list-synonyms"]
+=== List synonym sets API
+
+coming::[8.10.0]
+
+[role="exclude",id="put-synonym-rule"]
+=== Create or update synonym rule API
+
+coming::[8.10.0]
+
+[role="exclude",id="delete-synonyms"]
+=== Delete synonym sets API
+
+coming::[8.10.0]
+
+[role="exclude",id="put-synonyms"]
+=== Create or update synonym sets API
+
+coming::[8.10.0]


### PR DESCRIPTION
Relates to https://github.com/elastic/elasticsearch/pull/96985, https://github.com/elastic/elasticsearch/pull/96865, https://github.com/elastic/elasticsearch/pull/96566, https://github.com/elastic/elasticsearch/pull/96467, https://github.com/elastic/elasticsearch/pull/95895, https://github.com/elastic/elasticsearch/pull/96587

This PR addresses the following documentation build error:

````
18:14:23 INFO:build_docs:Bad cross-document links:
18:14:23 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.9/api-reference.html contains broken links to:
18:14:23 INFO:build_docs:   - en/elasticsearch/reference/8.9/delete-synonyms.html
18:14:23 INFO:build_docs:   - en/elasticsearch/reference/8.9/get-synonyms.html
18:14:23 INFO:build_docs:   - en/elasticsearch/reference/8.9/put-synonyms.html
18:14:23 INFO:build_docs:   - en/elasticsearch/reference/8.9/search-application-render-query.html
````