### PR TITLE
[8.9] [DOCS] Placeholder for synonym APIs (#97063)

### DIFF
--- a/docs/reference/redirects.asciidoc
+++ b/docs/reference/redirects.asciidoc
@@ -1881,3 +1881,33 @@ Refer to <<example-watches>> for other Watcher examples.
 === Fix watermark errors
 
 Refer to <<fix-watermark-errors>>.
+
+[role="exclude",id="get-synonym-rule"]
+=== Get synonym rule API
+
+coming::[8.10.0]
+
+[role="exclude",id="get-synonyms"]
+=== Get synonym set API
+
+coming::[8.10.0]
+
+[role="exclude",id="list-synonyms"]
+=== List synonym sets API
+
+coming::[8.10.0]
+
+[role="exclude",id="put-synonym-rule"]
+=== Create or update synonym rule API
+
+coming::[8.10.0]
+
+[role="exclude",id="delete-synonyms"]
+=== Delete synonym sets API
+
+coming::[8.10.0]
+
+[role="exclude",id="put-synonyms"]
+=== Create or update synonym sets API
+
+coming::[8.10.0]


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] Placeholder for synonym APIs (#97063)](https://github.com/elastic/elasticsearch/pull/97063)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)