### PR TITLE
Clean up executors in TransportNodesAction

### DIFF
--- a/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
+++ b/server/src/main/java/org/elasticsearch/action/admin/cluster/stats/TransportClusterStatsAction.java
@@ -96,7 +96,6 @@ public class TransportClusterStatsAction extends TransportNodesAction<
             ClusterStatsRequest::new,
             ClusterStatsNodeRequest::new,
             ThreadPool.Names.MANAGEMENT,
-            ThreadPool.Names.MANAGEMENT,
             ClusterStatsNodeResponse.class
         );
         this.nodeService = nodeService;

--- a/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
+++ b/server/src/test/java/org/elasticsearch/action/support/nodes/TransportNodesActionTests.java
@@ -158,7 +158,10 @@ public class TransportNodesActionTests extends ESTestCase {
 
         final CancellableTask cancellableTask = new CancellableTask(randomLong(), "transport", "action", "", null, emptyMap());
         final PlainActionFuture<TestNodesResponse> listener = new PlainActionFuture<>();
-        action.execute(cancellableTask, new TestNodesRequest(), listener);
+        action.execute(cancellableTask, new TestNodesRequest(), listener.delegateResponse((l, e) -> {
+            assert Thread.currentThread().getName().contains("[" + ThreadPool.Names.GENERIC + "]");
+            l.onFailure(e);
+        }));
 
         final List<CapturingTransport.CapturedRequest> capturedRequests = new ArrayList<>(
             Arrays.asList(transport.getCapturedRequestsAndClear())
@@ -266,7 +269,7 @@ public class TransportNodesActionTests extends ESTestCase {
             new ActionFilters(Collections.emptySet()),
             TestNodesRequest::new,
             TestNodeRequest::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.GENERIC
         );
     }
 
@@ -278,7 +281,7 @@ public class TransportNodesActionTests extends ESTestCase {
             new ActionFilters(Collections.emptySet()),
             TestNodesRequest::new,
             TestNodeRequest::new,
-            ThreadPool.Names.SAME
+            ThreadPool.Names.GENERIC
         );
     }
 

--- a/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
+++ b/x-pack/plugin/deprecation/src/test/java/org/elasticsearch/xpack/deprecation/TransportNodeDeprecationCheckActionTests.java
@@ -51,7 +51,7 @@ public class TransportNodeDeprecationCheckActionTests extends ESTestCase {
         settingsBuilder = Settings.builder();
         settingsBuilder.put("some.bad.dynamic.property", "someValue1");
         Settings dynamicSettings = settingsBuilder.build();
-        ThreadPool threadPool = null;
+        ThreadPool threadPool = Mockito.mock(ThreadPool.class);
         final XPackLicenseState licenseState = null;
         Metadata metadata = Metadata.builder().transientSettings(dynamicSettings).build();
         ClusterState clusterState = ClusterState.builder(ClusterName.DEFAULT).metadata(metadata).build();

--- a/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
+++ b/x-pack/plugin/enrich/src/main/java/org/elasticsearch/xpack/enrich/action/EnrichCoordinatorStatsAction.java
@@ -147,7 +147,7 @@ public class EnrichCoordinatorStatsAction extends ActionType<EnrichCoordinatorSt
                 actionFilters,
                 Request::new,
                 NodeRequest::new,
-                ThreadPool.Names.SAME,
+                ThreadPool.Names.GENERIC,
                 NodeResponse.class
             );
             this.enrichCache = enrichCache;

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportClearRepositoriesStatsArchiveAction.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportClearRepositoriesStatsArchiveAction.java
@@ -49,7 +49,7 @@ public final class TransportClearRepositoriesStatsArchiveAction extends Transpor
             actionFilters,
             ClearRepositoriesMeteringArchiveRequest::new,
             ClearRepositoriesStatsArchiveNodeRequest::new,
-            ThreadPool.Names.SAME,
+            ThreadPool.Names.GENERIC,
             RepositoriesNodeMeteringResponse.class
         );
         this.repositoriesService = repositoriesService;

--- a/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportRepositoriesStatsAction.java
+++ b/x-pack/plugin/repositories-metering-api/src/main/java/org/elasticsearch/xpack/repositories/metering/action/TransportRepositoriesStatsAction.java
@@ -47,7 +47,7 @@ public final class TransportRepositoriesStatsAction extends TransportNodesAction
             actionFilters,
             RepositoriesMeteringRequest::new,
             RepositoriesNodeStatsRequest::new,
-            ThreadPool.Names.SAME,
+            ThreadPool.Names.GENERIC,
             RepositoriesNodeMeteringResponse.class
         );
         this.repositoriesService = repositoriesService;

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotCacheStoresAction.java
@@ -63,7 +63,6 @@ public class TransportSearchableSnapshotCacheStoresAction extends TransportNodes
             Request::new,
             NodeRequest::new,
             ThreadPool.Names.MANAGEMENT,
-            ThreadPool.Names.SAME,
             NodeCacheFilesMetadata.class
         );
         this.cacheService = cacheService.get();

--- a/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
+++ b/x-pack/plugin/searchable-snapshots/src/main/java/org/elasticsearch/xpack/searchablesnapshots/action/cache/TransportSearchableSnapshotsNodeCachesStatsAction.java
@@ -74,7 +74,6 @@ public class TransportSearchableSnapshotsNodeCachesStatsAction extends Transport
             NodesRequest::new,
             NodeRequest::new,
             ThreadPool.Names.MANAGEMENT,
-            ThreadPool.Names.SAME,
             NodeCachesStatsResponse.class
         );
         this.frozenCacheService = frozenCacheService;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountNodesCredentialsAction.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/action/service/TransportGetServiceAccountNodesCredentialsAction.java
@@ -55,7 +55,7 @@ public class TransportGetServiceAccountNodesCredentialsAction extends TransportN
             actionFilters,
             GetServiceAccountCredentialsNodesRequest::new,
             GetServiceAccountCredentialsNodesRequest.Node::new,
-            ThreadPool.Names.SAME,
+            ThreadPool.Names.GENERIC,
             GetServiceAccountCredentialsNodesResponse.Node.class
         );
         this.fileServiceAccountTokenStore = fileServiceAccountTokenStore;


### PR DESCRIPTION
Today `TransportNodesAction` allows implementations to distinguish the
node-level action executor from the final executor which completes the
response, but it quietly replaces a final executor of `SAME` (the
default) with `GENERIC`. This commit removes this quiet replacement
behaviour in favour of being explicit about the forking and forbidding
`SAME` with an assertion.

Moreover it makes more sense for implementations to use the same
executor in both places (often `GENERIC` or `MANAGEMENT`, apart from a
small number of special cases). The actions that use `SAME` for the
node-level action have no good reason not to fork so this commit moves
them to `GENERIC` too.

Finally, it executes the final step using a `ThreadedActionListener` so
that failures are also handled on the correct executor.