### PR TITLE
[DOCS] Add link to Render Search Application Query docs

### DIFF
--- a/docs/reference/search-application/apis/index.asciidoc
+++ b/docs/reference/search-application/apis/index.asciidoc
@@ -16,11 +16,13 @@ Use Search Application APIs to manage tasks and resources related to Search Appl
 * <<list-search-applications>>
 * <<delete-search-application>>
 * <<search-application-search>>
-
+* <<search-application-search>>
+* <<search-application-render-query>>
 
 include::put-search-application.asciidoc[]
 include::get-search-application.asciidoc[]
 include::list-search-applications.asciidoc[]
 include::delete-search-application.asciidoc[]
 include::search-application-search.asciidoc[]
+include::search-application-render-query.asciidoc[]
 


### PR DESCRIPTION
The docs for Render Search Application Query were added in https://github.com/elastic/elasticsearch/pull/95513, but not included in `index.asciidoc`, so they're not actually part of the documentation. This PR includes the page, because its omission is causing docs build errors:

```
10:45:13 INFO:build_docs:Bad cross-document links:
10:45:13 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/javascript-api/8.9/api-reference.html contains broken links to:
10:45:13 INFO:build_docs:   - en/elasticsearch/reference/8.9/search-application-render-query.html
```

