### PR TITLE
[8.9] [DOCS] Add link to Render Search Application Query docs (#97067)

### DIFF
--- a/docs/reference/search-application/apis/index.asciidoc
+++ b/docs/reference/search-application/apis/index.asciidoc
@@ -16,11 +16,13 @@ Use Search Application APIs to manage tasks and resources related to Search Appl
 * <<list-search-applications>>
 * <<delete-search-application>>
 * <<search-application-search>>
-
+* <<search-application-search>>
+* <<search-application-render-query>>
 
 include::put-search-application.asciidoc[]
 include::get-search-application.asciidoc[]
 include::list-search-applications.asciidoc[]
 include::delete-search-application.asciidoc[]
 include::search-application-search.asciidoc[]
+include::search-application-render-query.asciidoc[]
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.9`:
 - [[DOCS] Add link to Render Search Application Query docs (#97067)](https://github.com/elastic/elasticsearch/pull/97067)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)