### PR TITLE
Log when update AffixSetting using addAffixMapUpdateConsumer

### DIFF
--- a/docs/changelog/97072.yaml
+++ b/docs/changelog/97072.yaml
@@ -1,0 +1,5 @@
+pr: 97072
+summary: Log when update AffixSetting using addAffixMapUpdateConsumer
+area: Infra/Logging
+type: bug
+issues: []

--- a/server/src/main/java/org/elasticsearch/common/settings/Setting.java
+++ b/server/src/main/java/org/elasticsearch/common/settings/Setting.java
@@ -1017,7 +1017,7 @@ public class Setting<T> implements ToXContentObject {
         }
 
         @Override
-        public String getLogString(final Settings settings) {
+        String getLogString(final Settings settings) {
             Settings filteredAffixSetting = settings.filter(this::match);
             try {
                 XContentBuilder builder = XContentFactory.jsonBuilder();


### PR DESCRIPTION
When updateing settings, most of SettingUpdater will call `org.elasticsearch.common.settings.Setting#logSettingUpdate` to log the difference between before and after. However, since version 6.1.0, the new subclass `AffixSetting` will not log any message when using `org.elasticsearch.common.settings.Setting.AffixSetting#newAffixMapUpdater` method to update settings. Currently, the scope of influence is this three settings in `FilterAllocationDecider`: `cluster.routing.allocation.require`, `cluster.routing.allocation.include`,`cluster.routing.allocation.exclude`, which are not easy to notice. Call `logSettingUpdate` in the same way as `GroupSetting`, I think it's ok to fix this issue. 


Manual test case after this fix:
```
PUT _cluster/settings
{
  "transient": {
    "cluster.routing.allocation.exclude._ip": "1.1.1.1",
    "cluster.routing.allocation.exclude._name": "abcde"
  }
}
```

`[2023-06-25T15:27:05,672][INFO ][o.e.c.s.ClusterSettings  ] [node1] updating [cluster.routing.allocation.exclude.] from [{}] to [{"cluster.routing.allocation.exclude._ip":"1.1.1.1","cluster.routing.allocation.exclude._name":"abcde"}]`

```
PUT _cluster/settings
{
  "transient": {
    "cluster.routing.allocation.exclude._ip": "1.1.1.1",
    "cluster.routing.allocation.exclude._name": null
  }
}
```

`[2023-06-25T15:28:07,868][INFO ][o.e.c.s.ClusterSettings  ] [node2] updating [cluster.routing.allocation.exclude.] from [{"cluster.routing.allocation.exclude._ip":"1.1.1.1","cluster.routing.allocation.exclude._name":"abcde"}] to [{"cluster.routing.allocation.exclude._ip":"1.1.1.1"}]`


