### PR TITLE
[8.9] [DOCS] Delete duplicated link (#97076)

### DIFF
--- a/docs/reference/search-application/apis/index.asciidoc
+++ b/docs/reference/search-application/apis/index.asciidoc
@@ -16,7 +16,6 @@ Use Search Application APIs to manage tasks and resources related to Search Appl
 * <<list-search-applications>>
 * <<delete-search-application>>
 * <<search-application-search>>
-* <<search-application-search>>
 * <<search-application-render-query>>
 
 include::put-search-application.asciidoc[]


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [DOCS] Delete duplicated link (#97076)