### PR TITLE
[DOCS] Adjusts the note about minimum recommended node size on the ELSER tutorial page

### DIFF
--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -29,8 +29,13 @@ in your cluster. Refer to the
 deploy the model.
 
 NOTE: The minimum dedicated ML node size for deploying and using the ELSER model 
-is 4 GB. This is a minimum and better performance can be achieved by using 
-bigger ML nodes.
+is 4 GB in Elasticsearch Service if 
+{cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
+autoscaling is recommended because it allows your deployment to dinamically 
+adjust resources based on demand. Better performance can be achieved by using 
+more allocations or more threads per allocation, which requires bigger ML nodes. 
+Autoscaling provide bigger nodes when required. If autoscaling is turned off, 
+you must provide suitably sized nodes yourself.
 
 
 [discrete]

--- a/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
+++ b/docs/reference/search/search-your-data/semantic-search-elser.asciidoc
@@ -31,10 +31,10 @@ deploy the model.
 NOTE: The minimum dedicated ML node size for deploying and using the ELSER model 
 is 4 GB in Elasticsearch Service if 
 {cloud}/ec-autoscaling.html[deployment autoscaling] is turned off. Turning on 
-autoscaling is recommended because it allows your deployment to dinamically 
+autoscaling is recommended because it allows your deployment to dynamically 
 adjust resources based on demand. Better performance can be achieved by using 
 more allocations or more threads per allocation, which requires bigger ML nodes. 
-Autoscaling provide bigger nodes when required. If autoscaling is turned off, 
+Autoscaling provides bigger nodes when required. If autoscaling is turned off, 
 you must provide suitably sized nodes yourself.
 
 


### PR DESCRIPTION
## Overview

Related to https://github.com/elastic/stack-docs/pull/2447.
This PR adjusts the note on the minimum ML node size on the ELSER tutorial page to include a reference to ESS and autoscaling.

### Preview

[ELSER Tutorial requirements](https://elasticsearch_97083.docs-preview.app.elstc.co/guide/en/elasticsearch/reference/master/semantic-search-elser.html#requirements)