### PR TITLE
[8.9] [TEST] Mute RemoteClusterClientTests.testConnectAndExecuteRequest #97084 (#97084)

### DIFF
--- a/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
+++ b/server/src/test/java/org/elasticsearch/transport/RemoteClusterClientTests.java
@@ -43,6 +43,7 @@ public class RemoteClusterClientTests extends ESTestCase {
         ThreadPool.terminate(threadPool, 10, TimeUnit.SECONDS);
     }
 
+    @AwaitsFix(bugUrl = "https://github.com/elastic/elasticsearch/issues/97080")
     public void testConnectAndExecuteRequest() throws Exception {
         Settings remoteSettings = Settings.builder()
             .put(ClusterName.CLUSTER_NAME_SETTING.getKey(), "foo_bar_cluster")


### PR DESCRIPTION
Backports the following commits to 8.9:
 - [TEST] Mute RemoteClusterClientTests.testConnectAndExecuteRequest #97084 (#97084)