### PR TITLE
[7.17] Fix ESCCRRestTestCase.verifyAutoFollowMonitoring (#97054)

### DIFF
--- a/x-pack/plugin/ccr/qa/src/main/java/org/elasticsearch/xpack/ccr/ESCCRRestTestCase.java
+++ b/x-pack/plugin/ccr/qa/src/main/java/org/elasticsearch/xpack/ccr/ESCCRRestTestCase.java
@@ -218,8 +218,21 @@ public class ESCCRRestTestCase extends ESRestTestCase {
     }
 
     protected static void verifyAutoFollowMonitoring() throws IOException {
-        Request request = new Request("GET", "/.monitoring-*/_search");
-        request.setJsonEntity("{\"query\": {\"term\": {\"type\": \"ccr_auto_follow_stats\"}}}");
+        Request request = new Request("GET", "/.monitoring-*/_count");
+        request.setJsonEntity(
+            "{"
+                + "  \"query\": {"
+                + "    \"bool\" : {"
+                + "      \"filter\": {"
+                + "        \"term\" : { \"type\" : \"ccr_auto_follow_stats\" }"
+                + "      },"
+                + "      \"must\" : {"
+                + "        \"range\" : {\"ccr_auto_follow_stats.number_of_successful_follow_indices\" : { \"gt\" : 0 }}"
+                + "      }"
+                + "    }"
+                + "  }"
+                + "}"
+        );
         String responseEntity;
         Map<String, ?> response;
         try {
@@ -229,25 +242,12 @@ public class ESCCRRestTestCase extends ESRestTestCase {
             throw new AssertionError("error while searching", e);
         }
         assertNotNull(responseEntity);
-        int numberOfSuccessfulFollowIndices = 0;
 
-        List<?> hits = (List<?>) XContentMapValues.extractValue("hits.hits", response);
-        assertThat(hits.size(), greaterThanOrEqualTo(1));
-
-        for (int i = 0; i < hits.size(); i++) {
-            Map<?, ?> hit = (Map<?, ?>) hits.get(i);
-
-            int foundNumberOfOperationsReceived = (int) XContentMapValues.extractValue(
-                "_source.ccr_auto_follow_stats.number_of_successful_follow_indices",
-                hit
-            );
-            numberOfSuccessfulFollowIndices = Math.max(numberOfSuccessfulFollowIndices, foundNumberOfOperationsReceived);
-        }
-
+        final Number count = (Number) XContentMapValues.extractValue("count", response);
         assertThat(
-            "Unexpected number of followed indices [" + responseEntity + ']',
-            numberOfSuccessfulFollowIndices,
-            greaterThanOrEqualTo(1)
+            "Expected at least 1 successfully followed index but found none, count returned [" + responseEntity + ']',
+            count.longValue(),
+            greaterThanOrEqualTo(1L)
         );
     }
 


### PR DESCRIPTION
The method `verifyAutoFollowMonitoring` searches for `ccr_auto_follow_stats` documents in `monitoring-es-*` indices to see if one document has the field `number_of_successful_follow_indices` greater than 0.

If such document is found, it means that x-pack monitoring successfully indexed documents about CCR stats and that CCR at that time had at least 1 following index successfully running.

But the current `verifyAutoFollowMonitoring` method only check the first 10 docs returned by the search requests. Recent failures of `AutoFollowIT.testAutoFollowPatterns` on 7.17 branch indicates that more than 10 docs were found, so I suspect one of them has `number_of_successful_follow_indices` > 0 but is not returned in the first 10 top docs.

This pull request changes the method to only count documents with `number_of_successful_follow_indices` > 0.

Closes #91984
